### PR TITLE
zcash_primitives: Benchmark trial decryption of compact outputs

### DIFF
--- a/components/equihash/Cargo.toml
+++ b/components/equihash/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2018"
 [dependencies]
 blake2b_simd = "0.5"
 byteorder = "1"
+
+[lib]
+bench = false

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -18,3 +18,6 @@ bs58 = { version = "0.4", features = ["check"] }
 
 [dev-dependencies]
 proptest = "0.10.1"
+
+[lib]
+bench = false

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -23,3 +23,6 @@ subtle = "2.2.3"
 [dev-dependencies]
 zcash_primitives = { version = "0.5", path = "../../zcash_primitives" }
 jubjub = "0.7"
+
+[lib]
+bench = false

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -44,5 +44,8 @@ zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
 [features]
 test-dependencies = ["proptest", "zcash_primitives/test-dependencies"]
 
+[lib]
+bench = false
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -32,3 +32,6 @@ zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
 [features]
 mainnet = []
 test-dependencies = ["zcash_client_backend/test-dependencies"]
+
+[lib]
+bench = false

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -23,3 +23,5 @@ secp256k1 = { version = "0.20", features = ["rand", "bitcoin_hashes"] }
 [features]
 transparent-inputs = []
 
+[lib]
+bench = false

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -15,3 +15,6 @@ quickcheck = "0.9"
 bigint = "4"
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "0.5" }
+
+[lib]
+bench = false

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -50,6 +50,9 @@ proptest = "1.0.0"
 rand_xorshift = "0.3"
 orchard = { version = "0.0", features = ["test-dependencies"] }
 
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.4.2", features = ["criterion", "flamegraph"] }
+
 [features]
 transparent-inputs = ["ripemd160", "secp256k1"]
 test-dependencies = ["proptest"]

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -58,6 +58,9 @@ transparent-inputs = ["ripemd160", "secp256k1"]
 test-dependencies = ["proptest"]
 zfuture = []
 
+[lib]
+bench = false
+
 [[bench]]
 name = "note_decryption"
 harness = false

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -95,6 +95,6 @@ criterion_group! {
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_note_decryption
 }
-#[cfg(windows)]
+#[cfg(not(unix))]
 criterion_group!(benches, bench_note_decryption);
 criterion_main!(benches);

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -18,6 +18,9 @@ use zcash_primitives::{
     },
 };
 
+#[cfg(unix)]
+use pprof::criterion::{Output, PProfProfiler};
+
 fn bench_note_decryption(c: &mut Criterion) {
     let mut rng = OsRng;
     let height = TEST_NETWORK.activation_height(Canopy).unwrap();
@@ -86,5 +89,12 @@ fn bench_note_decryption(c: &mut Criterion) {
     });
 }
 
+#[cfg(unix)]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_note_decryption
+}
+#[cfg(windows)]
 criterion_group!(benches, bench_note_decryption);
 criterion_main!(benches);

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -63,7 +63,7 @@ fn bench_note_decryption(c: &mut Criterion) {
         }
     };
 
-    let mut group = c.benchmark_group("Sapling note decryption");
+    let mut group = c.benchmark_group("sapling-note-decryption");
 
     group.bench_function("valid", |b| {
         b.iter(|| try_sapling_note_decryption(&TEST_NETWORK, height, &valid_ivk, &output).unwrap())

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -5,12 +5,15 @@ use zcash_primitives::{
     consensus::{NetworkUpgrade::Canopy, Parameters, TestNetwork, TEST_NETWORK},
     memo::MemoBytes,
     sapling::{
-        note_encryption::{sapling_note_encryption, try_sapling_note_decryption},
+        note_encryption::{
+            sapling_note_encryption, try_sapling_compact_note_decryption,
+            try_sapling_note_decryption,
+        },
         util::generate_random_rseed,
         Diversifier, PaymentAddress, SaplingIvk, ValueCommitment,
     },
     transaction::components::{
-        sapling::{GrothProofBytes, OutputDescription},
+        sapling::{CompactOutputDescription, GrothProofBytes, OutputDescription},
         GROTH_PROOF_SIZE,
     },
 };
@@ -65,6 +68,21 @@ fn bench_note_decryption(c: &mut Criterion) {
 
     group.bench_function("invalid", |b| {
         b.iter(|| try_sapling_note_decryption(&TEST_NETWORK, height, &invalid_ivk, &output))
+    });
+
+    let compact = CompactOutputDescription::from(output);
+
+    group.bench_function("compact-valid", |b| {
+        b.iter(|| {
+            try_sapling_compact_note_decryption(&TEST_NETWORK, height, &valid_ivk, &compact)
+                .unwrap()
+        })
+    });
+
+    group.bench_function("compact-invalid", |b| {
+        b.iter(|| {
+            try_sapling_compact_note_decryption(&TEST_NETWORK, height, &invalid_ivk, &compact)
+        })
     });
 }
 

--- a/zcash_primitives/benches/pedersen_hash.rs
+++ b/zcash_primitives/benches/pedersen_hash.rs
@@ -2,6 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand_core::{OsRng, RngCore};
 use zcash_primitives::sapling::pedersen_hash::{pedersen_hash, Personalization};
 
+#[cfg(unix)]
+use pprof::criterion::{Output, PProfProfiler};
+
 fn bench_pedersen_hash(c: &mut Criterion) {
     let rng = &mut OsRng;
     let bits = (0..510)
@@ -14,5 +17,12 @@ fn bench_pedersen_hash(c: &mut Criterion) {
     });
 }
 
+#[cfg(unix)]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_pedersen_hash
+}
+#[cfg(windows)]
 criterion_group!(benches, bench_pedersen_hash);
 criterion_main!(benches);

--- a/zcash_primitives/benches/pedersen_hash.rs
+++ b/zcash_primitives/benches/pedersen_hash.rs
@@ -23,6 +23,6 @@ criterion_group! {
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_pedersen_hash
 }
-#[cfg(windows)]
+#[cfg(not(unix))]
 criterion_group!(benches, bench_pedersen_hash);
 criterion_main!(benches);

--- a/zcash_primitives/benches/pedersen_hash.rs
+++ b/zcash_primitives/benches/pedersen_hash.rs
@@ -12,7 +12,7 @@ fn bench_pedersen_hash(c: &mut Criterion) {
         .collect::<Vec<_>>();
     let personalization = Personalization::MerkleTree(31);
 
-    c.bench_function("Pedersen hash", |b| {
+    c.bench_function("pedersen-hash", |b| {
         b.iter(|| pedersen_hash(personalization, bits.clone()))
     });
 }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -40,6 +40,9 @@ download-params = ["minreq"]
 local-prover = ["directories"]
 multicore = ["bellman/multicore"]
 
+[lib]
+bench = false
+
 [[bench]]
 name = "sapling"
 harness = false


### PR DESCRIPTION
These are effectively identical to full-output trial decryption (as the
primary cost is the scalar multiplication), but it's good to check.

This PR also now enables flamegraph profiling of the `zcash_primitives` benchmarks.