### PR TITLE
Store OutputDescription `ephemeral_key` as bytes

### DIFF
--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -33,6 +33,7 @@ impl AsRef<[u8]> for OutgoingCipherKey {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct EphemeralKeyBytes(pub [u8; 32]);
 
 impl AsRef<[u8]> for EphemeralKeyBytes {

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,6 +8,12 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.51.0.
+- `epk: jubjub::ExtendedPoint` has been replaced by
+  `ephemeral_key: zcash_note_encryption::EphemeralKeyBytes` in various places:
+  - `zcash_client_backend::wallet::WalletShieldedOutput`: the `epk` field has
+    been replaced by `ephemeral_key`.
+  - `zcash_client_backend::proto::compact_formats::CompactOutput`: the `epk`
+    method has been replaced by `ephemeral_key`.
 - Renamed the following in `zcash_client_backend::data_api` to use lower-case
   abbreviations (matching Rust naming conventions):
   - `error::Error::InvalidExtSK` to `Error::InvalidExtSk`

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -13,7 +13,7 @@ use zcash_primitives::{
     },
 };
 
-use zcash_note_encryption::COMPACT_NOTE_SIZE;
+use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
 
 pub mod compact_formats;
 
@@ -102,8 +102,11 @@ impl compact_formats::CompactOutput {
     /// A convenience method that parses [`CompactOutput.epk`].
     ///
     /// [`CompactOutput.epk`]: #structfield.epk
-    pub fn ephemeral_key(&self) -> Result<[u8; 32], ()> {
-        self.epk[..].try_into().map_err(|_| ())
+    pub fn ephemeral_key(&self) -> Result<EphemeralKeyBytes, ()> {
+        self.epk[..]
+            .try_into()
+            .map(EphemeralKeyBytes)
+            .map_err(|_| ())
     }
 }
 
@@ -111,7 +114,7 @@ impl<A: sapling::Authorization> From<OutputDescription<A>> for compact_formats::
     fn from(out: OutputDescription<A>) -> compact_formats::CompactOutput {
         let mut result = compact_formats::CompactOutput::new();
         result.set_cmu(out.cmu.to_repr().to_vec());
-        result.set_epk(out.ephemeral_key.to_vec());
+        result.set_epk(out.ephemeral_key.as_ref().to_vec());
         result.set_ciphertext(out.enc_ciphertext[..COMPACT_NOTE_SIZE].to_vec());
         result
     }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -1,7 +1,6 @@
 //! Generated code for handling light client protobuf structs.
 
 use ff::PrimeField;
-use group::GroupEncoding;
 use std::convert::{TryFrom, TryInto};
 
 use zcash_primitives::{
@@ -103,13 +102,8 @@ impl compact_formats::CompactOutput {
     /// A convenience method that parses [`CompactOutput.epk`].
     ///
     /// [`CompactOutput.epk`]: #structfield.epk
-    pub fn epk(&self) -> Result<jubjub::ExtendedPoint, ()> {
-        let p = jubjub::ExtendedPoint::from_bytes(&self.epk[..].try_into().map_err(|_| ())?);
-        if p.is_some().into() {
-            Ok(p.unwrap())
-        } else {
-            Err(())
-        }
+    pub fn ephemeral_key(&self) -> Result<[u8; 32], ()> {
+        self.epk[..].try_into().map_err(|_| ())
     }
 }
 
@@ -117,7 +111,7 @@ impl<A: sapling::Authorization> From<OutputDescription<A>> for compact_formats::
     fn from(out: OutputDescription<A>) -> compact_formats::CompactOutput {
         let mut result = compact_formats::CompactOutput::new();
         result.set_cmu(out.cmu.to_repr().to_vec());
-        result.set_epk(out.ephemeral_key.to_bytes().to_vec());
+        result.set_epk(out.ephemeral_key.to_vec());
         result.set_ciphertext(out.enc_ciphertext[..COMPACT_NOTE_SIZE].to_vec());
         result
     }
@@ -129,7 +123,7 @@ impl TryFrom<compact_formats::CompactOutput> for CompactOutputDescription {
     fn try_from(value: compact_formats::CompactOutput) -> Result<Self, Self::Error> {
         Ok(CompactOutputDescription {
             cmu: value.cmu()?,
-            epk: value.epk()?,
+            ephemeral_key: value.ephemeral_key()?,
             enc_ciphertext: value.ciphertext,
         })
     }

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -3,6 +3,7 @@
 
 use subtle::{Choice, ConditionallySelectable};
 
+use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_primitives::{
     merkle_tree::IncrementalWitness,
     sapling::{
@@ -54,7 +55,7 @@ pub struct WalletShieldedSpend {
 pub struct WalletShieldedOutput<N> {
     pub index: usize,
     pub cmu: bls12_381::Scalar,
-    pub ephemeral_key: [u8; 32],
+    pub ephemeral_key: EphemeralKeyBytes,
     pub account: AccountId,
     pub note: Note,
     pub to: PaymentAddress,

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -54,7 +54,7 @@ pub struct WalletShieldedSpend {
 pub struct WalletShieldedOutput<N> {
     pub index: usize,
     pub cmu: bls12_381::Scalar,
-    pub epk: jubjub::ExtendedPoint,
+    pub ephemeral_key: [u8; 32],
     pub account: AccountId,
     pub note: Note,
     pub to: PaymentAddress,

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -76,7 +76,7 @@ fn scan_output<P: consensus::Parameters, K: ScanningKey>(
         return Some(WalletShieldedOutput {
             index,
             cmu: output.cmu,
-            epk: output.epk,
+            ephemeral_key: output.ephemeral_key,
             account: **account,
             note,
             to,

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -93,6 +93,10 @@ and this library adheres to Rust's notion of
 - Generators for property testing have been moved out of the main transaction
   module such that they are now colocated in the modules with the types
   that they generate.
+- The `ephemeral_key` field of `OutputDescription` has had its type changed from
+  `jubjub::ExtendedPoint` to `zcash_note_encryption::EphemeralKeyBytes`.
+- The `epk: jubjub::ExtendedPoint` field of `CompactOutputDescription ` has been
+  replaced by `ephemeral_key: zcash_note_encryption::EphemeralKeyBytes`.
 
 ## [0.5.0] - 2021-03-26
 ### Added

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use ff::Field;
+use group::GroupEncoding;
 use rand_core::OsRng;
 use zcash_primitives::{
     consensus::{NetworkUpgrade::Canopy, Parameters, TestNetwork, TEST_NETWORK},
@@ -49,7 +50,7 @@ fn bench_note_decryption(c: &mut Criterion) {
 
         let ne =
             sapling_note_encryption::<_, TestNetwork>(None, note, pa, MemoBytes::empty(), &mut rng);
-        let ephemeral_key = *ne.epk();
+        let ephemeral_key = ne.epk().to_bytes();
         let enc_ciphertext = ne.encrypt_note_plaintext();
         let out_ciphertext = ne.encrypt_outgoing_plaintext(&cv, &cmu, &mut rng);
 

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -50,7 +50,7 @@ fn bench_note_decryption(c: &mut Criterion) {
 
         let ne =
             sapling_note_encryption::<_, TestNetwork>(None, note, pa, MemoBytes::empty(), &mut rng);
-        let ephemeral_key = ne.epk().to_bytes();
+        let ephemeral_key = ne.epk().to_bytes().into();
         let enc_ciphertext = ne.encrypt_note_plaintext();
         let out_ciphertext = ne.encrypt_outgoing_plaintext(&cv, &cmu, &mut rng);
 

--- a/zcash_primitives/src/sapling/note_encryption.rs
+++ b/zcash_primitives/src/sapling/note_encryption.rs
@@ -538,7 +538,7 @@ mod tests {
         let output = OutputDescription {
             cv,
             cmu,
-            ephemeral_key: epk.to_bytes(),
+            ephemeral_key: epk.to_bytes().into(),
             enc_ciphertext: ne.encrypt_note_plaintext(),
             out_ciphertext: ne.encrypt_outgoing_plaintext(&cv, &cmu, &mut rng),
             zkproof: [0u8; GROTH_PROOF_SIZE],
@@ -551,17 +551,12 @@ mod tests {
         ovk: &OutgoingViewingKey,
         cv: &jubjub::ExtendedPoint,
         cmu: &bls12_381::Scalar,
-        ephemeral_key: &[u8; 32],
+        ephemeral_key: &EphemeralKeyBytes,
         enc_ciphertext: &mut [u8; ENC_CIPHERTEXT_SIZE],
         out_ciphertext: &[u8; OUT_CIPHERTEXT_SIZE],
         modify_plaintext: impl Fn(&mut [u8; NOTE_PLAINTEXT_SIZE]),
     ) {
-        let ock = prf_ock(
-            &ovk,
-            &cv,
-            &cmu.to_repr(),
-            &EphemeralKeyBytes(*ephemeral_key),
-        );
+        let ock = prf_ock(&ovk, &cv, &cmu.to_repr(), ephemeral_key);
 
         let mut op = [0; OUT_CIPHERTEXT_SIZE];
         assert_eq!(
@@ -576,7 +571,7 @@ mod tests {
         let esk = jubjub::Fr::from_repr(op[32..OUT_PLAINTEXT_SIZE].try_into().unwrap()).unwrap();
 
         let shared_secret = sapling_ka_agree(&esk, &pk_d.into());
-        let key = kdf_sapling(shared_secret, &EphemeralKeyBytes(*ephemeral_key));
+        let key = kdf_sapling(shared_secret, ephemeral_key);
 
         let mut plaintext = {
             let mut buf = [0; ENC_CIPHERTEXT_SIZE];
@@ -669,7 +664,7 @@ mod tests {
         for &height in heights.iter() {
             let (_, _, ivk, mut output) = random_enc_ciphertext(height, &mut rng);
 
-            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes();
+            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes().into();
 
             assert_eq!(
                 try_sapling_note_decryption(&TEST_NETWORK, height, &ivk, &output,),
@@ -834,7 +829,7 @@ mod tests {
 
         for &height in heights.iter() {
             let (_, _, ivk, mut output) = random_enc_ciphertext(height, &mut rng);
-            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes();
+            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes().into();
 
             assert_eq!(
                 try_sapling_compact_note_decryption(
@@ -1066,7 +1061,7 @@ mod tests {
 
         for &height in heights.iter() {
             let (ovk, ock, _, mut output) = random_enc_ciphertext(height, &mut rng);
-            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes();
+            output.ephemeral_key = jubjub::ExtendedPoint::random(&mut rng).to_bytes().into();
 
             assert_eq!(
                 try_sapling_output_recovery(&TEST_NETWORK, height, &ovk, &output,),
@@ -1303,7 +1298,7 @@ mod tests {
             let output = OutputDescription {
                 cv,
                 cmu,
-                ephemeral_key: ephemeral_key.0,
+                ephemeral_key: ephemeral_key,
                 enc_ciphertext: tv.c_enc,
                 out_ciphertext: tv.c_out,
                 zkproof: [0u8; GROTH_PROOF_SIZE],

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -213,7 +213,7 @@ impl SpendDescriptionV5 {
 pub struct OutputDescription<Proof> {
     pub cv: jubjub::ExtendedPoint,
     pub cmu: bls12_381::Scalar,
-    pub ephemeral_key: jubjub::ExtendedPoint,
+    pub ephemeral_key: [u8; 32],
     pub enc_ciphertext: [u8; 580],
     pub out_ciphertext: [u8; 80],
     pub zkproof: Proof,
@@ -221,7 +221,7 @@ pub struct OutputDescription<Proof> {
 
 impl<P: consensus::Parameters, A> ShieldedOutput<SaplingDomain<P>> for OutputDescription<A> {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {
-        EphemeralKeyBytes(self.ephemeral_key.to_bytes())
+        EphemeralKeyBytes(self.ephemeral_key)
     }
 
     fn cmstar_bytes(&self) -> [u8; 32] {
@@ -255,9 +255,10 @@ impl OutputDescription<GrothProofBytes> {
         let cmu = read_base(&mut reader, "cmu")?;
 
         // Consensus rules (§4.5):
-        // - Canonical encoding is enforced here.
+        // - Canonical encoding is enforced in librustzcash_sapling_check_output by zcashd
         // - "Not small order" is enforced in SaplingVerificationContext::check_output()
-        let ephemeral_key = read_point(&mut reader, "ephemeral key")?;
+        let mut ephemeral_key = [0u8; 32];
+        reader.read_exact(&mut ephemeral_key)?;
 
         let mut enc_ciphertext = [0u8; 580];
         let mut out_ciphertext = [0u8; 80];
@@ -279,7 +280,7 @@ impl OutputDescription<GrothProofBytes> {
     pub fn write_v4<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.cv.to_bytes())?;
         writer.write_all(self.cmu.to_repr().as_ref())?;
-        writer.write_all(&self.ephemeral_key.to_bytes())?;
+        writer.write_all(&self.ephemeral_key)?;
         writer.write_all(&self.enc_ciphertext)?;
         writer.write_all(&self.out_ciphertext)?;
         writer.write_all(&self.zkproof)
@@ -288,7 +289,7 @@ impl OutputDescription<GrothProofBytes> {
     pub fn write_v5_without_proof<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.cv.to_bytes())?;
         writer.write_all(self.cmu.to_repr().as_ref())?;
-        writer.write_all(&self.ephemeral_key.to_bytes())?;
+        writer.write_all(&self.ephemeral_key)?;
         writer.write_all(&self.enc_ciphertext)?;
         writer.write_all(&self.out_ciphertext)
     }
@@ -298,7 +299,7 @@ impl OutputDescription<GrothProofBytes> {
 pub struct OutputDescriptionV5 {
     pub cv: jubjub::ExtendedPoint,
     pub cmu: bls12_381::Scalar,
-    pub ephemeral_key: jubjub::ExtendedPoint,
+    pub ephemeral_key: [u8; 32],
     pub enc_ciphertext: [u8; 580],
     pub out_ciphertext: [u8; 80],
 }
@@ -307,7 +308,12 @@ impl OutputDescriptionV5 {
     pub fn read<R: Read>(mut reader: &mut R) -> io::Result<Self> {
         let cv = read_point(&mut reader, "cv")?;
         let cmu = read_base(&mut reader, "cmu")?;
-        let ephemeral_key = read_point(&mut reader, "ephemeral key")?;
+
+        // Consensus rules (§4.5):
+        // - Canonical encoding is enforced in librustzcash_sapling_check_output by zcashd
+        // - "Not small order" is enforced in SaplingVerificationContext::check_output()
+        let mut ephemeral_key = [0u8; 32];
+        reader.read_exact(&mut ephemeral_key)?;
 
         let mut enc_ciphertext = [0u8; 580];
         let mut out_ciphertext = [0u8; 80];
@@ -339,7 +345,7 @@ impl OutputDescriptionV5 {
 }
 
 pub struct CompactOutputDescription {
-    pub epk: jubjub::ExtendedPoint,
+    pub ephemeral_key: [u8; 32],
     pub cmu: bls12_381::Scalar,
     pub enc_ciphertext: Vec<u8>,
 }
@@ -347,7 +353,7 @@ pub struct CompactOutputDescription {
 impl<A> From<OutputDescription<A>> for CompactOutputDescription {
     fn from(out: OutputDescription<A>) -> CompactOutputDescription {
         CompactOutputDescription {
-            epk: out.ephemeral_key,
+            ephemeral_key: out.ephemeral_key,
             cmu: out.cmu,
             enc_ciphertext: out.enc_ciphertext[..COMPACT_NOTE_SIZE].to_vec(),
         }
@@ -356,7 +362,7 @@ impl<A> From<OutputDescription<A>> for CompactOutputDescription {
 
 impl<P: consensus::Parameters> ShieldedOutput<SaplingDomain<P>> for CompactOutputDescription {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {
-        EphemeralKeyBytes(self.epk.to_bytes())
+        EphemeralKeyBytes(self.ephemeral_key)
     }
 
     fn cmstar_bytes(&self) -> [u8; 32] {
@@ -371,7 +377,7 @@ impl<P: consensus::Parameters> ShieldedOutput<SaplingDomain<P>> for CompactOutpu
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use ff::Field;
-    use group::Group;
+    use group::{Group, GroupEncoding};
     use proptest::collection::vec;
     use proptest::prelude::*;
     use rand::{rngs::StdRng, SeedableRng};
@@ -438,7 +444,7 @@ pub mod testing {
                 .prop_map(|v| bls12_381::Scalar::from_bytes_wide(&v)),
             enc_ciphertext in vec(any::<u8>(), 580)
                 .prop_map(|v| <[u8;580]>::try_from(v.as_slice()).unwrap()),
-            ephemeral_key in arb_extended_point(),
+            epk in arb_extended_point(),
             out_ciphertext in vec(any::<u8>(), 80)
                 .prop_map(|v| <[u8;80]>::try_from(v.as_slice()).unwrap()),
             zkproof in vec(any::<u8>(), GROTH_PROOF_SIZE)
@@ -447,7 +453,7 @@ pub mod testing {
             OutputDescription {
                 cv,
                 cmu,
-                ephemeral_key,
+                ephemeral_key: epk.to_bytes(),
                 enc_ciphertext,
                 out_ciphertext,
                 zkproof,

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -142,7 +142,7 @@ impl SaplingOutput {
         OutputDescription {
             cv,
             cmu,
-            ephemeral_key: epk.to_bytes(),
+            ephemeral_key: epk.to_bytes().into(),
             enc_ciphertext,
             out_ciphertext,
             zkproof,
@@ -464,7 +464,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
                     OutputDescription {
                         cv,
                         cmu,
-                        ephemeral_key: epk.to_bytes(),
+                        ephemeral_key: epk.to_bytes().into(),
                         enc_ciphertext,
                         out_ciphertext,
                         zkproof,

--- a/zcash_primitives/src/transaction/components/sapling/builder.rs
+++ b/zcash_primitives/src/transaction/components/sapling/builder.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::sync::mpsc::Sender;
 
 use ff::Field;
+use group::GroupEncoding;
 use rand::{seq::SliceRandom, RngCore};
 
 use crate::{
@@ -136,12 +137,12 @@ impl SaplingOutput {
         let enc_ciphertext = encryptor.encrypt_note_plaintext();
         let out_ciphertext = encryptor.encrypt_outgoing_plaintext(&cv, &cmu, rng);
 
-        let ephemeral_key = *encryptor.epk();
+        let epk = *encryptor.epk();
 
         OutputDescription {
             cv,
             cmu,
-            ephemeral_key,
+            ephemeral_key: epk.to_bytes(),
             enc_ciphertext,
             out_ciphertext,
             zkproof,
@@ -463,7 +464,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
                     OutputDescription {
                         cv,
                         cmu,
-                        ephemeral_key: epk.into(),
+                        ephemeral_key: epk.to_bytes(),
                         enc_ciphertext,
                         out_ciphertext,
                         zkproof,

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -173,7 +173,7 @@ pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>])
         let mut nh = hasher(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION);
         for s_out in shielded_outputs {
             ch.write_all(&s_out.cmu.to_repr().as_ref()).unwrap();
-            ch.write_all(&s_out.ephemeral_key).unwrap();
+            ch.write_all(s_out.ephemeral_key.as_ref()).unwrap();
             ch.write_all(&s_out.enc_ciphertext[..52]).unwrap();
 
             mh.write_all(&s_out.enc_ciphertext[52..564]).unwrap();

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -173,7 +173,7 @@ pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>])
         let mut nh = hasher(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION);
         for s_out in shielded_outputs {
             ch.write_all(&s_out.cmu.to_repr().as_ref()).unwrap();
-            ch.write_all(&s_out.ephemeral_key.to_bytes()).unwrap();
+            ch.write_all(&s_out.ephemeral_key).unwrap();
             ch.write_all(&s_out.enc_ciphertext[..52]).unwrap();
 
             mh.write_all(&s_out.enc_ciphertext[52..564]).unwrap();


### PR DESCRIPTION
This removes an unnecessary `to_bytes` during trial decryption of notes,
and more closely matches the protocol spec. We retain the consensus rule
canonicity check on epk due to `SaplingVerificationContext::check_output`
taking a `jubjub::ExtendedPoint`, forcing `zcashd` to parse the bytes.