### PR TITLE
Move Field operations to operator-backed traits

### DIFF
--- a/bellman/src/domain.rs
+++ b/bellman/src/domain.rs
@@ -13,6 +13,7 @@
 
 use ff::{Field, PrimeField, ScalarEngine};
 use group::CurveProjective;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use super::SynthesisError;
 

--- a/bellman/src/gadgets/lookup.rs
+++ b/bellman/src/gadgets/lookup.rs
@@ -1,6 +1,7 @@
 //! Window table lookup gadgets.
 
 use ff::{Field, ScalarEngine};
+use std::ops::AddAssign;
 
 use super::boolean::Boolean;
 use super::num::{AllocatedNum, Num};

--- a/bellman/src/gadgets/multipack.rs
+++ b/bellman/src/gadgets/multipack.rs
@@ -5,6 +5,7 @@ use super::num::Num;
 use super::Assignment;
 use crate::{ConstraintSystem, SynthesisError};
 use ff::{Field, PrimeField, ScalarEngine};
+use std::ops::AddAssign;
 
 /// Takes a sequence of booleans and exposes them as compact
 /// public inputs

--- a/bellman/src/gadgets/num.rs
+++ b/bellman/src/gadgets/num.rs
@@ -1,6 +1,7 @@
 //! Gadgets representing numbers in the scalar field of the underlying curve.
 
 use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, ScalarEngine};
+use std::ops::{AddAssign, MulAssign};
 
 use crate::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 
@@ -416,6 +417,7 @@ mod test {
     use pairing::bls12_381::{Bls12, Fr};
     use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
+    use std::ops::SubAssign;
 
     use super::{AllocatedNum, Boolean};
     use crate::gadgets::test::*;

--- a/bellman/src/gadgets/test/mod.rs
+++ b/bellman/src/gadgets/test/mod.rs
@@ -6,6 +6,7 @@ use crate::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable
 
 use std::collections::HashMap;
 use std::fmt::Write;
+use std::ops::{AddAssign, MulAssign};
 
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::Ordering;

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -1,5 +1,5 @@
 use rand_core::RngCore;
-
+use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use ff::{Field, PrimeField};

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -474,6 +474,7 @@ mod test_with_bls12_381 {
     use ff::Field;
     use pairing::bls12_381::{Bls12, Fr};
     use rand::thread_rng;
+    use std::ops::MulAssign;
 
     #[test]
     fn serialization() {

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -1,5 +1,5 @@
 use rand_core::RngCore;
-
+use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use futures::Future;

--- a/bellman/src/groth16/tests/mod.rs
+++ b/bellman/src/groth16/tests/mod.rs
@@ -5,6 +5,7 @@ mod dummy_engine;
 use self::dummy_engine::*;
 
 use std::marker::PhantomData;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use crate::{Circuit, ConstraintSystem, SynthesisError};
 

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -148,7 +148,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
-use std::ops::{Add, Sub};
+use std::ops::{Add, MulAssign, Sub};
 
 /// Computations are expressed in terms of arithmetic circuits, in particular
 /// rank-1 quadratic constraint systems. The `Circuit` trait represents a

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 // Bring in some tools for using pairing-friendly curves
 use ff::{Field, ScalarEngine};
 use pairing::Engine;
+use std::ops::{AddAssign, MulAssign};
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
 use pairing::bls12_381::Bls12;

--- a/ff/ff_derive/src/lib.rs
+++ b/ff/ff_derive/src/lib.rs
@@ -833,6 +833,119 @@ fn prime_field_impl(
             }
         }
 
+        impl<'r> ::std::ops::Add<&'r #name> for #name {
+            type Output = #name;
+
+            #[inline]
+            fn add(self, other: &#name) -> #name {
+                let mut ret = self;
+                ret.add_assign(other);
+                ret
+            }
+        }
+
+        impl ::std::ops::Add for #name {
+            type Output = #name;
+
+            #[inline]
+            fn add(self, other: #name) -> Self {
+                self + &other
+            }
+        }
+
+        impl<'r> ::std::ops::AddAssign<&'r #name> for #name {
+            #[inline]
+            fn add_assign(&mut self, other: &#name) {
+                // This cannot exceed the backing capacity.
+                self.0.add_nocarry(&other.0);
+
+                // However, it may need to be reduced.
+                self.reduce();
+            }
+        }
+
+        impl ::std::ops::AddAssign for #name {
+            #[inline]
+            fn add_assign(&mut self, other: #name) {
+                self.add_assign(&other);
+            }
+        }
+
+        impl<'r> ::std::ops::Sub<&'r #name> for #name {
+            type Output = #name;
+
+            #[inline]
+            fn sub(self, other: &#name) -> Self {
+                let mut ret = self;
+                ret.sub_assign(other);
+                ret
+            }
+        }
+
+        impl ::std::ops::Sub for #name {
+            type Output = #name;
+
+            #[inline]
+            fn sub(self, other: #name) -> Self {
+                self - &other
+            }
+        }
+
+        impl<'r> ::std::ops::SubAssign<&'r #name> for #name {
+            #[inline]
+            fn sub_assign(&mut self, other: &#name) {
+                // If `other` is larger than `self`, we'll need to add the modulus to self first.
+                if other.0 > self.0 {
+                    self.0.add_nocarry(&MODULUS);
+                }
+
+                self.0.sub_noborrow(&other.0);
+            }
+        }
+
+        impl ::std::ops::SubAssign for #name {
+            #[inline]
+            fn sub_assign(&mut self, other: #name) {
+                self.sub_assign(&other);
+            }
+        }
+
+        impl<'r> ::std::ops::Mul<&'r #name> for #name {
+            type Output = #name;
+
+            #[inline]
+            fn mul(self, other: &#name) -> Self {
+                let mut ret = self;
+                ret.mul_assign(other);
+                ret
+            }
+        }
+
+        impl ::std::ops::Mul for #name {
+            type Output = #name;
+
+            #[inline]
+            fn mul(self, other: #name) -> Self {
+                self * &other
+            }
+        }
+
+        impl<'r> ::std::ops::MulAssign<&'r #name> for #name {
+            #[inline]
+            fn mul_assign(&mut self, other: &#name)
+            {
+                #multiply_impl
+            }
+        }
+
+        impl ::std::ops::MulAssign for #name {
+            #[inline]
+            fn mul_assign(&mut self, other: #name)
+            {
+                self.mul_assign(&other);
+            }
+        }
+
         impl ::ff::PrimeField for #name {
             type Repr = #repr;
 
@@ -912,31 +1025,12 @@ fn prime_field_impl(
             }
 
             #[inline]
-            fn add_assign(&mut self, other: &#name) {
-                // This cannot exceed the backing capacity.
-                self.0.add_nocarry(&other.0);
-
-                // However, it may need to be reduced.
-                self.reduce();
-            }
-
-            #[inline]
             fn double(&mut self) {
                 // This cannot exceed the backing capacity.
                 self.0.mul2();
 
                 // However, it may need to be reduced.
                 self.reduce();
-            }
-
-            #[inline]
-            fn sub_assign(&mut self, other: &#name) {
-                // If `other` is larger than `self`, we'll need to add the modulus to self first.
-                if other.0 > self.0 {
-                    self.0.add_nocarry(&MODULUS);
-                }
-
-                self.0.sub_noborrow(&other.0);
             }
 
             #[inline]
@@ -1006,12 +1100,6 @@ fn prime_field_impl(
             #[inline(always)]
             fn frobenius_map(&mut self, _: usize) {
                 // This has no effect in a prime field.
-            }
-
-            #[inline]
-            fn mul_assign(&mut self, other: &#name)
-            {
-                #multiply_impl
             }
 
             #[inline]

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -11,10 +11,31 @@ use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
+    Sized
+    + Eq
+    + Copy
+    + Clone
+    + Send
+    + Sync
+    + fmt::Debug
+    + fmt::Display
+    + 'static
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + for<'a> Add<&'a Self, Output = Self>
+    + for<'a> Mul<&'a Self, Output = Self>
+    + for<'a> Sub<&'a Self, Output = Self>
+    + MulAssign
+    + AddAssign
+    + SubAssign
+    + for<'a> MulAssign<&'a Self>
+    + for<'a> AddAssign<&'a Self>
+    + for<'a> SubAssign<&'a Self>
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore>(rng: &mut R) -> Self;
@@ -36,15 +57,6 @@ pub trait Field:
 
     /// Negates this element.
     fn negate(&mut self);
-
-    /// Adds another element to this element.
-    fn add_assign(&mut self, other: &Self);
-
-    /// Subtracts another element from this element.
-    fn sub_assign(&mut self, other: &Self);
-
-    /// Multiplies another element by this element.
-    fn mul_assign(&mut self, other: &Self);
 
     /// Computes the multiplicative inverse of this element, if nonzero.
     fn inverse(&self) -> Option<Self>;

--- a/pairing/benches/bls12_381/fq.rs
+++ b/pairing/benches/bls12_381/fq.rs
@@ -1,5 +1,6 @@
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
 use pairing::bls12_381::*;

--- a/pairing/benches/bls12_381/fq12.rs
+++ b/pairing/benches/bls12_381/fq12.rs
@@ -1,5 +1,6 @@
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ff::Field;
 use pairing::bls12_381::*;

--- a/pairing/benches/bls12_381/fq2.rs
+++ b/pairing/benches/bls12_381/fq2.rs
@@ -1,5 +1,6 @@
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ff::{Field, SqrtField};
 use pairing::bls12_381::*;

--- a/pairing/benches/bls12_381/fr.rs
+++ b/pairing/benches/bls12_381/fr.rs
@@ -1,5 +1,6 @@
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
 use pairing::bls12_381::*;

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -627,6 +627,7 @@ pub mod g1 {
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
+    use std::ops::{AddAssign, MulAssign, SubAssign};
 
     curve_impl!(
         "G1",
@@ -1296,6 +1297,7 @@ pub mod g2 {
     use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
     use rand_core::RngCore;
     use std::fmt;
+    use std::ops::{AddAssign, MulAssign, SubAssign};
 
     curve_impl!(
         "G2",

--- a/pairing/src/bls12_381/fq.rs
+++ b/pairing/src/bls12_381/fq.rs
@@ -1,5 +1,6 @@
 use super::fq2::Fq2;
 use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 // B coefficient of BLS12-381 curve, 4.
 pub const B_COEFF: Fq = Fq(FqRepr([

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -3,6 +3,7 @@ use super::fq2::Fq2;
 use super::fq6::Fq6;
 use ff::Field;
 use rand_core::RngCore;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// An element of Fq12, represented by c0 + c1 * w.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -36,6 +37,112 @@ impl Fq12 {
         self.c0 = bb;
         self.c0.mul_by_nonresidue();
         self.c0.add_assign(&aa);
+    }
+}
+
+impl<'r> Add<&'r Fq12> for Fq12 {
+    type Output = Self;
+
+    fn add(self, other: &Self) -> Self {
+        Fq12 {
+            c0: self.c0 + other.c0,
+            c1: self.c1 + other.c1,
+        }
+    }
+}
+
+impl Add for Fq12 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        self + &other
+    }
+}
+
+impl<'r> AddAssign<&'r Fq12> for Fq12 {
+    fn add_assign(&mut self, other: &'r Self) {
+        self.c0.add_assign(&other.c0);
+        self.c1.add_assign(&other.c1);
+    }
+}
+
+impl AddAssign for Fq12 {
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other);
+    }
+}
+
+impl<'r> Sub<&'r Fq12> for Fq12 {
+    type Output = Self;
+
+    fn sub(self, other: &Self) -> Self {
+        Fq12 {
+            c0: self.c0 - other.c0,
+            c1: self.c1 - other.c1,
+        }
+    }
+}
+
+impl Sub for Fq12 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        self - &other
+    }
+}
+
+impl<'r> SubAssign<&'r Fq12> for Fq12 {
+    fn sub_assign(&mut self, other: &'r Self) {
+        self.c0.sub_assign(&other.c0);
+        self.c1.sub_assign(&other.c1);
+    }
+}
+
+impl SubAssign for Fq12 {
+    fn sub_assign(&mut self, other: Self) {
+        self.sub_assign(&other);
+    }
+}
+
+impl<'r> Mul<&'r Fq12> for Fq12 {
+    type Output = Self;
+
+    fn mul(self, other: &Self) -> Self {
+        let mut ret = self;
+        ret.mul_assign(other);
+        ret
+    }
+}
+
+impl Mul for Fq12 {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        self * &other
+    }
+}
+
+impl<'r> MulAssign<&'r Fq12> for Fq12 {
+    fn mul_assign(&mut self, other: &Self) {
+        let mut aa = self.c0;
+        aa.mul_assign(&other.c0);
+        let mut bb = self.c1;
+        bb.mul_assign(&other.c1);
+        let mut o = other.c0;
+        o.add_assign(&other.c1);
+        self.c1.add_assign(&self.c0);
+        self.c1.mul_assign(&o);
+        self.c1.sub_assign(&aa);
+        self.c1.sub_assign(&bb);
+        self.c0 = bb;
+        self.c0.mul_by_nonresidue();
+        self.c0.add_assign(&aa);
+    }
+}
+
+impl MulAssign for Fq12 {
+    fn mul_assign(&mut self, other: Self) {
+        self.mul_assign(&other);
     }
 }
 
@@ -75,16 +182,6 @@ impl Field for Fq12 {
         self.c1.negate();
     }
 
-    fn add_assign(&mut self, other: &Self) {
-        self.c0.add_assign(&other.c0);
-        self.c1.add_assign(&other.c1);
-    }
-
-    fn sub_assign(&mut self, other: &Self) {
-        self.c0.sub_assign(&other.c0);
-        self.c1.sub_assign(&other.c1);
-    }
-
     fn frobenius_map(&mut self, power: usize) {
         self.c0.frobenius_map(power);
         self.c1.frobenius_map(power);
@@ -109,22 +206,6 @@ impl Field for Fq12 {
         ab.mul_by_nonresidue();
         c0.sub_assign(&ab);
         self.c0 = c0;
-    }
-
-    fn mul_assign(&mut self, other: &Self) {
-        let mut aa = self.c0;
-        aa.mul_assign(&other.c0);
-        let mut bb = self.c1;
-        bb.mul_assign(&other.c1);
-        let mut o = other.c0;
-        o.add_assign(&other.c1);
-        self.c1.add_assign(&self.c0);
-        self.c1.mul_assign(&o);
-        self.c1.sub_assign(&aa);
-        self.c1.sub_assign(&bb);
-        self.c0 = bb;
-        self.c0.mul_by_nonresidue();
-        self.c0.add_assign(&aa);
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -1,8 +1,8 @@
 use super::fq::{Fq, FROBENIUS_COEFF_FQ2_C1, NEGATIVE_ONE};
 use ff::{Field, SqrtField};
 use rand_core::RngCore;
-
 use std::cmp::Ordering;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// An element of Fq2, represented by c0 + c1 * u.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -56,6 +56,111 @@ impl Fq2 {
     }
 }
 
+impl<'r> Add<&'r Fq2> for Fq2 {
+    type Output = Self;
+
+    fn add(self, other: &Self) -> Self {
+        Fq2 {
+            c0: self.c0 + other.c0,
+            c1: self.c1 + other.c1,
+        }
+    }
+}
+
+impl Add for Fq2 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        self + &other
+    }
+}
+
+impl<'r> AddAssign<&'r Fq2> for Fq2 {
+    fn add_assign(&mut self, other: &'r Self) {
+        self.c0.add_assign(&other.c0);
+        self.c1.add_assign(&other.c1);
+    }
+}
+
+impl AddAssign for Fq2 {
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other);
+    }
+}
+
+impl<'r> Sub<&'r Fq2> for Fq2 {
+    type Output = Self;
+
+    fn sub(self, other: &Self) -> Self {
+        Fq2 {
+            c0: self.c0 - other.c0,
+            c1: self.c1 - other.c1,
+        }
+    }
+}
+
+impl Sub for Fq2 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        self - &other
+    }
+}
+
+impl<'r> SubAssign<&'r Fq2> for Fq2 {
+    fn sub_assign(&mut self, other: &'r Self) {
+        self.c0.sub_assign(&other.c0);
+        self.c1.sub_assign(&other.c1);
+    }
+}
+
+impl SubAssign for Fq2 {
+    fn sub_assign(&mut self, other: Self) {
+        self.sub_assign(&other);
+    }
+}
+
+impl<'r> Mul<&'r Fq2> for Fq2 {
+    type Output = Self;
+
+    fn mul(self, other: &Self) -> Self {
+        let mut ret = self;
+        ret.mul_assign(other);
+        ret
+    }
+}
+
+impl Mul for Fq2 {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        self * &other
+    }
+}
+
+impl<'r> MulAssign<&'r Fq2> for Fq2 {
+    fn mul_assign(&mut self, other: &Self) {
+        let mut aa = self.c0;
+        aa.mul_assign(&other.c0);
+        let mut bb = self.c1;
+        bb.mul_assign(&other.c1);
+        let mut o = other.c0;
+        o.add_assign(&other.c1);
+        self.c1.add_assign(&self.c0);
+        self.c1.mul_assign(&o);
+        self.c1.sub_assign(&aa);
+        self.c1.sub_assign(&bb);
+        self.c0 = aa;
+        self.c0.sub_assign(&bb);
+    }
+}
+
+impl MulAssign for Fq2 {
+    fn mul_assign(&mut self, other: Self) {
+        self.mul_assign(&other);
+    }
+}
+
 impl Field for Fq2 {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Fq2 {
@@ -106,31 +211,6 @@ impl Field for Fq2 {
     fn negate(&mut self) {
         self.c0.negate();
         self.c1.negate();
-    }
-
-    fn add_assign(&mut self, other: &Self) {
-        self.c0.add_assign(&other.c0);
-        self.c1.add_assign(&other.c1);
-    }
-
-    fn sub_assign(&mut self, other: &Self) {
-        self.c0.sub_assign(&other.c0);
-        self.c1.sub_assign(&other.c1);
-    }
-
-    fn mul_assign(&mut self, other: &Self) {
-        let mut aa = self.c0;
-        aa.mul_assign(&other.c0);
-        let mut bb = self.c1;
-        bb.mul_assign(&other.c1);
-        let mut o = other.c0;
-        o.add_assign(&other.c1);
-        self.c1.add_assign(&self.c0);
-        self.c1.mul_assign(&o);
-        self.c1.sub_assign(&aa);
-        self.c1.sub_assign(&bb);
-        self.c0 = aa;
-        self.c0.sub_assign(&bb);
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -2,6 +2,7 @@ use super::fq::{FROBENIUS_COEFF_FQ6_C1, FROBENIUS_COEFF_FQ6_C2};
 use super::fq2::Fq2;
 use ff::Field;
 use rand_core::RngCore;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// An element of Fq6, represented by c0 + c1 * v + c2 * v^(2).
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -99,101 +100,93 @@ impl Fq6 {
     }
 }
 
-impl Field for Fq6 {
-    fn random<R: RngCore>(rng: &mut R) -> Self {
+impl<'r> Add<&'r Fq6> for Fq6 {
+    type Output = Self;
+
+    fn add(self, other: &Self) -> Self {
         Fq6 {
-            c0: Fq2::random(rng),
-            c1: Fq2::random(rng),
-            c2: Fq2::random(rng),
+            c0: self.c0 + other.c0,
+            c1: self.c1 + other.c1,
+            c2: self.c2 + other.c2,
         }
     }
+}
 
-    fn zero() -> Self {
-        Fq6 {
-            c0: Fq2::zero(),
-            c1: Fq2::zero(),
-            c2: Fq2::zero(),
-        }
+impl Add for Fq6 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        self + &other
     }
+}
 
-    fn one() -> Self {
-        Fq6 {
-            c0: Fq2::one(),
-            c1: Fq2::zero(),
-            c2: Fq2::zero(),
-        }
-    }
-
-    fn is_zero(&self) -> bool {
-        self.c0.is_zero() && self.c1.is_zero() && self.c2.is_zero()
-    }
-
-    fn double(&mut self) {
-        self.c0.double();
-        self.c1.double();
-        self.c2.double();
-    }
-
-    fn negate(&mut self) {
-        self.c0.negate();
-        self.c1.negate();
-        self.c2.negate();
-    }
-
-    fn add_assign(&mut self, other: &Self) {
+impl<'r> AddAssign<&'r Fq6> for Fq6 {
+    fn add_assign(&mut self, other: &'r Self) {
         self.c0.add_assign(&other.c0);
         self.c1.add_assign(&other.c1);
         self.c2.add_assign(&other.c2);
     }
+}
 
-    fn sub_assign(&mut self, other: &Self) {
+impl AddAssign for Fq6 {
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other);
+    }
+}
+
+impl<'r> Sub<&'r Fq6> for Fq6 {
+    type Output = Self;
+
+    fn sub(self, other: &Self) -> Self {
+        Fq6 {
+            c0: self.c0 - other.c0,
+            c1: self.c1 - other.c1,
+            c2: self.c2 - other.c2,
+        }
+    }
+}
+
+impl Sub for Fq6 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        self - &other
+    }
+}
+
+impl<'r> SubAssign<&'r Fq6> for Fq6 {
+    fn sub_assign(&mut self, other: &'r Self) {
         self.c0.sub_assign(&other.c0);
         self.c1.sub_assign(&other.c1);
         self.c2.sub_assign(&other.c2);
     }
+}
 
-    fn frobenius_map(&mut self, power: usize) {
-        self.c0.frobenius_map(power);
-        self.c1.frobenius_map(power);
-        self.c2.frobenius_map(power);
-
-        self.c1.mul_assign(&FROBENIUS_COEFF_FQ6_C1[power % 6]);
-        self.c2.mul_assign(&FROBENIUS_COEFF_FQ6_C2[power % 6]);
+impl SubAssign for Fq6 {
+    fn sub_assign(&mut self, other: Self) {
+        self.sub_assign(&other);
     }
+}
 
-    fn square(&mut self) {
-        let mut s0 = self.c0;
-        s0.square();
-        let mut ab = self.c0;
-        ab.mul_assign(&self.c1);
-        let mut s1 = ab;
-        s1.double();
-        let mut s2 = self.c0;
-        s2.sub_assign(&self.c1);
-        s2.add_assign(&self.c2);
-        s2.square();
-        let mut bc = self.c1;
-        bc.mul_assign(&self.c2);
-        let mut s3 = bc;
-        s3.double();
-        let mut s4 = self.c2;
-        s4.square();
+impl<'r> Mul<&'r Fq6> for Fq6 {
+    type Output = Self;
 
-        self.c0 = s3;
-        self.c0.mul_by_nonresidue();
-        self.c0.add_assign(&s0);
-
-        self.c1 = s4;
-        self.c1.mul_by_nonresidue();
-        self.c1.add_assign(&s1);
-
-        self.c2 = s1;
-        self.c2.add_assign(&s2);
-        self.c2.add_assign(&s3);
-        self.c2.sub_assign(&s0);
-        self.c2.sub_assign(&s4);
+    fn mul(self, other: &Self) -> Self {
+        let mut ret = self;
+        ret.mul_assign(other);
+        ret
     }
+}
 
+impl Mul for Fq6 {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        self * &other
+    }
+}
+
+impl<'r> MulAssign<&'r Fq6> for Fq6 {
     fn mul_assign(&mut self, other: &Self) {
         let mut a_a = self.c0;
         let mut b_b = self.c1;
@@ -243,6 +236,96 @@ impl Field for Fq6 {
         self.c0 = t1;
         self.c1 = t2;
         self.c2 = t3;
+    }
+}
+
+impl MulAssign for Fq6 {
+    fn mul_assign(&mut self, other: Self) {
+        self.mul_assign(&other);
+    }
+}
+
+impl Field for Fq6 {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
+        Fq6 {
+            c0: Fq2::random(rng),
+            c1: Fq2::random(rng),
+            c2: Fq2::random(rng),
+        }
+    }
+
+    fn zero() -> Self {
+        Fq6 {
+            c0: Fq2::zero(),
+            c1: Fq2::zero(),
+            c2: Fq2::zero(),
+        }
+    }
+
+    fn one() -> Self {
+        Fq6 {
+            c0: Fq2::one(),
+            c1: Fq2::zero(),
+            c2: Fq2::zero(),
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.c0.is_zero() && self.c1.is_zero() && self.c2.is_zero()
+    }
+
+    fn double(&mut self) {
+        self.c0.double();
+        self.c1.double();
+        self.c2.double();
+    }
+
+    fn negate(&mut self) {
+        self.c0.negate();
+        self.c1.negate();
+        self.c2.negate();
+    }
+
+    fn frobenius_map(&mut self, power: usize) {
+        self.c0.frobenius_map(power);
+        self.c1.frobenius_map(power);
+        self.c2.frobenius_map(power);
+
+        self.c1.mul_assign(&FROBENIUS_COEFF_FQ6_C1[power % 6]);
+        self.c2.mul_assign(&FROBENIUS_COEFF_FQ6_C2[power % 6]);
+    }
+
+    fn square(&mut self) {
+        let mut s0 = self.c0;
+        s0.square();
+        let mut ab = self.c0;
+        ab.mul_assign(&self.c1);
+        let mut s1 = ab;
+        s1.double();
+        let mut s2 = self.c0;
+        s2.sub_assign(&self.c1);
+        s2.add_assign(&self.c2);
+        s2.square();
+        let mut bc = self.c1;
+        bc.mul_assign(&self.c2);
+        let mut s3 = bc;
+        s3.double();
+        let mut s4 = self.c2;
+        s4.square();
+
+        self.c0 = s3;
+        self.c0.mul_by_nonresidue();
+        self.c0.add_assign(&s0);
+
+        self.c1 = s4;
+        self.c1.mul_by_nonresidue();
+        self.c1.add_assign(&s1);
+
+        self.c2 = s1;
+        self.c2.add_assign(&s2);
+        self.c2.add_assign(&s3);
+        self.c2.sub_assign(&s0);
+        self.c2.sub_assign(&s4);
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/pairing/src/bls12_381/fr.rs
+++ b/pairing/src/bls12_381/fr.rs
@@ -1,4 +1,5 @@
 use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 #[derive(PrimeField)]
 #[PrimeFieldModulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513"]

--- a/pairing/src/bls12_381/mod.rs
+++ b/pairing/src/bls12_381/mod.rs
@@ -25,6 +25,7 @@ use super::{Engine, PairingCurveAffine};
 
 use ff::{BitIterator, Field, ScalarEngine};
 use group::CurveAffine;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 // The BLS parameter x for BLS12-381 is -0xd201000000010000
 const BLS_X: u64 = 0xd201000000010000;

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -1,6 +1,7 @@
 use group::{CurveAffine, CurveProjective};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use std::ops::MulAssign;
 
 use crate::{Engine, Field, PairingCurveAffine, PrimeField};
 

--- a/zcash_primitives/src/jubjub/edwards.rs
+++ b/zcash_primitives/src/jubjub/edwards.rs
@@ -1,4 +1,5 @@
 use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use super::{montgomery, JubjubEngine, JubjubParams, PrimeOrder, Unknown};
 

--- a/zcash_primitives/src/jubjub/montgomery.rs
+++ b/zcash_primitives/src/jubjub/montgomery.rs
@@ -1,4 +1,5 @@
 use ff::{BitIterator, Field, PrimeField, PrimeFieldRepr, SqrtField};
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use super::{edwards, JubjubEngine, JubjubParams, PrimeOrder, Unknown};
 

--- a/zcash_primitives/src/jubjub/tests.rs
+++ b/zcash_primitives/src/jubjub/tests.rs
@@ -1,6 +1,7 @@
 use super::{edwards, montgomery, JubjubEngine, JubjubParams, PrimeOrder};
 
 use ff::{Field, LegendreSymbol, PrimeField, PrimeFieldRepr, SqrtField};
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;

--- a/zcash_primitives/src/pedersen_hash.rs
+++ b/zcash_primitives/src/pedersen_hash.rs
@@ -2,6 +2,7 @@
 
 use crate::jubjub::*;
 use ff::{Field, PrimeField, PrimeFieldRepr};
+use std::ops::AddAssign;
 
 #[derive(Copy, Clone)]
 pub enum Personalization {

--- a/zcash_primitives/src/redjubjub.rs
+++ b/zcash_primitives/src/redjubjub.rs
@@ -7,6 +7,7 @@ use crate::jubjub::{edwards::Point, FixedGenerators, JubjubEngine, JubjubParams,
 use ff::{Field, PrimeField, PrimeFieldRepr};
 use rand_core::RngCore;
 use std::io::{self, Read, Write};
+use std::ops::{AddAssign, MulAssign};
 
 use crate::util::hash_to_scalar;
 

--- a/zcash_primitives/src/zip32.rs
+++ b/zcash_primitives/src/zip32.rs
@@ -5,9 +5,9 @@
 use aes::Aes256;
 use blake2b_simd::Params as Blake2bParams;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
-use ff::Field;
 use fpe::ff1::{BinaryNumeralString, FF1};
 use pairing::bls12_381::Bls12;
+use std::ops::AddAssign;
 
 use crate::{
     jubjub::{fs::Fs, FixedGenerators, JubjubEngine, JubjubParams, ToUniform},

--- a/zcash_proofs/src/circuit/ecc.rs
+++ b/zcash_proofs/src/circuit/ecc.rs
@@ -2,6 +2,7 @@
 
 use ff::Field;
 use pairing::Engine;
+use std::ops::{AddAssign, MulAssign, SubAssign};
 
 use bellman::{ConstraintSystem, SynthesisError};
 
@@ -668,6 +669,7 @@ mod test {
     use pairing::bls12_381::{Bls12, Fr};
     use rand_core::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
+    use std::ops::SubAssign;
 
     use bellman::gadgets::test::*;
     use zcash_primitives::jubjub::fs::Fs;

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -5,6 +5,7 @@ use bellman::{
 use ff::Field;
 use pairing::bls12_381::{Bls12, Fr};
 use rand_core::OsRng;
+use std::ops::AddAssign;
 use zcash_primitives::{
     jubjub::{edwards, fs::Fs, FixedGenerators, JubjubBls12, Unknown},
     primitives::{Diversifier, Note, PaymentAddress, ProofGenerationKey, ValueCommitment},


### PR DESCRIPTION
The `ff_derive`, `pairing`, `zcash_primitives::jubjub`, and `bellman` `dummy_engine` changes are minimally implemented on top of the existing `*_assign()` functions.

Part of #159.