### PR TITLE
zcash_primitives: Small simplification to Script::address

### DIFF
--- a/zcash_primitives/src/legacy.rs
+++ b/zcash_primitives/src/legacy.rs
@@ -42,18 +42,14 @@ impl Script {
     /// Returns the address that this Script contains, if any.
     pub fn address(&self) -> Option<TransparentAddress> {
         if self.0.len() == 25
-            && self.0[0] == OpCode::Dup as u8
-            && self.0[1] == OpCode::Hash160 as u8
-            && self.0[2] == 0x14
-            && self.0[23] == OpCode::EqualVerify as u8
-            && self.0[24] == OpCode::CheckSig as u8
+            && self.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]
+            && self.0[23..25] == [OpCode::EqualVerify as u8, OpCode::CheckSig as u8]
         {
             let mut hash = [0; 20];
             hash.copy_from_slice(&self.0[3..23]);
             Some(TransparentAddress::PublicKey(hash))
         } else if self.0.len() == 23
-            && self.0[0] == OpCode::Hash160 as u8
-            && self.0[1] == 0x14
+            && self.0[0..2] == [OpCode::Hash160 as u8, 0x14]
             && self.0[22] == OpCode::Equal as u8
         {
             let mut hash = [0; 20];


### PR DESCRIPTION
Improves readability, and makes it clearer that we are splitting the output scripts into three subslices.