### PR TITLE
Place bellman multicore operations behind a (default) feature flag

### DIFF
--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -13,16 +13,17 @@ rand = "0.4"
 bit-vec = "0.4.4"
 ff = { path = "../ff" }
 futures = "0.1"
-futures-cpupool = "0.1"
+futures-cpupool = { version = "0.1", optional = true }
 group = { path = "../group" }
-num_cpus = "1"
-crossbeam = "0.3"
+num_cpus = { version = "1", optional = true }
+crossbeam = { version = "0.3", optional = true }
 pairing = { path = "../pairing", optional = true }
 byteorder = "1"
 
 [features]
 groth16 = ["pairing"]
-default = ["groth16"]
+multicore = ["futures-cpupool", "crossbeam", "num_cpus"]
+default = ["groth16", "multicore"]
 
 [[test]]
 name = "mimc"

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -3,12 +3,17 @@ extern crate group;
 #[cfg(feature = "pairing")]
 extern crate pairing;
 extern crate rand;
-extern crate num_cpus;
+
 extern crate futures;
-extern crate futures_cpupool;
 extern crate bit_vec;
-extern crate crossbeam;
 extern crate byteorder;
+
+#[cfg(feature = "multicore")]
+extern crate crossbeam;
+#[cfg(feature = "multicore")]
+extern crate futures_cpupool;
+#[cfg(feature = "multicore")]
+extern crate num_cpus;
 
 pub mod multicore;
 mod multiexp;

--- a/bellman/src/multicore.rs
+++ b/bellman/src/multicore.rs
@@ -4,103 +4,165 @@
 //! crossbeam but may be extended in the future to
 //! allow for various parallelism strategies.
 
-use num_cpus;
-use futures::{Future, IntoFuture, Poll};
-use futures_cpupool::{CpuPool, CpuFuture};
-use crossbeam::{self, Scope};
+#[cfg(feature = "multicore")]
+mod implementation {
+    use num_cpus;
+    use futures::{Future, IntoFuture, Poll};
+    use futures_cpupool::{CpuPool, CpuFuture};
+    use crossbeam::{self, Scope};
 
-#[derive(Clone)]
-pub struct Worker {
-    cpus: usize,
-    pool: CpuPool
-}
+    #[derive(Clone)]
+    pub struct Worker {
+        cpus: usize,
+        pool: CpuPool
+    }
 
-impl Worker {
-    // We don't expose this outside the library so that
-    // all `Worker` instances have the same number of
-    // CPUs configured.
-    pub(crate) fn new_with_cpus(cpus: usize) -> Worker {
-        Worker {
-            cpus: cpus,
-            pool: CpuPool::new(cpus)
+    impl Worker {
+        // We don't expose this outside the library so that
+        // all `Worker` instances have the same number of
+        // CPUs configured.
+        pub(crate) fn new_with_cpus(cpus: usize) -> Worker {
+            Worker {
+                cpus: cpus,
+                pool: CpuPool::new(cpus)
+            }
+        }
+
+        pub fn new() -> Worker {
+            Self::new_with_cpus(num_cpus::get())
+        }
+
+        pub fn log_num_cpus(&self) -> u32 {
+            log2_floor(self.cpus)
+        }
+
+        pub fn compute<F, R>(
+            &self, f: F
+        ) -> WorkerFuture<R::Item, R::Error>
+            where F: FnOnce() -> R + Send + 'static,
+                R: IntoFuture + 'static,
+                R::Future: Send + 'static,
+                R::Item: Send + 'static,
+                R::Error: Send + 'static
+        {
+            WorkerFuture {
+                future: self.pool.spawn_fn(f)
+            }
+        }
+
+        pub fn scope<'a, F, R>(
+            &self,
+            elements: usize,
+            f: F
+        ) -> R
+            where F: FnOnce(&Scope<'a>, usize) -> R
+        {
+            let chunk_size = if elements < self.cpus {
+                1
+            } else {
+                elements / self.cpus
+            };
+
+            crossbeam::scope(|scope| {
+                f(scope, chunk_size)
+            })
         }
     }
 
-    pub fn new() -> Worker {
-        Self::new_with_cpus(num_cpus::get())
+    pub struct WorkerFuture<T, E> {
+        future: CpuFuture<T, E>
     }
 
-    pub fn log_num_cpus(&self) -> u32 {
-        log2_floor(self.cpus)
-    }
+    impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
+        type Item = T;
+        type Error = E;
 
-    pub fn compute<F, R>(
-        &self, f: F
-    ) -> WorkerFuture<R::Item, R::Error>
-        where F: FnOnce() -> R + Send + 'static,
-              R: IntoFuture + 'static,
-              R::Future: Send + 'static,
-              R::Item: Send + 'static,
-              R::Error: Send + 'static
-    {
-        WorkerFuture {
-            future: self.pool.spawn_fn(f)
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error>
+        {
+            self.future.poll()
         }
     }
 
-    pub fn scope<'a, F, R>(
-        &self,
-        elements: usize,
-        f: F
-    ) -> R
-        where F: FnOnce(&Scope<'a>, usize) -> R
-    {
-        let chunk_size = if elements < self.cpus {
-            1
-        } else {
-            elements / self.cpus
-        };
+    fn log2_floor(num: usize) -> u32 {
+        assert!(num > 0);
 
-        crossbeam::scope(|scope| {
-            f(scope, chunk_size)
-        })
+        let mut pow = 0;
+
+        while (1 << (pow+1)) <= num {
+            pow += 1;
+        }
+
+        pow
+    }
+
+    #[test]
+    fn test_log2_floor() {
+        assert_eq!(log2_floor(1), 0);
+        assert_eq!(log2_floor(2), 1);
+        assert_eq!(log2_floor(3), 1);
+        assert_eq!(log2_floor(4), 2);
+        assert_eq!(log2_floor(5), 2);
+        assert_eq!(log2_floor(6), 2);
+        assert_eq!(log2_floor(7), 2);
+        assert_eq!(log2_floor(8), 3);
     }
 }
 
-pub struct WorkerFuture<T, E> {
-    future: CpuFuture<T, E>
-}
+#[cfg(not(feature = "multicore"))]
+mod implementation {
+    use futures::{future, Future, IntoFuture, Poll};
 
-impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
-    type Item = T;
-    type Error = E;
+    #[derive(Clone)]
+    pub struct Worker;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error>
-    {
-        self.future.poll()
+    impl Worker {
+        pub fn new() -> Worker {
+            Worker
+        }
+
+        pub fn log_num_cpus(&self) -> u32 {
+            0
+        }
+
+        pub fn compute<F, R>(&self, f: F) -> R::Future
+        where
+            F: FnOnce() -> R + Send + 'static,
+            R: IntoFuture + 'static,
+            R::Future: Send + 'static,
+            R::Item: Send + 'static,
+            R::Error: Send + 'static,
+        {
+            f().into_future()
+        }
+
+        pub fn scope<F, R>(&self, elements: usize, f: F) -> R
+        where
+            F: FnOnce(&DummyScope, usize) -> R,
+        {
+            f(&DummyScope, elements)
+        }
+    }
+
+    pub struct WorkerFuture<T, E> {
+        future: future::FutureResult<T, E>,
+    }
+
+    impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
+        type Item = T;
+        type Error = E;
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            self.future.poll()
+        }
+    }
+
+    pub struct DummyScope;
+
+    impl DummyScope {
+        pub fn spawn<F: FnOnce()>(&self, f: F) {
+            f();
+        }
     }
 }
 
-fn log2_floor(num: usize) -> u32 {
-    assert!(num > 0);
-
-    let mut pow = 0;
-
-    while (1 << (pow+1)) <= num {
-        pow += 1;
-    }
-
-    pow
-}
-
-#[test]
-fn test_log2_floor() {
-    assert_eq!(log2_floor(1), 0);
-    assert_eq!(log2_floor(2), 1);
-    assert_eq!(log2_floor(3), 1);
-    assert_eq!(log2_floor(4), 2);
-    assert_eq!(log2_floor(5), 2);
-    assert_eq!(log2_floor(6), 2);
-    assert_eq!(log2_floor(7), 2);
-    assert_eq!(log2_floor(8), 3);
-}
+pub use self::implementation::*;


### PR DESCRIPTION
When the `multicore` feature is disabled, an alternate implementation of the multicore operations is used that reduces the parallelization to 1 (preventing sharding of workloads), and immediately blocks on all operations.