### PR TITLE
Decrypt sapling output description given OCK 

### DIFF
--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -171,7 +171,7 @@ fn kdf_sapling(
 /// Sapling PRF^ock.
 ///
 /// Implemented per section 5.4.2 of the Zcash Protocol Specification.
-fn prf_ock(
+pub fn prf_ock(
     ovk: &OutgoingViewingKey,
     cv: &edwards::Point<Bls12, Unknown>,
     cmu: &Fr,

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -488,7 +488,7 @@ pub fn try_sapling_compact_note_decryption<P: consensus::Parameters>(
 /// `PaymentAddress` to which the note was sent.
 ///
 /// Implements part of section 4.17.3 of the Zcash Protocol Specification.
-/// For decryption using a Full Viewing Key see [try_sapling_output_recovery].
+/// For decryption using a Full Viewing Key see [`try_sapling_output_recovery`].
 pub fn try_sapling_output_recovery_with_ock<P: consensus::Parameters>(
     height: u32,
     ock: &[u8],
@@ -776,10 +776,8 @@ mod tests {
     ) {
         let ivk = Fs::random(&mut rng);
 
-        let (ovk, _, ivk, cv, cmu, epk, enc_ciphertext, out_ciphertext) =
+        let (ovk, ock, ivk, cv, cmu, epk, enc_ciphertext, out_ciphertext) =
             random_enc_ciphertext_with(height, ivk, rng);
-
-        let ock = prf_ock(&ovk, &cv, &cmu, &epk);
 
         assert!(try_sapling_note_decryption::<TestNetwork>(
             height,

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -628,8 +628,8 @@ mod tests {
         primitives::{Diversifier, PaymentAddress, Rseed, ValueCommitment},
         util::generate_random_rseed,
     };
+    use blake2b_simd::Hash as Blake2bHash;
     use crypto_api_chachapoly::ChachaPolyIetf;
-    use blake2b_simd::{Hash as Blake2bHash};
     use ff::{Field, PrimeField};
     use pairing::bls12_381::{Bls12, Fr, FrRepr};
     use rand_core::OsRng;
@@ -639,9 +639,9 @@ mod tests {
 
     use super::{
         kdf_sapling, prf_ock, sapling_ka_agree, try_sapling_compact_note_decryption,
-        try_sapling_note_decryption, try_sapling_output_recovery, try_sapling_output_recovery_with_ock,
-        Memo, SaplingNoteEncryption, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE, NOTE_PLAINTEXT_SIZE,
-        OUT_CIPHERTEXT_SIZE, OUT_PLAINTEXT_SIZE,
+        try_sapling_note_decryption, try_sapling_output_recovery,
+        try_sapling_output_recovery_with_ock, Memo, SaplingNoteEncryption, COMPACT_NOTE_SIZE,
+        ENC_CIPHERTEXT_SIZE, NOTE_PLAINTEXT_SIZE, OUT_CIPHERTEXT_SIZE, OUT_PLAINTEXT_SIZE,
     };
     use crate::{keys::OutgoingViewingKey, JUBJUB};
 
@@ -805,7 +805,7 @@ mod tests {
             &cmu,
             &epk,
             &enc_ciphertext,
-            &out_ciphertext
+            &out_ciphertext,
         );
         let ock_output_recovery = try_sapling_output_recovery_with_ock::<TestNetwork>(
             height,
@@ -813,7 +813,7 @@ mod tests {
             &cmu,
             &epk,
             &enc_ciphertext,
-            &out_ciphertext
+            &out_ciphertext,
         );
         assert!(ovk_output_recovery.is_some());
         assert!(ock_output_recovery.is_some());

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -491,7 +491,7 @@ pub fn try_sapling_compact_note_decryption<P: consensus::Parameters>(
 /// for decryption using a Full Viewing Key see [try_sapling_output_recovery].
 pub fn try_sapling_output_recovery_with_ock<P: consensus::Parameters>(
     height: u32,
-    ock: &Blake2bHash,
+    ock: &[u8],
     cmu: &Fr,
     epk: &edwards::Point<Bls12, PrimeOrder>,
     enc_ciphertext: &[u8],
@@ -503,7 +503,7 @@ pub fn try_sapling_output_recovery_with_ock<P: consensus::Parameters>(
     let mut op = [0; OUT_CIPHERTEXT_SIZE];
     assert_eq!(
         ChachaPolyIetf::aead_cipher()
-            .open_to(&mut op, &out_ciphertext, &[], &ock.as_bytes(), &[0u8; 12])
+            .open_to(&mut op, &out_ciphertext, &[], &ock, &[0u8; 12])
             .ok()?,
         OUT_PLAINTEXT_SIZE
     );
@@ -604,7 +604,7 @@ pub fn try_sapling_output_recovery<P: consensus::Parameters>(
 ) -> Option<(Note<Bls12>, PaymentAddress<Bls12>, Memo)> {
     try_sapling_output_recovery_with_ock::<P>(
       height,
-      &prf_ock(&ovk, &cv, &cmu, &epk),
+      &prf_ock(&ovk, &cv, &cmu, &epk).as_bytes(),
       cmu,
       epk,
       enc_ciphertext,

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -604,7 +604,7 @@ pub fn try_sapling_output_recovery<P: consensus::Parameters>(
 ) -> Option<(Note<Bls12>, PaymentAddress<Bls12>, Memo)> {
     try_sapling_output_recovery_with_ock::<P>(
       height,
-      &prf_ock(&ovk, &cv, &cmu, &epk).as_bytes(),
+      prf_ock(&ovk, &cv, &cmu, &epk).as_bytes(),
       cmu,
       epk,
       enc_ciphertext,

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -491,7 +491,7 @@ pub fn try_sapling_compact_note_decryption<P: consensus::Parameters>(
 /// for decryption using a Full Viewing Key see [try_sapling_output_recovery].
 pub fn try_sapling_output_recovery_with_ock<P: consensus::Parameters>(
     height: u32,
-    ock: Blake2bHash,
+    ock: &Blake2bHash,
     cmu: &Fr,
     epk: &edwards::Point<Bls12, PrimeOrder>,
     enc_ciphertext: &[u8],
@@ -503,7 +503,7 @@ pub fn try_sapling_output_recovery_with_ock<P: consensus::Parameters>(
     let mut op = [0; OUT_CIPHERTEXT_SIZE];
     assert_eq!(
         ChachaPolyIetf::aead_cipher()
-            .open_to(&mut op, &out_ciphertext, &[], ock.as_bytes(), &[0u8; 12])
+            .open_to(&mut op, &out_ciphertext, &[], &ock.as_bytes(), &[0u8; 12])
             .ok()?,
         OUT_PLAINTEXT_SIZE
     );
@@ -604,7 +604,7 @@ pub fn try_sapling_output_recovery<P: consensus::Parameters>(
 ) -> Option<(Note<Bls12>, PaymentAddress<Bls12>, Memo)> {
     try_sapling_output_recovery_with_ock::<P>(
       height,
-      prf_ock(&ovk, &cv, &cmu, &epk),
+      &prf_ock(&ovk, &cv, &cmu, &epk),
       cmu,
       epk,
       enc_ciphertext,

--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -603,13 +603,13 @@ pub fn try_sapling_output_recovery<P: consensus::Parameters>(
     out_ciphertext: &[u8],
 ) -> Option<(Note<Bls12>, PaymentAddress<Bls12>, Memo)> {
     try_sapling_output_recovery_with_ock::<P>(
-      height,
-      prf_ock(&ovk, &cv, &cmu, &epk).as_bytes(),
-      cmu,
-      epk,
-      enc_ciphertext,
-      out_ciphertext
-  )
+        height,
+        prf_ock(&ovk, &cv, &cmu, &epk).as_bytes(),
+        cmu,
+        epk,
+        enc_ciphertext,
+        out_ciphertext,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR slightly modifies the sapling recovery functionality to give users of this library the ability to decrypt a sapling output given they only have their `ock`, instead of the `ovk`.

`prf_ock` is also changed to public, to allow library users the ability to generate an ock for later usage. 