### PR TITLE
Add orchard bundle creation to `zcash_primitives::transaction::builder::Builder`

### DIFF
--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -78,6 +78,8 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
                 transparent_outputs,
                 sapling_inputs.len(),
                 sapling_outputs.len() + 1,
+                //Orchard is not yet supported in zcash_client_backend
+                0,
             )
             .unwrap(); // fixed::FeeRule::fee_required is infallible.
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -167,6 +167,8 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
                 // add one for Sapling change, then account for Sapling output padding performed by
                 // the transaction builder
                 std::cmp::max(sapling_outputs.len() + 1, 2),
+                //Orchard is not yet supported in zcash_client_backend
+                0,
             )
             .map_err(ChangeError::StrategyError)?;
 

--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -703,6 +703,8 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn ufvk_derivation() {
+        use super::UnifiedSpendingKey;
+
         for tv in test_vectors::UNIFIED {
             let usk = UnifiedSpendingKey::from_seed(
                 &MAIN_NETWORK,

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -87,6 +87,27 @@ and this library adheres to Rust's notion of
   `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.10`,
   `zcash_note_encryption 0.3`.
 
+### Added
+- `zcash_primitives::transaction::builder`:
+  - `NetworkUpgrade`
+  - `Builder::with_orchard_anchor`
+  - `Builder::add_orchard_spend`
+  - `Builder::add_orchard_output`
+- `zcash_primitives::transaction::components::orchard::builder` module
+
+### Changed
+- `zcash_primitives::transaction:`
+  - `builder::Builder::test_only_new_with_rng`
+    now returns an existential type: `Builder<'a, P, impl RngCore + CryptoRng>` 
+    instead of `Builder<'a, P, R>`
+  - `fees::FeeRule::fee_required` now takes an addition argument, `orchard_action_count`
+  - `Unauthorized`'s associated type `OrchardAuth` is now 
+    `orchard::builder::InProgress<orchard::builder::Unproven, orchard::builder::Unauthorized>`
+    instead of `zcash_primitives::transaction::components::orchard::Unauthorized`
+
+### Removed
+- `zcash_primitives::transaction::components::orchard::Unauthorized`
+
 ## [0.10.2] - 2023-03-16
 ### Added
 - `zcash_primitives::sapling::note`:

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -89,7 +89,6 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `zcash_primitives::transaction::builder`:
-  - `NetworkUpgrade`
   - `Builder::with_orchard_anchor`
   - `Builder::add_orchard_spend`
   - `Builder::add_orchard_output`
@@ -104,6 +103,7 @@ and this library adheres to Rust's notion of
   - `Unauthorized`'s associated type `OrchardAuth` is now 
     `orchard::builder::InProgress<orchard::builder::Unproven, orchard::builder::Unauthorized>`
     instead of `zcash_primitives::transaction::components::orchard::Unauthorized`
+- `zcash_primitives::consensus::NetworkUpgrade` now implements `PartialEq`, `Eq`
 
 ### Removed
 - `zcash_primitives::transaction::components::orchard::Unauthorized`

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -361,7 +361,7 @@ impl Parameters for Network {
 /// consensus rules enforced by the network are altered.
 ///
 /// See [ZIP 200](https://zips.z.cash/zip-0200) for more details.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NetworkUpgrade {
     /// The [Overwinter] network upgrade.
     ///

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -66,11 +66,11 @@ pub enum Error<FeeError> {
     /// An error occurred in constructing the Sapling parts of a transaction.
     SaplingBuild(sapling_builder::Error),
     /// An error occurred in constructing the Orchard parts of a transaction.
-    OrchardBuild(orchard::builder::Error),
+    OrchardBuild(orchard::builder::BuildError),
     /// An error occurred in adding an Orchard Spend a transaction.
-    OrchardSpend(&'static str),
+    OrchardSpend(orchard::builder::SpendError),
     /// An error occurred in adding an Orchard Output a transaction.
-    OrchardRecipient(&'static str),
+    OrchardRecipient(orchard::builder::OutputError),
     /// Orchard is not yet active on the network, and the user attempted to add
     /// Orchard parts to a transaction.
     NU5Inactive,
@@ -179,6 +179,10 @@ pub struct Builder<'a, P, R, O: MaybeOrchard = WithoutOrchard> {
     transparent_builder: TransparentBuilder,
     sapling_builder: SaplingBuilder<P>,
     orchard_builder: O,
+    // TODO: These should be calculated by the orchard builder and not cached here
+    // This requires publicizing methods or fields of the orchard builder
+    num_orchard_spends: usize,
+    num_orchard_outputs: usize,
     orchard_saks: Vec<orchard::keys::SpendAuthorizingKey>,
     #[cfg(feature = "zfuture")]
     tze_builder: TzeBuilder<'a, TransactionData<Unauthorized>>,
@@ -286,6 +290,8 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng, O: MaybeOrchard> Buil
             #[cfg(not(feature = "zfuture"))]
             tze_builder: std::marker::PhantomData,
             progress_notifier: None,
+            num_orchard_spends: 0,
+            num_orchard_outputs: 0,
         }
     }
 
@@ -387,6 +393,10 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng, O: MaybeOrchard> Buil
                 self.transparent_builder.outputs(),
                 self.sapling_builder.inputs().len(),
                 self.sapling_builder.bundle_output_count(),
+                match std::cmp::max(self.num_orchard_spends, self.num_orchard_outputs) {
+                    1 => 2,
+                    n => n,
+                },
             )
             .map_err(Error::Fee)?;
         self.build_internal(prover, fee)
@@ -550,6 +560,7 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R, Wit
     ) -> Result<(), Error<FR::Error>> {
         self.orchard_saks
             .push(orchard::keys::SpendAuthorizingKey::from(&sk));
+        self.num_orchard_spends += 1;
         self.orchard_builder
             .0
             .as_mut()
@@ -566,6 +577,7 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R, Wit
         value: u64,
         memo: MemoBytes,
     ) -> Result<(), Error<FR::Error>> {
+        self.num_orchard_outputs += 1;
         self.orchard_builder
             .0
             .as_mut()

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -542,12 +542,12 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R, Wit
     ///
     /// Returns an error if the given Merkle path does not have the required anchor for
     /// the given note.
-    pub fn add_orchard_spend<FE>(
+    pub fn add_orchard_spend<FR: FeeRule>(
         &mut self,
         sk: orchard::keys::SpendingKey,
         note: orchard::Note,
         merkle_path: orchard::tree::MerklePath,
-    ) -> Result<(), Error<FE>> {
+    ) -> Result<(), Error<FR::Error>> {
         self.orchard_saks
             .push(orchard::keys::SpendAuthorizingKey::from(&sk));
         self.orchard_builder
@@ -559,13 +559,13 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R, Wit
     }
 
     /// Adds an Orchard address which will receive funds in this transaction.
-    pub fn add_orchard_output<FE>(
+    pub fn add_orchard_output<FR: FeeRule>(
         &mut self,
         ovk: Option<orchard::keys::OutgoingViewingKey>,
         recipient: orchard::Address,
         value: u64,
         memo: MemoBytes,
-    ) -> Result<(), Error<FE>> {
+    ) -> Result<(), Error<FR::Error>> {
         self.orchard_builder
             .0
             .as_mut()

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -361,11 +361,14 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng, O: MaybeOrchard> Buil
         self.progress_notifier = Some(progress_notifier);
     }
 
-    /// Returns the sum of the transparent, Sapling, and TZE value balances.
+    /// Returns the sum of the transparent, Sapling, Orchard, and TZE value balances.
     fn value_balance(&self) -> Result<Amount, BalanceError> {
         let value_balances = [
             self.transparent_builder.value_balance()?,
             self.sapling_builder.value_balance(),
+            self.orchard_builder
+                .value_balance()
+                .map_err(|_| BalanceError::Overflow)?,
             #[cfg(feature = "zfuture")]
             self.tze_builder.value_balance()?,
         ];

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -778,6 +778,7 @@ mod tests {
     fn binding_sig_absent_if_no_shielded_spend_or_output() {
         use crate::consensus::NetworkUpgrade;
         use crate::transaction::builder::{self, TransparentBuilder};
+        use crate::transaction::components::orchard::builder::WithoutOrchard;
 
         let sapling_activation_height = TEST_NETWORK
             .activation_height(NetworkUpgrade::Sapling)
@@ -796,6 +797,8 @@ mod tests {
             #[cfg(not(feature = "zfuture"))]
             tze_builder: std::marker::PhantomData,
             progress_notifier: None,
+            orchard_builder: WithoutOrchard,
+            orchard_saks: Vec::new(),
         };
 
         let tsk = AccountPrivKey::from_seed(&TEST_NETWORK, &[0u8; 32], AccountId::from(0)).unwrap();

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -16,6 +16,8 @@ use zcash_encoding::{Array, CompactSize, Vector};
 use super::Amount;
 use crate::transaction::Transaction;
 
+pub mod builder;
+
 pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -22,14 +22,6 @@ pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
 
-/// Marker for a bundle with no proofs or signatures.
-#[derive(Debug)]
-pub struct Unauthorized;
-
-impl Authorization for Unauthorized {
-    type SpendAuth = ();
-}
-
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
     fn map_authorization(&self, a: A) -> B;

--- a/zcash_primitives/src/transaction/components/orchard/builder.rs
+++ b/zcash_primitives/src/transaction/components/orchard/builder.rs
@@ -1,0 +1,69 @@
+use crate::{
+    consensus::{self, BlockHeight, NetworkUpgrade},
+    transaction::components::Amount,
+};
+use orchard::{
+    builder::{Builder, Error, InProgress, Unauthorized, Unproven},
+    bundle::Bundle,
+    value::OverflowError,
+};
+
+pub struct WithoutOrchard;
+
+pub struct WithOrchard(pub(crate) Option<Builder>);
+
+pub trait MaybeOrchard {
+    fn build<V: core::convert::TryFrom<i64>>(
+        self,
+        rng: impl rand::RngCore,
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>>;
+    fn value_balance(&self) -> Result<Amount, OverflowError>;
+}
+
+impl MaybeOrchard for WithOrchard {
+    fn build<V: core::convert::TryFrom<i64>>(
+        self,
+        rng: impl rand::RngCore,
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>> {
+        self.0.map(|builder| builder.build(rng))
+    }
+
+    fn value_balance(&self) -> Result<Amount, OverflowError> {
+        match &self.0 {
+            Some(builder) => builder.value_balance(),
+            None => Ok(Amount::zero()),
+        }
+    }
+}
+
+impl MaybeOrchard for WithoutOrchard {
+    fn build<V: core::convert::TryFrom<i64>>(
+        self,
+        _: impl rand::RngCore,
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>> {
+        None
+    }
+
+    fn value_balance(&self) -> Result<Amount, OverflowError> {
+        Ok(Amount::zero())
+    }
+}
+
+impl WithOrchard {
+    pub(crate) fn new<P: consensus::Parameters>(
+        params: &P,
+        target_height: BlockHeight,
+        anchor: orchard::tree::Anchor,
+    ) -> Self {
+        let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
+            Some(orchard::builder::Builder::new(
+                orchard::bundle::Flags::from_parts(true, true),
+                anchor,
+            ))
+        } else {
+            None
+        };
+
+        Self(orchard_builder)
+    }
+}

--- a/zcash_primitives/src/transaction/components/orchard/builder.rs
+++ b/zcash_primitives/src/transaction/components/orchard/builder.rs
@@ -18,6 +18,8 @@ pub trait MaybeOrchard {
         rng: impl rand::RngCore,
     ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, BuildError>>;
     fn value_balance(&self) -> Result<Amount, OverflowError>;
+    fn input_count(&self) -> usize;
+    fn output_count(&self) -> usize;
 }
 
 impl MaybeOrchard for WithOrchard {
@@ -34,6 +36,22 @@ impl MaybeOrchard for WithOrchard {
             None => Ok(Amount::zero()),
         }
     }
+
+    fn input_count(&self) -> usize {
+        if let Some(ref builder) = self.0 {
+            builder.spends().len()
+        } else {
+            0
+        }
+    }
+
+    fn output_count(&self) -> usize {
+        if let Some(ref builder) = self.0 {
+            builder.outputs().len()
+        } else {
+            0
+        }
+    }
 }
 
 impl MaybeOrchard for WithoutOrchard {
@@ -46,6 +64,14 @@ impl MaybeOrchard for WithoutOrchard {
 
     fn value_balance(&self) -> Result<Amount, OverflowError> {
         Ok(Amount::zero())
+    }
+
+    fn input_count(&self) -> usize {
+        0
+    }
+
+    fn output_count(&self) -> usize {
+        0
     }
 }
 

--- a/zcash_primitives/src/transaction/components/orchard/builder.rs
+++ b/zcash_primitives/src/transaction/components/orchard/builder.rs
@@ -13,6 +13,7 @@ pub struct WithoutOrchard;
 pub struct WithOrchard(pub(crate) Option<Builder>);
 
 pub trait MaybeOrchard {
+    #[allow(clippy::type_complexity)]
     fn build<V: core::convert::TryFrom<i64>>(
         self,
         rng: impl rand::RngCore,

--- a/zcash_primitives/src/transaction/components/orchard/builder.rs
+++ b/zcash_primitives/src/transaction/components/orchard/builder.rs
@@ -3,7 +3,7 @@ use crate::{
     transaction::components::Amount,
 };
 use orchard::{
-    builder::{Builder, Error, InProgress, Unauthorized, Unproven},
+    builder::{BuildError, Builder, InProgress, Unauthorized, Unproven},
     bundle::Bundle,
     value::OverflowError,
 };
@@ -16,7 +16,7 @@ pub trait MaybeOrchard {
     fn build<V: core::convert::TryFrom<i64>>(
         self,
         rng: impl rand::RngCore,
-    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>>;
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, BuildError>>;
     fn value_balance(&self) -> Result<Amount, OverflowError>;
 }
 
@@ -24,7 +24,7 @@ impl MaybeOrchard for WithOrchard {
     fn build<V: core::convert::TryFrom<i64>>(
         self,
         rng: impl rand::RngCore,
-    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>> {
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, BuildError>> {
         self.0.map(|builder| builder.build(rng))
     }
 
@@ -40,7 +40,7 @@ impl MaybeOrchard for WithoutOrchard {
     fn build<V: core::convert::TryFrom<i64>>(
         self,
         _: impl rand::RngCore,
-    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error>> {
+    ) -> Option<Result<Bundle<InProgress<Unproven, Unauthorized>, V>, BuildError>> {
         None
     }
 

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -21,6 +21,7 @@ pub trait FeeRule {
     /// Implementations of this method should compute the fee amount given exactly the inputs and
     /// outputs specified, and should NOT compute speculative fees given any additional change
     /// outputs that may need to be created in order for inputs and outputs to balance.
+    #[allow(clippy::too_many_arguments)]
     fn fee_required<P: consensus::Parameters>(
         &self,
         params: &P,

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -29,6 +29,7 @@ pub trait FeeRule {
         transparent_outputs: &[impl transparent::OutputView],
         sapling_input_count: usize,
         sapling_output_count: usize,
+        orchard_action_count: usize,
     ) -> Result<Amount, Self::Error>;
 }
 

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -46,6 +46,7 @@ impl super::FeeRule for FeeRule {
         _transparent_outputs: &[impl transparent::OutputView],
         _sapling_input_count: usize,
         _sapling_output_count: usize,
+        _orchard_action_count: usize,
     ) -> Result<Amount, Self::Error> {
         Ok(self.fixed_fee)
     }

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -122,6 +122,7 @@ impl super::FeeRule for FeeRule {
         transparent_outputs: &[impl transparent::OutputView],
         sapling_input_count: usize,
         sapling_output_count: usize,
+        orchard_action_count: usize,
     ) -> Result<Amount, Self::Error> {
         let non_p2pkh_inputs: Vec<_> = transparent_inputs
             .iter()
@@ -144,7 +145,8 @@ impl super::FeeRule for FeeRule {
         let logical_actions = max(
             ceildiv(t_in_total_size, self.p2pkh_standard_input_size),
             ceildiv(t_out_total_size, self.p2pkh_standard_output_size),
-        ) + max(sapling_input_count, sapling_output_count);
+        ) + max(sapling_input_count, sapling_output_count)
+            + orchard_action_count;
 
         (self.marginal_fee * max(self.grace_actions, logical_actions))
             .ok_or_else(|| BalanceError::Overflow.into())

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -270,7 +270,8 @@ pub struct Unauthorized;
 impl Authorization for Unauthorized {
     type TransparentAuth = transparent::builder::Unauthorized;
     type SaplingAuth = sapling::builder::Unauthorized;
-    type OrchardAuth = orchard_serialization::Unauthorized;
+    type OrchardAuth =
+        orchard::builder::InProgress<orchard::builder::Unproven, orchard::builder::Unauthorized>;
 
     #[cfg(feature = "zfuture")]
     type TzeAuth = tze::builder::Unauthorized;


### PR DESCRIPTION
This adds a `with_orchard_anchor` constructor to the transaction builder, that allows for adding orchard components to transactions.