### PR TITLE
Upgrade rand crate dependency to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,8 @@ dependencies = [
  "group 0.1.0",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,18 +66,13 @@ dependencies = [
  "group 0.1.0",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-vec"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -143,11 +138,12 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
+name = "c2-chacha"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,7 +196,7 @@ version = "0.4.0"
 dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff_derive 0.3.0",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -226,11 +222,6 @@ dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
@@ -263,12 +254,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "group"
 version = "0.1.0"
 dependencies = [
  "ff 0.4.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -295,12 +295,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -312,11 +315,11 @@ dependencies = [
  "blake2s_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
  "zcash_proofs 0.0.0",
@@ -354,7 +357,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -374,9 +377,14 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "group 0.1.0",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro-hack"
@@ -409,106 +417,57 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_os"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -523,8 +482,8 @@ dependencies = [
  "ff 0.4.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -538,6 +497,11 @@ dependencies = [
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stream-cipher"
@@ -568,32 +532,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "zcash_client_backend"
 version = "0.0.0"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]
@@ -609,10 +554,10 @@ dependencies = [
  "ff 0.4.0",
  "fpe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -626,7 +571,7 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "pairing 0.14.2",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]
@@ -640,7 +585,6 @@ dependencies = [
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum blake2b_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d909f9ef55928e57e7de9638828bc9407233b5cb0904066a7edebbaa9946db2f"
 "checksum blake2s_simd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa20660ff9f1e6d0a05444b5ebbbae13e4c018d4c66cc78c7e421e3396358a52"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
@@ -649,7 +593,7 @@ dependencies = [
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crypto_api 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f855e87e75a4799e18b8529178adcde6fd4f97c1449ff4821e747ff728bb102"
@@ -658,16 +602,16 @@ dependencies = [
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fpe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3371c82bfbd984f624cab093f55e7336f5a6e589f8518e1258f54f011b89ad"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5f0e01bd8a71a224a4eedecaacfcabda388dbb7a80faf04d3514287572d95"
 "checksum hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d340b6514f232f6db1bd16db65302a5278a04fef9ce867cb932e7e5fa21130a"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
@@ -675,26 +619,20 @@ dependencies = [
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba8d4f9257b85eb6cdf13f055cea3190520aab1409ca2ab43493ea4820c25f0"
 "checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
 "checksum proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b331c6ad3411474cd55540398dc7ad89fc41488e64ec71fdecc9c9b86de96fb0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
+"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
+"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+"checksum rand_os 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e8c83d0434e67e7a92be561af33f3ca17ff9899a4acf28030fabb8c5c323a1a"
+"checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
  "zcash_proofs 0.0.0",
@@ -576,7 +576,7 @@ version = "0.0.0"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]
@@ -608,7 +608,7 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,14 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +222,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +280,7 @@ name = "group"
 version = "0.1.0"
 dependencies = [
  "ff 0.4.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -421,6 +434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -603,6 +628,7 @@ dependencies = [
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crypto_api 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f855e87e75a4799e18b8529178adcde6fd4f97c1449ff4821e747ff728bb102"
@@ -611,6 +637,7 @@ dependencies = [
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fpe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3371c82bfbd984f624cab093f55e7336f5a6e589f8518e1258f54f011b89ad"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
@@ -636,6 +663,7 @@ dependencies = [
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,8 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,8 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "group 0.1.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
  "ff 0.4.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,20 +228,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "futures"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,11 +240,6 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "generic-array"
@@ -421,26 +402,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -465,28 +426,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "sapling-crypto"
 version = "0.0.1"
 dependencies = [
@@ -499,7 +438,7 @@ dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -529,16 +468,6 @@ dependencies = [
  "proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "time"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -640,11 +569,8 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fpe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3371c82bfbd984f624cab093f55e7336f5a6e589f8518e1258f54f011b89ad"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -663,18 +589,12 @@ dependencies = [
 "checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
 "checksum proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b331c6ad3411474cd55540398dc7ad89fc41488e64ec71fdecc9c9b86de96fb0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
-"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,8 @@ dependencies = [
  "ff 0.4.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bech32"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,8 +66,8 @@ dependencies = [
  "group 0.1.0",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -195,7 +200,7 @@ version = "0.4.0"
 dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff_derive 0.3.0",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,7 +267,8 @@ name = "group"
 version = "0.1.0"
 dependencies = [
  "ff 0.4.0",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -367,8 +373,8 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "group 0.1.0",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -413,6 +419,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +457,70 @@ dependencies = [
 name = "rand_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sapling-crypto"
@@ -548,6 +645,7 @@ dependencies = [
 "checksum aesni 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6810b7fb9f2bb4f76f05ac1c170b8dde285b6308955dc3afd89710268c958d9e"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
@@ -590,8 +688,17 @@ dependencies = [
 "checksum proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b331c6ad3411474cd55540398dc7ad89fc41488e64ec71fdecc9c9b86de96fb0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ version = "0.4.0"
 dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff_derive 0.3.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -425,6 +425,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +636,8 @@ dependencies = [
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,8 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
  "zcash_proofs 0.0.0",
@@ -404,18 +405,6 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -603,7 +592,8 @@ version = "0.0.0"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]
@@ -636,7 +626,7 @@ dependencies = [
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0",
  "pairing 0.14.2",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapling-crypto 0.0.1",
  "zcash_primitives 0.0.0",
 ]
@@ -689,7 +679,6 @@ dependencies = [
 "checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
 "checksum proc-macro2 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b331c6ad3411474cd55540398dc7ad89fc41488e64ec71fdecc9c9b86de96fb0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ebfull/bellman"
 version = "0.1.0"
 
 [dependencies]
-rand_core = "0.3"
+rand_core = "0.4"
 bit-vec = "0.4.4"
 ff = { path = "../ff" }
 futures = "0.1"
@@ -21,7 +21,7 @@ pairing = { path = "../pairing", optional = true }
 byteorder = "1"
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"
 
 [features]
 groth16 = ["pairing"]

--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/ebfull/bellman"
 version = "0.1.0"
 
 [dependencies]
-rand_core = "0.4"
 bit-vec = "0.4.4"
 ff = { path = "../ff" }
 futures = "0.1"
@@ -18,10 +17,11 @@ group = { path = "../group" }
 num_cpus = { version = "1", optional = true }
 crossbeam = { version = "0.3", optional = true }
 pairing = { path = "../pairing", optional = true }
+rand_core = "0.5"
 byteorder = "1"
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"
 
 [features]
 groth16 = ["pairing"]

--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ebfull/bellman"
 version = "0.1.0"
 
 [dependencies]
-rand = "0.4"
+rand_core = "0.3"
 bit-vec = "0.4.4"
 ff = { path = "../ff" }
 futures = "0.1"
@@ -19,6 +19,9 @@ num_cpus = { version = "1", optional = true }
 crossbeam = { version = "0.3", optional = true }
 pairing = { path = "../pairing", optional = true }
 byteorder = "1"
+
+[dev-dependencies]
+rand = "0.5"
 
 [features]
 groth16 = ["pairing"]

--- a/bellman/src/domain.rs
+++ b/bellman/src/domain.rs
@@ -375,16 +375,16 @@ fn parallel_fft<E: ScalarEngine, T: Group<E>>(
 #[test]
 fn polynomial_arith() {
     use pairing::bls12_381::Bls12;
-    use rand::{self, Rand};
+    use rand_core::RngCore;
 
-    fn test_mul<E: ScalarEngine, R: rand::Rng>(rng: &mut R)
+    fn test_mul<E: ScalarEngine, R: RngCore>(rng: &mut R)
     {
         let worker = Worker::new();
 
         for coeffs_a in 0..70 {
             for coeffs_b in 0..70 {
-                let mut a: Vec<_> = (0..coeffs_a).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect();
-                let mut b: Vec<_> = (0..coeffs_b).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect();
+                let mut a: Vec<_> = (0..coeffs_a).map(|_| Scalar::<E>(E::Fr::random(rng))).collect();
+                let mut b: Vec<_> = (0..coeffs_b).map(|_| Scalar::<E>(E::Fr::random(rng))).collect();
 
                 // naive evaluation
                 let mut naive = vec![Scalar(E::Fr::zero()); coeffs_a + coeffs_b];
@@ -423,9 +423,9 @@ fn polynomial_arith() {
 #[test]
 fn fft_composition() {
     use pairing::bls12_381::Bls12;
-    use rand;
+    use rand_core::RngCore;
 
-    fn test_comp<E: ScalarEngine, R: rand::Rng>(rng: &mut R)
+    fn test_comp<E: ScalarEngine, R: RngCore>(rng: &mut R)
     {
         let worker = Worker::new();
 
@@ -434,7 +434,7 @@ fn fft_composition() {
 
             let mut v = vec![];
             for _ in 0..coeffs {
-                v.push(Scalar::<E>(rng.gen()));
+                v.push(Scalar::<E>(E::Fr::random(rng)));
             }
 
             let mut domain = EvaluationDomain::from_coeffs(v.clone()).unwrap();
@@ -462,10 +462,10 @@ fn fft_composition() {
 #[test]
 fn parallel_fft_consistency() {
     use pairing::bls12_381::Bls12;
-    use rand::{self, Rand};
+    use rand_core::RngCore;
     use std::cmp::min;
 
-    fn test_consistency<E: ScalarEngine, R: rand::Rng>(rng: &mut R)
+    fn test_consistency<E: ScalarEngine, R: RngCore>(rng: &mut R)
     {
         let worker = Worker::new();
 
@@ -473,7 +473,7 @@ fn parallel_fft_consistency() {
             for log_d in 0..10 {
                 let d = 1 << log_d;
 
-                let v1 = (0..d).map(|_| Scalar::<E>(E::Fr::rand(rng))).collect::<Vec<_>>();
+                let v1 = (0..d).map(|_| Scalar::<E>(E::Fr::random(rng))).collect::<Vec<_>>();
                 let mut v1 = EvaluationDomain::from_coeffs(v1).unwrap();
                 let mut v2 = EvaluationDomain::from_coeffs(v1.coeffs.clone()).unwrap();
 

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand_core::RngCore;
 
 use std::sync::Arc;
 
@@ -35,15 +35,15 @@ pub fn generate_random_parameters<E, C, R>(
     circuit: C,
     rng: &mut R
 ) -> Result<Parameters<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>, R: Rng
+    where E: Engine, C: Circuit<E>, R: RngCore
 {
-    let g1 = rng.gen();
-    let g2 = rng.gen();
-    let alpha = rng.gen();
-    let beta = rng.gen();
-    let gamma = rng.gen();
-    let delta = rng.gen();
-    let tau = rng.gen();
+    let g1 = E::G1::random(rng);
+    let g2 = E::G2::random(rng);
+    let alpha = E::Fr::random(rng);
+    let beta = E::Fr::random(rng);
+    let gamma = E::Fr::random(rng);
+    let delta = E::Fr::random(rng);
+    let tau = E::Fr::random(rng);
 
     generate_parameters::<E, C>(
         circuit,

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -487,7 +487,7 @@ mod test_with_bls12_381 {
     use {Circuit, SynthesisError, ConstraintSystem};
 
     use ff::Field;
-    use rand::{Rand, thread_rng};
+    use rand::{thread_rng};
     use pairing::bls12_381::{Bls12, Fr};
 
     #[test]
@@ -547,8 +547,8 @@ mod test_with_bls12_381 {
         let pvk = prepare_verifying_key::<Bls12>(&params.vk);
 
         for _ in 0..100 {
-            let a = Fr::rand(rng);
-            let b = Fr::rand(rng);
+            let a = Fr::random(rng);
+            let b = Fr::random(rng);
             let mut c = a;
             c.mul_assign(&b);
 

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand_core::RngCore;
 
 use std::sync::Arc;
 
@@ -189,10 +189,10 @@ pub fn create_random_proof<E, C, R, P: ParameterSource<E>>(
     params: P,
     rng: &mut R
 ) -> Result<Proof<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>, R: Rng
+    where E: Engine, C: Circuit<E>, R: RngCore
 {
-    let r = rng.gen();
-    let s = rng.gen();
+    let r = E::Fr::random(rng);
+    let s = E::Fr::random(rng);
 
     create_proof::<E, C, P>(circuit, params, r, s)
 }

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -6,7 +6,7 @@ use pairing::{Engine, PairingCurveAffine};
 
 use std::cmp::Ordering;
 use std::fmt;
-use rand::{Rand, Rng};
+use rand_core::RngCore;
 use std::num::Wrapping;
 
 const MODULUS_R: Wrapping<u32> = Wrapping(64513);
@@ -20,13 +20,11 @@ impl fmt::Display for Fr {
     }
 }
 
-impl Rand for Fr {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        Fr(Wrapping(rng.gen()) % MODULUS_R)
-    }
-}
-
 impl Field for Fr {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
+        Fr(Wrapping(rng.next_u32()) % MODULUS_R)
+    }
+
     fn zero() -> Self {
         Fr(Wrapping(0))
     }
@@ -142,12 +140,6 @@ impl Ord for FrRepr {
 impl PartialOrd for FrRepr {
     fn partial_cmp(&self, other: &FrRepr) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl Rand for FrRepr {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        FrRepr([rng.gen()])
     }
 }
 
@@ -299,6 +291,10 @@ impl CurveProjective for Fr {
     type Base = Fr;
     type Scalar = Fr;
     type Engine = DummyEngine;
+
+    fn random<R: RngCore>(rng: &mut R) -> Self {
+        <Fr as Field>::random(rng)
+    }
 
     fn zero() -> Self {
         <Fr as Field>::zero()

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -2,7 +2,7 @@ extern crate ff;
 extern crate group;
 #[cfg(feature = "pairing")]
 extern crate pairing;
-extern crate rand;
+extern crate rand_core;
 
 extern crate futures;
 extern crate bit_vec;
@@ -14,6 +14,9 @@ extern crate crossbeam;
 extern crate futures_cpupool;
 #[cfg(feature = "multicore")]
 extern crate num_cpus;
+
+#[cfg(test)]
+extern crate rand;
 
 pub mod multicore;
 mod multiexp;

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -274,14 +274,14 @@ fn test_with_bls12() {
         acc
     }
 
-    use rand::{self, Rand};
+    use rand;
     use pairing::{bls12_381::Bls12, Engine};
 
     const SAMPLES: usize = 1 << 14;
 
     let rng = &mut rand::thread_rng();
-    let v = Arc::new((0..SAMPLES).map(|_| <Bls12 as ScalarEngine>::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
-    let g = Arc::new((0..SAMPLES).map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>());
+    let v = Arc::new((0..SAMPLES).map(|_| <Bls12 as ScalarEngine>::Fr::random(rng).into_repr()).collect::<Vec<_>>());
+    let g = Arc::new((0..SAMPLES).map(|_| <Bls12 as Engine>::G1::random(rng).into_affine()).collect::<Vec<_>>());
 
     let naive = naive_multiexp(g.clone(), v.clone());
 

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -4,13 +4,13 @@ extern crate pairing;
 extern crate rand;
 
 // For randomness (during paramgen and proof generation)
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 
 // For benchmarking
 use std::time::{Duration, Instant};
 
 // Bring in some tools for using pairing-friendly curves
-use ff::Field;
+use ff::{Field, ScalarEngine};
 use pairing::Engine;
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
@@ -172,7 +172,7 @@ fn test_mimc() {
     let rng = &mut thread_rng();
 
     // Generate the MiMC round constants
-    let constants = (0..MIMC_ROUNDS).map(|_| rng.gen()).collect::<Vec<_>>();
+    let constants = (0..MIMC_ROUNDS).map(|_| <Bls12 as ScalarEngine>::Fr::random(rng)).collect::<Vec<_>>();
 
     println!("Creating parameters...");
 
@@ -203,8 +203,8 @@ fn test_mimc() {
 
     for _ in 0..SAMPLES {
         // Generate a random preimage and compute the image
-        let xl = rng.gen();
-        let xr = rng.gen();
+        let xl = <Bls12 as ScalarEngine>::Fr::random(rng);
+        let xr = <Bls12 as ScalarEngine>::Fr::random(rng);
         let image = mimc::<Bls12>(xl, xr, &constants);
 
         proof_vec.truncate(0);

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/ebfull/ff"
 
 [dependencies]
 byteorder = "1"
-rand_core = "0.4"
 ff_derive = { version = "0.3.0", path = "ff_derive", optional = true }
+rand_core = "0.5"
 
 [features]
 default = []

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ebfull/ff"
 
 [dependencies]
 byteorder = "1"
-rand_core = "0.3"
+rand_core = "0.4"
 ff_derive = { version = "0.3.0", path = "ff_derive", optional = true }
 
 [features]

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ebfull/ff"
 
 [dependencies]
 byteorder = "1"
-rand = "0.4"
+rand_core = "0.3"
 ff_derive = { version = "0.3.0", path = "ff_derive", optional = true }
 
 [features]

--- a/ff/ff_derive/src/lib.rs
+++ b/ff/ff_derive/src/lib.rs
@@ -892,7 +892,7 @@ fn prime_field_impl(
                         #name(#repr(repr))
                     };
 
-                    // Mask away the unused bits at the beginning.
+                    // Mask away the unused most-significant bits.
                     tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;
 
                     if tmp.is_valid() {

--- a/ff/ff_derive/src/lib.rs
+++ b/ff/ff_derive/src/lib.rs
@@ -136,13 +136,6 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
             }
         }
 
-        impl ::rand::Rand for #repr {
-            #[inline(always)]
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
-                #repr(rng.gen())
-            }
-        }
-
         impl ::std::fmt::Display for #repr {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 try!(write!(f, "0x"));
@@ -839,22 +832,6 @@ fn prime_field_impl(
             }
         }
 
-        impl ::rand::Rand for #name {
-            /// Computes a uniformly random element using rejection sampling.
-            fn rand<R: ::rand::Rng>(rng: &mut R) -> Self {
-                loop {
-                    let mut tmp = #name(#repr::rand(rng));
-
-                    // Mask away the unused bits at the beginning.
-                    tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;
-
-                    if tmp.is_valid() {
-                        return tmp
-                    }
-                }
-            }
-        }
-
         impl From<#name> for #repr {
             fn from(e: #name) -> #repr {
                 e.into_repr()
@@ -904,6 +881,26 @@ fn prime_field_impl(
         }
 
         impl ::ff::Field for #name {
+            /// Computes a uniformly random element using rejection sampling.
+            fn random<R: ::rand_core::RngCore>(rng: &mut R) -> Self {
+                loop {
+                    let mut tmp = {
+                        let mut repr = [0u64; #limbs];
+                        for i in 0..#limbs {
+                            repr[i] = rng.next_u64();
+                        }
+                        #name(#repr(repr))
+                    };
+
+                    // Mask away the unused bits at the beginning.
+                    tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;
+
+                    if tmp.is_valid() {
+                        return tmp
+                    }
+                }
+            }
+
             #[inline]
             fn zero() -> Self {
                 #name(#repr::from(0))

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 extern crate byteorder;
-extern crate rand;
+extern crate rand_core;
 
 #[cfg(feature = "derive")]
 #[macro_use]
@@ -10,14 +10,18 @@ extern crate ff_derive;
 #[cfg(feature = "derive")]
 pub use ff_derive::*;
 
+use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + rand::Rand
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
 {
+    /// Returns an element chosen uniformly at random using a user-provided RNG.
+    fn random<R: RngCore>(rng: &mut R) -> Self;
+
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self;
 
@@ -100,7 +104,6 @@ pub trait PrimeFieldRepr:
     + fmt::Debug
     + fmt::Display
     + 'static
-    + rand::Rand
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>

--- a/group/Cargo.toml
+++ b/group/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/ebfull/group"
 
 [dependencies]
 ff = { path = "../ff" }
-rand = "0.6"
-rand_xorshift = "0.1"
+rand = "0.7"
+rand_xorshift = "0.2"

--- a/group/Cargo.toml
+++ b/group/Cargo.toml
@@ -14,4 +14,5 @@ repository = "https://github.com/ebfull/group"
 
 [dependencies]
 ff = { path = "../ff" }
-rand = "0.5"
+rand = "0.6"
+rand_xorshift = "0.1"

--- a/group/Cargo.toml
+++ b/group/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/ebfull/group"
 
 [dependencies]
 ff = { path = "../ff" }
-rand = "0.4"
+rand = "0.5"

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -2,6 +2,7 @@ extern crate ff;
 extern crate rand;
 
 use ff::{PrimeField, PrimeFieldDecodingError, ScalarEngine, SqrtField};
+use rand::RngCore;
 use std::error::Error;
 use std::fmt;
 
@@ -13,22 +14,15 @@ pub use self::wnaf::Wnaf;
 /// Projective representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
 pub trait CurveProjective:
-    PartialEq
-    + Eq
-    + Sized
-    + Copy
-    + Clone
-    + Send
-    + Sync
-    + fmt::Debug
-    + fmt::Display
-    + rand::Rand
-    + 'static
+    PartialEq + Eq + Sized + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
 {
     type Engine: ScalarEngine<Fr = Self::Scalar>;
     type Scalar: PrimeField + SqrtField;
     type Base: SqrtField;
     type Affine: CurveAffine<Projective = Self, Scalar = Self::Scalar>;
+
+    /// Returns an element chosen uniformly at random using a user-provided RNG.
+    fn random<R: RngCore>(rng: &mut R) -> Self;
 
     /// Returns the additive identity.
     fn zero() -> Self;

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate ff;
 extern crate rand;
+extern crate rand_xorshift;
 
 use ff::{PrimeField, PrimeFieldDecodingError, ScalarEngine, SqrtField};
 use rand::RngCore;

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -1,9 +1,13 @@
-use rand::{Rand, Rng, SeedableRng, XorShiftRng};
+use ff::{Field, PrimeField};
+use rand::{SeedableRng, XorShiftRng};
 
 use {CurveAffine, CurveProjective, EncodedPoint};
 
 pub fn curve_tests<G: CurveProjective>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     // Negation edge case with zero.
     {
@@ -21,7 +25,7 @@ pub fn curve_tests<G: CurveProjective>() {
 
     // Addition edge cases with zero
     {
-        let mut r = G::rand(&mut rng);
+        let mut r = G::random(&mut rng);
         let rcopy = r;
         r.add_assign(&G::zero());
         assert_eq!(r, rcopy);
@@ -45,9 +49,10 @@ pub fn curve_tests<G: CurveProjective>() {
 
     // Transformations
     {
-        let a = G::rand(&mut rng);
+        let a = G::random(&mut rng);
         let b = a.into_affine().into_projective();
-        let c = a.into_affine()
+        let c = a
+            .into_affine()
             .into_projective()
             .into_affine()
             .into_projective();
@@ -65,11 +70,12 @@ pub fn curve_tests<G: CurveProjective>() {
 }
 
 fn random_wnaf_tests<G: CurveProjective>() {
-    use ff::PrimeField;
-
     use wnaf::*;
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     {
         let mut table = vec![];
@@ -77,8 +83,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
 
         for w in 2..14 {
             for _ in 0..100 {
-                let g = G::rand(&mut rng);
-                let s = G::Scalar::rand(&mut rng).into_repr();
+                let g = G::random(&mut rng);
+                let s = G::Scalar::random(&mut rng).into_repr();
                 let mut g1 = g;
                 g1.mul_assign(s);
 
@@ -95,8 +101,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
         fn only_compiles_if_send<S: Send>(_: &S) {}
 
         for _ in 0..100 {
-            let g = G::rand(&mut rng);
-            let s = G::Scalar::rand(&mut rng).into_repr();
+            let g = G::random(&mut rng);
+            let s = G::Scalar::random(&mut rng).into_repr();
             let mut g1 = g;
             g1.mul_assign(s);
 
@@ -129,7 +135,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
                 let mut wnaf = Wnaf::new();
                 {
                     // Populate the vectors.
-                    wnaf.base(rng.gen(), 1).scalar(rng.gen());
+                    wnaf.base(G::random(&mut rng), 1)
+                        .scalar(G::Scalar::random(&mut rng).into_repr());
                 }
                 wnaf.base(g, 1).scalar(s)
             };
@@ -137,7 +144,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
                 let mut wnaf = Wnaf::new();
                 {
                     // Populate the vectors.
-                    wnaf.base(rng.gen(), 1).scalar(rng.gen());
+                    wnaf.base(G::random(&mut rng), 1)
+                        .scalar(G::Scalar::random(&mut rng).into_repr());
                 }
                 wnaf.scalar(s).base(g)
             };
@@ -145,7 +153,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
                 let mut wnaf = Wnaf::new();
                 {
                     // Populate the vectors.
-                    wnaf.base(rng.gen(), 1).scalar(rng.gen());
+                    wnaf.base(G::random(&mut rng), 1)
+                        .scalar(G::Scalar::random(&mut rng).into_repr());
                 }
                 let mut shared = wnaf.base(g, 1).shared();
 
@@ -157,7 +166,8 @@ fn random_wnaf_tests<G: CurveProjective>() {
                 let mut wnaf = Wnaf::new();
                 {
                     // Populate the vectors.
-                    wnaf.base(rng.gen(), 1).scalar(rng.gen());
+                    wnaf.base(G::random(&mut rng), 1)
+                        .scalar(G::Scalar::random(&mut rng).into_repr());
                 }
                 let mut shared = wnaf.scalar(s).shared();
 
@@ -179,14 +189,15 @@ fn random_wnaf_tests<G: CurveProjective>() {
 }
 
 fn random_negation_tests<G: CurveProjective>() {
-    use ff::Field;
-
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let r = G::rand(&mut rng);
+        let r = G::random(&mut rng);
 
-        let s = G::Scalar::rand(&mut rng);
+        let s = G::Scalar::random(&mut rng);
         let mut sneg = s;
         sneg.negate();
 
@@ -210,11 +221,14 @@ fn random_negation_tests<G: CurveProjective>() {
 }
 
 fn random_doubling_tests<G: CurveProjective>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let mut a = G::rand(&mut rng);
-        let mut b = G::rand(&mut rng);
+        let mut a = G::random(&mut rng);
+        let mut b = G::random(&mut rng);
 
         // 2(a + b)
         let mut tmp1 = a;
@@ -237,15 +251,18 @@ fn random_doubling_tests<G: CurveProjective>() {
 }
 
 fn random_multiplication_tests<G: CurveProjective>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let mut a = G::rand(&mut rng);
-        let mut b = G::rand(&mut rng);
+        let mut a = G::random(&mut rng);
+        let mut b = G::random(&mut rng);
         let a_affine = a.into_affine();
         let b_affine = b.into_affine();
 
-        let s = G::Scalar::rand(&mut rng);
+        let s = G::Scalar::random(&mut rng);
 
         // s ( a + b )
         let mut tmp1 = a;
@@ -269,12 +286,15 @@ fn random_multiplication_tests<G: CurveProjective>() {
 }
 
 fn random_addition_tests<G: CurveProjective>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let a = G::rand(&mut rng);
-        let b = G::rand(&mut rng);
-        let c = G::rand(&mut rng);
+        let a = G::random(&mut rng);
+        let b = G::random(&mut rng);
+        let c = G::random(&mut rng);
         let a_affine = a.into_affine();
         let b_affine = b.into_affine();
         let c_affine = c.into_affine();
@@ -347,10 +367,13 @@ fn random_addition_tests<G: CurveProjective>() {
 }
 
 fn random_transformation_tests<G: CurveProjective>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let g = G::rand(&mut rng);
+        let g = G::random(&mut rng);
         let g_affine = g.into_affine();
         let g_projective = g_affine.into_projective();
         assert_eq!(g, g_projective);
@@ -358,24 +381,25 @@ fn random_transformation_tests<G: CurveProjective>() {
 
     // Batch normalization
     for _ in 0..10 {
-        let mut v = (0..1000).map(|_| G::rand(&mut rng)).collect::<Vec<_>>();
+        let mut v = (0..1000).map(|_| G::random(&mut rng)).collect::<Vec<_>>();
 
         for i in &v {
             assert!(!i.is_normalized());
         }
 
-        use rand::distributions::{IndependentSample, Range};
-        let between = Range::new(0, 1000);
+        use rand::distributions::{Distribution, Uniform};
+        let between = Uniform::new(0, 1000);
         // Sprinkle in some normalized points
         for _ in 0..5 {
-            v[between.ind_sample(&mut rng)] = G::zero();
+            v[between.sample(&mut rng)] = G::zero();
         }
         for _ in 0..5 {
-            let s = between.ind_sample(&mut rng);
+            let s = between.sample(&mut rng);
             v[s] = v[s].into_affine().into_projective();
         }
 
-        let expected_v = v.iter()
+        let expected_v = v
+            .iter()
             .map(|v| v.into_affine().into_projective())
             .collect::<Vec<_>>();
         G::batch_normalization(&mut v);
@@ -389,7 +413,10 @@ fn random_transformation_tests<G: CurveProjective>() {
 }
 
 fn random_encoding_tests<G: CurveAffine>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     assert_eq!(
         G::zero().into_uncompressed().into_affine().unwrap(),
@@ -402,7 +429,7 @@ fn random_encoding_tests<G: CurveAffine>() {
     );
 
     for _ in 0..1000 {
-        let mut r = G::Projective::rand(&mut rng).into_affine();
+        let mut r = G::Projective::random(&mut rng).into_affine();
 
         let uncompressed = r.into_uncompressed();
         let de_uncompressed = uncompressed.into_affine().unwrap();

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -1,5 +1,6 @@
 use ff::{Field, PrimeField};
-use rand::{SeedableRng, XorShiftRng};
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
 use {CurveAffine, CurveProjective, EncodedPoint};
 

--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -22,8 +22,8 @@ libc = "0.2"
 pairing = { path = "../pairing" }
 lazy_static = "1"
 byteorder = "1"
-rand_core = "0.4"
-rand_os = "0.1"
+rand_core = "0.5"
+rand_os = "0.2"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 zcash_proofs = { path = "../zcash_proofs" }

--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2"
 pairing = { path = "../pairing" }
 lazy_static = "1"
 byteorder = "1"
-rand = "0.4"
+rand = "0.5"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 zcash_proofs = { path = "../zcash_proofs" }

--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -22,7 +22,8 @@ libc = "0.2"
 pairing = { path = "../pairing" }
 lazy_static = "1"
 byteorder = "1"
-rand = "0.5"
+rand_core = "0.4"
+rand_os = "0.1"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 zcash_proofs = { path = "../zcash_proofs" }

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -5,7 +5,8 @@ extern crate byteorder;
 extern crate ff;
 extern crate libc;
 extern crate pairing;
-extern crate rand;
+extern crate rand_core;
+extern crate rand_os;
 extern crate sapling_crypto;
 extern crate zcash_primitives;
 extern crate zcash_proofs;
@@ -37,7 +38,8 @@ use blake2s_simd::Params as Blake2sParams;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use rand::{OsRng, Rng};
+use rand_core::RngCore;
+use rand_os::OsRng;
 use std::io::BufReader;
 
 use libc::{c_char, c_uchar, int64_t, size_t, uint32_t, uint64_t};
@@ -388,9 +390,7 @@ pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32
     // create random 64 byte buffer
     let mut rng = OsRng::new().expect("should be able to construct RNG");
     let mut buffer = [0u8; 64];
-    for i in 0..buffer.len() {
-        buffer[i] = rng.gen();
-    }
+    rng.fill_bytes(&mut buffer);
 
     // reduce to uniform value
     let r = <Bls12 as JubjubEngine>::Fs::to_uniform(&buffer[..]);

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -388,7 +388,7 @@ fn test_gen_r() {
 #[no_mangle]
 pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32]) {
     // create random 64 byte buffer
-    let mut rng = OsRng::new().expect("should be able to construct RNG");
+    let mut rng = OsRng;
     let mut buffer = [0u8; 64];
     rng.fill_bytes(&mut buffer);
 
@@ -858,7 +858,7 @@ pub extern "system" fn librustzcash_sprout_prove(
     drop(sprout_fs);
 
     // Initialize secure RNG
-    let mut rng = OsRng::new().expect("should be able to construct RNG");
+    let mut rng = OsRng;
 
     let proof = create_random_proof(js, &params, &mut rng).expect("proving should not fail");
 

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -42,7 +42,7 @@ use rand_core::RngCore;
 use rand_os::OsRng;
 use std::io::BufReader;
 
-use libc::{c_char, c_uchar, int64_t, size_t, uint32_t, uint64_t};
+use libc::{c_char, c_uchar, size_t};
 use std::ffi::CStr;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -404,7 +404,7 @@ pub extern "system" fn librustzcash_sapling_generate_r(result: *mut [c_uchar; 32
 fn priv_get_note(
     diversifier: *const [c_uchar; 11],
     pk_d: *const [c_uchar; 32],
-    value: uint64_t,
+    value: u64,
     r: *const [c_uchar; 32],
 ) -> Result<sapling_crypto::primitives::Note<Bls12>, ()> {
     let diversifier = sapling_crypto::primitives::Diversifier(unsafe { *diversifier });
@@ -444,11 +444,11 @@ fn priv_get_note(
 pub extern "system" fn librustzcash_sapling_compute_nf(
     diversifier: *const [c_uchar; 11],
     pk_d: *const [c_uchar; 32],
-    value: uint64_t,
+    value: u64,
     r: *const [c_uchar; 32],
     ak: *const [c_uchar; 32],
     nk: *const [c_uchar; 32],
-    position: uint64_t,
+    position: u64,
     result: *mut [c_uchar; 32],
 ) -> bool {
     let note = match priv_get_note(diversifier, pk_d, value, r) {
@@ -489,7 +489,7 @@ pub extern "system" fn librustzcash_sapling_compute_nf(
 pub extern "system" fn librustzcash_sapling_compute_cm(
     diversifier: *const [c_uchar; 11],
     pk_d: *const [c_uchar; 32],
-    value: uint64_t,
+    value: u64,
     r: *const [c_uchar; 32],
     result: *mut [c_uchar; 32],
 ) -> bool {
@@ -562,8 +562,8 @@ pub extern "system" fn librustzcash_sapling_ka_derivepublic(
 
 #[no_mangle]
 pub extern "system" fn librustzcash_eh_isvalid(
-    n: uint32_t,
-    k: uint32_t,
+    n: u32,
+    k: u32,
     input: *const c_uchar,
     input_len: size_t,
     nonce: *const c_uchar,
@@ -700,7 +700,7 @@ pub extern "system" fn librustzcash_sapling_check_output(
 #[no_mangle]
 pub extern "system" fn librustzcash_sapling_final_check(
     ctx: *mut SaplingVerificationContext,
-    value_balance: int64_t,
+    value_balance: i64,
     binding_sig: *const [c_uchar; 64],
     sighash_value: *const [c_uchar; 32],
 ) -> bool {
@@ -728,31 +728,31 @@ pub extern "system" fn librustzcash_sprout_prove(
 
     // First input
     in_sk1: *const [c_uchar; 32],
-    in_value1: uint64_t,
+    in_value1: u64,
     in_rho1: *const [c_uchar; 32],
     in_r1: *const [c_uchar; 32],
     in_auth1: *const [c_uchar; 1 + 33 * SPROUT_TREE_DEPTH + 8],
 
     // Second input
     in_sk2: *const [c_uchar; 32],
-    in_value2: uint64_t,
+    in_value2: u64,
     in_rho2: *const [c_uchar; 32],
     in_r2: *const [c_uchar; 32],
     in_auth2: *const [c_uchar; 1 + 33 * SPROUT_TREE_DEPTH + 8],
 
     // First output
     out_pk1: *const [c_uchar; 32],
-    out_value1: uint64_t,
+    out_value1: u64,
     out_r1: *const [c_uchar; 32],
 
     // Second output
     out_pk2: *const [c_uchar; 32],
-    out_value2: uint64_t,
+    out_value2: u64,
     out_r2: *const [c_uchar; 32],
 
     // Public value
-    vpub_old: uint64_t,
-    vpub_new: uint64_t,
+    vpub_old: u64,
+    vpub_new: u64,
 ) {
     let phi = unsafe { *phi };
     let rt = unsafe { *rt };
@@ -878,8 +878,8 @@ pub extern "system" fn librustzcash_sprout_verify(
     nf2: *const [c_uchar; 32],
     cm1: *const [c_uchar; 32],
     cm2: *const [c_uchar; 32],
-    vpub_old: uint64_t,
-    vpub_new: uint64_t,
+    vpub_old: u64,
+    vpub_new: u64,
 ) -> bool {
     // Prepare the public input for the verifier
     let mut public_input = Vec::with_capacity((32 * 8) + (8 * 2));
@@ -923,7 +923,7 @@ pub extern "system" fn librustzcash_sapling_output_proof(
     diversifier: *const [c_uchar; 11],
     pk_d: *const [c_uchar; 32],
     rcm: *const [c_uchar; 32],
-    value: uint64_t,
+    value: u64,
     cv: *mut [c_uchar; 32],
     zkproof: *mut [c_uchar; GROTH_PROOF_SIZE],
 ) -> bool {
@@ -1015,7 +1015,7 @@ pub extern "system" fn librustzcash_sapling_spend_sig(
 #[no_mangle]
 pub extern "system" fn librustzcash_sapling_binding_sig(
     ctx: *const SaplingProvingContext,
-    value_balance: int64_t,
+    value_balance: i64,
     sighash: *const [c_uchar; 32],
     result: *mut [c_uchar; 64],
 ) -> bool {
@@ -1040,7 +1040,7 @@ pub extern "system" fn librustzcash_sapling_spend_proof(
     diversifier: *const [c_uchar; 11],
     rcm: *const [c_uchar; 32],
     ar: *const [c_uchar; 32],
-    value: uint64_t,
+    value: u64,
     anchor: *const [c_uchar; 32],
     witness: *const [c_uchar; 1 + 33 * SAPLING_TREE_DEPTH + 8],
     cv: *mut [c_uchar; 32],
@@ -1161,7 +1161,7 @@ pub extern "system" fn librustzcash_zip32_xsk_master(
 #[no_mangle]
 pub extern "system" fn librustzcash_zip32_xsk_derive(
     xsk_parent: *const [c_uchar; 169],
-    i: uint32_t,
+    i: u32,
     xsk_i: *mut [c_uchar; 169],
 ) {
     let xsk_parent = zip32::ExtendedSpendingKey::read(&unsafe { *xsk_parent }[..])
@@ -1177,7 +1177,7 @@ pub extern "system" fn librustzcash_zip32_xsk_derive(
 #[no_mangle]
 pub extern "system" fn librustzcash_zip32_xfvk_derive(
     xfvk_parent: *const [c_uchar; 169],
-    i: uint32_t,
+    i: u32,
     xfvk_i: *mut [c_uchar; 169],
 ) -> bool {
     let xfvk_parent = zip32::ExtendedFullViewingKey::read(&unsafe { *xfvk_parent }[..])

--- a/librustzcash/src/tests/key_agreement.rs
+++ b/librustzcash/src/tests/key_agreement.rs
@@ -1,6 +1,7 @@
 use ff::{PrimeField, PrimeFieldRepr};
 use pairing::bls12_381::Bls12;
-use rand::{OsRng, Rng};
+use rand_core::RngCore;
+use rand_os::OsRng;
 use sapling_crypto::jubjub::{edwards, JubjubBls12};
 use sapling_crypto::primitives::{Diversifier, ViewingKey};
 
@@ -22,7 +23,9 @@ fn test_key_agreement() {
 
     // Create a random address with the viewing key
     let addr = loop {
-        match vk.into_payment_address(Diversifier(rng.gen()), &params) {
+        let mut d = [0; 11];
+        rng.fill_bytes(&mut d);
+        match vk.into_payment_address(Diversifier(d), &params) {
             Some(a) => break a,
             None => {}
         }

--- a/librustzcash/src/tests/key_agreement.rs
+++ b/librustzcash/src/tests/key_agreement.rs
@@ -13,7 +13,7 @@ use {
 #[test]
 fn test_key_agreement() {
     let params = JubjubBls12::new();
-    let mut rng = OsRng::new().unwrap();
+    let mut rng = OsRng;
 
     // Create random viewing key
     let vk = ViewingKey::<Bls12> {

--- a/pairing/Cargo.toml
+++ b/pairing/Cargo.toml
@@ -15,13 +15,13 @@ homepage = "https://github.com/ebfull/pairing"
 repository = "https://github.com/ebfull/pairing"
 
 [dependencies]
-rand_core = "0.4"
 byteorder = "1"
 ff = { path = "../ff", features = ["derive"] }
 group = { path = "../group" }
+rand_core = "0.5"
 
 [dev-dependencies]
-rand_xorshift = "0.1"
+rand_xorshift = "0.2"
 
 [features]
 unstable-features = ["expose-arith"]

--- a/pairing/Cargo.toml
+++ b/pairing/Cargo.toml
@@ -15,10 +15,13 @@ homepage = "https://github.com/ebfull/pairing"
 repository = "https://github.com/ebfull/pairing"
 
 [dependencies]
-rand = "0.4"
+rand_core = "0.3"
 byteorder = "1"
 ff = { path = "../ff", features = ["derive"] }
 group = { path = "../group" }
+
+[dev-dependencies]
+rand = "0.5"
 
 [features]
 unstable-features = ["expose-arith"]

--- a/pairing/Cargo.toml
+++ b/pairing/Cargo.toml
@@ -15,13 +15,13 @@ homepage = "https://github.com/ebfull/pairing"
 repository = "https://github.com/ebfull/pairing"
 
 [dependencies]
-rand_core = "0.3"
+rand_core = "0.4"
 byteorder = "1"
 ff = { path = "../ff", features = ["derive"] }
 group = { path = "../group" }
 
 [dev-dependencies]
-rand = "0.5"
+rand_xorshift = "0.1"
 
 [features]
 unstable-features = ["expose-arith"]

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -200,11 +200,16 @@ macro_rules! curve_impl {
 
         }
 
-        impl Rand for $projective {
-            fn rand<R: Rng>(rng: &mut R) -> Self {
+        impl CurveProjective for $projective {
+            type Engine = Bls12;
+            type Scalar = $scalarfield;
+            type Base = $basefield;
+            type Affine = $affine;
+
+            fn random<R: RngCore>(rng: &mut R) -> Self {
                 loop {
-                    let x = rng.gen();
-                    let greatest = rng.gen();
+                    let x = $basefield::random(rng);
+                    let greatest = rng.next_u32() % 2 != 0;
 
                     if let Some(p) = $affine::get_point_from_x(x, greatest) {
                         let p = p.scale_by_cofactor();
@@ -215,13 +220,6 @@ macro_rules! curve_impl {
                     }
                 }
             }
-        }
-
-        impl CurveProjective for $projective {
-            type Engine = Bls12;
-            type Scalar = $scalarfield;
-            type Base = $basefield;
-            type Affine = $affine;
 
             // The point at infinity is always represented by
             // Z = 0.
@@ -629,7 +627,7 @@ pub mod g1 {
     use super::g2::G2Affine;
     use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
-    use rand::{Rand, Rng};
+    use rand_core::RngCore;
     use std::fmt;
     use {Engine, PairingCurveAffine};
 
@@ -1276,7 +1274,7 @@ pub mod g2 {
     use super::g1::G1Affine;
     use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
-    use rand::{Rand, Rng};
+    use rand_core::RngCore;
     use std::fmt;
     use {Engine, PairingCurveAffine};
 

--- a/pairing/src/bls12_381/fq.rs
+++ b/pairing/src/bls12_381/fq.rs
@@ -1173,7 +1173,7 @@ fn test_neg_one() {
 }
 
 #[cfg(test)]
-use rand::{Rand, SeedableRng, XorShiftRng};
+use rand::{SeedableRng, XorShiftRng};
 
 #[test]
 fn test_fq_repr_ordering() {
@@ -1396,7 +1396,10 @@ fn test_fq_repr_num_bits() {
 
 #[test]
 fn test_fq_repr_sub_noborrow() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let mut t = FqRepr([
         0x827a4a08041ebd9,
@@ -1426,7 +1429,7 @@ fn test_fq_repr_sub_noborrow() {
     );
 
     for _ in 0..1000 {
-        let mut a = FqRepr::rand(&mut rng);
+        let mut a = Fq::random(&mut rng).into_repr();
         a.0[5] >>= 30;
         let mut b = a;
         for _ in 0..10 {
@@ -1483,7 +1486,10 @@ fn test_fq_repr_sub_noborrow() {
 
 #[test]
 fn test_fq_repr_add_nocarry() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let mut t = FqRepr([
         0x827a4a08041ebd9,
@@ -1514,9 +1520,9 @@ fn test_fq_repr_add_nocarry() {
 
     // Test for the associativity of addition.
     for _ in 0..1000 {
-        let mut a = FqRepr::rand(&mut rng);
-        let mut b = FqRepr::rand(&mut rng);
-        let mut c = FqRepr::rand(&mut rng);
+        let mut a = Fq::random(&mut rng).into_repr();
+        let mut b = Fq::random(&mut rng).into_repr();
+        let mut c = Fq::random(&mut rng).into_repr();
 
         // Unset the first few bits, so that overflow won't occur.
         a.0[5] >>= 3;
@@ -1595,10 +1601,13 @@ fn test_fq_is_valid() {
         ])).is_valid()
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
         assert!(a.is_valid());
     }
 }
@@ -1708,13 +1717,16 @@ fn test_fq_add_assign() {
 
     // Test associativity
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
-        let a = Fq::rand(&mut rng);
-        let b = Fq::rand(&mut rng);
-        let c = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
+        let b = Fq::random(&mut rng);
+        let c = Fq::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.add_assign(&b);
@@ -1818,12 +1830,15 @@ fn test_fq_sub_assign() {
         );
     }
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
-        let a = Fq::rand(&mut rng);
-        let b = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
+        let b = Fq::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.sub_assign(&b);
@@ -1865,13 +1880,16 @@ fn test_fq_mul_assign() {
         ]))
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
-        let a = Fq::rand(&mut rng);
-        let b = Fq::rand(&mut rng);
-        let c = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
+        let b = Fq::random(&mut rng);
+        let c = Fq::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.mul_assign(&b);
@@ -1887,10 +1905,10 @@ fn test_fq_mul_assign() {
     for _ in 0..1000000 {
         // Ensure that r * (a + b + c) = r*a + r*b + r*c
 
-        let r = Fq::rand(&mut rng);
-        let mut a = Fq::rand(&mut rng);
-        let mut b = Fq::rand(&mut rng);
-        let mut c = Fq::rand(&mut rng);
+        let r = Fq::random(&mut rng);
+        let mut a = Fq::random(&mut rng);
+        let mut b = Fq::random(&mut rng);
+        let mut c = Fq::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.add_assign(&b);
@@ -1932,11 +1950,14 @@ fn test_fq_squaring() {
         ])).unwrap()
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
 
         let mut tmp = a;
         tmp.square();
@@ -1952,13 +1973,16 @@ fn test_fq_squaring() {
 fn test_fq_inverse() {
     assert!(Fq::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let one = Fq::one();
 
     for _ in 0..1000 {
         // Ensure that a * a^-1 = 1
-        let mut a = Fq::rand(&mut rng);
+        let mut a = Fq::random(&mut rng);
         let ainv = a.inverse().unwrap();
         a.mul_assign(&ainv);
         assert_eq!(a, one);
@@ -1967,11 +1991,14 @@ fn test_fq_inverse() {
 
 #[test]
 fn test_fq_double() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
-        let mut a = Fq::rand(&mut rng);
+        let mut a = Fq::random(&mut rng);
         let mut b = a;
         b.add_assign(&a);
         a.double();
@@ -1988,11 +2015,14 @@ fn test_fq_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
-        let mut a = Fq::rand(&mut rng);
+        let mut a = Fq::random(&mut rng);
         let mut b = a;
         b.negate();
         a.add_assign(&b);
@@ -2003,12 +2033,15 @@ fn test_fq_negate() {
 
 #[test]
 fn test_fq_pow() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
         // multiplication.
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
         let target = a.pow(&[i]);
         let mut c = Fq::one();
         for _ in 0..i {
@@ -2019,7 +2052,7 @@ fn test_fq_pow() {
 
     for _ in 0..1000 {
         // Exponentiating by the modulus should have no effect in a prime field.
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
 
         assert_eq!(a, a.pow(Fq::char()));
     }
@@ -2029,13 +2062,16 @@ fn test_fq_pow() {
 fn test_fq_sqrt() {
     use ff::SqrtField;
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     assert_eq!(Fq::zero().sqrt().unwrap(), Fq::zero());
 
     for _ in 0..1000 {
         // Ensure sqrt(a^2) = a or -a
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
         let mut nega = a;
         nega.negate();
         let mut b = a;
@@ -2048,7 +2084,7 @@ fn test_fq_sqrt() {
 
     for _ in 0..1000 {
         // Ensure sqrt(a)^2 = a for random a
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
 
         if let Some(mut tmp) = a.sqrt() {
             tmp.square();
@@ -2108,11 +2144,14 @@ fn test_fq_from_into_repr() {
     // Zero should be in the field.
     assert!(Fq::from_repr(FqRepr::from(0)).unwrap().is_zero());
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Try to turn Fq elements into representations and back again, and compare.
-        let a = Fq::rand(&mut rng);
+        let a = Fq::random(&mut rng);
         let a_repr = a.into_repr();
         let b_repr = FqRepr::from(a);
         assert_eq!(a_repr, b_repr);
@@ -2205,7 +2244,7 @@ fn test_fq_ordering() {
 
 #[test]
 fn fq_repr_tests() {
-    ::tests::repr::random_repr_tests::<FqRepr>();
+    ::tests::repr::random_repr_tests::<Fq>();
 }
 
 #[test]

--- a/pairing/src/bls12_381/fq.rs
+++ b/pairing/src/bls12_381/fq.rs
@@ -1173,7 +1173,9 @@ fn test_neg_one() {
 }
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fq_repr_ordering() {

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -147,7 +147,9 @@ impl Field for Fq12 {
 }
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fq12_mul_by_014() {

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -2,7 +2,7 @@ use super::fq::FROBENIUS_COEFF_FQ12_C1;
 use super::fq2::Fq2;
 use super::fq6::Fq6;
 use ff::Field;
-use rand::{Rand, Rng};
+use rand_core::{RngCore};
 
 /// An element of Fq12, represented by c0 + c1 * w.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -14,15 +14,6 @@ pub struct Fq12 {
 impl ::std::fmt::Display for Fq12 {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "Fq12({} + {} * w)", self.c0, self.c1)
-    }
-}
-
-impl Rand for Fq12 {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        Fq12 {
-            c0: rng.gen(),
-            c1: rng.gen(),
-        }
     }
 }
 
@@ -49,6 +40,13 @@ impl Fq12 {
 }
 
 impl Field for Fq12 {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
+        Fq12 {
+            c0: Fq6::random(rng),
+            c1: Fq6::random(rng),
+        }
+    }
+
     fn zero() -> Self {
         Fq12 {
             c0: Fq6::zero(),
@@ -153,13 +151,16 @@ use rand::{SeedableRng, XorShiftRng};
 
 #[test]
 fn test_fq12_mul_by_014() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let c0 = Fq2::rand(&mut rng);
-        let c1 = Fq2::rand(&mut rng);
-        let c5 = Fq2::rand(&mut rng);
-        let mut a = Fq12::rand(&mut rng);
+        let c0 = Fq2::random(&mut rng);
+        let c1 = Fq2::random(&mut rng);
+        let c5 = Fq2::random(&mut rng);
+        let mut a = Fq12::random(&mut rng);
         let mut b = a;
 
         a.mul_by_014(&c0, &c1, &c5);

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -877,7 +877,9 @@ fn test_fq2_legendre() {
 }
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fq2_mul_nonresidue() {

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -1,6 +1,6 @@
 use super::fq::{FROBENIUS_COEFF_FQ2_C1, Fq, NEGATIVE_ONE};
 use ff::{Field, SqrtField};
-use rand::{Rand, Rng};
+use rand_core::RngCore;
 
 use std::cmp::Ordering;
 
@@ -56,16 +56,14 @@ impl Fq2 {
     }
 }
 
-impl Rand for Fq2 {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
+impl Field for Fq2 {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
         Fq2 {
-            c0: rng.gen(),
-            c1: rng.gen(),
+            c0: Fq::random(rng),
+            c1: Fq::random(rng),
         }
     }
-}
 
-impl Field for Fq2 {
     fn zero() -> Self {
         Fq2 {
             c0: Fq::zero(),
@@ -883,7 +881,10 @@ use rand::{SeedableRng, XorShiftRng};
 
 #[test]
 fn test_fq2_mul_nonresidue() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let nqr = Fq2 {
         c0: Fq::one(),
@@ -891,7 +892,7 @@ fn test_fq2_mul_nonresidue() {
     };
 
     for _ in 0..1000 {
-        let mut a = Fq2::rand(&mut rng);
+        let mut a = Fq2::random(&mut rng);
         let mut b = a;
         a.mul_by_nonresidue();
         b.mul_assign(&nqr);

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -301,7 +301,9 @@ impl Field for Fq6 {
 }
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fq6_mul_nonresidue() {

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -1,7 +1,7 @@
 use super::fq::{FROBENIUS_COEFF_FQ6_C1, FROBENIUS_COEFF_FQ6_C2};
 use super::fq2::Fq2;
 use ff::Field;
-use rand::{Rand, Rng};
+use rand_core::RngCore;
 
 /// An element of Fq6, represented by c0 + c1 * v + c2 * v^(2).
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -17,15 +17,6 @@ impl ::std::fmt::Display for Fq6 {
     }
 }
 
-impl Rand for Fq6 {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        Fq6 {
-            c0: rng.gen(),
-            c1: rng.gen(),
-            c2: rng.gen(),
-        }
-    }
-}
 
 impl Fq6 {
     /// Multiply by quadratic nonresidue v.
@@ -110,6 +101,14 @@ impl Fq6 {
 }
 
 impl Field for Fq6 {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
+        Fq6 {
+            c0: Fq2::random(rng),
+            c1: Fq2::random(rng),
+            c2: Fq2::random(rng),
+        }
+    }
+
     fn zero() -> Self {
         Fq6 {
             c0: Fq2::zero(),
@@ -306,7 +305,10 @@ use rand::{SeedableRng, XorShiftRng};
 
 #[test]
 fn test_fq6_mul_nonresidue() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let nqr = Fq6 {
         c0: Fq2::zero(),
@@ -315,7 +317,7 @@ fn test_fq6_mul_nonresidue() {
     };
 
     for _ in 0..1000 {
-        let mut a = Fq6::rand(&mut rng);
+        let mut a = Fq6::random(&mut rng);
         let mut b = a;
         a.mul_by_nonresidue();
         b.mul_assign(&nqr);
@@ -326,11 +328,14 @@ fn test_fq6_mul_nonresidue() {
 
 #[test]
 fn test_fq6_mul_by_1() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let c1 = Fq2::rand(&mut rng);
-        let mut a = Fq6::rand(&mut rng);
+        let c1 = Fq2::random(&mut rng);
+        let mut a = Fq6::random(&mut rng);
         let mut b = a;
 
         a.mul_by_1(&c1);
@@ -346,12 +351,15 @@ fn test_fq6_mul_by_1() {
 
 #[test]
 fn test_fq6_mul_by_01() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let c0 = Fq2::rand(&mut rng);
-        let c1 = Fq2::rand(&mut rng);
-        let mut a = Fq6::rand(&mut rng);
+        let c0 = Fq2::random(&mut rng);
+        let c1 = Fq2::random(&mut rng);
+        let mut a = Fq6::random(&mut rng);
         let mut b = a;
 
         a.mul_by_01(&c0, &c1);

--- a/pairing/src/bls12_381/fr.rs
+++ b/pairing/src/bls12_381/fr.rs
@@ -6,7 +6,7 @@ use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
 pub struct Fr(FrRepr);
 
 #[cfg(test)]
-use rand::{Rand, SeedableRng, XorShiftRng};
+use rand::{SeedableRng, XorShiftRng};
 
 #[test]
 fn test_fr_repr_ordering() {
@@ -197,7 +197,10 @@ fn test_fr_repr_num_bits() {
 
 #[test]
 fn test_fr_repr_sub_noborrow() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let mut t = FrRepr([
         0x8e62a7e85264e2c3,
@@ -221,7 +224,7 @@ fn test_fr_repr_sub_noborrow() {
     );
 
     for _ in 0..1000 {
-        let mut a = FrRepr::rand(&mut rng);
+        let mut a = Fr::random(&mut rng).into_repr();
         a.0[3] >>= 30;
         let mut b = a;
         for _ in 0..10 {
@@ -296,7 +299,10 @@ fn test_fr_legendre() {
 
 #[test]
 fn test_fr_repr_add_nocarry() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let mut t = FrRepr([
         0xd64f669809cbc6a4,
@@ -322,9 +328,9 @@ fn test_fr_repr_add_nocarry() {
 
     // Test for the associativity of addition.
     for _ in 0..1000 {
-        let mut a = FrRepr::rand(&mut rng);
-        let mut b = FrRepr::rand(&mut rng);
-        let mut c = FrRepr::rand(&mut rng);
+        let mut a = Fr::random(&mut rng).into_repr();
+        let mut b = Fr::random(&mut rng).into_repr();
+        let mut c = Fr::random(&mut rng).into_repr();
 
         // Unset the first few bits, so that overflow won't occur.
         a.0[3] >>= 3;
@@ -397,10 +403,13 @@ fn test_fr_is_valid() {
         ])).is_valid()
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
         assert!(a.is_valid());
     }
 }
@@ -492,13 +501,16 @@ fn test_fr_add_assign() {
 
     // Test associativity
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
-        let a = Fr::rand(&mut rng);
-        let b = Fr::rand(&mut rng);
-        let c = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
+        let b = Fr::random(&mut rng);
+        let c = Fr::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.add_assign(&b);
@@ -586,12 +598,15 @@ fn test_fr_sub_assign() {
         );
     }
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
-        let a = Fr::rand(&mut rng);
-        let b = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
+        let b = Fr::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.sub_assign(&b);
@@ -627,13 +642,16 @@ fn test_fr_mul_assign() {
         ]))
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
-        let a = Fr::rand(&mut rng);
-        let b = Fr::rand(&mut rng);
-        let c = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
+        let b = Fr::random(&mut rng);
+        let c = Fr::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.mul_assign(&b);
@@ -649,10 +667,10 @@ fn test_fr_mul_assign() {
     for _ in 0..1000000 {
         // Ensure that r * (a + b + c) = r*a + r*b + r*c
 
-        let r = Fr::rand(&mut rng);
-        let mut a = Fr::rand(&mut rng);
-        let mut b = Fr::rand(&mut rng);
-        let mut c = Fr::rand(&mut rng);
+        let r = Fr::random(&mut rng);
+        let mut a = Fr::random(&mut rng);
+        let mut b = Fr::random(&mut rng);
+        let mut c = Fr::random(&mut rng);
 
         let mut tmp1 = a;
         tmp1.add_assign(&b);
@@ -690,11 +708,14 @@ fn test_fr_squaring() {
         ])).unwrap()
     );
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
 
         let mut tmp = a;
         tmp.square();
@@ -710,13 +731,16 @@ fn test_fr_squaring() {
 fn test_fr_inverse() {
     assert!(Fr::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     let one = Fr::one();
 
     for _ in 0..1000 {
         // Ensure that a * a^-1 = 1
-        let mut a = Fr::rand(&mut rng);
+        let mut a = Fr::random(&mut rng);
         let ainv = a.inverse().unwrap();
         a.mul_assign(&ainv);
         assert_eq!(a, one);
@@ -725,11 +749,14 @@ fn test_fr_inverse() {
 
 #[test]
 fn test_fr_double() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
-        let mut a = Fr::rand(&mut rng);
+        let mut a = Fr::random(&mut rng);
         let mut b = a;
         b.add_assign(&a);
         a.double();
@@ -746,11 +773,14 @@ fn test_fr_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
-        let mut a = Fr::rand(&mut rng);
+        let mut a = Fr::random(&mut rng);
         let mut b = a;
         b.negate();
         a.add_assign(&b);
@@ -761,12 +791,15 @@ fn test_fr_negate() {
 
 #[test]
 fn test_fr_pow() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
         // multiplication.
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
         let target = a.pow(&[i]);
         let mut c = Fr::one();
         for _ in 0..i {
@@ -777,7 +810,7 @@ fn test_fr_pow() {
 
     for _ in 0..1000 {
         // Exponentiating by the modulus should have no effect in a prime field.
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
 
         assert_eq!(a, a.pow(Fr::char()));
     }
@@ -787,13 +820,16 @@ fn test_fr_pow() {
 fn test_fr_sqrt() {
     use ff::SqrtField;
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     assert_eq!(Fr::zero().sqrt().unwrap(), Fr::zero());
 
     for _ in 0..1000 {
         // Ensure sqrt(a^2) = a or -a
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
         let mut nega = a;
         nega.negate();
         let mut b = a;
@@ -806,7 +842,7 @@ fn test_fr_sqrt() {
 
     for _ in 0..1000 {
         // Ensure sqrt(a)^2 = a for random a
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
 
         if let Some(mut tmp) = a.sqrt() {
             tmp.square();
@@ -858,11 +894,14 @@ fn test_fr_from_into_repr() {
     // Zero should be in the field.
     assert!(Fr::from_repr(FrRepr::from(0)).unwrap().is_zero());
 
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         // Try to turn Fr elements into representations and back again, and compare.
-        let a = Fr::rand(&mut rng);
+        let a = Fr::random(&mut rng);
         let a_repr = a.into_repr();
         let b_repr = FrRepr::from(a);
         assert_eq!(a_repr, b_repr);
@@ -982,5 +1021,5 @@ fn fr_field_tests() {
 
 #[test]
 fn fr_repr_tests() {
-    ::tests::repr::random_repr_tests::<FrRepr>();
+    ::tests::repr::random_repr_tests::<Fr>();
 }

--- a/pairing/src/bls12_381/fr.rs
+++ b/pairing/src/bls12_381/fr.rs
@@ -6,7 +6,9 @@ use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
 pub struct Fr(FrRepr);
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fr_repr_ordering() {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -14,6 +14,9 @@
 extern crate byteorder;
 extern crate ff;
 extern crate group;
+extern crate rand_core;
+
+#[cfg(test)]
 extern crate rand;
 
 #[cfg(test)]

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -17,7 +17,7 @@ extern crate group;
 extern crate rand_core;
 
 #[cfg(test)]
-extern crate rand;
+extern crate rand_xorshift;
 
 #[cfg(test)]
 pub mod tests;

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -1,5 +1,6 @@
 use group::{CurveAffine, CurveProjective};
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
 use {Engine, Field, PairingCurveAffine, PrimeField};
 

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -1,14 +1,17 @@
 use group::{CurveAffine, CurveProjective};
-use rand::{Rand, SeedableRng, XorShiftRng};
+use rand::{SeedableRng, XorShiftRng};
 
 use {Engine, Field, PairingCurveAffine, PrimeField};
 
 pub fn engine_tests<E: Engine>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..10 {
-        let a = E::G1::rand(&mut rng).into_affine();
-        let b = E::G2::rand(&mut rng).into_affine();
+        let a = E::G1::random(&mut rng).into_affine();
+        let b = E::G2::random(&mut rng).into_affine();
 
         assert!(a.pairing_with(&b) == b.pairing_with(&a));
         assert!(a.pairing_with(&b) == E::pairing(a, b));
@@ -18,10 +21,10 @@ pub fn engine_tests<E: Engine>() {
         let z1 = E::G1Affine::zero().prepare();
         let z2 = E::G2Affine::zero().prepare();
 
-        let a = E::G1::rand(&mut rng).into_affine().prepare();
-        let b = E::G2::rand(&mut rng).into_affine().prepare();
-        let c = E::G1::rand(&mut rng).into_affine().prepare();
-        let d = E::G2::rand(&mut rng).into_affine().prepare();
+        let a = E::G1::random(&mut rng).into_affine().prepare();
+        let b = E::G2::random(&mut rng).into_affine().prepare();
+        let c = E::G1::random(&mut rng).into_affine().prepare();
+        let d = E::G2::random(&mut rng).into_affine().prepare();
 
         assert_eq!(
             E::Fqk::one(),
@@ -49,12 +52,15 @@ pub fn engine_tests<E: Engine>() {
 }
 
 fn random_miller_loop_tests<E: Engine>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     // Exercise the miller loop for a reduced pairing
     for _ in 0..1000 {
-        let a = E::G1::rand(&mut rng);
-        let b = E::G2::rand(&mut rng);
+        let a = E::G1::random(&mut rng);
+        let b = E::G2::random(&mut rng);
 
         let p2 = E::pairing(a, b);
 
@@ -68,10 +74,10 @@ fn random_miller_loop_tests<E: Engine>() {
 
     // Exercise a double miller loop
     for _ in 0..1000 {
-        let a = E::G1::rand(&mut rng);
-        let b = E::G2::rand(&mut rng);
-        let c = E::G1::rand(&mut rng);
-        let d = E::G2::rand(&mut rng);
+        let a = E::G1::random(&mut rng);
+        let b = E::G2::random(&mut rng);
+        let c = E::G1::random(&mut rng);
+        let d = E::G2::random(&mut rng);
 
         let ab = E::pairing(a, b);
         let cd = E::pairing(c, d);
@@ -92,14 +98,17 @@ fn random_miller_loop_tests<E: Engine>() {
 }
 
 fn random_bilinearity_tests<E: Engine>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let a = E::G1::rand(&mut rng);
-        let b = E::G2::rand(&mut rng);
+        let a = E::G1::random(&mut rng);
+        let b = E::G2::random(&mut rng);
 
-        let c = E::Fr::rand(&mut rng);
-        let d = E::Fr::rand(&mut rng);
+        let c = E::Fr::random(&mut rng);
+        let d = E::Fr::random(&mut rng);
 
         let mut ac = a;
         ac.mul_assign(c);

--- a/pairing/src/tests/field.rs
+++ b/pairing/src/tests/field.rs
@@ -1,5 +1,6 @@
 use ff::{Field, LegendreSymbol, PrimeField, SqrtField};
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand_core::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
 
 pub fn random_frobenius_tests<F: Field, C: AsRef<[u64]>>(characteristic: C, maxpower: usize) {
     let mut rng = XorShiftRng::from_seed([
@@ -121,7 +122,7 @@ pub fn from_str_tests<F: PrimeField>() {
         ]);
 
         for _ in 0..1000 {
-            let n: u64 = rng.gen();
+            let n = rng.next_u64();
 
             let a = F::from_str(&format!("{}", n)).unwrap();
             let b = F::from_repr(n.into()).unwrap();
@@ -136,7 +137,7 @@ pub fn from_str_tests<F: PrimeField>() {
     assert!(F::from_str("00000000000").is_none());
 }
 
-fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_multiplication_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let a = F::random(rng);
         let b = F::random(rng);
@@ -159,7 +160,7 @@ fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_addition_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_addition_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let a = F::random(rng);
         let b = F::random(rng);
@@ -182,7 +183,7 @@ fn random_addition_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_subtraction_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_subtraction_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let b = F::random(rng);
         let a = F::random(rng);
@@ -200,7 +201,7 @@ fn random_subtraction_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_negation_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_negation_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let a = F::random(rng);
         let mut b = a;
@@ -211,7 +212,7 @@ fn random_negation_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_doubling_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_doubling_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let mut a = F::random(rng);
         let mut b = a;
@@ -222,7 +223,7 @@ fn random_doubling_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_squaring_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_squaring_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         let mut a = F::random(rng);
         let mut b = a;
@@ -233,7 +234,7 @@ fn random_squaring_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_inversion_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_inversion_tests<F: Field, R: RngCore>(rng: &mut R) {
     assert!(F::zero().inverse().is_none());
 
     for _ in 0..10000 {
@@ -245,7 +246,7 @@ fn random_inversion_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
-fn random_expansion_tests<F: Field, R: Rng>(rng: &mut R) {
+fn random_expansion_tests<F: Field, R: RngCore>(rng: &mut R) {
     for _ in 0..10000 {
         // Compare (a + b)(c + d) and (a*c + b*c + a*d + b*d)
 

--- a/pairing/src/tests/field.rs
+++ b/pairing/src/tests/field.rs
@@ -2,11 +2,14 @@ use ff::{Field, LegendreSymbol, PrimeField, SqrtField};
 use rand::{Rng, SeedableRng, XorShiftRng};
 
 pub fn random_frobenius_tests<F: Field, C: AsRef<[u64]>>(characteristic: C, maxpower: usize) {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..100 {
         for i in 0..(maxpower + 1) {
-            let mut a = F::rand(&mut rng);
+            let mut a = F::random(&mut rng);
             let mut b = a;
 
             for _ in 0..i {
@@ -20,10 +23,13 @@ pub fn random_frobenius_tests<F: Field, C: AsRef<[u64]>>(characteristic: C, maxp
 }
 
 pub fn random_sqrt_tests<F: SqrtField>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..10000 {
-        let a = F::rand(&mut rng);
+        let a = F::random(&mut rng);
         let mut b = a;
         b.square();
         assert_eq!(b.legendre(), LegendreSymbol::QuadraticResidue);
@@ -54,7 +60,10 @@ pub fn random_sqrt_tests<F: SqrtField>() {
 }
 
 pub fn random_field_tests<F: Field>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     random_multiplication_tests::<F, _>(&mut rng);
     random_addition_tests::<F, _>(&mut rng);
@@ -76,14 +85,14 @@ pub fn random_field_tests<F: Field>() {
 
     // Multiplication by zero
     {
-        let mut a = F::rand(&mut rng);
+        let mut a = F::random(&mut rng);
         a.mul_assign(&F::zero());
         assert!(a.is_zero());
     }
 
     // Addition by zero
     {
-        let mut a = F::rand(&mut rng);
+        let mut a = F::random(&mut rng);
         let copy = a;
         a.add_assign(&F::zero());
         assert_eq!(a, copy);
@@ -106,7 +115,10 @@ pub fn from_str_tests<F: PrimeField>() {
     }
 
     {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let n: u64 = rng.gen();
@@ -126,9 +138,9 @@ pub fn from_str_tests<F: PrimeField>() {
 
 fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let a = F::rand(rng);
-        let b = F::rand(rng);
-        let c = F::rand(rng);
+        let a = F::random(rng);
+        let b = F::random(rng);
+        let c = F::random(rng);
 
         let mut t0 = a; // (a * b) * c
         t0.mul_assign(&b);
@@ -149,9 +161,9 @@ fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_addition_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let a = F::rand(rng);
-        let b = F::rand(rng);
-        let c = F::rand(rng);
+        let a = F::random(rng);
+        let b = F::random(rng);
+        let c = F::random(rng);
 
         let mut t0 = a; // (a + b) + c
         t0.add_assign(&b);
@@ -172,8 +184,8 @@ fn random_addition_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_subtraction_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let a = F::rand(rng);
-        let b = F::rand(rng);
+        let b = F::random(rng);
+        let a = F::random(rng);
 
         let mut t0 = a; // (a - b)
         t0.sub_assign(&b);
@@ -190,7 +202,7 @@ fn random_subtraction_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_negation_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let a = F::rand(rng);
+        let a = F::random(rng);
         let mut b = a;
         b.negate();
         b.add_assign(&a);
@@ -201,7 +213,7 @@ fn random_negation_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_doubling_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let mut a = F::rand(rng);
+        let mut a = F::random(rng);
         let mut b = a;
         a.add_assign(&b);
         b.double();
@@ -212,7 +224,7 @@ fn random_doubling_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_squaring_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
-        let mut a = F::rand(rng);
+        let mut a = F::random(rng);
         let mut b = a;
         a.mul_assign(&b);
         b.square();
@@ -225,7 +237,7 @@ fn random_inversion_tests<F: Field, R: Rng>(rng: &mut R) {
     assert!(F::zero().inverse().is_none());
 
     for _ in 0..10000 {
-        let mut a = F::rand(rng);
+        let mut a = F::random(rng);
         let b = a.inverse().unwrap(); // probablistically nonzero
         a.mul_assign(&b);
 
@@ -237,10 +249,10 @@ fn random_expansion_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..10000 {
         // Compare (a + b)(c + d) and (a*c + b*c + a*d + b*d)
 
-        let a = F::rand(rng);
-        let b = F::rand(rng);
-        let c = F::rand(rng);
-        let d = F::rand(rng);
+        let a = F::random(rng);
+        let b = F::random(rng);
+        let c = F::random(rng);
+        let d = F::random(rng);
 
         let mut t0 = a;
         t0.add_assign(&b);

--- a/pairing/src/tests/repr.rs
+++ b/pairing/src/tests/repr.rs
@@ -1,5 +1,6 @@
 use ff::{PrimeField, PrimeFieldRepr};
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
 pub fn random_repr_tests<P: PrimeField>() {
     random_encoding_tests::<P>();

--- a/pairing/src/tests/repr.rs
+++ b/pairing/src/tests/repr.rs
@@ -1,21 +1,24 @@
-use ff::PrimeFieldRepr;
+use ff::{PrimeField, PrimeFieldRepr};
 use rand::{SeedableRng, XorShiftRng};
 
-pub fn random_repr_tests<R: PrimeFieldRepr>() {
-    random_encoding_tests::<R>();
-    random_shl_tests::<R>();
-    random_shr_tests::<R>();
+pub fn random_repr_tests<P: PrimeField>() {
+    random_encoding_tests::<P>();
+    random_shl_tests::<P>();
+    random_shr_tests::<P>();
 }
 
-fn random_encoding_tests<R: PrimeFieldRepr>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+fn random_encoding_tests<P: PrimeField>() {
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let r = R::rand(&mut rng);
+        let r = P::random(&mut rng).into_repr();
 
         // Big endian
         {
-            let mut rdecoded = R::default();
+            let mut rdecoded = <P as PrimeField>::Repr::default();
 
             let mut v: Vec<u8> = vec![];
             r.write_be(&mut v).unwrap();
@@ -26,7 +29,7 @@ fn random_encoding_tests<R: PrimeFieldRepr>() {
 
         // Little endian
         {
-            let mut rdecoded = R::default();
+            let mut rdecoded = <P as PrimeField>::Repr::default();
 
             let mut v: Vec<u8> = vec![];
             r.write_le(&mut v).unwrap();
@@ -36,8 +39,8 @@ fn random_encoding_tests<R: PrimeFieldRepr>() {
         }
 
         {
-            let mut rdecoded_le = R::default();
-            let mut rdecoded_be_flip = R::default();
+            let mut rdecoded_le = <P as PrimeField>::Repr::default();
+            let mut rdecoded_be_flip = <P as PrimeField>::Repr::default();
 
             let mut v: Vec<u8> = vec![];
             r.write_le(&mut v).unwrap();
@@ -55,11 +58,14 @@ fn random_encoding_tests<R: PrimeFieldRepr>() {
     }
 }
 
-fn random_shl_tests<R: PrimeFieldRepr>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+fn random_shl_tests<P: PrimeField>() {
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..100 {
-        let r = R::rand(&mut rng);
+        let r = P::random(&mut rng).into_repr();
 
         for shift in 0..(r.num_bits() + 1) {
             let mut r1 = r;
@@ -76,11 +82,14 @@ fn random_shl_tests<R: PrimeFieldRepr>() {
     }
 }
 
-fn random_shr_tests<R: PrimeFieldRepr>() {
-    let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+fn random_shr_tests<P: PrimeField>() {
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..100 {
-        let r = R::rand(&mut rng);
+        let r = P::random(&mut rng).into_repr();
 
         for shift in 0..(r.num_bits() + 1) {
             let mut r1 = r;

--- a/sapling-crypto/Cargo.toml
+++ b/sapling-crypto/Cargo.toml
@@ -17,7 +17,7 @@ bellman = { path = "../bellman" }
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 ff = { path = "../ff" }
-rand = "0.4"
+rand = "0.5"
 digest = "0.7"
 byteorder = "1"
 

--- a/sapling-crypto/Cargo.toml
+++ b/sapling-crypto/Cargo.toml
@@ -17,11 +17,11 @@ bellman = { path = "../bellman" }
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 ff = { path = "../ff" }
-rand_core = "0.4"
+rand_core = "0.5"
 digest = "0.7"
 byteorder = "1"
 
 [dev-dependencies]
 hex-literal = "0.1"
-rand_xorshift = "0.1"
+rand_xorshift = "0.2"
 sha2 = "0.8"

--- a/sapling-crypto/Cargo.toml
+++ b/sapling-crypto/Cargo.toml
@@ -17,10 +17,11 @@ bellman = { path = "../bellman" }
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 ff = { path = "../ff" }
-rand = "0.5"
+rand_core = "0.4"
 digest = "0.7"
 byteorder = "1"
 
 [dev-dependencies]
 hex-literal = "0.1"
+rand_xorshift = "0.1"
 sha2 = "0.8"

--- a/sapling-crypto/Cargo.toml
+++ b/sapling-crypto/Cargo.toml
@@ -23,4 +23,4 @@ byteorder = "1"
 
 [dev-dependencies]
 hex-literal = "0.1"
-rust-crypto = "0.2"
+sha2 = "0.8"

--- a/sapling-crypto/examples/bench.rs
+++ b/sapling-crypto/examples/bench.rs
@@ -1,8 +1,10 @@
+extern crate ff;
 extern crate sapling_crypto;
 extern crate bellman;
 extern crate rand;
 extern crate pairing;
 
+use ff::Field;
 use std::time::{Duration, Instant};
 use sapling_crypto::jubjub::{
     JubjubBls12,
@@ -18,14 +20,17 @@ use sapling_crypto::primitives::{
     ValueCommitment
 };
 use bellman::groth16::*;
-use rand::{XorShiftRng, SeedableRng, Rng};
+use rand::{XorShiftRng, SeedableRng, Rng, RngCore};
 use pairing::bls12_381::{Bls12, Fr};
 
 const TREE_DEPTH: usize = 32;
 
 fn main() {
     let jubjub_params = &JubjubBls12::new();
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     println!("Creating sample parameters...");
     let groth_params = generate_random_parameters::<Bls12, _, _>(
@@ -48,10 +53,10 @@ fn main() {
     for _ in 0..SAMPLES {
         let value_commitment = ValueCommitment {
             value: 1,
-            randomness: rng.gen()
+            randomness: fs::Fs::random(rng)
         };
 
-        let nsk: fs::Fs = rng.gen();
+        let nsk = fs::Fs::random(rng);
         let ak = edwards::Point::rand(rng, jubjub_params).mul_by_cofactor(jubjub_params);
 
         let proof_generation_key = ProofGenerationKey {
@@ -64,7 +69,11 @@ fn main() {
         let payment_address;
 
         loop {
-            let diversifier = Diversifier(rng.gen());
+            let diversifier = {
+                let mut d = [0; 11];
+                rng.fill_bytes(&mut d);
+                Diversifier(d)
+            };
 
             if let Some(p) = viewing_key.into_payment_address(
                 diversifier,
@@ -76,10 +85,10 @@ fn main() {
             }
         }
 
-        let commitment_randomness: fs::Fs = rng.gen();
-        let auth_path = vec![Some((rng.gen(), rng.gen())); TREE_DEPTH];
-        let ar: fs::Fs = rng.gen();
-        let anchor: Fr = rng.gen();
+        let commitment_randomness = fs::Fs::random(rng);
+        let auth_path = vec![Some((Fr::random(rng), rng.gen())); TREE_DEPTH];
+        let ar = fs::Fs::random(rng);
+        let anchor = Fr::random(rng);
 
         let start = Instant::now();
         let _ = create_random_proof(Spend {

--- a/sapling-crypto/examples/bench.rs
+++ b/sapling-crypto/examples/bench.rs
@@ -1,8 +1,9 @@
 extern crate ff;
 extern crate sapling_crypto;
 extern crate bellman;
-extern crate rand;
 extern crate pairing;
+extern crate rand_core;
+extern crate rand_xorshift;
 
 use ff::Field;
 use std::time::{Duration, Instant};
@@ -20,7 +21,8 @@ use sapling_crypto::primitives::{
     ValueCommitment
 };
 use bellman::groth16::*;
-use rand::{XorShiftRng, SeedableRng, Rng, RngCore};
+use rand_core::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
 use pairing::bls12_381::{Bls12, Fr};
 
 const TREE_DEPTH: usize = 32;
@@ -86,7 +88,7 @@ fn main() {
         }
 
         let commitment_randomness = fs::Fs::random(rng);
-        let auth_path = vec![Some((Fr::random(rng), rng.gen())); TREE_DEPTH];
+        let auth_path = vec![Some((Fr::random(rng), rng.next_u32() % 2 != 0)); TREE_DEPTH];
         let ar = fs::Fs::random(rng);
         let anchor = Fr::random(rng);
 

--- a/sapling-crypto/src/circuit/blake2s.rs
+++ b/sapling-crypto/src/circuit/blake2s.rs
@@ -321,8 +321,10 @@ pub fn blake2s<E: Engine, CS: ConstraintSystem<E>>(
 #[cfg(test)]
 mod test {
     use blake2s_simd::Params as Blake2sParams;
-    use rand::{XorShiftRng, SeedableRng, Rng};
     use pairing::bls12_381::{Bls12};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
     use ::circuit::boolean::{Boolean, AllocatedBit};
     use ::circuit::test::TestConstraintSystem;
     use super::blake2s;
@@ -371,7 +373,7 @@ mod test {
             0xe5,
         ]);
         let input_bits: Vec<_> = (0..512)
-          .map(|_| Boolean::constant(rng.gen()))
+          .map(|_| Boolean::constant(rng.next_u32() % 2 != 0))
           .chain((0..512)
                         .map(|i| AllocatedBit::alloc(cs.namespace(|| format!("input bit {}", i)), Some(true)).unwrap().into()))
           .collect();
@@ -387,7 +389,7 @@ mod test {
             0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
             0xe5,
         ]);
-        let input_bits: Vec<_> = (0..512).map(|_| Boolean::constant(rng.gen())).collect();
+        let input_bits: Vec<_> = (0..512).map(|_| Boolean::constant(rng.next_u32() % 2 != 0)).collect();
         blake2s(&mut cs, &input_bits, b"12345678").unwrap();
         assert_eq!(cs.num_constraints(), 0);
     }
@@ -403,7 +405,7 @@ mod test {
         {
             let mut h = Blake2sParams::new().hash_length(32).personal(b"12345678").to_state();
 
-            let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
+            let data: Vec<u8> = (0..input_len).map(|_| rng.next_u32() as u8).collect();
 
             h.update(&data);
 

--- a/sapling-crypto/src/circuit/blake2s.rs
+++ b/sapling-crypto/src/circuit/blake2s.rs
@@ -366,7 +366,10 @@ mod test {
         // doesn't result in more constraints.
 
         let mut cs = TestConstraintSystem::<Bls12>::new();
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let input_bits: Vec<_> = (0..512)
           .map(|_| Boolean::constant(rng.gen()))
           .chain((0..512)
@@ -380,7 +383,10 @@ mod test {
     #[test]
     fn test_blake2s_constant_constraints() {
         let mut cs = TestConstraintSystem::<Bls12>::new();
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let input_bits: Vec<_> = (0..512).map(|_| Boolean::constant(rng.gen())).collect();
         blake2s(&mut cs, &input_bits, b"12345678").unwrap();
         assert_eq!(cs.num_constraints(), 0);
@@ -388,7 +394,10 @@ mod test {
 
     #[test]
     fn test_blake2s() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for input_len in (0..32).chain((32..256).filter(|a| a % 8 == 0))
         {

--- a/sapling-crypto/src/circuit/ecc.rs
+++ b/sapling-crypto/src/circuit/ecc.rs
@@ -748,7 +748,7 @@ impl<E: JubjubEngine> MontgomeryPoint<E> {
 #[cfg(test)]
 mod test {
     use bellman::{ConstraintSystem};
-    use rand::{XorShiftRng, SeedableRng, Rand, Rng};
+    use rand::{XorShiftRng, SeedableRng, Rng};
     use ff::{BitIterator, Field, PrimeField};
     use pairing::bls12_381::{Bls12, Fr};
     use ::circuit::test::*;
@@ -774,7 +774,10 @@ mod test {
     #[test]
     fn test_into_edwards() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -798,12 +801,12 @@ mod test {
             assert!(q.x.get_value().unwrap() == u);
             assert!(q.y.get_value().unwrap() == v);
 
-            cs.set("u/num", rng.gen());
+            cs.set("u/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied().unwrap(), "u computation");
             cs.set("u/num", u);
             assert!(cs.is_satisfied());
 
-            cs.set("v/num", rng.gen());
+            cs.set("v/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied().unwrap(), "v computation");
             cs.set("v/num", v);
             assert!(cs.is_satisfied());
@@ -813,7 +816,10 @@ mod test {
     #[test]
     fn test_interpret() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let p = edwards::Point::<Bls12, _>::rand(rng, &params);
@@ -853,8 +859,8 @@ mod test {
 
         // Random (x, y) are unlikely to be on the curve.
         for _ in 0..100 {
-            let x = rng.gen();
-            let y = rng.gen();
+            let x = Fr::random(rng);
+            let y = Fr::random(rng);
 
             let mut cs = TestConstraintSystem::<Bls12>::new();
             let numx = AllocatedNum::alloc(cs.namespace(|| "x"), || {
@@ -873,13 +879,16 @@ mod test {
     #[test]
     fn test_edwards_fixed_base_multiplication()  {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
             let p = params.generator(FixedGenerators::NoteCommitmentRandomness);
-            let s = Fs::rand(rng);
+            let s = Fs::random(rng);
             let q = p.mul(s, params);
             let (x1, y1) = q.into_xy();
 
@@ -908,13 +917,16 @@ mod test {
     #[test]
     fn test_edwards_multiplication() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
             let p = edwards::Point::<Bls12, _>::rand(rng, params);
-            let s = Fs::rand(rng);
+            let s = Fs::random(rng);
             let q = p.mul(s, params);
 
             let (x0, y0) = p.into_xy();
@@ -965,7 +977,10 @@ mod test {
     #[test]
     fn test_conditionally_select() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -1031,7 +1046,10 @@ mod test {
     #[test]
     fn test_edwards_addition() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let p1 = edwards::Point::<Bls12, _>::rand(rng, params);
@@ -1077,19 +1095,19 @@ mod test {
             assert!(p3.y.get_value().unwrap() == y2);
 
             let u = cs.get("addition/U/num");
-            cs.set("addition/U/num", rng.gen());
+            cs.set("addition/U/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/U computation"));
             cs.set("addition/U/num", u);
             assert!(cs.is_satisfied());
 
             let x3 = cs.get("addition/x3/num");
-            cs.set("addition/x3/num", rng.gen());
+            cs.set("addition/x3/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/x3 computation"));
             cs.set("addition/x3/num", x3);
             assert!(cs.is_satisfied());
 
             let y3 = cs.get("addition/y3/num");
-            cs.set("addition/y3/num", rng.gen());
+            cs.set("addition/y3/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/y3 computation"));
             cs.set("addition/y3/num", y3);
             assert!(cs.is_satisfied());
@@ -1099,7 +1117,10 @@ mod test {
     #[test]
     fn test_edwards_doubling() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let p1 = edwards::Point::<Bls12, _>::rand(rng, params);
@@ -1134,11 +1155,14 @@ mod test {
     #[test]
     fn test_montgomery_addition() {
         let params = &JubjubBls12::new();
-        let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let p1 = loop {
-                let x: Fr = rng.gen();
+                let x = Fr::random(rng);
                 let s: bool = rng.gen();
 
                 if let Some(p) = montgomery::Point::<Bls12, _>::get_for_x(x, s, params) {
@@ -1147,7 +1171,7 @@ mod test {
             };
 
             let p2 = loop {
-                let x: Fr = rng.gen();
+                let x = Fr::random(rng);
                 let s: bool = rng.gen();
 
                 if let Some(p) = montgomery::Point::<Bls12, _>::get_for_x(x, s, params) {
@@ -1194,17 +1218,17 @@ mod test {
             assert!(p3.x.get_value().unwrap() == x2);
             assert!(p3.y.get_value().unwrap() == y2);
 
-            cs.set("addition/yprime/num", rng.gen());
+            cs.set("addition/yprime/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/evaluate yprime"));
             cs.set("addition/yprime/num", y2);
             assert!(cs.is_satisfied());
 
-            cs.set("addition/xprime/num", rng.gen());
+            cs.set("addition/xprime/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/evaluate xprime"));
             cs.set("addition/xprime/num", x2);
             assert!(cs.is_satisfied());
 
-            cs.set("addition/lambda/num", rng.gen());
+            cs.set("addition/lambda/num", Fr::random(rng));
             assert_eq!(cs.which_is_unsatisfied(), Some("addition/evaluate lambda"));
         }
     }

--- a/sapling-crypto/src/circuit/ecc.rs
+++ b/sapling-crypto/src/circuit/ecc.rs
@@ -748,9 +748,11 @@ impl<E: JubjubEngine> MontgomeryPoint<E> {
 #[cfg(test)]
 mod test {
     use bellman::{ConstraintSystem};
-    use rand::{XorShiftRng, SeedableRng, Rng};
     use ff::{BitIterator, Field, PrimeField};
     use pairing::bls12_381::{Bls12, Fr};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
     use ::circuit::test::*;
     use ::jubjub::{
         montgomery,
@@ -1001,10 +1003,10 @@ mod test {
                 y: num_y0
             };
 
-            let mut should_we_select = rng.gen();
+            let mut should_we_select = rng.next_u32() % 2 != 0;
 
             // Conditionally allocate
-            let mut b = if rng.gen() {
+            let mut b = if rng.next_u32() % 2 != 0 {
                 Boolean::from(AllocatedBit::alloc(
                     cs.namespace(|| "condition"),
                     Some(should_we_select)
@@ -1014,7 +1016,7 @@ mod test {
             };
 
             // Conditionally negate
-            if rng.gen() {
+            if rng.next_u32() % 2 != 0 {
                 b = b.not();
                 should_we_select = !should_we_select;
             }
@@ -1163,7 +1165,7 @@ mod test {
         for _ in 0..100 {
             let p1 = loop {
                 let x = Fr::random(rng);
-                let s: bool = rng.gen();
+                let s: bool = rng.next_u32() % 2 != 0;
 
                 if let Some(p) = montgomery::Point::<Bls12, _>::get_for_x(x, s, params) {
                     break p;
@@ -1172,7 +1174,7 @@ mod test {
 
             let p2 = loop {
                 let x = Fr::random(rng);
-                let s: bool = rng.gen();
+                let s: bool = rng.next_u32() % 2 != 0;
 
                 if let Some(p) = montgomery::Point::<Bls12, _>::get_for_x(x, s, params) {
                     break p;

--- a/sapling-crypto/src/circuit/lookup.rs
+++ b/sapling-crypto/src/circuit/lookup.rs
@@ -196,7 +196,7 @@ pub fn lookup3_xy_with_conditional_negation<E: Engine, CS>(
 
 #[cfg(test)]
 mod test {
-    use rand::{SeedableRng, Rand, Rng, XorShiftRng};
+    use rand::{SeedableRng, Rng, XorShiftRng};
     use super::*;
     use ::circuit::test::*;
     use ::circuit::boolean::{Boolean, AllocatedBit};
@@ -204,7 +204,10 @@ mod test {
 
     #[test]
     fn test_lookup3_xy() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0656]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -226,7 +229,7 @@ mod test {
 
             let bits = vec![a, b, c];
 
-            let points: Vec<(Fr, Fr)> = (0..8).map(|_| (rng.gen(), rng.gen())).collect();
+            let points: Vec<(Fr, Fr)> = (0..8).map(|_| (Fr::random(&mut rng), Fr::random(&mut rng))).collect();
 
             let res = lookup3_xy(&mut cs, &bits, &points).unwrap();
 
@@ -244,7 +247,10 @@ mod test {
 
     #[test]
     fn test_lookup3_xy_with_conditional_negation() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -266,7 +272,7 @@ mod test {
 
             let bits = vec![a, b, c];
 
-            let points: Vec<(Fr, Fr)> = (0..4).map(|_| (rng.gen(), rng.gen())).collect();
+            let points: Vec<(Fr, Fr)> = (0..4).map(|_| (Fr::random(&mut rng), Fr::random(&mut rng))).collect();
 
             let res = lookup3_xy_with_conditional_negation(&mut cs, &bits, &points).unwrap();
 
@@ -285,12 +291,15 @@ mod test {
 
     #[test]
     fn test_synth() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         let window_size = 4;
 
         let mut assignment = vec![Fr::zero(); 1 << window_size];
-        let constants: Vec<_> = (0..(1 << window_size)).map(|_| Fr::rand(&mut rng)).collect();
+        let constants: Vec<_> = (0..(1 << window_size)).map(|_| Fr::random(&mut rng)).collect();
 
         synth::<Bls12, _>(window_size, &constants, &mut assignment);
 

--- a/sapling-crypto/src/circuit/lookup.rs
+++ b/sapling-crypto/src/circuit/lookup.rs
@@ -196,11 +196,12 @@ pub fn lookup3_xy_with_conditional_negation<E: Engine, CS>(
 
 #[cfg(test)]
 mod test {
-    use rand::{SeedableRng, Rng, XorShiftRng};
     use super::*;
     use ::circuit::test::*;
     use ::circuit::boolean::{Boolean, AllocatedBit};
     use pairing::bls12_381::{Bls12, Fr};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_lookup3_xy() {
@@ -212,17 +213,17 @@ mod test {
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a_val = rng.gen();
+            let a_val = rng.next_u32() % 2 != 0;
             let a = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "a"), Some(a_val)).unwrap()
             );
 
-            let b_val = rng.gen();
+            let b_val = rng.next_u32() % 2 != 0;
             let b = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "b"), Some(b_val)).unwrap()
             );
 
-            let c_val = rng.gen();
+            let c_val = rng.next_u32() % 2 != 0;
             let c = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "c"), Some(c_val)).unwrap()
             );
@@ -255,17 +256,17 @@ mod test {
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a_val = rng.gen();
+            let a_val = rng.next_u32() % 2 != 0;
             let a = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "a"), Some(a_val)).unwrap()
             );
 
-            let b_val = rng.gen();
+            let b_val = rng.next_u32() % 2 != 0;
             let b = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "b"), Some(b_val)).unwrap()
             );
 
-            let c_val = rng.gen();
+            let c_val = rng.next_u32() % 2 != 0;
             let c = Boolean::from(
                 AllocatedBit::alloc(cs.namespace(|| "c"), Some(c_val)).unwrap()
             );

--- a/sapling-crypto/src/circuit/multipack.rs
+++ b/sapling-crypto/src/circuit/multipack.rs
@@ -80,9 +80,11 @@ pub fn compute_multipacking<E: Engine>(
 
 #[test]
 fn test_multipacking() {
-    use rand::{SeedableRng, Rng, XorShiftRng};
     use bellman::{ConstraintSystem};
     use pairing::bls12_381::{Bls12};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
     use ::circuit::test::*;
     use super::boolean::{AllocatedBit, Boolean};
 
@@ -94,7 +96,7 @@ fn test_multipacking() {
     for num_bits in 0..1500 {
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
-        let bits: Vec<bool> = (0..num_bits).map(|_| rng.gen()).collect();
+        let bits: Vec<bool> = (0..num_bits).map(|_| rng.next_u32() % 2 != 0).collect();
 
         let circuit_bits = bits.iter().enumerate()
                                .map(|(i, &b)| {

--- a/sapling-crypto/src/circuit/multipack.rs
+++ b/sapling-crypto/src/circuit/multipack.rs
@@ -86,7 +86,10 @@ fn test_multipacking() {
     use ::circuit::test::*;
     use super::boolean::{AllocatedBit, Boolean};
 
-    let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for num_bits in 0..1500 {
         let mut cs = TestConstraintSystem::<Bls12>::new();

--- a/sapling-crypto/src/circuit/num.rs
+++ b/sapling-crypto/src/circuit/num.rs
@@ -455,10 +455,12 @@ impl<E: Engine> Num<E> {
 
 #[cfg(test)]
 mod test {
-    use rand::{SeedableRng, XorShiftRng};
     use bellman::{ConstraintSystem};
     use ff::{BitIterator, Field, PrimeField};
     use pairing::bls12_381::{Bls12, Fr};
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
     use ::circuit::test::*;
     use super::{AllocatedNum, Boolean};
 

--- a/sapling-crypto/src/circuit/num.rs
+++ b/sapling-crypto/src/circuit/num.rs
@@ -455,7 +455,7 @@ impl<E: Engine> Num<E> {
 
 #[cfg(test)]
 mod test {
-    use rand::{SeedableRng, Rand, Rng, XorShiftRng};
+    use rand::{SeedableRng, XorShiftRng};
     use bellman::{ConstraintSystem};
     use ff::{BitIterator, Field, PrimeField};
     use pairing::bls12_381::{Bls12, Fr};
@@ -502,12 +502,15 @@ mod test {
 
     #[test]
     fn test_num_conditional_reversal() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(rng.gen())).unwrap();
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(rng.gen())).unwrap();
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(&mut rng))).unwrap();
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(&mut rng))).unwrap();
             let condition = Boolean::constant(false);
             let (c, d) = AllocatedNum::conditionally_reverse(&mut cs, &a, &b, &condition).unwrap();
 
@@ -520,8 +523,8 @@ mod test {
         {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(rng.gen())).unwrap();
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(rng.gen())).unwrap();
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(&mut rng))).unwrap();
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(&mut rng))).unwrap();
             let condition = Boolean::constant(true);
             let (c, d) = AllocatedNum::conditionally_reverse(&mut cs, &a, &b, &condition).unwrap();
 
@@ -573,10 +576,13 @@ mod test {
 
     #[test]
     fn test_into_bits() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for i in 0..200 {
-            let r = Fr::rand(&mut rng);
+            let r = Fr::random(&mut rng);
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
             let n = AllocatedNum::alloc(&mut cs, || Ok(r)).unwrap();
@@ -597,7 +603,7 @@ mod test {
                 }
             }
 
-            cs.set("num", Fr::rand(&mut rng));
+            cs.set("num", Fr::random(&mut rng));
             assert!(!cs.is_satisfied());
             cs.set("num", r);
             assert!(cs.is_satisfied());

--- a/sapling-crypto/src/circuit/pedersen_hash.rs
+++ b/sapling-crypto/src/circuit/pedersen_hash.rs
@@ -112,12 +112,13 @@ pub fn pedersen_hash<E: JubjubEngine, CS>(
 
 #[cfg(test)]
 mod test {
-    use rand::{SeedableRng, Rng, XorShiftRng};
     use super::*;
     use ::circuit::test::*;
     use ::circuit::boolean::{Boolean, AllocatedBit};
     use ff::PrimeField;
     use pairing::bls12_381::{Bls12, Fr};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_pedersen_hash_constraints() {
@@ -128,7 +129,7 @@ mod test {
         let params = &JubjubBls12::new();
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
-        let input: Vec<bool> = (0..(Fr::NUM_BITS * 2)).map(|_| rng.gen()).collect();
+        let input: Vec<bool> = (0..(Fr::NUM_BITS * 2)).map(|_| rng.next_u32() % 2 != 0).collect();
 
         let input_bools: Vec<Boolean> = input.iter().enumerate().map(|(i, b)| {
             Boolean::from(
@@ -157,7 +158,7 @@ mod test {
 
         for length in 0..751 {
             for _ in 0..5 {
-                let mut input: Vec<bool> = (0..length).map(|_| rng.gen()).collect();
+                let mut input: Vec<bool> = (0..length).map(|_| rng.next_u32() % 2 != 0).collect();
 
                 let mut cs = TestConstraintSystem::<Bls12>::new();
 

--- a/sapling-crypto/src/circuit/pedersen_hash.rs
+++ b/sapling-crypto/src/circuit/pedersen_hash.rs
@@ -121,7 +121,10 @@ mod test {
 
     #[test]
     fn test_pedersen_hash_constraints() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let params = &JubjubBls12::new();
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
@@ -146,7 +149,10 @@ mod test {
 
     #[test]
     fn test_pedersen_hash() {
-        let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let params = &JubjubBls12::new();
 
         for length in 0..751 {

--- a/sapling-crypto/src/circuit/sapling/mod.rs
+++ b/sapling-crypto/src/circuit/sapling/mod.rs
@@ -600,7 +600,9 @@ impl<'a, E: JubjubEngine> Circuit<E> for Output<'a, E> {
 fn test_input_circuit_with_bls12_381() {
     use ff::{BitIterator, Field};
     use pairing::bls12_381::*;
-    use rand::{SeedableRng, Rng, RngCore, XorShiftRng};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
     use ::circuit::test::*;
     use jubjub::{JubjubBls12, fs, edwards};
 
@@ -614,7 +616,7 @@ fn test_input_circuit_with_bls12_381() {
 
     for _ in 0..10 {
         let value_commitment = ValueCommitment {
-            value: rng.gen(),
+            value: rng.next_u64(),
             randomness: fs::Fs::random(rng),
         };
 
@@ -649,7 +651,7 @@ fn test_input_circuit_with_bls12_381() {
 
         let g_d = payment_address.diversifier.g_d(params).unwrap();
         let commitment_randomness = fs::Fs::random(rng);
-        let auth_path = vec![Some((Fr::random(rng), rng.gen())); tree_depth];
+        let auth_path = vec![Some((Fr::random(rng), rng.next_u32() % 2 != 0)); tree_depth];
         let ar = fs::Fs::random(rng);
 
         {
@@ -739,7 +741,8 @@ fn test_input_circuit_with_bls12_381() {
 fn test_output_circuit_with_bls12_381() {
     use ff::Field;
     use pairing::bls12_381::*;
-    use rand::{SeedableRng, Rng, RngCore, XorShiftRng};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
     use ::circuit::test::*;
     use jubjub::{JubjubBls12, fs, edwards};
 
@@ -751,7 +754,7 @@ fn test_output_circuit_with_bls12_381() {
 
     for _ in 0..100 {
         let value_commitment = ValueCommitment {
-            value: rng.gen(),
+            value: rng.next_u64(),
             randomness: fs::Fs::random(rng),
         };
 

--- a/sapling-crypto/src/circuit/sha256.rs
+++ b/sapling-crypto/src/circuit/sha256.rs
@@ -308,7 +308,8 @@ mod test {
     use circuit::boolean::AllocatedBit;
     use pairing::bls12_381::Bls12;
     use circuit::test::TestConstraintSystem;
-    use rand::{XorShiftRng, SeedableRng, Rng};
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_blank_hash() {
@@ -353,7 +354,7 @@ mod test {
             Boolean::from(
                 AllocatedBit::alloc(
                     cs.namespace(|| format!("input bit {}", i)),
-                    Some(rng.gen())
+                    Some(rng.next_u32() % 2 != 0)
                 ).unwrap()
             )
         }).collect();
@@ -380,7 +381,7 @@ mod test {
         for input_len in (0..32).chain((32..256).filter(|a| a % 8 == 0))
         {
             let mut h = Sha256::new();
-            let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
+            let data: Vec<u8> = (0..input_len).map(|_| rng.next_u32() as u8).collect();
             h.input(&data);
             let hash_result = h.result();
 

--- a/sapling-crypto/src/circuit/sha256.rs
+++ b/sapling-crypto/src/circuit/sha256.rs
@@ -341,7 +341,10 @@ mod test {
 
     #[test]
     fn test_full_block() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         let iv = get_sha256_iv();
 
@@ -370,7 +373,10 @@ mod test {
         use crypto::sha2::Sha256;
         use crypto::digest::Digest;
 
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for input_len in (0..32).chain((32..256).filter(|a| a % 8 == 0))
         {

--- a/sapling-crypto/src/circuit/sha256.rs
+++ b/sapling-crypto/src/circuit/sha256.rs
@@ -370,8 +370,7 @@ mod test {
 
     #[test]
     fn test_against_vectors() {
-        use crypto::sha2::Sha256;
-        use crypto::digest::Digest;
+        use sha2::{Digest, Sha256};
 
         let mut rng = XorShiftRng::from_seed([
             0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
@@ -383,8 +382,7 @@ mod test {
             let mut h = Sha256::new();
             let data: Vec<u8> = (0..input_len).map(|_| rng.gen()).collect();
             h.input(&data);
-            let mut hash_result = [0u8; 32];
-            h.result(&mut hash_result[..]);
+            let hash_result = h.result();
 
             let mut cs = TestConstraintSystem::<Bls12>::new();
             let mut input_bits = vec![];

--- a/sapling-crypto/src/circuit/uint32.rs
+++ b/sapling-crypto/src/circuit/uint32.rs
@@ -420,7 +420,10 @@ mod test {
 
     #[test]
     fn test_uint32_from_bits_be() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut v = (0..32).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -451,7 +454,10 @@ mod test {
 
     #[test]
     fn test_uint32_from_bits() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut v = (0..32).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
@@ -482,7 +488,10 @@ mod test {
 
     #[test]
     fn test_uint32_xor() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -524,7 +533,10 @@ mod test {
 
     #[test]
     fn test_uint32_addmany_constants() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -563,7 +575,10 @@ mod test {
 
     #[test]
     fn test_uint32_addmany() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -620,7 +635,10 @@ mod test {
 
     #[test]
     fn test_uint32_rotr() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         let mut num = rng.gen();
 
@@ -650,7 +668,10 @@ mod test {
 
     #[test]
     fn test_uint32_shr() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..50 {
             for i in 0..60 {
@@ -670,7 +691,10 @@ mod test {
 
     #[test]
     fn test_uint32_sha256_maj() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -711,7 +735,10 @@ mod test {
 
     #[test]
     fn test_uint32_sha256_ch() {
-        let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
 
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();

--- a/sapling-crypto/src/circuit/uint32.rs
+++ b/sapling-crypto/src/circuit/uint32.rs
@@ -409,7 +409,6 @@ impl UInt32 {
 
 #[cfg(test)]
 mod test {
-    use rand::{XorShiftRng, SeedableRng, Rng};
     use ::circuit::boolean::{Boolean};
     use super::{UInt32};
     use ff::Field;
@@ -417,6 +416,8 @@ mod test {
     use ::circuit::test::*;
     use bellman::{ConstraintSystem};
     use circuit::multieq::MultiEq;
+    use rand_core::{RngCore, SeedableRng};
+    use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_uint32_from_bits_be() {
@@ -426,7 +427,7 @@ mod test {
         ]);
 
         for _ in 0..1000 {
-            let mut v = (0..32).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
+            let mut v = (0..32).map(|_| Boolean::constant(rng.next_u32() % 2 != 0)).collect::<Vec<_>>();
 
             let b = UInt32::from_bits_be(&v);
 
@@ -460,7 +461,7 @@ mod test {
         ]);
 
         for _ in 0..1000 {
-            let mut v = (0..32).map(|_| Boolean::constant(rng.gen())).collect::<Vec<_>>();
+            let mut v = (0..32).map(|_| Boolean::constant(rng.next_u32() % 2 != 0)).collect::<Vec<_>>();
 
             let b = UInt32::from_bits(&v);
 
@@ -496,9 +497,9 @@ mod test {
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a: u32 = rng.gen();
-            let b: u32 = rng.gen();
-            let c: u32 = rng.gen();
+            let a = rng.next_u32();
+            let b = rng.next_u32();
+            let c = rng.next_u32();
 
             let mut expected = a ^ b ^ c;
 
@@ -541,9 +542,9 @@ mod test {
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a: u32 = rng.gen();
-            let b: u32 = rng.gen();
-            let c: u32 = rng.gen();
+            let a = rng.next_u32();
+            let b = rng.next_u32();
+            let c = rng.next_u32();
 
             let a_bit = UInt32::constant(a);
             let b_bit = UInt32::constant(b);
@@ -583,10 +584,10 @@ mod test {
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a: u32 = rng.gen();
-            let b: u32 = rng.gen();
-            let c: u32 = rng.gen();
-            let d: u32 = rng.gen();
+            let a = rng.next_u32();
+            let b = rng.next_u32();
+            let c = rng.next_u32();
+            let d = rng.next_u32();
 
             let mut expected = (a ^ b).wrapping_add(c).wrapping_add(d);
 
@@ -640,7 +641,7 @@ mod test {
             0xe5,
         ]);
 
-        let mut num = rng.gen();
+        let mut num = rng.next_u32();
 
         let a = UInt32::constant(num);
 
@@ -675,7 +676,7 @@ mod test {
 
         for _ in 0..50 {
             for i in 0..60 {
-                let num = rng.gen();
+                let num = rng.next_u32();
                 let a = UInt32::constant(num).shr(i);
                 let b = UInt32::constant(num.wrapping_shr(i as u32));
 
@@ -699,9 +700,9 @@ mod test {
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a: u32 = rng.gen();
-            let b: u32 = rng.gen();
-            let c: u32 = rng.gen();
+            let a = rng.next_u32();
+            let b = rng.next_u32();
+            let c = rng.next_u32();
 
             let mut expected = (a & b) ^ (a & c) ^ (b & c);
 
@@ -743,9 +744,9 @@ mod test {
         for _ in 0..1000 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a: u32 = rng.gen();
-            let b: u32 = rng.gen();
-            let c: u32 = rng.gen();
+            let a = rng.next_u32();
+            let b = rng.next_u32();
+            let c = rng.next_u32();
 
             let mut expected = (a & b) ^ ((!a) & c);
 

--- a/sapling-crypto/src/jubjub/edwards.rs
+++ b/sapling-crypto/src/jubjub/edwards.rs
@@ -8,9 +8,7 @@ use super::{
     montgomery
 };
 
-use rand::{
-    Rng
-};
+use rand_core::RngCore;
 
 use std::marker::PhantomData;
 
@@ -185,12 +183,13 @@ impl<E: JubjubEngine> Point<E, Unknown> {
         convert_subgroup(&tmp)
     }
 
-    pub fn rand<R: Rng>(rng: &mut R, params: &E::Params) -> Self
+    pub fn rand<R: RngCore>(rng: &mut R, params: &E::Params) -> Self
     {
         loop {
             let y = E::Fr::random(rng);
+            let sign = rng.next_u32() % 2 != 0;
 
-            if let Some(p) = Self::get_for_y(y, rng.gen(), params) {
+            if let Some(p) = Self::get_for_y(y, sign, params) {
                 return p;
             }
         }

--- a/sapling-crypto/src/jubjub/edwards.rs
+++ b/sapling-crypto/src/jubjub/edwards.rs
@@ -188,7 +188,7 @@ impl<E: JubjubEngine> Point<E, Unknown> {
     pub fn rand<R: Rng>(rng: &mut R, params: &E::Params) -> Self
     {
         loop {
-            let y: E::Fr = rng.gen();
+            let y = E::Fr::random(rng);
 
             if let Some(p) = Self::get_for_y(y, rng.gen(), params) {
                 return p;

--- a/sapling-crypto/src/jubjub/fs.rs
+++ b/sapling-crypto/src/jubjub/fs.rs
@@ -4,7 +4,7 @@ use ff::{
     LegendreSymbol::{self, *},
     PrimeField, PrimeFieldDecodingError, PrimeFieldRepr, SqrtField,
 };
-use rand::RngCore;
+use rand_core::RngCore;
 
 use super::ToUniform;
 
@@ -620,7 +620,9 @@ fn test_neg_one() {
 }
 
 #[cfg(test)]
-use rand::{SeedableRng, XorShiftRng};
+use rand_core::SeedableRng;
+#[cfg(test)]
+use rand_xorshift::XorShiftRng;
 
 #[test]
 fn test_fs_repr_ordering() {

--- a/sapling-crypto/src/jubjub/fs.rs
+++ b/sapling-crypto/src/jubjub/fs.rs
@@ -292,7 +292,7 @@ impl Field for Fs {
                 Fs(FsRepr(repr))
             };
 
-            // Mask away the unused bits at the beginning.
+            // Mask away the unused most-significant bits.
             tmp.0.as_mut()[3] &= 0xffffffffffffffff >> REPR_SHAVE_BITS;
 
             if tmp.is_valid() {

--- a/sapling-crypto/src/jubjub/montgomery.rs
+++ b/sapling-crypto/src/jubjub/montgomery.rs
@@ -104,7 +104,7 @@ impl<E: JubjubEngine> Point<E, Unknown> {
     pub fn rand<R: Rng>(rng: &mut R, params: &E::Params) -> Self
     {
         loop {
-            let x: E::Fr = rng.gen();
+            let x = E::Fr::random(rng);
 
             match Self::get_for_x(x, rng.gen(), params) {
                 Some(p) => {

--- a/sapling-crypto/src/jubjub/montgomery.rs
+++ b/sapling-crypto/src/jubjub/montgomery.rs
@@ -8,9 +8,7 @@ use super::{
     edwards
 };
 
-use rand::{
-    Rng
-};
+use rand_core::RngCore;
 
 use std::marker::PhantomData;
 
@@ -101,12 +99,13 @@ impl<E: JubjubEngine> Point<E, Unknown> {
         convert_subgroup(&tmp)
     }
 
-    pub fn rand<R: Rng>(rng: &mut R, params: &E::Params) -> Self
+    pub fn rand<R: RngCore>(rng: &mut R, params: &E::Params) -> Self
     {
         loop {
             let x = E::Fr::random(rng);
+            let sign = rng.next_u32() % 2 != 0;
 
-            match Self::get_for_x(x, rng.gen(), params) {
+            match Self::get_for_x(x, sign, params) {
                 Some(p) => {
                     return p
                 },

--- a/sapling-crypto/src/jubjub/tests.rs
+++ b/sapling-crypto/src/jubjub/tests.rs
@@ -14,7 +14,7 @@ use ff::{
     LegendreSymbol
 };
 
-use rand::{XorShiftRng, SeedableRng, Rand};
+use rand::{RngCore, XorShiftRng, SeedableRng};
 
 pub fn test_suite<E: JubjubEngine>(params: &E::Params) {
     test_back_and_forth::<E>(params);
@@ -78,7 +78,10 @@ fn is_on_twisted_edwards_curve<E: JubjubEngine, P: JubjubParams<E>>(
 }
 
 fn test_loworder<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
     let inf = montgomery::Point::zero();
 
     // try to find a point of order 8
@@ -109,15 +112,18 @@ fn test_loworder<E: JubjubEngine>(params: &E::Params) {
 
 fn test_mul_associativity<E: JubjubEngine>(params: &E::Params) {
     use self::edwards::Point;
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..100 {
         // Pick a random point and multiply it by the cofactor
         let base = Point::<E, _>::rand(rng, params).mul_by_cofactor(params);
 
-        let mut a = E::Fs::rand(rng);
-        let b = E::Fs::rand(rng);
-        let c = E::Fs::rand(rng);
+        let mut a = E::Fs::random(rng);
+        let b = E::Fs::random(rng);
+        let c = E::Fs::random(rng);
 
         let res1 = base.mul(a, params).mul(b, params).mul(c, params);
         let res2 = base.mul(b, params).mul(c, params).mul(a, params);
@@ -143,7 +149,10 @@ fn test_mul_associativity<E: JubjubEngine>(params: &E::Params) {
 
 fn test_order<E: JubjubEngine>(params: &E::Params) {
     use self::edwards::Point;
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     // The neutral element is in the prime order subgroup.
     assert!(Point::<E, PrimeOrder>::zero().as_prime_order(params).is_some());
@@ -170,7 +179,10 @@ fn test_order<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_addition_associativity<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         use self::montgomery::Point;
@@ -194,7 +206,10 @@ fn test_addition_associativity<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_identities<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     {
         use self::edwards::Point;
@@ -228,11 +243,14 @@ fn test_identities<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_get_for<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let y = E::Fr::rand(rng);
-        let sign = bool::rand(rng);
+        let y = E::Fr::random(rng);
+        let sign = rng.next_u32() % 2 == 1;
 
         if let Some(mut p) = edwards::Point::<E, _>::get_for_y(y, sign, params) {
             assert!(p.into_xy().0.into_repr().is_odd() == sign);
@@ -247,7 +265,10 @@ fn test_get_for<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_read_write<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         let e = edwards::Point::<E, _>::rand(rng, params);
@@ -262,7 +283,10 @@ fn test_read_write<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_rand<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
         let p = montgomery::Point::<E, _>::rand(rng, params);
@@ -281,10 +305,13 @@ fn test_rand<E: JubjubEngine>(params: &E::Params) {
 }
 
 fn test_back_and_forth<E: JubjubEngine>(params: &E::Params) {
-    let rng = &mut XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let rng = &mut XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x3d, 0x76, 0x5d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
 
     for _ in 0..1000 {
-        let s = E::Fs::rand(rng);
+        let s = E::Fs::random(rng);
         let edwards_p1 = edwards::Point::<E, _>::rand(rng, params);
         let mont_p1 = montgomery::Point::from_edwards(&edwards_p1, params);
         let mont_p2 = montgomery::Point::<E, _>::rand(rng, params);

--- a/sapling-crypto/src/jubjub/tests.rs
+++ b/sapling-crypto/src/jubjub/tests.rs
@@ -14,7 +14,8 @@ use ff::{
     LegendreSymbol
 };
 
-use rand::{RngCore, XorShiftRng, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
 
 pub fn test_suite<E: JubjubEngine>(params: &E::Params) {
     test_back_and_forth::<E>(params);

--- a/sapling-crypto/src/lib.rs
+++ b/sapling-crypto/src/lib.rs
@@ -12,7 +12,7 @@ extern crate byteorder;
 extern crate hex_literal;
 
 #[cfg(test)]
-extern crate crypto;
+extern crate sha2;
 
 pub mod jubjub;
 pub mod group_hash;

--- a/sapling-crypto/src/lib.rs
+++ b/sapling-crypto/src/lib.rs
@@ -4,12 +4,15 @@ extern crate blake2b_simd;
 extern crate blake2s_simd;
 extern crate digest;
 extern crate ff;
-extern crate rand;
+extern crate rand_core;
 extern crate byteorder;
 
 #[cfg(test)]
 #[macro_use]
 extern crate hex_literal;
+
+#[cfg(test)]
+extern crate rand_xorshift;
 
 #[cfg(test)]
 extern crate sha2;

--- a/sapling-crypto/src/redjubjub.rs
+++ b/sapling-crypto/src/redjubjub.rs
@@ -2,7 +2,7 @@
 //! See section 5.4.6 of the Sapling protocol specification.
 
 use ff::{Field, PrimeField, PrimeFieldRepr};
-use rand::{Rng, Rand};
+use rand::{Rng};
 use std::io::{self, Read, Write};
 
 use jubjub::{FixedGenerators, JubjubEngine, JubjubParams, Unknown, edwards::Point};
@@ -184,7 +184,7 @@ pub fn batch_verify<'a, E: JubjubEngine, R: Rng>(
 
         let mut c = h_star::<E>(&entry.sig.rbar[..], entry.msg);
 
-        let z = E::Fs::rand(rng);
+        let z = E::Fs::random(rng);
 
         s.mul_assign(&z);
         s.negate();
@@ -218,13 +218,13 @@ mod tests {
         let params = &JubjubBls12::new();
         let p_g = FixedGenerators::SpendingKeyGenerator;
 
-        let sk1 = PrivateKey::<Bls12>(rng.gen());
+        let sk1 = PrivateKey::<Bls12>(Fs::random(rng));
         let vk1 = PublicKey::from_private(&sk1, p_g, params);
         let msg1 = b"Foo bar";
         let sig1 = sk1.sign(msg1, rng, p_g, params);
         assert!(vk1.verify(msg1, &sig1, p_g, params));
 
-        let sk2 = PrivateKey::<Bls12>(rng.gen());
+        let sk2 = PrivateKey::<Bls12>(Fs::random(rng));
         let vk2 = PublicKey::from_private(&sk2, p_g, params);
         let msg2 = b"Foo bar";
         let sig2 = sk2.sign(msg2, rng, p_g, params);
@@ -262,7 +262,7 @@ mod tests {
             }
         };
 
-        let sk = PrivateKey::<Bls12>(rng.gen());
+        let sk = PrivateKey::<Bls12>(Fs::random(rng));
         let vk = PublicKey::from_private(&sk, p_g, params);
 
         // TODO: This test will need to change when #77 is fixed
@@ -281,7 +281,7 @@ mod tests {
         let params = &JubjubBls12::new();
 
         for _ in 0..1000 {
-            let sk = PrivateKey::<Bls12>(rng.gen());
+            let sk = PrivateKey::<Bls12>(Fs::random(rng));
             let vk = PublicKey::from_private(&sk, p_g, params);
             let msg = b"Foo bar";
             let sig = sk.sign(msg, rng, p_g, params);
@@ -314,7 +314,7 @@ mod tests {
         let params = &JubjubBls12::new();
 
         for _ in 0..1000 {
-            let sk = PrivateKey::<Bls12>(rng.gen());
+            let sk = PrivateKey::<Bls12>(Fs::random(rng));
             let vk = PublicKey::from_private(&sk, p_g, params);
 
             let msg1 = b"Foo bar";
@@ -328,7 +328,7 @@ mod tests {
             assert!(!vk.verify(msg1, &sig2, p_g, params));
             assert!(!vk.verify(msg2, &sig1, p_g, params));
 
-            let alpha = rng.gen();
+            let alpha = Fs::random(rng);
             let rsk = sk.randomize(alpha);
             let rvk = vk.randomize(alpha, p_g, params);
 

--- a/sapling-crypto/src/redjubjub.rs
+++ b/sapling-crypto/src/redjubjub.rs
@@ -2,7 +2,7 @@
 //! See section 5.4.6 of the Sapling protocol specification.
 
 use ff::{Field, PrimeField, PrimeFieldRepr};
-use rand::{Rng};
+use rand_core::RngCore;
 use std::io::{self, Read, Write};
 
 use jubjub::{FixedGenerators, JubjubEngine, JubjubParams, Unknown, edwards::Point};
@@ -71,7 +71,7 @@ impl<E: JubjubEngine> PrivateKey<E> {
         write_scalar::<E, W>(&self.0, writer)
     }
 
-    pub fn sign<R: Rng>(
+    pub fn sign<R: RngCore>(
         &self,
         msg: &[u8],
         rng: &mut R,
@@ -163,7 +163,7 @@ pub struct BatchEntry<'a, E: JubjubEngine> {
 
 // TODO: #82: This is a naive implementation currently,
 // and doesn't use multiexp.
-pub fn batch_verify<'a, E: JubjubEngine, R: Rng>(
+pub fn batch_verify<'a, E: JubjubEngine, R: RngCore>(
     rng: &mut R,
     batch: &[BatchEntry<'a, E>],
     p_g: FixedGenerators,
@@ -206,7 +206,8 @@ pub fn batch_verify<'a, E: JubjubEngine, R: Rng>(
 #[cfg(test)]
 mod tests {
     use pairing::bls12_381::Bls12;
-    use rand::thread_rng;
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
 
     use jubjub::{JubjubBls12, fs::Fs, edwards};
 
@@ -214,7 +215,10 @@ mod tests {
 
     #[test]
     fn test_batch_verify() {
-        let rng = &mut thread_rng();
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let params = &JubjubBls12::new();
         let p_g = FixedGenerators::SpendingKeyGenerator;
 
@@ -244,7 +248,10 @@ mod tests {
 
     #[test]
     fn cofactor_check() {
-        let rng = &mut thread_rng();
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let params = &JubjubBls12::new();
         let zero = edwards::Point::zero();
         let p_g = FixedGenerators::SpendingKeyGenerator;
@@ -276,7 +283,10 @@ mod tests {
 
     #[test]
     fn round_trip_serialization() {
-        let rng = &mut thread_rng();
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let p_g = FixedGenerators::SpendingKeyGenerator;
         let params = &JubjubBls12::new();
 
@@ -309,7 +319,10 @@ mod tests {
 
     #[test]
     fn random_signatures() {
-        let rng = &mut thread_rng();
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+            0xe5,
+        ]);
         let p_g = FixedGenerators::SpendingKeyGenerator;
         let params = &JubjubBls12::new();
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -13,4 +13,4 @@ sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 
 [dev-dependencies]
-rand = "0.4"
+rand = "0.5"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -13,5 +13,5 @@ sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 
 [dev-dependencies]
-rand_core = "0.4"
-rand_xorshift = "0.1"
+rand_core = "0.5"
+rand_xorshift = "0.2"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -13,4 +13,5 @@ sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }
 
 [dev-dependencies]
-rand = "0.5"
+rand_core = "0.4"
+rand_xorshift = "0.1"

--- a/zcash_client_backend/src/encoding.rs
+++ b/zcash_client_backend/src/encoding.rs
@@ -112,7 +112,10 @@ pub fn decode_extended_full_viewing_key(
 /// };
 /// use zcash_primitives::JUBJUB;
 ///
-/// let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+/// let rng = &mut XorShiftRng::from_seed([
+///     0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+///     0xbc, 0xe5,
+/// ]);
 ///
 /// let pa = PaymentAddress {
 ///     diversifier: Diversifier([0u8; 11]),
@@ -121,7 +124,7 @@ pub fn decode_extended_full_viewing_key(
 ///
 /// assert_eq!(
 ///     encode_payment_address(HRP_SAPLING_PAYMENT_ADDRESS, &pa),
-///     "ztestsapling1qqqqqqqqqqqqqqqqqqxrrfaccydp867g6zg7ne5ht37z38jtfyw0ygmp0ja6hhf07twjq6awtaj",
+///     "ztestsapling1qqqqqqqqqqqqqqqqqrjq05nyfku05msvu49mawhg6kr0wwljahypwyk2h88z6975u563j0ym7pe",
 /// );
 /// ```
 pub fn encode_payment_address(hrp: &str, addr: &PaymentAddress<Bls12>) -> String {
@@ -148,7 +151,10 @@ pub fn encode_payment_address(hrp: &str, addr: &PaymentAddress<Bls12>) -> String
 /// };
 /// use zcash_primitives::JUBJUB;
 ///
-/// let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+/// let rng = &mut XorShiftRng::from_seed([
+///     0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+///     0xbc, 0xe5,
+/// ]);
 ///
 /// let pa = PaymentAddress {
 ///     diversifier: Diversifier([0u8; 11]),
@@ -158,7 +164,7 @@ pub fn encode_payment_address(hrp: &str, addr: &PaymentAddress<Bls12>) -> String
 /// assert_eq!(
 ///     decode_payment_address(
 ///         HRP_SAPLING_PAYMENT_ADDRESS,
-///         "ztestsapling1qqqqqqqqqqqqqqqqqqxrrfaccydp867g6zg7ne5ht37z38jtfyw0ygmp0ja6hhf07twjq6awtaj",
+///         "ztestsapling1qqqqqqqqqqqqqqqqqrjq05nyfku05msvu49mawhg6kr0wwljahypwyk2h88z6975u563j0ym7pe",
 ///     ),
 ///     Ok(Some(pa)),
 /// );
@@ -194,7 +200,10 @@ mod tests {
 
     #[test]
     fn payment_address() {
-        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
 
         let addr = PaymentAddress {
             diversifier: Diversifier([0u8; 11]),
@@ -202,9 +211,9 @@ mod tests {
         };
 
         let encoded_main =
-            "zs1qqqqqqqqqqqqqqqqqqxrrfaccydp867g6zg7ne5ht37z38jtfyw0ygmp0ja6hhf07twjqj2ug6x";
+            "zs1qqqqqqqqqqqqqqqqqrjq05nyfku05msvu49mawhg6kr0wwljahypwyk2h88z6975u563j8nfaxd";
         let encoded_test =
-            "ztestsapling1qqqqqqqqqqqqqqqqqqxrrfaccydp867g6zg7ne5ht37z38jtfyw0ygmp0ja6hhf07twjq6awtaj";
+            "ztestsapling1qqqqqqqqqqqqqqqqqrjq05nyfku05msvu49mawhg6kr0wwljahypwyk2h88z6975u563j0ym7pe";
 
         assert_eq!(
             encode_payment_address(constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS, &addr),
@@ -235,7 +244,10 @@ mod tests {
 
     #[test]
     fn invalid_diversifier() {
-        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+        let rng = &mut XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x3d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
 
         let addr = PaymentAddress {
             diversifier: Diversifier([1u8; 11]),

--- a/zcash_client_backend/src/encoding.rs
+++ b/zcash_client_backend/src/encoding.rs
@@ -101,7 +101,8 @@ pub fn decode_extended_full_viewing_key(
 ///
 /// ```
 /// use pairing::bls12_381::Bls12;
-/// use rand::{SeedableRng, XorShiftRng};
+/// use rand_core::SeedableRng;
+/// use rand_xorshift::XorShiftRng;
 /// use sapling_crypto::{
 ///     jubjub::edwards,
 ///     primitives::{Diversifier, PaymentAddress},
@@ -140,7 +141,8 @@ pub fn encode_payment_address(hrp: &str, addr: &PaymentAddress<Bls12>) -> String
 ///
 /// ```
 /// use pairing::bls12_381::Bls12;
-/// use rand::{SeedableRng, XorShiftRng};
+/// use rand_core::SeedableRng;
+/// use rand_xorshift::XorShiftRng;
 /// use sapling_crypto::{
 ///     jubjub::edwards,
 ///     primitives::{Diversifier, PaymentAddress},
@@ -188,7 +190,8 @@ pub fn decode_payment_address(hrp: &str, s: &str) -> Result<Option<PaymentAddres
 #[cfg(test)]
 mod tests {
     use pairing::bls12_381::Bls12;
-    use rand::{SeedableRng, XorShiftRng};
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
     use sapling_crypto::{
         jubjub::edwards,
         primitives::{Diversifier, PaymentAddress},

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -15,7 +15,7 @@ fpe = "0.1"
 hex = "0.3"
 lazy_static = "1"
 pairing = { path = "../pairing" }
-rand_core = "0.4"
-rand_os = "0.1"
+rand_core = "0.5"
+rand_os = "0.2"
 sapling-crypto = { path = "../sapling-crypto" }
 sha2 = "0.8"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -15,6 +15,7 @@ fpe = "0.1"
 hex = "0.3"
 lazy_static = "1"
 pairing = { path = "../pairing" }
-rand = "0.5"
+rand_core = "0.4"
+rand_os = "0.1"
 sapling-crypto = { path = "../sapling-crypto" }
 sha2 = "0.8"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -15,6 +15,6 @@ fpe = "0.1"
 hex = "0.3"
 lazy_static = "1"
 pairing = { path = "../pairing" }
-rand = "0.4"
+rand = "0.5"
 sapling-crypto = { path = "../sapling-crypto" }
 sha2 = "0.8"

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -9,7 +9,8 @@ extern crate ff;
 extern crate fpe;
 extern crate hex;
 extern crate pairing;
-extern crate rand;
+extern crate rand_core;
+extern crate rand_os;
 extern crate sapling_crypto;
 extern crate sha2;
 

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -202,12 +202,12 @@ impl<Node: Hashable> CommitmentTree<Node> {
 /// ```
 /// extern crate ff;
 /// extern crate pairing;
-/// extern crate rand;
+/// extern crate rand_os;
 /// extern crate zcash_primitives;
 ///
 /// use ff::{Field, PrimeField};
 /// use pairing::bls12_381::Fr;
-/// use rand::OsRng;
+/// use rand_os::OsRng;
 /// use zcash_primitives::{
 ///     merkle_tree::{CommitmentTree, IncrementalWitness},
 ///     sapling::Node,

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -200,12 +200,14 @@ impl<Node: Hashable> CommitmentTree<Node> {
 /// # Examples
 ///
 /// ```
+/// extern crate ff;
 /// extern crate pairing;
 /// extern crate rand;
 /// extern crate zcash_primitives;
 ///
-/// use pairing::bls12_381::FrRepr;
-/// use rand::{OsRng, Rand};
+/// use ff::{Field, PrimeField};
+/// use pairing::bls12_381::Fr;
+/// use rand::OsRng;
 /// use zcash_primitives::{
 ///     merkle_tree::{CommitmentTree, IncrementalWitness},
 ///     sapling::Node,
@@ -214,13 +216,13 @@ impl<Node: Hashable> CommitmentTree<Node> {
 /// let mut rng = OsRng::new().unwrap();
 /// let mut tree = CommitmentTree::<Node>::new();
 ///
-/// tree.append(Node::new(FrRepr::rand(&mut rng)));
-/// tree.append(Node::new(FrRepr::rand(&mut rng)));
+/// tree.append(Node::new(Fr::random(&mut rng).into_repr()));
+/// tree.append(Node::new(Fr::random(&mut rng).into_repr()));
 /// let mut witness = IncrementalWitness::from_tree(&tree);
 /// assert_eq!(witness.position(), 1);
 /// assert_eq!(tree.root(), witness.root());
 ///
-/// let cmu = Node::new(FrRepr::rand(&mut rng));
+/// let cmu = Node::new(Fr::random(&mut rng).into_repr());
 /// tree.append(cmu);
 /// witness.append(cmu);
 /// assert_eq!(tree.root(), witness.root());

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -137,7 +137,7 @@ impl Memo {
 
 fn generate_esk() -> Fs {
     // create random 64 byte buffer
-    let mut rng = OsRng::new().expect("should be able to construct RNG");
+    let mut rng = OsRng;
     let mut buffer = [0u8; 64];
     rng.fill_bytes(&mut buffer);
 
@@ -228,7 +228,7 @@ fn prf_ock(
 ///     JUBJUB,
 /// };
 ///
-/// let mut rng = OsRng::new().unwrap();
+/// let mut rng = OsRng;
 ///
 /// let diversifier = Diversifier([0; 11]);
 /// let pk_d = diversifier.g_d::<Bls12>(&JUBJUB).unwrap();
@@ -848,7 +848,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_ivk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, _, _, cmu, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_epk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, ivk, _, cmu, _, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -877,7 +877,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_cmu() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, ivk, _, _, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -889,7 +889,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_tag() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, ivk, _, cmu, epk, mut enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_version_byte() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn decryption_with_incorrect_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_ivk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, _, _, cmu, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -985,7 +985,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_epk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, ivk, _, cmu, _, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_cmu() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (_, ivk, _, _, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_version_byte() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1073,7 +1073,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_incorrect_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_ovk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (mut ovk, _, cv, cmu, epk, enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1114,7 +1114,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_cv() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, _, cmu, epk, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_cmu() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, _, epk, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1152,7 +1152,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_epk() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, _, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1171,7 +1171,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_enc_tag() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1185,7 +1185,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_out_tag() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, epk, enc_ciphertext, mut out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_version_byte() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1221,7 +1221,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn recovery_with_incorrect_diversifier() {
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -5,7 +5,8 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crypto_api_chachapoly::{ChaCha20Ietf, ChachaPolyIetf};
 use ff::{PrimeField, PrimeFieldRepr};
 use pairing::bls12_381::{Bls12, Fr};
-use rand::{OsRng, Rng};
+use rand_core::RngCore;
+use rand_os::OsRng;
 use sapling_crypto::{
     jubjub::{
         edwards,
@@ -138,9 +139,7 @@ fn generate_esk() -> Fs {
     // create random 64 byte buffer
     let mut rng = OsRng::new().expect("should be able to construct RNG");
     let mut buffer = [0u8; 64];
-    for i in 0..buffer.len() {
-        buffer[i] = rng.gen();
-    }
+    rng.fill_bytes(&mut buffer);
 
     // reduce to uniform value
     Fs::to_uniform(&buffer[..])
@@ -213,12 +212,12 @@ fn prf_ock(
 /// ```
 /// extern crate ff;
 /// extern crate pairing;
-/// extern crate rand;
+/// extern crate rand_os;
 /// extern crate sapling_crypto;
 ///
 /// use ff::Field;
 /// use pairing::bls12_381::Bls12;
-/// use rand::OsRng;
+/// use rand_os::OsRng;
 /// use sapling_crypto::{
 ///     jubjub::fs::Fs,
 ///     primitives::{Diversifier, PaymentAddress, ValueCommitment},
@@ -562,7 +561,8 @@ mod tests {
     use crypto_api_chachapoly::ChachaPolyIetf;
     use ff::{Field, PrimeField, PrimeFieldRepr};
     use pairing::bls12_381::{Bls12, Fr, FrRepr};
-    use rand::{thread_rng, RngCore};
+    use rand_core::RngCore;
+    use rand_os::OsRng;
     use sapling_crypto::{
         jubjub::{
             edwards,
@@ -848,7 +848,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_ivk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, _, _, cmu, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_epk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, ivk, _, cmu, _, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -877,7 +877,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_cmu() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, ivk, _, _, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -889,7 +889,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_tag() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, ivk, _, cmu, epk, mut enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_version_byte() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn decryption_with_invalid_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn decryption_with_incorrect_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_ivk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, _, _, cmu, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -985,7 +985,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_epk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, ivk, _, cmu, _, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_cmu() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (_, ivk, _, _, epk, enc_ciphertext, _) = random_enc_ciphertext(&mut rng);
 
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_version_byte() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_invalid_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1073,7 +1073,7 @@ mod tests {
 
     #[test]
     fn compact_decryption_with_incorrect_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, ivk, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_ovk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (mut ovk, _, cv, cmu, epk, enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1114,7 +1114,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_cv() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, _, cmu, epk, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_cmu() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, _, epk, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1152,7 +1152,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_epk() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, _, enc_ciphertext, out_ciphertext) = random_enc_ciphertext(&mut rng);
 
@@ -1171,7 +1171,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_enc_tag() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1185,7 +1185,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_out_tag() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, epk, enc_ciphertext, mut out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_version_byte() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1221,7 +1221,7 @@ mod tests {
 
     #[test]
     fn recovery_with_invalid_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn recovery_with_incorrect_diversifier() {
-        let mut rng = thread_rng();
+        let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         let (ovk, _, cv, cmu, epk, mut enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext(&mut rng);

--- a/zcash_primitives/src/sapling.rs
+++ b/zcash_primitives/src/sapling.rs
@@ -113,7 +113,7 @@ pub fn spend_sig(
     params: &JubjubBls12,
 ) -> Signature {
     // Initialize secure RNG
-    let mut rng = OsRng::new().expect("should be able to construct RNG");
+    let mut rng = OsRng;
 
     // We compute `rsk`...
     let rsk = ask.randomize(ar);

--- a/zcash_primitives/src/sapling.rs
+++ b/zcash_primitives/src/sapling.rs
@@ -2,7 +2,7 @@
 
 use ff::{BitIterator, PrimeField, PrimeFieldRepr};
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
-use rand::OsRng;
+use rand_os::OsRng;
 use sapling_crypto::{
     jubjub::{fs::Fs, FixedGenerators, JubjubBls12},
     pedersen_hash::{pedersen_hash, Personalization},

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1,6 +1,6 @@
 use ff::Field;
 use pairing::bls12_381::Bls12;
-use rand::thread_rng;
+use rand_os::OsRng;
 use sapling_crypto::{
     jubjub::{fs::Fs, FixedGenerators},
     redjubjub::PrivateKey,
@@ -197,7 +197,7 @@ fn tx_write_rejects_unexpected_binding_sig() {
 
     // Fails with an unexpected binding signature
     {
-        let rng = &mut thread_rng();
+        let rng = &mut OsRng::new().expect("should be able to construct RNG");
         let sk = PrivateKey::<Bls12>(Fs::random(rng));
         let sig = sk.sign(
             b"Foo bar",

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -197,7 +197,7 @@ fn tx_write_rejects_unexpected_binding_sig() {
 
     // Fails with an unexpected binding signature
     {
-        let rng = &mut OsRng::new().expect("should be able to construct RNG");
+        let rng = &mut OsRng;
         let sk = PrivateKey::<Bls12>(Fs::random(rng));
         let sig = sk.sign(
             b"Foo bar",

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1,6 +1,10 @@
+use ff::Field;
 use pairing::bls12_381::Bls12;
-use rand::{thread_rng, Rng};
-use sapling_crypto::{jubjub::FixedGenerators, redjubjub::PrivateKey};
+use rand::thread_rng;
+use sapling_crypto::{
+    jubjub::{fs::Fs, FixedGenerators},
+    redjubjub::PrivateKey,
+};
 
 use super::{
     components::{Amount, Script},
@@ -194,7 +198,7 @@ fn tx_write_rejects_unexpected_binding_sig() {
     // Fails with an unexpected binding signature
     {
         let rng = &mut thread_rng();
-        let sk = PrivateKey::<Bls12>(rng.gen());
+        let sk = PrivateKey::<Bls12>(Fs::random(rng));
         let sig = sk.sign(
             b"Foo bar",
             rng,

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -11,6 +11,6 @@ blake2b_simd = "0.5"
 byteorder = "1"
 ff = { path = "../ff" }
 pairing = { path = "../pairing" }
-rand = "0.4"
+rand = "0.5"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -11,6 +11,6 @@ blake2b_simd = "0.5"
 byteorder = "1"
 ff = { path = "../ff" }
 pairing = { path = "../pairing" }
-rand = "0.5"
+rand_os = "0.1"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -11,6 +11,6 @@ blake2b_simd = "0.5"
 byteorder = "1"
 ff = { path = "../ff" }
 pairing = { path = "../pairing" }
-rand_os = "0.1"
+rand_os = "0.2"
 sapling-crypto = { path = "../sapling-crypto" }
 zcash_primitives = { path = "../zcash_primitives" }

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -3,7 +3,7 @@ extern crate blake2b_simd;
 extern crate byteorder;
 extern crate ff;
 extern crate pairing;
-extern crate rand;
+extern crate rand_os;
 extern crate sapling_crypto;
 extern crate zcash_primitives;
 

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -3,7 +3,7 @@ use bellman::groth16::{
 };
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};
-use rand::{OsRng, Rand};
+use rand::OsRng;
 use sapling_crypto::{
     circuit::{
         multipack,
@@ -59,7 +59,7 @@ impl SaplingProvingContext {
         let mut rng = OsRng::new().expect("should be able to construct RNG");
 
         // We create the randomness of the value commitment
-        let rcv = Fs::rand(&mut rng);
+        let rcv = Fs::random(&mut rng);
 
         // Accumulate the value commitment randomness in the context
         {
@@ -194,7 +194,7 @@ impl SaplingProvingContext {
         // We construct ephemeral randomness for the value commitment. This
         // randomness is not given back to the caller, but the synthetic
         // blinding factor `bsk` is accumulated in the context.
-        let rcv = Fs::rand(&mut rng);
+        let rcv = Fs::random(&mut rng);
 
         // Accumulate the value commitment randomness in the context
         {

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -56,7 +56,7 @@ impl SaplingProvingContext {
         (),
     > {
         // Initialize secure RNG
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         // We create the randomness of the value commitment
         let rcv = Fs::random(&mut rng);
@@ -189,7 +189,7 @@ impl SaplingProvingContext {
         params: &JubjubBls12,
     ) -> (Proof<Bls12>, edwards::Point<Bls12, Unknown>) {
         // Initialize secure RNG
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         // We construct ephemeral randomness for the value commitment. This
         // randomness is not given back to the caller, but the synthetic
@@ -250,7 +250,7 @@ impl SaplingProvingContext {
         params: &JubjubBls12,
     ) -> Result<Signature, ()> {
         // Initialize secure RNG
-        let mut rng = OsRng::new().expect("should be able to construct RNG");
+        let mut rng = OsRng;
 
         // Grab the current `bsk` from the context
         let bsk = PrivateKey::<Bls12>(self.bsk);

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -3,7 +3,7 @@ use bellman::groth16::{
 };
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};
-use rand::OsRng;
+use rand_os::OsRng;
 use sapling_crypto::{
     circuit::{
         multipack,


### PR DESCRIPTION
Also moves to `rand_core` where possible, to reduce the dependency surface.

Closes #60.