### PR TITLE
Set NU5 testnet reactivation height.

### DIFF
--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -240,7 +240,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Blossom => Some(BlockHeight(584_000)),
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
-            NetworkUpgrade::Nu5 => None,
+            NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }


### PR DESCRIPTION
The previous version of this pull request was made from a fork, rather than from the main zcash/librustzcash repository. This commit needs to be referenced directly by https://github.com/zcash/zcash/pull/5868; this PR should not be merged until after that PR's contents have been merged to the `master` branch and zcashd v4.7.0 has been released.