### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ codegen-units = 1
 
 [patch.crates-io]
 # In development.
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "26047eaf323929935fd1e6aa3ae100b1113706e0" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "f8280c98a3d0e41b8ff5b7f615802bd197f781e1" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "a7cd600eb60b1528159b92af5e426adcc615de1a" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "8779ce8f1a638ebbc9b229d4eff3a29ef4de7ac0" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
 zcash_encoding = { path = "components/zcash_encoding" }
 zcash_note_encryption = { path = "components/zcash_note_encryption" }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 memuse = "0.2"
 nonempty = "0.7"
 orchard = "0.0"
-pasta_curves = "0.2"
+pasta_curves = "0.2.1"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 rand_core = "0.6"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 [dependencies]
 aes = "0.7"
 bitvec = "0.22"
-bip0039 = { version = "0.8.0", features = ["std", "all-languages"] }
+bip0039 = { version = "0.9", features = ["std", "all-languages"] }
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 bls12_381 = "0.6"

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -19,7 +19,7 @@ bellman = { version = "0.11.1", default-features = false, features = ["groth16"]
 blake2b_simd = "0.5"
 bls12_381 = "0.6"
 byteorder = "1"
-directories = { version = "3", optional = true }
+directories = { version = "4", optional = true }
 ff = "0.11"
 group = "0.11"
 jubjub = "0.8"


### PR DESCRIPTION
Includes `halo2` and `orchard` crate versions with the BOSL exception for our crates.