### PR TITLE
Add database migrations to zcash_client_sqlite.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ codegen-units = 1
 [patch.crates-io]
 zcash_encoding = { path = "components/zcash_encoding" }
 zcash_note_encryption = { path = "components/zcash_note_encryption" }
+schemer = { git = "https://github.com/aschampion/schemer.git", rev = "2370c96f43eda5b2cb267bbc9355f0fefff850bb" }
+schemer-rusqlite = { git = "https://github.com/aschampion/schemer.git", rev = "2370c96f43eda5b2cb267bbc9355f0fefff850bb" }

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -37,6 +37,7 @@ and this library adheres to Rust's notion of
   - `TransactionRequest::new` for constructing a request from `Vec<Payment>`.
   - `TransactionRequest::payments` for accessing the `Payments` that make up a
     request.
+- `zcash_client_backend::encoding::KeyError` 
 - New experimental APIs that should be considered unstable, and are
   likely to be modified and/or moved to a different module in a future
   release:
@@ -113,7 +114,11 @@ and this library adheres to Rust's notion of
   derived from ZIP 316 UFVKs and UIVKs.
 - `welding_rig::scan_block` now uses batching for trial-decryption of
   transaction outputs.
-
+- The return type of the following methods in `zcash_client_backend::encoding`
+  have been changed to improve error reporting:
+  - `decode_extended_spending_key`
+  - `decode_extended_full_viewing_key`
+  - `decode_payment_address`
 
 ### Removed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/examples/diversify-address.rs
+++ b/zcash_client_backend/examples/diversify-address.rs
@@ -9,16 +9,12 @@ use zcash_primitives::{
 
 fn parse_viewing_key(s: &str) -> Result<(ExtendedFullViewingKey, bool), &'static str> {
     decode_extended_full_viewing_key(mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY, s)
-        .ok()
-        .flatten()
         .map(|vk| (vk, true))
-        .or_else(|| {
+        .or_else(|_| {
             decode_extended_full_viewing_key(testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY, s)
-                .ok()
-                .flatten()
                 .map(|vk| (vk, false))
         })
-        .ok_or("Invalid Sapling viewing key")
+        .map_err(|_| "Invalid Sapling viewing key")
 }
 
 fn parse_diversifier_index(s: &str) -> Result<DiversifierIndex, &'static str> {

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -793,7 +793,7 @@ mod tests {
         let expected = TransactionRequest {
             payments: vec![
                 Payment {
-                    recipient_address: RecipientAddress::Shielded(decode_payment_address(TEST_NETWORK.hrp_sapling_payment_address(), "ztestsapling1n65uaftvs2g7075q2x2a04shfk066u3lldzxsrprfrqtzxnhc9ps73v4lhx4l9yfxj46sl0q90k").unwrap().unwrap()),
+                    recipient_address: RecipientAddress::Shielded(decode_payment_address(TEST_NETWORK.hrp_sapling_payment_address(), "ztestsapling1n65uaftvs2g7075q2x2a04shfk066u3lldzxsrprfrqtzxnhc9ps73v4lhx4l9yfxj46sl0q90k").unwrap()),
                     amount: Amount::from_u64(376876902796286).unwrap(),
                     memo: None,
                     label: None,
@@ -811,7 +811,7 @@ mod tests {
         let req = TransactionRequest {
             payments: vec![
                 Payment {
-                    recipient_address: RecipientAddress::Shielded(decode_payment_address(TEST_NETWORK.hrp_sapling_payment_address(), "ztestsapling1n65uaftvs2g7075q2x2a04shfk066u3lldzxsrprfrqtzxnhc9ps73v4lhx4l9yfxj46sl0q90k").unwrap().unwrap()),
+                    recipient_address: RecipientAddress::Shielded(decode_payment_address(TEST_NETWORK.hrp_sapling_payment_address(), "ztestsapling1n65uaftvs2g7075q2x2a04shfk066u3lldzxsrprfrqtzxnhc9ps73v4lhx4l9yfxj46sl0q90k").unwrap()),
                     amount: Amount::from_u64(0).unwrap(),
                     memo: None,
                     label: None,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -19,7 +19,10 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Various **BREAKING CHANGES** have been made to the database tables. These will
-  require migrations, which may need to be performed in multiple steps.
+  require migrations, which may need to be performed in multiple steps. Migrations
+  will now be automatically performed for any user using
+  `zcash_client_sqlite::wallet::init_wallet_db`and it is recommended to use this
+  method to maintain the state of the database going forward.
   - The `extfvk` column in the `accounts` table has been replaced by a `ufvk`
     column. Values for this column should be derived from the wallet's seed and
     the account number; the Sapling component of the resulting Unified Full
@@ -48,6 +51,11 @@ and this library adheres to Rust's notion of
   method to be used in contexts where a transaction has just been
   constructed, rather than only in the case that a transaction has
   been decrypted after being retrieved from the network.
+- `zcash_client_sqlite::wallet::init_wallet_db` has been modified to
+  take the wallet seed as an argument so that it can correctly perform
+  migrations that require re-deriving key material. In particular for
+  this upgrade, the seed is used to derive UFVKs to replace the currently
+  stored Sapling extfvks as part of the migration process.
 
 ### Removed
 - `zcash_client_sqlite::wallet`:

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -21,7 +21,7 @@ and this library adheres to Rust's notion of
 - Various **BREAKING CHANGES** have been made to the database tables. These will
   require migrations, which may need to be performed in multiple steps. Migrations
   will now be automatically performed for any user using
-  `zcash_client_sqlite::wallet::init_wallet_db`and it is recommended to use this
+  `zcash_client_sqlite::wallet::init_wallet_db` and it is recommended to use this
   method to maintain the state of the database going forward.
   - The `extfvk` column in the `accounts` table has been replaced by a `ufvk`
     column. Values for this column should be derived from the wallet's seed and
@@ -55,7 +55,8 @@ and this library adheres to Rust's notion of
   take the wallet seed as an argument so that it can correctly perform
   migrations that require re-deriving key material. In particular for
   this upgrade, the seed is used to derive UFVKs to replace the currently
-  stored Sapling extfvks as part of the migration process.
+  stored Sapling extfvks (without loss of information) as part of the
+  migration process.
 
 ### Removed
 - `zcash_client_sqlite::wallet`:

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -22,7 +22,10 @@ protobuf = "~2.27.1" # MSRV 1.52.1
 rand_core = "0.6"
 rusqlite = { version = "0.24", features = ["bundled", "time"] }
 secp256k1 = { version = "0.21" }
+schemer = "0.1.2"
+schemer-rusqlite = "0.1.1"
 time = "0.2"
+uuid = "1.1"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.7", path = "../zcash_primitives" }
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -24,6 +24,7 @@ rusqlite = { version = "0.24", features = ["bundled", "time"] }
 secp256k1 = { version = "0.21" }
 schemer = "0.1.2"
 schemer-rusqlite = "0.1.1"
+secrecy = "0.8"
 time = "0.2"
 uuid = "1.1"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -97,8 +97,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -176,8 +176,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -246,8 +246,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -316,8 +316,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -385,8 +385,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -440,8 +440,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -492,8 +492,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -67,6 +67,7 @@ where
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
+    use secrecy::Secret;
     use tempfile::NamedTempFile;
 
     use zcash_primitives::{
@@ -98,7 +99,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -177,7 +178,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -247,7 +248,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -317,7 +318,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -386,7 +387,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -441,7 +442,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -493,7 +494,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -98,7 +98,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -177,7 +177,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -247,7 +247,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -317,7 +317,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -386,7 +386,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -441,7 +441,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -493,7 +493,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -99,7 +99,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -178,7 +178,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -248,7 +248,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -318,7 +318,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -387,7 +387,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -442,7 +442,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);
@@ -494,7 +494,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let (dfvk, _taddr) = init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -181,17 +181,15 @@ pub(crate) fn get_unified_full_viewing_keys<P: consensus::Parameters>(
         .conn
         .prepare("SELECT account, ufvk FROM accounts ORDER BY account ASC")?;
 
-    let rows = stmt_fetch_accounts
-        .query_map(NO_PARAMS, |row| {
-            let acct: u32 = row.get(0)?;
-            let account = AccountId::from(acct);
-            let ufvk_str: String = row.get(1)?;
-            let ufvk = UnifiedFullViewingKey::decode(&wdb.params, &ufvk_str)
-                .map_err(SqliteClientError::CorruptedData);
+    let rows = stmt_fetch_accounts.query_map(NO_PARAMS, |row| {
+        let acct: u32 = row.get(0)?;
+        let account = AccountId::from(acct);
+        let ufvk_str: String = row.get(1)?;
+        let ufvk = UnifiedFullViewingKey::decode(&wdb.params, &ufvk_str)
+            .map_err(SqliteClientError::CorruptedData);
 
-            Ok((account, ufvk))
-        })
-        .map_err(SqliteClientError::from)?;
+        Ok((account, ufvk))
+    })?;
 
     let mut res: HashMap<AccountId, UnifiedFullViewingKey> = HashMap::new();
     for row in rows {
@@ -1243,7 +1241,7 @@ mod tests {
     fn empty_database_has_no_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         tests::init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1227,6 +1227,7 @@ pub fn insert_sent_utxo<'a, P: consensus::Parameters>(
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
+    use secrecy::Secret;
     use tempfile::NamedTempFile;
 
     use zcash_primitives::transaction::components::Amount;
@@ -1241,7 +1242,7 @@ mod tests {
     fn empty_database_has_no_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         tests::init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1242,8 +1242,8 @@ mod tests {
     #[test]
     fn empty_database_has_no_balance() {
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         tests::init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1242,7 +1242,7 @@ mod tests {
     fn empty_database_has_no_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         tests::init_test_accounts_table(&db_data);

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -197,13 +197,7 @@ impl<P: consensus::Parameters> RusqliteMigration for WalletMigration2<P> {
         for row in rows {
             let (account, address) = row?;
             let decoded_address =
-                decode_payment_address(self.params.hrp_sapling_payment_address(), &address)?
-                    .ok_or_else(|| {
-                        SqliteClientError::CorruptedData(format!(
-                            "Not a valid Sapling payment address: {}",
-                            address
-                        ))
-                    })?;
+                decode_payment_address(self.params.hrp_sapling_payment_address(), &address)?;
 
             let usk =
                 UnifiedSpendingKey::from_seed(&self.params, self.seed.expose_secret(), account)

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -229,7 +229,8 @@ impl<P: consensus::Parameters> RusqliteMigration for WalletMigration2<P> {
         //
 
         transaction.execute_batch(
-            "CREATE TABLE sent_notes_new (
+            "PRAGMA foreign_keys = ON;
+            CREATE TABLE sent_notes_new (
                 id_note INTEGER PRIMARY KEY,
                 tx INTEGER NOT NULL,
                 output_pool INTEGER NOT NULL ,
@@ -273,7 +274,8 @@ impl<P: consensus::Parameters> RusqliteMigration for WalletMigration2<P> {
         }
 
         transaction.execute_batch(
-            "DROP TABLE sent_notes;
+            "PRAGMA foreign_keys = OFF;
+            DROP TABLE sent_notes;
             ALTER TABLE sent_notes_new RENAME TO sent_notes;
             PRAGMA foreign_keys = ON;",
         )?;
@@ -540,7 +542,7 @@ mod tests {
             account: AccountId,
         ) -> Result<(), rusqlite::Error> {
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS accounts (
+                "CREATE TABLE accounts (
                     account INTEGER PRIMARY KEY,
                     extfvk TEXT NOT NULL,
                     address TEXT NOT NULL
@@ -548,7 +550,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS blocks (
+                "CREATE TABLE blocks (
                     height INTEGER PRIMARY KEY,
                     hash BLOB NOT NULL,
                     time INTEGER NOT NULL,
@@ -557,7 +559,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS transactions (
+                "CREATE TABLE transactions (
                     id_tx INTEGER PRIMARY KEY,
                     txid BLOB NOT NULL UNIQUE,
                     created TEXT,
@@ -570,7 +572,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS received_notes (
+                "CREATE TABLE received_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_index INTEGER NOT NULL,
@@ -590,7 +592,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sapling_witnesses (
+                "CREATE TABLE sapling_witnesses (
                     id_witness INTEGER PRIMARY KEY,
                     note INTEGER NOT NULL,
                     block INTEGER NOT NULL,
@@ -602,7 +604,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sent_notes (
+                "CREATE TABLE sent_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_index INTEGER NOT NULL,
@@ -656,7 +658,7 @@ mod tests {
             account: AccountId,
         ) -> Result<(), rusqlite::Error> {
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS accounts (
+                "CREATE TABLE accounts (
                     account INTEGER PRIMARY KEY,
                     extfvk TEXT NOT NULL,
                     address TEXT NOT NULL,
@@ -665,7 +667,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS blocks (
+                "CREATE TABLE blocks (
                     height INTEGER PRIMARY KEY,
                     hash BLOB NOT NULL,
                     time INTEGER NOT NULL,
@@ -674,7 +676,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS transactions (
+                "CREATE TABLE transactions (
                     id_tx INTEGER PRIMARY KEY,
                     txid BLOB NOT NULL UNIQUE,
                     created TEXT,
@@ -687,7 +689,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS received_notes (
+                "CREATE TABLE received_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_index INTEGER NOT NULL,
@@ -707,7 +709,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sapling_witnesses (
+                "CREATE TABLE sapling_witnesses (
                     id_witness INTEGER PRIMARY KEY,
                     note INTEGER NOT NULL,
                     block INTEGER NOT NULL,
@@ -719,7 +721,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sent_notes (
+                "CREATE TABLE sent_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_index INTEGER NOT NULL,
@@ -734,7 +736,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS utxos (
+                "CREATE TABLE utxos (
                     id_utxo INTEGER PRIMARY KEY,
                     address TEXT NOT NULL,
                     prevout_txid BLOB NOT NULL,
@@ -784,7 +786,7 @@ mod tests {
     fn init_migrate_from_main_pre_migrations() {
         fn init_main<P>(wdb: &WalletDb<P>) -> Result<(), rusqlite::Error> {
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS accounts (
+                "CREATE TABLE accounts (
                     account INTEGER PRIMARY KEY,
                     ufvk TEXT,
                     address TEXT,
@@ -793,7 +795,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS blocks (
+                "CREATE TABLE blocks (
                     height INTEGER PRIMARY KEY,
                     hash BLOB NOT NULL,
                     time INTEGER NOT NULL,
@@ -802,7 +804,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS transactions (
+                "CREATE TABLE transactions (
                     id_tx INTEGER PRIMARY KEY,
                     txid BLOB NOT NULL UNIQUE,
                     created TEXT,
@@ -815,7 +817,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS received_notes (
+                "CREATE TABLE received_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_index INTEGER NOT NULL,
@@ -835,7 +837,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sapling_witnesses (
+                "CREATE TABLE sapling_witnesses (
                     id_witness INTEGER PRIMARY KEY,
                     note INTEGER NOT NULL,
                     block INTEGER NOT NULL,
@@ -847,7 +849,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS sent_notes (
+                "CREATE TABLE sent_notes (
                     id_note INTEGER PRIMARY KEY,
                     tx INTEGER NOT NULL,
                     output_pool INTEGER NOT NULL,
@@ -863,7 +865,7 @@ mod tests {
                 NO_PARAMS,
             )?;
             wdb.conn.execute(
-                "CREATE TABLE IF NOT EXISTS utxos (
+                "CREATE TABLE utxos (
                     id_utxo INTEGER PRIMARY KEY,
                     address TEXT NOT NULL,
                     prevout_txid BLOB NOT NULL,

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -157,6 +157,7 @@ pub fn select_spendable_sapling_notes<P>(
 #[allow(deprecated)]
 mod tests {
     use rusqlite::Connection;
+    use secrecy::Secret;
     use std::collections::HashMap;
     use tempfile::NamedTempFile;
 
@@ -206,7 +207,7 @@ mod tests {
     fn create_to_address_fails_on_incorrect_extsk() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         let acct0 = AccountId::from(0);
         let acct1 = AccountId::from(1);
@@ -290,7 +291,7 @@ mod tests {
     fn create_to_address_fails_with_no_blocks() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -328,7 +329,7 @@ mod tests {
     fn create_to_address_fails_on_insufficient_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
         init_blocks_table(
             &db_data,
             BlockHeight::from(1u32),
@@ -386,7 +387,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -521,7 +522,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -652,7 +653,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -764,7 +765,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, vec![]).unwrap();
+        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -207,7 +207,7 @@ mod tests {
     fn create_to_address_fails_on_incorrect_extsk() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         let acct0 = AccountId::from(0);
         let acct1 = AccountId::from(1);
@@ -291,7 +291,7 @@ mod tests {
     fn create_to_address_fails_with_no_blocks() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -329,7 +329,7 @@ mod tests {
     fn create_to_address_fails_on_insufficient_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
         init_blocks_table(
             &db_data,
             BlockHeight::from(1u32),
@@ -387,7 +387,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -522,7 +522,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -653,7 +653,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -765,7 +765,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data, Secret::new(vec![])).unwrap();
+        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -206,7 +206,7 @@ mod tests {
     fn create_to_address_fails_on_incorrect_extsk() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         let acct0 = AccountId::from(0);
         let acct1 = AccountId::from(1);
@@ -290,7 +290,7 @@ mod tests {
     fn create_to_address_fails_with_no_blocks() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -328,7 +328,7 @@ mod tests {
     fn create_to_address_fails_on_insufficient_balance() {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
         init_blocks_table(
             &db_data,
             BlockHeight::from(1u32),
@@ -386,7 +386,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -521,7 +521,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -652,7 +652,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -764,7 +764,7 @@ mod tests {
 
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&mut db_data).unwrap();
+        init_wallet_db(&mut db_data, vec![]).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -205,8 +205,8 @@ mod tests {
     #[test]
     fn create_to_address_fails_on_incorrect_extsk() {
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         let acct0 = AccountId::from(0);
         let acct1 = AccountId::from(1);
@@ -289,8 +289,8 @@ mod tests {
     #[test]
     fn create_to_address_fails_with_no_blocks() {
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -327,8 +327,8 @@ mod tests {
     #[test]
     fn create_to_address_fails_on_insufficient_balance() {
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
         init_blocks_table(
             &db_data,
             BlockHeight::from(1u32),
@@ -385,8 +385,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -520,8 +520,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -651,8 +651,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), network).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
@@ -763,8 +763,8 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
-        init_wallet_db(&db_data).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        init_wallet_db(&mut db_data).unwrap();
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);

--- a/zcash_primitives/src/sapling/keys.rs
+++ b/zcash_primitives/src/sapling/keys.rs
@@ -288,7 +288,6 @@ impl DiversifiableFullViewingKey {
 
     /// Returns the payment address corresponding to the smallest valid diversifier index,
     /// along with that index.
-    // TODO: See if this is only used in tests.
     pub fn default_address(&self) -> (zip32::DiversifierIndex, PaymentAddress) {
         zip32::sapling_default_address(&self.fvk, &self.dk)
     }


### PR DESCRIPTION
This change adds database migration infrastructure to zcash_client_sqlite,
and replaces wallet database initialization with running database migrations.

The migrations introduced by this change should be able to safely upgrade 
wallet databases based on `librustzcash` versions 0.3.0 and also any databases
that have already applied the changes to wallet initialization expected by the
09f4d90a32434462fcd37e9f843cb015cf313fa7 lineage of commits.