### PR TITLE
Edition 2018 clean up

### DIFF
--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 name = "bellman"
 repository = "https://github.com/ebfull/bellman"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 bit-vec = "0.4.4"

--- a/bellman/src/gadgets/uint32.rs
+++ b/bellman/src/gadgets/uint32.rs
@@ -401,7 +401,7 @@ mod test {
         ]);
 
         for _ in 0..1000 {
-            let mut v = (0..32)
+            let v = (0..32)
                 .map(|_| Boolean::constant(rng.next_u32() % 2 != 0))
                 .collect::<Vec<_>>();
 
@@ -436,7 +436,7 @@ mod test {
         ]);
 
         for _ in 0..1000 {
-            let mut v = (0..32)
+            let v = (0..32)
                 .map(|_| Boolean::constant(rng.next_u32() % 2 != 0))
                 .collect::<Vec<_>>();
 

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -8,11 +8,11 @@ use pairing::Engine;
 
 use super::{Parameters, VerifyingKey};
 
-use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use crate::{Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
-use domain::{EvaluationDomain, Scalar};
+use crate::domain::{EvaluationDomain, Scalar};
 
-use multicore::Worker;
+use crate::multicore::Worker;
 
 /// Generates a random common reference string for
 /// a circuit.

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -1,10 +1,10 @@
 use group::{CurveAffine, EncodedPoint};
 use pairing::{Engine, PairingCurveAffine};
 
-use SynthesisError;
+use crate::SynthesisError;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use multiexp::SourceBuilder;
+use crate::multiexp::SourceBuilder;
 use std::io::{self, Read, Write};
 use std::sync::Arc;
 
@@ -465,7 +465,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a Parameters<E> {
 #[cfg(test)]
 mod test_with_bls12_381 {
     use super::*;
-    use {Circuit, ConstraintSystem, SynthesisError};
+    use crate::{Circuit, ConstraintSystem, SynthesisError};
 
     use ff::Field;
     use pairing::bls12_381::{Bls12, Fr};

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -3,8 +3,8 @@ use pairing::{Engine, PairingCurveAffine};
 
 use crate::SynthesisError;
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crate::multiexp::SourceBuilder;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
 use std::sync::Arc;
 

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -10,13 +10,13 @@ use pairing::Engine;
 
 use super::{ParameterSource, Proof};
 
-use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use crate::{Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
-use domain::{EvaluationDomain, Scalar};
+use crate::domain::{EvaluationDomain, Scalar};
 
-use multiexp::{multiexp, DensityTracker, FullDensity};
+use crate::multiexp::{multiexp, DensityTracker, FullDensity};
 
-use multicore::Worker;
+use crate::multicore::Worker;
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -16,7 +16,7 @@ const MODULUS_R: Wrapping<u32> = Wrapping(64513);
 pub struct Fr(Wrapping<u32>);
 
 impl fmt::Display for Fr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", (self.0).0)
     }
 }
@@ -149,7 +149,7 @@ impl PartialOrd for FrRepr {
 }
 
 impl fmt::Display for FrRepr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", (self.0)[0])
     }
 }

--- a/bellman/src/groth16/tests/mod.rs
+++ b/bellman/src/groth16/tests/mod.rs
@@ -6,7 +6,7 @@ use self::dummy_engine::*;
 
 use std::marker::PhantomData;
 
-use {Circuit, ConstraintSystem, SynthesisError};
+use crate::{Circuit, ConstraintSystem, SynthesisError};
 
 use super::{create_proof, generate_parameters, prepare_verifying_key, verify_proof};
 

--- a/bellman/src/groth16/verifier.rs
+++ b/bellman/src/groth16/verifier.rs
@@ -4,7 +4,7 @@ use pairing::{Engine, PairingCurveAffine};
 
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 
-use SynthesisError;
+use crate::SynthesisError;
 
 pub fn prepare_verifying_key<E: Engine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     let mut gamma = vk.gamma_g2;

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -1,18 +1,16 @@
-extern crate ff;
-extern crate group;
-#[cfg(feature = "pairing")]
-extern crate pairing;
-extern crate rand_core;
 
-extern crate bit_vec;
-extern crate blake2s_simd;
-extern crate byteorder;
-extern crate futures;
+
+
+
+
+
+
+
+
 
 #[cfg(feature = "multicore")]
 extern crate crossbeam;
-#[cfg(feature = "multicore")]
-extern crate futures_cpupool;
+
 #[cfg(feature = "multicore")]
 extern crate num_cpus;
 
@@ -23,11 +21,9 @@ extern crate hex_literal;
 #[cfg(test)]
 extern crate rand;
 
-#[cfg(test)]
-extern crate rand_xorshift;
 
-#[cfg(test)]
-extern crate sha2;
+
+
 
 pub mod domain;
 pub mod gadgets;
@@ -230,7 +226,7 @@ impl Error for SynthesisError {
 }
 
 impl fmt::Display for SynthesisError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         if let &SynthesisError::IoError(ref e) = self {
             write!(f, "I/O error: ")?;
             e.fmt(f)
@@ -309,7 +305,7 @@ pub trait ConstraintSystem<E: ScalarEngine>: Sized {
 
 /// This is a "namespaced" constraint system which borrows a constraint system (pushing
 /// a namespace context) and, when dropped, pops out of the namespace context.
-pub struct Namespace<'a, E: ScalarEngine, CS: ConstraintSystem<E> + 'a>(&'a mut CS, PhantomData<E>);
+pub struct Namespace<'a, E: ScalarEngine, CS: ConstraintSystem<E>>(&'a mut CS, PhantomData<E>);
 
 impl<'cs, E: ScalarEngine, CS: ConstraintSystem<E>> ConstraintSystem<E> for Namespace<'cs, E, CS> {
     type Root = CS::Root;

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -1,13 +1,3 @@
-
-
-
-
-
-
-
-
-
-
 #[cfg(feature = "multicore")]
 extern crate crossbeam;
 
@@ -20,10 +10,6 @@ extern crate hex_literal;
 
 #[cfg(test)]
 extern crate rand;
-
-
-
-
 
 pub mod domain;
 pub mod gadgets;

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -153,7 +153,7 @@ fn multiexp_inner<Q, D, G, S>(
     mut skip: u32,
     c: u32,
     handle_trivial: bool,
-) -> Box<Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
+) -> Box<dyn Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
 where
     for<'a> &'a Q: QueryDensity,
     D: Send + Sync + 'static + Clone + AsRef<Q>,
@@ -256,7 +256,7 @@ pub fn multiexp<Q, D, G, S>(
     bases: S,
     density_map: D,
     exponents: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
-) -> Box<Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
+) -> Box<dyn Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
 where
     for<'a> &'a Q: QueryDensity,
     D: Send + Sync + 'static + Clone + AsRef<Q>,

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -1,7 +1,7 @@
-extern crate bellman;
-extern crate ff;
-extern crate pairing;
-extern crate rand;
+
+
+
+
 
 // For randomness (during paramgen and proof generation)
 use rand::thread_rng;

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -1,8 +1,3 @@
-
-
-
-
-
 // For randomness (during paramgen and proof generation)
 use rand::thread_rng;
 

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -90,12 +90,12 @@ impl<'a, E: Engine> Circuit<E> for MiMCDemo<'a, E> {
             let cs = &mut cs.namespace(|| format!("round {}", i));
 
             // tmp = (xL + Ci)^2
-            let mut tmp_value = xl_value.map(|mut e| {
+            let tmp_value = xl_value.map(|mut e| {
                 e.add_assign(&self.constants[i]);
                 e.square();
                 e
             });
-            let mut tmp = cs.alloc(
+            let tmp = cs.alloc(
                 || "tmp",
                 || tmp_value.ok_or(SynthesisError::AssignmentMissing),
             )?;
@@ -110,14 +110,14 @@ impl<'a, E: Engine> Circuit<E> for MiMCDemo<'a, E> {
             // new_xL = xR + (xL + Ci)^3
             // new_xL = xR + tmp * (xL + Ci)
             // new_xL - xR = tmp * (xL + Ci)
-            let mut new_xl_value = xl_value.map(|mut e| {
+            let new_xl_value = xl_value.map(|mut e| {
                 e.add_assign(&self.constants[i]);
                 e.mul_assign(&tmp_value.unwrap());
                 e.add_assign(&xr_value.unwrap());
                 e
             });
 
-            let mut new_xl = if i == (MIMC_ROUNDS - 1) {
+            let new_xl = if i == (MIMC_ROUNDS - 1) {
                 // This is the last round, xL is our image and so
                 // we allocate a public input.
                 cs.alloc_input(

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/ff/"
 homepage = "https://github.com/ebfull/ff"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/ebfull/ff"
+edition = "2018"
 
 [dependencies]
 byteorder = "1"

--- a/ff/ff_derive/Cargo.toml
+++ b/ff/ff_derive/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/ff/"
 homepage = "https://github.com/ebfull/ff"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/ebfull/ff"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/ff/ff_derive/src/lib.rs
+++ b/ff/ff_derive/src/lib.rs
@@ -122,9 +122,9 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
         impl ::std::fmt::Debug for #repr
         {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                try!(write!(f, "0x"));
+                write!(f, "0x")?;
                 for i in self.0.iter().rev() {
-                    try!(write!(f, "{:016x}", *i));
+                    write!(f, "{:016x}", *i)?;
                 }
 
                 Ok(())
@@ -133,9 +133,9 @@ fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenS
 
         impl ::std::fmt::Display for #repr {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                try!(write!(f, "0x"));
+                write!(f, "0x")?;
                 for i in self.0.iter().rev() {
-                    try!(write!(f, "{:016x}", *i));
+                    write!(f, "{:016x}", *i)?;
                 }
 
                 Ok(())

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -266,7 +266,7 @@ pub trait PrimeField: Field {
     }
 
     /// Convert this prime field element into a biginteger representation.
-    fn from_repr(Self::Repr) -> Result<Self, PrimeFieldDecodingError>;
+    fn from_repr(_: Self::Repr) -> Result<Self, PrimeFieldDecodingError>;
 
     /// Convert a biginteger representation into a prime field element, if
     /// the number is an element of the field.

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
-extern crate byteorder;
-extern crate rand_core;
+
+
 
 #[cfg(feature = "derive")]
 #[macro_use]
@@ -210,7 +210,7 @@ impl Error for PrimeFieldDecodingError {
 }
 
 impl fmt::Display for PrimeFieldDecodingError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             PrimeFieldDecodingError::NotInField(ref repr) => {
                 write!(f, "{} is not an element of the field", repr)

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -1,8 +1,5 @@
 #![allow(unused_imports)]
 
-
-
-
 #[cfg(feature = "derive")]
 #[macro_use]
 extern crate ff_derive;

--- a/group/Cargo.toml
+++ b/group/Cargo.toml
@@ -11,6 +11,7 @@ description = "Elliptic curve group traits and utilities"
 documentation = "https://docs.rs/group/"
 homepage = "https://github.com/ebfull/group"
 repository = "https://github.com/ebfull/group"
+edition = "2018"
 
 [dependencies]
 ff = { path = "../ff" }

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -1,6 +1,6 @@
-extern crate ff;
-extern crate rand;
-extern crate rand_xorshift;
+
+
+
 
 use ff::{PrimeField, PrimeFieldDecodingError, ScalarEngine, SqrtField};
 use rand::RngCore;
@@ -180,7 +180,7 @@ impl Error for GroupDecodingError {
 }
 
 impl fmt::Display for GroupDecodingError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             GroupDecodingError::CoordinateDecodingError(description, ref err) => {
                 write!(f, "{} decoding error: {}", description, err)

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -1,7 +1,3 @@
-
-
-
-
 use ff::{PrimeField, PrimeFieldDecodingError, ScalarEngine, SqrtField};
 use rand::RngCore;
 use std::error::Error;

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -2,7 +2,7 @@ use ff::{Field, PrimeField};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use {CurveAffine, CurveProjective, EncodedPoint};
+use crate::{CurveAffine, CurveProjective, EncodedPoint};
 
 pub fn curve_tests<G: CurveProjective>() {
     let mut rng = XorShiftRng::from_seed([
@@ -71,7 +71,7 @@ pub fn curve_tests<G: CurveProjective>() {
 }
 
 fn random_wnaf_tests<G: CurveProjective>() {
-    use wnaf::*;
+    use crate::wnaf::*;
 
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,

--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -6,7 +6,8 @@ authors = [
     "Jack Grigg <jack@z.cash>",
     "Jay Graber <jay@z.cash>",
     "Simon Liu <simon@z.cash>"
-    ]
+]
+edition = "2018"
 
 [lib]
 name = "rustzcash"

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -1,15 +1,3 @@
-
-
-
-
-
-
-
-
-
-
-
-
 use lazy_static;
 
 use ff::{PrimeField, PrimeFieldRepr};

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -1,16 +1,16 @@
-extern crate bellman;
-extern crate blake2b_simd;
-extern crate blake2s_simd;
-extern crate byteorder;
-extern crate ff;
-extern crate libc;
-extern crate pairing;
-extern crate rand_core;
-extern crate rand_os;
-extern crate zcash_primitives;
-extern crate zcash_proofs;
 
-extern crate lazy_static;
+
+
+
+
+
+
+
+
+
+
+
+use lazy_static;
 
 use ff::{PrimeField, PrimeFieldRepr};
 use pairing::bls12_381::{Bls12, Fr, FrRepr};

--- a/librustzcash/src/tests/key_agreement.rs
+++ b/librustzcash/src/tests/key_agreement.rs
@@ -5,7 +5,7 @@ use rand_os::OsRng;
 use zcash_primitives::jubjub::{edwards, JubjubBls12};
 use zcash_primitives::primitives::{Diversifier, ViewingKey};
 
-use {
+use crate::{
     librustzcash_sapling_generate_r, librustzcash_sapling_ka_agree,
     librustzcash_sapling_ka_derivepublic,
 };

--- a/librustzcash/src/tests/key_components.rs
+++ b/librustzcash/src/tests/key_components.rs
@@ -7,7 +7,7 @@ use zcash_primitives::{
 
 use super::JUBJUB;
 
-use {
+use crate::{
     librustzcash_ask_to_ak, librustzcash_check_diversifier, librustzcash_crh_ivk,
     librustzcash_ivk_to_pkd, librustzcash_nsk_to_nk,
 };

--- a/librustzcash/src/tests/notes.rs
+++ b/librustzcash/src/tests/notes.rs
@@ -1,5 +1,5 @@
-use librustzcash_sapling_compute_cm;
-use librustzcash_sapling_compute_nf;
+use crate::librustzcash_sapling_compute_cm;
+use crate::librustzcash_sapling_compute_nf;
 
 #[test]
 fn notes() {

--- a/pairing/Cargo.toml
+++ b/pairing/Cargo.toml
@@ -13,6 +13,7 @@ description = "Pairing-friendly elliptic curve library"
 documentation = "https://docs.rs/pairing/"
 homepage = "https://github.com/ebfull/pairing"
 repository = "https://github.com/ebfull/pairing"
+edition ="2018"
 
 [dependencies]
 byteorder = "1"

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -18,7 +18,7 @@ macro_rules! curve_impl {
         }
 
         impl ::std::fmt::Display for $affine {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 if self.infinity {
                     write!(f, "{}(Infinity)", $name)
                 } else {
@@ -35,7 +35,7 @@ macro_rules! curve_impl {
         }
 
         impl ::std::fmt::Display for $projective {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(f, "{}", self.into_affine())
             }
         }
@@ -656,7 +656,7 @@ pub mod g1 {
     }
 
     impl fmt::Debug for G1Uncompressed {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
             self.0[..].fmt(formatter)
         }
     }
@@ -766,7 +766,7 @@ pub mod g1 {
     }
 
     impl fmt::Debug for G1Compressed {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
             self.0[..].fmt(formatter)
         }
     }
@@ -1325,7 +1325,7 @@ pub mod g2 {
     }
 
     impl fmt::Debug for G2Uncompressed {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
             self.0[..].fmt(formatter)
         }
     }
@@ -1451,7 +1451,7 @@ pub mod g2 {
     }
 
     impl fmt::Debug for G2Compressed {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
             self.0[..].fmt(formatter)
         }
     }

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -626,7 +626,7 @@ pub mod g1 {
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
-    use {Engine, PairingCurveAffine};
+    use crate::{Engine, PairingCurveAffine};
 
     curve_impl!(
         "G1",
@@ -934,7 +934,7 @@ pub mod g1 {
 
     #[test]
     fn g1_generator() {
-        use SqrtField;
+        use crate::SqrtField;
 
         let mut x = Fq::zero();
         let mut i = 0;
@@ -1295,7 +1295,7 @@ pub mod g2 {
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
-    use {Engine, PairingCurveAffine};
+    use crate::{Engine, PairingCurveAffine};
 
     curve_impl!(
         "G2",
@@ -1640,7 +1640,7 @@ pub mod g2 {
 
     #[test]
     fn g2_generator() {
-        use SqrtField;
+        use crate::SqrtField;
 
         let mut x = Fq2::zero();
         let mut i = 0;

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -622,11 +622,11 @@ macro_rules! curve_impl {
 pub mod g1 {
     use super::super::{Bls12, Fq, Fq12, FqRepr, Fr, FrRepr};
     use super::g2::G2Affine;
+    use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
-    use crate::{Engine, PairingCurveAffine};
 
     curve_impl!(
         "G1",
@@ -1291,11 +1291,11 @@ pub mod g1 {
 pub mod g2 {
     use super::super::{Bls12, Fq, Fq12, Fq2, FqRepr, Fr, FrRepr};
     use super::g1::G1Affine;
+    use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
-    use crate::{Engine, PairingCurveAffine};
 
     curve_impl!(
         "G2",

--- a/pairing/src/bls12_381/fq.rs
+++ b/pairing/src/bls12_381/fq.rs
@@ -2225,10 +2225,10 @@ fn test_fq_root_of_unity() {
 
 #[test]
 fn fq_field_tests() {
-    ::tests::field::random_field_tests::<Fq>();
-    ::tests::field::random_sqrt_tests::<Fq>();
-    ::tests::field::random_frobenius_tests::<Fq, _>(Fq::char(), 13);
-    ::tests::field::from_str_tests::<Fq>();
+    crate::tests::field::random_field_tests::<Fq>();
+    crate::tests::field::random_sqrt_tests::<Fq>();
+    crate::tests::field::random_frobenius_tests::<Fq, _>(Fq::char(), 13);
+    crate::tests::field::from_str_tests::<Fq>();
 }
 
 #[test]
@@ -2244,7 +2244,7 @@ fn test_fq_ordering() {
 
 #[test]
 fn fq_repr_tests() {
-    ::tests::repr::random_repr_tests::<Fq>();
+    crate::tests::repr::random_repr_tests::<Fq>();
 }
 
 #[test]

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -187,6 +187,6 @@ fn test_fq12_mul_by_014() {
 fn fq12_field_tests() {
     use ff::PrimeField;
 
-    ::tests::field::random_field_tests::<Fq12>();
-    ::tests::field::random_frobenius_tests::<Fq12, _>(super::fq::Fq::char(), 13);
+    crate::tests::field::random_field_tests::<Fq12>();
+    crate::tests::field::random_frobenius_tests::<Fq12, _>(super::fq::Fq::char(), 13);
 }

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -12,7 +12,7 @@ pub struct Fq12 {
 }
 
 impl ::std::fmt::Display for Fq12 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Fq12({} + {} * w)", self.c0, self.c1)
     }
 }

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -12,7 +12,7 @@ pub struct Fq2 {
 }
 
 impl ::std::fmt::Display for Fq2 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Fq2({} + {} * u)", self.c0, self.c1)
     }
 }

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -958,7 +958,7 @@ fn test_fq2_mul_nonresidue() {
 fn fq2_field_tests() {
     use ff::PrimeField;
 
-    ::tests::field::random_field_tests::<Fq2>();
-    ::tests::field::random_sqrt_tests::<Fq2>();
-    ::tests::field::random_frobenius_tests::<Fq2, _>(super::fq::Fq::char(), 13);
+    crate::tests::field::random_field_tests::<Fq2>();
+    crate::tests::field::random_sqrt_tests::<Fq2>();
+    crate::tests::field::random_frobenius_tests::<Fq2, _>(super::fq::Fq::char(), 13);
 }

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -378,6 +378,6 @@ fn test_fq6_mul_by_01() {
 fn fq6_field_tests() {
     use ff::PrimeField;
 
-    ::tests::field::random_field_tests::<Fq6>();
-    ::tests::field::random_frobenius_tests::<Fq6, _>(super::fq::Fq::char(), 13);
+    crate::tests::field::random_field_tests::<Fq6>();
+    crate::tests::field::random_frobenius_tests::<Fq6, _>(super::fq::Fq::char(), 13);
 }

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -12,7 +12,7 @@ pub struct Fq6 {
 }
 
 impl ::std::fmt::Display for Fq6 {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Fq6({} + {} * v, {} * v^2)", self.c0, self.c1, self.c2)
     }
 }

--- a/pairing/src/bls12_381/fr.rs
+++ b/pairing/src/bls12_381/fr.rs
@@ -1015,13 +1015,13 @@ fn test_fr_root_of_unity() {
 
 #[test]
 fn fr_field_tests() {
-    ::tests::field::random_field_tests::<Fr>();
-    ::tests::field::random_sqrt_tests::<Fr>();
-    ::tests::field::random_frobenius_tests::<Fr, _>(Fr::char(), 13);
-    ::tests::field::from_str_tests::<Fr>();
+    crate::tests::field::random_field_tests::<Fr>();
+    crate::tests::field::random_sqrt_tests::<Fr>();
+    crate::tests::field::random_frobenius_tests::<Fr, _>(Fr::char(), 13);
+    crate::tests::field::from_str_tests::<Fr>();
 }
 
 #[test]
 fn fr_repr_tests() {
-    ::tests::repr::random_repr_tests::<Fr>();
+    crate::tests::repr::random_repr_tests::<Fr>();
 }

--- a/pairing/src/bls12_381/mod.rs
+++ b/pairing/src/bls12_381/mod.rs
@@ -366,5 +366,5 @@ impl G2Prepared {
 
 #[test]
 fn bls12_engine_tests() {
-    ::tests::engine::engine_tests::<Bls12>();
+    crate::tests::engine::engine_tests::<Bls12>();
 }

--- a/pairing/src/bls12_381/tests/mod.rs
+++ b/pairing/src/bls12_381/tests/mod.rs
@@ -2,7 +2,7 @@ use ff::PrimeFieldRepr;
 use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
 
 use super::*;
-use *;
+use crate::*;
 
 #[test]
 fn test_pairing_result_against_relic() {

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -11,13 +11,6 @@
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 
-
-
-
-
-
-
-
 #[cfg(test)]
 pub mod tests;
 

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -11,13 +11,12 @@
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 
-extern crate byteorder;
-extern crate ff;
-extern crate group;
-extern crate rand_core;
 
-#[cfg(test)]
-extern crate rand_xorshift;
+
+
+
+
+
 
 #[cfg(test)]
 pub mod tests;

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -87,7 +87,7 @@ pub trait Engine: ScalarEngine {
         >;
 
     /// Perform final exponentiation of the result of a miller loop.
-    fn final_exponentiation(&Self::Fqk) -> Option<Self::Fqk>;
+    fn final_exponentiation(_: &Self::Fqk) -> Option<Self::Fqk>;
 
     /// Performs a complete pairing operation `(p, q)`.
     fn pairing<G1, G2>(p: G1, q: G2) -> Self::Fqk

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -2,7 +2,7 @@ use group::{CurveAffine, CurveProjective};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use {Engine, Field, PairingCurveAffine, PrimeField};
+use crate::{Engine, Field, PairingCurveAffine, PrimeField};
 
 pub fn engine_tests<E: Engine>() {
     let mut rng = XorShiftRng::from_seed([

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
+edition = "2018"
 
 [dependencies]
 aes = "0.3"

--- a/zcash_primitives/src/block.rs
+++ b/zcash_primitives/src/block.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-use serialize::Vector;
+use crate::serialize::Vector;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BlockHash(pub [u8; 32]);

--- a/zcash_primitives/src/block.rs
+++ b/zcash_primitives/src/block.rs
@@ -10,7 +10,7 @@ use crate::serialize::Vector;
 pub struct BlockHash(pub [u8; 32]);
 
 impl fmt::Display for BlockHash {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut data = self.0.clone();
         data.reverse();
         formatter.write_str(&hex::encode(data))

--- a/zcash_primitives/src/group_hash.rs
+++ b/zcash_primitives/src/group_hash.rs
@@ -1,9 +1,9 @@
-use jubjub::{edwards, JubjubEngine, PrimeOrder};
+use crate::jubjub::{edwards, JubjubEngine, PrimeOrder};
 
 use ff::PrimeField;
 
 use blake2s_simd::Params;
-use constants;
+use crate::constants;
 
 /// Produces a random point in the Jubjub curve.
 /// The point is guaranteed to be prime order

--- a/zcash_primitives/src/group_hash.rs
+++ b/zcash_primitives/src/group_hash.rs
@@ -2,8 +2,8 @@ use crate::jubjub::{edwards, JubjubEngine, PrimeOrder};
 
 use ff::PrimeField;
 
-use blake2s_simd::Params;
 use crate::constants;
+use blake2s_simd::Params;
 
 /// Produces a random point in the Jubjub curve.
 /// The point is guaranteed to be prime order

--- a/zcash_primitives/src/jubjub/fs.rs
+++ b/zcash_primitives/src/jubjub/fs.rs
@@ -74,7 +74,7 @@ const NEGATIVE_ONE: Fs = Fs(FsRepr([
 pub struct FsRepr(pub [u64; 4]);
 
 impl ::std::fmt::Display for FsRepr {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         r#write!(f, "0x")?;
         for i in self.0.iter().rev() {
             r#write!(f, "{:016x}", *i)?;
@@ -257,7 +257,7 @@ impl PrimeFieldRepr for FsRepr {
 pub struct Fs(FsRepr);
 
 impl ::std::fmt::Display for Fs {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "Fs({})", self.into_repr())
     }
 }

--- a/zcash_primitives/src/jubjub/fs.rs
+++ b/zcash_primitives/src/jubjub/fs.rs
@@ -75,9 +75,9 @@ pub struct FsRepr(pub [u64; 4]);
 
 impl ::std::fmt::Display for FsRepr {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        r#write!(f, "0x")?;
+        write!(f, "0x")?;
         for i in self.0.iter().rev() {
-            r#write!(f, "{:016x}", *i)?;
+            write!(f, "{:016x}", *i)?;
         }
 
         Ok(())

--- a/zcash_primitives/src/jubjub/fs.rs
+++ b/zcash_primitives/src/jubjub/fs.rs
@@ -75,9 +75,9 @@ pub struct FsRepr(pub [u64; 4]);
 
 impl ::std::fmt::Display for FsRepr {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        try!(write!(f, "0x"));
+        r#try!(write!(f, "0x"));
         for i in self.0.iter().rev() {
-            try!(write!(f, "{:016x}", *i));
+            r#try!(write!(f, "{:016x}", *i));
         }
 
         Ok(())

--- a/zcash_primitives/src/jubjub/fs.rs
+++ b/zcash_primitives/src/jubjub/fs.rs
@@ -75,9 +75,9 @@ pub struct FsRepr(pub [u64; 4]);
 
 impl ::std::fmt::Display for FsRepr {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        r#try!(write!(f, "0x"));
+        r#write!(f, "0x")?;
         for i in self.0.iter().rev() {
-            r#try!(write!(f, "{:016x}", *i));
+            r#write!(f, "{:016x}", *i)?;
         }
 
         Ok(())

--- a/zcash_primitives/src/jubjub/mod.rs
+++ b/zcash_primitives/src/jubjub/mod.rs
@@ -20,9 +20,9 @@
 use ff::{Field, PrimeField, SqrtField};
 use pairing::Engine;
 
-use group_hash::group_hash;
+use crate::group_hash::group_hash;
 
-use constants;
+use crate::constants;
 
 use pairing::bls12_381::{Bls12, Fr};
 
@@ -122,7 +122,7 @@ pub trait JubjubParams<E: JubjubEngine>: Sized {
     fn generator(&self, base: FixedGenerators) -> &edwards::Point<E, PrimeOrder>;
     /// Returns a window table [0, 1, ..., 8] for different magnitudes of some
     /// fixed generator.
-    fn circuit_generators(&self, FixedGenerators) -> &[Vec<(E::Fr, E::Fr)>];
+    fn circuit_generators(&self, _: FixedGenerators) -> &[Vec<(E::Fr, E::Fr)>];
     /// Returns the window size for exponentiation of Pedersen hash generators
     /// outside the circuit
     fn pedersen_hash_exp_window_size() -> u32;

--- a/zcash_primitives/src/jubjub/mod.rs
+++ b/zcash_primitives/src/jubjub/mod.rs
@@ -374,7 +374,7 @@ impl JubjubBls12 {
             let mut pedersen_circuit_generators = vec![];
 
             // Process each segment
-            for mut gen in tmp_params.pedersen_hash_generators.iter().cloned() {
+            for gen in tmp_params.pedersen_hash_generators.iter().cloned() {
                 let mut gen = montgomery::Point::from_edwards(&gen, &tmp_params);
                 let mut windows = vec![];
                 for _ in 0..tmp_params.pedersen_hash_chunks_per_generator() {

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -43,7 +43,7 @@ pub mod zip32;
 #[cfg(test)]
 mod test_vectors;
 
-use jubjub::JubjubBls12;
+use crate::jubjub::JubjubBls12;
 
 lazy_static! {
     pub static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -1,25 +1,9 @@
 #[macro_use]
 extern crate lazy_static;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #[cfg(test)]
 #[macro_use]
 extern crate hex_literal;
-
-
 
 pub mod block;
 pub mod constants;

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -1,26 +1,25 @@
 #[macro_use]
 extern crate lazy_static;
 
-extern crate aes;
-extern crate blake2b_simd;
-extern crate blake2s_simd;
-extern crate byteorder;
-extern crate crypto_api_chachapoly;
-extern crate ff;
-extern crate fpe;
-extern crate hex;
-extern crate pairing;
-extern crate rand;
-extern crate rand_core;
-extern crate rand_os;
-extern crate sha2;
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 #[cfg(test)]
 #[macro_use]
 extern crate hex_literal;
 
-#[cfg(test)]
-extern crate rand_xorshift;
+
 
 pub mod block;
 pub mod constants;

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -5,8 +5,8 @@ use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::iter;
 
-use sapling::SAPLING_COMMITMENT_TREE_DEPTH;
-use serialize::{Optional, Vector};
+use crate::sapling::SAPLING_COMMITMENT_TREE_DEPTH;
+use crate::serialize::{Optional, Vector};
 
 /// A hashable node within a Merkle tree.
 pub trait Hashable: Clone + Copy {
@@ -17,13 +17,13 @@ pub trait Hashable: Clone + Copy {
     fn write<W: Write>(&self, writer: W) -> io::Result<()>;
 
     /// Returns the parent node within the tree of the two given nodes.
-    fn combine(usize, &Self, &Self) -> Self;
+    fn combine(_: usize, _: &Self, _: &Self) -> Self;
 
     /// Returns a blank leaf node.
     fn blank() -> Self;
 
     /// Returns the empty root for the given depth.
-    fn empty_root(usize) -> Self;
+    fn empty_root(_: usize) -> Self;
 }
 
 struct PathFiller<Node: Hashable> {
@@ -509,7 +509,7 @@ impl<Node: Hashable> CommitmentTreeWitness<Node> {
 #[cfg(test)]
 mod tests {
     use super::{CommitmentTree, CommitmentTreeWitness, Hashable, IncrementalWitness, PathFiller};
-    use sapling::Node;
+    use crate::sapling::Node;
 
     use ff::PrimeFieldRepr;
     use hex;

--- a/zcash_primitives/src/pedersen_hash.rs
+++ b/zcash_primitives/src/pedersen_hash.rs
@@ -1,5 +1,5 @@
-use ff::{Field, PrimeField, PrimeFieldRepr};
 use crate::jubjub::*;
+use ff::{Field, PrimeField, PrimeFieldRepr};
 
 #[derive(Copy, Clone)]
 pub enum Personalization {

--- a/zcash_primitives/src/pedersen_hash.rs
+++ b/zcash_primitives/src/pedersen_hash.rs
@@ -1,5 +1,5 @@
 use ff::{Field, PrimeField, PrimeFieldRepr};
-use jubjub::*;
+use crate::jubjub::*;
 
 #[derive(Copy, Clone)]
 pub enum Personalization {

--- a/zcash_primitives/src/primitives.rs
+++ b/zcash_primitives/src/primitives.rs
@@ -1,14 +1,14 @@
 use ff::{Field, PrimeField, PrimeFieldRepr};
 
-use constants;
+use crate::constants;
 
-use group_hash::group_hash;
+use crate::group_hash::group_hash;
 
-use pedersen_hash::{pedersen_hash, Personalization};
+use crate::pedersen_hash::{pedersen_hash, Personalization};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 
-use jubjub::{edwards, FixedGenerators, JubjubEngine, JubjubParams, PrimeOrder};
+use crate::jubjub::{edwards, FixedGenerators, JubjubEngine, JubjubParams, PrimeOrder};
 
 use blake2s_simd::Params as Blake2sParams;
 

--- a/zcash_primitives/src/redjubjub.rs
+++ b/zcash_primitives/src/redjubjub.rs
@@ -6,7 +6,7 @@ use ff::{Field, PrimeField, PrimeFieldRepr};
 use rand_core::RngCore;
 use std::io::{self, Read, Write};
 
-use util::hash_to_scalar;
+use crate::util::hash_to_scalar;
 
 fn read_scalar<E: JubjubEngine, R: Read>(reader: R) -> io::Result<E::Fs> {
     let mut s_repr = <E::Fs as PrimeField>::Repr::default();

--- a/zcash_primitives/src/sapling.rs
+++ b/zcash_primitives/src/sapling.rs
@@ -12,7 +12,7 @@ use std::io::{self, Read, Write};
 
 use crate::merkle_tree::Hashable;
 use crate::redjubjub::{PrivateKey, PublicKey, Signature};
-use JUBJUB;
+use crate::JUBJUB;
 
 pub const SAPLING_COMMITMENT_TREE_DEPTH: usize = 32;
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1,5 +1,6 @@
 //! Structs for building transactions.
 
+use crate::zip32::ExtendedSpendingKey;
 use crate::{
     jubjub::fs::Fs,
     primitives::{Diversifier, Note, PaymentAddress},
@@ -7,7 +8,6 @@ use crate::{
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};
 use rand::{rngs::OsRng, seq::SliceRandom, CryptoRng, RngCore};
-use crate::zip32::ExtendedSpendingKey;
 
 use crate::{
     keys::OutgoingViewingKey,

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -7,7 +7,7 @@ use crate::{
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};
 use rand::{rngs::OsRng, seq::SliceRandom, CryptoRng, RngCore};
-use zip32::ExtendedSpendingKey;
+use crate::zip32::ExtendedSpendingKey;
 
 use crate::{
     keys::OutgoingViewingKey,

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -4,9 +4,9 @@ use ff::{PrimeField, PrimeFieldRepr};
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
 use std::io::{self, Read, Write};
 
-use legacy::Script;
-use redjubjub::{PublicKey, Signature};
-use JUBJUB;
+use crate::legacy::Script;
+use crate::redjubjub::{PublicKey, Signature};
+use crate::JUBJUB;
 
 pub mod amount;
 pub use self::amount::Amount;

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -104,7 +104,7 @@ pub struct SpendDescription {
 }
 
 impl std::fmt::Debug for SpendDescription {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "SpendDescription(cv = {:?}, anchor = {:?}, nullifier = {:?}, rk = {:?}, spend_auth_sig = {:?})",
@@ -186,7 +186,7 @@ pub struct OutputDescription {
 }
 
 impl std::fmt::Debug for OutputDescription {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "OutputDescription(cv = {:?}, cmu = {:?}, ephemeral_key = {:?})",
@@ -253,7 +253,7 @@ enum SproutProof {
 }
 
 impl std::fmt::Debug for SproutProof {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             SproutProof::Groth(_) => write!(f, "SproutProof::Groth"),
             SproutProof::PHGR(_) => write!(f, "SproutProof::PHGR"),
@@ -275,7 +275,7 @@ pub struct JSDescription {
 }
 
 impl std::fmt::Debug for JSDescription {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "JSDescription(

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -206,7 +206,7 @@ mod tests {
     #[should_panic]
     fn add_panics_on_overflow() {
         let v = Amount(MAX_MONEY);
-        let sum = v + Amount(1);
+        let _sum = v + Amount(1);
     }
 
     #[test]
@@ -220,7 +220,7 @@ mod tests {
     #[should_panic]
     fn sub_panics_on_underflow() {
         let v = Amount(-MAX_MONEY);
-        let diff = v - Amount(1);
+        let _diff = v - Amount(1);
     }
 
     #[test]

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -28,7 +28,7 @@ const SAPLING_TX_VERSION: u32 = 4;
 pub struct TxId(pub [u8; 32]);
 
 impl fmt::Display for TxId {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut data = self.0.clone();
         data.reverse();
         formatter.write_str(&hex::encode(data))
@@ -74,7 +74,7 @@ pub struct TransactionData {
 }
 
 impl std::fmt::Debug for TransactionData {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "TransactionData(

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-use redjubjub::Signature;
-use serialize::Vector;
+use crate::redjubjub::Signature;
+use crate::serialize::Vector;
 
 pub mod builder;
 pub mod components;

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -7,7 +7,7 @@ use super::{
     Transaction, TransactionData, OVERWINTER_VERSION_GROUP_ID, SAPLING_TX_VERSION,
     SAPLING_VERSION_GROUP_ID,
 };
-use legacy::Script;
+use crate::legacy::Script;
 
 const ZCASH_SIGHASH_PERSONALIZATION_PREFIX: &'static [u8; 12] = b"ZcashSigHash";
 const ZCASH_PREVOUTS_HASH_PERSONALIZATION: &'static [u8; 16] = b"ZcashPrevoutHash";

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -5,9 +5,9 @@ use rand_os::OsRng;
 use crate::jubjub::{fs::Fs, FixedGenerators};
 
 use super::{components::Amount, sighash::signature_hash, Transaction, TransactionData};
-use legacy::Script;
-use redjubjub::PrivateKey;
-use JUBJUB;
+use crate::legacy::Script;
+use crate::redjubjub::PrivateKey;
+use crate::JUBJUB;
 
 #[test]
 fn tx_read_write() {

--- a/zcash_primitives/src/zip32.rs
+++ b/zcash_primitives/src/zip32.rs
@@ -198,7 +198,7 @@ impl std::cmp::PartialEq for ExtendedSpendingKey {
 }
 
 impl std::fmt::Debug for ExtendedSpendingKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "ExtendedSpendingKey(d = {}, tag_p = {:?}, i = {:?})",
@@ -221,7 +221,7 @@ impl std::cmp::PartialEq for ExtendedFullViewingKey {
 }
 
 impl std::fmt::Debug for ExtendedFullViewingKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "ExtendedFullViewingKey(d = {}, tag_p = {:?}, i = {:?})",

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
+edition = "2018"
 
 [dependencies]
 bellman = { path = "../bellman" }

--- a/zcash_proofs/examples/bench.rs
+++ b/zcash_proofs/examples/bench.rs
@@ -1,11 +1,3 @@
-extern crate bellman;
-extern crate ff;
-extern crate pairing;
-extern crate rand_core;
-extern crate rand_xorshift;
-extern crate zcash_primitives;
-extern crate zcash_proofs;
-
 use bellman::groth16::*;
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};

--- a/zcash_proofs/src/circuit/pedersen_hash.rs
+++ b/zcash_proofs/src/circuit/pedersen_hash.rs
@@ -163,7 +163,7 @@ mod test {
 
         for length in 0..751 {
             for _ in 0..5 {
-                let mut input: Vec<bool> = (0..length).map(|_| rng.next_u32() % 2 != 0).collect();
+                let input: Vec<bool> = (0..length).map(|_| rng.next_u32() % 2 != 0).collect();
 
                 let mut cs = TestConstraintSystem::<Bls12>::new();
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -1,20 +1,3 @@
-extern crate bellman;
-extern crate blake2b_simd;
-extern crate byteorder;
-extern crate ff;
-extern crate pairing;
-extern crate rand_os;
-extern crate zcash_primitives;
-
-#[cfg(feature = "local-prover")]
-extern crate directories;
-
-#[cfg(test)]
-extern crate rand_core;
-
-#[cfg(test)]
-extern crate rand_xorshift;
-
 use bellman::groth16::{prepare_verifying_key, Parameters, PreparedVerifyingKey, VerifyingKey};
 use pairing::bls12_381::Bls12;
 use std::fs::File;


### PR DESCRIPTION
This PR runs `cargo fix --edition` and `cargo fix --edition-idioms` on all of the modules which needed it, and includes some warning cleanup along the way. The folders  `zcash_primitives/benches/...` and `pairing/benches/...` were omitted when running the fix because they depend on unstable features, so it is possible that they no longer work. @ebfull suggested updating the benchmarks to use https://docs.rs/criterion/0.2.11/criterion/ which could be done as part of this PR, but might make more sense to be done as follow up.

Closes #97.