### PR TITLE
Make Sapling spend and output arity configurable in transaction builder

### DIFF
--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -418,6 +418,20 @@ pub struct MerklePath<Node: Hashable> {
 }
 
 impl<Node: Hashable> MerklePath<Node> {
+    /// Constructs an empty Merkle path.
+    ///
+    /// This is used to create dummy Sapling spends.
+    pub(crate) fn empty() -> Self {
+        let mut filler = PathFiller::empty();
+
+        MerklePath {
+            auth_path: (0..SAPLING_COMMITMENT_TREE_DEPTH)
+                .map(|i| (filler.next(i), false))
+                .collect(),
+            position: 0,
+        }
+    }
+
     /// Constructs a Merkle path directly from a path and position.
     pub fn from_path(auth_path: Vec<(Node, bool)>, position: u64) -> Self {
         MerklePath {

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -35,8 +35,8 @@ const DEFAULT_TX_EXPIRY_DELTA: u32 = 20;
 
 /// If there are any shielded inputs, always have at least two shielded outputs, padding
 /// with dummy outputs if necessary. See https://github.com/zcash/zcash/issues/3615
-fn default_sapling_output_arity<T>(spends: &[T]) -> Option<Arity> {
-    if spends.is_empty() {
+fn default_sapling_output_arity(num_spends: usize) -> Option<Arity> {
+    if num_spends == 0 {
         None
     } else {
         Some(Arity::Minimum(2))
@@ -711,7 +711,7 @@ impl<R: RngCore + CryptoRng> Builder<R> {
         let orig_outputs_len = outputs.len();
         if let Some(output_arity) = self
             .output_arity
-            .or_else(|| default_sapling_output_arity(&spends))
+            .or_else(|| default_sapling_output_arity(spends.len()))
         {
             output_arity
                 .enforce(&mut outputs, || None)


### PR DESCRIPTION
This enables the caller to specify a preferred policy for padding Sapling spends or outputs to a specific arity. The existing default (no padding of spends, padding to 2 outputs if there are any spends) is maintained.