### PR TITLE
group crate refactoring

### DIFF
--- a/bellman/src/domain.rs
+++ b/bellman/src/domain.rs
@@ -218,7 +218,7 @@ impl<G: CurveProjective> Clone for Point<G> {
 
 impl<G: CurveProjective> Group<G::Engine> for Point<G> {
     fn group_zero() -> Self {
-        Point(G::zero())
+        Point(G::identity())
     }
     fn group_mul_assign(&mut self, by: &G::Scalar) {
         self.0.mul_assign(by.to_repr());

--- a/bellman/src/domain.rs
+++ b/bellman/src/domain.rs
@@ -221,7 +221,7 @@ impl<G: CurveProjective, E: ScalarEngine<Fr = G::Scalar>> Group<E> for Point<G> 
         Point(G::identity())
     }
     fn group_mul_assign(&mut self, by: &G::Scalar) {
-        self.0.mul_assign(by.to_repr());
+        self.0.mul_assign(by);
     }
     fn group_add_assign(&mut self, other: &Self) {
         self.0.add_assign(&other.0);

--- a/bellman/src/domain.rs
+++ b/bellman/src/domain.rs
@@ -216,7 +216,7 @@ impl<G: CurveProjective> Clone for Point<G> {
     }
 }
 
-impl<G: CurveProjective> Group<G::Engine> for Point<G> {
+impl<G: CurveProjective, E: ScalarEngine<Fr = G::Scalar>> Group<E> for Point<G> {
     fn group_zero() -> Self {
         Point(G::identity())
     }

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -234,7 +234,7 @@ where
 
     let worker = Worker::new();
 
-    let mut h = vec![E::G1::zero(); powers_of_tau.as_ref().len() - 1];
+    let mut h = vec![E::G1::identity(); powers_of_tau.as_ref().len() - 1];
     {
         // Compute powers of tau
         {
@@ -287,11 +287,11 @@ where
     powers_of_tau.ifft(&worker);
     let powers_of_tau = powers_of_tau.into_coeffs();
 
-    let mut a = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];
-    let mut b_g1 = vec![E::G1::zero(); assembly.num_inputs + assembly.num_aux];
-    let mut b_g2 = vec![E::G2::zero(); assembly.num_inputs + assembly.num_aux];
-    let mut ic = vec![E::G1::zero(); assembly.num_inputs];
-    let mut l = vec![E::G1::zero(); assembly.num_aux];
+    let mut a = vec![E::G1::identity(); assembly.num_inputs + assembly.num_aux];
+    let mut b_g1 = vec![E::G1::identity(); assembly.num_inputs + assembly.num_aux];
+    let mut b_g2 = vec![E::G2::identity(); assembly.num_inputs + assembly.num_aux];
+    let mut ic = vec![E::G1::identity(); assembly.num_inputs];
+    let mut l = vec![E::G1::identity(); assembly.num_aux];
 
     fn eval<E: Engine>(
         // wNAF window tables
@@ -446,7 +446,7 @@ where
     // Don't allow any elements be unconstrained, so that
     // the L query is always fully dense.
     for e in l.iter() {
-        if e.is_zero() {
+        if e.is_identity() {
             return Err(SynthesisError::UnconstrainedVariable);
         }
     }
@@ -472,19 +472,19 @@ where
         // Filter points at infinity away from A/B queries
         a: Arc::new(
             a.into_iter()
-                .filter(|e| !e.is_zero())
+                .filter(|e| !e.is_identity())
                 .map(|e| e.into_affine())
                 .collect(),
         ),
         b_g1: Arc::new(
             b_g1.into_iter()
-                .filter(|e| !e.is_zero())
+                .filter(|e| !e.is_identity())
                 .map(|e| e.into_affine())
                 .collect(),
         ),
         b_g2: Arc::new(
             b_g2.into_iter()
-                .filter(|e| !e.is_zero())
+                .filter(|e| !e.is_identity())
                 .map(|e| e.into_affine())
                 .collect(),
         ),

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -3,7 +3,7 @@ use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use ff::Field;
-use group::{CurveAffine, CurveProjective, Wnaf};
+use group::{CurveAffine, CurveProjective, Group, Wnaf};
 use pairing::Engine;
 
 use super::{Parameters, VerifyingKey};

--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -446,7 +446,7 @@ where
     // Don't allow any elements be unconstrained, so that
     // the L query is always fully dense.
     for e in l.iter() {
-        if e.is_identity() {
+        if e.is_identity().into() {
             return Err(SynthesisError::UnconstrainedVariable);
         }
     }
@@ -472,19 +472,19 @@ where
         // Filter points at infinity away from A/B queries
         a: Arc::new(
             a.into_iter()
-                .filter(|e| !e.is_identity())
+                .filter(|e| bool::from(!e.is_identity()))
                 .map(|e| e.into_affine())
                 .collect(),
         ),
         b_g1: Arc::new(
             b_g1.into_iter()
-                .filter(|e| !e.is_identity())
+                .filter(|e| bool::from(!e.is_identity()))
                 .map(|e| e.into_affine())
                 .collect(),
         ),
         b_g2: Arc::new(
             b_g2.into_iter()
-                .filter(|e| !e.is_identity())
+                .filter(|e| bool::from(!e.is_identity()))
                 .map(|e| e.into_affine())
                 .collect(),
         ),

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -54,7 +54,7 @@ impl<E: Engine> Proof<E> {
             .into_affine()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             .and_then(|e| {
-                if e.is_zero() {
+                if e.is_identity() {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "point at infinity",
@@ -69,7 +69,7 @@ impl<E: Engine> Proof<E> {
             .into_affine()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             .and_then(|e| {
-                if e.is_zero() {
+                if e.is_identity() {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "point at infinity",
@@ -84,7 +84,7 @@ impl<E: Engine> Proof<E> {
             .into_affine()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             .and_then(|e| {
-                if e.is_zero() {
+                if e.is_identity() {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "point at infinity",
@@ -198,7 +198,7 @@ impl<E: Engine> VerifyingKey<E> {
                 .into_affine()
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
                 .and_then(|e| {
-                    if e.is_zero() {
+                    if e.is_identity() {
                         Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             "point at infinity",
@@ -303,7 +303,7 @@ impl<E: Engine> Parameters<E> {
             }
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             .and_then(|e| {
-                if e.is_zero() {
+                if e.is_identity() {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "point at infinity",
@@ -325,7 +325,7 @@ impl<E: Engine> Parameters<E> {
             }
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             .and_then(|e| {
-                if e.is_zero() {
+                if e.is_identity() {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "point at infinity",

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -317,7 +317,7 @@ where
     let mut a_answer = a_inputs.wait()?;
     AddAssign::<&E::G1>::add_assign(&mut a_answer, &a_aux.wait()?);
     AddAssign::<&E::G1>::add_assign(&mut g_a, &a_answer);
-    a_answer.mul_assign(s);
+    MulAssign::<E::Fr>::mul_assign(&mut a_answer, s);
     AddAssign::<&E::G1>::add_assign(&mut g_c, &a_answer);
 
     let mut b1_answer: E::G1 = b_g1_inputs.wait()?;
@@ -326,7 +326,7 @@ where
     AddAssign::<&E::G2>::add_assign(&mut b2_answer, &b_g2_aux.wait()?);
 
     AddAssign::<&E::G2>::add_assign(&mut g_b, &b2_answer);
-    b1_answer.mul_assign(r);
+    MulAssign::<E::Fr>::mul_assign(&mut b1_answer, r);
     AddAssign::<&E::G1>::add_assign(&mut g_c, &b1_answer);
     AddAssign::<&E::G1>::add_assign(&mut g_c, &h.wait()?);
     AddAssign::<&E::G1>::add_assign(&mut g_c, &l.wait()?);

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -295,7 +295,7 @@ where
     );
     let b_g2_aux = multiexp(&worker, b_g2_aux_source, b_aux_density, aux_assignment);
 
-    if vk.delta_g1.is_zero() || vk.delta_g2.is_zero() {
+    if vk.delta_g1.is_identity() || vk.delta_g2.is_identity() {
         // If this element is zero, someone is trying to perform a
         // subversion-CRS attack.
         return Err(SynthesisError::UnexpectedIdentity);

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -380,8 +380,8 @@ impl CurveProjective for Fr {
         true
     }
 
-    fn double(&mut self) {
-        self.0 = <Fr as Field>::double(self).0;
+    fn double(&self) -> Self {
+        <Fr as Field>::double(self)
     }
 
     fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S) {

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -381,6 +381,10 @@ impl Group for Fr {
     fn is_identity(&self) -> bool {
         <Fr as Field>::is_zero(self)
     }
+
+    fn double(&self) -> Self {
+        <Fr as Field>::double(self)
+    }
 }
 
 impl PrimeGroup for Fr {}
@@ -394,10 +398,6 @@ impl CurveProjective for Fr {
 
     fn is_normalized(&self) -> bool {
         true
-    }
-
-    fn double(&self) -> Self {
-        <Fr as Field>::double(self)
     }
 
     fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S) {

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -4,6 +4,7 @@ use pairing::{Engine, PairingCurveAffine};
 
 use rand_core::RngCore;
 use std::fmt;
+use std::iter::Sum;
 use std::num::Wrapping;
 use std::ops::{Add, AddAssign, BitAnd, Mul, MulAssign, Neg, Shr, Sub, SubAssign};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -44,6 +45,18 @@ impl ConditionallySelectable for Fr {
             &(b.0).0,
             choice,
         )))
+    }
+}
+
+impl Sum for Fr {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), ::std::ops::Add::add)
+    }
+}
+
+impl<'r> Sum<&'r Fr> for Fr {
+    fn sum<I: Iterator<Item = &'r Fr>>(iter: I) -> Self {
+        iter.fold(Self::zero(), ::std::ops::Add::add)
     }
 }
 

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -356,7 +356,6 @@ impl CurveProjective for Fr {
     type Affine = Fr;
     type Base = Fr;
     type Scalar = Fr;
-    type Engine = DummyEngine;
 
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         <Fr as Field>::random(rng)
@@ -448,7 +447,6 @@ impl CurveAffine for Fr {
     type Projective = Fr;
     type Base = Fr;
     type Scalar = Fr;
-    type Engine = DummyEngine;
 
     fn identity() -> Self {
         <Fr as Field>::zero()

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -366,6 +366,8 @@ impl Engine for DummyEngine {
 }
 
 impl Group for Fr {
+    type Subgroup = Fr;
+
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         <Fr as Field>::random(rng)
     }

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -1,5 +1,5 @@
 use ff::{Field, PrimeField, ScalarEngine};
-use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
+use group::{CurveAffine, CurveProjective, EncodedPoint, Group, GroupDecodingError, PrimeGroup};
 use pairing::{Engine, PairingCurveAffine};
 
 use rand_core::RngCore;
@@ -352,11 +352,7 @@ impl Engine for DummyEngine {
     }
 }
 
-impl CurveProjective for Fr {
-    type Affine = Fr;
-    type Base = Fr;
-    type Scalar = Fr;
-
+impl Group for Fr {
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         <Fr as Field>::random(rng)
     }
@@ -372,6 +368,14 @@ impl CurveProjective for Fr {
     fn is_identity(&self) -> bool {
         <Fr as Field>::is_zero(self)
     }
+}
+
+impl PrimeGroup for Fr {}
+
+impl CurveProjective for Fr {
+    type Affine = Fr;
+    type Base = Fr;
+    type Scalar = Fr;
 
     fn batch_normalization(_: &mut [Self]) {}
 

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -381,8 +381,8 @@ impl Group for Fr {
         <Fr as Field>::one()
     }
 
-    fn is_identity(&self) -> bool {
-        <Fr as Field>::is_zero(self)
+    fn is_identity(&self) -> Choice {
+        Choice::from(if <Fr as Field>::is_zero(self) { 1 } else { 0 })
     }
 
     fn double(&self) -> Self {

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -166,7 +166,7 @@ impl Shr<u32> for Fr {
 }
 
 impl Field for Fr {
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         Fr(Wrapping(rng.next_u32()) % MODULUS_R)
     }
 
@@ -358,7 +358,7 @@ impl CurveProjective for Fr {
     type Scalar = Fr;
     type Engine = DummyEngine;
 
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         <Fr as Field>::random(rng)
     }
 

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -362,15 +362,15 @@ impl CurveProjective for Fr {
         <Fr as Field>::random(rng)
     }
 
-    fn zero() -> Self {
+    fn identity() -> Self {
         <Fr as Field>::zero()
     }
 
-    fn one() -> Self {
+    fn generator() -> Self {
         <Fr as Field>::one()
     }
 
-    fn is_zero(&self) -> bool {
+    fn is_identity(&self) -> bool {
         <Fr as Field>::is_zero(self)
     }
 
@@ -450,15 +450,15 @@ impl CurveAffine for Fr {
     type Scalar = Fr;
     type Engine = DummyEngine;
 
-    fn zero() -> Self {
+    fn identity() -> Self {
         <Fr as Field>::zero()
     }
 
-    fn one() -> Self {
+    fn generator() -> Self {
         <Fr as Field>::one()
     }
 
-    fn is_zero(&self) -> bool {
+    fn is_identity(&self) -> bool {
         <Fr as Field>::is_zero(self)
     }
 

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -367,6 +367,7 @@ impl Engine for DummyEngine {
 
 impl Group for Fr {
     type Subgroup = Fr;
+    type Scalar = Fr;
 
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         <Fr as Field>::random(rng)
@@ -394,18 +395,11 @@ impl PrimeGroup for Fr {}
 impl CurveProjective for Fr {
     type Affine = Fr;
     type Base = Fr;
-    type Scalar = Fr;
 
     fn batch_normalization(_: &mut [Self]) {}
 
     fn is_normalized(&self) -> bool {
         true
-    }
-
-    fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S) {
-        let tmp = Fr::from_repr(other.into()).unwrap();
-
-        MulAssign::mul_assign(self, &tmp);
     }
 
     fn into_affine(&self) -> Fr {

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -314,6 +314,7 @@ fn test_with_bls12() {
         acc
     }
 
+    use group::Group;
     use pairing::{bls12_381::Bls12, Engine};
     use rand;
 

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -55,7 +55,7 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
             .into());
         }
 
-        if self.0[self.1].is_zero() {
+        if self.0[self.1].is_identity() {
             return Err(SynthesisError::UnexpectedIdentity);
         }
 
@@ -173,13 +173,13 @@ where
 
         pool.compute(move || {
             // Accumulate the result
-            let mut acc = G::zero();
+            let mut acc = G::identity();
 
             // Build a source for the bases
             let mut bases = bases.new();
 
             // Create space for the buckets
-            let mut buckets = vec![G::zero(); (1 << c) - 1];
+            let mut buckets = vec![G::identity(); (1 << c) - 1];
 
             let one = <G::Engine as ScalarEngine>::Fr::one();
 
@@ -222,7 +222,7 @@ where
             // e.g. 3a + 2b + 1c = a +
             //                    (a) + b +
             //                    ((a) + b) + c
-            let mut running_sum = G::zero();
+            let mut running_sum = G::identity();
             for exp in buckets.into_iter().rev() {
                 running_sum.add_assign(&exp);
                 acc.add_assign(&running_sum);
@@ -302,7 +302,7 @@ fn test_with_bls12() {
     ) -> G {
         assert_eq!(bases.len(), exponents.len());
 
-        let mut acc = G::zero();
+        let mut acc = G::identity();
 
         for (base, exp) in bases.iter().zip(exponents.iter()) {
             AddAssign::<&G>::add_assign(&mut acc, &base.mul(exp.to_repr()));

--- a/bellman/src/multiexp.rs
+++ b/bellman/src/multiexp.rs
@@ -252,7 +252,7 @@ where
             ))
             .map(move |(this, mut higher): (_, G)| {
                 for _ in 0..c {
-                    higher.double();
+                    higher = higher.double();
                 }
 
                 higher.add_assign(&this);

--- a/ff/ff_derive/src/lib.rs
+++ b/ff/ff_derive/src/lib.rs
@@ -1188,7 +1188,7 @@ fn prime_field_impl(
 
         impl ::ff::Field for #name {
             /// Computes a uniformly random element using rejection sampling.
-            fn random<R: ::rand_core::RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+            fn random<R: ::rand_core::RngCore + ?Sized>(rng: &mut R) -> Self {
                 loop {
                     let mut tmp = {
                         let mut repr = [0u64; #limbs];

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -50,7 +50,7 @@ pub trait Field:
     + for<'a> SubAssign<&'a Self>
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
 
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self;

--- a/group/Cargo.toml
+++ b/group/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = { version = "1", default-features = false }
 ff = { version = "0.6", path = "../ff" }
 rand = "0.7"
 rand_xorshift = "0.2"
+subtle = { version = "2.2.1", default-features = false }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -5,6 +5,7 @@ use ff::{Field, PrimeField};
 use rand::RngCore;
 use std::error::Error;
 use std::fmt;
+use std::iter::Sum;
 use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 pub mod tests;
@@ -38,6 +39,8 @@ pub trait Group:
     + Send
     + Sync
     + 'static
+    + Sum
+    + for<'a> Sum<&'a Self>
     + Neg<Output = Self>
     + GroupOps
     + GroupOpsOwned

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -44,7 +44,13 @@ pub trait Group:
     + Neg<Output = Self>
     + GroupOps
     + GroupOpsOwned
+    + GroupOps<<Self as Group>::Subgroup>
+    + GroupOpsOwned<<Self as Group>::Subgroup>
 {
+    /// The large prime-order subgroup in which cryptographic operations are performed.
+    /// If `Self` implements `PrimeGroup`, then `Self::Subgroup` may be `Self`.
+    type Subgroup: PrimeGroup;
+
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
 
@@ -52,7 +58,7 @@ pub trait Group:
     fn identity() -> Self;
 
     /// Returns a fixed generator of the prime-order subgroup.
-    fn generator() -> Self;
+    fn generator() -> Self::Subgroup;
 
     /// Determines if this point is the identity.
     fn is_identity(&self) -> bool;

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -1,7 +1,7 @@
 // Catch documentation errors caused by code changes.
 #![deny(intra_doc_link_resolution_failure)]
 
-use ff::{Field, PrimeField, ScalarEngine};
+use ff::{Field, PrimeField};
 use rand::RngCore;
 use std::error::Error;
 use std::fmt;
@@ -46,7 +46,6 @@ pub trait CurveProjective:
     + CurveOps<<Self as CurveProjective>::Affine>
     + CurveOpsOwned<<Self as CurveProjective>::Affine>
 {
-    type Engine: ScalarEngine<Fr = Self::Scalar>;
     type Scalar: PrimeField;
     type Base: Field;
     type Affine: CurveAffine<Projective = Self, Scalar = Self::Scalar>;
@@ -105,7 +104,6 @@ pub trait CurveAffine:
     + 'static
     + Neg<Output = Self>
 {
-    type Engine: ScalarEngine<Fr = Self::Scalar>;
     type Scalar: PrimeField;
     type Base: Field;
     type Projective: CurveProjective<Affine = Self, Scalar = Self::Scalar>;

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -52,7 +52,7 @@ pub trait CurveProjective:
     type Affine: CurveAffine<Projective = Self, Scalar = Self::Scalar>;
 
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
 
     /// Returns the additive identity.
     fn zero() -> Self;

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use subtle::Choice;
 
 pub mod tests;
 
@@ -80,7 +81,7 @@ pub trait Group:
     fn generator() -> Self::Subgroup;
 
     /// Determines if this point is the identity.
-    fn is_identity(&self) -> bool;
+    fn is_identity(&self) -> Choice;
 
     /// Doubles this element.
     #[must_use]

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -72,7 +72,8 @@ pub trait CurveProjective:
     fn is_normalized(&self) -> bool;
 
     /// Doubles this element.
-    fn double(&mut self);
+    #[must_use]
+    fn double(&self) -> Self;
 
     /// Performs scalar multiplication of this element.
     fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S);

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -55,13 +55,13 @@ pub trait CurveProjective:
     fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
 
     /// Returns the additive identity.
-    fn zero() -> Self;
+    fn identity() -> Self;
 
     /// Returns a fixed generator of unknown exponent.
-    fn one() -> Self;
+    fn generator() -> Self;
 
     /// Determines if this point is the point at infinity.
-    fn is_zero(&self) -> bool;
+    fn is_identity(&self) -> bool;
 
     /// Normalizes a slice of projective elements so that
     /// conversion to affine is cheap.
@@ -112,14 +112,14 @@ pub trait CurveAffine:
     type Compressed: EncodedPoint<Affine = Self>;
 
     /// Returns the additive identity.
-    fn zero() -> Self;
+    fn identity() -> Self;
 
     /// Returns a fixed generator of unknown exponent.
-    fn one() -> Self;
+    fn generator() -> Self;
 
     /// Determines if this point represents the point at infinity; the
     /// additive identity.
-    fn is_zero(&self) -> bool;
+    fn is_identity(&self) -> bool;
 
     /// Performs scalar multiplication of this element with mixed addition.
     fn mul<S: Into<<Self::Scalar as PrimeField>::Repr>>(&self, other: S) -> Self::Projective;

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -56,6 +56,10 @@ pub trait Group:
 
     /// Determines if this point is the identity.
     fn is_identity(&self) -> bool;
+
+    /// Doubles this element.
+    #[must_use]
+    fn double(&self) -> Self;
 }
 
 /// This trait represents an element of a prime-order cryptographic group.
@@ -79,10 +83,6 @@ pub trait CurveProjective:
     /// Checks if the point is already "normalized" so that
     /// cheap affine conversion is possible.
     fn is_normalized(&self) -> bool;
-
-    /// Doubles this element.
-    #[must_use]
-    fn double(&self) -> Self;
 
     /// Performs scalar multiplication of this element.
     fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S);

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -19,8 +19,7 @@ pub fn curve_tests<G: CurveProjective>() {
 
     // Doubling edge case with identity.
     {
-        let mut z = G::identity();
-        z.double();
+        let z = G::identity().double();
         assert!(z.is_identity());
     }
 
@@ -230,13 +229,11 @@ fn random_doubling_tests<G: CurveProjective>() {
         let mut b = G::random(&mut rng);
 
         // 2(a + b)
-        let mut tmp1 = a;
-        tmp1.add_assign(&b);
-        tmp1.double();
+        let tmp1 = (a + b).double();
 
         // 2a + 2b
-        a.double();
-        b.double();
+        a = a.double();
+        b = b.double();
 
         let mut tmp2 = a;
         tmp2.add_assign(&b);
@@ -306,8 +303,7 @@ fn random_addition_tests<G: CurveProjective>() {
             let mut aplusamixed = a;
             aplusamixed.add_assign(&a.into_affine());
 
-            let mut adouble = a;
-            adouble.double();
+            let adouble = a.double();
 
             assert_eq!(aplusa, adouble);
             assert_eq!(aplusa, aplusamixed);

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -14,13 +14,13 @@ pub fn curve_tests<G: CurveProjective>() {
     // Negation edge case with identity.
     {
         let z = G::identity().neg();
-        assert!(z.is_identity());
+        assert!(bool::from(z.is_identity()));
     }
 
     // Doubling edge case with identity.
     {
         let z = G::identity().double();
-        assert!(z.is_identity());
+        assert!(bool::from(z.is_identity()));
     }
 
     // Addition edge cases with identity
@@ -34,9 +34,9 @@ pub fn curve_tests<G: CurveProjective>() {
 
         let mut z = G::identity();
         z.add_assign(&G::identity());
-        assert!(z.is_identity());
+        assert!(bool::from(z.is_identity()));
         z.add_assign(&G::Affine::identity());
-        assert!(z.is_identity());
+        assert!(bool::from(z.is_identity()));
 
         let mut z2 = z;
         z2.add_assign(&r);
@@ -208,11 +208,11 @@ fn random_negation_tests<G: CurveProjective>() {
 
         let mut t3 = t1;
         t3.add_assign(&t2);
-        assert!(t3.is_identity());
+        assert!(bool::from(t3.is_identity()));
 
         let mut t4 = t1;
         t4.add_assign(&t2.into_affine());
-        assert!(t4.is_identity());
+        assert!(bool::from(t4.is_identity()));
 
         assert_eq!(t1.neg(), t2);
     }

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -11,33 +11,33 @@ pub fn curve_tests<G: CurveProjective>() {
         0xe5,
     ]);
 
-    // Negation edge case with zero.
+    // Negation edge case with identity.
     {
-        let z = G::zero().neg();
-        assert!(z.is_zero());
+        let z = G::identity().neg();
+        assert!(z.is_identity());
     }
 
-    // Doubling edge case with zero.
+    // Doubling edge case with identity.
     {
-        let mut z = G::zero();
+        let mut z = G::identity();
         z.double();
-        assert!(z.is_zero());
+        assert!(z.is_identity());
     }
 
-    // Addition edge cases with zero
+    // Addition edge cases with identity
     {
         let mut r = G::random(&mut rng);
         let rcopy = r;
-        r.add_assign(&G::zero());
+        r.add_assign(&G::identity());
         assert_eq!(r, rcopy);
-        r.add_assign(&G::Affine::zero());
+        r.add_assign(&G::Affine::identity());
         assert_eq!(r, rcopy);
 
-        let mut z = G::zero();
-        z.add_assign(&G::zero());
-        assert!(z.is_zero());
-        z.add_assign(&G::Affine::zero());
-        assert!(z.is_zero());
+        let mut z = G::identity();
+        z.add_assign(&G::identity());
+        assert!(z.is_identity());
+        z.add_assign(&G::Affine::identity());
+        assert!(z.is_identity());
 
         let mut z2 = z;
         z2.add_assign(&r);
@@ -209,11 +209,11 @@ fn random_negation_tests<G: CurveProjective>() {
 
         let mut t3 = t1;
         t3.add_assign(&t2);
-        assert!(t3.is_zero());
+        assert!(t3.is_identity());
 
         let mut t4 = t1;
         t4.add_assign(&t2.into_affine());
-        assert!(t4.is_zero());
+        assert!(t4.is_identity());
 
         assert_eq!(t1.neg(), t2);
     }
@@ -313,7 +313,7 @@ fn random_addition_tests<G: CurveProjective>() {
             assert_eq!(aplusa, aplusamixed);
         }
 
-        let mut tmp = vec![G::zero(); 6];
+        let mut tmp = vec![G::identity(); 6];
 
         // (a + b) + c
         tmp[0] = a;
@@ -390,7 +390,7 @@ fn random_transformation_tests<G: CurveProjective>() {
         let between = Uniform::new(0, 1000);
         // Sprinkle in some normalized points
         for _ in 0..5 {
-            v[between.sample(&mut rng)] = G::zero();
+            v[between.sample(&mut rng)] = G::identity();
         }
         for _ in 0..5 {
             let s = between.sample(&mut rng);
@@ -418,13 +418,19 @@ fn random_encoding_tests<G: CurveProjective>() {
     ]);
 
     assert_eq!(
-        G::Affine::zero().into_uncompressed().into_affine().unwrap(),
-        G::Affine::zero()
+        G::Affine::identity()
+            .into_uncompressed()
+            .into_affine()
+            .unwrap(),
+        G::Affine::identity()
     );
 
     assert_eq!(
-        G::Affine::zero().into_compressed().into_affine().unwrap(),
-        G::Affine::zero()
+        G::Affine::identity()
+            .into_compressed()
+            .into_affine()
+            .unwrap(),
+        G::Affine::identity()
     );
 
     for _ in 0..1000 {

--- a/group/src/wnaf.rs
+++ b/group/src/wnaf.rs
@@ -9,8 +9,7 @@ pub(crate) fn wnaf_table<G: CurveProjective>(table: &mut Vec<G>, mut base: G, wi
     table.truncate(0);
     table.reserve(1 << (window - 1));
 
-    let mut dbl = base;
-    dbl.double();
+    let dbl = base.double();
 
     for _ in 0..(1 << (window - 1)) {
         table.push(base);
@@ -86,7 +85,7 @@ pub(crate) fn wnaf_exp<G: CurveProjective>(table: &[G], wnaf: &[i64]) -> G {
 
     for n in wnaf.iter().rev() {
         if found_one {
-            result.double();
+            result = result.double();
         }
 
         if *n != 0 {

--- a/group/src/wnaf.rs
+++ b/group/src/wnaf.rs
@@ -2,7 +2,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use ff::PrimeField;
 use std::iter;
 
-use super::CurveProjective;
+use super::{CurveProjective, Group};
 
 /// Replaces the contents of `table` with a w-NAF window table for the given window size.
 pub(crate) fn wnaf_table<G: CurveProjective>(table: &mut Vec<G>, mut base: G, window: usize) {
@@ -140,10 +140,7 @@ impl<G: CurveProjective> Wnaf<(), Vec<G>, Vec<i64>> {
 
     /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
     /// exponentiations with `.base(..)`.
-    pub fn scalar(
-        &mut self,
-        scalar: &<G as CurveProjective>::Scalar,
-    ) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
+    pub fn scalar(&mut self, scalar: &<G as Group>::Scalar) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
         // Compute the appropriate window size for the scalar.
         let window_size = G::recommended_wnaf_for_scalar(&scalar);
 
@@ -198,7 +195,7 @@ impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
 
 impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
     /// Performs exponentiation given a scalar.
-    pub fn scalar<G: CurveProjective>(&mut self, scalar: &<G as CurveProjective>::Scalar) -> G
+    pub fn scalar<G: CurveProjective>(&mut self, scalar: &<G as Group>::Scalar) -> G
     where
         B: AsRef<[G]>,
     {

--- a/group/src/wnaf.rs
+++ b/group/src/wnaf.rs
@@ -80,7 +80,7 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
 /// This function must be provided a `table` and `wnaf` that were constructed with
 /// the same window size; otherwise, it may panic or produce invalid results.
 pub(crate) fn wnaf_exp<G: CurveProjective>(table: &[G], wnaf: &[i64]) -> G {
-    let mut result = G::zero();
+    let mut result = G::identity();
 
     let mut found_one = false;
 

--- a/pairing/benches/bls12_381/ec.rs
+++ b/pairing/benches/bls12_381/ec.rs
@@ -5,7 +5,7 @@ pub(crate) mod g1 {
     use std::ops::AddAssign;
 
     use ff::Field;
-    use group::{CurveProjective, Group};
+    use group::Group;
     use pairing::bls12_381::*;
 
     fn bench_g1_mul_assign(c: &mut Criterion) {
@@ -24,7 +24,7 @@ pub(crate) mod g1 {
         c.bench_function("G1::mul_assign", |b| {
             b.iter(|| {
                 let mut tmp = v[count].0;
-                tmp.mul_assign(v[count].1);
+                tmp *= v[count].1;
                 count = (count + 1) % SAMPLES;
                 tmp
             })
@@ -92,7 +92,7 @@ pub(crate) mod g2 {
     use std::ops::AddAssign;
 
     use ff::Field;
-    use group::{CurveProjective, Group};
+    use group::Group;
     use pairing::bls12_381::*;
 
     fn bench_g2_mul_assign(c: &mut Criterion) {
@@ -111,7 +111,7 @@ pub(crate) mod g2 {
         c.bench_function("G2::mul_assign", |b| {
             b.iter(|| {
                 let mut tmp = v[count].0;
-                tmp.mul_assign(v[count].1);
+                tmp *= v[count].1;
                 count = (count + 1) % SAMPLES;
                 tmp
             })

--- a/pairing/benches/bls12_381/ec.rs
+++ b/pairing/benches/bls12_381/ec.rs
@@ -5,7 +5,7 @@ pub(crate) mod g1 {
     use std::ops::AddAssign;
 
     use ff::Field;
-    use group::CurveProjective;
+    use group::{CurveProjective, Group};
     use pairing::bls12_381::*;
 
     fn bench_g1_mul_assign(c: &mut Criterion) {
@@ -92,7 +92,7 @@ pub(crate) mod g2 {
     use std::ops::AddAssign;
 
     use ff::Field;
-    use group::CurveProjective;
+    use group::{CurveProjective, Group};
     use pairing::bls12_381::*;
 
     fn bench_g2_mul_assign(c: &mut Criterion) {

--- a/pairing/benches/bls12_381/mod.rs
+++ b/pairing/benches/bls12_381/mod.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, Criterion};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use group::CurveProjective;
+use group::Group;
 use pairing::bls12_381::*;
 use pairing::{Engine, PairingCurveAffine};
 

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -42,11 +42,11 @@ macro_rules! curve_impl {
 
         impl PartialEq for $projective {
             fn eq(&self, other: &$projective) -> bool {
-                if self.is_identity() {
-                    return other.is_identity();
+                if self.is_identity().into() {
+                    return other.is_identity().into();
                 }
 
-                if other.is_identity() {
+                if other.is_identity().into() {
                     return false;
                 }
 
@@ -126,7 +126,7 @@ macro_rules! curve_impl {
             }
 
             fn is_on_curve(&self) -> bool {
-                if self.is_identity() {
+                if self.is_identity().into() {
                     true
                 } else {
                     // Check that the point is on the curve
@@ -141,7 +141,7 @@ macro_rules! curve_impl {
             }
 
             fn is_in_correct_subgroup_assuming_on_curve(&self) -> bool {
-                self.mul($scalarfield::char()).is_identity()
+                self.mul($scalarfield::char()).is_identity().into()
             }
         }
 
@@ -151,7 +151,7 @@ macro_rules! curve_impl {
             #[inline]
             fn neg(self) -> Self {
                 let mut ret = self;
-                if !ret.is_identity() {
+                if bool::from(!ret.is_identity()) {
                     ret.y = ret.y.neg();
                 }
                 ret
@@ -223,7 +223,7 @@ macro_rules! curve_impl {
             #[inline]
             fn neg(self) -> Self {
                 let mut ret = self;
-                if !ret.is_identity() {
+                if bool::from(!ret.is_identity()) {
                     ret.y = ret.y.neg();
                 }
                 ret
@@ -252,12 +252,12 @@ macro_rules! curve_impl {
 
         impl<'r> ::std::ops::AddAssign<&'r $projective> for $projective {
             fn add_assign(&mut self, other: &Self) {
-                if self.is_identity() {
+                if self.is_identity().into() {
                     *self = *other;
                     return;
                 }
 
-                if other.is_identity() {
+                if other.is_identity().into() {
                     return;
                 }
 
@@ -401,11 +401,11 @@ macro_rules! curve_impl {
             for $projective
         {
             fn add_assign(&mut self, other: &<$projective as CurveProjective>::Affine) {
-                if other.is_identity() {
+                if other.is_identity().into() {
                     return;
                 }
 
-                if self.is_identity() {
+                if self.is_identity().into() {
                     self.x = other.x;
                     self.y = other.y;
                     self.z = $basefield::one();
@@ -579,7 +579,7 @@ macro_rules! curve_impl {
                     if p.is_some().into() {
                         let p = p.unwrap().scale_by_cofactor();
 
-                        if !p.is_identity() {
+                        if bool::from(!p.is_identity()) {
                             return p;
                         }
                     }
@@ -602,12 +602,12 @@ macro_rules! curve_impl {
 
             // The point at infinity is always represented by
             // Z = 0.
-            fn is_identity(&self) -> bool {
-                self.z.is_zero()
+            fn is_identity(&self) -> Choice {
+                Choice::from(if self.z.is_zero() { 1 } else { 0 })
             }
 
             fn double(&self) -> Self {
-                if self.is_identity() {
+                if self.is_identity().into() {
                     return *self;
                 }
 
@@ -662,7 +662,7 @@ macro_rules! curve_impl {
             type Affine = $affine;
 
             fn is_normalized(&self) -> bool {
-                self.is_identity() || self.z == $basefield::one()
+                self.is_identity().into() || self.z == $basefield::one()
             }
 
             fn batch_normalization(v: &mut [Self]) {
@@ -737,7 +737,7 @@ macro_rules! curve_impl {
         // coordinates with Z = 1.
         impl From<$affine> for $projective {
             fn from(p: $affine) -> $projective {
-                if p.is_identity() {
+                if p.is_identity().into() {
                     $projective::identity()
                 } else {
                     $projective {
@@ -753,7 +753,7 @@ macro_rules! curve_impl {
         // coordinates as X/Z^2, Y/Z^3.
         impl From<$projective> for $affine {
             fn from(p: $projective) -> $affine {
-                if p.is_identity() {
+                if p.is_identity().into() {
                     $affine::identity()
                 } else if p.z == $basefield::one() {
                     // If Z is one, the point is already normalized.
@@ -798,7 +798,7 @@ pub mod g1 {
     use rand_core::RngCore;
     use std::fmt;
     use std::ops::{AddAssign, MulAssign, Neg, SubAssign};
-    use subtle::CtOption;
+    use subtle::{Choice, CtOption};
 
     curve_impl!(
         "G1",
@@ -1114,7 +1114,7 @@ pub mod g1 {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
 
                 let g1 = p.scale_by_cofactor();
-                if !g1.is_identity() {
+                if bool::from(!g1.is_identity()) {
                     assert_eq!(i, 4);
                     let g1 = G1Affine::from(g1);
 
@@ -1408,7 +1408,7 @@ pub mod g2 {
     use rand_core::RngCore;
     use std::fmt;
     use std::ops::{AddAssign, MulAssign, Neg, SubAssign};
-    use subtle::CtOption;
+    use subtle::{Choice, CtOption};
 
     curve_impl!(
         "G2",
@@ -1767,7 +1767,7 @@ pub mod g2 {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
 
                 let g2 = p.scale_by_cofactor();
-                if !g2.is_identity() {
+                if bool::from(!g2.is_identity()) {
                     assert_eq!(i, 2);
                     let g2 = G2Affine::from(g2);
 

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -159,7 +159,6 @@ macro_rules! curve_impl {
         }
 
         impl CurveAffine for $affine {
-            type Engine = Bls12;
             type Scalar = $scalarfield;
             type Base = $basefield;
             type Projective = $projective;
@@ -510,7 +509,6 @@ macro_rules! curve_impl {
         }
 
         impl CurveProjective for $projective {
-            type Engine = Bls12;
             type Scalar = $scalarfield;
             type Base = $basefield;
             type Affine = $affine;
@@ -746,7 +744,7 @@ macro_rules! curve_impl {
 }
 
 pub mod g1 {
-    use super::super::{Bls12, Fq, Fq12, FqRepr, Fr};
+    use super::super::{Fq, Fq12, FqRepr, Fr};
     use super::g2::G2Affine;
     use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField};
@@ -1354,7 +1352,7 @@ pub mod g1 {
 }
 
 pub mod g2 {
-    use super::super::{Bls12, Fq, Fq12, Fq2, FqRepr, Fr};
+    use super::super::{Fq, Fq12, Fq2, FqRepr, Fr};
     use super::g1::G1Affine;
     use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField};

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -205,6 +205,18 @@ macro_rules! curve_impl {
             }
         }
 
+        impl ::std::iter::Sum for $projective {
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::identity(), ::std::ops::Add::add)
+            }
+        }
+
+        impl<'r> ::std::iter::Sum<&'r $projective> for $projective {
+            fn sum<I: Iterator<Item = &'r $projective>>(iter: I) -> Self {
+                iter.fold(Self::identity(), ::std::ops::Add::add)
+            }
+        }
+
         impl ::std::ops::Neg for $projective {
             type Output = Self;
 

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -515,7 +515,7 @@ macro_rules! curve_impl {
             type Base = $basefield;
             type Affine = $affine;
 
-            fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+            fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
                 loop {
                     let x = $basefield::random(rng);
                     let greatest = rng.next_u32() % 2 != 0;

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -521,6 +521,8 @@ macro_rules! curve_impl {
         }
 
         impl Group for $projective {
+            type Subgroup = Self;
+
             fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
                 loop {
                     let x = $basefield::random(rng);

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -508,11 +508,7 @@ macro_rules! curve_impl {
             }
         }
 
-        impl CurveProjective for $projective {
-            type Scalar = $scalarfield;
-            type Base = $basefield;
-            type Affine = $affine;
-
+        impl Group for $projective {
             fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
                 loop {
                     let x = $basefield::random(rng);
@@ -548,6 +544,14 @@ macro_rules! curve_impl {
             fn is_identity(&self) -> bool {
                 self.z.is_zero()
             }
+        }
+
+        impl PrimeGroup for $projective {}
+
+        impl CurveProjective for $projective {
+            type Scalar = $scalarfield;
+            type Base = $basefield;
+            type Affine = $affine;
 
             fn is_normalized(&self) -> bool {
                 self.is_identity() || self.z == $basefield::one()
@@ -748,7 +752,9 @@ pub mod g1 {
     use super::g2::G2Affine;
     use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField};
-    use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
+    use group::{
+        CurveAffine, CurveProjective, EncodedPoint, Group, GroupDecodingError, PrimeGroup,
+    };
     use rand_core::RngCore;
     use std::fmt;
     use std::ops::{AddAssign, MulAssign, Neg, SubAssign};
@@ -1356,7 +1362,9 @@ pub mod g2 {
     use super::g1::G1Affine;
     use crate::{Engine, PairingCurveAffine};
     use ff::{BitIterator, Field, PrimeField};
-    use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
+    use group::{
+        CurveAffine, CurveProjective, EncodedPoint, Group, GroupDecodingError, PrimeGroup,
+    };
     use rand_core::RngCore;
     use std::fmt;
     use std::ops::{AddAssign, MulAssign, Neg, SubAssign};

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -42,11 +42,11 @@ macro_rules! curve_impl {
 
         impl PartialEq for $projective {
             fn eq(&self, other: &$projective) -> bool {
-                if self.is_zero() {
-                    return other.is_zero();
+                if self.is_identity() {
+                    return other.is_identity();
                 }
 
-                if other.is_zero() {
+                if other.is_identity() {
                     return false;
                 }
 
@@ -82,7 +82,7 @@ macro_rules! curve_impl {
 
         impl $affine {
             fn mul_bits_u64<S: AsRef<[u64]>>(&self, bits: BitIterator<u64, S>) -> $projective {
-                let mut res = $projective::zero();
+                let mut res = $projective::identity();
                 for i in bits {
                     res.double();
                     if i {
@@ -93,7 +93,7 @@ macro_rules! curve_impl {
             }
 
             fn mul_bits_u8<S: AsRef<[u8]>>(&self, bits: BitIterator<u8, S>) -> $projective {
-                let mut res = $projective::zero();
+                let mut res = $projective::identity();
                 for i in bits {
                     res.double();
                     if i {
@@ -126,7 +126,7 @@ macro_rules! curve_impl {
             }
 
             fn is_on_curve(&self) -> bool {
-                if self.is_zero() {
+                if self.is_identity() {
                     true
                 } else {
                     // Check that the point is on the curve
@@ -141,7 +141,7 @@ macro_rules! curve_impl {
             }
 
             fn is_in_correct_subgroup_assuming_on_curve(&self) -> bool {
-                self.mul($scalarfield::char()).is_zero()
+                self.mul($scalarfield::char()).is_identity()
             }
         }
 
@@ -151,7 +151,7 @@ macro_rules! curve_impl {
             #[inline]
             fn neg(self) -> Self {
                 let mut ret = self;
-                if !ret.is_zero() {
+                if !ret.is_identity() {
                     ret.y = ret.y.neg();
                 }
                 ret
@@ -166,7 +166,7 @@ macro_rules! curve_impl {
             type Uncompressed = $uncompressed;
             type Compressed = $compressed;
 
-            fn zero() -> Self {
+            fn identity() -> Self {
                 $affine {
                     x: $basefield::zero(),
                     y: $basefield::one(),
@@ -174,11 +174,11 @@ macro_rules! curve_impl {
                 }
             }
 
-            fn one() -> Self {
+            fn generator() -> Self {
                 Self::get_generator()
             }
 
-            fn is_zero(&self) -> bool {
+            fn is_identity(&self) -> bool {
                 self.infinity
             }
 
@@ -212,7 +212,7 @@ macro_rules! curve_impl {
             #[inline]
             fn neg(self) -> Self {
                 let mut ret = self;
-                if !ret.is_zero() {
+                if !ret.is_identity() {
                     ret.y = ret.y.neg();
                 }
                 ret
@@ -241,12 +241,12 @@ macro_rules! curve_impl {
 
         impl<'r> ::std::ops::AddAssign<&'r $projective> for $projective {
             fn add_assign(&mut self, other: &Self) {
-                if self.is_zero() {
+                if self.is_identity() {
                     *self = *other;
                     return;
                 }
 
-                if other.is_zero() {
+                if other.is_identity() {
                     return;
                 }
 
@@ -390,11 +390,11 @@ macro_rules! curve_impl {
             for $projective
         {
             fn add_assign(&mut self, other: &<$projective as CurveProjective>::Affine) {
-                if other.is_zero() {
+                if other.is_identity() {
                     return;
                 }
 
-                if self.is_zero() {
+                if self.is_identity() {
                     self.x = other.x;
                     self.y = other.y;
                     self.z = $basefield::one();
@@ -524,7 +524,7 @@ macro_rules! curve_impl {
                     if p.is_some().into() {
                         let p = p.unwrap().scale_by_cofactor();
 
-                        if !p.is_zero() {
+                        if !p.is_identity() {
                             return p;
                         }
                     }
@@ -533,7 +533,7 @@ macro_rules! curve_impl {
 
             // The point at infinity is always represented by
             // Z = 0.
-            fn zero() -> Self {
+            fn identity() -> Self {
                 $projective {
                     x: $basefield::zero(),
                     y: $basefield::one(),
@@ -541,18 +541,18 @@ macro_rules! curve_impl {
                 }
             }
 
-            fn one() -> Self {
-                $affine::one().into()
+            fn generator() -> Self {
+                $affine::generator().into()
             }
 
             // The point at infinity is always represented by
             // Z = 0.
-            fn is_zero(&self) -> bool {
+            fn is_identity(&self) -> bool {
                 self.z.is_zero()
             }
 
             fn is_normalized(&self) -> bool {
-                self.is_zero() || self.z == $basefield::one()
+                self.is_identity() || self.z == $basefield::one()
             }
 
             fn batch_normalization(v: &mut [Self]) {
@@ -609,7 +609,7 @@ macro_rules! curve_impl {
             }
 
             fn double(&mut self) {
-                if self.is_zero() {
+                if self.is_identity() {
                     return;
                 }
 
@@ -662,7 +662,7 @@ macro_rules! curve_impl {
             }
 
             fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S) {
-                let mut res = Self::zero();
+                let mut res = Self::identity();
 
                 let mut found_one = false;
 
@@ -700,8 +700,8 @@ macro_rules! curve_impl {
         // coordinates with Z = 1.
         impl From<$affine> for $projective {
             fn from(p: $affine) -> $projective {
-                if p.is_zero() {
-                    $projective::zero()
+                if p.is_identity() {
+                    $projective::identity()
                 } else {
                     $projective {
                         x: p.x,
@@ -716,8 +716,8 @@ macro_rules! curve_impl {
         // coordinates as X/Z^2, Y/Z^3.
         impl From<$projective> for $affine {
             fn from(p: $projective) -> $affine {
-                if p.is_zero() {
-                    $affine::zero()
+                if p.is_identity() {
+                    $affine::identity()
                 } else if p.z == $basefield::one() {
                     // If Z is one, the point is already normalized.
                     $affine {
@@ -830,7 +830,7 @@ pub mod g1 {
                 copy[0] &= 0x3f;
 
                 if copy.iter().all(|b| *b == 0) {
-                    Ok(G1Affine::zero())
+                    Ok(G1Affine::identity())
                 } else {
                     Err(GroupDecodingError::UnexpectedInformation)
                 }
@@ -867,7 +867,7 @@ pub mod g1 {
         fn from_affine(affine: G1Affine) -> Self {
             let mut res = Self::empty();
 
-            if affine.is_zero() {
+            if affine.is_identity() {
                 // Set the second-most significant bit to indicate this point
                 // is at infinity.
                 res.0[0] |= 1 << 6;
@@ -937,7 +937,7 @@ pub mod g1 {
                 copy[0] &= 0x3f;
 
                 if copy.iter().all(|b| *b == 0) {
-                    Ok(G1Affine::zero())
+                    Ok(G1Affine::identity())
                 } else {
                     Err(GroupDecodingError::UnexpectedInformation)
                 }
@@ -964,7 +964,7 @@ pub mod g1 {
         fn from_affine(affine: G1Affine) -> Self {
             let mut res = Self::empty();
 
-            if affine.is_zero() {
+            if affine.is_identity() {
                 // Set the second-most significant bit to indicate this point
                 // is at infinity.
                 res.0[0] |= 1 << 6;
@@ -1043,8 +1043,8 @@ pub mod g1 {
     pub struct G1Prepared(pub(crate) G1Affine);
 
     impl G1Prepared {
-        pub fn is_zero(&self) -> bool {
-            self.0.is_zero()
+        pub fn is_identity(&self) -> bool {
+            self.0.is_identity()
         }
 
         pub fn from_affine(p: G1Affine) -> Self {
@@ -1075,13 +1075,13 @@ pub mod g1 {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
 
                 let g1 = p.scale_by_cofactor();
-                if !g1.is_zero() {
+                if !g1.is_identity() {
                     assert_eq!(i, 4);
                     let g1 = G1Affine::from(g1);
 
                     assert!(g1.is_in_correct_subgroup_assuming_on_curve());
 
-                    assert_eq!(g1, G1Affine::one());
+                    assert_eq!(g1, G1Affine::generator());
                     break;
                 }
             }
@@ -1440,7 +1440,7 @@ pub mod g2 {
                 copy[0] &= 0x3f;
 
                 if copy.iter().all(|b| *b == 0) {
-                    Ok(G2Affine::zero())
+                    Ok(G2Affine::identity())
                 } else {
                     Err(GroupDecodingError::UnexpectedInformation)
                 }
@@ -1489,7 +1489,7 @@ pub mod g2 {
         fn from_affine(affine: G2Affine) -> Self {
             let mut res = Self::empty();
 
-            if affine.is_zero() {
+            if affine.is_identity() {
                 // Set the second-most significant bit to indicate this point
                 // is at infinity.
                 res.0[0] |= 1 << 6;
@@ -1561,7 +1561,7 @@ pub mod g2 {
                 copy[0] &= 0x3f;
 
                 if copy.iter().all(|b| *b == 0) {
-                    Ok(G2Affine::zero())
+                    Ok(G2Affine::identity())
                 } else {
                     Err(GroupDecodingError::UnexpectedInformation)
                 }
@@ -1603,7 +1603,7 @@ pub mod g2 {
         fn from_affine(affine: G2Affine) -> Self {
             let mut res = Self::empty();
 
-            if affine.is_zero() {
+            if affine.is_identity() {
                 // Set the second-most significant bit to indicate this point
                 // is at infinity.
                 res.0[0] |= 1 << 6;
@@ -1728,12 +1728,12 @@ pub mod g2 {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
 
                 let g2 = p.scale_by_cofactor();
-                if !g2.is_zero() {
+                if !g2.is_identity() {
                     assert_eq!(i, 2);
                     let g2 = G2Affine::from(g2);
 
                     assert!(g2.is_in_correct_subgroup_assuming_on_curve());
-                    assert_eq!(g2, G2Affine::one());
+                    assert_eq!(g2, G2Affine::generator());
                     break;
                 }
             }

--- a/pairing/src/bls12_381/fq12.rs
+++ b/pairing/src/bls12_381/fq12.rs
@@ -177,7 +177,7 @@ impl MulAssign for Fq12 {
 }
 
 impl Field for Fq12 {
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         Fq12 {
             c0: Fq6::random(rng),
             c1: Fq6::random(rng),

--- a/pairing/src/bls12_381/fq2.rs
+++ b/pairing/src/bls12_381/fq2.rs
@@ -185,7 +185,7 @@ impl MulAssign for Fq2 {
 }
 
 impl Field for Fq2 {
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         Fq2 {
             c0: Fq::random(rng),
             c1: Fq::random(rng),

--- a/pairing/src/bls12_381/fq6.rs
+++ b/pairing/src/bls12_381/fq6.rs
@@ -278,7 +278,7 @@ impl MulAssign for Fq6 {
 }
 
 impl Field for Fq6 {
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         Fq6 {
             c0: Fq2::random(rng),
             c1: Fq2::random(rng),

--- a/pairing/src/bls12_381/mod.rs
+++ b/pairing/src/bls12_381/mod.rs
@@ -59,7 +59,7 @@ impl Engine for Bls12 {
     {
         let mut pairs = vec![];
         for &(p, q) in i {
-            if !p.is_zero() && !q.is_zero() {
+            if !p.is_identity() && !q.is_identity() {
                 pairs.push((p, q.coeffs.iter()));
             }
         }
@@ -168,12 +168,12 @@ impl Engine for Bls12 {
 }
 
 impl G2Prepared {
-    pub fn is_zero(&self) -> bool {
+    pub fn is_identity(&self) -> bool {
         self.infinity
     }
 
     pub fn from_affine(q: G2Affine) -> Self {
-        if q.is_zero() {
+        if q.is_identity() {
             return G2Prepared {
                 coeffs: vec![],
                 infinity: true,

--- a/pairing/src/bls12_381/tests/mod.rs
+++ b/pairing/src/bls12_381/tests/mod.rs
@@ -1,5 +1,5 @@
 use ff::PrimeField;
-use group::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
+use group::{CurveAffine, CurveProjective, EncodedPoint, Group, GroupDecodingError};
 
 use super::*;
 use crate::*;

--- a/pairing/src/bls12_381/tests/mod.rs
+++ b/pairing/src/bls12_381/tests/mod.rs
@@ -23,7 +23,7 @@ fn test_pairing_result_against_relic() {
     0F41E58663BF08CF 068672CBD01A7EC7 3BACA4D72CA93544 DEFF686BFD6DF543 D48EAA24AFE47E1E FDE449383B676631
     */
 
-    assert_eq!(Bls12::pairing(G1::one(), G2::one()), Fq12 {
+    assert_eq!(Bls12::pairing(G1::generator(), G2::generator()), Fq12 {
         c0: Fq6 {
             c0: Fq2 {
                 c0: Fq::from_str("2819105605953691245277803056322684086884703000473961065716485506033588504203831029066448642358042597501014294104502").unwrap(),
@@ -56,7 +56,7 @@ fn test_pairing_result_against_relic() {
 }
 
 fn test_vectors<G: CurveProjective, E: EncodedPoint<Affine = G::Affine>>(expected: &[u8]) {
-    let mut e = G::zero();
+    let mut e = G::identity();
 
     let mut v = vec![];
     {
@@ -72,7 +72,7 @@ fn test_vectors<G: CurveProjective, E: EncodedPoint<Affine = G::Affine>>(expecte
             let decoded = decoded.into_affine().unwrap();
             assert_eq!(e_affine, decoded);
 
-            e.add_assign(&G::one());
+            e.add_assign(&G::generator());
         }
     }
 
@@ -102,7 +102,7 @@ fn test_g2_compressed_valid_vectors() {
 #[test]
 fn test_g1_uncompressed_invalid_vectors() {
     {
-        let z = G1Affine::zero().into_uncompressed();
+        let z = G1Affine::identity().into_uncompressed();
 
         {
             let mut z = z;
@@ -135,7 +135,7 @@ fn test_g1_uncompressed_invalid_vectors() {
         }
     }
 
-    let o = G1Affine::one().into_uncompressed();
+    let o = G1Affine::generator().into_uncompressed();
 
     {
         let mut o = o;
@@ -218,7 +218,7 @@ fn test_g1_uncompressed_invalid_vectors() {
 #[test]
 fn test_g2_uncompressed_invalid_vectors() {
     {
-        let z = G2Affine::zero().into_uncompressed();
+        let z = G2Affine::identity().into_uncompressed();
 
         {
             let mut z = z;
@@ -251,7 +251,7 @@ fn test_g2_uncompressed_invalid_vectors() {
         }
     }
 
-    let o = G2Affine::one().into_uncompressed();
+    let o = G2Affine::generator().into_uncompressed();
 
     {
         let mut o = o;
@@ -362,7 +362,7 @@ fn test_g2_uncompressed_invalid_vectors() {
 #[test]
 fn test_g1_compressed_invalid_vectors() {
     {
-        let z = G1Affine::zero().into_compressed();
+        let z = G1Affine::identity().into_compressed();
 
         {
             let mut z = z;
@@ -395,7 +395,7 @@ fn test_g1_compressed_invalid_vectors() {
         }
     }
 
-    let o = G1Affine::one().into_compressed();
+    let o = G1Affine::generator().into_compressed();
 
     {
         let mut o = o;
@@ -476,7 +476,7 @@ fn test_g1_compressed_invalid_vectors() {
 #[test]
 fn test_g2_compressed_invalid_vectors() {
     {
-        let z = G2Affine::zero().into_compressed();
+        let z = G2Affine::identity().into_compressed();
 
         {
             let mut z = z;
@@ -509,7 +509,7 @@ fn test_g2_compressed_invalid_vectors() {
         }
     }
 
-    let o = G2Affine::one().into_compressed();
+    let o = G2Affine::generator().into_compressed();
 
     {
         let mut o = o;

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -21,7 +21,7 @@ pub mod tests;
 pub mod bls12_381;
 
 use ff::{Field, PrimeField, ScalarEngine};
-use group::{CurveAffine, CurveOps, CurveOpsOwned, CurveProjective};
+use group::{CurveAffine, CurveProjective, GroupOps, GroupOpsOwned};
 use subtle::CtOption;
 
 /// An "engine" is a collection of types (fields, elliptic curve groups, etc.)
@@ -31,8 +31,8 @@ pub trait Engine: ScalarEngine {
     /// The projective representation of an element in G1.
     type G1: CurveProjective<Base = Self::Fq, Scalar = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
-        + CurveOps<Self::G1Affine>
-        + CurveOpsOwned<Self::G1Affine>;
+        + GroupOps<Self::G1Affine>
+        + GroupOpsOwned<Self::G1Affine>;
 
     /// The affine representation of an element in G1.
     type G1Affine: PairingCurveAffine<
@@ -46,8 +46,8 @@ pub trait Engine: ScalarEngine {
     /// The projective representation of an element in G2.
     type G2: CurveProjective<Base = Self::Fqe, Scalar = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
-        + CurveOps<Self::G2Affine>
-        + CurveOpsOwned<Self::G2Affine>;
+        + GroupOps<Self::G2Affine>
+        + GroupOpsOwned<Self::G2Affine>;
 
     /// The affine representation of an element in G2.
     type G2Affine: PairingCurveAffine<

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -29,14 +29,13 @@ use subtle::CtOption;
 /// of prime order `r`, and are equipped with a bilinear pairing function.
 pub trait Engine: ScalarEngine {
     /// The projective representation of an element in G1.
-    type G1: CurveProjective<Engine = Self, Base = Self::Fq, Scalar = Self::Fr, Affine = Self::G1Affine>
+    type G1: CurveProjective<Base = Self::Fq, Scalar = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
         + CurveOps<Self::G1Affine>
         + CurveOpsOwned<Self::G1Affine>;
 
     /// The affine representation of an element in G1.
     type G1Affine: PairingCurveAffine<
-            Engine = Self,
             Base = Self::Fq,
             Scalar = Self::Fr,
             Projective = Self::G1,
@@ -45,14 +44,13 @@ pub trait Engine: ScalarEngine {
         > + From<Self::G1>;
 
     /// The projective representation of an element in G2.
-    type G2: CurveProjective<Engine = Self, Base = Self::Fqe, Scalar = Self::Fr, Affine = Self::G2Affine>
+    type G2: CurveProjective<Base = Self::Fqe, Scalar = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
         + CurveOps<Self::G2Affine>
         + CurveOpsOwned<Self::G2Affine>;
 
     /// The affine representation of an element in G2.
     type G2Affine: PairingCurveAffine<
-            Engine = Self,
             Base = Self::Fqe,
             Scalar = Self::Fr,
             Projective = Self::G2,

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -21,7 +21,7 @@ pub mod tests;
 pub mod bls12_381;
 
 use ff::{Field, PrimeField, ScalarEngine};
-use group::{CurveAffine, CurveProjective, GroupOps, GroupOpsOwned};
+use group::{CurveAffine, CurveProjective, GroupOps, GroupOpsOwned, ScalarMul, ScalarMulOwned};
 use subtle::CtOption;
 
 /// An "engine" is a collection of types (fields, elliptic curve groups, etc.)
@@ -32,7 +32,9 @@ pub trait Engine: ScalarEngine {
     type G1: CurveProjective<Base = Self::Fq, Scalar = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
         + GroupOps<Self::G1Affine>
-        + GroupOpsOwned<Self::G1Affine>;
+        + GroupOpsOwned<Self::G1Affine>
+        + ScalarMul<Self::Fr>
+        + ScalarMulOwned<Self::Fr>;
 
     /// The affine representation of an element in G1.
     type G1Affine: PairingCurveAffine<
@@ -47,7 +49,9 @@ pub trait Engine: ScalarEngine {
     type G2: CurveProjective<Base = Self::Fqe, Scalar = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
         + GroupOps<Self::G2Affine>
-        + GroupOpsOwned<Self::G2Affine>;
+        + GroupOpsOwned<Self::G2Affine>
+        + ScalarMul<Self::Fr>
+        + ScalarMulOwned<Self::Fr>;
 
     /// The affine representation of an element in G2.
     type G2Affine: PairingCurveAffine<

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -21,8 +21,8 @@ pub fn engine_tests<E: Engine>() {
     }
 
     for _ in 0..1000 {
-        let z1 = E::G1Affine::zero().prepare();
-        let z2 = E::G2Affine::zero().prepare();
+        let z1 = E::G1Affine::identity().prepare();
+        let z2 = E::G2Affine::identity().prepare();
 
         let a = E::G1::random(&mut rng).into_affine().prepare();
         let b = E::G2::random(&mut rng).into_affine().prepare();

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -1,5 +1,5 @@
 use ff::{Endianness, Field, PrimeField};
-use group::{CurveAffine, CurveProjective};
+use group::{CurveAffine, CurveProjective, Group};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::MulAssign;

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -114,23 +114,21 @@ fn random_bilinearity_tests<E: Engine>() {
         let d = E::Fr::random(&mut rng);
 
         let mut ac = a;
-        ac.mul_assign(c);
+        MulAssign::<&E::Fr>::mul_assign(&mut ac, &c);
 
         let mut ad = a;
-        ad.mul_assign(d);
+        MulAssign::<&E::Fr>::mul_assign(&mut ad, &d);
 
         let mut bc = b;
-        bc.mul_assign(c);
+        MulAssign::<&E::Fr>::mul_assign(&mut bc, &c);
 
         let mut bd = b;
-        bd.mul_assign(d);
+        MulAssign::<&E::Fr>::mul_assign(&mut bd, &d);
 
         let acbd = E::pairing(ac, bd);
         let adbc = E::pairing(ad, bc);
 
-        let mut cd = c;
-        cd.mul_assign(&d);
-        let mut cd = cd.to_repr();
+        let mut cd = (c * &d).to_repr();
         <E::Fr as PrimeField>::ReprEndianness::toggle_little_endian(&mut cd);
 
         use byteorder::ByteOrder;

--- a/zcash_primitives/src/jubjub/fs.rs
+++ b/zcash_primitives/src/jubjub/fs.rs
@@ -362,7 +362,7 @@ impl PrimeField for Fs {
 }
 
 impl Field for Fs {
-    fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self {
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         loop {
             let mut tmp = {
                 let mut repr = [0u64; 4];


### PR DESCRIPTION
The new `Group` trait represents a cryptographic group with a large prime-order subgroup and a small cofactor. The `PrimeGroup` trait further constrains the group to have a cofactor of one. `CurveProjective` now primarily contains EC-specific functionality.

Part of #161.