### PR TITLE
Sapling proof API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sapling-crypto 0.0.1 (git+https://github.com/zcash-hackworks/sapling-crypto?rev=6abfcca25ae233922ecc18a4d2d0b5cb7aab7c8c)",
+ "sapling-crypto 0.0.1 (git+https://github.com/zcash-hackworks/sapling-crypto?rev=c2862a43829632d64f0654e8a9cde9680ba48076)",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.0.1"
-source = "git+https://github.com/zcash-hackworks/sapling-crypto?rev=6abfcca25ae233922ecc18a4d2d0b5cb7aab7c8c#6abfcca25ae233922ecc18a4d2d0b5cb7aab7c8c"
+source = "git+https://github.com/zcash-hackworks/sapling-crypto?rev=c2862a43829632d64f0654e8a9cde9680ba48076#c2862a43829632d64f0654e8a9cde9680ba48076"
 dependencies = [
  "bellman 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
@@ -214,7 +214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceda21136251c6d5a422d3d798d8ac22515a6e8d3521bb60c59a8349d36d0d57"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum sapling-crypto 0.0.1 (git+https://github.com/zcash-hackworks/sapling-crypto?rev=6abfcca25ae233922ecc18a4d2d0b5cb7aab7c8c)" = "<none>"
+"checksum sapling-crypto 0.0.1 (git+https://github.com/zcash-hackworks/sapling-crypto?rev=c2862a43829632d64f0654e8a9cde9680ba48076)" = "<none>"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"
 
 [dependencies.sapling-crypto]
 git = "https://github.com/zcash-hackworks/sapling-crypto"
-rev = "6abfcca25ae233922ecc18a4d2d0b5cb7aab7c8c"
+rev = "c2862a43829632d64f0654e8a9cde9680ba48076"
 
 [profile.release]
 lto = true

--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -60,6 +60,68 @@ extern "C" {
         unsigned char *result
     );
 
+    /// Computes the signature for each Spend description, given the key
+    /// `ask`, the re-randomization `ar`, the 32-byte sighash `sighash`,
+    /// and an output `result` buffer of 64-bytes for the signature.
+    ///
+    /// This function will fail if the provided `ask` or `ar` are invalid.
+    bool librustzcash_sapling_spend_sig(
+        const unsigned char *ask,
+        const unsigned char *ar,
+        const unsigned char *sighash,
+        unsigned char *result
+    );
+
+    /// Creates a Sapling proving context. Please free this when you're done.
+    void * librustzcash_sapling_proving_ctx_init();
+
+    /// This function (using the proving context) constructs a Spend proof
+    /// given the necessary witness information. It outputs `cv` (the value
+    /// commitment) and `rk` (so that you don't have to compute it) along
+    /// with the proof.
+    bool librustzcash_sapling_spend_proof(
+        void *ctx,
+        const unsigned char *ak,
+        const unsigned char *nsk,
+        const unsigned char *diversifier,
+        const unsigned char *rcm,
+        const unsigned char *ar,
+        const uint64_t value,
+        const unsigned char *anchor,
+        const unsigned char *witness,
+        unsigned char *cv,
+        unsigned char *rk,
+        unsigned char *zkproof
+    );
+
+    /// This function (using the proving context) constructs an Output
+    /// proof given the necessary witness information. It outputs `cv`
+    /// and the `zkproof`.
+    bool librustzcash_sapling_output_proof(
+        void *ctx,
+        const unsigned char *esk,
+        const unsigned char *diversifier,
+        const unsigned char *pk_d,
+        const unsigned char *rcm,
+        const uint64_t value,
+        unsigned char *cv,
+        unsigned char *zkproof
+    );
+
+    /// This function (using the proving context) constructs a binding
+    /// signature. You must provide the intended valueBalance so that
+    /// we can internally check consistency.
+    bool librustzcash_sapling_binding_sig(
+        void *ctx,
+        int64_t valueBalance,
+        const unsigned char *sighash,
+        unsigned char *result
+    );
+
+    /// Frees a Sapling proving context returned from
+    /// `librustzcash_sapling_proving_ctx_init`.
+    void librustzcash_sapling_proving_ctx_free(void *);
+
     /// Creates a Sapling verification context. Please free this
     /// when you're done.
     void * librustzcash_sapling_verification_ctx_init();

--- a/include/librustzcash.h
+++ b/include/librustzcash.h
@@ -112,7 +112,7 @@ extern "C" {
     /// signature. You must provide the intended valueBalance so that
     /// we can internally check consistency.
     bool librustzcash_sapling_binding_sig(
-        void *ctx,
+        const void *ctx,
         int64_t valueBalance,
         const unsigned char *sighash,
         unsigned char *result

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -1188,7 +1188,7 @@ pub extern "system" fn librustzcash_sapling_spend_sig(
 
 #[no_mangle]
 pub extern "system" fn librustzcash_sapling_binding_sig(
-    ctx: *mut SaplingProvingContext,
+    ctx: *const SaplingProvingContext,
     value_balance: int64_t,
     sighash: *const [c_uchar; 32],
     result: *mut [c_uchar; 64],

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -695,7 +695,7 @@ pub extern "system" fn librustzcash_sapling_check_output(
     // Accumulate the value commitment in the context
     {
         let mut tmp = cv.clone();
-        tmp.negate(); // Outputs subtract from the total.
+        tmp = tmp.negate(); // Outputs subtract from the total.
         tmp = tmp.add(&unsafe { &*ctx }.bvk, &JUBJUB);
 
         // Update the context


### PR DESCRIPTION
Written alongside @gtank.

This C API allows you to construct Sapling proofs.

1. Create a context with `librustzcash_sapling_proving_ctx_init`. This context contains the current value of `bsk`.
2. Create Spend proofs with `librustzcash_sapling_spend_proof`. Give it the witness and it'll output `cv` (`rcv` is chosen randomly for you), `rk` (so you don't have to compute it), and `zkproof`.
3. Create Output proofs with `librustzcash_sapling_output_proof`. Give it the witness and it'll output `cv` (again, `rcv` is randomly chosen for you) and the `zkproof`.
4. Once you're ready, run `librustzcash_sapling_binding_sig` to sign for the transaction with the binding key.
5. Finally, sign for all the inputs with `librustzcash_sapling_spend_sig`.
6. Finally finally, free the context with `librustzcash_sapling_proving_ctx_free`.

Closes #22.