### PR TITLE
Specify rand_core >= 0.5.1 for OsRng import.

### DIFF
--- a/librustzcash/Cargo.toml
+++ b/librustzcash/Cargo.toml
@@ -24,6 +24,6 @@ libc = "0.2"
 pairing = { path = "../pairing" }
 lazy_static = "1"
 byteorder = "1"
-rand_core = "0.5"
+rand_core = "0.5.1"
 zcash_primitives = { path = "../zcash_primitives" }
 zcash_proofs = { path = "../zcash_proofs" }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1"
 log = "0.4"
 pairing = { path = "../pairing" }
 rand = "0.7"
-rand_core = "0.5"
+rand_core = "0.5.1"
 sha2 = "0.8"
 
 [dev-dependencies]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1"
 directories = { version = "1", optional = true }
 ff = { path = "../ff" }
 pairing = { path = "../pairing" }
-rand_core = "0.5"
+rand_core = "0.5.1"
 zcash_primitives = { path = "../zcash_primitives" }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes issue introduced by #134. `rand_core` 0.5.0 does not export `OsRng` in the crate root but 0.5.1 does.

@NikVolf 