### PR TITLE
Version bump 0.4.0 for crates

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
@@ -21,7 +21,7 @@ hex = "0.4"
 jubjub = "0.5.1"
 protobuf = "2.15"
 subtle = "2"
-zcash_primitives = { version = "0.3", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.4", path = "../zcash_primitives" }
 
 [build-dependencies]
 protobuf-codegen-pure = "2.15"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
@@ -21,13 +21,13 @@ protobuf = "2.15"
 rand_core = "0.5.1"
 rusqlite = { version = "0.24", features = ["bundled", "time"] }
 time = "0.2"
-zcash_client_backend = { version = "0.3", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.3", path = "../zcash_primitives" }
+zcash_client_backend = { version = "0.4", path = "../zcash_client_backend" }
+zcash_primitives = { version = "0.4", path = "../zcash_primitives" }
 
 [dev-dependencies]
 rand_core = "0.5.1"
 tempfile = "3"
-zcash_proofs = { version = "0.3", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.4", path = "../zcash_proofs" }
 
 [features]
 mainnet = []

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
@@ -27,7 +27,7 @@ lazy_static = "1"
 minreq = { version = "2", features = ["https"], optional = true }
 rand_core = "0.5.1"
 wagyu-zcash-parameters = { version = "0.2", optional = true }
-zcash_primitives = { version = "0.3", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.4", path = "../zcash_primitives" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Bumps zcash_proofs, zcash_primitives, zcash_client_backend to 0.4.0
Also bumps zcash_client_sqlite to 0.2.0