### PR TITLE
zcash_client_backend: Add tags to IVKs in the batch scanner

### DIFF
--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -232,10 +232,12 @@ where
 
     let mut batch_runner = BatchRunner::new(
         100,
-        dfvks
-            .iter()
-            .flat_map(|(_, dfvk)| [dfvk.to_ivk(Scope::External), dfvk.to_ivk(Scope::Internal)])
-            .collect(),
+        dfvks.iter().flat_map(|(account, dfvk)| {
+            [
+                ((**account, Scope::External), dfvk.to_ivk(Scope::External)),
+                ((**account, Scope::Internal), dfvk.to_ivk(Scope::Internal)),
+            ]
+        }),
     );
 
     cache.with_blocks(last_height, limit, |block: CompactBlock| {

--- a/zcash_client_backend/src/scan.rs
+++ b/zcash_client_backend/src/scan.rs
@@ -42,6 +42,7 @@ struct OutputIndex<V> {
 }
 
 type OutputReplier<A, D> = OutputIndex<channel::Sender<OutputIndex<Option<DecryptedNote<A, D>>>>>;
+type OutputResult<A, D> = channel::Receiver<OutputIndex<Option<DecryptedNote<A, D>>>>;
 
 /// A batch of outputs to trial decrypt.
 struct Batch<A, D: BatchDomain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>> {
@@ -130,8 +131,7 @@ type ResultKey = (BlockHash, TxId);
 pub(crate) struct BatchRunner<A, D: BatchDomain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>> {
     batch_size_threshold: usize,
     acc: Batch<A, D, Output>,
-    pending_results:
-        HashMap<ResultKey, channel::Receiver<OutputIndex<Option<DecryptedNote<A, D>>>>>,
+    pending_results: HashMap<ResultKey, OutputResult<A, D>>,
 }
 
 impl<A, D, Output> BatchRunner<A, D, Output>

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -177,10 +177,13 @@ pub fn scan_block<P: consensus::Parameters + Send + 'static, K: ScanningKey>(
     )
 }
 
+type TaggedBatchRunner<P, S> =
+    BatchRunner<(AccountId, S), SaplingDomain<P>, CompactOutputDescription>;
+
 pub(crate) fn add_block_to_runner<P, S>(
     params: &P,
     block: CompactBlock,
-    batch_runner: &mut BatchRunner<(AccountId, S), SaplingDomain<P>, CompactOutputDescription>,
+    batch_runner: &mut TaggedBatchRunner<P, S>,
 ) where
     P: consensus::Parameters + Send + 'static,
     S: Clone + Send + 'static,
@@ -215,9 +218,7 @@ pub(crate) fn scan_block_with_runner<P: consensus::Parameters + Send + 'static, 
     nullifiers: &[(AccountId, Nullifier)],
     tree: &mut CommitmentTree<Node>,
     existing_witnesses: &mut [&mut IncrementalWitness<Node>],
-    mut batch_runner: Option<
-        &mut BatchRunner<(AccountId, K::Scope), SaplingDomain<P>, CompactOutputDescription>,
-    >,
+    mut batch_runner: Option<&mut TaggedBatchRunner<P, K::Scope>>,
 ) -> Vec<WalletTx<K::Nf>> {
     let mut wtxs: Vec<WalletTx<K::Nf>> = vec![];
     let block_height = block.height();

--- a/zcash_primitives/src/sapling/keys.rs
+++ b/zcash_primitives/src/sapling/keys.rs
@@ -191,7 +191,7 @@ impl FullViewingKey {
 /// to other people. For example, a user can give an external [`SaplingIvk`] to a merchant
 /// terminal, enabling it to only detect "real" transactions from customers and not
 /// internal transactions from the wallet.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Scope {
     /// A scope used for wallet-external operations, namely deriving addresses to give to
     /// other users in order to receive funds.


### PR DESCRIPTION
This removes the dependency on `SaplingIvk::to_repr()`, and enables us to alter the type of `D::IncomingViewingKey` to improve the performance of batch scanning.

For the welding rig, we already annotate the viewing keys with `AccountId`, so we use `(AccountId, Scope)` as the tag.