### PR TITLE
CI: Build zcash_proofs against WASM targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,31 @@ jobs:
           command: test
           args: --verbose --release --all -- --ignored
 
+  build:
+    name: Build target ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+          - wasm32-wasi
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.40.0
+          override: true
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: Build zcash_proofs for target
+        working-directory: ./zcash_proofs
+        run: cargo build --verbose --no-default-features --target ${{ matrix.target }}
+
   codecov:
     name: Code coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that we don't introduce any regressions for WASM consumers.

Closes zcash/zcash#4655.