### PR TITLE
UX refactors for proving-related APIs

### DIFF
--- a/zcash_primitives/src/prover.rs
+++ b/zcash_primitives/src/prover.rs
@@ -7,7 +7,7 @@ use crate::{
 use pairing::bls12_381::{Bls12, Fr};
 
 use crate::{
-    merkle_tree::CommitmentTreeWitness,
+    merkle_tree::MerklePath,
     redjubjub::{PublicKey, Signature},
     sapling::Node,
     transaction::components::{Amount, GROTH_PROOF_SIZE},
@@ -35,7 +35,7 @@ pub trait TxProver {
         ar: Fs,
         value: u64,
         anchor: Fr,
-        witness: CommitmentTreeWitness<Node>,
+        merkle_path: MerklePath<Node>,
     ) -> Result<
         (
             [u8; GROTH_PROOF_SIZE],
@@ -82,7 +82,7 @@ pub(crate) mod mock {
     };
 
     use crate::{
-        merkle_tree::CommitmentTreeWitness,
+        merkle_tree::MerklePath,
         redjubjub::{PublicKey, Signature},
         sapling::Node,
         transaction::components::{Amount, GROTH_PROOF_SIZE},
@@ -108,7 +108,7 @@ pub(crate) mod mock {
             ar: Fs,
             value: u64,
             _anchor: Fr,
-            _witness: CommitmentTreeWitness<Node>,
+            _merkle_path: MerklePath<Node>,
         ) -> Result<
             (
                 [u8; GROTH_PROOF_SIZE],

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -435,7 +435,7 @@ impl<R: RngCore + CryptoRng> Builder<R> {
     pub fn build(
         mut self,
         consensus_branch_id: consensus::BranchId,
-        prover: impl TxProver,
+        prover: &impl TxProver,
     ) -> Result<(Transaction, TransactionMetadata), Error> {
         let mut tx_metadata = TransactionMetadata::new();
 
@@ -558,7 +558,7 @@ impl<R: RngCore + CryptoRng> Builder<R> {
                 // Record the post-randomized output location
                 tx_metadata.output_indices[pos] = i;
 
-                output.build(&prover, &mut ctx, &mut self.rng)
+                output.build(prover, &mut ctx, &mut self.rng)
             } else {
                 // This is a dummy output
                 let (dummy_to, dummy_note) = {
@@ -718,7 +718,7 @@ mod tests {
         {
             let builder = Builder::new(0);
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, MockTxProver),
+                builder.build(consensus::BranchId::Sapling, &MockTxProver),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-10000).unwrap()))
             );
         }
@@ -740,7 +740,7 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, MockTxProver),
+                builder.build(consensus::BranchId::Sapling, &MockTxProver),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-60000).unwrap()))
             );
         }
@@ -756,7 +756,7 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, MockTxProver),
+                builder.build(consensus::BranchId::Sapling, &MockTxProver),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-60000).unwrap()))
             );
         }
@@ -796,7 +796,7 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, MockTxProver),
+                builder.build(consensus::BranchId::Sapling, &MockTxProver),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-1).unwrap()))
             );
         }
@@ -835,7 +835,7 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, MockTxProver),
+                builder.build(consensus::BranchId::Sapling, &MockTxProver),
                 Err(Error::BindingSig)
             )
         }

--- a/zcash_proofs/src/prover.rs
+++ b/zcash_proofs/src/prover.rs
@@ -9,7 +9,7 @@ use zcash_primitives::{
     primitives::{Diversifier, PaymentAddress, ProofGenerationKey},
 };
 use zcash_primitives::{
-    merkle_tree::CommitmentTreeWitness,
+    merkle_tree::MerklePath,
     prover::TxProver,
     redjubjub::{PublicKey, Signature},
     sapling::Node,
@@ -127,7 +127,7 @@ impl TxProver for LocalTxProver {
         ar: Fs,
         value: u64,
         anchor: Fr,
-        witness: CommitmentTreeWitness<Node>,
+        merkle_path: MerklePath<Node>,
     ) -> Result<
         (
             [u8; GROTH_PROOF_SIZE],
@@ -143,7 +143,7 @@ impl TxProver for LocalTxProver {
             ar,
             value,
             anchor,
-            witness,
+            merkle_path,
             &self.spend_params,
             &self.spend_vk,
             &JUBJUB,

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -10,7 +10,7 @@ use zcash_primitives::{
     primitives::{Diversifier, Note, PaymentAddress, ProofGenerationKey, ValueCommitment},
 };
 use zcash_primitives::{
-    merkle_tree::CommitmentTreeWitness,
+    merkle_tree::MerklePath,
     redjubjub::{PrivateKey, PublicKey, Signature},
     sapling::Node,
     transaction::components::Amount,
@@ -46,7 +46,7 @@ impl SaplingProvingContext {
         ar: Fs,
         value: u64,
         anchor: Fr,
-        witness: CommitmentTreeWitness<Node>,
+        merkle_path: MerklePath<Node>,
         proving_key: &Parameters<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
         params: &JubjubBls12,
@@ -104,7 +104,7 @@ impl SaplingProvingContext {
             r: rcm,
         };
 
-        let nullifier = note.nf(&viewing_key, witness.position, params);
+        let nullifier = note.nf(&viewing_key, merkle_path.position, params);
 
         // We now have the full witness for our circuit
         let instance = Spend {
@@ -114,7 +114,7 @@ impl SaplingProvingContext {
             payment_address: Some(payment_address),
             commitment_randomness: Some(rcm),
             ar: Some(ar),
-            auth_path: witness
+            auth_path: merkle_path
                 .auth_path
                 .iter()
                 .map(|(node, b)| Some(((*node).into(), *b)))

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -117,7 +117,7 @@ impl SaplingProvingContext {
             auth_path: witness
                 .auth_path
                 .iter()
-                .map(|n| n.map(|(node, b)| (node.into(), b)))
+                .map(|(node, b)| Some(((*node).into(), *b)))
                 .collect(),
             anchor: Some(anchor),
         };


### PR DESCRIPTION
Most of this is much-needed refactoring, but there are a few small usability improvements:

- `Builder::add_sapling_spend` now takes a `MerklePath` directly, thanks to the newly-added `MerklePath::root(leaf: Node)`.
- `Builder::build` now takes `impl TxProver` by reference, so the caller may reuse it.