### PR TITLE
Lint fixes

### DIFF
--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -340,7 +340,7 @@ impl fmt::Display for SynthesisError {
             write!(f, "I/O error: ")?;
             e.fmt(f)
         } else {
-            write!(f, "{}", self.description())
+            write!(f, "{}", self)
         }
     }
 }

--- a/bls12_381/src/notes/design.rs
+++ b/bls12_381/src/notes/design.rs
@@ -18,7 +18,7 @@
 //!
 //! This can be derived using the following sage script:
 //!
-//! ```norun
+//! ```text
 //! param = -0xd201000000010000
 //! def r(x):
 //!     return (x**4) - (x**2) + 1

--- a/pairing/src/bls12_381/ec.rs
+++ b/pairing/src/bls12_381/ec.rs
@@ -899,7 +899,7 @@ impl fmt::Display for GroupDecodingError {
             GroupDecodingError::CoordinateDecodingError(description) => {
                 write!(f, "{} decoding error", description)
             }
-            _ => write!(f, "{}", self.description()),
+            _ => write!(f, "{}", self),
         }
     }
 }

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -21,7 +21,7 @@ subtle = "2"
 zcash_primitives = { version = "0.2", path = "../zcash_primitives" }
 
 [build-dependencies]
-protobuf-codegen-pure = "2"
+protobuf-codegen-pure = "2.14"
 
 [dev-dependencies]
 rand_core = "0.5"

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -1,11 +1,10 @@
 use protobuf_codegen_pure;
 
 fn main() {
-    protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
-        out_dir: "src/proto",
-        input: &["proto/compact_formats.proto"],
-        includes: &["proto"],
-        customize: Default::default(),
-    })
-    .expect("protoc");
+    protobuf_codegen_pure::Codegen::new()
+        .out_dir("src/proto")
+        .inputs(&["proto/compact_formats.proto"])
+        .includes(&["proto"])
+        .run()
+        .expect("Protobuf codegen failed");
 }

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -33,5 +33,5 @@ mod test_vectors;
 use crate::jubjub::JubjubBls12;
 
 lazy_static! {
-    pub static ref JUBJUB: JubjubBls12 = { JubjubBls12::new() };
+    pub static ref JUBJUB: JubjubBls12 = JubjubBls12::new();
 }

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -23,19 +23,13 @@ use crate::{keys::OutgoingViewingKey, JUBJUB};
 pub const KDF_SAPLING_PERSONALIZATION: &[u8; 16] = b"Zcash_SaplingKDF";
 pub const PRF_OCK_PERSONALIZATION: &[u8; 16] = b"Zcash_Derive_ock";
 
-const COMPACT_NOTE_SIZE: usize = (
-    1  + // version
+const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
-    32
-    // rcv
-);
+    32; // rcv
 const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
-const OUT_PLAINTEXT_SIZE: usize = (
-    32 + // pk_d
-    32
-    // esk
-);
+const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
+    32; // esk
 const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + 16;
 const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + 16;
 

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -14,9 +14,9 @@ pub mod amount;
 pub use self::amount::Amount;
 
 // π_A + π_B + π_C
-pub const GROTH_PROOF_SIZE: usize = (48 + 96 + 48);
+pub const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;
 // π_A + π_A' + π_B + π_B' + π_C + π_C' + π_K + π_H
-const PHGR_PROOF_SIZE: usize = (33 + 33 + 65 + 33 + 33 + 33 + 33 + 33);
+const PHGR_PROOF_SIZE: usize = 33 + 33 + 65 + 33 + 33 + 33 + 33 + 33;
 
 const ZC_NUM_JS_INPUTS: usize = 2;
 const ZC_NUM_JS_OUTPUTS: usize = 2;


### PR DESCRIPTION
Addresses lints that are [visible when checking with nightly](https://github.com/zcash/librustzcash/pull/205/files) (rather than the current MSRV of 1.39).