### PR TITLE
Track inputs sent to wallet-internal recipients

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -31,6 +31,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::address`:
   - `RecipientAddress::Unified`
 - `zcash_client_backend::data_api`:
+  - `Recipient`
+  - `SentTransactionOutput`
   - `WalletRead::get_unified_full_viewing_keys`
   - `WalletRead::get_current_address`
   - `WalletRead::get_all_nullifiers`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -31,6 +31,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::address`:
   - `RecipientAddress::Unified`
 - `zcash_client_backend::data_api`:
+  - `PoolType`
   - `Recipient`
   - `SentTransactionOutput`
   - `WalletRead::get_unified_full_viewing_keys`
@@ -39,6 +40,8 @@ and this library adheres to Rust's notion of
   - `WalletWrite::create_account`
   - `WalletWrite::remove_unmined_tx` (behind the `unstable` feature flag).
   - `WalletWrite::get_next_available_address`
+- `zcash_client_backend::decrypt`:
+  - `TransferType`
 - `zcash_client_backend::proto`:
   - `actions` field on `compact_formats::CompactTx`
   - `compact_formats::CompactOrchardAction`
@@ -46,7 +49,10 @@ and this library adheres to Rust's notion of
   - `TransactionRequest::new` for constructing a request from `Vec<Payment>`.
   - `TransactionRequest::payments` for accessing the `Payments` that make up a
     request.
-- `zcash_client_backend::encoding::KeyError` 
+- `zcash_client_backend::encoding`
+  - `KeyError`
+  - `AddressCodec` implementations for `sapling::PaymentAddress` and
+    `UnifiedAddress`
 - New experimental APIs that should be considered unstable, and are
   likely to be modified and/or moved to a different module in a future
   release:

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -248,13 +248,19 @@ pub struct SentTransaction<'a> {
     pub tx: &'a Transaction,
     pub created: time::OffsetDateTime,
     pub account: AccountId,
-    pub outputs: Vec<SentTransactionOutput<'a>>,
+    pub outputs: Vec<SentTransactionOutput>,
     pub fee_amount: Amount,
     #[cfg(feature = "transparent-inputs")]
     pub utxos_spent: Vec<OutPoint>,
 }
 
-pub struct SentTransactionOutput<'a> {
+#[derive(Debug, Clone)]
+pub enum Recipient {
+    Address(RecipientAddress),
+    InternalAccount(AccountId),
+}
+
+pub struct SentTransactionOutput {
     /// The index within the transaction that contains the recipient output.
     ///
     /// - If `recipient_address` is a Sapling address, this is an index into the Sapling
@@ -262,7 +268,7 @@ pub struct SentTransactionOutput<'a> {
     /// - If `recipient_address` is a transparent address, this is an index into the
     ///   transparent outputs of the transaction.
     pub output_index: usize,
-    pub recipient_address: &'a RecipientAddress,
+    pub recipient: Recipient,
     pub value: Amount,
     pub memo: Option<MemoBytes>,
 }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -255,12 +255,24 @@ pub struct SentTransaction<'a> {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Recipient {
     Address(RecipientAddress),
     InternalAccount(AccountId),
 }
 
+/// A value pool to which the wallet supports sending transaction outputs.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PoolType {
+    /// The transparent value pool
+    Transparent,
+    /// The Sapling value pool
+    Sapling,
+}
+
 pub struct SentTransactionOutput {
+    /// The value in which the output has been created
+    pub output_pool: PoolType,
     /// The index within the transaction that contains the recipient output.
     ///
     /// - If `recipient_address` is a Sapling address, this is an index into the Sapling
@@ -268,8 +280,12 @@ pub struct SentTransactionOutput {
     /// - If `recipient_address` is a transparent address, this is an index into the
     ///   transparent outputs of the transaction.
     pub output_index: usize,
+    /// The recipient address of the transaction, or the account
+    /// id for wallet-internal transactions.
     pub recipient: Recipient,
+    /// The value of the newly created output
     pub value: Amount,
+    /// The memo that was attached to the output, if any
     pub memo: Option<MemoBytes>,
 }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -376,13 +376,13 @@ where
     let sent_outputs = request.payments().iter().enumerate().map(|(i, payment)| {
         let (output_index, recipient) = match &payment.recipient_address {
             // Sapling outputs are shuffled, so we need to look up where the output ended up.
-            // TODO: When we add Orchard support, we will need to trial-decrypt to find them,
-            // and return the appropriate pool type.
             RecipientAddress::Shielded(addr) => {
                 let idx = tx_metadata.output_index(i).expect("An output should exist in the transaction for each shielded payment.");
                 (idx, Recipient::Sapling(addr.clone()))
             }
             RecipientAddress::Unified(addr) => {
+                // TODO: When we add Orchard support, we will need to trial-decrypt to find them,
+                // and return the appropriate pool type.
                 let idx = tx_metadata.output_index(i).expect("An output should exist in the transaction for each shielded payment.");
                 (idx, Recipient::Unified(addr.clone(), PoolType::Sapling))
             }

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -18,11 +18,14 @@ use crate::keys::UnifiedFullViewingKey;
 /// An enumeration of the possible relationships a TXO can have to the wallet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TransferType {
-    /// The transfer was received on one of the wallet's external addresses.
+    /// The output was received on one of the wallet's external addresses via decryption using the
+    /// associated incoming viewing key, or at one of the wallet's transparent addresses.
     Incoming,
-    /// The transfer was received on one of the wallet's internal-only addresses.
+    /// The output was received on one of the wallet's internal-only shielded addresses via trial
+    /// decryption using one of the wallet's internal incoming viewing keys.
     WalletInternal,
-    /// The transfer was decrypted using one of the wallet's outgoing viewing keys.
+    /// The output was decrypted using one of the wallet's outgoing viewing keys, or was created
+    /// in a transaction constructed by this wallet.
     Outgoing,
 }
 

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -19,4 +19,4 @@ pub mod wallet;
 pub mod welding_rig;
 pub mod zip321;
 
-pub use decrypt::{decrypt_transaction, DecryptedOutput};
+pub use decrypt::{decrypt_transaction, DecryptedOutput, TransferType};

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -89,12 +89,15 @@ and this library adheres to Rust's notion of
   migration process.
 
 ### Removed
-- `zcash_client_sqlite::wallet`:
-  - `get_extended_full_viewing_keys` (use
-    `zcash_client_backend::data_api::WalletRead::get_unified_full_viewing_keys`
-    instead).
-  - `delete_utxos_above` (use
-    `zcash_client_backend::data_api::WalletWrite::rewind_to_height` instead)
+- The following functions have been removed from the public interface of
+  `zcash_client_sqlite::wallet`. Prefer methods defined on 
+  `zcash_client_backend::data_api::{WalletRead, WalletWrite}` instead.
+  - `get_extended_full_viewing_keys` (use `WalletRead::get_unified_full_viewing_keys` instead).
+  - `insert_sent_note` (use `WalletWrite::store_sent_tx` instead)
+  - `insert_sent_utxo` (use `WalletWrite::store_sent_tx` instead)
+  - `put_sent_note` (use `WalletWrite::store_decrypted_tx` instead)
+  - `put_sent_utxo` (use `WalletWrite::store_decrypted_tx` instead)
+  - `delete_utxos_above` (use `WalletWrite::rewind_to_height` instead)
 - `zcash_client_sqlite::with_blocks` (use
   `zcash_client_backend::data_api::BlockSource::with_blocks` instead)
 
@@ -131,7 +134,6 @@ and this library adheres to Rust's notion of
     - `insert_witness`
     - `prune_witnesses`
     - `update_expired_notes`
-    - `put_sent_note`
     - `put_sent_utxo`
     - `insert_sent_note`
     - `insert_sent_utxo`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -90,7 +90,7 @@ and this library adheres to Rust's notion of
 
 ### Removed
 - The following functions have been removed from the public interface of
-  `zcash_client_sqlite::wallet`. Prefer methods defined on 
+  `zcash_client_sqlite::wallet`. Prefer methods defined on
   `zcash_client_backend::data_api::{WalletRead, WalletWrite}` instead.
   - `get_extended_full_viewing_keys` (use `WalletRead::get_unified_full_viewing_keys` instead).
   - `insert_sent_note` (use `WalletWrite::store_sent_tx` instead)

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -76,11 +76,6 @@ and this library adheres to Rust's notion of
   - `zcash_client_sqlite::wallet`:
     - `get_spendable_notes` to `get_spendable_sapling_notes`.
     - `select_spendable_notes` to `select_spendable_sapling_notes`.
-- Altered the arguments to `zcash_client_sqlite::wallet::put_sent_note`
-  to take the components of a `DecryptedOutput` value to allow this
-  method to be used in contexts where a transaction has just been
-  constructed, rather than only in the case that a transaction has
-  been decrypted after being retrieved from the network.
 - `zcash_client_sqlite::wallet::init_wallet_db` has been modified to
   take the wallet seed as an argument so that it can correctly perform
   migrations that require re-deriving key material. In particular for
@@ -114,7 +109,6 @@ and this library adheres to Rust's notion of
   `zcash_client_backend::data_api` traits mentioned above instead.
   - Deprecated in `zcash_client_sqlite::wallet`:
     - `get_address`
-    - `get_extended_full_viewing_keys`
     - `is_valid_account_extfvk`
     - `get_balance`
     - `get_balance_at`
@@ -134,9 +128,6 @@ and this library adheres to Rust's notion of
     - `insert_witness`
     - `prune_witnesses`
     - `update_expired_notes`
-    - `put_sent_utxo`
-    - `insert_sent_note`
-    - `insert_sent_utxo`
     - `get_address`
   - Deprecated in `zcash_client_sqlite::wallet::transact`:
     - `get_spendable_sapling_notes`

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -545,8 +545,9 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
                             tx_ref,
                             output.index,
                             &recipient,
-                            Amount::from_u64(output.note.value).unwrap(),
-                            Some(&output.memo)
+                            Amount::from_u64(output.note.value).map_err(|_|
+                                SqliteClientError::CorruptedData("Note value is not a valid Zcash amount.".to_string()))?,
+                            Some(&output.memo),
                         )?;
                     }
                     TransferType::Incoming => {

--- a/zcash_client_sqlite/src/prepared.rs
+++ b/zcash_client_sqlite/src/prepared.rs
@@ -358,6 +358,8 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
     ///
     /// `output_index` is the index within the transaction that contains the recipient output:
     ///
+    /// - If `to` is a Unified address, this is an index into the outputs of the transaction
+    ///   within the bundle associated with the recipient's output pool.
     /// - If `to` is a Sapling address, this is an index into the Sapling outputs of the
     ///   transaction.
     /// - If `to` is a transparent address, this is an index into the transparent outputs of

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1154,7 +1154,6 @@ pub(crate) fn insert_sent_output<'a, P: consensus::Parameters>(
 ) -> Result<(), SqliteClientError> {
     stmts.stmt_insert_sent_output(
         tx_ref,
-        output.output_pool,
         output.output_index,
         from_account,
         &output.recipient,
@@ -1171,24 +1170,14 @@ pub(crate) fn put_sent_output<'a, P: consensus::Parameters>(
     stmts: &mut DataConnStmtCache<'a, P>,
     from_account: AccountId,
     tx_ref: i64,
-    output_pool: PoolType,
     output_index: usize,
     recipient: &Recipient,
     value: Amount,
     memo: Option<&MemoBytes>,
 ) -> Result<(), SqliteClientError> {
-    if !stmts.stmt_update_sent_output(
-        from_account,
-        recipient,
-        value,
-        memo,
-        tx_ref,
-        output_pool,
-        output_index,
-    )? {
+    if !stmts.stmt_update_sent_output(from_account, recipient, value, memo, tx_ref, output_index)? {
         stmts.stmt_insert_sent_output(
             tx_ref,
-            output_pool,
             output_index,
             from_account,
             recipient,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -27,15 +27,13 @@ use zcash_primitives::{
 
 use zcash_client_backend::{
     address::{RecipientAddress, UnifiedAddress},
-    data_api::{error::Error, Recipient},
+    data_api::{error::Error, PoolType, Recipient, SentTransactionOutput},
     keys::UnifiedFullViewingKey,
     wallet::{WalletShieldedOutput, WalletTx},
     DecryptedOutput,
 };
 
 use crate::{error::SqliteClientError, DataConnStmtCache, NoteId, WalletDb, PRUNING_HEIGHT};
-
-use zcash_primitives::legacy::TransparentAddress;
 
 #[cfg(feature = "transparent-inputs")]
 use {
@@ -44,7 +42,7 @@ use {
     std::collections::HashSet,
     zcash_client_backend::{encoding::AddressCodec, wallet::WalletTransparentOutput},
     zcash_primitives::{
-        legacy::{keys::IncomingViewingKey, Script},
+        legacy::{keys::IncomingViewingKey, Script, TransparentAddress},
         transaction::components::{OutPoint, TxOut},
     },
 };
@@ -52,20 +50,13 @@ use {
 pub mod init;
 pub mod transact;
 
-pub(crate) enum PoolType {
-    Transparent,
-    Sapling,
-}
-
-impl PoolType {
-    pub(crate) fn typecode(&self) -> i64 {
-        // These constants are *incidentally* shared with the typecodes
-        // for unified addresses, but this is exclusively an internal
-        // implementation detail.
-        match self {
-            PoolType::Transparent => 0i64,
-            PoolType::Sapling => 2i64,
-        }
+pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
+    // These constants are *incidentally* shared with the typecodes
+    // for unified addresses, but this is exclusively an internal
+    // implementation detail.
+    match pool_type {
+        PoolType::Transparent => 0i64,
+        PoolType::Sapling => 2i64,
     }
 }
 
@@ -1152,121 +1143,61 @@ pub fn update_expired_notes<P>(
     stmts.stmt_update_expired(height)
 }
 
-/// Records information about a note that your wallet created.
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletWrite::store_decrypted_tx instead."
-)]
-#[allow(deprecated)]
-pub fn put_sent_note<'a, P: consensus::Parameters>(
+/// Records information about a transaction output that your wallet created.
+///
+/// This is a crate-internal convenience method.
+pub(crate) fn insert_sent_output<'a, P: consensus::Parameters>(
     stmts: &mut DataConnStmtCache<'a, P>,
     tx_ref: i64,
-    output_index: usize,
-    account: AccountId,
-    to: &Recipient,
-    value: Amount,
-    memo: Option<&MemoBytes>,
-) -> Result<(), SqliteClientError> {
-    // Try updating an existing sent note.
-    if !stmts.stmt_update_sent_note(
-        account,
-        to,
-        value,
-        memo,
-        tx_ref,
-        PoolType::Sapling,
-        output_index,
-    )? {
-        // It isn't there, so insert.
-        insert_sent_note(stmts, tx_ref, output_index, account, to, value, memo)?
-    }
-
-    Ok(())
-}
-
-/// Adds information about a sent transparent UTXO to the database if it does not already
-/// exist, or updates it if a record for the UTXO already exists.
-///
-/// `output_index` is the index within transparent UTXOs of the transaction that contains the recipient output.
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletWrite::store_decrypted_tx instead."
-)]
-#[allow(deprecated)]
-pub fn put_sent_utxo<'a, P: consensus::Parameters>(
-    stmts: &mut DataConnStmtCache<'a, P>,
-    tx_ref: i64,
-    output_index: usize,
-    account: AccountId,
-    to: &TransparentAddress,
-    value: Amount,
-) -> Result<(), SqliteClientError> {
-    // Try updating an existing sent UTXO.
-    if !stmts.stmt_update_sent_note(
-        account,
-        &Recipient::Address(RecipientAddress::Transparent(*to)),
-        value,
-        None,
-        tx_ref,
-        PoolType::Transparent,
-        output_index,
-    )? {
-        // It isn't there, so insert.
-        insert_sent_utxo(stmts, tx_ref, output_index, account, to, value)?
-    }
-
-    Ok(())
-}
-
-/// Inserts a sent note into the wallet database.
-///
-/// `output_index` is the index within the transaction that contains the recipient output:
-///
-/// - If `to` is a Sapling address, this is an index into the Sapling outputs of the
-///   transaction.
-/// - If `to` is a transparent address, this is an index into the transparent outputs of
-///   the transaction.
-pub(crate) fn insert_sent_note<'a, P: consensus::Parameters>(
-    stmts: &mut DataConnStmtCache<'a, P>,
-    tx_ref: i64,
-    output_index: usize,
     from_account: AccountId,
-    to: &Recipient,
-    value: Amount,
-    memo: Option<&MemoBytes>,
+    output: &SentTransactionOutput,
 ) -> Result<(), SqliteClientError> {
-    stmts.stmt_insert_sent_note(
+    stmts.stmt_insert_sent_output(
         tx_ref,
-        PoolType::Sapling,
-        output_index,
+        output.output_pool,
+        output.output_index,
         from_account,
-        to,
-        value,
-        memo,
+        &output.recipient,
+        output.value,
+        output.memo.as_ref(),
     )
 }
 
-/// Inserts information about a sent transparent UTXO into the wallet database.
+/// Records information about a transaction output that your wallet created.
 ///
-/// `output_index` is the index within transparent UTXOs of the transaction that contains the recipient output.
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletWrite::store_sent_tx instead."
-)]
-pub fn insert_sent_utxo<'a, P: consensus::Parameters>(
+/// This is a crate-internal convenience method.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn put_sent_output<'a, P: consensus::Parameters>(
     stmts: &mut DataConnStmtCache<'a, P>,
+    from_account: AccountId,
     tx_ref: i64,
+    output_pool: PoolType,
     output_index: usize,
-    account: AccountId,
-    to: &TransparentAddress,
+    recipient: &Recipient,
     value: Amount,
+    memo: Option<&MemoBytes>,
 ) -> Result<(), SqliteClientError> {
-    stmts.stmt_insert_sent_note(
-        tx_ref,
-        PoolType::Transparent,
-        output_index,
-        account,
-        &Recipient::Address(RecipientAddress::Transparent(*to)),
+    if !stmts.stmt_update_sent_output(
+        from_account,
+        recipient,
         value,
-        None,
-    )
+        memo,
+        tx_ref,
+        output_pool,
+        output_index,
+    )? {
+        stmts.stmt_insert_sent_output(
+            tx_ref,
+            output_pool,
+            output_index,
+            from_account,
+            recipient,
+            value,
+            memo,
+        )?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -392,8 +392,7 @@ mod tests {
                 FOREIGN KEY (to_account) REFERENCES accounts(account),
                 CONSTRAINT tx_output UNIQUE (tx, output_pool, output_index),
                 CONSTRAINT note_recipient CHECK (
-                    (to_address IS NOT NULL OR to_account IS NOT NULL)
-                    AND NOT (to_address IS NOT NULL AND to_account IS NOT NULL)
+                    (to_address IS NOT NULL) != (to_account IS NOT NULL)
                 )
             )",
             "CREATE TABLE transactions (

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -127,7 +127,7 @@ fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
     wdb.conn
         .execute_batch(
             "PRAGMA foreign_keys = OFF;
-                        PRAGMA legacy_alter_table = TRUE;",
+             PRAGMA legacy_alter_table = TRUE;",
         )
         .map_err(|e| MigratorError::Adapter(WalletMigrationError::from(e)))?;
     let adapter = RusqliteAdapter::new(&mut wdb.conn, Some("schemer_migrations".to_string()));

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -309,14 +309,17 @@ mod tests {
     use crate::{
         error::SqliteClientError,
         tests::{self, network},
-        wallet::{get_address, pool_code},
+        wallet::get_address,
         AccountId, WalletDb,
     };
 
     use super::{init_accounts_table, init_blocks_table, init_wallet_db};
 
     #[cfg(feature = "transparent-inputs")]
-    use {crate::wallet::PoolType, zcash_primitives::legacy::keys as transparent};
+    use {
+        crate::wallet::{pool_code, PoolType},
+        zcash_primitives::legacy::keys as transparent,
+    };
 
     #[test]
     fn verify_schema() {

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -2,6 +2,7 @@ mod add_transaction_views;
 mod add_utxo_account;
 mod addresses_table;
 mod initial_setup;
+mod sent_notes_to_internal;
 mod ufvk_support;
 mod utxos_table;
 
@@ -31,5 +32,6 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         Box::new(add_utxo_account::Migration {
             _params: params.clone(),
         }),
+        Box::new(sent_notes_to_internal::Migration {}),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
@@ -60,8 +60,7 @@ impl RusqliteMigration for Migration {
                 FOREIGN KEY (to_account) REFERENCES accounts(account),
                 CONSTRAINT tx_output UNIQUE (tx, output_pool, output_index),
                 CONSTRAINT note_recipient CHECK (
-                    (to_address IS NOT NULL OR to_account IS NOT NULL)
-                    AND NOT (to_address IS NOT NULL AND to_account IS NOT NULL)
+                    (to_address IS NOT NULL) != (to_account IS NOT NULL)
                 )
             );
             INSERT INTO sent_notes_new (

--- a/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
@@ -1,0 +1,88 @@
+//! A migration that adds an identifier for the account that received a sent note
+//! on an internal address to the sent_notes table.
+use std::collections::HashSet;
+
+use rusqlite;
+use schemer;
+use schemer_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use super::{addresses_table, utxos_table};
+use crate::wallet::init::WalletMigrationError;
+
+/// This migration adds the `to_account` field to the `sent_notes` table.
+///
+/// 0ddbe561-8259-4212-9ab7-66fdc4a74e1d
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_fields(
+    0x0ddbe561,
+    0x8259,
+    0x4212,
+    b"\x9a\xb7\x66\xfd\xc4\xa7\x4e\x1d",
+);
+
+pub(super) struct Migration;
+
+impl schemer::Migration for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        [utxos_table::MIGRATION_ID, addresses_table::MIGRATION_ID]
+            .into_iter()
+            .collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds an identifier for the account that received an internal note to the sent_notes table"
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        transaction.execute_batch("ALTER TABLE sent_notes ADD COLUMN to_account INTEGER;")?;
+
+        // `to_account` should be null for all migrated rows, since internal addresses
+        // have not been used for change or shielding prior to this migration.
+        transaction.execute_batch(
+            "CREATE TABLE sent_notes_new (
+                id_note INTEGER PRIMARY KEY,
+                tx INTEGER NOT NULL,
+                output_pool INTEGER NOT NULL ,
+                output_index INTEGER NOT NULL,
+                from_account INTEGER NOT NULL,
+                to_address TEXT,
+                to_account INTEGER,
+                value INTEGER NOT NULL,
+                memo BLOB,
+                FOREIGN KEY (tx) REFERENCES transactions(id_tx),
+                FOREIGN KEY (from_account) REFERENCES accounts(account),
+                FOREIGN KEY (to_account) REFERENCES accounts(account),
+                CONSTRAINT tx_output UNIQUE (tx, output_pool, output_index)
+            );
+            INSERT INTO sent_notes_new (
+                id_note, tx, output_pool, output_index,
+                from_account, to_address,
+                value, memo)
+            SELECT
+                id_note, tx, output_pool, output_index,
+                from_account, address,
+                value, memo
+            FROM sent_notes;",
+        )?;
+
+        transaction.execute_batch(
+            "DROP TABLE sent_notes;
+            ALTER TABLE sent_notes_new RENAME TO sent_notes;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // TODO: something better than just panic?
+        panic!("Cannot revert this migration.");
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -7,7 +7,9 @@ use schemer_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
 
-use zcash_client_backend::{address::RecipientAddress, keys::UnifiedSpendingKey};
+use zcash_client_backend::{
+    address::RecipientAddress, data_api::PoolType, keys::UnifiedSpendingKey,
+};
 use zcash_primitives::{consensus, zip32::AccountId};
 
 #[cfg(feature = "transparent-inputs")]
@@ -18,7 +20,7 @@ use zcash_client_backend::encoding::AddressCodec;
 
 use crate::wallet::{
     init::{migrations::utxos_table, WalletMigrationError},
-    PoolType,
+    pool_code,
 };
 
 pub(super) const MIGRATION_ID: Uuid = Uuid::from_fields(
@@ -227,8 +229,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                         ))
                     })?;
                 let output_pool = match decoded_address {
-                    RecipientAddress::Shielded(_) => Ok(PoolType::Sapling.typecode()),
-                    RecipientAddress::Transparent(_) => Ok(PoolType::Transparent.typecode()),
+                    RecipientAddress::Shielded(_) => Ok(pool_code(PoolType::Sapling)),
+                    RecipientAddress::Transparent(_) => Ok(pool_code(PoolType::Transparent)),
                     RecipientAddress::Unified(_) => Err(WalletMigrationError::CorruptedData(
                         "Unified addresses should not yet appear in the sent_notes table."
                             .to_string(),


### PR DESCRIPTION
This adds trial decryption with the internal IVK and correctly tracks payments sent to the wallet-internal address in the wallet database.
