### PR TITLE
Hard-code Sapling circuit hashes in zcash_proofs crate

### DIFF
--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -84,7 +84,7 @@ pub fn load_parameters(
         panic!("Sapling output parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 
-    if sprout_fs.map(|fs| fs.into_hash()) != Some(SPROUT_HASH.to_owned()) {
+    if sprout_fs.map(|fs| fs.into_hash() != SPROUT_HASH).unwrap_or(false) {
         panic!("Sprout groth16 parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -84,7 +84,10 @@ pub fn load_parameters(
         panic!("Sapling output parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 
-    if sprout_fs.map(|fs| fs.into_hash() != SPROUT_HASH).unwrap_or(false) {
+    if sprout_fs
+        .map(|fs| fs.into_hash() != SPROUT_HASH)
+        .unwrap_or(false)
+    {
         panic!("Sprout groth16 parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -22,11 +22,8 @@ pub mod prover;
 
 pub fn load_parameters(
     spend_path: &Path,
-    spend_hash: &str,
     output_path: &Path,
-    output_hash: &str,
     sprout_path: Option<&Path>,
-    sprout_hash: Option<&str>,
 ) -> (
     Parameters<Bls12>,
     PreparedVerifyingKey<Bls12>,
@@ -34,6 +31,11 @@ pub fn load_parameters(
     PreparedVerifyingKey<Bls12>,
     Option<PreparedVerifyingKey<Bls12>>,
 ) {
+    // Sapling circuit hashes
+    const SAPLING_SPEND_HASH: &str = "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c";
+    const SAPLING_OUTPUT_HASH: &str = "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028";
+    const SPROUT_HASH: &str = "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a";
+
     // Load from each of the paths
     let spend_fs = File::open(spend_path).expect("couldn't load Sapling spend parameters file");
     let output_fs = File::open(output_path).expect("couldn't load Sapling output parameters file");
@@ -74,15 +76,15 @@ pub fn load_parameters(
             .expect("couldn't finish reading Sprout groth16 parameter file");
     }
 
-    if spend_fs.into_hash() != spend_hash {
+    if spend_fs.into_hash() != SAPLING_SPEND_HASH {
         panic!("Sapling spend parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 
-    if output_fs.into_hash() != output_hash {
+    if output_fs.into_hash() != SAPLING_OUTPUT_HASH {
         panic!("Sapling output parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 
-    if sprout_fs.map(|fs| fs.into_hash()) != sprout_hash.map(|h| h.to_owned()) {
+    if sprout_fs.map(|fs| fs.into_hash()) != Some(SPROUT_HASH.to_owned()) {
         panic!("Sprout groth16 parameter file is not correct, please clean your `~/.zcash-params/` and re-run `fetch-params`.");
     }
 

--- a/zcash_proofs/src/prover.rs
+++ b/zcash_proofs/src/prover.rs
@@ -19,9 +19,6 @@ use zcash_primitives::{
 
 use crate::{load_parameters, sapling::SaplingProvingContext};
 
-const SAPLING_SPEND_HASH: &str = "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c";
-const SAPLING_OUTPUT_HASH: &str = "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028";
-
 /// An implementation of [`TxProver`] using Sapling Spend and Output parameters from
 /// locally-accessible paths.
 pub struct LocalTxProver {
@@ -50,14 +47,8 @@ impl LocalTxProver {
     /// This function will panic if the paths do not point to valid parameter files with
     /// the expected hashes.
     pub fn new(spend_path: &Path, output_path: &Path) -> Self {
-        let (spend_params, spend_vk, output_params, _, _) = load_parameters(
-            spend_path,
-            SAPLING_SPEND_HASH,
-            output_path,
-            SAPLING_OUTPUT_HASH,
-            None,
-            None,
-        );
+        let (spend_params, spend_vk, output_params, _, _) =
+            load_parameters(spend_path, output_path, None);
         LocalTxProver {
             spend_params,
             spend_vk,


### PR DESCRIPTION
Define the spend_hash and output_hash circuit hashes as constants in the load_parameters function, so we don't have to take them as function arguments.

Closes #106 