### PR TITLE
Add Transaction DerefMut and ::new()

### DIFF
--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -5,7 +5,7 @@ use hex;
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::io::{self, Read, Write};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use crate::{consensus::BlockHeight, redjubjub::Signature, serialize::Vector};
 
@@ -54,11 +54,23 @@ pub struct Transaction {
     data: TransactionData,
 }
 
+impl Transaction {
+    pub fn new(txid: TxId, data: TransactionData) -> Self {
+        Transaction { txid, data }
+    }
+}
+
 impl Deref for Transaction {
     type Target = TransactionData;
 
     fn deref(&self) -> &TransactionData {
         &self.data
+    }
+}
+
+impl DerefMut for Transaction {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }
 


### PR DESCRIPTION
These methods are needed for Zecwallet Lite's test cases. We need a way to create new Transaction objects with known-good data and a way to update that data.

I could live without the `DerefMut` if it violates a principle, but it would be nice to have. 