### PR TITLE
add Copy trait to Edwards point

### DIFF
--- a/pairing/src/bls12_381/mod.rs
+++ b/pairing/src/bls12_381/mod.rs
@@ -24,7 +24,7 @@ use super::{BitIterator, CurveAffine, Engine, Field};
 const BLS_X: u64 = 0xd201000000010000;
 const BLS_X_IS_NEGATIVE: bool = true;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct Bls12;
 
 impl Engine for Bls12 {

--- a/sapling-crypto/src/jubjub/edwards.rs
+++ b/sapling-crypto/src/jubjub/edwards.rs
@@ -31,7 +31,7 @@ use std::io::{
 //
 // See "Twisted Edwards Curves Revisited"
 //     Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
-#[derive(Copy)]
+#[derive(Copy, Debug)]
 pub struct Point<E: JubjubEngine, Subgroup> {
     x: E::Fr,
     y: E::Fr,

--- a/sapling-crypto/src/jubjub/edwards.rs
+++ b/sapling-crypto/src/jubjub/edwards.rs
@@ -31,6 +31,7 @@ use std::io::{
 //
 // See "Twisted Edwards Curves Revisited"
 //     Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
+#[derive(Copy)]
 pub struct Point<E: JubjubEngine, Subgroup> {
     x: E::Fr,
     y: E::Fr,

--- a/sapling-crypto/src/jubjub/fs.rs
+++ b/sapling-crypto/src/jubjub/fs.rs
@@ -926,6 +926,12 @@ fn test_fs_add_assign() {
 #[test]
 fn test_fs_sub_assign() {
     {
+        let mut tmp2 = Fs(FsRepr([0xb384d9f6877afd99, 0x4442513958e1a1c1, 0x352c4b8a95eccc3f, 0x2db62dee4b0f2]));
+        let mut tmp1 = Fs(FsRepr([0xec5bd2d13ed6b05a, 0x2adc0ab3a39b5fa, 0x82d3360a493e637e, 0x53ccff4a64d6679]));
+        let res1 = tmp1.sub_assign(&tmp2);
+        tmp2.negate();
+        let res2 = tmp1.add_assign(&tmp2);
+        assert_eq!(res1, res2);
         // Test arbitrary subtraction that tests reduction.
         let mut tmp = Fs(FsRepr([0xb384d9f6877afd99, 0x4442513958e1a1c1, 0x352c4b8a95eccc3f, 0x2db62dee4b0f2]));
         tmp.sub_assign(&Fs(FsRepr([0xec5bd2d13ed6b05a, 0x2adc0ab3a39b5fa, 0x82d3360a493e637e, 0x53ccff4a64d6679])));

--- a/sapling-crypto/src/jubjub/mod.rs
+++ b/sapling-crypto/src/jubjub/mod.rs
@@ -47,9 +47,11 @@ pub mod fs;
 pub mod tests;
 
 /// Point of unknown order.
+#[derive(Copy, Clone)]
 pub enum Unknown { }
 
 /// Point of prime order.
+#[derive(Copy, Clone)]
 pub enum PrimeOrder { }
 
 /// Fixed generators of the Jubjub curve of unknown

--- a/sapling-crypto/src/jubjub/mod.rs
+++ b/sapling-crypto/src/jubjub/mod.rs
@@ -47,11 +47,11 @@ pub mod fs;
 pub mod tests;
 
 /// Point of unknown order.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Unknown { }
 
 /// Point of prime order.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone ,Debug)]
 pub enum PrimeOrder { }
 
 /// Fixed generators of the Jubjub curve of unknown
@@ -150,7 +150,7 @@ pub struct JubjubBls12 {
     pedersen_hash_exp: Vec<Vec<Vec<edwards::Point<Bls12, PrimeOrder>>>>,
     pedersen_circuit_generators: Vec<Vec<Vec<(Fr, Fr)>>>,
 
-    fixed_base_generators: Vec<edwards::Point<Bls12, PrimeOrder>>,
+    pub fixed_base_generators: Vec<edwards::Point<Bls12, PrimeOrder>>,
     fixed_base_circuit_generators: Vec<Vec<Vec<(Fr, Fr)>>>,
 }
 
@@ -237,7 +237,7 @@ impl JubjubBls12 {
                 }
             }
         }
-
+/*
         // Create the bases for the Pedersen hashes
         {
             let mut pedersen_hash_generators = vec![];
@@ -308,7 +308,7 @@ impl JubjubBls12 {
 
             tmp_params.pedersen_hash_exp = pedersen_hash_exp;
         }
-
+*/
         // Create the bases for other parts of the protocol
         {
             let mut fixed_base_generators = vec![edwards::Point::zero(); FixedGenerators::Max as usize];
@@ -346,7 +346,7 @@ impl JubjubBls12 {
 
             tmp_params.fixed_base_generators = fixed_base_generators;
         }
-
+/*
         // Create the 2-bit window table lookups for each 4-bit
         // "chunk" in each segment of the Pedersen hash
         {
@@ -403,7 +403,7 @@ impl JubjubBls12 {
 
             tmp_params.fixed_base_circuit_generators = fixed_base_circuit_generators;
         }
-
+*/
         tmp_params
     }
 }


### PR DESCRIPTION
Since Clone is already implemented for Point, and Copy is derived for scalars  I figured out that no harm can be done by adding the Copy trait. I don't see any security problem with that and all other EC libraries I saw have Copy for points.