### PR TITLE
Builder: Move progress notifier configuration to a builder method

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_primitives::transaction::Builder::with_progress_notifier`, for setting
+  a notification channel on which transaction build progress updates will be
+  sent.
+
 ### Changed
 - MSRV is now 1.51.0.
 - The following modules and helpers have been moved into


### PR DESCRIPTION
This is what builder methods are for :) and it helps to limit the growth of alternate `build` methods.