### PR TITLE
Make fixed generator functions publicly accessible

### DIFF
--- a/zcash_proofs/src/constants.rs
+++ b/zcash_proofs/src/constants.rs
@@ -68,7 +68,7 @@ lazy_static! {
 
 /// Creates the 3-bit window table `[0, 1, ..., 8]` for different magnitudes of a fixed
 /// generator.
-fn generate_circuit_generator(mut gen: jubjub::SubgroupPoint) -> FixedGeneratorOwned {
+pub fn generate_circuit_generator(mut gen: jubjub::SubgroupPoint) -> FixedGeneratorOwned {
     let mut windows = vec![];
 
     for _ in 0..FIXED_BASE_CHUNKS_PER_GENERATOR {

--- a/zcash_proofs/src/constants.rs
+++ b/zcash_proofs/src/constants.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use zcash_primitives::constants::{PEDERSEN_HASH_CHUNKS_PER_GENERATOR, PEDERSEN_HASH_GENERATORS};
 
 /// The `d` constant of the twisted Edwards curve.
-pub const EDWARDS_D: Scalar = Scalar::from_raw([
+pub(crate) const EDWARDS_D: Scalar = Scalar::from_raw([
     0x0106_5fd6_d634_3eb1,
     0x292d_7f6d_3757_9d26,
     0xf5fd_9207_e6bd_7fd4,
@@ -16,7 +16,7 @@ pub const EDWARDS_D: Scalar = Scalar::from_raw([
 ]);
 
 /// The `A` constant of the birationally equivalent Montgomery curve.
-pub const MONTGOMERY_A: Scalar = Scalar::from_raw([
+pub(crate) const MONTGOMERY_A: Scalar = Scalar::from_raw([
     0x0000_0000_0000_a002,
     0x0000_0000_0000_0000,
     0x0000_0000_0000_0000,
@@ -24,7 +24,7 @@ pub const MONTGOMERY_A: Scalar = Scalar::from_raw([
 ]);
 
 /// The scaling factor used for conversion to and from the Montgomery form.
-pub const MONTGOMERY_SCALE: Scalar = Scalar::from_raw([
+pub(crate) const MONTGOMERY_SCALE: Scalar = Scalar::from_raw([
     0x8f45_35f7_cf82_b8d9,
     0xce40_6970_3da8_8abd,
     0x31de_341e_77d7_64e5,
@@ -62,7 +62,7 @@ lazy_static! {
 
     /// The pre-computed window tables `[-4, 3, 2, 1, 1, 2, 3, 4]` of different magnitudes
     /// of the Pedersen hash segment generators.
-    pub static ref PEDERSEN_CIRCUIT_GENERATORS: Vec<Vec<Vec<(Scalar, Scalar)>>> =
+    pub(crate) static ref PEDERSEN_CIRCUIT_GENERATORS: Vec<Vec<Vec<(Scalar, Scalar)>>> =
         generate_pedersen_circuit_generators();
 }
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -19,7 +19,7 @@ use directories::BaseDirs;
 use std::path::PathBuf;
 
 pub mod circuit;
-mod constants;
+pub mod constants;
 mod hashreader;
 pub mod sapling;
 pub mod sprout;


### PR DESCRIPTION
To be able to use the `ecc::fixed_base_multiplication` (which is publicly exposed in the API), you need to be able to access these constants and potentially generate your own.