### PR TITLE
Rename librustzcash_sapling_compute_cm

### DIFF
--- a/librustzcash/include/librustzcash.h
+++ b/librustzcash/include/librustzcash.h
@@ -196,7 +196,7 @@ extern "C" {
     /// The `pk_d` and `r` parameters must be of length 32.
     /// The result is also of length 32 and placed in `result`.
     /// Returns false if the diversifier or pk_d is not valid
-    bool librustzcash_sapling_compute_cm(
+    bool librustzcash_sapling_compute_cmu(
         const unsigned char *diversifier,
         const unsigned char *pk_d,
         const uint64_t value,

--- a/librustzcash/src/rustzcash.rs
+++ b/librustzcash/src/rustzcash.rs
@@ -479,7 +479,7 @@ pub extern "C" fn librustzcash_sapling_compute_nf(
 /// The result is also of length 32 and placed in `result`.
 /// Returns false if `diversifier` or `pk_d` is not valid.
 #[no_mangle]
-pub extern "C" fn librustzcash_sapling_compute_cm(
+pub extern "C" fn librustzcash_sapling_compute_cmu(
     diversifier: *const [c_uchar; 11],
     pk_d: *const [c_uchar; 32],
     value: u64,

--- a/librustzcash/src/tests/notes.rs
+++ b/librustzcash/src/tests/notes.rs
@@ -1,4 +1,4 @@
-use crate::librustzcash_sapling_compute_cm;
+use crate::librustzcash_sapling_compute_cmu;
 use crate::librustzcash_sapling_compute_nf;
 
 #[test]
@@ -648,7 +648,7 @@ fn notes() {
     for tv in test_vectors {
         // Compute commitment and compare with test vector
         let mut result = [0u8; 32];
-        assert!(librustzcash_sapling_compute_cm(
+        assert!(librustzcash_sapling_compute_cmu(
             &tv.default_d,
             &tv.default_pk_d,
             tv.note_v,


### PR DESCRIPTION
Apologies for sneaking here as i don't know any rust(yet) but made this pr while working on https://github.com/zcash/zcash/issues/3446 .

Will reference the corresponding zcashd for it here: https://github.com/zcash/zcash/pull/4381