### PR TITLE
Add changelogs to the crates

### DIFF
--- a/components/equihash/CHANGELOG.md
+++ b/components/equihash/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2020-07-10
+Initial release.

--- a/components/equihash/CHANGELOG.md
+++ b/components/equihash/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+TBD
+
+## [0.4.0] - 2020-09-09
+### Changed
+- MSRV is now 1.44.1.
+- Bumped dependencies to `ff 0.8`, `group 0.8`, `bls12_381 0.3.1`,
+  `jubjub 0.5.1`, `protobuf 2.15`.
+
+## [0.3.0] - 2020-08-24
+TBD
+
+## [0.2.0] - 2020-03-13
+TBD
+
+## [0.1.0] - 2019-10-08
+Initial release.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -5,8 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+TBD
+
 ## [0.2.1] - 2020-10-24
 ### Fixed
 - `transact::create_to_address` now correctly reconstructs notes from the data
   DB after Canopy activation (zcash/librustzcash#311). This is critcal to correct
   operation of spends after Canopy.
+
+## [0.2.0] - 2020-09-09
+### Changed
+- MSRV is now 1.44.1.
+- Bumped dependencies to `ff 0.8`, `group 0.8`, `jubjub 0.5.1`, `protobuf 2.15`,
+  `rusqlite 0.24`, `zcash_primitives 0.4`, `zcash_client_backend 0.4`.
+
+## [0.1.0] - 2020-08-24
+Initial release.

--- a/zcash_extensions/CHANGELOG.md
+++ b/zcash_extensions/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+Initial release.

--- a/zcash_extensions/CHANGELOG.md
+++ b/zcash_extensions/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2020-03-13
+No changes, just a version bump.
+
+## [0.0.1] - 2020-03-04
+Initial release.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+TBD
+
+## [0.4.0] - 2020-09-09
+### Added
+- `zcash_primitives::note_encryption::OutgoingCipherKey` - a symmetric key that
+  can be used to recover a single Sapling output. This will eventually be used
+  to implement Sapling payment disclosures.
+
+### Changed
+- MSRV is now 1.44.1.
+- `zcash_primitives::note_encryption`:
+  - `SaplingNoteEncryption::new` now takes `Option<OutgoingViewingKey>`. Setting
+    this to `None` prevents the note from being recovered from the block chain
+    by the sender.
+    - The `rng: &mut R` parameter (where `R: RngCore + CryptoRng`) has been
+      changed to `rng: R` to enable this use case.
+  - `prf_ock` now returns `OutgoingCipherKey`.
+  - `try_sapling_output_recovery_with_ock` now takes `&OutgoingCipherKey`.
+- `zcash_primitives::transaction::builder`:
+  - `SaplingOutput::new` and `Builder::add_sapling_output` now take
+    `Option<OutgoingViewingKey>` (exposing the new unrecoverable note option).
+- Bumped dependencies to `ff 0.8`, `group 0.8`, `bls12_381 0.3.1`,
+  `jubjub 0.5.1`, `secp256k1 0.19`.
+
+## [0.3.0] - 2020-08-24
+TBD
+
+## [0.2.0] - 2020-03-13
+TBD
+
+## [0.1.0] - 2019-10-08
+Initial release.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to this library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to Rust's notion of
+and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+TBD
+
+## [0.4.0] - 2020-09-09
+### Changed
+- MSRV is now 1.44.1.
+- Bumped dependencies to `ff 0.8`, `group 0.8`, `bellman 0.8`,
+  `bls12_381 0.3.1`, `jubjub 0.5.1`.
+
+## Fixed
+- Performance regressions to Sapling proof creation in 0.3.0 have been partially
+  mitigated by fixes in `bellman 0.8`.
+
+## [0.3.0] - 2020-08-24
+TBD
+
+## [0.2.0] - 2020-03-13
+TBD
+
+## [0.1.0] - 2019-10-08
+Initial release.


### PR DESCRIPTION
The changelogs are accurate for the 0.4.0 release tag, but don't yet
include changes before or after that tag.