### PR TITLE
zcash_address: Add `ZcashAddress::convert_if_network`

### DIFF
--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -9,6 +9,8 @@ and this library adheres to Rust's notion of
 ### Added
 - `zcash_address::ConversionError`
 - `zcash_address::TryFromAddress`
+- `zcash_address::TryFromRawAddress`
+- `zcash_address::ZcashAddress::convert_if_network`
 
 ### Removed
 - `zcash_address::FromAddress` (use `TryFromAddress` instead).

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -5,7 +5,9 @@ mod kind;
 #[cfg(test)]
 mod test_vectors;
 
-pub use convert::{ConversionError, ToAddress, TryFromAddress, UnsupportedAddress};
+pub use convert::{
+    ConversionError, ToAddress, TryFromAddress, TryFromRawAddress, UnsupportedAddress,
+};
 pub use encoding::ParseError;
 pub use kind::unified;
 
@@ -102,6 +104,45 @@ impl ZcashAddress {
             AddressKind::Unified(data) => T::try_from_unified(self.net, data),
             AddressKind::P2pkh(data) => T::try_from_transparent_p2pkh(self.net, data),
             AddressKind::P2sh(data) => T::try_from_transparent_p2sh(self.net, data),
+        }
+    }
+
+    /// Converts this address into another type, if it matches the expected network.
+    ///
+    /// `convert_if_network` can convert into any type that implements the
+    /// [`TryFromRawAddress`] trait. This enables `ZcashAddress` to be used as a common
+    /// parsing and serialization interface for Zcash addresses, while delegating
+    /// operations on those addresses (such as constructing transactions) to downstream
+    /// crates.
+    ///
+    /// If you want to get the encoded string for this address, use the [`encode`]
+    /// method or the [`Display` implementation] via [`address.to_string()`] instead.
+    ///
+    /// [`encode`]: Self::encode
+    /// [`Display` implementation]: std::fmt::Display
+    /// [`address.to_string()`]: std::string::ToString
+    pub fn convert_if_network<T: TryFromRawAddress>(
+        self,
+        net: Network,
+    ) -> Result<T, ConversionError<T::Error>> {
+        let network_matches = self.net == net;
+        // The Sprout and transparent address encodings use the same prefix for testnet
+        // and regtest, so we need to allow parsing testnet addresses as regtest.
+        let regtest_exception =
+            network_matches || (self.net == Network::Test && net == Network::Regtest);
+
+        match self.kind {
+            AddressKind::Sprout(data) if regtest_exception => T::try_from_raw_sprout(data),
+            AddressKind::Sapling(data) if network_matches => T::try_from_raw_sapling(data),
+            AddressKind::Unified(data) if network_matches => T::try_from_raw_unified(data),
+            AddressKind::P2pkh(data) if regtest_exception => {
+                T::try_from_raw_transparent_p2pkh(data)
+            }
+            AddressKind::P2sh(data) if regtest_exception => T::try_from_raw_transparent_p2sh(data),
+            _ => Err(ConversionError::IncorrectNetwork {
+                expected: net,
+                actual: self.net,
+            }),
         }
     }
 }


### PR DESCRIPTION
This, along with the corresponding `TryFromRawAddress` trait, enables converting `ZcashAddress` into a network-agnostic type.

Closes zcash/librustzcash#564.