### PR TITLE
Release `zcash_primitives 0.6.0` et al

### DIFF
--- a/components/f4jumble/CHANGELOG.md
+++ b/components/f4jumble/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-05-11
+Initial release.

--- a/components/f4jumble/Cargo.toml
+++ b/components/f4jumble/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "f4jumble"
 description = "Implementation of Zcash's F4Jumble algorithm"
-version = "0.0.0"
+version = "0.1.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",
@@ -12,6 +12,8 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["encoding"]
+keywords = ["feistel"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-05-11
+Initial release.

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 bech32 = "0.8"
 bs58 = { version = "0.4", features = ["check"] }
-f4jumble = { version = "0.0", path = "../f4jumble" }
+f4jumble = { version = "0.1", path = "../f4jumble" }
 zcash_encoding = { version = "0.0", path = "../zcash_encoding" }
 
 [dev-dependencies]

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_address"
 description = "Zcash address parsing and serialization"
-version = "0.0.0"
+version = "0.1.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
@@ -10,6 +10,8 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["cryptography::cryptocurrencies", "encoding"]
+keywords = ["zcash", "address", "sapling", "unified"]
 
 [dependencies]
 bech32 = "0.8"

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 bech32 = "0.8"
 bs58 = { version = "0.4", features = ["check"] }
 f4jumble = { version = "0.1", path = "../f4jumble" }
-zcash_encoding = { version = "0.0", path = "../zcash_encoding" }
+zcash_encoding = { version = "0.1", path = "../zcash_encoding" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-05-11
+Initial release.

--- a/components/zcash_encoding/Cargo.toml
+++ b/components/zcash_encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_encoding"
 description = "Binary encodings used throughout the Zcash ecosystem."
-version = "0.0.0"
+version = "0.1.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",
@@ -11,6 +11,8 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["cryptography::cryptocurrencies", "encoding"]
+keywords = ["zcash"]
 
 [dependencies]
 byteorder = "1"

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -25,7 +25,7 @@ subtle = { version = "2.2.3", default-features = false }
 
 [dev-dependencies]
 ff = { version = "0.12", default-features = false }
-zcash_primitives = { version = "0.5", path = "../../zcash_primitives" }
+zcash_primitives = { version = "0.6", path = "../../zcash_primitives" }
 jubjub = "0.9"
 
 [features]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -43,7 +43,7 @@ protobuf-codegen-pure = "~2.27.1" # MSRV 1.52.1
 gumdrop = "0.8"
 rand_xorshift = "0.3"
 tempfile = "3.1.0"
-zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.6", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = ["ripemd", "hdwallet", "sha2", "secp256k1", "zcash_primitives/transparent-inputs"]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = { version = "0.10.1", optional = true }
 subtle = "2.2.3"
 time = "0.2"
 zcash_note_encryption = { version = "0.1", path = "../components/zcash_note_encryption" }
-zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.6", path = "../zcash_primitives" }
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.27.1" # MSRV 1.52.1

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -28,7 +28,7 @@ zcash_primitives = { version = "0.6", path = "../zcash_primitives" }
 
 [dev-dependencies]
 tempfile = "3"
-zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.6", path = "../zcash_proofs" }
 
 [features]
 mainnet = []

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -24,7 +24,7 @@ rusqlite = { version = "0.24", features = ["bundled", "time"] }
 secp256k1 = { version = "0.21" }
 time = "0.2"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.6", path = "../zcash_primitives" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -16,7 +16,7 @@ zcash_primitives = { version = "0.6", path = "../zcash_primitives", features = [
 ff = "0.12"
 jubjub = "0.9"
 rand_core = "0.6"
-zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.6", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = []

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 blake2b_simd = "1"
-zcash_primitives = { version = "0.5", path = "../zcash_primitives", features = ["zfuture" ] }
+zcash_primitives = { version = "0.6", path = "../zcash_primitives", features = ["zfuture" ] }
 
 [dev-dependencies]
 ff = "0.12"

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2022-05-11
 ### Added
 - Support for multiple history tree versions:
   - `zcash_history::Version` trait.

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "zcash_history"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/zcash_history/"
 description = "Library for Zcash blockchain history tools"
+categories = ["cryptography::cryptocurrencies"]
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2022-05-11
 ### Added
 - `zcash_primitives::sapling::redjubjub::PublicKey::verify_with_zip216`, for
   controlling how RedJubjub signatures are validated. `PublicKey::verify` has

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -44,7 +44,7 @@ ripemd = { version = "0.1", optional = true }
 secp256k1 = { version = "0.21", optional = true }
 sha2 = "0.9"
 subtle = "2.2.3"
-zcash_encoding = { version = "0.0", path = "../components/zcash_encoding" }
+zcash_encoding = { version = "0.1", path = "../components/zcash_encoding" }
 
 [dependencies.zcash_note_encryption]
 version = "0.1"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -11,6 +11,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2022-05-11
 ### Changed
 - MSRV is now 1.56.1.
 - Bumped dependencies to `ff 0.12`, `group 0.12`, `bellman 0.13`,

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1"
 minreq = { version = "2", features = ["https"], optional = true }
 rand_core = "0.6"
 wagyu-zcash-parameters = { version = "0.2", optional = true }
-zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.6", path = "../zcash_primitives" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
@@ -10,6 +10,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Closes #492.
Closes #458.