### PR TITLE
ZIP-225/244 #2: Refactor transaction builder to create separate builders for each section.

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -8,7 +8,7 @@ use zcash_primitives::{
     transaction::{
         builder::Builder,
         components::{amount::DEFAULT_FEE, Amount},
-        Transaction,
+        Transaction, TxVersion,
     },
     zip32::{ExtendedFullViewingKey, ExtendedSpendingKey},
 };
@@ -230,7 +230,7 @@ where
 
     let consensus_branch_id = BranchId::for_height(params, height);
     let (tx, tx_metadata) = builder
-        .build(consensus_branch_id, &prover)
+        .build(TxVersion::Sapling, consensus_branch_id, &prover)
         .map_err(Error::Builder)?;
 
     let output_index = match to {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2,13 +2,13 @@
 use std::fmt::Debug;
 
 use zcash_primitives::{
-    consensus::{self, BranchId, NetworkUpgrade},
+    consensus::{self, NetworkUpgrade},
     memo::MemoBytes,
     sapling::prover::TxProver,
     transaction::{
         builder::Builder,
         components::{amount::DEFAULT_FEE, Amount},
-        Transaction, TxVersion,
+        Transaction,
     },
     zip32::{ExtendedFullViewingKey, ExtendedSpendingKey},
 };
@@ -228,10 +228,7 @@ where
     }
     .map_err(Error::Builder)?;
 
-    let consensus_branch_id = BranchId::for_height(params, height);
-    let (tx, tx_metadata) = builder
-        .build(TxVersion::Sapling, consensus_branch_id, &prover)
-        .map_err(Error::Builder)?;
+    let (tx, tx_metadata) = builder.build(&prover).map_err(Error::Builder)?;
 
     let output_index = match to {
         // Sapling outputs are shuffled, so we need to look up where the output ended up.

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -467,7 +467,7 @@ mod tests {
     use zcash_proofs::prover::LocalTxProver;
 
     use zcash_primitives::{
-        consensus::{BranchId, H0, TEST_NETWORK},
+        consensus::{H0, TEST_NETWORK},
         extensions::transparent::{self as tze, Extension, FromPayload, ToPayload},
         legacy::TransparentAddress,
         merkle_tree::{CommitmentTree, IncrementalWitness},
@@ -479,7 +479,7 @@ mod tests {
                 amount::{Amount, DEFAULT_FEE},
                 TzeIn, TzeOut, TzeOutPoint,
             },
-            Transaction, TransactionData, TxVersion,
+            Transaction, TransactionData,
         },
         zip32::ExtendedSpendingKey,
     };
@@ -723,7 +723,7 @@ mod tests {
             .map_err(|e| format!("open failure: {:?}", e))
             .unwrap();
         let (tx_a, _) = builder_a
-            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
+            .build(&prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 
@@ -745,7 +745,7 @@ mod tests {
             .map_err(|e| format!("transfer failure: {:?}", e))
             .unwrap();
         let (tx_b, _) = builder_b
-            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
+            .build(&prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 
@@ -774,7 +774,7 @@ mod tests {
             .unwrap();
 
         let (tx_c, _) = builder_c
-            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
+            .build(&prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -479,7 +479,7 @@ mod tests {
                 amount::{Amount, DEFAULT_FEE},
                 TzeIn, TzeOut, TzeOutPoint,
             },
-            Transaction, TransactionData,
+            Transaction, TransactionData, TxVersion,
         },
         zip32::ExtendedSpendingKey,
     };
@@ -693,7 +693,7 @@ mod tests {
         //
 
         let mut rng = OsRng;
-        let mut builder_a = Builder::new_with_rng_zfuture(TEST_NETWORK, H0, rng);
+        let mut builder_a = Builder::new(TEST_NETWORK, H0);
 
         // create some inputs to spend
         let extsk = ExtendedSpendingKey::master(&[]);
@@ -723,7 +723,7 @@ mod tests {
             .map_err(|e| format!("open failure: {:?}", e))
             .unwrap();
         let (tx_a, _) = builder_a
-            .build(BranchId::Canopy, &prover)
+            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 
@@ -731,7 +731,7 @@ mod tests {
         // Transfer
         //
 
-        let mut builder_b = Builder::new_with_rng_zfuture(TEST_NETWORK, H0, rng);
+        let mut builder_b = Builder::new(TEST_NETWORK, H0);
         let mut db_b = DemoBuilder {
             txn_builder: &mut builder_b,
             extension_id: 0,
@@ -745,7 +745,7 @@ mod tests {
             .map_err(|e| format!("transfer failure: {:?}", e))
             .unwrap();
         let (tx_b, _) = builder_b
-            .build(BranchId::Canopy, &prover)
+            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 
@@ -753,7 +753,7 @@ mod tests {
         // Closing transaction
         //
 
-        let mut builder_c = Builder::new_with_rng_zfuture(TEST_NETWORK, H0, rng);
+        let mut builder_c = Builder::new(TEST_NETWORK, H0);
         let mut db_c = DemoBuilder {
             txn_builder: &mut builder_c,
             extension_id: 0,
@@ -774,7 +774,7 @@ mod tests {
             .unwrap();
 
         let (tx_c, _) = builder_c
-            .build(BranchId::Canopy, &prover)
+            .build(TxVersion::ZFuture, BranchId::ZFuture, &prover)
             .map_err(|e| format!("build failure: {:?}", e))
             .unwrap();
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -16,12 +16,11 @@ and this library adheres to Rust's notion of
   to provide range values for branch active heights.
 - `zcash_primitives::consensus::NetworkUpgrade::Nu5` value representing the Nu5 upgrade.
 - `zcash_primitives::consensus::BranchId::Nu5` value representing the Nu5 consensus branch.
-- `zcash_primitives::transaction::components::sapling::builder` builder for Sapling 
-  transaction components
-- `zcash_primitives::transaction::components::transparent::builder` builder for transparent 
-  transaction components
-- `zcash_primitives::transaction::components::tze::builder` builder for TZE 
-  transaction components
+- New modules under `zcash_primitives::transaction::components` for building parts of
+  transactions:
+  - `sapling::builder` for Sapling transaction components.
+  - `transparent::builder` for transparent transaction components.
+  - `tze::builder` for TZE transaction components.
 
 ### Changed
 - MSRV is now 1.51.0.
@@ -43,17 +42,12 @@ and this library adheres to Rust's notion of
   now taxes a TxId rather than a raw byte array.
 - `zcash_primitives::transaction::components::Amount` addition, subtraction,
   and summation now return `Option` rather than panicing on overflow.
-- `zcash_primitives::transaction::builder::Error` has been modified to
-  wrap the error types produced by its child builders.
-- `zcash_primitives::transaction::builder::Builder` now delegates to the
-  newly created child builder components.
-- `zcash_primitives::transaction::builder::Builder::build` now takes the 
-  version of the transaction being constructed as an argument. Instead of
-  constructing an empty transaction and mutating that transaction through
-  a series of build steps, the individual component builders construct
-  parts of the transaction independently and then these parts are brought
-  together to construct a new `TransactionData` value prior to the generation 
-  of signatures.
+- `zcash_primitives::transaction::builder`:
+  - `Error` has been modified to wrap the error types produced by its child
+    builders.
+  - `Builder::build` no longer takes a consensus branch ID parameter. The
+    builder now selects the correct consensus branch ID for the given target
+    height.
 
 ## [0.5.0] - 2021-03-26
 ### Added

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -16,6 +16,13 @@ and this library adheres to Rust's notion of
   to provide range values for branch active heights.
 - `zcash_primitives::consensus::NetworkUpgrade::Nu5` value representing the Nu5 upgrade.
 - `zcash_primitives::consensus::BranchId::Nu5` value representing the Nu5 consensus branch.
+- `zcash_primitives::transaction::components::sapling::builder` builder for Sapling 
+  transaction components
+- `zcash_primitives::transaction::components::transparent::builder` builder for transparent 
+  transaction components
+- `zcash_primitives::transaction::components::tze::builder` builder for TZE 
+  transaction components
+
 ### Changed
 - MSRV is now 1.51.0.
 - The following modules and helpers have been moved into
@@ -36,6 +43,17 @@ and this library adheres to Rust's notion of
   now taxes a TxId rather than a raw byte array.
 - `zcash_primitives::transaction::components::Amount` addition, subtraction,
   and summation now return `Option` rather than panicing on overflow.
+- `zcash_primitives::transaction::builder::Error` has been modified to
+  wrap the error types produced by its child builders.
+- `zcash_primitives::transaction::builder::Builder` now delegates to the
+  newly created child builder components.
+- `zcash_primitives::transaction::builder::Builder::build` now takes the 
+  version of the transaction being constructed as an argument. Instead of
+  constructing an empty transaction and mutating that transaction through
+  a series of build steps, the individual component builders construct
+  parts of the transaction independently and then these parts are brought
+  together to construct a new `TransactionData` value prior to the generation 
+  of signatures.
 
 ## [0.5.0] - 2021-03-26
 ### Added

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -83,7 +83,7 @@ pub struct Progress {
 }
 
 impl Progress {
-    fn new(cur: u32, end: Option<u32>) -> Self {
+    pub fn new(cur: u32, end: Option<u32>) -> Self {
         Self { cur, end }
     }
 
@@ -312,6 +312,7 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
                 &mut ctx,
                 &mut self.rng,
                 self.target_height,
+                self.progress_notifier.as_ref(),
             )
             .map_err(Error::SaplingBuildError)?;
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -250,7 +250,8 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
         self.progress_notifier = Some(progress_notifier);
     }
 
-    pub fn value_balance(&self) -> Result<Amount, Error> {
+    /// Returns the sum of the transparent, Sapling, and TZE value balances.
+    fn value_balance(&self) -> Result<Amount, Error> {
         let value_balances = [
             self.transparent_builder
                 .value_balance()
@@ -602,9 +603,7 @@ mod tests {
                 &TransparentAddress::PublicKey([0; 20]),
                 Amount::from_i64(-1).unwrap(),
             ),
-            Err(Error::TransparentBuild(
-                transparent::Error::InvalidAmount
-            ))
+            Err(Error::TransparentBuild(transparent::Error::InvalidAmount))
         );
     }
 

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 pub const COIN: i64 = 1_0000_0000;
 pub const MAX_MONEY: i64 = 21_000_000 * COIN;
@@ -169,6 +169,14 @@ impl SubAssign<Amount> for Amount {
 impl Sum<Amount> for Option<Amount> {
     fn sum<I: Iterator<Item = Amount>>(iter: I) -> Self {
         iter.fold(Some(Amount::zero()), |acc, a| acc? + a)
+    }
+}
+
+impl Neg for Amount {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Amount(-self.0)
     }
 }
 

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -18,6 +18,8 @@ use zcash_note_encryption::COMPACT_NOTE_SIZE;
 
 use super::GROTH_PROOF_SIZE;
 
+pub mod builder;
+
 #[derive(Clone)]
 pub struct SpendDescription {
     pub cv: jubjub::ExtendedPoint,

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -33,11 +33,11 @@ const MIN_SHIELDED_OUTPUTS: usize = 2;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    InvalidAmount,
-    InvalidAddress,
     AnchorMismatch,
-    SpendProof,
     BindingSig,
+    InvalidAddress,
+    InvalidAmount,
+    SpendProof,
 }
 
 impl fmt::Display for Error {

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -205,6 +205,7 @@ impl SaplingMetadata {
 }
 
 pub struct SaplingBuilder<P: consensus::Parameters> {
+    params: P,
     anchor: Option<bls12_381::Scalar>,
     target_height: BlockHeight,
     value_balance: Amount,
@@ -213,8 +214,9 @@ pub struct SaplingBuilder<P: consensus::Parameters> {
 }
 
 impl<P: consensus::Parameters> SaplingBuilder<P> {
-    pub fn empty(target_height: BlockHeight) -> Self {
+    pub fn empty(params: P, target_height: BlockHeight) -> Self {
         SaplingBuilder {
+            params,
             anchor: None,
             target_height,
             value_balance: Amount::zero(),
@@ -270,14 +272,13 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
     pub fn add_output<R: RngCore>(
         &mut self,
         mut rng: R,
-        params: &P,
         ovk: Option<OutgoingViewingKey>,
         to: PaymentAddress,
         value: Amount,
         memo: Option<MemoBytes>,
     ) -> Result<(), Error> {
         let output = SaplingOutput::new_internal(
-            params,
+            &self.params,
             self.target_height,
             &mut rng,
             ovk,
@@ -304,7 +305,6 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
     pub fn build<Pr: TxProver, R: RngCore>(
         &self,
-        params: &P,
         prover: &Pr,
         ctx: &mut Pr::SaplingProvingContext,
         mut rng: R,
@@ -440,7 +440,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
                             }
                         };
 
-                        let rseed = generate_random_rseed_internal(params, target_height, &mut rng);
+                        let rseed = generate_random_rseed_internal(&self.params, target_height, &mut rng);
 
                         (
                             payment_address,

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -225,6 +225,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
         }
     }
 
+    /// Returns the net value represented by the spends and outputs added to this builder.
     pub fn value_balance(&self) -> Amount {
         self.value_balance
     }

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -278,8 +278,15 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
         value: Amount,
         memo: Option<MemoBytes>,
     ) -> Result<(), Error> {
-        let output =
-            SaplingOutput::new_internal(params, self.target_height, &mut rng, ovk, to, value, memo)?;
+        let output = SaplingOutput::new_internal(
+            params,
+            self.target_height,
+            &mut rng,
+            ovk,
+            to,
+            value,
+            memo,
+        )?;
 
         self.value_balance -= value;
 
@@ -290,7 +297,9 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
     /// Send change to the specified change address. If no change address
     /// was set, send change to the first Sapling address given as input.
-    pub fn get_candidate_change_address(&self) -> Result<(OutgoingViewingKey, PaymentAddress), Error> {
+    pub fn get_candidate_change_address(
+        &self,
+    ) -> Result<(OutgoingViewingKey, PaymentAddress), Error> {
         if !self.spends.is_empty() {
             PaymentAddress::from_parts(self.spends[0].diversifier, self.spends[0].note.pk_d)
                 .map(|addr| (self.spends[0].extsk.expsk.ovk, addr))

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -166,7 +166,7 @@ impl<P: consensus::Parameters> SaplingOutput<P> {
     }
 }
 
-/// Metadata about a transaction created by a [`Builder`].
+/// Metadata about a transaction created by a [`SaplingBuilder`].
 #[derive(Debug, PartialEq)]
 pub struct SaplingMetadata {
     spend_indices: Vec<usize>,
@@ -182,22 +182,22 @@ impl SaplingMetadata {
     }
 
     /// Returns the index within the transaction of the [`SpendDescription`] corresponding
-    /// to the `n`-th call to [`Builder::add_sapling_spend`].
+    /// to the `n`-th call to [`SaplingBuilder::add_spend`].
     ///
     /// Note positions are randomized when building transactions for indistinguishability.
     /// This means that the transaction consumer cannot assume that e.g. the first spend
-    /// they added (via the first call to [`Builder::add_sapling_spend`]) is the first
+    /// they added (via the first call to [`SaplingBuilder::add_spend`]) is the first
     /// [`SpendDescription`] in the transaction.
     pub fn spend_index(&self, n: usize) -> Option<usize> {
         self.spend_indices.get(n).copied()
     }
 
     /// Returns the index within the transaction of the [`OutputDescription`] corresponding
-    /// to the `n`-th call to [`Builder::add_sapling_output`].
+    /// to the `n`-th call to [`SaplingBuilder::add_output`].
     ///
     /// Note positions are randomized when building transactions for indistinguishability.
     /// This means that the transaction consumer cannot assume that e.g. the first output
-    /// they added (via the first call to [`Builder::add_sapling_output`]) is the first
+    /// they added (via the first call to [`SaplingBuilder::add_output`]) is the first
     /// [`OutputDescription`] in the transaction.
     pub fn output_index(&self, n: usize) -> Option<usize> {
         self.output_indices.get(n).copied()
@@ -440,7 +440,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
                             }
                         };
 
-                        let rseed = generate_random_rseed_internal(&self.params, target_height, &mut rng);
+                        let rseed =
+                            generate_random_rseed_internal(&self.params, target_height, &mut rng);
 
                         (
                             payment_address,

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -1,0 +1,508 @@
+//! Types and functions for building Sapling transaction components.
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use ff::Field;
+use rand::{seq::SliceRandom, CryptoRng, RngCore};
+
+use crate::{
+    consensus::{self, BlockHeight},
+    memo::MemoBytes,
+    merkle_tree::MerklePath,
+    sapling::{
+        keys::OutgoingViewingKey,
+        note_encryption::sapling_note_encryption,
+        prover::TxProver,
+        redjubjub::{PrivateKey, Signature},
+        spend_sig_internal,
+        util::generate_random_rseed_internal,
+        Diversifier, Node, Note, PaymentAddress,
+    },
+    transaction::components::{amount::Amount, OutputDescription, SpendDescription},
+    zip32::ExtendedSpendingKey,
+};
+
+/// If there are any shielded inputs, always have at least two shielded outputs, padding
+/// with dummy outputs if necessary. See <https://github.com/zcash/zcash/issues/3615>.
+const MIN_SHIELDED_OUTPUTS: usize = 2;
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidAmount,
+    InvalidAddress,
+    AnchorMismatch,
+    NoChangeAddress,
+    SpendProof,
+    BindingSig,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::AnchorMismatch => {
+                write!(f, "Anchor mismatch (anchors for all spends must be equal)")
+            }
+            Error::BindingSig => write!(f, "Failed to create bindingSig"),
+            Error::InvalidAddress => write!(f, "Invalid address"),
+            Error::InvalidAmount => write!(f, "Invalid amount"),
+            Error::NoChangeAddress => write!(f, "No change address specified or discoverable"),
+            Error::SpendProof => write!(f, "Failed to create Sapling spend proof"),
+        }
+    }
+}
+
+struct SpendDescriptionInfo {
+    extsk: ExtendedSpendingKey,
+    diversifier: Diversifier,
+    note: Note,
+    alpha: jubjub::Fr,
+    merkle_path: MerklePath<Node>,
+}
+
+#[derive(Clone)]
+pub struct SaplingOutput<P: consensus::Parameters> {
+    /// `None` represents the `ovk = ⊥` case.
+    ovk: Option<OutgoingViewingKey>,
+    to: PaymentAddress,
+    note: Note,
+    memo: MemoBytes,
+    _params: PhantomData<P>,
+}
+
+impl<P: consensus::Parameters> SaplingOutput<P> {
+    pub fn new<R: RngCore + CryptoRng>(
+        params: &P,
+        target_height: BlockHeight,
+        rng: &mut R,
+        ovk: Option<OutgoingViewingKey>,
+        to: PaymentAddress,
+        value: Amount,
+        memo: Option<MemoBytes>,
+    ) -> Result<Self, Error> {
+        Self::new_internal(params, target_height, rng, ovk, to, value, memo)
+    }
+
+    fn new_internal<R: RngCore>(
+        params: &P,
+        target_height: BlockHeight,
+        rng: &mut R,
+        ovk: Option<OutgoingViewingKey>,
+        to: PaymentAddress,
+        value: Amount,
+        memo: Option<MemoBytes>,
+    ) -> Result<Self, Error> {
+        let g_d = to.g_d().ok_or(Error::InvalidAddress)?;
+        if value.is_negative() {
+            return Err(Error::InvalidAmount);
+        }
+
+        let rseed = generate_random_rseed_internal(params, target_height, rng);
+
+        let note = Note {
+            g_d,
+            pk_d: *to.pk_d(),
+            value: value.into(),
+            rseed,
+        };
+
+        Ok(SaplingOutput {
+            ovk,
+            to,
+            note,
+            memo: memo.unwrap_or_else(MemoBytes::empty),
+            _params: PhantomData::default(),
+        })
+    }
+
+    pub fn build<Pr: TxProver, R: RngCore + CryptoRng>(
+        self,
+        prover: &Pr,
+        ctx: &mut Pr::SaplingProvingContext,
+        rng: &mut R,
+    ) -> OutputDescription {
+        self.build_internal(prover, ctx, rng)
+    }
+
+    fn build_internal<Pr: TxProver, R: RngCore>(
+        self,
+        prover: &Pr,
+        ctx: &mut Pr::SaplingProvingContext,
+        rng: &mut R,
+    ) -> OutputDescription {
+        let encryptor = sapling_note_encryption::<R, P>(
+            self.ovk,
+            self.note.clone(),
+            self.to.clone(),
+            self.memo,
+            rng,
+        );
+
+        let (zkproof, cv) = prover.output_proof(
+            ctx,
+            *encryptor.esk(),
+            self.to,
+            self.note.rcm(),
+            self.note.value,
+        );
+
+        let cmu = self.note.cmu();
+
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+        let out_ciphertext = encryptor.encrypt_outgoing_plaintext(&cv, &cmu, rng);
+
+        let ephemeral_key = *encryptor.epk();
+
+        OutputDescription {
+            cv,
+            cmu,
+            ephemeral_key,
+            enc_ciphertext,
+            out_ciphertext,
+            zkproof,
+        }
+    }
+}
+
+/// Metadata about a transaction created by a [`Builder`].
+#[derive(Debug, PartialEq)]
+pub struct SaplingMetadata {
+    spend_indices: Vec<usize>,
+    output_indices: Vec<usize>,
+}
+
+impl SaplingMetadata {
+    pub fn empty() -> Self {
+        SaplingMetadata {
+            spend_indices: vec![],
+            output_indices: vec![],
+        }
+    }
+
+    /// Returns the index within the transaction of the [`SpendDescription`] corresponding
+    /// to the `n`-th call to [`Builder::add_sapling_spend`].
+    ///
+    /// Note positions are randomized when building transactions for indistinguishability.
+    /// This means that the transaction consumer cannot assume that e.g. the first spend
+    /// they added (via the first call to [`Builder::add_sapling_spend`]) is the first
+    /// [`SpendDescription`] in the transaction.
+    pub fn spend_index(&self, n: usize) -> Option<usize> {
+        self.spend_indices.get(n).copied()
+    }
+
+    /// Returns the index within the transaction of the [`OutputDescription`] corresponding
+    /// to the `n`-th call to [`Builder::add_sapling_output`].
+    ///
+    /// Note positions are randomized when building transactions for indistinguishability.
+    /// This means that the transaction consumer cannot assume that e.g. the first output
+    /// they added (via the first call to [`Builder::add_sapling_output`]) is the first
+    /// [`OutputDescription`] in the transaction.
+    pub fn output_index(&self, n: usize) -> Option<usize> {
+        self.output_indices.get(n).copied()
+    }
+}
+
+pub struct SaplingBuilder<P: consensus::Parameters> {
+    anchor: Option<bls12_381::Scalar>,
+    value_balance: Amount,
+    spends: Vec<SpendDescriptionInfo>,
+    outputs: Vec<SaplingOutput<P>>,
+    change_address: Option<(OutgoingViewingKey, PaymentAddress)>,
+}
+
+impl<P: consensus::Parameters> SaplingBuilder<P> {
+    pub fn empty() -> Self {
+        SaplingBuilder {
+            anchor: None,
+            value_balance: Amount::zero(),
+            spends: vec![],
+            outputs: vec![],
+            change_address: None,
+        }
+    }
+
+    pub fn value_balance(&self) -> Amount {
+        self.value_balance
+    }
+
+    /// Adds a Sapling note to be spent in this transaction.
+    ///
+    /// Returns an error if the given Merkle path does not have the same anchor as the
+    /// paths for previous Sapling notes.
+    pub fn add_spend<R: RngCore>(
+        &mut self,
+        mut rng: R,
+        extsk: ExtendedSpendingKey,
+        diversifier: Diversifier,
+        note: Note,
+        merkle_path: MerklePath<Node>,
+    ) -> Result<(), Error> {
+        // Consistency check: all anchors must equal the first one
+        let cmu = Node::new(note.cmu().into());
+        if let Some(anchor) = self.anchor {
+            let path_root: bls12_381::Scalar = merkle_path.root(cmu).into();
+            if path_root != anchor {
+                return Err(Error::AnchorMismatch);
+            }
+        } else {
+            self.anchor = Some(merkle_path.root(cmu).into())
+        }
+
+        let alpha = jubjub::Fr::random(&mut rng);
+
+        self.value_balance += Amount::from_u64(note.value).map_err(|_| Error::InvalidAmount)?;
+
+        self.spends.push(SpendDescriptionInfo {
+            extsk,
+            diversifier,
+            note,
+            alpha,
+            merkle_path,
+        });
+
+        Ok(())
+    }
+
+    /// Adds a Sapling address to send funds to.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_output<R: RngCore>(
+        &mut self,
+        mut rng: R,
+        params: &P,
+        target_height: BlockHeight,
+        ovk: Option<OutgoingViewingKey>,
+        to: PaymentAddress,
+        value: Amount,
+        memo: Option<MemoBytes>,
+    ) -> Result<(), Error> {
+        let output =
+            SaplingOutput::new_internal(params, target_height, &mut rng, ovk, to, value, memo)?;
+
+        self.value_balance -= value;
+
+        self.outputs.push(output);
+
+        Ok(())
+    }
+
+    /// Sets the Sapling address to which any change will be sent.
+    ///
+    /// By default, change is sent to the Sapling address corresponding to the first note
+    /// being spent (i.e. the first call to [`Builder::add_sapling_spend`]).
+    pub fn send_change_to(&mut self, ovk: OutgoingViewingKey, to: PaymentAddress) {
+        self.change_address = Some((ovk, to));
+    }
+
+    /// Send change to the specified change address. If no change address
+    /// was set, send change to the first Sapling address given as input.
+    pub fn get_change_address(&self) -> Result<(OutgoingViewingKey, PaymentAddress), Error> {
+        if let Some(change_address) = &self.change_address {
+            Ok(change_address.clone())
+        } else if !self.spends.is_empty() {
+            PaymentAddress::from_parts(self.spends[0].diversifier, self.spends[0].note.pk_d)
+                .map(|addr| (self.spends[0].extsk.expsk.ovk, addr))
+                .ok_or(Error::InvalidAddress)
+        } else {
+            Err(Error::NoChangeAddress)
+        }
+    }
+
+    pub fn build<Pr: TxProver, R: RngCore>(
+        &self,
+        params: &P,
+        prover: &Pr,
+        ctx: &mut Pr::SaplingProvingContext,
+        mut rng: R,
+        target_height: BlockHeight,
+    ) -> Result<
+        (
+            Vec<SpendDescription>,
+            Vec<OutputDescription>,
+            SaplingMetadata,
+        ),
+        Error,
+    > {
+        // Record initial positions of spends and outputs
+        let mut indexed_spends: Vec<_> = self.spends.iter().enumerate().collect();
+        let mut indexed_outputs: Vec<_> = self
+            .outputs
+            .iter()
+            .enumerate()
+            .map(|(i, o)| Some((i, o)))
+            .collect();
+
+        // Set up the transaction metadata that will be used to record how
+        // inputs and outputs are shuffled.
+        let mut tx_metadata = SaplingMetadata::empty();
+        tx_metadata.spend_indices.resize(indexed_spends.len(), 0);
+        tx_metadata.output_indices.resize(indexed_outputs.len(), 0);
+
+        // Pad Sapling outputs
+        if !indexed_spends.is_empty() {
+            while indexed_outputs.len() < MIN_SHIELDED_OUTPUTS {
+                indexed_outputs.push(None);
+            }
+        }
+
+        // Randomize order of inputs and outputs
+        indexed_spends.shuffle(&mut rng);
+        indexed_outputs.shuffle(&mut rng);
+
+        // Create Sapling SpendDescriptions
+        let spend_descs = if !indexed_spends.is_empty() {
+            let anchor = self
+                .anchor
+                .expect("Sapling anchor must be set if Sapling spends are present.");
+
+            indexed_spends
+                .iter()
+                .enumerate()
+                .map(|(i, (pos, spend))| {
+                    let proof_generation_key = spend.extsk.expsk.proof_generation_key();
+
+                    let nullifier = spend.note.nf(
+                        &proof_generation_key.to_viewing_key(),
+                        spend.merkle_path.position,
+                    );
+
+                    let (zkproof, cv, rk) = prover
+                        .spend_proof(
+                            ctx,
+                            proof_generation_key,
+                            spend.diversifier,
+                            spend.note.rseed,
+                            spend.alpha,
+                            spend.note.value,
+                            anchor,
+                            spend.merkle_path.clone(),
+                        )
+                        .map_err(|_| Error::SpendProof)?;
+
+                    // Record the post-randomized spend location
+                    tx_metadata.spend_indices[*pos] = i;
+
+                    Ok(SpendDescription {
+                        cv,
+                        anchor,
+                        nullifier,
+                        rk,
+                        zkproof,
+                        spend_auth_sig: None,
+                    })
+                })
+                .collect::<Result<Vec<_>, Error>>()?
+        } else {
+            vec![]
+        };
+
+        // Create Sapling OutputDescriptions
+        let output_descs = indexed_outputs
+            .into_iter()
+            .enumerate()
+            .map(|(i, output)| {
+                if let Some((pos, output)) = output {
+                    // Record the post-randomized output location
+                    tx_metadata.output_indices[pos] = i;
+
+                    output.clone().build_internal(prover, ctx, &mut rng)
+                } else {
+                    // This is a dummy output
+                    let (dummy_to, dummy_note) = {
+                        let (diversifier, g_d) = {
+                            let mut diversifier;
+                            let g_d;
+                            loop {
+                                let mut d = [0; 11];
+                                rng.fill_bytes(&mut d);
+                                diversifier = Diversifier(d);
+                                if let Some(val) = diversifier.g_d() {
+                                    g_d = val;
+                                    break;
+                                }
+                            }
+                            (diversifier, g_d)
+                        };
+
+                        let (pk_d, payment_address) = loop {
+                            let dummy_ivk = jubjub::Fr::random(&mut rng);
+                            let pk_d = g_d * dummy_ivk;
+                            if let Some(addr) = PaymentAddress::from_parts(diversifier, pk_d) {
+                                break (pk_d, addr);
+                            }
+                        };
+
+                        let rseed = generate_random_rseed_internal(params, target_height, &mut rng);
+
+                        (
+                            payment_address,
+                            Note {
+                                g_d,
+                                pk_d,
+                                rseed,
+                                value: 0,
+                            },
+                        )
+                    };
+
+                    let esk = dummy_note.generate_or_derive_esk_internal(&mut rng);
+                    let epk = dummy_note.g_d * esk;
+
+                    let (zkproof, cv) =
+                        prover.output_proof(ctx, esk, dummy_to, dummy_note.rcm(), dummy_note.value);
+
+                    let cmu = dummy_note.cmu();
+
+                    let mut enc_ciphertext = [0u8; 580];
+                    let mut out_ciphertext = [0u8; 80];
+                    rng.fill_bytes(&mut enc_ciphertext[..]);
+                    rng.fill_bytes(&mut out_ciphertext[..]);
+
+                    OutputDescription {
+                        cv,
+                        cmu,
+                        ephemeral_key: epk.into(),
+                        enc_ciphertext,
+                        out_ciphertext,
+                        zkproof,
+                    }
+                }
+            })
+            .collect();
+
+        Ok((spend_descs, output_descs, tx_metadata))
+    }
+
+    pub fn create_signatures<Pr: TxProver, R: RngCore>(
+        self,
+        prover: &Pr,
+        ctx: &mut Pr::SaplingProvingContext,
+        rng: &mut R,
+        sighash_bytes: &[u8; 32],
+        tx_metadata: &SaplingMetadata,
+    ) -> Result<(Vec<Option<Signature>>, Option<Signature>), Error> {
+        // Create Sapling spendAuth and binding signatures
+        let mut spend_sigs = vec![None; self.spends.len()];
+        for (i, spend) in self.spends.into_iter().enumerate() {
+            spend_sigs[tx_metadata.spend_indices[i]] = Some(spend_sig_internal(
+                PrivateKey(spend.extsk.expsk.ask),
+                spend.alpha,
+                sighash_bytes,
+                rng,
+            ));
+        }
+
+        // Add a binding signature if needed
+        let binding_sig =
+            if tx_metadata.spend_indices.is_empty() && tx_metadata.output_indices.is_empty() {
+                None
+            } else {
+                Some(
+                    prover
+                        .binding_sig(ctx, self.value_balance, &sighash_bytes)
+                        .map_err(|_| Error::BindingSig)?,
+                )
+            };
+
+        Ok((spend_sigs, binding_sig))
+    }
+}

--- a/zcash_primitives/src/transaction/components/transparent.rs
+++ b/zcash_primitives/src/transaction/components/transparent.rs
@@ -8,6 +8,8 @@ use crate::legacy::Script;
 
 use super::amount::Amount;
 
+pub mod builder;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct OutPoint {
     hash: [u8; 32],

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -1,0 +1,175 @@
+//! Types and functions for building transparent transaction components.
+
+use std::fmt;
+
+use crate::{
+    legacy::TransparentAddress,
+    transaction::components::{amount::Amount, TxIn, TxOut},
+};
+
+#[cfg(feature = "transparent-inputs")]
+use crate::{
+    consensus::{self},
+    legacy::Script,
+    transaction::{
+        components::OutPoint, sighash::signature_hash_data, SignableInput, TransactionData,
+        SIGHASH_ALL,
+    },
+};
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidAddress,
+    InvalidAmount,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidAddress => write!(f, "Invalid address"),
+            Error::InvalidAmount => write!(f, "Invalid amount"),
+        }
+    }
+}
+
+#[cfg(feature = "transparent-inputs")]
+struct TransparentInputInfo {
+    sk: secp256k1::SecretKey,
+    pubkey: [u8; secp256k1::constants::PUBLIC_KEY_SIZE],
+    utxo: OutPoint,
+    coin: TxOut,
+}
+
+pub struct TransparentBuilder {
+    #[cfg(feature = "transparent-inputs")]
+    secp: secp256k1::Secp256k1<secp256k1::SignOnly>,
+    #[cfg(feature = "transparent-inputs")]
+    inputs: Vec<TransparentInputInfo>,
+    vout: Vec<TxOut>,
+}
+
+impl TransparentBuilder {
+    pub fn empty() -> Self {
+        TransparentBuilder {
+            #[cfg(feature = "transparent-inputs")]
+            secp: secp256k1::Secp256k1::gen_new(),
+            #[cfg(feature = "transparent-inputs")]
+            inputs: vec![],
+            vout: vec![],
+        }
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    pub fn add_input(
+        &mut self,
+        sk: secp256k1::SecretKey,
+        utxo: OutPoint,
+        coin: TxOut,
+    ) -> Result<(), Error> {
+        if coin.value.is_negative() {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Ensure that the RIPEMD-160 digest of the public key associated with the
+        // provided secret key matches that of the address to which the provided
+        // output may be spent.
+        let pubkey = secp256k1::PublicKey::from_secret_key(&self.secp, &sk).serialize();
+        match coin.script_pubkey.address() {
+            Some(TransparentAddress::PublicKey(hash)) => {
+                use ripemd160::Ripemd160;
+                use sha2::{Digest, Sha256};
+
+                if hash[..] != Ripemd160::digest(&Sha256::digest(&pubkey))[..] {
+                    return Err(Error::InvalidAddress);
+                }
+            }
+            _ => return Err(Error::InvalidAddress),
+        }
+
+        self.inputs.push(TransparentInputInfo {
+            sk,
+            pubkey,
+            utxo,
+            coin,
+        });
+
+        Ok(())
+    }
+
+    pub fn add_output(&mut self, to: &TransparentAddress, value: Amount) -> Result<(), Error> {
+        if value.is_negative() {
+            return Err(Error::InvalidAmount);
+        }
+
+        self.vout.push(TxOut {
+            value,
+            script_pubkey: to.script(),
+        });
+
+        Ok(())
+    }
+
+    pub fn value_balance(&self) -> Option<Amount> {
+        #[cfg(feature = "transparent-inputs")]
+        let input_sum = self
+            .inputs
+            .iter()
+            .map(|input| input.coin.value)
+            .sum::<Option<Amount>>()?;
+
+        #[cfg(not(feature = "transparent-inputs"))]
+        let input_sum = Amount::zero();
+
+        input_sum
+            - self
+                .vout
+                .iter()
+                .map(|vo| vo.value)
+                .sum::<Option<Amount>>()?
+    }
+
+    pub fn build(&self) -> (Vec<TxIn>, Vec<TxOut>) {
+        #[cfg(feature = "transparent-inputs")]
+        let vin = self
+            .inputs
+            .iter()
+            .map(|i| TxIn::new(i.utxo.clone()))
+            .collect();
+
+        #[cfg(not(feature = "transparent-inputs"))]
+        let vin = vec![];
+
+        (vin, self.vout.clone())
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    pub fn create_signatures(
+        self,
+        mtx: &TransactionData,
+        consensus_branch_id: consensus::BranchId,
+    ) -> Vec<Script> {
+        self.inputs
+            .iter()
+            .enumerate()
+            .map(|(i, info)| {
+                let mut sighash = [0u8; 32];
+                sighash.copy_from_slice(&signature_hash_data(
+                    mtx,
+                    consensus_branch_id,
+                    SIGHASH_ALL,
+                    SignableInput::transparent(i, &info.coin.script_pubkey, info.coin.value),
+                ));
+
+                let msg = secp256k1::Message::from_slice(sighash.as_ref()).expect("32 bytes");
+                let sig = self.secp.sign(&msg, &info.sk);
+
+                // Signature has to have "SIGHASH_ALL" appended to it
+                let mut sig_bytes: Vec<u8> = sig.serialize_der()[..].to_vec();
+                sig_bytes.extend(&[SIGHASH_ALL as u8]);
+
+                // P2PKH scriptSig
+                Script::default() << &sig_bytes[..] << &info.pubkey[..]
+            })
+            .collect()
+    }
+}

--- a/zcash_primitives/src/transaction/components/tze.rs
+++ b/zcash_primitives/src/transaction/components/tze.rs
@@ -15,6 +15,8 @@ use crate::{
 
 use super::amount::Amount;
 
+pub mod builder;
+
 fn to_io_error(_: std::num::TryFromIntError) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, "value out of range")
 }

--- a/zcash_primitives/src/transaction/components/tze/builder.rs
+++ b/zcash_primitives/src/transaction/components/tze/builder.rs
@@ -1,0 +1,127 @@
+//! Types and functions for building TZE transaction components
+#![cfg(feature = "zfuture")]
+
+use std::fmt;
+
+use crate::{
+    extensions::transparent::{self as tze, ToPayload},
+    transaction::components::{amount::Amount, TzeIn, TzeOut, TzeOutPoint},
+};
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidAmount,
+    WitnessModeMismatch(u32, u32),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidAmount => write!(f, "Invalid amount"),
+            Error::WitnessModeMismatch(expected, actual) =>
+                write!(f, "TZE witness builder returned a mode that did not match the mode with which the input was initially constructed: expected = {:?}, actual = {:?}", expected, actual),
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+struct TzeSigner<'a, BuildCtx> {
+    prevout: TzeOut,
+    builder: Box<dyn FnOnce(&BuildCtx) -> Result<(u32, Vec<u8>), Error> + 'a>,
+}
+
+pub struct TzeBuilder<'a, BuildCtx> {
+    signers: Vec<TzeSigner<'a, BuildCtx>>,
+    tze_inputs: Vec<TzeIn>,
+    tze_outputs: Vec<TzeOut>,
+}
+
+impl<'a, BuildCtx> TzeBuilder<'a, BuildCtx> {
+    pub fn empty() -> Self {
+        TzeBuilder {
+            signers: vec![],
+            tze_inputs: vec![],
+            tze_outputs: vec![],
+        }
+    }
+
+    pub fn add_input<WBuilder, W: ToPayload>(
+        &mut self,
+        extension_id: u32,
+        mode: u32,
+        (outpoint, prevout): (TzeOutPoint, TzeOut),
+        witness_builder: WBuilder,
+    ) where
+        WBuilder: 'a + FnOnce(&BuildCtx) -> Result<W, Error>,
+    {
+        self.tze_inputs
+            .push(TzeIn::new(outpoint, extension_id, mode));
+        self.signers.push(TzeSigner {
+            prevout,
+            builder: Box::new(move |ctx| witness_builder(&ctx).map(|x| x.to_payload())),
+        });
+    }
+
+    pub fn add_output<G: ToPayload>(
+        &mut self,
+        extension_id: u32,
+        value: Amount,
+        guarded_by: &G,
+    ) -> Result<(), Error> {
+        if value.is_negative() {
+            return Err(Error::InvalidAmount);
+        }
+
+        let (mode, payload) = guarded_by.to_payload();
+        self.tze_outputs.push(TzeOut {
+            value,
+            precondition: tze::Precondition {
+                extension_id,
+                mode,
+                payload,
+            },
+        });
+
+        Ok(())
+    }
+
+    pub fn value_balance(&self) -> Option<Amount> {
+        self.signers
+            .iter()
+            .map(|s| s.prevout.value)
+            .sum::<Option<Amount>>()?
+            - self
+                .tze_outputs
+                .iter()
+                .map(|tzo| tzo.value)
+                .sum::<Option<Amount>>()?
+    }
+
+    pub fn build(&self) -> (Vec<TzeIn>, Vec<TzeOut>) {
+        (self.tze_inputs.clone(), self.tze_outputs.clone())
+    }
+
+    pub fn create_signatures(self, mtx: &BuildCtx) -> Result<Vec<Vec<u8>>, Error> {
+        // Create TZE input witnesses
+        let tzein = self.tze_inputs;
+        let payloads = self
+            .signers
+            .into_iter()
+            .enumerate()
+            .map(|(i, tze_in)| {
+                // The witness builder function should have cached/closed over whatever data was
+                // necessary for the witness to commit to at the time it was added to the
+                // transaction builder; here, it then computes those commitments.
+                let (mode, payload) = (tze_in.builder)(&mtx)?;
+                let input_mode = tzein[i].witness.mode;
+                if mode != input_mode {
+                    return Err(Error::WitnessModeMismatch(input_mode, mode));
+                }
+
+                Ok(payload)
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(payloads)
+    }
+}

--- a/zcash_primitives/src/transaction/components/tze/builder.rs
+++ b/zcash_primitives/src/transaction/components/tze/builder.rs
@@ -101,19 +101,18 @@ impl<'a, BuildCtx> TzeBuilder<'a, BuildCtx> {
         (self.tze_inputs.clone(), self.tze_outputs.clone())
     }
 
-    pub fn create_signatures(self, mtx: &BuildCtx) -> Result<Vec<Vec<u8>>, Error> {
+    pub fn create_witnesses(self, mtx: &BuildCtx) -> Result<Vec<Vec<u8>>, Error> {
         // Create TZE input witnesses
-        let tzein = self.tze_inputs;
         let payloads = self
             .signers
             .into_iter()
-            .enumerate()
-            .map(|(i, tze_in)| {
+            .zip(self.tze_inputs.into_iter())
+            .map(|(signer, tzein)| {
                 // The witness builder function should have cached/closed over whatever data was
                 // necessary for the witness to commit to at the time it was added to the
                 // transaction builder; here, it then computes those commitments.
-                let (mode, payload) = (tze_in.builder)(&mtx)?;
-                let input_mode = tzein[i].witness.mode;
+                let (mode, payload) = (signer.builder)(&mtx)?;
+                let input_mode = tzein.witness.mode;
                 if mode != input_mode {
                     return Err(Error::WitnessModeMismatch(input_mode, mode));
                 }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -181,7 +181,7 @@ impl TxVersion {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 TxVersion::Sapling
             }
-            BranchId::Nu5 => unimplemented!(),
+            BranchId::Nu5 => TxVersion::Sapling, //TEMPORARY WORKAROUND
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
         }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -181,7 +181,7 @@ impl TxVersion {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 TxVersion::Sapling
             }
-            BranchId::Nu5 => TxVersion::ZFuture,
+            BranchId::Nu5 => unimplemented!(),
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
         }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -5,7 +5,11 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-use crate::{consensus::BlockHeight, sapling::redjubjub::Signature, serialize::Vector};
+use crate::{
+    consensus::{BlockHeight, BranchId},
+    sapling::redjubjub::Signature,
+    serialize::Vector,
+};
 
 use self::util::sha256d::{HashReader, HashWriter};
 
@@ -167,6 +171,19 @@ impl TxVersion {
             TxVersion::Sapling => true,
             #[cfg(feature = "zfuture")]
             TxVersion::ZFuture => true,
+        }
+    }
+
+    pub fn suggested_for_branch(consensus_branch_id: BranchId) -> Self {
+        match consensus_branch_id {
+            BranchId::Sprout => TxVersion::Sprout(2),
+            BranchId::Overwinter => TxVersion::Overwinter,
+            BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
+                TxVersion::Sapling
+            }
+            BranchId::Nu5 => TxVersion::ZFuture,
+            #[cfg(feature = "zfuture")]
+            BranchId::ZFuture => TxVersion::ZFuture,
         }
     }
 }


### PR DESCRIPTION
This extends from #385 as refactoring prior to ZIP-225 implementation.