### PR TITLE
Empty zcash_note_encryption crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "components/equihash",
+    "components/zcash_note_encryption",
     "zcash_client_backend",
     "zcash_client_sqlite",
     "zcash_extensions",

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zcash_note_encryption"
+description = "TBD"
+version = "0.0.0"
+authors = [
+    "Jack Grigg <jack@electriccoin.co>",
+]
+homepage = "https://github.com/zcash/librustzcash"
+repository = "https://github.com/zcash/librustzcash"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
The general note encryption logic shared between Sapling and Orchard will be moved into here.