### PR TITLE
Rename `intra_doc_link_resolution_failure` lint to `broken_intra_doc_links`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           command: fetch
 
       # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crates.
+      # Requires #![deny(broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
         uses: actions-rs/cargo@v1
         with:

--- a/bellman/src/lib.rs
+++ b/bellman/src/lib.rs
@@ -135,7 +135,7 @@
 //! be separate crates that pull in the dependencies they require.
 
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 pub mod domain;
 pub mod gadgets;

--- a/bls12_381/.github/workflows/ci.yml
+++ b/bls12_381/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           command: fetch
 
       # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crate.
+      # Requires #![deny(broken_intra_doc_links)] in crate.
       - name: Check intra-doc links
         uses: actions-rs/cargo@v1
         with:

--- a/bls12_381/src/lib.rs
+++ b/bls12_381/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -2,7 +2,7 @@
 
 // Catch documentation errors caused by code changes.
 #![no_std]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![allow(unused_imports)]
 
 #[cfg(feature = "std")]

--- a/group/src/lib.rs
+++ b/group/src/lib.rs
@@ -1,5 +1,5 @@
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 use ff::PrimeField;
 use rand::RngCore;

--- a/jubjub/.github/workflows/ci.yml
+++ b/jubjub/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           command: fetch
 
       # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crate.
+      # Requires #![deny(broken_intra_doc_links)] in crate.
       - name: Check intra-doc links
         uses: actions-rs/cargo@v1
         with:

--- a/jubjub/src/lib.rs
+++ b/jubjub/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![no_std]
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]

--- a/pairing/src/lib.rs
+++ b/pairing/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -4,7 +4,7 @@
 //! light clients.
 
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 pub mod constants;
 mod decrypt;

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -4,7 +4,7 @@
 //! for working with Zcash.
 
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 pub mod block;
 pub mod consensus;

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -4,7 +4,7 @@
 //! and verifying proofs.
 
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 use bellman::groth16::{prepare_verifying_key, Parameters, PreparedVerifyingKey, VerifyingKey};
 use bls12_381::Bls12;


### PR DESCRIPTION
Fixes #279. This is dependent on updating Rust to a version that supports `#![deny(broken_intra_doc_links)]`.