### PR TITLE
Build transparent inputs as a part of github actions build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
           command: build
           args: --all
 
+      # Build with the "transparent-inputs" feature enabled
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path zcash_primitives/Cargo.toml --features transparent-inputs
+
       # Ensure all code has been formatted with rustfmt
       - run: rustup component add rustfmt
       - name: Check formatting


### PR DESCRIPTION
Github Actions will build with transparent-features enabled to prevent compile errors and other breaking changes creeping in unexpectedly. 