### PR TITLE
Impl ZIP 216 on SaplingVerificationContext and redjubjub::PublicKey

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
+- `zcash_primitives::sapling::redjubjub::PublicKey::verify_with_zip216`, for
+  controlling how RedJubjub signatures are validated. `PublicKey::verify` has
+  been altered to always use post-ZIP 216 validation rules.
 - `zcash_primitives::transaction::Builder::with_progress_notifier`, for setting
   a notification channel on which transaction build progress updates will be
   sent.

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -8,10 +8,16 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.51.0.
+- `zcash_proofs::sapling::SaplingVerificationContext::new` now takes a
+  `zip216_enabled` boolean; this is used to control how RedJubjub signatures are
+  validated.
 - Renamed the following in `zcash_proofs::circuit::sprout` to use lower-case
   abbreviations (matching Rust naming conventions):
   - `JSInput` to `JsInput`
   - `JSOutput` to `JsOutput`
+
+### Removed
+- `zcash_proofs::sapling::SaplingVerificationContext: Default`
 
 ## [0.5.0] - 2021-03-26
 ### Added


### PR DESCRIPTION
`PublicKey::verify` now always uses post-ZIP 216 validation rules, which
is fine in non-consensus contexts.

`SaplingVerificationContext` is used by `zcashd`'s consensus rules.

Closes zcash/librustzcash#394.