### PR TITLE
[WIP] Unsafe consolidation

### DIFF
--- a/src/equihash.rs
+++ b/src/equihash.rs
@@ -149,8 +149,7 @@ fn expand_array(vin: &[u8], bit_len: usize, byte_pad: usize) -> Vec<u8> {
                 vout[j + x] = ((
                     // Big-endian
                     acc_value >> (acc_bits + (8 * (out_width - x - 1)))
-                )
-                    & (
+                ) & (
                     // Apply bit_len_mask across byte boundaries
                     (bit_len_mask >> (8 * (out_width - x - 1))) & 0xFF
                 )) as u8;

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -285,12 +285,10 @@ pub extern "system" fn librustzcash_merkle_hash(
     b: *const [c_uchar; 32],
     result: *mut [c_uchar; 32],
 ) {
-    let tmp = unsafe {
-        // Should be okay, because caller is responsible for ensuring
-        // the pointer is a valid pointer to 32 bytes, and that is the
-        // size of the representation
-        librustzcash_merkle_hash_safe(depth, *a, *b)
-    };
+    // Should be okay, because caller is responsible for ensuring
+    // the pointer is a valid pointer to 32 bytes, and that is the
+    // size of the representation
+    let tmp = librustzcash_merkle_hash_safe(depth, unsafe { *a }, unsafe { *b });
 
     // Should be okay, caller is responsible for ensuring the pointer
     // is a valid pointer to 32 bytes that can be mutated.

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -251,7 +251,7 @@ pub extern "system" fn librustzcash_tree_uncommitted(result: *mut [c_uchar; 32])
     write_le(tmp, &mut result[..]);
 }
 
-fn librustzcash_merkle_hash_safe(depth: usize, a: [u8; 32], b: [u8; 32]) -> FrRepr {
+fn librustzcash_merkle_hash_safe(depth: usize, a: &[u8; 32], b: &[u8; 32]) -> FrRepr {
     let a_repr = read_le(&a[..]);
     let b_repr = read_le(&b[..]);
 
@@ -288,7 +288,7 @@ pub extern "system" fn librustzcash_merkle_hash(
     // Should be okay, because caller is responsible for ensuring
     // the pointer is a valid pointer to 32 bytes, and that is the
     // size of the representation
-    let tmp = librustzcash_merkle_hash_safe(depth, unsafe { *a }, unsafe { *b });
+    let tmp = librustzcash_merkle_hash_safe(depth, unsafe { &*a }, unsafe { &*b });
 
     // Should be okay, caller is responsible for ensuring the pointer
     // is a valid pointer to 32 bytes that can be mutated.

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -397,9 +397,7 @@ pub extern "system" fn librustzcash_ivk_to_pkd(
     }
 }
 
-/// Return 32 byte random scalar, uniformly.
-#[no_mangle]
-pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32]) {
+fn librustzcash_sapling_generate_r_safe() -> Fs {
     // create random 64 byte buffer
     let mut rng = OsRng::new().expect("should be able to construct RNG");
     let mut buffer = [0u8; 64];
@@ -408,7 +406,13 @@ pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32
     }
 
     // reduce to uniform value
-    let r = <Bls12 as JubjubEngine>::Fs::to_uniform(&buffer[..]);
+    <Bls12 as JubjubEngine>::Fs::to_uniform(&buffer[..])
+}
+
+/// Return 32 byte random scalar, uniformly.
+#[no_mangle]
+pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32]) {
+    let r = librustzcash_sapling_generate_r_safe();
     let result = unsafe { &mut *result };
     r.into_repr()
         .write_le(&mut result[..])

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -53,9 +53,6 @@ use sapling_crypto::primitives::{ProofGenerationKey, ValueCommitment, ViewingKey
 
 pub mod equihash;
 
-#[cfg(test)]
-mod tests;
-
 lazy_static! {
     static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
 }
@@ -390,25 +387,6 @@ pub extern "system" fn librustzcash_ivk_to_pkd(
     } else {
         false
     }
-}
-
-/// Test generation of commitment randomness
-#[test]
-fn test_gen_r() {
-    let mut r1 = [0u8; 32];
-    let mut r2 = [0u8; 32];
-
-    // Verify different r values are generated
-    librustzcash_sapling_generate_r(&mut r1);
-    librustzcash_sapling_generate_r(&mut r2);
-    assert_ne!(r1, r2);
-
-    // Verify r values are valid in the field
-    let mut repr = FsRepr::default();
-    repr.read_le(&r1[..]).expect("length is not 32 bytes");
-    let _ = Fs::from_repr(repr).unwrap();
-    repr.read_le(&r2[..]).expect("length is not 32 bytes");
-    let _ = Fs::from_repr(repr).unwrap();
 }
 
 /// Return 32 byte random scalar, uniformly.
@@ -1588,4 +1566,31 @@ pub extern "system" fn librustzcash_sapling_proving_ctx_init() -> *mut SaplingPr
 #[no_mangle]
 pub extern "system" fn librustzcash_sapling_proving_ctx_free(ctx: *mut SaplingProvingContext) {
     drop(unsafe { Box::from_raw(ctx) });
+}
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod rustzcash_tests {
+    use super::*;
+
+    /// Test generation of commitment randomness
+    #[test]
+    fn test_gen_r() {
+        let mut r1 = [0u8; 32];
+        let mut r2 = [0u8; 32];
+
+        // Verify different r values are generated
+        librustzcash_sapling_generate_r(&mut r1);
+        librustzcash_sapling_generate_r(&mut r2);
+        assert_ne!(r1, r2);
+
+        // Verify r values are valid in the field
+        let mut repr = FsRepr::default();
+        repr.read_le(&r1[..]).expect("length is not 32 bytes");
+        let _ = Fs::from_repr(repr).unwrap();
+        repr.read_le(&r2[..]).expect("length is not 32 bytes");
+        let _ = Fs::from_repr(repr).unwrap();
+    }
 }

--- a/src/rustzcash.rs
+++ b/src/rustzcash.rs
@@ -712,13 +712,7 @@ fn librustzcash_sapling_check_spend_safe(
     }
 
     // Accumulate the value commitment in the context
-    {
-        let mut tmp = cv.clone();
-        tmp = tmp.add(&ctx.bvk, &JUBJUB);
-
-        // Update the context
-        ctx.bvk = tmp;
-    }
+    ctx.bvk = cv.clone().add(&ctx.bvk, &JUBJUB);
 
     // Deserialize the anchor, which should be an element
     // of Fr.
@@ -845,14 +839,8 @@ fn librustzcash_sapling_check_output_safe(
     }
 
     // Accumulate the value commitment in the context
-    {
-        let mut tmp = cv.clone();
-        tmp = tmp.negate(); // Outputs subtract from the total.
-        tmp = tmp.add(&ctx.bvk, &JUBJUB);
-
-        // Update the context
-        ctx.bvk = tmp;
-    }
+    // Outputs subtract from the total.
+    ctx.bvk = cv.clone().negate().add(&ctx.bvk, &JUBJUB);
 
     // Deserialize the commitment, which should be an element
     // of Fr.

--- a/src/tests/signatures.rs
+++ b/src/tests/signatures.rs
@@ -1,6 +1,7 @@
 use pairing::{bls12_381::Bls12, PrimeField, PrimeFieldRepr};
 use sapling_crypto::{
-    jubjub::{FixedGenerators, JubjubEngine}, redjubjub::{PrivateKey, PublicKey, Signature},
+    jubjub::{FixedGenerators, JubjubEngine},
+    redjubjub::{PrivateKey, PublicKey, Signature},
 };
 
 use super::JUBJUB;


### PR DESCRIPTION
This PR is intended to isolate the _unsafe_ code in rustzcash.rs. I considered each function marked `#[no_mangle]`. The functions which are essentially one-lines have been crossed off below. For the remaining functions, I have gone through each one and created a "safe" version which should be exactly the same, except that we pass in the unsafe parameters rather than use them inline. They will also differ in that they will return some type, or in many cases a `Result<>`, which is then used in the unsafe version to communicate back through the interface.

Note: This is a WIP. Some functions are still to be done.

- [X] librustzcash_init_zksnark_params
~~librustzcash_tree_uncommitted~~
- [X] librustzcash_merkle_hash
~~librustzcash_to_scalar~~
~~librustzcash_ask_to_ak~~
~~librustzcash_nsk_to_nk~~
- [X] librustzcash_crh_ivk
~~librustzcash_check_diversifier~~
- [X] librustzcash_ivk_to_pkd
- [X] librustzcash_sapling_generate_r
- [X] librustzcash_sapling_compute_nf
- [X] librustzcash_sapling_compute_cm
- [X] librustzcash_sapling_ka_agree
- [X] librustzcash_sapling_ka_derivepublic
- [ ] librustzcash_eh_isvalid
~~librustzcash_sapling_verification_ctx_init~~
~~librustzcash_sapling_verification_ctx_free~~
- [X] librustzcash_sapling_check_spend
- [X] librustzcash_sapling_check_output
- [X] librustzcash_sapling_final_check
- [ ] librustzcash_sprout_prove
- [ ] librustzcash_sprout_verify
- [ ] librustzcash_sapling_output_proof
- [ ] librustzcash_sapling_spend_sig
- [ ] librustzcash_sapling_binding_sig
- [ ] librustzcash_sapling_spend_proof
~~librustzcash_sapling_proving_ctx_init~~
~~librustzcash_sapling_proving_ctx_free~~