### PR TITLE
Migrate to blake2b_simd and blake2s_simd crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.32.0
+  - 1.36.0
 
 cache: cargo
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,8 +31,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -70,12 +75,22 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9#7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"
+name = "blake2b_simd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -292,7 +307,8 @@ name = "librustzcash"
 version = "0.1.0"
 dependencies = [
  "bellman 0.1.0",
- "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
+ "blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2s_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +451,8 @@ name = "sapling-crypto"
 version = "0.0.1"
 dependencies = [
  "bellman 0.1.0",
- "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
+ "blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2s_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
@@ -529,7 +546,7 @@ name = "zcash_primitives"
 version = "0.0.0"
 dependencies = [
  "aes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
+ "blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto_api_chachapoly 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
@@ -547,7 +564,7 @@ name = "zcash_proofs"
 version = "0.0.0"
 dependencies = [
  "bellman 0.1.0",
- "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
+ "blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "pairing 0.14.2",
@@ -559,11 +576,13 @@ dependencies = [
 "checksum aes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6fb1737cdc8da3db76e90ca817a194249a38fcb500c2e6ecec39b29448aa873"
 "checksum aes-soft 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67cc03b0a090a05cb01e96998a01905d7ceedce1bc23b756c0bb7faa0682ccb1"
 "checksum aesni 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6810b7fb9f2bb4f76f05ac1c170b8dde285b6308955dc3afd89710268c958d9e"
-"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)" = "<none>"
+"checksum blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d909f9ef55928e57e7de9638828bc9407233b5cb0904066a7edebbaa9946db2f"
+"checksum blake2s_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa20660ff9f1e6d0a05444b5ebbbae13e4c018d4c66cc78c7e421e3396358a52"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "370424437b9459f3dfd68428ed9376ddfe03d8b70ede29cc533b3557df186ab4"
 "checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"

--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -15,6 +15,8 @@ crate-type = ["staticlib"]
 
 [dependencies]
 bellman = { path = "../bellman" }
+blake2b_simd = "0.5"
+blake2s_simd = "0.5"
 ff = { path = "../ff" }
 libc = "0.2"
 pairing = { path = "../pairing" }
@@ -24,7 +26,3 @@ rand = "0.4"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 zcash_proofs = { path = "../zcash_proofs" }
-
-[dependencies.blake2-rfc]
-git = "https://github.com/gtank/blake2-rfc"
-rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -1,5 +1,6 @@
 extern crate bellman;
-extern crate blake2_rfc;
+extern crate blake2b_simd;
+extern crate blake2s_simd;
 extern crate byteorder;
 extern crate ff;
 extern crate libc;
@@ -33,7 +34,7 @@ use bellman::groth16::{
     create_random_proof, verify_proof, Parameters, PreparedVerifyingKey, Proof,
 };
 
-use blake2_rfc::blake2s::Blake2s;
+use blake2s_simd::Params as Blake2sParams;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -336,7 +337,10 @@ pub extern "system" fn librustzcash_crh_ivk(
     let ak = unsafe { &*ak };
     let nk = unsafe { &*nk };
 
-    let mut h = Blake2s::with_params(32, &[], &[], CRH_IVK_PERSONALIZATION);
+    let mut h = Blake2sParams::new()
+        .hash_length(32)
+        .personal(CRH_IVK_PERSONALIZATION)
+        .to_state();
     h.update(ak);
     h.update(nk);
     let mut h = h.finalize().as_ref().to_vec();

--- a/sapling-crypto/Cargo.toml
+++ b/sapling-crypto/Cargo.toml
@@ -14,14 +14,12 @@ features = ["expose-arith"]
 
 [dependencies]
 bellman = { path = "../bellman" }
+blake2b_simd = "0.5"
+blake2s_simd = "0.5"
 ff = { path = "../ff" }
 rand = "0.4"
 digest = "0.7"
 byteorder = "1"
-
-[dependencies.blake2-rfc]
-git = "https://github.com/gtank/blake2-rfc"
-rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"
 
 [dev-dependencies]
 hex-literal = "0.1"

--- a/sapling-crypto/src/circuit/blake2s.rs
+++ b/sapling-crypto/src/circuit/blake2s.rs
@@ -320,13 +320,13 @@ pub fn blake2s<E: Engine, CS: ConstraintSystem<E>>(
 
 #[cfg(test)]
 mod test {
+    use blake2s_simd::Params as Blake2sParams;
     use rand::{XorShiftRng, SeedableRng, Rng};
     use pairing::bls12_381::{Bls12};
     use ::circuit::boolean::{Boolean, AllocatedBit};
     use ::circuit::test::TestConstraintSystem;
     use super::blake2s;
     use bellman::{ConstraintSystem};
-    use blake2_rfc::blake2s::Blake2s;
 
     #[test]
     fn test_blank_hash() {
@@ -392,7 +392,7 @@ mod test {
 
         for input_len in (0..32).chain((32..256).filter(|a| a % 8 == 0))
         {
-            let mut h = Blake2s::with_params(32, &[], &[], b"12345678");
+            let mut h = Blake2sParams::new().hash_length(32).personal(b"12345678").to_state();
 
             let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
 

--- a/sapling-crypto/src/circuit/test/mod.rs
+++ b/sapling-crypto/src/circuit/test/mod.rs
@@ -16,7 +16,7 @@ use byteorder::{BigEndian, ByteOrder};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use blake2_rfc::blake2s::Blake2s;
+use blake2s_simd::{Params as Blake2sParams, State as Blake2sState};
 
 #[derive(Debug)]
 enum NamedObject {
@@ -96,7 +96,7 @@ fn proc_lc<E: Engine>(
 
 fn hash_lc<E: Engine>(
     terms: &[(Variable, E::Fr)],
-    h: &mut Blake2s
+    h: &mut Blake2sState
 )
 {
     let map = proc_lc::<E>(terms);
@@ -226,7 +226,7 @@ impl<E: Engine> TestConstraintSystem<E> {
     }
 
     pub fn hash(&self) -> String {
-        let mut h = Blake2s::new(32);
+        let mut h = Blake2sParams::new().hash_length(32).to_state();
         {
             let mut buf = [0u8; 24];
 

--- a/sapling-crypto/src/lib.rs
+++ b/sapling-crypto/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate pairing;
 extern crate bellman;
-extern crate blake2_rfc;
+extern crate blake2b_simd;
+extern crate blake2s_simd;
 extern crate digest;
 extern crate ff;
 extern crate rand;

--- a/sapling-crypto/src/util.rs
+++ b/sapling-crypto/src/util.rs
@@ -1,9 +1,9 @@
-use blake2_rfc::blake2b::Blake2b;
+use blake2b_simd::Params;
 
 use jubjub::{JubjubEngine, ToUniform};
 
 pub fn hash_to_scalar<E: JubjubEngine>(persona: &[u8], a: &[u8], b: &[u8]) -> E::Fs {
-    let mut hasher = Blake2b::with_params(64, &[], &[], persona);
+    let mut hasher = Params::new().hash_length(64).personal(persona).to_state();
     hasher.update(a);
     hasher.update(b);
     let ret = hasher.finalize();

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 
 [dependencies]
 aes = "0.2"
+blake2b_simd = "0.5"
 byteorder = "1"
 crypto_api_chachapoly = "0.1"
 ff = { path = "../ff" }
@@ -17,7 +18,3 @@ pairing = { path = "../pairing" }
 rand = "0.4"
 sapling-crypto = { path = "../sapling-crypto" }
 sha2 = "0.8"
-
-[dependencies.blake2-rfc]
-git = "https://github.com/gtank/blake2-rfc"
-rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"

--- a/zcash_primitives/src/keys.rs
+++ b/zcash_primitives/src/keys.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements section 4.2.2 of the Zcash Protocol Specification.
 
-use blake2_rfc::blake2b::{Blake2b, Blake2bResult};
+use blake2b_simd::{Hash as Blake2bHash, Params as Blake2bParams};
 use ff::{PrimeField, PrimeFieldRepr};
 use sapling_crypto::{
     jubjub::{edwards, FixedGenerators, JubjubEngine, JubjubParams, ToUniform, Unknown},
@@ -13,12 +13,15 @@ use std::io::{self, Read, Write};
 pub const PRF_EXPAND_PERSONALIZATION: &'static [u8; 16] = b"Zcash_ExpandSeed";
 
 /// PRF^expand(sk, t) := BLAKE2b-512("Zcash_ExpandSeed", sk || t)
-pub fn prf_expand(sk: &[u8], t: &[u8]) -> Blake2bResult {
-    prf_expand_vec(sk, &[t])
+pub fn prf_expand(sk: &[u8], t: &[u8]) -> Blake2bHash {
+    prf_expand_vec(sk, &vec![t])
 }
 
-pub fn prf_expand_vec(sk: &[u8], ts: &[&[u8]]) -> Blake2bResult {
-    let mut h = Blake2b::with_params(64, &[], &[], PRF_EXPAND_PERSONALIZATION);
+pub fn prf_expand_vec(sk: &[u8], ts: &[&[u8]]) -> Blake2bHash {
+    let mut h = Blake2bParams::new()
+        .hash_length(64)
+        .personal(PRF_EXPAND_PERSONALIZATION)
+        .to_state();
     h.update(sk);
     for t in ts {
         h.update(t);

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate lazy_static;
 
 extern crate aes;
-extern crate blake2_rfc;
+extern crate blake2b_simd;
 extern crate byteorder;
 extern crate crypto_api_chachapoly;
 extern crate ff;

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -7,12 +7,9 @@ authors = [
 
 [dependencies]
 bellman = { path = "../bellman" }
+blake2b_simd = "0.5"
 byteorder = "1"
 ff = { path = "../ff" }
 pairing = { path = "../pairing" }
 rand = "0.4"
 sapling-crypto = { path = "../sapling-crypto" }
-
-[dependencies.blake2-rfc]
-git = "https://github.com/gtank/blake2-rfc"
-rev = "7a5b5fc99ae483a0043db7547fb79a6fa44b88a9"

--- a/zcash_proofs/src/hashreader.rs
+++ b/zcash_proofs/src/hashreader.rs
@@ -1,10 +1,10 @@
-use blake2_rfc::blake2b::Blake2b;
+use blake2b_simd::State;
 use std::io::{self, Read};
 
 /// Abstraction over a reader which hashes the data being read.
 pub struct HashReader<R: Read> {
     reader: R,
-    hasher: Blake2b,
+    hasher: State,
 }
 
 impl<R: Read> HashReader<R> {
@@ -12,7 +12,7 @@ impl<R: Read> HashReader<R> {
     pub fn new(reader: R) -> Self {
         HashReader {
             reader: reader,
-            hasher: Blake2b::new(64),
+            hasher: State::new(),
         }
     }
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate bellman;
-extern crate blake2_rfc;
+extern crate blake2b_simd;
 extern crate byteorder;
 extern crate ff;
 extern crate pairing;


### PR DESCRIPTION
The primary reason for migrating is that these crates provide APIs for
setting the personalisation string. This enables us to depend solely on
published crates, and thus publish our own crates. (In order for a crate
to be published, it can't depend on unpublished ones.)

The SIMD implementations are ported from libsodium.

Closes #67.