### PR TITLE
bellman: add VerificationError

### DIFF
--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -560,8 +560,8 @@ mod test_with_bls12_381 {
             let de_proof = Proof::read(&v[..]).unwrap();
             assert!(proof == de_proof);
 
-            assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
-            assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
+            assert!(verify_proof(&pvk, &proof, &[c]).is_ok());
+            assert!(verify_proof(&pvk, &proof, &[a]).is_err());
         }
     }
 }

--- a/bellman/src/groth16/tests/mod.rs
+++ b/bellman/src/groth16/tests/mod.rs
@@ -377,5 +377,5 @@ fn test_xordemo() {
         assert_eq!(expected_c, proof.c);
     }
 
-    assert!(verify_proof(&pvk, &proof, &[Fr::one()]).unwrap());
+    assert!(verify_proof(&pvk, &proof, &[Fr::one()]).is_ok());
 }

--- a/bellman/src/groth16/verifier.rs
+++ b/bellman/src/groth16/verifier.rs
@@ -24,7 +24,7 @@ pub fn verify_proof<'a, E: MultiMillerLoop>(
     public_inputs: &[E::Fr],
 ) -> Result<(), VerificationError> {
     if (public_inputs.len() + 1) != pvk.ic.len() {
-        return Err(VerificationError::MalformedVerifyingKey);
+        return Err(VerificationError::InvalidVerifyingKey);
     }
 
     let mut acc = pvk.ic[0].to_curve();
@@ -51,6 +51,6 @@ pub fn verify_proof<'a, E: MultiMillerLoop>(
     {
         Ok(())
     } else {
-        Err(VerificationError::Failed)
+        Err(VerificationError::InvalidProof)
     }
 }

--- a/bellman/src/groth16/verifier.rs
+++ b/bellman/src/groth16/verifier.rs
@@ -4,7 +4,7 @@ use std::ops::{AddAssign, Neg};
 
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 
-use crate::SynthesisError;
+use crate::VerificationError;
 
 pub fn prepare_verifying_key<E: MultiMillerLoop>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     let gamma = vk.gamma_g2.neg();
@@ -22,9 +22,9 @@ pub fn verify_proof<'a, E: MultiMillerLoop>(
     pvk: &'a PreparedVerifyingKey<E>,
     proof: &Proof<E>,
     public_inputs: &[E::Fr],
-) -> Result<bool, SynthesisError> {
+) -> Result<(), VerificationError> {
     if (public_inputs.len() + 1) != pvk.ic.len() {
-        return Err(SynthesisError::MalformedVerifyingKey);
+        return Err(VerificationError::MalformedVerifyingKey);
     }
 
     let mut acc = pvk.ic[0].to_curve();
@@ -41,11 +41,16 @@ pub fn verify_proof<'a, E: MultiMillerLoop>(
     // A * B + inputs * (-gamma) + C * (-delta) = alpha * beta
     // which allows us to do a single final exponentiation.
 
-    Ok(E::multi_miller_loop(&[
-        (&proof.a, &proof.b.into()),
-        (&acc.to_affine(), &pvk.neg_gamma_g2),
-        (&proof.c, &pvk.neg_delta_g2),
-    ])
-    .final_exponentiation()
-        == pvk.alpha_g1_beta_g2)
+    if pvk.alpha_g1_beta_g2
+        == E::multi_miller_loop(&[
+            (&proof.a, &proof.b.into()),
+            (&acc.to_affine(), &pvk.neg_gamma_g2),
+            (&proof.c, &pvk.neg_delta_g2),
+        ])
+        .final_exponentiation()
+    {
+        Ok(())
+    } else {
+        Err(VerificationError::Failed)
+    }
 }

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -122,7 +122,7 @@
 //! let inputs = multipack::compute_multipacking(&hash_bits);
 //!
 //! // Check the proof!
-//! assert!(groth16::verify_proof(&pvk, &proof, &inputs).unwrap());
+//! assert!(groth16::verify_proof(&pvk, &proof, &inputs).is_ok());
 //! ```
 //!
 //! # Roadmap

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -301,7 +301,7 @@ impl<'a, Scalar: PrimeField> Sub<(Scalar, &'a LinearCombination<Scalar>)>
 }
 
 /// This is an error that could occur during circuit synthesis contexts,
-/// such as CRS generation, proving or verification.
+/// such as CRS generation or proving.
 #[derive(Debug)]
 pub enum SynthesisError {
     /// During synthesis, we lacked knowledge of a variable assignment.
@@ -316,8 +316,6 @@ pub enum SynthesisError {
     UnexpectedIdentity,
     /// During proof generation, we encountered an I/O error with the CRS
     IoError(io::Error),
-    /// During verification, our verifying key was malformed.
-    MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     UnconstrainedVariable,
 }
@@ -339,7 +337,6 @@ impl Error for SynthesisError {
             SynthesisError::PolynomialDegreeTooLarge => "polynomial degree is too large",
             SynthesisError::UnexpectedIdentity => "encountered an identity element in the CRS",
             SynthesisError::IoError(_) => "encountered an I/O error",
-            SynthesisError::MalformedVerifyingKey => "malformed verifying key",
             SynthesisError::UnconstrainedVariable => "auxiliary variable was unconstrained",
         }
     }
@@ -353,6 +350,30 @@ impl fmt::Display for SynthesisError {
         } else {
             write!(f, "{}", self)
         }
+    }
+}
+
+/// An error during verification.
+#[derive(Debug)]
+pub enum VerificationError {
+    /// Verification was attempted with a malformed verifying key.
+    MalformedVerifyingKey,
+    /// Proof verification failed.
+    Failed,
+}
+
+impl Error for VerificationError {
+    fn description(&self) -> &str {
+        match *self {
+            VerificationError::MalformedVerifyingKey => "malformed verifying key",
+            VerificationError::Failed => "proof verification failed",
+        }
+    }
+}
+
+impl fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self)
     }
 }
 

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -354,7 +354,7 @@ impl fmt::Display for SynthesisError {
 }
 
 /// An error during verification.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum VerificationError {
     /// Verification was attempted with a malformed verifying key.
     InvalidVerifyingKey,

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -357,16 +357,16 @@ impl fmt::Display for SynthesisError {
 #[derive(Debug)]
 pub enum VerificationError {
     /// Verification was attempted with a malformed verifying key.
-    MalformedVerifyingKey,
+    InvalidVerifyingKey,
     /// Proof verification failed.
-    Failed,
+    InvalidProof,
 }
 
 impl Error for VerificationError {
     fn description(&self) -> &str {
         match *self {
-            VerificationError::MalformedVerifyingKey => "malformed verifying key",
-            VerificationError::Failed => "proof verification failed",
+            VerificationError::InvalidVerifyingKey => "malformed verifying key",
+            VerificationError::InvalidProof => "proof verification failed",
         }
     }
 }

--- a/bellman/tests/mimc.rs
+++ b/bellman/tests/mimc.rs
@@ -210,7 +210,7 @@ fn test_mimc() {
         let start = Instant::now();
         let proof = Proof::read(&proof_vec[..]).unwrap();
         // Check the proof
-        assert!(verify_proof(&pvk, &proof, &[image]).unwrap());
+        assert!(verify_proof(&pvk, &proof, &[image]).is_ok());
         total_verifying += start.elapsed();
     }
     let proving_avg = total_proving / SAMPLES;

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -154,15 +154,7 @@ impl SaplingProvingContext {
         }
 
         // Verify the proof
-        match verify_proof(verifying_key, &proof, &public_input[..]) {
-            // No error, and proof verification successful
-            Ok(true) => {}
-
-            // Any other case
-            _ => {
-                return Err(());
-            }
-        }
+        verify_proof(verifying_key, &proof, &public_input[..]).map_err(|_| ())?;
 
         // Compute value commitment
         let value_commitment: edwards::Point<Bls12, Unknown> = value_commitment.cm(params).into();

--- a/zcash_proofs/src/sapling/verifier.rs
+++ b/zcash_proofs/src/sapling/verifier.rs
@@ -106,13 +106,7 @@ impl SaplingVerificationContext {
         }
 
         // Verify the proof
-        match verify_proof(verifying_key, &zkproof, &public_input[..]) {
-            // No error, and proof verification successful
-            Ok(true) => true,
-
-            // Any other case
-            _ => false,
-        }
+        verify_proof(verifying_key, &zkproof, &public_input[..]).is_ok()
     }
 
     /// Perform consensus checks on a Sapling OutputDescription, while
@@ -159,13 +153,7 @@ impl SaplingVerificationContext {
         public_input[4] = cm;
 
         // Verify the proof
-        match verify_proof(verifying_key, &zkproof, &public_input[..]) {
-            // No error, and proof verification successful
-            Ok(true) => true,
-
-            // Any other case
-            _ => false,
-        }
+        verify_proof(verifying_key, &zkproof, &public_input[..]).is_ok()
     }
 
     /// Perform consensus checks on the valueBalance and bindingSig parts of a

--- a/zcash_proofs/src/sprout.rs
+++ b/zcash_proofs/src/sprout.rs
@@ -169,11 +169,5 @@ pub fn verify_proof(
     };
 
     // Verify the proof
-    match groth16::verify_proof(verifying_key, &proof, &public_input[..]) {
-        // No error, and proof verification successful
-        Ok(true) => true,
-
-        // Any other case
-        _ => false,
-    }
+    groth16::verify_proof(verifying_key, &proof, &public_input[..]).is_ok()
 }


### PR DESCRIPTION
This adds a distinct VerificationError type to the crate and changes
`verify_proof` to return `Result<(), VerificationError>` rather than
`Result<bool, SynthesisError>`.  This is significantly safer, because it avoids
the need to mix pattern-matching logic with boolean logic (the cause of
RUSTSEC-2019-0004).