### PR TITLE
Replace the deprecated `bigint` crate with `primitive-types`.

### DIFF
--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -12,7 +12,7 @@ assert_matches = "1.3.0"
 quickcheck = "0.9"
 
 [dependencies]
-bigint = "4"
+primitive-types = "0.11"
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "1" }
 

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -1,5 +1,5 @@
-use bigint::U256;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use primitive_types::U256;
 
 use crate::Version;
 


### PR DESCRIPTION
`bigint`'s deprecation message suggests to use `uint` instead.
`uint`'s documentation suggests using `primitive-types` for
128 and 256 bit unsigned integers; these use `uint` under the
hood but do provide a somewhat more complete (and hopefully stable)
API.

Fixes #527