### PR TITLE
Restrict cargo to `protobuf >=2.20,<2.26`

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -24,7 +24,7 @@ jubjub = "0.8"
 nom = "7"
 percent-encoding = "2.1.0"
 proptest = { version = "1.0.0", optional = true }
-protobuf = "2.20"
+protobuf = ">=2.20,<2.26" # protobuf 2.26 bumped MSRV to 1.52.1
 rand_core = "0.6"
 subtle = "2.2.3"
 time = "0.2"
@@ -32,7 +32,7 @@ zcash_note_encryption = { version = "0.1", path = "../components/zcash_note_encr
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
 
 [build-dependencies]
-protobuf-codegen-pure = "2.20"
+protobuf-codegen-pure = ">=2.20,<2.26" # protobuf 2.26 bumped MSRV to 1.52.1
 
 [dev-dependencies]
 gumdrop = "0.8"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -18,7 +18,7 @@ bs58 = { version = "0.4", features = ["check"] }
 ff = "0.11"
 group = "0.11"
 jubjub = "0.8"
-protobuf = "2.20"
+protobuf = ">=2.20,<2.26" # protobuf 2.26 bumped MSRV to 1.52.1
 rand_core = "0.6"
 rusqlite = { version = "0.24", features = ["bundled", "time"] }
 time = "0.2"


### PR DESCRIPTION
`protobuf 2.26.0` bumped its MSRV to 1.52.1, which is incompatible with
our current MSRV.