### PR TITLE
zcash_client_backend: Use correct output index for t-addr recipients

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -195,6 +195,12 @@ pub struct ReceivedTransaction<'a> {
 pub struct SentTransaction<'a> {
     pub tx: &'a Transaction,
     pub created: time::OffsetDateTime,
+    /// The index within the transaction that contains the recipient output.
+    ///
+    /// - If `recipient_address` is a Sapling address, this is an index into the Sapling
+    ///   outputs of the transaction.
+    /// - If `recipient_address` is a transparent address, this is an index into the
+    ///   transparent outputs of the transaction.
     pub output_index: usize,
     pub account: AccountId,
     pub recipient_address: &'a RecipientAddress,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -235,10 +235,15 @@ where
             Some(idx) => idx,
             None => panic!("Output 0 should exist in the transaction"),
         },
-        // This function only spends shielded notes, so there will only ever be a single
-        // transparent output in this case (and even if there were more, we don't shuffle
-        // the transparent outputs).
-        RecipientAddress::Transparent(_) => 0,
+        RecipientAddress::Transparent(addr) => {
+            let script = addr.script();
+            tx.vout
+                .iter()
+                .enumerate()
+                .find(|(_, tx_out)| tx_out.script_pubkey == script)
+                .map(|(index, _)| index)
+                .expect("we sent to this address")
+        }
     };
 
     wallet_db.store_sent_tx(&SentTransaction {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -232,7 +232,7 @@ where
     let output_index = match to {
         // Sapling outputs are shuffled, so we need to look up where the output ended up.
         RecipientAddress::Shielded(_) => match tx_metadata.output_index(0) {
-            Some(idx) => idx as i64,
+            Some(idx) => idx,
             None => panic!("Output 0 should exist in the transaction"),
         },
         // This function only spends shielded notes, so there will only ever be a single
@@ -244,7 +244,7 @@ where
     wallet_db.store_sent_tx(&SentTransaction {
         tx: &tx,
         created: time::OffsetDateTime::now_utc(),
-        output_index: output_index as usize,
+        output_index,
         account,
         recipient_address: to,
         value,

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -152,7 +152,7 @@ impl ScanningKey for SaplingIvk {
 /// The implementation of [`ScanningKey`] may either support or omit the computation of
 /// the nullifiers for received notes; the implementation for [`ExtendedFullViewingKey`]
 /// will derive the nullifiers for received notes and return them as part of the resulting
-/// [`WalletShieldedOutput`]s, whereas since the implementation for [`SaplingIvk`] cannot 
+/// [`WalletShieldedOutput`]s, whereas since the implementation for [`SaplingIvk`] cannot
 /// do so and it will return the unit value in those outputs instead.
 ///
 /// [`ExtendedFullViewingKey`]: zcash_primitives::zip32::ExtendedFullViewingKey

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -715,6 +715,14 @@ pub fn put_sent_note<'a, P: consensus::Parameters>(
     Ok(())
 }
 
+/// Inserts a sent note into the wallet database.
+///
+/// `output_index` is the index within the transaction that contains the recipient output:
+///
+/// - If `to` is a Sapling address, this is an index into the Sapling outputs of the
+///   transaction.
+/// - If `to` is a transparent address, this is an index into the transparent outputs of
+///   the transaction.
 pub fn insert_sent_note<'a, P: consensus::Parameters>(
     stmts: &mut DataConnStmtCache<'a, P>,
     tx_ref: i64,


### PR DESCRIPTION
Fixes zcash/librustzcash#356.