### PR TITLE
Remove unused dependencies

### DIFF
--- a/components/f4jumble/Cargo.toml
+++ b/components/f4jumble/Cargo.toml
@@ -16,6 +16,9 @@ rust-version = "1.51"
 categories = ["encoding"]
 keywords = ["feistel"]
 
+[package.metadata.cargo-udeps.ignore]
+development = ["hex"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -22,13 +22,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 cipher = { version = "0.4", default-features = false }
 chacha20 = { version = "0.9", default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
-group = "0.12"
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.3", default-features = false }
-
-[dev-dependencies]
-ff = { version = "0.12", default-features = false }
-jubjub = "0.9"
 
 [features]
 default = ["alloc"]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.56.1"
 
+[package.metadata.cargo-udeps.ignore]
+development = ["zcash_proofs"]
+
 [dependencies]
 base64 = "0.13"
 bech32 = "0.8"
@@ -24,7 +27,6 @@ group = "0.12"
 hex = "0.4"
 hdwallet = { version = "0.3.1", optional = true }
 jubjub = "0.9"
-log = "0.4"
 memuse = "0.2"
 nom = "7"
 orchard = "0.2"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -22,7 +22,6 @@ jubjub = "0.9"
 protobuf = "~2.27.1" # MSRV 1.52.1
 rand_core = "0.6"
 rusqlite = { version = "0.25", features = ["bundled", "time"] }
-secp256k1 = { version = "0.21" }
 schemer = "0.2"
 schemer-rusqlite = "0.2"
 secrecy = "0.8"


### PR DESCRIPTION
These were mostly detected with `cargo-udeps`, for which I've also added exclusions for the dependencies it can't detect are used in doc-tests.