### PR TITLE
Move code coverage from Travis CI to Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,31 @@ jobs:
           command: test
           args: --verbose --release --all -- --ignored
 
+  codecov:
+    name: Code coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.37.0
+          override: true
+      - name: Install cargo-tarpaulin
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-tarpaulin
+      - name: Generate coverage report
+        uses: actions-rs/cargo@v1
+        with:
+          command: tarpaulin
+          args: --release --timeout 600 --out Xml --packages "librustzcash,zcash_client_backend,zcash_primitives,zcash_proofs"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+
   doc-links:
     name: Nightly lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI checks
 
 on: [push, pull_request]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: rust
 rust:
   - 1.37.0
 
-addons:
-  apt:
-    packages:
-      # For cargo-tarpaulin
-      - libssl-dev
-
 cache: cargo
 
 before_script:
@@ -21,11 +15,5 @@ script:
 
 before_cache:
   - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
-  - cargo install cargo-tarpaulin || echo "cargo-tarpaulin already installed"
   - cargo install cargo-update || echo "cargo-update already installed"
   - cargo install-update -a # update outdated cached binaries
-
-after_success:
-  # Manually exclude packages that are going to be removed from the workspace
-  - travis_wait 35 cargo tarpaulin --release --timeout 600 --out Xml --packages "librustzcash,zcash_client_backend,zcash_primitives,zcash_proofs"
-  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This should make both coverage generation and Travis CI more reliable (the latter shouldn't time out anymore).