### PR TITLE
Add `#![no_std]` support for zcash_note_encryption

### DIFF
--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -12,18 +12,22 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-blake2b_simd = "0.5"
-byteorder = "1"
-chacha20 = "0.8"
-chacha20poly1305 = "0.9"
-ff = "0.11"
-group = "0.11"
-rand_core = "0.6"
-subtle = "2.2.3"
+blake2b_simd = { version = "0.5", default-features = false }
+byteorder = { version = "1", default-features = false }
+chacha20 = { version = "0.8", default-features = false }
+chacha20poly1305 = { version = "0.9", default-features = false }
+ff = { version = "0.11", default-features = false }
+group = { version = "0.11", default-features = false }
+rand_core = { version = "0.6", default-features = false }
+subtle = { version = "2.2.3", default-features = false }
 
 [dev-dependencies]
 zcash_primitives = { version = "0.5", path = "../../zcash_primitives" }
 jubjub = "0.8"
+
+[features]
+default = ["alloc"]
+alloc = []
 
 [lib]
 bench = false

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -26,8 +26,9 @@ zcash_primitives = { version = "0.5", path = "../../zcash_primitives" }
 jubjub = "0.8"
 
 [features]
-default = ["alloc"]
+default = ["std"]
 alloc = []
+std = ["alloc", "blake2b_simd/std"]
 
 [lib]
 bench = false

--- a/components/zcash_note_encryption/src/batch.rs
+++ b/components/zcash_note_encryption/src/batch.rs
@@ -1,6 +1,7 @@
 //! APIs for batch trial decryption.
 
-use std::iter;
+use alloc::vec::Vec; // module is alloc only
+use core::iter;
 
 use crate::{
     try_compact_note_decryption_inner, try_note_decryption_inner, BatchDomain, EphemeralKeyBytes,

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -181,6 +181,7 @@ pub trait Domain {
     fn extract_esk(out_plaintext: &[u8; OUT_PLAINTEXT_SIZE]) -> Option<Self::EphemeralSecretKey>;
 }
 
+#[cfg(feature = "alloc")]
 pub trait BatchDomain: Domain {
     /// Computes `Self::kdf` on a batch of items.
     ///

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -3,12 +3,18 @@
 //! functionality that is shared between the Sapling and Orchard
 //! protocols.
 
+#![no_std]
 // Catch documentation errors caused by code changes.
 #![deny(broken_intra_doc_links)]
 #![deny(unsafe_code)]
 // TODO: #![deny(missing_docs)]
 
-use std::convert::TryInto;
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use core::convert::TryInto;
 
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
@@ -22,6 +28,7 @@ use chacha20poly1305::{
 use rand_core::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 
+#[cfg(feature = "alloc")]
 pub mod batch;
 
 pub const COMPACT_NOTE_SIZE: usize = 1 + // version


### PR DESCRIPTION
This PR adds no_std compatibility for zcash_note_encryption.

All functionalities and API are preserved. Modifications are light and straightforward.

Motivation: implementation into Trezor and other hardware wallets.