### PR TITLE
Implement sorting for TxIDs

### DIFF
--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -24,7 +24,7 @@ const OVERWINTER_TX_VERSION: u32 = 3;
 const SAPLING_VERSION_GROUP_ID: u32 = 0x892F2085;
 const SAPLING_TX_VERSION: u32 = 4;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct TxId(pub [u8; 32]);
 
 impl fmt::Display for TxId {


### PR DESCRIPTION
Implement PartialOrd and Ord for TxIds, which allows for sorting TxIDs, which is useful for detecting duplicates (~`HashSet` and~ `Vec::dedup` need sorted lists)