### PR TITLE
librustzcash APIs for wallet key manipulation

### DIFF
--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -12,6 +12,8 @@ extern "C" {
 
     void librustzcash_nsk_to_nk(const unsigned char *nsk, unsigned char *result);
 
+    void librustzcash_crh_ivk(const unsigned char *ak, const unsigned char *nk, unsigned char *result);
+
     /// Loads the zk-SNARK parameters into memory and saves
     /// paths as necessary. Only called once.
     void librustzcash_init_zksnark_params(

--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -8,6 +8,10 @@ extern "C" {
 
     void librustzcash_to_scalar(const unsigned char *input, unsigned char *result);
 
+    void librustzcash_ask_to_ak(const unsigned char *ask, unsigned char *result);
+
+    void librustzcash_nsk_to_nk(const unsigned char *nsk, unsigned char *result);
+
     /// Loads the zk-SNARK parameters into memory and saves
     /// paths as necessary. Only called once.
     void librustzcash_init_zksnark_params(

--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -14,6 +14,10 @@ extern "C" {
 
     void librustzcash_crh_ivk(const unsigned char *ak, const unsigned char *nk, unsigned char *result);
 
+    bool librustzcash_check_diversifier(const unsigned char *diversifier);
+
+    bool librustzcash_ivk_to_pkd(const unsigned char *ivk, const unsigned char *diversifier, unsigned char *result);
+
     /// Loads the zk-SNARK parameters into memory and saves
     /// paths as necessary. Only called once.
     void librustzcash_init_zksnark_params(

--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -6,6 +6,8 @@
 extern "C" {
     uint64_t librustzcash_xor(uint64_t a, uint64_t b);
 
+    void librustzcash_to_scalar(const unsigned char *input, unsigned char *result);
+
     /// Loads the zk-SNARK parameters into memory and saves
     /// paths as necessary. Only called once.
     void librustzcash_init_zksnark_params(


### PR DESCRIPTION
- `librustzcash_to_scalar`
- `librustzcash_ask_to_ak`
- `librustzcash_nsk_to_nk`
- `librustzcash_crh_ivk`
- `librustzcash_check_diversifier`
- `librustzcash_ivk_to_pkd`