### PR TITLE
Add `encrypt-to-recipient` feature to `zcash_note_encryption`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ members = [
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+[patch.crates-io]
+zcash_encoding = { path = "components/zcash_encoding" }
+zcash_note_encryption = { path = "components/zcash_note_encryption" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "082c8de59c666c2361b70aba0c4429c96c6c5b16" }

--- a/components/zcash_note_encryption/CHANGELOG.md
+++ b/components/zcash_note_encryption/CHANGELOG.md
@@ -33,7 +33,7 @@ and this library adheres to Rust's notion of
   - `Domain::prepare_epk` method, which produces the above type.
 - Feature `encrypt-to-recipient`, which allows the encryption of an arbitrary
   payload decryptable by the recipient of a shielded note. This adds the
-  following trats and functions:
+  following traits and functions:
   - `PayloadEncryptionDomain`
   - `decrypt_associated_ciphertext_ivk`
   - `decrypt_associated_ciphertext_ovk`

--- a/components/zcash_note_encryption/CHANGELOG.md
+++ b/components/zcash_note_encryption/CHANGELOG.md
@@ -31,6 +31,16 @@ and this library adheres to Rust's notion of
 - `zcash_note_encryption::Domain`:
   - `Domain::PreparedEphemeralPublicKey` associated type.
   - `Domain::prepare_epk` method, which produces the above type.
+- Feature `encrypt-to-recipient`, which allows the encryption of an arbitrary
+  payload decryptable by the recipient of a shielded note. This adds the
+  following trats and functions:
+  - `PayloadEncryptionDomain`
+  - `decrypt_associated_ciphertext_ivk`
+  - `decrypt_associated_ciphertext_ovk`
+- A new `KeyedOutput` supertrait for `zcash_note_encryption::ShieldedOutput`
+- A new `RecoverableOutput` subtrait for `zcash_note_encryption::ShieldedOutput`,
+  which is used to simplify the type signatures of `try_output_recovery_with_ock`
+  and `try_output_recovery_with_ovk`.
 
 ### Changed
 - MSRV is now 1.56.1.
@@ -45,6 +55,17 @@ and this library adheres to Rust's notion of
     decryption results of the same length and in the same order as the `outputs`
     argument to the function. Each successful result includes the index of the
     entry in `ivks` used to decrypt the value.
+- Changes to the `zcash_note_encryption::ShieldedOutput` trait:
+  - The `ephemeral_key` and `cmstar_bytes` method have been moved into
+    a `KeyedOutput` supertrait of `ShieldedOutput`, for use in methods that
+    do not require the `enc_ciphertext` capability, such as
+    `decrypt_associated_ciphertext_ivk`.
+- The signatures of `try_output_recovery_with_ovk` and
+  `try_output_recovery_with_ock` have been changed to no longer take `cv` and
+  `out_ciphertext` parameters; instead, the output passed to these functions
+  must implement the `RecoverableOutput` trait. This ensures that the value
+  commitment and `out_ciphertext` values must correspond to the output being
+  decrypted, and simplifies the API.
 
 ## [0.1.0] - 2021-12-17
 Initial release.

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+aead = { version = "0.5.1", default-features = false }
 cipher = { version = "0.4", default-features = false }
 chacha20 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
@@ -29,6 +30,7 @@ subtle = { version = "2.3", default-features = false }
 default = ["alloc"]
 alloc = []
 pre-zip-212 = []
+encrypt-to-recipient = ["alloc", "aead/alloc", "aead/rand_core"]
 
 [lib]
 bench = false

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -331,7 +331,7 @@ pub trait PayloadEncryptionDomain: Domain {
     /// Derives a `SymmetricKey` used to encrypt the an arbitrary payload distinct from the note
     /// plaintext.
     ///
-    /// This method provides the ability to use arbitrary personalization for the derivation of the
+    /// This method provides the ability to use personalization for the derivation of the
     /// secret key, so as to provide domain separation of the symmetric key when encrypting a
     /// payload to be readable by the recipient of a shielded note.
     ///

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -316,7 +316,7 @@ pub trait BatchDomain: Domain {
 
 /// An extension to the `Domain` trait that provides symmetric key derivation in a similar
 /// fashion to [`Domain::kdf`], but which allows the user to provide additional domain separation
-/// to the key derivation function. This is used in [`NoteEncryption::encrypt_to_note_recipient`] 
+/// to the key derivation function. This is used in [`NoteEncryption::encrypt_to_note_recipient`]
 /// to allow senders to encrypt an arbitrary payload such that it will be decryptable by the
 /// recipient of a shielded note while avoiding potential issues of key reuse.
 ///

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -89,7 +89,7 @@ use std::convert::Infallible;
 use zcash_primitives::{
     block::BlockHash,
     consensus::{self, BlockHeight},
-    sapling::{self, note_encryption::PreparedIncomingViewingKey, Nullifier},
+    sapling::{self, keys::PreparedIncomingViewingKey, Nullifier},
     zip32::Scope,
 };
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -5,10 +5,7 @@ use zcash_primitives::{
     consensus::{self, NetworkUpgrade},
     memo::MemoBytes,
     sapling::{
-        self,
-        note_encryption::{try_sapling_note_decryption, PreparedIncomingViewingKey},
-        prover::TxProver as SaplingProver,
-        Node,
+        self, note_encryption::try_sapling_note_decryption, prover::TxProver as SaplingProver, Node,
     },
     transaction::{
         builder::Builder,
@@ -562,7 +559,8 @@ where
     // Build the transaction with the specified fee rule
     let (tx, sapling_build_meta) = builder.build(&prover, proposal.fee_rule())?;
 
-    let internal_ivk = PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::Internal));
+    let internal_ivk =
+        sapling::keys::PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::Internal));
     let sapling_outputs =
         sapling_output_meta
             .into_iter()

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -5,9 +5,8 @@ use zcash_primitives::{
     memo::MemoBytes,
     sapling::{
         self,
-        note_encryption::{
-            try_sapling_note_decryption, try_sapling_output_recovery, PreparedIncomingViewingKey,
-        },
+        keys::PreparedIncomingViewingKey,
+        note_encryption::{try_sapling_note_decryption, try_sapling_output_recovery},
     },
     transaction::Transaction,
     zip32::{AccountId, Scope},

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -8,9 +8,8 @@ use zcash_note_encryption::batch;
 use zcash_primitives::{
     consensus,
     sapling::{
-        self,
-        note_encryption::{PreparedIncomingViewingKey, SaplingDomain},
-        Node, Note, Nullifier, NullifierDerivingKey, SaplingIvk,
+        self, keys::PreparedIncomingViewingKey, note_encryption::SaplingDomain, Node, Note,
+        Nullifier, NullifierDerivingKey, SaplingIvk,
     },
     transaction::components::sapling::CompactOutputDescription,
     zip32::{sapling::DiversifiableFullViewingKey, AccountId, Scope},
@@ -396,7 +395,8 @@ mod tests {
         constants::SPENDING_KEY_GENERATOR,
         memo::MemoBytes,
         sapling::{
-            note_encryption::{sapling_note_encryption, PreparedIncomingViewingKey, SaplingDomain},
+            keys::PreparedIncomingViewingKey,
+            note_encryption::{sapling_note_encryption, SaplingDomain},
             util::generate_random_rseed,
             value::NoteValue,
             CommitmentTree, Note, Nullifier, SaplingIvk,

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- Support for the `encrypt-to-recipient` feature for Sapling outputs.
+
 ## [0.12.0] - 2023-06-06
 ### Added
 - `zcash_primitives::transaction`:

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -104,6 +104,7 @@ transparent-inputs = ["hdwallet", "ripemd", "secp256k1"]
 temporary-zcashd = []
 test-dependencies = ["proptest", "orchard/test-dependencies"]
 zfuture = []
+encrypt-to-recipient = ["zcash_note_encryption/encrypt-to-recipient"]
 
 [lib]
 bench = false

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -440,7 +440,7 @@ pub struct OutputDescription<Proof> {
     cv: ValueCommitment,
     cmu: ExtractedNoteCommitment,
     ephemeral_key: EphemeralKeyBytes,
-    enc_ciphertext: [u8; 580],
+    enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
     out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
     zkproof: Proof,
 }
@@ -461,7 +461,7 @@ impl<Proof> OutputDescription<Proof> {
     }
 
     /// Returns the encrypted note ciphertext.
-    pub fn enc_ciphertext(&self) -> &[u8; 580] {
+    pub fn enc_ciphertext(&self) -> &[u8; ENC_CIPHERTEXT_SIZE] {
         &self.enc_ciphertext
     }
 
@@ -499,7 +499,7 @@ impl<Proof> OutputDescription<Proof> {
         cv: ValueCommitment,
         cmu: ExtractedNoteCommitment,
         ephemeral_key: EphemeralKeyBytes,
-        enc_ciphertext: [u8; 580],
+        enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
         out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
         zkproof: Proof,
     ) -> Self {
@@ -525,7 +525,7 @@ impl<Proof> OutputDescription<Proof> {
     pub(crate) fn ephemeral_key_mut(&mut self) -> &mut EphemeralKeyBytes {
         &mut self.ephemeral_key
     }
-    pub(crate) fn enc_ciphertext_mut(&mut self) -> &mut [u8; 580] {
+    pub(crate) fn enc_ciphertext_mut(&mut self) -> &mut [u8; ENC_CIPHERTEXT_SIZE] {
         &mut self.enc_ciphertext
     }
     pub(crate) fn out_ciphertext_mut(&mut self) -> &mut [u8; OUT_CIPHERTEXT_SIZE] {
@@ -600,7 +600,7 @@ impl OutputDescription<GrothProofBytes> {
         let mut ephemeral_key = EphemeralKeyBytes([0u8; 32]);
         reader.read_exact(&mut ephemeral_key.0)?;
 
-        let mut enc_ciphertext = [0u8; 580];
+        let mut enc_ciphertext = [0u8; ENC_CIPHERTEXT_SIZE];
         let mut out_ciphertext = [0u8; OUT_CIPHERTEXT_SIZE];
         reader.read_exact(&mut enc_ciphertext)?;
         reader.read_exact(&mut out_ciphertext)?;
@@ -640,7 +640,7 @@ pub struct OutputDescriptionV5 {
     cv: ValueCommitment,
     cmu: ExtractedNoteCommitment,
     ephemeral_key: EphemeralKeyBytes,
-    enc_ciphertext: [u8; 580],
+    enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
     out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
 }
 
@@ -657,7 +657,7 @@ impl OutputDescriptionV5 {
         let mut ephemeral_key = EphemeralKeyBytes([0u8; 32]);
         reader.read_exact(&mut ephemeral_key.0)?;
 
-        let mut enc_ciphertext = [0u8; 580];
+        let mut enc_ciphertext = [0u8; ENC_CIPHERTEXT_SIZE];
         let mut out_ciphertext = [0u8; OUT_CIPHERTEXT_SIZE];
         reader.read_exact(&mut enc_ciphertext)?;
         reader.read_exact(&mut out_ciphertext)?;
@@ -730,7 +730,7 @@ pub mod testing {
     use proptest::collection::vec;
     use proptest::prelude::*;
     use rand::{rngs::StdRng, SeedableRng};
-    use zcash_note_encryption::OUT_CIPHERTEXT_SIZE;
+    use zcash_note_encryption::{ENC_CIPHERTEXT_SIZE, OUT_CIPHERTEXT_SIZE};
 
     use crate::{
         constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
@@ -799,8 +799,8 @@ pub mod testing {
             cmu in vec(any::<u8>(), 64)
                 .prop_map(|v| <[u8;64]>::try_from(v.as_slice()).unwrap())
                 .prop_map(|v| bls12_381::Scalar::from_bytes_wide(&v)),
-            enc_ciphertext in vec(any::<u8>(), 580)
-                .prop_map(|v| <[u8;580]>::try_from(v.as_slice()).unwrap()),
+            enc_ciphertext in vec(any::<u8>(), ENC_CIPHERTEXT_SIZE)
+                .prop_map(|v| <[u8;ENC_CIPHERTEXT_SIZE]>::try_from(v.as_slice()).unwrap()),
             epk in arb_extended_point(),
             out_ciphertext in vec(any::<u8>(), OUT_CIPHERTEXT_SIZE)
                 .prop_map(|v| <[u8;OUT_CIPHERTEXT_SIZE]>::try_from(v.as_slice()).unwrap()),


### PR DESCRIPTION
This adds a feature that provides the ability to encrypt an arbitrary payload such that it may be decrypted by both the recipient of a particular Zcash note and the holder of an OVK that can decrypt that note, if any such OVK exists.