### PR TITLE
zcash_address: Replace `FromAddress` with `TryFromAddress`

### DIFF
--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -6,6 +6,12 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_address::ConversionError`
+- `zcash_address::TryFromAddress`
+
+### Removed
+- `zcash_address::FromAddress` (use `TryFromAddress` instead).
 
 ## [0.1.0] - 2022-05-11
 Initial release.

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -5,7 +5,7 @@ mod kind;
 #[cfg(test)]
 mod test_vectors;
 
-pub use convert::{FromAddress, ToAddress, UnsupportedAddress};
+pub use convert::{ConversionError, ToAddress, TryFromAddress, UnsupportedAddress};
 pub use encoding::ParseError;
 pub use kind::unified;
 
@@ -84,7 +84,7 @@ impl ZcashAddress {
 
     /// Converts this address into another type.
     ///
-    /// `convert` can convert into any type that implements the [`FromAddress`] trait.
+    /// `convert` can convert into any type that implements the [`TryFromAddress`] trait.
     /// This enables `ZcashAddress` to be used as a common parsing and serialization
     /// interface for Zcash addresses, while delegating operations on those addresses
     /// (such as constructing transactions) to downstream crates.
@@ -95,13 +95,13 @@ impl ZcashAddress {
     /// [`encode`]: Self::encode
     /// [`Display` implementation]: std::fmt::Display
     /// [`address.to_string()`]: std::string::ToString
-    pub fn convert<T: FromAddress>(self) -> Result<T, UnsupportedAddress> {
+    pub fn convert<T: TryFromAddress>(self) -> Result<T, ConversionError<T::Error>> {
         match self.kind {
-            AddressKind::Sprout(data) => T::from_sprout(self.net, data),
-            AddressKind::Sapling(data) => T::from_sapling(self.net, data),
-            AddressKind::Unified(data) => T::from_unified(self.net, data),
-            AddressKind::P2pkh(data) => T::from_transparent_p2pkh(self.net, data),
-            AddressKind::P2sh(data) => T::from_transparent_p2sh(self.net, data),
+            AddressKind::Sprout(data) => T::try_from_sprout(self.net, data),
+            AddressKind::Sapling(data) => T::try_from_sapling(self.net, data),
+            AddressKind::Unified(data) => T::try_from_unified(self.net, data),
+            AddressKind::P2pkh(data) => T::try_from_transparent_p2pkh(self.net, data),
+            AddressKind::P2sh(data) => T::try_from_transparent_p2sh(self.net, data),
         }
     }
 }


### PR DESCRIPTION
This enables the user-defined conversions to be fallible, which they will almost always want to be (as address data needs to be validated before it can be used).

Closes zcash/librustzcash#563.