### PR TITLE
Download sprout parameters in zcash_proofs

### DIFF
--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -60,5 +60,9 @@ required-features = ["directories"]
 name = "download-params"
 required-features = ["download-params"]
 
+[[example]]
+name = "download-sprout-and-sapling-params"
+required-features = ["download-params"]
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -40,7 +40,7 @@ pprof = { version = "0.8", features = ["criterion", "flamegraph"] } # MSRV 1.56
 [features]
 default = ["local-prover", "multicore"]
 bundled-prover = ["wagyu-zcash-parameters"]
-download-params = ["minreq"]
+download-params = ["minreq", "directories"]
 local-prover = ["directories"]
 multicore = ["bellman/multicore"]
 

--- a/zcash_proofs/examples/download-params.rs
+++ b/zcash_proofs/examples/download-params.rs
@@ -1,3 +1,4 @@
 fn main() -> Result<(), minreq::Error> {
+    #[allow(deprecated)]
     zcash_proofs::download_parameters()
 }

--- a/zcash_proofs/examples/download-sprout-and-sapling-params.rs
+++ b/zcash_proofs/examples/download-sprout-and-sapling-params.rs
@@ -1,0 +1,17 @@
+fn main() -> Result<(), minreq::Error> {
+    const DOWNLOAD_TIMEOUT_SECONDS: u64 = 3600;
+
+    // Always do a download to /tmp, if compiled with `RUSTFLAGS="--cfg always_download"`
+    #[cfg(always_download)]
+    {
+        std::env::set_var("HOME", "/tmp");
+        let _ = std::fs::remove_dir(
+            zcash_proofs::default_params_folder().expect("unexpected missing HOME env var"),
+        );
+    }
+
+    zcash_proofs::download_sapling_parameters(Some(DOWNLOAD_TIMEOUT_SECONDS))?;
+    zcash_proofs::download_sprout_parameters(Some(DOWNLOAD_TIMEOUT_SECONDS))?;
+
+    Ok(())
+}

--- a/zcash_proofs/examples/download-sprout-and-sapling-params.rs
+++ b/zcash_proofs/examples/download-sprout-and-sapling-params.rs
@@ -1,16 +1,25 @@
 fn main() -> Result<(), minreq::Error> {
     const DOWNLOAD_TIMEOUT_SECONDS: u64 = 3600;
 
+    #[allow(unused_mut, unused_assignments)]
+    let mut params_folder =
+        zcash_proofs::default_params_folder().expect("unexpected missing HOME env var");
+
     // Always do a download to /tmp, if compiled with `RUSTFLAGS="--cfg always_download"`
     #[cfg(always_download)]
     {
         std::env::set_var("HOME", "/tmp");
-        let _ = std::fs::remove_dir(
-            zcash_proofs::default_params_folder().expect("unexpected missing HOME env var"),
-        );
+        params_folder =
+            zcash_proofs::default_params_folder().expect("unexpected missing HOME env var");
+
+        println!("removing temporary parameters folder: {:?}", params_folder);
+        let _ = std::fs::remove_dir_all(&params_folder);
     }
 
+    println!("downloading sapling parameters to: {:?}", params_folder);
     zcash_proofs::download_sapling_parameters(Some(DOWNLOAD_TIMEOUT_SECONDS))?;
+
+    println!("downloading sprout parameters to: {:?}", params_folder);
     zcash_proofs::download_sprout_parameters(Some(DOWNLOAD_TIMEOUT_SECONDS))?;
 
     Ok(())

--- a/zcash_proofs/src/downloadreader.rs
+++ b/zcash_proofs/src/downloadreader.rs
@@ -1,0 +1,79 @@
+//! [`io::Read`] implementations for [`minreq`].
+
+use std::io;
+
+/// A wrapper that implements [`io::Read`] on a [`minreq::ResponseLazy`].
+pub enum ResponseLazyReader {
+    Request(minreq::Request),
+    Response(minreq::ResponseLazy),
+    Complete(Result<(), String>),
+}
+
+impl From<minreq::Request> for ResponseLazyReader {
+    fn from(request: minreq::Request) -> ResponseLazyReader {
+        ResponseLazyReader::Request(request)
+    }
+}
+
+impl From<minreq::ResponseLazy> for ResponseLazyReader {
+    fn from(response: minreq::ResponseLazy) -> ResponseLazyReader {
+        ResponseLazyReader::Response(response)
+    }
+}
+
+impl io::Read for ResponseLazyReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        use ResponseLazyReader::*;
+
+        // Zero-sized buffer. This should never happen.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            match self {
+                // Launch a lazy response for this request
+                Request(request) => match request.clone().send_lazy() {
+                    Ok(response) => *self = Response(response),
+                    Err(error) => {
+                        let error = Err(format!("download request failed: {:?}", error));
+
+                        *self = Complete(error);
+                    }
+                },
+
+                // Read from the response
+                Response(response) => {
+                    // minreq has a very limited lazy reading interface.
+                    match &mut response.next() {
+                        // Read one byte into the buffer.
+                        // We ignore the expected length, because we have no way of telling the BufReader.
+                        Some(Ok((byte, _length))) => {
+                            buf[0] = *byte;
+                            return Ok(1);
+                        }
+
+                        // Reading failed.
+                        Some(Err(error)) => {
+                            let error = Err(format!("download response failed: {:?}", error));
+
+                            *self = Complete(error);
+                        }
+
+                        // Finished reading.
+                        None => *self = Complete(Ok(())),
+                    }
+                }
+
+                Complete(result) => {
+                    return match result {
+                        // Return a zero-byte read for download success and EOF.
+                        Ok(()) => Ok(0),
+                        // Keep returning the download error,
+                        Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.clone())),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/zcash_proofs/src/downloadreader.rs
+++ b/zcash_proofs/src/downloadreader.rs
@@ -23,7 +23,7 @@ impl From<minreq::ResponseLazy> for ResponseLazyReader {
 
 impl io::Read for ResponseLazyReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        use ResponseLazyReader::{Request, Response};
+        use ResponseLazyReader::{Complete, Request, Response};
 
         // Zero-sized buffer. This should never happen.
         if buf.is_empty() {

--- a/zcash_proofs/src/downloadreader.rs
+++ b/zcash_proofs/src/downloadreader.rs
@@ -23,7 +23,7 @@ impl From<minreq::ResponseLazy> for ResponseLazyReader {
 
 impl io::Read for ResponseLazyReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        use ResponseLazyReader::*;
+        use ResponseLazyReader::{Request, Response};
 
         // Zero-sized buffer. This should never happen.
         if buf.is_empty() {

--- a/zcash_proofs/src/hashreader.rs
+++ b/zcash_proofs/src/hashreader.rs
@@ -1,5 +1,9 @@
+use std::{
+    fmt::Write,
+    io::{self, Read},
+};
+
 use blake2b_simd::State;
-use std::io::{self, Read};
 
 /// Abstraction over a reader which hashes the data being read.
 pub struct HashReader<R: Read> {
@@ -24,7 +28,7 @@ impl<R: Read> HashReader<R> {
 
         let mut s = String::new();
         for c in hash.as_bytes().iter() {
-            s += &format!("{:02x}", c);
+            write!(&mut s, "{:02x}", c).expect("writing to a string never fails");
         }
 
         s

--- a/zcash_proofs/src/hashreader.rs
+++ b/zcash_proofs/src/hashreader.rs
@@ -5,6 +5,7 @@ use std::io::{self, Read};
 pub struct HashReader<R: Read> {
     reader: R,
     hasher: State,
+    byte_count: usize,
 }
 
 impl<R: Read> HashReader<R> {
@@ -13,6 +14,7 @@ impl<R: Read> HashReader<R> {
         HashReader {
             reader,
             hasher: State::new(),
+            byte_count: 0,
         }
     }
 
@@ -27,6 +29,11 @@ impl<R: Read> HashReader<R> {
 
         s
     }
+
+    /// Return the number of bytes read so far.
+    pub fn byte_count(&self) -> usize {
+        self.byte_count
+    }
 }
 
 impl<R: Read> Read for HashReader<R> {
@@ -35,6 +42,7 @@ impl<R: Read> Read for HashReader<R> {
 
         if bytes > 0 {
             self.hasher.update(&buf[0..bytes]);
+            self.byte_count += bytes;
         }
 
         Ok(bytes)

--- a/zcash_proofs/src/hashreader.rs
+++ b/zcash_proofs/src/hashreader.rs
@@ -1,3 +1,5 @@
+//! Abstraction over a reader which hashes the data being read.
+
 use std::{
     fmt::Write,
     io::{self, Read},

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -68,13 +68,29 @@ pub fn default_params_folder() -> Option<PathBuf> {
     })
 }
 
+/// Download the Zcash Sapling parameters, check their hash, and store them in the default location.
+///
+/// This mirrors the behaviour of the `fetch-params.sh` script from `zcashd`.
+#[cfg(feature = "download-params")]
+#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
+#[deprecated(
+    since = "0.6.0",
+    note = "please replace with `download_sapling_parameters`, and add `download_sprout_parameters` if needed"
+)]
+pub fn download_parameters() -> Result<(), minreq::Error> {
+    download_sapling_parameters()
+}
+
 /// Download the Zcash Sapling parameters, storing them in the default location.
 ///
 /// This mirrors the behaviour of the `fetch-params.sh` script from `zcashd`.
 #[cfg(feature = "download-params")]
 #[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
-pub fn download_parameters() -> Result<(), minreq::Error> {
-    download_sapling_parameters()
+pub fn download_sapling_parameters() -> Result<(), minreq::Error> {
+    fetch_params(SAPLING_SPEND_NAME, SAPLING_SPEND_HASH)?;
+    fetch_params(SAPLING_OUTPUT_NAME, SAPLING_OUTPUT_HASH)?;
+
+    Ok(())
 }
 
 /// Download the Zcash Sprout parameters, check their has, and store them in the default location.

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -33,6 +33,10 @@ pub mod sprout;
 )]
 pub mod prover;
 
+#[cfg(feature = "download-params")]
+#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
+mod downloadreader;
+
 // Circuit names
 
 /// The sapling spend parameters file name.
@@ -249,8 +253,8 @@ fn stream_params_downloads_to_disk(
 
     // Download the responses and write them to a new file,
     // verifying the hash as bytes are read.
-    let params_download_1 = ResponseLazyReader::from(params_download_1);
-    let params_download_2 = ResponseLazyReader::from(params_download_2);
+    let params_download_1 = downloadreader::ResponseLazyReader::from(params_download_1);
+    let params_download_2 = downloadreader::ResponseLazyReader::from(params_download_2);
 
     // Limit the download size to avoid DoS.
     // This also avoids launching the second request, if the first request provides enough bytes.
@@ -270,86 +274,6 @@ fn stream_params_downloads_to_disk(
     )?;
 
     Ok(())
-}
-
-/// A wrapper that implements [`io::Read`] on a [`minreq::ResponseLazy`].
-#[cfg(feature = "download-params")]
-enum ResponseLazyReader {
-    Request(minreq::Request),
-    Response(minreq::ResponseLazy),
-    Complete(Result<(), String>),
-}
-
-#[cfg(feature = "download-params")]
-impl From<minreq::Request> for ResponseLazyReader {
-    fn from(request: minreq::Request) -> ResponseLazyReader {
-        ResponseLazyReader::Request(request)
-    }
-}
-
-#[cfg(feature = "download-params")]
-impl From<minreq::ResponseLazy> for ResponseLazyReader {
-    fn from(response: minreq::ResponseLazy) -> ResponseLazyReader {
-        ResponseLazyReader::Response(response)
-    }
-}
-
-#[cfg(feature = "download-params")]
-impl io::Read for ResponseLazyReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        use ResponseLazyReader::*;
-
-        // Zero-sized buffer. This should never happen.
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        loop {
-            match self {
-                // Launch a lazy response for this request
-                Request(request) => match request.clone().send_lazy() {
-                    Ok(response) => *self = Response(response),
-                    Err(error) => {
-                        let error = Err(format!("download request failed: {:?}", error));
-
-                        *self = Complete(error);
-                    }
-                },
-
-                // Read from the response
-                Response(response) => {
-                    // minreq has a very limited lazy reading interface.
-                    match &mut response.next() {
-                        // Read one byte into the buffer.
-                        // We ignore the expected length, because we have no way of telling the BufReader.
-                        Some(Ok((byte, _length))) => {
-                            buf[0] = *byte;
-                            return Ok(1);
-                        }
-
-                        // Reading failed.
-                        Some(Err(error)) => {
-                            let error = Err(format!("download response failed: {:?}", error));
-
-                            *self = Complete(error);
-                        }
-
-                        // Finished reading.
-                        None => *self = Complete(Ok(())),
-                    }
-                }
-
-                Complete(result) => {
-                    return match result {
-                        // Return a zero-byte read for download success and EOF.
-                        Ok(()) => Ok(0),
-                        // Keep returning the download error,
-                        Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.clone())),
-                    };
-                }
-            }
-        }
-    }
 }
 
 /// Zcash Sprout and Sapling groth16 circuit parameters.

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -75,7 +75,7 @@ pub fn default_params_folder() -> Option<PathBuf> {
 #[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 #[deprecated(
     since = "0.6.0",
-    note = "please replace with `download_sapling_parameters`, and add `download_sprout_parameters` if needed"
+    note = "please replace with `download_sapling_parameters`, and use `download_sprout_parameters` if needed"
 )]
 pub fn download_parameters() -> Result<(), minreq::Error> {
     download_sapling_parameters()

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -448,8 +448,9 @@ fn verify_file_size(
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "{} failed validation: expected {} bytes, \
-                 actual {} bytes from {:?}",
+                "{} failed validation:\n\
+                 expected: {} bytes,\n\
+                 actual:   {} bytes from {:?}",
                 name, expected_bytes, file_size, params_source,
             ),
         ));
@@ -479,11 +480,14 @@ fn verify_hash<R: io::Read, W: io::Write>(
         return Err(io::Error::new(
             read_error.kind(),
             format!(
-                "{} failed reading after {} bytes, expected {} bytes from {:?}, error: {:?}",
+                "{} failed reading:\n\
+                 expected: {} bytes,\n\
+                 actual:   {} bytes from {:?},\n\
+                 error: {:?}",
                 name,
-                params_source,
-                hash_reader.byte_count(),
                 expected_bytes,
+                hash_reader.byte_count(),
+                params_source,
                 read_error,
             ),
         ));
@@ -495,8 +499,9 @@ fn verify_hash<R: io::Read, W: io::Write>(
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "{} failed validation: expected: {} hashing {} bytes, \
-                 actual: {} hashing {} bytes from {:?}",
+                "{} failed validation:\n\
+                 expected: {} hashing {} bytes,\n\
+                 actual:   {} hashing {} bytes from {:?}",
                 name, expected_hash, expected_bytes, hash, byte_count, params_source,
             ),
         ));

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -66,6 +66,7 @@ const DOWNLOAD_URL: &str = "https://download.z.cash/downloads";
 
 /// The paths to the Sapling parameter files.
 #[cfg(feature = "download-params")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SaplingParameterPaths {
     /// The path to the Sapling spend parameter file.
     pub spend: PathBuf,

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -34,10 +34,14 @@ pub mod sprout;
 pub mod prover;
 
 // Circuit names
-#[cfg(feature = "local-prover")]
-const SAPLING_SPEND_NAME: &str = "sapling-spend.params";
-#[cfg(feature = "local-prover")]
-const SAPLING_OUTPUT_NAME: &str = "sapling-output.params";
+
+/// The sapling spend parameters file name.
+#[cfg(any(feature = "local-prover", feature = "download-params"))]
+pub const SAPLING_SPEND_NAME: &str = "sapling-spend.params";
+
+/// The sapling output parameters file name.
+#[cfg(any(feature = "local-prover", feature = "download-params"))]
+pub const SAPLING_OUTPUT_NAME: &str = "sapling-output.params";
 
 // Circuit hashes
 const SAPLING_SPEND_HASH: &str = "8270785a1a0d0bc77196f000ee6d221c9c9894f55307bd9357c3f0105d31ca63991ab91324160d8f53e2bbd3c2633a6eb8bdf5205d822e7f3f73edac51b2b70c";

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -81,6 +81,8 @@ pub fn default_params_folder() -> Option<PathBuf> {
 /// Download the Zcash Sapling parameters if needed, and store them in the default location.
 /// Always checks the hashes of the files, even if they didn't need to be downloaded.
 ///
+/// A timeout can be set using the `MINREQ_TIMEOUT` environmental variable.
+///
 /// This mirrors the behaviour of the `fetch-params.sh` script from `zcashd`.
 #[cfg(feature = "download-params")]
 #[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -370,19 +370,23 @@ fn verify_hash<R: io::Read, W: io::Write>(
         return Err(io::Error::new(
             read_error.kind(),
             format!(
-                "{} failed reading: {:?}, error: {:?}",
-                name, params_source, read_error,
+                "{} failed reading after {} bytes from {}, error: {:?}",
+                name,
+                params_source,
+                hash_reader.byte_count(),
+                read_error,
             ),
         ));
     }
 
+    let byte_count = hash_reader.byte_count();
     let hash = hash_reader.into_hash();
     if hash != expected_hash {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "{} failed validation: expected: {}, actual: {}, from: {:?}",
-                name, expected_hash, hash, params_source,
+                "{} failed validation: expected: {}, actual: {}, hashed {} bytes from {}",
+                name, expected_hash, hash, byte_count, params_source,
             ),
         ));
     }

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -303,6 +303,7 @@ impl io::Read for ResponseLazyReader {
     }
 }
 
+/// Zcash Sprout and Sapling groth16 circuit parameters.
 pub struct ZcashParameters {
     pub spend_params: Parameters<Bls12>,
     pub spend_vk: PreparedVerifyingKey<Bls12>,

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -460,9 +460,9 @@ fn verify_file_size(
 }
 
 /// Check if the Blake2b hash from `hash_reader` matches `expected_hash`,
-/// while streaming from `data` into `sink`.
+/// while streaming from `hash_reader` into `sink`.
 ///
-/// `hash_reader` can be used to partially read `data`,
+/// `hash_reader` can be used to partially read its inner reader's data,
 /// before verifying the hash using this function.
 ///
 /// Returns an error containing `name` and `params_source` on failure.

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -9,14 +9,11 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
-use std::{
-    fs::File,
-    io::{self, BufReader},
-    path::Path,
-};
-
 use bellman::groth16::{prepare_verifying_key, Parameters, PreparedVerifyingKey, VerifyingKey};
 use bls12_381::Bls12;
+use std::fs::File;
+use std::io::{self, BufReader};
+use std::path::Path;
 
 #[cfg(feature = "directories")]
 use directories::BaseDirs;
@@ -25,7 +22,7 @@ use std::path::PathBuf;
 
 pub mod circuit;
 pub mod constants;
-pub mod hashreader;
+mod hashreader;
 pub mod sapling;
 pub mod sprout;
 

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -289,6 +289,7 @@ pub struct ZcashParameters {
 /// Load the specified parameters, checking the sizes and hashes of the files.
 ///
 /// Returns the loaded parameters.
+#[cfg(any(feature = "local-prover", feature = "download-params"))]
 pub fn load_parameters(
     spend_path: &Path,
     output_path: &Path,

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -9,11 +9,14 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::Path,
+};
+
 use bellman::groth16::{prepare_verifying_key, Parameters, PreparedVerifyingKey, VerifyingKey};
 use bls12_381::Bls12;
-use std::fs::File;
-use std::io::{self, BufReader};
-use std::path::Path;
 
 #[cfg(feature = "directories")]
 use directories::BaseDirs;
@@ -22,7 +25,7 @@ use std::path::PathBuf;
 
 pub mod circuit;
 pub mod constants;
-mod hashreader;
+pub mod hashreader;
 pub mod sapling;
 pub mod sprout;
 
@@ -40,15 +43,12 @@ mod downloadreader;
 // Circuit names
 
 /// The sapling spend parameters file name.
-#[cfg(any(feature = "local-prover", feature = "download-params"))]
 pub const SAPLING_SPEND_NAME: &str = "sapling-spend.params";
 
 /// The sapling output parameters file name.
-#[cfg(any(feature = "local-prover", feature = "download-params"))]
 pub const SAPLING_OUTPUT_NAME: &str = "sapling-output.params";
 
 /// The sprout parameters file name.
-#[cfg(any(feature = "local-prover", feature = "download-params"))]
 pub const SPROUT_NAME: &str = "sprout-groth16.params";
 
 // Circuit hashes
@@ -66,6 +66,7 @@ const DOWNLOAD_URL: &str = "https://download.z.cash/downloads";
 
 /// The paths to the Sapling parameter files.
 #[cfg(feature = "download-params")]
+#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SaplingParameterPaths {
     /// The path to the Sapling spend parameter file.
@@ -289,7 +290,6 @@ pub struct ZcashParameters {
 /// Load the specified parameters, checking the sizes and hashes of the files.
 ///
 /// Returns the loaded parameters.
-#[cfg(any(feature = "local-prover", feature = "download-params"))]
 pub fn load_parameters(
     spend_path: &Path,
     output_path: &Path,


### PR DESCRIPTION
## Motivation

Zebra wants to use `zcash_proofs` to download both Sprout and Sapling parameters.

## Changes

Add sprout:
- Add a `download_sprout_parameters` function.
- Stream sprout and sapling downloads to disk, rather than loading the whole file into RAM.

Functionality changes:
- If the parameter files already exist, check them instead of starting a download.
- Allow the caller to specify a download timeout.
- Check file sizes as well as file hashes (useful for debugging).
- Remove downloaded files on error (but leave existing files alone) .

Interface changes:
- Add `download_sapling_parameters` and deprecate `download_parameters`. This avoids confusion between sprout and sapling downloads, while maintaining backward compatibility.
- Make the Sprout and Sapling parameter file names public. This makes it easier for callers to supply the correct paths to `load_parameters`.

Bug fixes:
- Add a missing feature dependency: `download_params` -> `directories`. This makes sure `download_parameters` will work if it's the only feature specified.

Tweaks:
- Refactor file loads to use the same verifying function as downloads.