### PR TITLE
Refactor fixes

### DIFF
--- a/bellman/src/groth16/generator.rs
+++ b/bellman/src/groth16/generator.rs
@@ -3,7 +3,7 @@ use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use ff::{Field, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group, Wnaf, WnafGroup};
+use group::{prime::PrimeCurveAffine, Curve, Group, Wnaf, WnafGroup};
 use pairing::Engine;
 
 use super::{Parameters, VerifyingKey};

--- a/bellman/src/groth16/mod.rs
+++ b/bellman/src/groth16/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! [Groth16]: https://eprint.iacr.org/2016/260
 
-use group::{cofactor::CofactorCurveAffine, GroupEncoding, UncompressedEncoding};
+use group::{prime::PrimeCurveAffine, GroupEncoding, UncompressedEncoding};
 use pairing::{Engine, MultiMillerLoop};
 
 use crate::SynthesisError;

--- a/bellman/src/groth16/prover.rs
+++ b/bellman/src/groth16/prover.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::Future;
 
 use ff::{Field, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve};
+use group::{prime::PrimeCurveAffine, Curve};
 use pairing::Engine;
 
 use super::{ParameterSource, Proof};

--- a/bellman/src/groth16/tests/dummy_engine.rs
+++ b/bellman/src/groth16/tests/dummy_engine.rs
@@ -1,7 +1,6 @@
 use ff::{Field, PrimeField};
 use group::{
-    cofactor::{CofactorCurve, CofactorCurveAffine, CofactorGroup},
-    prime::PrimeGroup,
+    prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
     Curve, Group, GroupEncoding, UncompressedEncoding, WnafGroup,
 };
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
@@ -396,18 +395,6 @@ impl Group for Fr {
 
 impl PrimeGroup for Fr {}
 
-impl CofactorGroup for Fr {
-    type Subgroup = Fr;
-
-    fn clear_cofactor(&self) -> Self::Subgroup {
-        *self
-    }
-
-    fn into_subgroup(self) -> CtOption<Self::Subgroup> {
-        CtOption::new(self, Choice::from(1))
-    }
-}
-
 impl Curve for Fr {
     type AffineRepr = Fr;
 
@@ -422,7 +409,7 @@ impl WnafGroup for Fr {
     }
 }
 
-impl CofactorCurve for Fr {
+impl PrimeCurve for Fr {
     type Affine = Fr;
 }
 
@@ -441,7 +428,7 @@ impl AsRef<[u8]> for FakePoint {
     }
 }
 
-impl CofactorCurveAffine for Fr {
+impl PrimeCurveAffine for Fr {
     type Curve = Fr;
     type Scalar = Fr;
 

--- a/bellman/src/groth16/verifier.rs
+++ b/bellman/src/groth16/verifier.rs
@@ -1,4 +1,4 @@
-use group::{cofactor::CofactorCurveAffine, Curve};
+use group::{prime::PrimeCurveAffine, Curve};
 use pairing::{MillerLoopResult, MultiMillerLoop};
 use std::ops::{AddAssign, Neg};
 

--- a/bls12_381/src/fp.rs
+++ b/bls12_381/src/fp.rs
@@ -47,7 +47,7 @@ impl Eq for Fp {}
 impl PartialEq for Fp {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -566,7 +566,7 @@ fn test_equality() {
         let eq = a == b;
         let ct_eq = a.ct_eq(&b);
 
-        assert_eq!(eq, ct_eq.unwrap_u8() == 1);
+        assert_eq!(eq, bool::from(ct_eq));
 
         eq
     }
@@ -762,18 +762,16 @@ fn test_from_bytes() {
         .unwrap()
     );
 
-    assert!(
+    assert!(bool::from(
         Fp::from_bytes(&[
             27, 1, 17, 234, 57, 127, 230, 154, 75, 27, 167, 182, 67, 75, 172, 215, 100, 119, 75,
             132, 243, 133, 18, 191, 103, 48, 210, 160, 246, 176, 246, 36, 30, 171, 255, 254, 177,
             83, 255, 255, 185, 254, 255, 255, 255, 255, 170, 170
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
-    assert!(Fp::from_bytes(&[0xff; 48]).is_none().unwrap_u8() == 1);
+    assert!(bool::from(Fp::from_bytes(&[0xff; 48]).is_none()));
 }
 
 #[test]
@@ -823,7 +821,7 @@ fn test_inversion() {
     ]);
 
     assert_eq!(a.invert().unwrap(), b);
-    assert!(Fp::zero().invert().is_none().unwrap_u8() == 1);
+    assert!(bool::from(Fp::zero().invert().is_none()));
 }
 
 #[test]

--- a/bls12_381/src/fp2.rs
+++ b/bls12_381/src/fp2.rs
@@ -44,7 +44,7 @@ impl Eq for Fp2 {}
 impl PartialEq for Fp2 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -361,7 +361,7 @@ fn test_equality() {
         let eq = a == b;
         let ct_eq = a.ct_eq(&b);
 
-        assert_eq!(eq, ct_eq.unwrap_u8() == 1);
+        assert_eq!(eq, bool::from(ct_eq));
 
         eq
     }
@@ -788,7 +788,7 @@ fn test_inversion() {
 
     assert_eq!(a.invert().unwrap(), b);
 
-    assert!(Fp2::zero().invert().is_none().unwrap_u8() == 1);
+    assert!(bool::from(Fp2::zero().invert().is_none()));
 }
 
 #[test]

--- a/bls12_381/src/scalar.rs
+++ b/bls12_381/src/scalar.rs
@@ -54,7 +54,7 @@ impl ConstantTimeEq for Scalar {
 impl PartialEq for Scalar {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -834,55 +834,45 @@ fn test_from_bytes() {
     );
 
     // -1 should work
-    assert!(
+    assert!(bool::from(
         Scalar::from_bytes(&[
             0, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115
         ])
         .is_some()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
     // modulus is invalid
-    assert!(
+    assert!(bool::from(
         Scalar::from_bytes(&[
             1, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
     // Anything larger than the modulus is invalid
-    assert!(
+    assert!(bool::from(
         Scalar::from_bytes(&[
             2, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
-    assert!(
+    ));
+    assert!(bool::from(
         Scalar::from_bytes(&[
             1, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 58, 51, 72, 125, 157, 41, 83, 167, 237, 115
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
-    assert!(
+    ));
+    assert!(bool::from(
         Scalar::from_bytes(&[
             1, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 116
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 }
 
 #[test]
@@ -1083,7 +1073,7 @@ fn test_squaring() {
 
 #[test]
 fn test_inversion() {
-    assert_eq!(Scalar::zero().invert().is_none().unwrap_u8(), 1);
+    assert!(bool::from(Scalar::zero().invert().is_none()));
     assert_eq!(Scalar::one().invert().unwrap(), Scalar::one());
     assert_eq!((-&Scalar::one()).invert().unwrap(), -&Scalar::one());
 
@@ -1143,7 +1133,7 @@ fn test_sqrt() {
 
     for _ in 0..100 {
         let square_root = square.sqrt();
-        if square_root.is_none().unwrap_u8() == 1 {
+        if bool::from(square_root.is_none()) {
             none_count += 1;
         } else {
             assert_eq!(square_root.unwrap() * square_root.unwrap(), square);

--- a/group/src/tests/mod.rs
+++ b/group/src/tests/mod.rs
@@ -4,12 +4,12 @@ use rand_xorshift::XorShiftRng;
 use std::ops::{Mul, Neg};
 
 use crate::{
-    cofactor::{CofactorCurve, CofactorCurveAffine},
+    prime::{PrimeCurve, PrimeCurveAffine},
     wnaf::WnafGroup,
     GroupEncoding, UncompressedEncoding,
 };
 
-pub fn curve_tests<G: CofactorCurve>() {
+pub fn curve_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -187,7 +187,7 @@ pub fn random_wnaf_tests<G: WnafGroup>() {
     }
 }
 
-fn random_negation_tests<G: CofactorCurve>() {
+fn random_negation_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -217,7 +217,7 @@ fn random_negation_tests<G: CofactorCurve>() {
     }
 }
 
-fn random_doubling_tests<G: CofactorCurve>() {
+fn random_doubling_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -245,7 +245,7 @@ fn random_doubling_tests<G: CofactorCurve>() {
     }
 }
 
-fn random_multiplication_tests<G: CofactorCurve>() {
+fn random_multiplication_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -280,7 +280,7 @@ fn random_multiplication_tests<G: CofactorCurve>() {
     }
 }
 
-fn random_addition_tests<G: CofactorCurve>() {
+fn random_addition_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -360,7 +360,7 @@ fn random_addition_tests<G: CofactorCurve>() {
     }
 }
 
-fn random_transformation_tests<G: CofactorCurve>() {
+fn random_transformation_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -397,7 +397,7 @@ fn random_transformation_tests<G: CofactorCurve>() {
     }
 }
 
-fn random_compressed_encoding_tests<G: CofactorCurve>() {
+fn random_compressed_encoding_tests<G: PrimeCurve>() {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
         0xe5,
@@ -423,9 +423,9 @@ fn random_compressed_encoding_tests<G: CofactorCurve>() {
     }
 }
 
-pub fn random_uncompressed_encoding_tests<G: CofactorCurve>()
+pub fn random_uncompressed_encoding_tests<G: PrimeCurve>()
 where
-    <G as CofactorCurve>::Affine: UncompressedEncoding,
+    <G as PrimeCurve>::Affine: UncompressedEncoding,
 {
     let mut rng = XorShiftRng::from_seed([
         0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,

--- a/jubjub/src/fr.rs
+++ b/jubjub/src/fr.rs
@@ -54,7 +54,7 @@ impl ConstantTimeEq for Fr {
 impl PartialEq for Fr {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -805,57 +805,47 @@ fn test_from_bytes() {
     );
 
     // -1 should work
-    assert!(
+    assert!(bool::from(
         Fr::from_bytes(&[
             182, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
         ])
         .is_some()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
     // modulus is invalid
-    assert!(
+    assert!(bool::from(
         Fr::from_bytes(&[
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
     // Anything larger than the modulus is invalid
-    assert!(
+    assert!(bool::from(
         Fr::from_bytes(&[
             184, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
-    assert!(
+    assert!(bool::from(
         Fr::from_bytes(&[
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 104, 6, 169, 175, 51, 101, 234, 180, 125, 14
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 
-    assert!(
+    assert!(bool::from(
         Fr::from_bytes(&[
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 15
         ])
         .is_none()
-        .unwrap_u8()
-            == 1
-    );
+    ));
 }
 
 #[test]
@@ -1056,7 +1046,7 @@ fn test_squaring() {
 
 #[test]
 fn test_inversion() {
-    assert_eq!(Fr::zero().invert().is_none().unwrap_u8(), 1);
+    assert!(bool::from(Fr::zero().invert().is_none()));
     assert_eq!(Fr::one().invert().unwrap(), Fr::one());
     assert_eq!((-&Fr::one()).invert().unwrap(), -&Fr::one());
 
@@ -1113,7 +1103,7 @@ fn test_sqrt() {
 
     for _ in 0..100 {
         let square_root = square.sqrt();
-        if square_root.is_none().unwrap_u8() == 1 {
+        if bool::from(square_root.is_none()) {
             none_count += 1;
         } else {
             assert_eq!(square_root.unwrap() * square_root.unwrap(), square);

--- a/jubjub/src/lib.rs
+++ b/jubjub/src/lib.rs
@@ -77,7 +77,7 @@ impl ConstantTimeEq for AffinePoint {
 
 impl PartialEq for AffinePoint {
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -136,7 +136,7 @@ impl ConditionallySelectable for ExtendedPoint {
 
 impl PartialEq for ExtendedPoint {
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -907,9 +907,9 @@ fn test_is_on_curve_var() {
 
 #[test]
 fn test_d_is_non_quadratic_residue() {
-    assert!(EDWARDS_D.sqrt().is_none().unwrap_u8() == 1);
-    assert!((-EDWARDS_D).sqrt().is_none().unwrap_u8() == 1);
-    assert!((-EDWARDS_D).invert().unwrap().sqrt().is_none().unwrap_u8() == 1);
+    assert!(bool::from(EDWARDS_D.sqrt().is_none()));
+    assert!(bool::from((-EDWARDS_D).sqrt().is_none()));
+    assert!(bool::from((-EDWARDS_D).invert().unwrap().sqrt().is_none()));
 }
 
 #[test]
@@ -1121,9 +1121,9 @@ const EIGHT_TORSION: [AffinePoint; 8] = [
 #[test]
 fn find_eight_torsion() {
     let g = ExtendedPoint::from(FULL_GENERATOR);
-    assert!(g.is_small_order().unwrap_u8() == 0);
+    assert!(!bool::from(g.is_small_order()));
     let g = g.multiply(&FR_MODULUS_BYTES);
-    assert!(g.is_small_order().unwrap_u8() == 1);
+    assert!(bool::from(g.is_small_order()));
 
     let mut cur = g;
 
@@ -1142,22 +1142,22 @@ fn find_curve_generator() {
     let mut trial_bytes = [0; 32];
     for _ in 0..255 {
         let a = AffinePoint::from_bytes(trial_bytes);
-        if a.is_some().unwrap_u8() == 1 {
+        if bool::from(a.is_some()) {
             let a = a.unwrap();
             assert!(a.is_on_curve_vartime());
             let b = ExtendedPoint::from(a);
             let b = b.multiply(&FR_MODULUS_BYTES);
-            assert!(b.is_small_order().unwrap_u8() == 1);
+            assert!(bool::from(b.is_small_order()));
             let b = b.double();
-            assert!(b.is_small_order().unwrap_u8() == 1);
+            assert!(bool::from(b.is_small_order()));
             let b = b.double();
-            assert!(b.is_small_order().unwrap_u8() == 1);
-            if b.is_identity().unwrap_u8() == 0 {
+            assert!(bool::from(b.is_small_order()));
+            if !bool::from(b.is_identity()) {
                 let b = b.double();
-                assert!(b.is_small_order().unwrap_u8() == 1);
-                assert!(b.is_identity().unwrap_u8() == 1);
+                assert!(bool::from(b.is_small_order()));
+                assert!(bool::from(b.is_identity()));
                 assert_eq!(FULL_GENERATOR, a);
-                assert!(a.mul_by_cofactor().is_torsion_free().unwrap_u8() == 1);
+                assert!(bool::from(a.mul_by_cofactor().is_torsion_free()));
                 return;
             }
         }
@@ -1171,7 +1171,7 @@ fn find_curve_generator() {
 #[test]
 fn test_small_order() {
     for point in EIGHT_TORSION.iter() {
-        assert!(point.is_small_order().unwrap_u8() == 1);
+        assert!(bool::from(point.is_small_order()));
     }
 }
 
@@ -1186,11 +1186,11 @@ fn test_is_identity() {
     assert!(a.v != b.v);
     assert!(a.z != b.z);
 
-    assert!(a.is_identity().unwrap_u8() == 1);
-    assert!(b.is_identity().unwrap_u8() == 1);
+    assert!(bool::from(a.is_identity()));
+    assert!(bool::from(b.is_identity()));
 
     for point in EIGHT_TORSION.iter() {
-        assert!(point.mul_by_cofactor().is_identity().unwrap_u8() == 1);
+        assert!(bool::from(point.mul_by_cofactor().is_identity()));
     }
 }
 

--- a/pairing/src/bls12_381/mod.rs
+++ b/pairing/src/bls12_381/mod.rs
@@ -24,7 +24,7 @@ pub use self::fr::{Fr, FrRepr};
 use super::{Engine, MillerLoopResult, MultiMillerLoop};
 
 use ff::{BitIterator, Field, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Group};
+use group::{prime::PrimeCurveAffine, Group};
 use rand_core::RngCore;
 use std::fmt;
 use std::iter::Sum;

--- a/pairing/src/bls12_381/tests/mod.rs
+++ b/pairing/src/bls12_381/tests/mod.rs
@@ -1,8 +1,5 @@
 use ff::PrimeField;
-use group::{
-    cofactor::{CofactorCurve, CofactorCurveAffine},
-    GroupEncoding, UncompressedEncoding,
-};
+use group::{GroupEncoding, UncompressedEncoding};
 
 use super::*;
 use crate::*;
@@ -58,7 +55,7 @@ fn test_pairing_result_against_relic() {
     }));
 }
 
-fn uncompressed_test_vectors<G: CofactorCurve>(expected: &[u8])
+fn uncompressed_test_vectors<G: PrimeCurve>(expected: &[u8])
 where
     G::Affine: UncompressedEncoding,
 {
@@ -88,7 +85,7 @@ where
     assert_eq!(&v[..], expected);
 }
 
-fn compressed_test_vectors<G: CofactorCurve>(expected: &[u8]) {
+fn compressed_test_vectors<G: PrimeCurve>(expected: &[u8]) {
     let mut e = G::identity();
     let encoded_len = <G::Affine as GroupEncoding>::Repr::default().as_ref().len();
 

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -23,7 +23,7 @@ pub mod bls12_381;
 use core::ops::Mul;
 use ff::PrimeField;
 use group::{
-    cofactor::{CofactorCurve, CofactorCurveAffine},
+    prime::{PrimeCurve, PrimeCurveAffine},
     Group, GroupOps, GroupOpsOwned, ScalarMul, ScalarMulOwned, UncompressedEncoding,
 };
 
@@ -35,7 +35,7 @@ pub trait Engine: Sized + 'static + Clone {
     type Fr: PrimeField;
 
     /// The projective representation of an element in G1.
-    type G1: CofactorCurve<Scalar = Self::Fr, Affine = Self::G1Affine>
+    type G1: PrimeCurve<Scalar = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
         + GroupOps<Self::G1Affine>
         + GroupOpsOwned<Self::G1Affine>
@@ -53,7 +53,7 @@ pub trait Engine: Sized + 'static + Clone {
         + for<'a> Mul<&'a Self::Fr, Output = Self::G1>;
 
     /// The projective representation of an element in G2.
-    type G2: CofactorCurve<Scalar = Self::Fr, Affine = Self::G2Affine>
+    type G2: PrimeCurve<Scalar = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
         + GroupOps<Self::G2Affine>
         + GroupOpsOwned<Self::G2Affine>
@@ -80,7 +80,7 @@ pub trait Engine: Sized + 'static + Clone {
 
 /// Affine representation of an elliptic curve point that can be used
 /// to perform pairings.
-pub trait PairingCurveAffine: CofactorCurveAffine + UncompressedEncoding {
+pub trait PairingCurveAffine: PrimeCurveAffine + UncompressedEncoding {
     type Pair: PairingCurveAffine<Pair = Self>;
     type PairingResult: Group;
 

--- a/pairing/src/tests/engine.rs
+++ b/pairing/src/tests/engine.rs
@@ -1,5 +1,5 @@
 use ff::Field;
-use group::{cofactor::CofactorCurveAffine, Curve, Group};
+use group::{prime::PrimeCurveAffine, Curve, Group};
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::Mul;


### PR DESCRIPTION
- `pairing::Engine` now requires G1 and G2 to be prime-order groups.
- We no longer use `Choice::unwrap_u8`.