### PR TITLE
`zcash_address` cleanups

### DIFF
--- a/components/f4jumble/src/lib.rs
+++ b/components/f4jumble/src/lib.rs
@@ -155,25 +155,15 @@ pub fn f4jumble_inv_mut(message: &mut [u8]) -> Result<(), Error> {
 }
 
 #[cfg(feature = "std")]
-pub fn f4jumble(message: &[u8]) -> Option<Vec<u8>> {
+pub fn f4jumble(message: &[u8]) -> Result<Vec<u8>, Error> {
     let mut result = message.to_vec();
-    let res = f4jumble_mut(&mut result);
-    if res.is_ok() {
-        Some(result)
-    } else {
-        None
-    }
+    f4jumble_mut(&mut result).map(|()| result)
 }
 
 #[cfg(feature = "std")]
-pub fn f4jumble_inv(message: &[u8]) -> Option<Vec<u8>> {
+pub fn f4jumble_inv(message: &[u8]) -> Result<Vec<u8>, Error> {
     let mut result = message.to_vec();
-    let res = f4jumble_inv_mut(&mut result);
-    if res.is_ok() {
-        Some(result)
-    } else {
-        None
-    }
+    f4jumble_inv_mut(&mut result).map(|()| result)
 }
 
 #[cfg(test)]

--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -222,7 +222,8 @@ pub(crate) mod private {
             writer.write_all(&padding).unwrap();
 
             let padded = writer.into_inner();
-            f4jumble::f4jumble(&padded).unwrap_or_else(|| panic!("f4jumble failed on {:?}", padded))
+            f4jumble::f4jumble(&padded)
+                .unwrap_or_else(|e| panic!("f4jumble failed on {:?}: {}", padded, e))
         }
 
         /// Parse the items of the unified container.
@@ -265,8 +266,8 @@ pub(crate) mod private {
                 result
             }
 
-            let encoded = f4jumble::f4jumble_inv(buf).ok_or_else(|| {
-                ParseError::InvalidEncoding("F4Jumble decoding failed".to_owned())
+            let encoded = f4jumble::f4jumble_inv(buf).map_err(|e| {
+                ParseError::InvalidEncoding(format!("F4Jumble decoding failed: {}", e))
             })?;
 
             // Validate and strip trailing padding bytes.

--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -227,7 +227,7 @@ pub(crate) mod private {
         }
 
         /// Parse the items of the unified container.
-        fn parse_items(hrp: &str, buf: &[u8]) -> Result<Vec<Self::Item>, ParseError> {
+        fn parse_items<T: Into<Vec<u8>>>(hrp: &str, buf: T) -> Result<Vec<Self::Item>, ParseError> {
             fn read_receiver<R: SealedItem>(
                 mut cursor: &mut std::io::Cursor<&[u8]>,
             ) -> Result<R, ParseError> {
@@ -266,7 +266,9 @@ pub(crate) mod private {
                 result
             }
 
-            let encoded = f4jumble::f4jumble_inv(buf).map_err(|e| {
+            // Here we allocate if necessary to get a mutable Vec<u8> to unjumble.
+            let mut encoded = buf.into();
+            f4jumble::f4jumble_inv_mut(&mut encoded[..]).map_err(|e| {
                 ParseError::InvalidEncoding(format!("F4Jumble decoding failed: {}", e))
             })?;
 
@@ -327,7 +329,7 @@ pub(crate) mod private {
             }
         }
 
-        fn parse_internal(hrp: &str, buf: &[u8]) -> Result<Self, ParseError> {
+        fn parse_internal<T: Into<Vec<u8>>>(hrp: &str, buf: T) -> Result<Self, ParseError> {
             Self::parse_items(hrp, buf).and_then(Self::try_from_items_internal)
         }
     }
@@ -365,7 +367,7 @@ pub trait Encoding: private::SealedContainer {
             let data = Vec::<u8>::from_base32(&data)
                 .map_err(|e| ParseError::InvalidEncoding(e.to_string()))?;
 
-            Self::parse_internal(hrp, &data[..]).map(|value| (net, value))
+            Self::parse_internal(hrp, data).map(|value| (net, value))
         } else {
             Err(ParseError::NotUnified)
         }


### PR DESCRIPTION
Following on from the work to make `f4jumble` no-std compatible.