### PR TITLE
Replace `get_address` with `get_current_address` and `get_next_available_address`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -32,8 +32,10 @@ and this library adheres to Rust's notion of
   - `RecipientAddress::Unified`
 - `zcash_client_backend::data_api`:
   - `WalletRead::get_unified_full_viewing_keys`
+  - `WalletRead::get_current_address`
   - `WalletRead::get_all_nullifiers`
   - `WalletWrite::remove_unmined_tx` (behind the `unstable` feature flag).
+  - `WalletWrite::get_next_available_address`
 - `zcash_client_backend::proto`:
   - `actions` field on `compact_formats::CompactTx`
   - `compact_formats::CompactOrchardAction`
@@ -79,8 +81,6 @@ and this library adheres to Rust's notion of
     a `min_confirmations` argument that is used to compute an upper bound on
     the anchor height being returned; this had previously been hardcoded to
     `data_api::wallet::ANCHOR_OFFSET`.
-  - `WalletRead::get_address` now returns a `UnifiedAddress` instead of a
-    `sapling::PaymentAddress`.
   - `WalletRead::get_spendable_notes` has been renamed to
     `get_spendable_sapling_notes`
   - `WalletRead::select_spendable_notes` has been renamed to
@@ -127,6 +127,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api`:
   - `WalletRead::get_extended_full_viewing_keys` (use
     `WalletRead::get_unified_full_viewing_keys` instead).
+  - `WalletRead::get_address` (use `WalletRead::get_current_address` or
+    `WalletWrite::get_next_available_address` instead.)
 - The hardcoded `data_api::wallet::ANCHOR_OFFSET` constant.
 - `zcash_client_backend::wallet::AccountId` (moved to `zcash_primitives::zip32::AccountId`).
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -114,12 +114,15 @@ pub trait WalletRead {
     /// or `Ok(None)` if the transaction is not mined in the main chain.
     fn get_tx_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error>;
 
-    /// Returns the unified address for the specified account, if the account
-    /// identifier specified refers to a valid account for this wallet.
+    /// Returns the most recently generated unified address for the specified account, if the
+    /// account identifier specified refers to a valid account for this wallet.
     ///
     /// This will return `Ok(None)` if the account identifier does not correspond
     /// to a known account.
-    fn get_address(&self, account: AccountId) -> Result<Option<UnifiedAddress>, Self::Error>;
+    fn get_current_address(
+        &self,
+        account: AccountId,
+    ) -> Result<Option<UnifiedAddress>, Self::Error>;
 
     /// Returns all unified full viewing keys known to this wallet.
     fn get_unified_full_viewing_keys(
@@ -265,6 +268,16 @@ pub struct SentTransactionOutput<'a> {
 /// This trait encapsulates the write capabilities required to update stored
 /// wallet data.
 pub trait WalletWrite: WalletRead {
+    /// Generates and persists the next available diversified address, given the current
+    /// addresses known to the wallet.
+    ///
+    /// Returns `Ok(None)` if the account identifier does not correspond to a known
+    /// account.
+    fn get_next_available_address(
+        &mut self,
+        account: AccountId,
+    ) -> Result<Option<UnifiedAddress>, Self::Error>;
+
     /// Updates the state of the wallet database by persisting the provided
     /// block information, along with the updated witness data that was
     /// produced when scanning the block for transactions pertaining to
@@ -282,6 +295,8 @@ pub trait WalletWrite: WalletRead {
         received_tx: &DecryptedTransaction,
     ) -> Result<Self::TxRef, Self::Error>;
 
+    /// Saves information about a transaction that was constructed and sent by the wallet to the
+    /// persistent wallet store.
     fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<Self::TxRef, Self::Error>;
 
     /// Removes the specified unmined transaction from the persistent wallet store, if it
@@ -408,7 +423,10 @@ pub mod testing {
             Ok(None)
         }
 
-        fn get_address(&self, _account: AccountId) -> Result<Option<UnifiedAddress>, Self::Error> {
+        fn get_current_address(
+            &self,
+            _account: AccountId,
+        ) -> Result<Option<UnifiedAddress>, Self::Error> {
             Ok(None)
         }
 
@@ -502,6 +520,13 @@ pub mod testing {
     }
 
     impl WalletWrite for MockWalletDb {
+        fn get_next_available_address(
+            &mut self,
+            _account: AccountId,
+        ) -> Result<Option<UnifiedAddress>, Self::Error> {
+            Ok(None)
+        }
+
         #[allow(clippy::type_complexity)]
         fn advance_by_block(
             &mut self,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -16,6 +16,8 @@ and this library adheres to Rust's notion of
     transparent address decoding.
   - `SqliteClientError::RequestedRewindInvalid`, to report when requested
     rewinds exceed supported bounds.
+  - `SqliteClientError::DiversifierIndexOutOfRange`, to report when the space
+    of available diversifier indices has been exhausted. 
 - An `unstable` feature flag; this is added to parts of the API that may change
   in any release. It enables `zcash_client_backend`'s `unstable` feature flag.
 

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -65,6 +65,10 @@ pub enum SqliteClientError {
 
     /// Wrapper for errors from zcash_client_backend
     BackendError(data_api::error::Error<NoteId>),
+
+    /// The space of allocatable diversifier indices has been exhausted for
+    /// the given account.
+    DiversifierIndexOutOfRange,
 }
 
 impl error::Error for SqliteClientError {
@@ -103,6 +107,7 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::Io(e) => write!(f, "{}", e),
             SqliteClientError::InvalidMemo(e) => write!(f, "{}", e),
             SqliteClientError::BackendError(e) => write!(f, "{}", e),
+            SqliteClientError::DiversifierIndexOutOfRange => write!(f, "The space of available diversifier indices is exhausted"),
         }
     }
 }

--- a/zcash_client_sqlite/src/prepared.rs
+++ b/zcash_client_sqlite/src/prepared.rs
@@ -15,8 +15,10 @@ use zcash_primitives::{
     merkle_tree::{CommitmentTree, IncrementalWitness},
     sapling::{Diversifier, Node, Nullifier},
     transaction::{components::Amount, TxId},
-    zip32::AccountId,
+    zip32::{AccountId, DiversifierIndex},
 };
+
+use zcash_client_backend::address::UnifiedAddress;
 
 use crate::{error::SqliteClientError, wallet::PoolType, NoteId, WalletDb};
 
@@ -64,6 +66,8 @@ pub struct DataConnStmtCache<'a, P> {
     stmt_insert_witness: Statement<'a>,
     stmt_prune_witnesses: Statement<'a>,
     stmt_update_expired: Statement<'a>,
+
+    stmt_insert_address: Statement<'a>,
 }
 
 impl<'a, P> DataConnStmtCache<'a, P> {
@@ -151,6 +155,10 @@ impl<'a, P> DataConnStmtCache<'a, P> {
                         SELECT id_tx FROM transactions
                         WHERE id_tx = received_notes.spent AND block IS NULL AND expiry_height < ?
                     )",
+                )?,
+                stmt_insert_address: wallet_db.conn.prepare(
+                    "INSERT INTO addresses (account, diversifier_index_be, address)
+                    VALUES (:account, :diversifier_index_be, :address)",
                 )?,
             }
         )
@@ -355,6 +363,27 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
         let rows = self.stmt_delete_utxos.execute_named(sql_args)?;
 
         Ok(rows)
+    }
+
+    /// Adds the given address and diversifier index to the addresses table.
+    ///
+    /// Returns the database row for the newly-inserted address.
+    pub(crate) fn stmt_insert_address(
+        &mut self,
+        account: AccountId,
+        mut diversifier_index: DiversifierIndex,
+        address: &UnifiedAddress,
+    ) -> Result<i64, SqliteClientError> {
+        diversifier_index.0.reverse();
+        let sql_args: &[(&str, &dyn ToSql)] = &[
+            (":account", &u32::from(account)),
+            (":diversifier_index_be", &&diversifier_index.0[..]),
+            (":address", &address.encode(&self.wallet_db.params)),
+        ];
+
+        self.stmt_insert_address.execute_named(sql_args)?;
+
+        Ok(self.wallet_db.conn.last_insert_rowid())
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -593,14 +593,16 @@ fn add_account_internal<P: consensus::Parameters, E: From<rusqlite::Error>>(
     )?;
 
     // Always derive the default Unified Address for the account.
-    let (address, idx) = key.default_address();
+    let (address, mut idx) = key.default_address();
     let address_str: String = address.encode(network);
+    // the diversifier index is stored in big-endian order to allow sorting
+    idx.0.reverse();
     conn.execute_named(
-        "INSERT INTO addresses (account, diversifier_index, address)
-        VALUES (:account, :diversifier_index, :address)",
+        "INSERT INTO addresses (account, diversifier_index_be, address)
+        VALUES (:account, :diversifier_index_be, :address)",
         &[
             (":account", &<u32>::from(account)),
-            (":diversifier_index", &&idx.0[..]),
+            (":diversifier_index_be", &&idx.0[..]),
             (":address", &address_str),
         ],
     )?;
@@ -716,10 +718,10 @@ mod tests {
             )",
             "CREATE TABLE addresses (
                 account INTEGER NOT NULL,
-                diversifier_index BLOB NOT NULL,
+                diversifier_index_be BLOB NOT NULL,
                 address TEXT NOT NULL,
                 FOREIGN KEY (account) REFERENCES accounts(account),
-                CONSTRAINT diversification UNIQUE (account, diversifier_index)
+                CONSTRAINT diversification UNIQUE (account, diversifier_index_be)
             )",
             "CREATE TABLE blocks (
                 height INTEGER PRIMARY KEY,

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -51,10 +51,10 @@ impl<P: consensus::Parameters> RusqliteMigration for AddressesTableMigration<P> 
         transaction.execute_batch(
             "CREATE TABLE addresses (
                 account INTEGER NOT NULL,
-                diversifier_index BLOB NOT NULL,
+                diversifier_index_be BLOB NOT NULL,
                 address TEXT NOT NULL,
                 FOREIGN KEY (account) REFERENCES accounts(account),
-                CONSTRAINT diversification UNIQUE (account, diversifier_index)
+                CONSTRAINT diversification UNIQUE (account, diversifier_index_be)
             );
             CREATE TABLE accounts_new (
                 account INTEGER PRIMARY KEY,


### PR DESCRIPTION
This updates the data access API to provide diversified address functionality. In order to support this change, the addresses table is updated to store diversifier index information in big-endian order to allow sorting by diversifier index, and account initialization is updated to store the diversifier index accordingly. The currently unreleased `addresses_table` migration is updated to reflect this change.