### PR TITLE
Make data access API write calls atomic.

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -206,7 +206,7 @@ pub struct SentTransaction<'a> {
 /// wallet data.
 pub trait WalletWrite: WalletRead {
     #[allow(clippy::type_complexity)]
-    fn insert_pruned_block(
+    fn advance_by_block(
         &mut self,
         block: &PrunedBlock,
         updated_witnesses: &[(Self::NoteRef, IncrementalWitness<Node>)],
@@ -385,7 +385,7 @@ pub mod testing {
 
     impl WalletWrite for MockWalletDB {
         #[allow(clippy::type_complexity)]
-        fn insert_pruned_block(
+        fn advance_by_block(
             &mut self,
             _block: &PrunedBlock,
             _updated_witnesses: &[(Self::NoteRef, IncrementalWitness<Node>)],

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -177,6 +177,33 @@ pub trait WalletRead {
     ) -> Result<Vec<SpendableNote>, Self::Error>;
 }
 
+// /// The subset of information that is relevant to this wallet that has been
+// /// decrypted and extracted from a [CompactBlock].
+// pub struct PrunedBlock {
+//     block_height: BlockHeight,
+//     block_hash: BlockHash,
+//     block_time: u32,
+//     commitment_tree: &CommitmentTree<Node>,
+//     transactions: &Vec<ChainTx>,
+// }
+//
+// pub struct BlockInserted {
+//     witnesses: Vec<(Self::NoteRef, IncrementalWitness<Node>)>
+// }
+//
+//
+//
+//
+// pub trait WalletWrite2: WalletRead {
+//     fn insert_pruned_block(
+//         &mut self,
+//         block: &PrunedBlock
+//     ) -> Result<BlockInserted, Self::Error>;
+//
+//
+//
+// }
+
 /// This trait encapsulates the write capabilities required to update stored
 /// wallet data.
 pub trait WalletWrite: WalletRead {
@@ -243,7 +270,6 @@ pub trait WalletWrite: WalletRead {
     fn put_received_note<T: ShieldedOutput>(
         &mut self,
         output: &T,
-        nf: &Option<Nullifier>,
         tx_ref: Self::TxRef,
     ) -> Result<Self::NoteRef, Self::Error>;
 
@@ -317,6 +343,7 @@ pub trait ShieldedOutput {
     fn note(&self) -> &Note;
     fn memo(&self) -> Option<&Memo>;
     fn is_change(&self) -> Option<bool>;
+    fn nullifier(&self) -> Option<Nullifier>;
 }
 
 impl ShieldedOutput for WalletShieldedOutput {
@@ -338,6 +365,10 @@ impl ShieldedOutput for WalletShieldedOutput {
     fn is_change(&self) -> Option<bool> {
         Some(self.is_change)
     }
+
+    fn nullifier(&self) -> Option<Nullifier> {
+        self.nf.clone()
+    }
 }
 
 impl ShieldedOutput for DecryptedOutput {
@@ -357,6 +388,9 @@ impl ShieldedOutput for DecryptedOutput {
         Some(&self.memo)
     }
     fn is_change(&self) -> Option<bool> {
+        None
+    }
+    fn nullifier(&self) -> Option<Nullifier> {
         None
     }
 }
@@ -537,7 +571,6 @@ pub mod testing {
         fn put_received_note<T: ShieldedOutput>(
             &mut self,
             _output: &T,
-            _nf: &Option<Nullifier>,
             _tx_ref: Self::TxRef,
         ) -> Result<Self::NoteRef, Self::Error> {
             Ok(0u32)

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -339,12 +339,6 @@ where
             &witnesses,
         )?;
 
-        // Prune the stored witnesses (we only expect rollbacks of at most 100 blocks).
-        data.prune_witnesses(current_height - 100)?;
-
-        // Update now-expired transactions that didn't get mined.
-        data.update_expired_notes(current_height)?;
-
         let spent_nf: Vec<Nullifier> = txs
             .iter()
             .flat_map(|tx| tx.shielded_spends.iter().map(|spend| spend.nf))

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -291,7 +291,7 @@ where
         let block_hash = BlockHash::from_slice(&block.hash);
         let block_time = block.time;
 
-        let txs: Vec<WalletTx> = {
+        let txs: Vec<WalletTx<Nullifier>> = {
             let mut witness_refs: Vec<_> = witnesses.iter_mut().map(|w| &mut w.1).collect();
 
             scan_block(
@@ -344,11 +344,10 @@ where
             .flat_map(|tx| tx.shielded_spends.iter().map(|spend| spend.nf))
             .collect();
         nullifiers.retain(|(_, nf)| !spent_nf.contains(nf));
-        nullifiers.extend(txs.iter().flat_map(|tx| {
-            tx.shielded_outputs
-                .iter()
-                .flat_map(|out| out.nf.map(|nf| (out.account, nf)))
-        }));
+        nullifiers.extend(
+            txs.iter()
+                .flat_map(|tx| tx.shielded_outputs.iter().map(|out| (out.account, out.nf))),
+        );
 
         witnesses.extend(new_witnesses);
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -59,7 +59,7 @@ where
                 if output.outgoing {
                     up.put_sent_note(&output, tx_ref)?;
                 } else {
-                    up.put_received_note(&output, &None, tx_ref)?;
+                    up.put_received_note(&output, tx_ref)?;
                 }
             }
 

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -30,13 +30,13 @@ impl ConditionallySelectable for AccountId {
 /// A subset of a [`Transaction`] relevant to wallets and light clients.
 ///
 /// [`Transaction`]: zcash_primitives::transaction::Transaction
-pub struct WalletTx {
+pub struct WalletTx<N> {
     pub txid: TxId,
     pub index: usize,
     pub num_spends: usize,
     pub num_outputs: usize,
     pub shielded_spends: Vec<WalletShieldedSpend>,
-    pub shielded_outputs: Vec<WalletShieldedOutput>,
+    pub shielded_outputs: Vec<WalletShieldedOutput<N>>,
 }
 
 /// A subset of a [`SpendDescription`] relevant to wallets and light clients.
@@ -51,7 +51,7 @@ pub struct WalletShieldedSpend {
 /// A subset of an [`OutputDescription`] relevant to wallets and light clients.
 ///
 /// [`OutputDescription`]: zcash_primitives::transaction::components::OutputDescription
-pub struct WalletShieldedOutput {
+pub struct WalletShieldedOutput<N> {
     pub index: usize,
     pub cmu: bls12_381::Scalar,
     pub epk: jubjub::ExtendedPoint,
@@ -60,7 +60,7 @@ pub struct WalletShieldedOutput {
     pub to: PaymentAddress,
     pub is_change: bool,
     pub witness: IncrementalWitness<Node>,
-    pub nf: Option<Nullifier>,
+    pub nf: N,
 }
 
 pub struct SpendableNote {

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -60,6 +60,7 @@ pub struct WalletShieldedOutput {
     pub to: PaymentAddress,
     pub is_change: bool,
     pub witness: IncrementalWitness<Node>,
+    pub nf: Option<Nullifier>,
 }
 
 pub struct SpendableNote {

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -16,10 +16,10 @@ use zcash_primitives::{
 use crate::proto::compact_formats::{CompactBlock, CompactOutput};
 use crate::wallet::{AccountId, WalletShieldedOutput, WalletShieldedSpend, WalletTx};
 
-/// Scans a [`CompactOutput`] with a set of [`ExtendedFullViewingKey`]s.
+/// Scans a [`CompactOutput`] with a set of [`ScanningKey`]s.
 ///
 /// Returns a [`WalletShieldedOutput`] and corresponding [`IncrementalWitness`] if this
-/// output belongs to any of the given [`ExtendedFullViewingKey`]s.
+/// output belongs to any of the given [`ScanningKey`]s.
 ///
 /// The given [`CommitmentTree`] and existing [`IncrementalWitness`]es are incremented
 /// with this output's commitment.
@@ -86,7 +86,9 @@ fn scan_output<P: consensus::Parameters, K: ScanningKey>(
 }
 
 /// A key that can be used to perform trial decryption and nullifier
-/// computation for a Sapling [`ShieldedOutput`]
+/// computation for a Sapling [`CompactOutput`]
+///
+/// [`CompactOutput`]: crate::proto::compact_formats::CompactOutput
 pub trait ScanningKey {
     type Nf;
 
@@ -146,6 +148,20 @@ impl ScanningKey for SaplingIvk {
 ///
 /// The given [`CommitmentTree`] and existing [`IncrementalWitness`]es are
 /// incremented appropriately.
+///
+/// The implementation of [`ScanningKey`] may either support or omit the computation of
+/// the nullifiers for received notes; the implementation for [`ExtendedFullViewingKey`]
+/// will derive the nullifiers for received notes and return them as part of the resulting
+/// [`WalletShieldedOutput`]s, whereas since the implementation for [`SaplingIvk`] cannot 
+/// do so and it will return the unit value in those outputs instead.
+///
+/// [`ExtendedFullViewingKey`]: zcash_primitives::zip32::ExtendedFullViewingKey
+/// [`SaplingIvk`]: zcash_primitives::SaplingIvk
+/// [`CompactBlock`]: crate::proto::compact_formats::CompactBlock
+/// [`ScanningKey`]: self::ScanningKey
+/// [`CommitmentTree`]: zcash_primitives::merkle_tree::CommitmentTree
+/// [`IncrementalWitness`]: zcash_primitives::merkle_tree::IncrementalWitness
+/// [`WalletShieldedOutput`]: crate::wallet::WalletShieldedOutput
 pub fn scan_block<P: consensus::Parameters, K: ScanningKey>(
     params: &P,
     block: CompactBlock,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -388,6 +388,7 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
 }
 
 impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
+    #[allow(clippy::type_complexity)]
     fn insert_pruned_block(
         &mut self,
         block: &PrunedBlock,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -427,10 +427,9 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
     fn put_received_note<T: ShieldedOutput>(
         &mut self,
         output: &T,
-        nf_opt: &Option<Nullifier>,
         tx_ref: Self::TxRef,
     ) -> Result<Self::NoteRef, Self::Error> {
-        wallet::put_received_note(self, output, nf_opt, tx_ref)
+        wallet::put_received_note(self, output, tx_ref)
     }
 
     fn insert_witness(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -389,7 +389,7 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
 
 impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
     #[allow(clippy::type_complexity)]
-    fn insert_pruned_block(
+    fn advance_by_block(
         &mut self,
         block: &PrunedBlock,
         updated_witnesses: &[(Self::NoteRef, IncrementalWitness<Node>)],
@@ -427,6 +427,8 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
             {
                 if let NoteId::ReceivedNoteId(rnid) = *received_note_id {
                     wallet::insert_witness(up, rnid, witness, block.block_height)?;
+                } else {
+                    return Err(SqliteClientError::InvalidNoteId);
                 }
             }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -534,7 +534,6 @@ pub fn mark_spent<'a, P>(
 pub fn put_received_note<'a, P, T: ShieldedOutput>(
     stmts: &mut DataConnStmtCache<'a, P>,
     output: &T,
-    nf_opt: &Option<Nullifier>,
     tx_ref: i64,
 ) -> Result<NoteId, SqliteClientError> {
     let rcm = output.note().rcm().to_repr();
@@ -546,7 +545,7 @@ pub fn put_received_note<'a, P, T: ShieldedOutput>(
     let is_change = output.is_change();
     let tx = tx_ref;
     let output_index = output.index() as i64;
-    let nf_bytes = nf_opt.map(|nf| nf.0.to_vec());
+    let nf_bytes = output.nullifier().map(|nf| nf.0.to_vec());
 
     let sql_args: &[(&str, &dyn ToSql)] = &[
         (&":account", &account),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -644,7 +644,7 @@ pub fn put_sent_note<'a, P: consensus::Parameters>(
             &RecipientAddress::Shielded(output.to.clone()),
             Amount::from_u64(output.note.value)
                 .map_err(|_| SqliteClientError::CorruptedData("Note value invalid.".to_string()))?,
-            Some(output.memo.clone()),
+            &Some(output.memo.clone()),
         )?
     }
 
@@ -658,7 +658,7 @@ pub fn insert_sent_note<'a, P: consensus::Parameters>(
     account: AccountId,
     to: &RecipientAddress,
     value: Amount,
-    memo: Option<Memo>,
+    memo: &Option<Memo>,
 ) -> Result<(), SqliteClientError> {
     let to_str = to.encode(&stmts.wallet_db.params);
     let ivalue: i64 = value.into();
@@ -668,7 +668,7 @@ pub fn insert_sent_note<'a, P: consensus::Parameters>(
         account.0,
         to_str,
         ivalue,
-        memo.map(|m| m.as_bytes().to_vec()),
+        memo.as_ref().map(|m| m.as_bytes().to_vec()),
     ])?;
 
     Ok(())

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -3,7 +3,6 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
-use std::iter;
 
 use crate::sapling::SAPLING_COMMITMENT_TREE_DEPTH;
 use crate::serialize::{Optional, Vector};
@@ -274,17 +273,9 @@ impl<Node: Hashable> IncrementalWitness<Node> {
             .as_ref()
             .map(|c| c.root_inner(self.cursor_depth, PathFiller::empty()));
 
-        let queue = if let Some(node) = cursor_root {
-            self.filled
-                .iter()
-                .cloned()
-                .chain(iter::once(node))
-                .collect()
-        } else {
-            self.filled.iter().cloned().collect()
-        };
-
-        PathFiller { queue }
+        PathFiller {
+            queue: self.filled.iter().cloned().chain(cursor_root).collect(),
+        }
     }
 
     /// Finds the next "depth" of an unfilled subtree.

--- a/zcash_primitives/src/primitives.rs
+++ b/zcash_primitives/src/primitives.rs
@@ -48,7 +48,7 @@ impl ProofGenerationKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ViewingKey {
     pub ak: jubjub::SubgroupPoint,
     pub nk: jubjub::SubgroupPoint,


### PR DESCRIPTION
This removes the `WalletWrite::transactionally` method to make this interface implementable for back-ends that do not support transactionality (such as FFI or network calls). The `WalletWrite` trait is also simplified so as not to tie wallet backends to using the same data representation as the SQLite backend.

Careful review is requested to ensure that incremental witness update semantics are correctly preserved by this refactoring.