### PR TITLE
[WIP] ZIP 212

### DIFF
--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -26,7 +26,7 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Sapling => Some(419_200),
             NetworkUpgrade::Blossom => Some(653_600),
             NetworkUpgrade::Heartwood => Some(903_000),
-            NetworkUpgrade::Canopy => None,
+            NetworkUpgrade::Canopy => Some(1103_000),
         }
     }
 }
@@ -42,7 +42,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Sapling => Some(280_000),
             NetworkUpgrade::Blossom => Some(584_000),
             NetworkUpgrade::Heartwood => Some(903_800),
-            NetworkUpgrade::Canopy => None,
+            NetworkUpgrade::Canopy => Some(1103_000),
         }
     }
 }
@@ -243,7 +243,7 @@ mod tests {
             BranchId::Sapling,
         );
         assert_eq!(
-            BranchId::for_height::<MainNetwork>(5_000_000),
+            BranchId::for_height::<MainNetwork>(1_000_000),
             BranchId::Heartwood,
         );
     }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -5,10 +5,10 @@ use std::fmt;
 
 /// Zcash consensus parameters.
 pub trait Parameters {
-    fn activation_height(nu: NetworkUpgrade) -> Option<u32>;
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<u32>;
 
-    fn is_nu_active(nu: NetworkUpgrade, height: u32) -> bool {
-        match Self::activation_height(nu) {
+    fn is_nu_active(&self, nu: NetworkUpgrade, height: u32) -> bool {
+        match self.activation_height(nu) {
             Some(h) if h <= height => true,
             _ => false,
         }
@@ -20,7 +20,7 @@ pub trait Parameters {
 pub struct MainNetwork;
 
 impl Parameters for MainNetwork {
-    fn activation_height(nu: NetworkUpgrade) -> Option<u32> {
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<u32> {
         match nu {
             NetworkUpgrade::Overwinter => Some(347_500),
             NetworkUpgrade::Sapling => Some(419_200),
@@ -36,7 +36,7 @@ impl Parameters for MainNetwork {
 pub struct TestNetwork;
 
 impl Parameters for TestNetwork {
-    fn activation_height(nu: NetworkUpgrade) -> Option<u32> {
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<u32> {
         match nu {
             NetworkUpgrade::Overwinter => Some(207_500),
             NetworkUpgrade::Sapling => Some(280_000),
@@ -174,9 +174,9 @@ impl BranchId {
     /// the given height.
     ///
     /// This is the branch ID that should be used when creating transactions.
-    pub fn for_height<C: Parameters>(height: u32) -> Self {
+    pub fn for_height<C: Parameters>(parameters: C, height: u32) -> Self {
         for nu in UPGRADES_IN_ORDER.iter().rev() {
-            if C::is_nu_active(*nu, height) {
+            if parameters.is_nu_active(*nu, height) {
                 return nu.branch_id();
             }
         }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -198,8 +198,8 @@ mod tests {
             let nu_a = UPGRADES_IN_ORDER[i - 1];
             let nu_b = UPGRADES_IN_ORDER[i];
             match (
-                MainNetwork::activation_height(nu_a),
-                MainNetwork::activation_height(nu_b),
+                MainNetwork.activation_height(nu_a),
+                MainNetwork.activation_height(nu_b),
             ) {
                 (Some(a), Some(b)) if a < b => (),
                 (Some(_), None) => (),
@@ -214,15 +214,9 @@ mod tests {
 
     #[test]
     fn nu_is_active() {
-        assert!(!MainNetwork::is_nu_active(NetworkUpgrade::Overwinter, 0));
-        assert!(!MainNetwork::is_nu_active(
-            NetworkUpgrade::Overwinter,
-            347_499
-        ));
-        assert!(MainNetwork::is_nu_active(
-            NetworkUpgrade::Overwinter,
-            347_500
-        ));
+        assert!(!MainNetwork.is_nu_active(NetworkUpgrade::Overwinter, 0));
+        assert!(!MainNetwork.is_nu_active(NetworkUpgrade::Overwinter, 347_499));
+        assert!(MainNetwork.is_nu_active(NetworkUpgrade::Overwinter, 347_500));
     }
 
     #[test]
@@ -233,17 +227,20 @@ mod tests {
 
     #[test]
     fn branch_id_for_height() {
-        assert_eq!(BranchId::for_height::<MainNetwork>(0), BranchId::Sprout,);
         assert_eq!(
-            BranchId::for_height::<MainNetwork>(419_199),
+            BranchId::for_height::<MainNetwork>(MainNetwork, 0),
+            BranchId::Sprout,
+        );
+        assert_eq!(
+            BranchId::for_height::<MainNetwork>(MainNetwork, 419_199),
             BranchId::Overwinter,
         );
         assert_eq!(
-            BranchId::for_height::<MainNetwork>(419_200),
+            BranchId::for_height::<MainNetwork>(MainNetwork, 419_200),
             BranchId::Sapling,
         );
         assert_eq!(
-            BranchId::for_height::<MainNetwork>(1_000_000),
+            BranchId::for_height::<MainNetwork>(MainNetwork, 1_000_000),
             BranchId::Heartwood,
         );
     }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -26,6 +26,7 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Sapling => Some(419_200),
             NetworkUpgrade::Blossom => Some(653_600),
             NetworkUpgrade::Heartwood => Some(903_000),
+            NetworkUpgrade::Canopy => None,
         }
     }
 }
@@ -41,6 +42,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Sapling => Some(280_000),
             NetworkUpgrade::Blossom => Some(584_000),
             NetworkUpgrade::Heartwood => Some(903_800),
+            NetworkUpgrade::Canopy => None,
         }
     }
 }
@@ -67,6 +69,10 @@ pub enum NetworkUpgrade {
     ///
     /// [Heartwood]: https://z.cash/upgrade/heartwood/
     Heartwood,
+    /// The [Canopy] network upgrade.
+    ///
+    /// [Canopy]: https://z.cash/upgrade/canopy/
+    Canopy,
 }
 
 impl fmt::Display for NetworkUpgrade {
@@ -76,6 +82,7 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Sapling => write!(f, "Sapling"),
             NetworkUpgrade::Blossom => write!(f, "Blossom"),
             NetworkUpgrade::Heartwood => write!(f, "Heartwood"),
+            NetworkUpgrade::Canopy => write!(f, "Canopy"),
         }
     }
 }
@@ -87,6 +94,7 @@ impl NetworkUpgrade {
             NetworkUpgrade::Sapling => BranchId::Sapling,
             NetworkUpgrade::Blossom => BranchId::Blossom,
             NetworkUpgrade::Heartwood => BranchId::Heartwood,
+            NetworkUpgrade::Canopy => BranchId::Canopy,
         }
     }
 }
@@ -100,6 +108,7 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Sapling,
     NetworkUpgrade::Blossom,
     NetworkUpgrade::Heartwood,
+    NetworkUpgrade::Canopy,
 ];
 
 /// A globally-unique identifier for a set of consensus rules within the Zcash chain.
@@ -127,6 +136,8 @@ pub enum BranchId {
     Blossom,
     /// The consensus rules deployed by [`NetworkUpgrade::Heartwood`].
     Heartwood,
+    /// The consensus rules deployed by [`NetworkUpgrade::Canopy`].
+    Canopy,
 }
 
 impl TryFrom<u32> for BranchId {
@@ -139,6 +150,7 @@ impl TryFrom<u32> for BranchId {
             0x76b8_09bb => Ok(BranchId::Sapling),
             0x2bb4_0e60 => Ok(BranchId::Blossom),
             0xf5b9_230b => Ok(BranchId::Heartwood),
+            0xe9ff_75a6 => Ok(BranchId::Canopy),
             _ => Err("Unknown consensus branch ID"),
         }
     }
@@ -152,6 +164,7 @@ impl From<BranchId> for u32 {
             BranchId::Sapling => 0x76b8_09bb,
             BranchId::Blossom => 0x2bb4_0e60,
             BranchId::Heartwood => 0xf5b9_230b,
+            BranchId::Canopy => 0xe9ff_75a6,
         }
     }
 }

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -761,6 +761,7 @@ mod tests {
         // Create a builder with 0 fee, so we can construct t outputs
         let mut builder = builder::Builder {
             rng: OsRng,
+            height: 0,
             mtx: TransactionData::new(),
             fee: Amount::zero(),
             anchor: None,
@@ -776,7 +777,11 @@ mod tests {
             .unwrap();
 
         let (tx, _) = builder
-            .build(consensus::BranchId::Sapling, &MockTxProver)
+            .build(
+                consensus::MainNetwork,
+                consensus::BranchId::Sapling,
+                &MockTxProver,
+            )
             .unwrap();
         // No binding signature, because only t input and outputs
         assert!(tx.binding_sig.is_none());
@@ -817,7 +822,11 @@ mod tests {
         // Expect a binding signature error, because our inputs aren't valid, but this shows
         // that a binding signature was attempted
         assert_eq!(
-            builder.build(consensus::BranchId::Sapling, &MockTxProver),
+            builder.build(
+                consensus::MainNetwork,
+                consensus::BranchId::Sapling,
+                &MockTxProver
+            ),
             Err(Error::BindingSig)
         );
     }
@@ -846,7 +855,11 @@ mod tests {
         {
             let builder = Builder::new(0);
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, &MockTxProver),
+                builder.build(
+                    consensus::MainNetwork,
+                    consensus::BranchId::Sapling,
+                    &MockTxProver
+                ),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-10000).unwrap()))
             );
         }
@@ -868,7 +881,11 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, &MockTxProver),
+                builder.build(
+                    consensus::MainNetwork,
+                    consensus::BranchId::Sapling,
+                    &MockTxProver
+                ),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-60000).unwrap()))
             );
         }
@@ -884,7 +901,11 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, &MockTxProver),
+                builder.build(
+                    consensus::MainNetwork,
+                    consensus::BranchId::Sapling,
+                    &MockTxProver
+                ),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-60000).unwrap()))
             );
         }
@@ -924,7 +945,11 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, &MockTxProver),
+                builder.build(
+                    consensus::MainNetwork,
+                    consensus::BranchId::Sapling,
+                    &MockTxProver
+                ),
                 Err(Error::ChangeIsNegative(Amount::from_i64(-1).unwrap()))
             );
         }
@@ -963,7 +988,11 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(
-                builder.build(consensus::BranchId::Sapling, &MockTxProver),
+                builder.build(
+                    consensus::MainNetwork,
+                    consensus::BranchId::Sapling,
+                    &MockTxProver
+                ),
                 Err(Error::BindingSig)
             )
         }


### PR DESCRIPTION
Draft PR. Partially implements [ZIP 212](https://github.com/zcash/zips/pull/222), addresses https://github.com/zcash/zcash/issues/4557. 

- defines new note encryption `SaplingNoteEncryption::new_v2` which generates `rcm`, `esk` from `rseed`
- defines new note plaintext encryption  `SaplingNoteEncryption::encrypt_note_plaintext_v2` with version `0x02` version and replaces `rcm` with `rseed`
- adds logic for decrypting `v2` plaintext in `parse_note_plaintext_without_memo`
- introduce grace period for `v1` notes received past Canopy activation height
- update old tests 

TODO:
- add new tests
- should mirror C++ implementation https://github.com/zcash/zcash/pull/4578.