### PR TITLE
Migrate to bitvec 0.22, ff 0.10, etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,15 @@ members = [
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+[patch.crates-io]
+# Pending https://github.com/zkcrypto/bellman/pull/70
+bellman = { git = "https://github.com/zkcrypto/bellman.git", rev = "2de275fb205bb908a371ce6af4dbd997efaad6da" }
+
+# To resolve the funty mess. Removing this probably blocks on a nom 7 release.
+# - https://github.com/Geal/nom/issues/1302
+# - https://github.com/Geal/nom/pull/1304
+nom = { git = "https://github.com/myrrlyn/nom.git", rev = "d6b81f5303b0a347726e1f3f428751f376e7b771" }
+
+# In development.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "87a3d52641df732e4d0661699e7b32ad1299cd75" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-# Pending https://github.com/zkcrypto/bellman/pull/70
-bellman = { git = "https://github.com/zkcrypto/bellman.git", rev = "2de275fb205bb908a371ce6af4dbd997efaad6da" }
-
 # To resolve the funty mess. Removing this probably blocks on a nom 7 release.
 # - https://github.com/Geal/nom/issues/1302
 # - https://github.com/Geal/nom/pull/1304

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2018"
 blake2b_simd = "0.5"
 byteorder = "1"
 crypto_api_chachapoly = "0.4"
-ff = "0.9"
-group = "0.9"
+ff = "0.10"
+group = "0.10"
 rand_core = "0.6"
 subtle = "2.2.3"
 
 [dev-dependencies]
 zcash_primitives = { version = "0.5", path = "../../zcash_primitives" }
-jubjub = "0.6"
+jubjub = "0.7"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2018"
 
 [dependencies]
 bech32 = "0.8"
-bls12_381 = "0.4"
+bls12_381 = "0.5"
 bs58 = { version = "0.4", features = ["check"] }
 base64 = "0.13"
-ff = "0.9"
-group = "0.9"
+ff = "0.10"
+group = "0.10"
 hex = "0.4"
-jubjub = "0.6"
+jubjub = "0.7"
 nom = "6.1"
 percent-encoding = "2.1.0"
 proptest = { version = "1.0.0", optional = true }

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 [dependencies]
 bech32 = "0.8"
 bs58 = { version = "0.4", features = ["check"] }
-ff = "0.9"
-group = "0.9"
-jubjub = "0.6"
+ff = "0.10"
+group = "0.10"
+jubjub = "0.7"
 protobuf = "2.20"
 rand_core = "0.6"
 rusqlite = { version = "0.24", features = ["bundled", "time"] }

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -13,11 +13,11 @@ blake2b_simd = "0.5"
 zcash_primitives = { version = "0.5", path = "../zcash_primitives", features = ["zfuture"] }
 
 [dev-dependencies]
-ff = "0.9"
-jubjub = "0.6"
+ff = "0.10"
+jubjub = "0.7"
+orchard = "0.0"
 rand_core = "0.6"
 zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
-orchard = { git = "https://github.com/zcash/orchard", branch = "main" }
 secp256k1 = { version = "0.20", features = ["rand", "bitcoin_hashes"] }
 
 [features]

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -17,22 +17,23 @@ all-features = true
 
 [dependencies]
 aes = "0.6"
-bitvec = "0.20"
+bitvec = "0.22"
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
-bls12_381 = "0.4"
+bls12_381 = "0.5"
 byteorder = "1"
 crypto_api_chachapoly = "0.4"
 equihash = { version = "0.1", path = "../components/equihash" }
-ff = "0.9"
+ff = "0.10"
 fpe = "0.4"
-group = "0.9"
+group = "0.10"
 hex = "0.4"
-jubjub = "0.6"
+jubjub = "0.7"
 lazy_static = "1"
 log = "0.4"
 nonempty = "0.6"
-orchard = { git = "https://github.com/zcash/orchard", branch = "main" }
+orchard = "0.0"
+pasta_curves = "0.1"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 rand_core = "0.6"
@@ -42,19 +43,12 @@ sha2 = "0.9"
 subtle = "2.2.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 
-# Temporary workaround for https://github.com/myrrlyn/funty/issues/3
-funty = "=1.1.0"
-
-[dependencies.pasta_curves]
-git = "https://github.com/zcash/pasta_curves.git"
-rev = "b55a6960dfafd7f767e2820ddf1adaa499322f98"
-
 [dev-dependencies]
 criterion = "0.3"
 hex-literal = "0.3"
 proptest = "1.0.0"
 rand_xorshift = "0.3"
-orchard = { git = "https://github.com/zcash/orchard", branch = "main", features = ["test-dependencies"] }
+orchard = { version = "0.0", features = ["test-dependencies"] }
 
 [features]
 transparent-inputs = ["ripemd160", "secp256k1"]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-bellman = { version = "0.9", default-features = false, features = ["groth16"] }
+bellman = { version = "0.10", default-features = false, features = ["groth16"] }
 blake2b_simd = "0.5"
 bls12_381 = "0.5"
 byteorder = "1"

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -17,12 +17,12 @@ all-features = true
 [dependencies]
 bellman = { version = "0.9", default-features = false, features = ["groth16"] }
 blake2b_simd = "0.5"
-bls12_381 = "0.4"
+bls12_381 = "0.5"
 byteorder = "1"
 directories = { version = "3", optional = true }
-ff = "0.9"
-group = "0.9"
-jubjub = "0.6"
+ff = "0.10"
+group = "0.10"
+jubjub = "0.7"
 lazy_static = "1"
 minreq = { version = "2", features = ["https"], optional = true }
 rand_core = "0.6"

--- a/zcash_proofs/src/circuit/ecc.rs
+++ b/zcash_proofs/src/circuit/ecc.rs
@@ -620,7 +620,7 @@ impl MontgomeryPoint {
 #[cfg(test)]
 mod test {
     use bellman::ConstraintSystem;
-    use ff::{Field, PrimeField};
+    use ff::{Field, PrimeField, PrimeFieldBits};
     use group::{Curve, Group};
     use rand_core::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;

--- a/zcash_proofs/src/circuit/sapling.rs
+++ b/zcash_proofs/src/circuit/sapling.rs
@@ -24,6 +24,9 @@ use bellman::gadgets::multipack;
 use bellman::gadgets::num;
 use bellman::gadgets::Assignment;
 
+#[cfg(test)]
+use ff::PrimeFieldBits;
+
 pub const TREE_DEPTH: usize = SAPLING_COMMITMENT_TREE_DEPTH;
 
 /// This is an instance of the `Spend` circuit.


### PR DESCRIPTION
Requires patching two dependencies:

- nom is part of the funty breakage; we are blocking on a new release.
- orchard is in development.