### PR TITLE
Remove the `WalletReadTransparent` and `WalletWriteTransparent` extension traits.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,10 +13,6 @@ and this library adheres to Rust's notion of
   - A new `data_api::wallet::shield_transparent_funds` method has been added
     to facilitate the automatic shielding of transparent funds received
     by the wallet.
-  - `zcash_client_backend::data_api::WalletReadTransparent` read-only operations
-    related to information the wallet maintains about transparent funds.
-  - `zcash_client_backend::data_api::WalletWriteTransparent` operations
-    related persisting information the wallet maintains about transparent funds.
   - A `zcash_client_backend::wallet::WalletTransparentOutput` type
     has been added under the `transparent-inputs` feature flag in support
     of autoshielding functionality.
@@ -38,9 +34,12 @@ and this library adheres to Rust's notion of
   - `WalletRead::get_account_for_ufvk`
   - `WalletRead::get_current_address`
   - `WalletRead::get_all_nullifiers`
+  - `WalletRead::get_transparent_receivers`
+  - `WalletRead::get_unspent_transparent_outputs`
   - `WalletWrite::create_account`
   - `WalletWrite::remove_unmined_tx` (behind the `unstable` feature flag).
   - `WalletWrite::get_next_available_address`
+  - `WalletWrite::put_received_transparent_utxo`
 - `zcash_client_backend::decrypt`:
   - `TransferType`
 - `zcash_client_backend::proto`:

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -78,6 +78,11 @@ pub enum Error<NoteId> {
     /// An error occurred deriving a spending key from a seed and an account
     /// identifier.
     KeyDerivationError(AccountId),
+
+    /// An error indicating that a call was attempted to a method providing
+    /// support
+    #[cfg(not(feature = "transparent-inputs"))]
+    TransparentInputsNotSupported,
 }
 
 impl ChainInvalid {
@@ -133,6 +138,11 @@ impl<N: fmt::Display> fmt::Display for Error<N> {
             Error::SaplingNotActive => write!(f, "Could not determine Sapling upgrade activation height."),
             Error::MemoForbidden => write!(f, "It is not possible to send a memo to a transparent address."),
             Error::KeyDerivationError(acct_id) => write!(f, "Key derivation failed for account {:?}", acct_id),
+
+            #[cfg(not(feature = "transparent-inputs"))]
+            Error::TransparentInputsNotSupported => {
+                write!(f, "This wallet does not support spending or manipulating transparent UTXOs.")
+            }
         }
     }
 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -25,9 +25,6 @@ use crate::{
     zip321::{Payment, TransactionRequest},
 };
 
-#[cfg(feature = "transparent-inputs")]
-use crate::data_api::WalletWriteTransparent;
-
 /// Scans a [`Transaction`] for any information that can be decrypted by the accounts in
 /// the wallet, and saves it to the wallet.
 pub fn decrypt_and_store_transaction<N, E, P, D>(
@@ -454,7 +451,7 @@ where
     E: From<Error<N>>,
     P: consensus::Parameters,
     R: Copy + Debug,
-    D: WalletWrite<Error = E, TxRef = R> + WalletWriteTransparent<UtxoRef = U>,
+    D: WalletWrite<Error = E, TxRef = R>,
 {
     let account = wallet_db
         .get_account_for_ufvk(&usk.to_unified_full_viewing_key())?

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -3,18 +3,19 @@
 
 use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_primitives::{
+    consensus::BlockHeight,
     keys::OutgoingViewingKey,
+    legacy::TransparentAddress,
     merkle_tree::IncrementalWitness,
     sapling::{Diversifier, Node, Note, Nullifier, PaymentAddress, Rseed},
-    transaction::{components::Amount, TxId},
+    transaction::{
+        components::{
+            transparent::{OutPoint, TxOut},
+            Amount,
+        },
+        TxId,
+    },
     zip32::AccountId,
-};
-
-#[cfg(feature = "transparent-inputs")]
-use zcash_primitives::{
-    consensus::BlockHeight,
-    legacy::TransparentAddress,
-    transaction::components::{OutPoint, TxOut},
 };
 
 /// A subset of a [`Transaction`] relevant to wallets and light clients.
@@ -29,14 +30,12 @@ pub struct WalletTx<N> {
     pub shielded_outputs: Vec<WalletShieldedOutput<N>>,
 }
 
-#[cfg(feature = "transparent-inputs")]
 pub struct WalletTransparentOutput {
     pub outpoint: OutPoint,
     pub txout: TxOut,
     pub height: BlockHeight,
 }
 
-#[cfg(feature = "transparent-inputs")]
 impl WalletTransparentOutput {
     pub fn address(&self) -> TransparentAddress {
         self.txout.script_pubkey.address().unwrap()


### PR DESCRIPTION
These traits introduce a problem, in that constraints on a method cannot be conditionally required based upon the presence or absence of a feature flag. Instead, we make the methods previously introduced by the removed traits present in all cases on the `WalletRead` and `WalletWrite` traits, but ensure that their implementations return an error if the caller attempts to use them in a wallet that has not been configured with support for transparent inputs functionality.