### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,6 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-# To resolve the funty mess. Removing this probably blocks on a nom 7 release.
-# - https://github.com/Geal/nom/issues/1302
-# - https://github.com/Geal/nom/pull/1304
-nom = { git = "https://github.com/myrrlyn/nom.git", rev = "d6b81f5303b0a347726e1f3f428751f376e7b771" }
-
 # In development.
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "27c4187673a9c6ade13fbdbd4f20955530c22d7f" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "d0baa18fc6105df4a7847de2b6dc50c5919b3123" }

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -17,7 +17,7 @@ blake2b_simd = "0.5"
 bs58 = { version = "0.4", features = ["check"] }
 
 [dev-dependencies]
-proptest = "0.10.1"
+proptest = "1"
 
 [lib]
 bench = false

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -21,7 +21,7 @@ ff = "0.10"
 group = "0.10"
 hex = "0.4"
 jubjub = "0.7"
-nom = "6.1"
+nom = "7"
 percent-encoding = "2.1.0"
 proptest = { version = "1.0.0", optional = true }
 protobuf = "2.20"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -53,7 +53,7 @@ rand_xorshift = "0.3"
 orchard = { version = "0.0", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-pprof = { version = "0.4.2", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.5", features = ["criterion", "flamegraph"] }
 
 [features]
 transparent-inputs = ["ripemd160", "secp256k1"]

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-aes = "0.6"
+aes = "0.7"
 bitvec = "0.22"
 bip0039 = { version = "0.8.0", features = ["std", "all-languages"] }
 blake2b_simd = "0.5"
@@ -26,7 +26,7 @@ byteorder = "1"
 crypto_api_chachapoly = "0.4"
 equihash = { version = "0.1", path = "../components/equihash" }
 ff = "0.10"
-fpe = "0.4"
+fpe = "0.5"
 group = "0.10"
 hex = "0.4"
 incrementalmerkletree = "0.1"


### PR DESCRIPTION
This bumps everything that isn't a patched dependency, except:
- `rusqlite` (we should merge #341 first).
- `quickcheck` (the `1.0` is painful, we should switch to `proptest` instead like everything else).