### PR TITLE
Mark our utxos spent when we detect them as inputs to a transaction.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -14,8 +14,7 @@ and this library adheres to Rust's notion of
     to facilitate the automatic shielding of transparent funds received
     by the wallet.
   - A `zcash_client_backend::wallet::WalletTransparentOutput` type
-    has been added under the `transparent-inputs` feature flag in support
-    of autoshielding functionality.
+    in support of `transparent-inputs` functionality.
 - A new `data_api::wallet::spend` method has been added, which is
   intended to supersede the `data_api::wallet::create_spend_to_address`
   method. This new method now constructs transactions via interpretation

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -475,7 +475,7 @@ where
     let utxos = wallet_db.get_unspent_transparent_outputs(&taddr, latest_anchor)?;
     let total_amount = utxos
         .iter()
-        .map(|utxo| utxo.txout.value)
+        .map(|utxo| utxo.txout().value)
         .sum::<Option<Amount>>()
         .ok_or_else(|| E::from(Error::InvalidAmount))?;
 
@@ -494,7 +494,7 @@ where
         .unwrap();
     for utxo in &utxos {
         builder
-            .add_transparent_input(secret_key, utxo.outpoint.clone(), utxo.txout.clone())
+            .add_transparent_input(secret_key, utxo.outpoint().clone(), utxo.txout().clone())
             .map_err(Error::Builder)?;
     }
 
@@ -522,6 +522,6 @@ where
             memo: Some(memo.clone()),
         }],
         fee_amount: fee,
-        utxos_spent: utxos.iter().map(|utxo| utxo.outpoint.clone()).collect(),
+        utxos_spent: utxos.iter().map(|utxo| utxo.outpoint().clone()).collect(),
     })
 }

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -30,15 +30,44 @@ pub struct WalletTx<N> {
     pub shielded_outputs: Vec<WalletShieldedOutput<N>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct WalletTransparentOutput {
-    pub outpoint: OutPoint,
-    pub txout: TxOut,
-    pub height: BlockHeight,
+    outpoint: OutPoint,
+    txout: TxOut,
+    height: BlockHeight,
+    recipient_address: TransparentAddress,
 }
 
 impl WalletTransparentOutput {
-    pub fn address(&self) -> TransparentAddress {
-        self.txout.script_pubkey.address().unwrap()
+    pub fn from_parts(
+        outpoint: OutPoint,
+        txout: TxOut,
+        height: BlockHeight,
+    ) -> Option<WalletTransparentOutput> {
+        txout
+            .recipient_address()
+            .map(|recipient_address| WalletTransparentOutput {
+                outpoint,
+                txout,
+                height,
+                recipient_address,
+            })
+    }
+
+    pub fn outpoint(&self) -> &OutPoint {
+        &self.outpoint
+    }
+
+    pub fn txout(&self) -> &TxOut {
+        &self.txout
+    }
+
+    pub fn height(&self) -> BlockHeight {
+        self.height
+    }
+
+    pub fn recipient_address(&self) -> &TransparentAddress {
+        &self.recipient_address
     }
 }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -596,16 +596,17 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
                         .any(|input| *nf == input.nullifier)
                 ) {
                     for (output_index, txout) in d_tx.tx.transparent_bundle().iter().flat_map(|b| b.vout.iter()).enumerate() {
-                        let recipient = Recipient::Transparent(txout.script_pubkey.address().unwrap());
-                        wallet::put_sent_output(
-                            up,
-                            *account_id,
-                            tx_ref,
-                            output_index,
-                            &recipient,
-                            txout.value,
-                            None
-                        )?;
+                        if let Some(address) = txout.recipient_address() {
+                            wallet::put_sent_output(
+                                up,
+                                *account_id,
+                                tx_ref,
+                                output_index,
+                                &Recipient::Transparent(address),
+                                txout.value,
+                                None
+                            )?;
+                        }
                     }
                 }
             }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -538,7 +538,6 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
         &mut self,
         d_tx: &DecryptedTransaction,
     ) -> Result<Self::TxRef, Self::Error> {
-        let nullifiers = self.wallet_db.get_all_nullifiers()?;
         self.transactionally(|up| {
             let tx_ref = wallet::put_tx_data(up, d_tx.tx, None, None)?;
 
@@ -579,8 +578,15 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
                 }
             }
 
+            // If any of the utxos spent in the transaction are ours, mark them as spent.
+            #[cfg(feature = "transparent-inputs")]
+            for txin in d_tx.tx.transparent_bundle().iter().flat_map(|b| b.vin.iter()) {
+                wallet::mark_transparent_utxo_spent(up, tx_ref, &txin.prevout)?;
+            }
+
             // If we have some transparent outputs:
             if !d_tx.tx.transparent_bundle().iter().any(|b| b.vout.is_empty()) {
+                let nullifiers = self.wallet_db.get_all_nullifiers()?;
                 // If the transaction contains shielded spends from our wallet, we will store z->t
                 // transactions we observe in the same way they would be stored by
                 // create_spend_to_address. 

--- a/zcash_client_sqlite/src/prepared.rs
+++ b/zcash_client_sqlite/src/prepared.rs
@@ -513,12 +513,12 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
         self.stmt_insert_received_transparent_utxo
             .query_row(
                 named_params![
-                    ":address": &output.address().encode(&self.wallet_db.params),
-                    ":prevout_txid": &output.outpoint.hash().to_vec(),
-                    ":prevout_idx": &output.outpoint.n(),
-                    ":script": &output.txout.script_pubkey.0,
-                    ":value_zat": &i64::from(output.txout.value),
-                    ":height": &u32::from(output.height),
+                    ":address": &output.recipient_address().encode(&self.wallet_db.params),
+                    ":prevout_txid": &output.outpoint().hash().to_vec(),
+                    ":prevout_idx": &output.outpoint().n(),
+                    ":script": &output.txout().script_pubkey.0,
+                    ":value_zat": &i64::from(output.txout().value),
+                    ":height": &u32::from(output.height()),
                 ],
                 |row| {
                     let id = row.get(0)?;
@@ -540,12 +540,12 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
         self.stmt_update_received_transparent_utxo
             .query_row(
                 named_params![
-                    ":prevout_txid": &output.outpoint.hash().to_vec(),
-                    ":prevout_idx": &output.outpoint.n(),
-                    ":address": &output.address().encode(&self.wallet_db.params),
-                    ":script": &output.txout.script_pubkey.0,
-                    ":value_zat": &i64::from(output.txout.value),
-                    ":height": &u32::from(output.height),
+                    ":prevout_txid": &output.outpoint().hash().to_vec(),
+                    ":prevout_idx": &output.outpoint().n(),
+                    ":address": &output.recipient_address().encode(&self.wallet_db.params),
+                    ":script": &output.txout().script_pubkey.0,
+                    ":value_zat": &i64::from(output.txout().value),
+                    ":height": &u32::from(output.height()),
                 ],
                 |row| {
                     let id = row.get(0)?;

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -39,6 +39,7 @@ and this library adheres to Rust's notion of
   - `JSDescription::net_value`
 - Added in `zcash_primitives::transaction::components::transparent`
   - `Bundle::value_balance`
+  - `TxOut::recipient_address`
 - Implementations of `memuse::DynamicUsage` for the following types:
   - `zcash_primitives::block::BlockHash`
   - `zcash_primitives::consensus`:
@@ -72,6 +73,12 @@ and this library adheres to Rust's notion of
     instead of `SaplingIvk`.
   - `try_sapling_note_decryption` and `try_sapling_compact_note_decryption` now
     take `&PreparedIncomingViewingKey` instead of `&SaplingIvk`.
+
+### Removed
+- `zcash_primitives::legacy::Script::address` This method was not generally
+  safe to use on arbitrary scripts, only on script_pubkey values. Its
+  functionality is now available via
+  `zcash_primitives::transaction::components::transparent::TxOut::recipient_address`
 
 ## [0.7.0] - 2022-06-24
 ### Changed

--- a/zcash_primitives/src/legacy.rs
+++ b/zcash_primitives/src/legacy.rs
@@ -43,7 +43,7 @@ impl Script {
     }
 
     /// Returns the address that this Script contains, if any.
-    pub fn address(&self) -> Option<TransparentAddress> {
+    pub(crate) fn address(&self) -> Option<TransparentAddress> {
         if self.0.len() == 25
             && self.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]
             && self.0[23..25] == [OpCode::EqualVerify as u8, OpCode::CheckSig as u8]

--- a/zcash_primitives/src/transaction/components/transparent.rs
+++ b/zcash_primitives/src/transaction/components/transparent.rs
@@ -5,7 +5,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt::Debug;
 use std::io::{self, Read, Write};
 
-use crate::legacy::Script;
+use crate::legacy::{Script, TransparentAddress};
 
 use super::amount::{Amount, BalanceError};
 
@@ -181,6 +181,11 @@ impl TxOut {
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.value.to_i64_le_bytes())?;
         self.script_pubkey.write(&mut writer)
+    }
+
+    /// Returns the address to which the TxOut was sent, if this is a valid P2SH or P2PKH output.
+    pub fn recipient_address(&self) -> Option<TransparentAddress> {
+        self.script_pubkey.address()
     }
 }
 


### PR DESCRIPTION
This modifies `decrypt_and_store_transaction` to check for inputs
to a transaction being decrypted that correspond to addresses in
our wallet. For each such UTXO found, it is marked spent in our
`utxos` table if present.
