### PR TITLE
zcash_primitives: Make `NullifierDerivingKey` internals public

### DIFF
--- a/zcash_primitives/src/sapling.rs
+++ b/zcash_primitives/src/sapling.rs
@@ -192,7 +192,7 @@ impl ProofGenerationKey {
 
 /// A key used to derive the nullifier for a Sapling note.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct NullifierDerivingKey(pub(crate) jubjub::SubgroupPoint);
+pub struct NullifierDerivingKey(pub jubjub::SubgroupPoint);
 
 #[derive(Debug, Clone)]
 pub struct ViewingKey {


### PR DESCRIPTION
The `zcashd` Rust code relies on being able to construct the Sapling
types transparently. This part of the "public API" of the crate was
broken when the `NullifierDerivingKey` newtype was introduced. We do
want to migrate to all of these types having stronger type safety
guarantees (by only constructing them via constructors), but that should
be done consistently across the types. For now we maintain the existing
API by changing `NullifierDerivingKey` to be a transparent newtype.