### PR TITLE
Update chacha20poly1305 dependency in zcash_primitives to 0.10

### DIFF
--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -26,7 +26,7 @@ blake2s_simd = "1"
 bls12_381 = "0.7"
 bs58 = { version = "0.4", features = ["check"], optional = true }
 byteorder = "1"
-chacha20poly1305 = "0.9"
+chacha20poly1305 = "0.10"
 equihash = { version = "0.2", path = "../components/equihash" }
 ff = "0.12"
 fpe = "0.5"

--- a/zcash_primitives/src/sapling/note_encryption.rs
+++ b/zcash_primitives/src/sapling/note_encryption.rs
@@ -542,7 +542,7 @@ pub fn try_sapling_output_recovery<P: consensus::Parameters>(
 #[cfg(test)]
 mod tests {
     use chacha20poly1305::{
-        aead::{AeadInPlace, NewAead},
+        aead::{AeadInPlace, KeyInit},
         ChaCha20Poly1305,
     };
     use ff::{Field, PrimeField};


### PR DESCRIPTION
This makes it consistent with zcash_note_encryption. fixes #650