### PR TITLE
zcash_history: Migrate from bigint to uint.

### DIFF
--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -12,9 +12,9 @@ assert_matches = "1.3.0"
 quickcheck = "0.9"
 
 [dependencies]
-bigint = "4"
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "1" }
+uint = "=0.9.1" # uint 0.9.2 bumps the MSRV to 1.56.1
 
 [lib]
 bench = false

--- a/zcash_history/examples/lib/shared.rs
+++ b/zcash_history/examples/lib/shared.rs
@@ -78,7 +78,7 @@ fn leaf(height: u32) -> NodeData {
         end_target: 100 + (height + 1) * 10,
         start_sapling_root: [0u8; 32],
         end_sapling_root: [0u8; 32],
-        subtree_total_work: 0.into(),
+        subtree_total_work: [0u8; 32],
         start_height: height as u64,
         end_height: height as u64,
         sapling_tx: 5 + height as u64,

--- a/zcash_history/src/tree.rs
+++ b/zcash_history/src/tree.rs
@@ -343,7 +343,7 @@ mod tests {
                 end_target: 0,
                 start_sapling_root: [0u8; 32],
                 end_sapling_root: [0u8; 32],
-                subtree_total_work: 0.into(),
+                subtree_total_work: [0u8; 32],
                 start_height: height as u64,
                 end_height: height as u64,
                 sapling_tx: 7,


### PR DESCRIPTION
Closes #527. 

Alternate to #537 