### PR TITLE
librustzcash: Fix typo in Windows parameter init; Correctly map sprout_path. Includes a GitHub actions improvement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -191,7 +191,7 @@ pub extern "system" fn librustzcash_init_zksnark_params(
         spend_hash,
         Path::new(&output_path),
         output_hash,
-        Path::new(&sprout_path),
+        sprout_path.as_ref().map(|p| Path::new(p)),
         sprout_hash,
     )
 }

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -181,7 +181,7 @@ pub extern "system" fn librustzcash_init_zksnark_params(
     let sprout_path = if sprout_path.is_null() {
         None
     } else {
-        Some(OsStr::from_wide(unsafe {
+        Some(OsString::from_wide(unsafe {
             slice::from_raw_parts(sprout_path, sprout_path_len)
         }))
     };


### PR DESCRIPTION
Introduced in #98.