### PR TITLE
impl From<Amount> for orchard::ValueSum

### DIFF
--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -182,6 +182,12 @@ impl Neg for Amount {
     }
 }
 
+impl From<Amount> for orchard::ValueSum {
+    fn from(v: Amount) -> Self {
+        orchard::ValueSum::from_raw(v.0)
+    }
+}
+
 impl TryFrom<orchard::ValueSum> for Amount {
     type Error = ();
 


### PR DESCRIPTION
This is necessary in order to be able to calculate bvk for Orchard bundles.