### PR TITLE
Bump orchard deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,6 @@ codegen-units = 1
 nom = { git = "https://github.com/myrrlyn/nom.git", rev = "d6b81f5303b0a347726e1f3f428751f376e7b771" }
 
 # In development.
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "87a3d52641df732e4d0661699e7b32ad1299cd75" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "236115917df9db45282fec24d1e1e36f275f71ab" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "37b1b7f357cd34d93f9c55bb96efd05ab4e84408" }
+zcash_note_encryption = { path = "components/zcash_note_encryption" }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -156,9 +156,14 @@ pub fn read_flags<R: Read>(mut reader: R) -> io::Result<Flags> {
 }
 
 pub fn read_anchor<R: Read>(mut reader: R) -> io::Result<Anchor> {
-    let mut anchor = Anchor([0u8; 32]);
-    reader.read_exact(&mut anchor.0)?;
-    Ok(anchor)
+    let mut bytes = [0u8; 32];
+    reader.read_exact(&mut bytes)?;
+    Anchor::from_bytes(bytes).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid Orchard anchor".to_owned(),
+        )
+    })
 }
 
 pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signature<T>> {
@@ -252,7 +257,7 @@ pub fn write_flags<W: Write>(mut writer: W, flags: &Flags) -> io::Result<()> {
 }
 
 pub fn write_anchor<W: Write>(mut writer: W, anchor: &Anchor) -> io::Result<()> {
-    writer.write_all(&anchor.0)
+    writer.write_all(&anchor.to_bytes())
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]


### PR DESCRIPTION
Includes additional patched dependencies, now that the orchard crate is not pinning specific revisions of the in-development crates.