### PR TITLE
Use wNAF multiplication for Sapling key agreement.

### DIFF
--- a/zcash_primitives/src/note_encryption.rs
+++ b/zcash_primitives/src/note_encryption.rs
@@ -136,7 +136,9 @@ pub fn sapling_ka_agree(esk: &jubjub::Fr, pk_d: &jubjub::ExtendedPoint) -> jubju
     // [8 esk] pk_d
     // <ExtendedPoint as CofactorGroup>::clear_cofactor is implemented using
     // ExtendedPoint::mul_by_cofactor in the jubjub crate.
-    CofactorGroup::clear_cofactor(&(pk_d * esk))
+
+    let mut wnaf = group::Wnaf::new();
+    wnaf.scalar(esk).base(*pk_d).clear_cofactor()
 }
 
 /// Sapling KDF for note encryption.


### PR DESCRIPTION
```
Sapling note decryption/valid                                                                            
                        time:   [581.10 us 582.21 us 583.60 us]
                        change: [-7.7891% -7.3391% -6.7990%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
Sapling note decryption/invalid                                                                            
                        time:   [84.959 us 85.175 us 85.431 us]
                        change: [-31.862% -31.399% -30.921%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```