### PR TITLE
zcash_client_backend: Add `WalletWrite::remove_unmined_tx` method

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,10 +26,13 @@ and this library adheres to Rust's notion of
   of a `zcash_client_backend::zip321::TransactionRequest` value.
   This facilitates the implementation of ZIP 321 support in wallets and
   provides substantially greater flexibility in transaction creation.
+- An `unstable` feature flag; this is added to parts of the API that may change
+  in any release.
 - `zcash_client_backend::address`:
   - `RecipientAddress::Unified`
 - `zcash_client_backend::data_api`:
-    `WalletRead::get_unified_full_viewing_keys`
+  - `WalletRead::get_unified_full_viewing_keys`
+  - `WalletWrite::remove_tx` (behind the `unstable` feature flag).
 - `zcash_client_backend::proto`:
   - `actions` field on `compact_formats::CompactTx`
   - `compact_formats::CompactOrchardAction`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -32,7 +32,7 @@ and this library adheres to Rust's notion of
   - `RecipientAddress::Unified`
 - `zcash_client_backend::data_api`:
   - `WalletRead::get_unified_full_viewing_keys`
-  - `WalletWrite::remove_tx` (behind the `unstable` feature flag).
+  - `WalletWrite::remove_unmined_tx` (behind the `unstable` feature flag).
 - `zcash_client_backend::proto`:
   - `actions` field on `compact_formats::CompactTx`
   - `compact_formats::CompactOrchardAction`

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -57,6 +57,7 @@ test-dependencies = [
     "orchard/test-dependencies",
     "zcash_primitives/test-dependencies",
 ]
+unstable = []
 
 [lib]
 bench = false

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -272,11 +272,13 @@ pub trait WalletWrite: WalletRead {
 
     fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<Self::TxRef, Self::Error>;
 
-    /// Removes the specified transaction from the persistent wallet store, if it exists.
+    /// Removes the specified unmined transaction from the persistent wallet store, if it
+    /// exists.
     ///
-    /// Any effects of the transaction (such as spending received notes) are unwound.
+    /// Returns an error if the specified transaction has been mined. To remove a mined
+    /// transaction, first use [`WalletWrite::rewind_to_height`] to unmine it.
     #[cfg(feature = "unstable")]
-    fn remove_tx(&mut self, txid: &TxId) -> Result<(), Self::Error>;
+    fn remove_unmined_tx(&mut self, txid: &TxId) -> Result<(), Self::Error>;
 
     /// Rewinds the wallet database to the specified height.
     ///
@@ -501,7 +503,7 @@ pub mod testing {
         }
 
         #[cfg(feature = "unstable")]
-        fn remove_tx(&mut self, _txid: &TxId) -> Result<(), Self::Error> {
+        fn remove_unmined_tx(&mut self, _txid: &TxId) -> Result<(), Self::Error> {
             Ok(())
         }
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -272,6 +272,12 @@ pub trait WalletWrite: WalletRead {
 
     fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<Self::TxRef, Self::Error>;
 
+    /// Removes the specified transaction from the persistent wallet store, if it exists.
+    ///
+    /// Any effects of the transaction (such as spending received notes) are unwound.
+    #[cfg(feature = "unstable")]
+    fn remove_tx(&mut self, txid: &TxId) -> Result<(), Self::Error>;
+
     /// Rewinds the wallet database to the specified height.
     ///
     /// This method assumes that the state of the underlying data store is
@@ -492,6 +498,11 @@ pub mod testing {
             _sent_tx: &SentTransaction,
         ) -> Result<Self::TxRef, Self::Error> {
             Ok(TxId::from_bytes([0u8; 32]))
+        }
+
+        #[cfg(feature = "unstable")]
+        fn remove_tx(&mut self, _txid: &TxId) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn rewind_to_height(&mut self, _block_height: BlockHeight) -> Result<(), Self::Error> {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -16,6 +16,8 @@ and this library adheres to Rust's notion of
     transparent address decoding.
   - `SqliteClientError::RequestedRewindInvalid`, to report when requested
     rewinds exceed supported bounds.
+- An `unstable` feature flag; this is added to parts of the API that may change
+  in any release. It enables `zcash_client_backend`'s `unstable` feature flag.
 
 ### Changed
 - Various **BREAKING CHANGES** have been made to the database tables. These will

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -38,6 +38,7 @@ zcash_proofs = { version = "0.7", path = "../zcash_proofs" }
 mainnet = []
 test-dependencies = ["zcash_client_backend/test-dependencies"]
 transparent-inputs = ["zcash_client_backend/transparent-inputs"]
+unstable = ["zcash_client_backend/unstable"]
 
 [lib]
 bench = false

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -11,6 +11,9 @@ use zcash_primitives::consensus::BlockHeight;
 
 use crate::{NoteId, PRUNING_HEIGHT};
 
+#[cfg(feature = "unstable")]
+use zcash_primitives::transaction::TxId;
+
 /// The primary error type for the SQLite wallet backend.
 #[derive(Debug)]
 pub enum SqliteClientError {
@@ -29,6 +32,10 @@ pub enum SqliteClientError {
 
     /// Illegal attempt to reinitialize an already-initialized wallet database.
     TableNotEmpty,
+
+    /// A transaction that has already been mined was requested for removal.
+    #[cfg(feature = "unstable")]
+    TransactionIsMined(TxId),
 
     /// A Bech32-encoded key or address decoding error
     Bech32DecodeError(Bech32DecodeError),
@@ -85,6 +92,8 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::Base58(e) => write!(f, "{}", e),
             SqliteClientError::TransparentAddress(e) => write!(f, "{}", e),
             SqliteClientError::TableNotEmpty => write!(f, "Table is not empty"),
+            #[cfg(feature = "unstable")]
+            SqliteClientError::TransactionIsMined(txid) => write!(f, "Cannot remove transaction {} which has already been mined", txid),
             SqliteClientError::DbError(e) => write!(f, "{}", e),
             SqliteClientError::Io(e) => write!(f, "{}", e),
             SqliteClientError::InvalidMemo(e) => write!(f, "{}", e),


### PR DESCRIPTION
This is to replace the database mutations in the Android SDK. It is placed behind an `unstable` feature flag until we are satisfied that it is suitable as a general-purpose API (or replace it).