### PR TITLE
zcash_client_backend: Fix missing bound

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -447,7 +447,7 @@ where
     E: From<Error<N>>,
     P: consensus::Parameters,
     R: Copy + Debug,
-    D: WalletWrite<Error = E, TxRef = R>,
+    D: WalletWrite<Error = E, TxRef = R, UtxoRef = U>,
 {
     let account = wallet_db
         .get_account_for_ufvk(&usk.to_unified_full_viewing_key())?


### PR DESCRIPTION
In 47a0d0d2b789c816525aa1d07c0ebbfd67758cf1 `WalletWriteTransparent` was merged into `WalletWrite`, including its associated type `UtxoRef`. However, `shield_transparent_funds` placed a bound on this associated type that was not moved to `WalletWrite`. This left the generic parameter `U` unconstrained, which didn't cause a local failure because the method has no local tests, but was immediately apparent when trying to use the method in the mobile SDKs.