### PR TITLE
Expose the `hash` and `n` fields of Transparent Outputs

### DIFF
--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -43,6 +43,14 @@ impl OutPoint {
         writer.write_all(&self.hash)?;
         writer.write_u32::<LittleEndian>(self.n)
     }
+
+    pub fn n(&self) -> u32 {
+        self.n
+    }
+
+    pub fn hash(&self) -> &[u8; 32] {
+        &self.hash
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Zecwallet Lite currently depends on a fork of `librustzcash`, which has some minor additions to the upstream `librustzcash`. It would be awesome if `librustzcash` added these changes, so I can depend directly on `librustzcash`. 