### PR TITLE
zcash_proofs: Temporarily fix params download

### DIFF
--- a/zcash_proofs/src/downloadreader.rs
+++ b/zcash_proofs/src/downloadreader.rs
@@ -44,14 +44,14 @@ impl io::Read for ResponseLazyReader {
 
                 // Read from the response
                 Response(response) => {
-                    for i in 0..buf.len() {
+                    for (i, buf_byte) in buf.iter_mut().enumerate() {
                         match response.next() {
                             // Load a byte into the buffer.
                             Some(Ok((byte, _length))) => {
-                                buf[i] = byte;
+                                *buf_byte = byte;
                             }
 
-                            // We're finished with the whole response.
+                            // The whole response has been processed.
                             None => {
                                 *self = Complete(Ok(()));
                                 return Ok(i);

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -228,6 +228,7 @@ fn stream_params_downloads_to_disk(
     expected_bytes: u64,
     timeout: Option<u64>,
 ) -> Result<(), minreq::Error> {
+    use downloadreader::ResponseLazyReader;
     use std::io::{BufWriter, Read};
 
     // Fail early if the directory isn't writeable.
@@ -252,8 +253,8 @@ fn stream_params_downloads_to_disk(
 
     // Download the responses and write them to a new file,
     // verifying the hash as bytes are read.
-    let params_download_1 = downloadreader::ResponseLazyReader::from(params_download_1);
-    let params_download_2 = downloadreader::ResponseLazyReader::from(params_download_2);
+    let params_download_1 = ResponseLazyReader::from(params_download_1);
+    let params_download_2 = ResponseLazyReader::from(params_download_2);
 
     // Limit the download size to avoid DoS.
     // This also avoids launching the second request, if the first request provides enough bytes.


### PR DESCRIPTION
The implementation of `io:Read` for `ResponseLazyReader` used to return
only one byte regardless of the size of the provided `buf`, which
degraded the performance of loading the response.

This change makes use of the provided `buf`. On my machine with Rust
1.64, the downloading speed went up from ~100 KiB/s to ~2 MiB/s.
However, as before this change, the process still uses 100% of a single
CPU thread when downloading the response. The most likely reason is that
we still manually read each byte of the response. I can download the
same data with ~ 50 MiB/s on my machine using a different HTTP client.

This fix seems to be sufficient for now.