### PR TITLE
Panic if spending_key is given a seed shorter than 32 bytes

### DIFF
--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -30,3 +30,14 @@ pub fn spending_key(seed: &[u8], coin_type: u32, account: u32) -> ExtendedSpendi
         ],
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::spending_key;
+
+    #[test]
+    #[should_panic]
+    fn spending_key_panics_on_short_seed() {
+        let _ = spending_key(&[0; 31][..], 0, 0);
+    }
+}

--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -5,6 +5,10 @@ use zcash_primitives::zip32::{ChildIndex, ExtendedSpendingKey};
 /// Derives the ZIP 32 [`ExtendedSpendingKey`] for a given coin type and account from the
 /// given seed.
 ///
+/// # Panics
+///
+/// Panics if `seed` is shorter than 32 bytes.
+///
 /// # Examples
 ///
 /// ```
@@ -13,6 +17,10 @@ use zcash_primitives::zip32::{ChildIndex, ExtendedSpendingKey};
 /// let extsk = spending_key(&[0; 32][..], COIN_TYPE, 0);
 /// ```
 pub fn spending_key(seed: &[u8], coin_type: u32, account: u32) -> ExtendedSpendingKey {
+    if seed.len() < 32 {
+        panic!("ZIP 32 seeds MUST be at least 32 bytes");
+    }
+
     ExtendedSpendingKey::from_path(
         &ExtendedSpendingKey::master(&seed),
         &[


### PR DESCRIPTION
This enforces the MUST requirement in ZIP 32. A panic is used instead of
an error because this should be considered an implementation error.
Ideally the type system would prevent this from occurring at all.

Closes #125.