### PR TITLE
Run Siderophile on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
+dist: xenial
 language: rust
 rust:
   - 1.36.0
+
+addons:
+  apt:
+    sources:
+     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    packages:
+     - llvm-9
+     - llvm-9-tools
 
 cache: cargo
 
 script:
   - cargo test --verbose --release --all
+  - CARGO_INCREMENTAL=0 ./ci/siderophile.sh bellman ff group librustzcash pairing sapling-crypto zcash_client_backend zcash_primitives zcash_proofs

--- a/ci/siderophile.sh
+++ b/ci/siderophile.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -uex
+
+python3 --version
+opt --version
+
+if [ -z ${SIDEROPHILE_DIR+x} ]; then
+    TEMP=$(mktemp -d -t)
+    SIDEROPHILE_DIR="$TEMP/siderophile"
+    git clone -b taylor-patches https://github.com/defuse/siderophile/ "$TEMP/siderophile"
+    cd "$SIDEROPHILE_DIR"
+    git rev-parse HEAD
+    ./setup.sh
+    cd -
+fi
+
+for crate in "$@"
+do
+    cd $crate
+    rm -rf siderophile_out
+    # Find the last-installed version of LLVM.
+    # From https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/master/.travis.yml
+    VERSION=`ls -t /usr/lib/ | grep '^llvm-' | head -n 1 | sed -E 's/llvm-(.+)/\1/'`
+    export PATH="$(llvm-config-$VERSION --bindir):$PATH"
+    # TODO: We probably want an arbitrary map between directory / crate names.
+    crate_underscore=$(echo "$crate" | tr "-" "_" | sed 's/librustzcash/rustzcash/')
+    "$SIDEROPHILE_DIR/analyze.sh" $crate_underscore > /dev/null
+    cd ..
+done
+
+set +x
+
+for crate in "$@"
+do
+    cd $crate
+
+    CRATE_ARTIFACTS="../ci/artifacts/$crate/siderophile"
+    mkdir -p "$CRATE_ARTIFACTS"
+    cp siderophile_out/nodes_to_taint.txt "$CRATE_ARTIFACTS/nodes_to_taint.txt"
+    cp siderophile_out/badness.txt "$CRATE_ARTIFACTS/badness.txt"
+
+    echo "CRATE: $crate"
+    echo "Nodes to taint:"
+    cat siderophile_out/nodes_to_taint.txt | sed 's/^/    /'
+    echo "Badness:"
+    cat siderophile_out/badness.txt | sed 's/^/    /'
+    cd ..
+done


### PR DESCRIPTION
This adds a script to run [siderophile](https://blog.trailofbits.com/2019/07/01/siderophile-expose-your-crates-unsafety/) against all of the crates in librustzcash, and makes it run on Travis-CI.

You may want to hold off on merging this because (a) it allows me to push malicious code to my fork of siderophile which will be executed by the script and (b) the dev-inf team (@mdr0id et al.) are working on better CI, and with that we'll be able to put the results somewhere more visible than the Travis-CI output log.

You should be able to see the current results in the Travis-CI log for this PR.

