### PR TITLE
Update zcash_primitives to orchard 0.3; release zcash_primitives and zcash_proofs 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,5 @@ codegen-units = 1
 [patch.crates-io]
 zcash_encoding = { path = "components/zcash_encoding" }
 zcash_note_encryption = { path = "components/zcash_note_encryption" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "4035a97d178f99bb889f4d7ed26c59378fa88961" }
 schemer = { git = "https://github.com/aschampion/schemer.git", rev = "6726b60f43f72c6e24a18d31be0ec7d42829e5e1" }
 schemer-rusqlite = { git = "https://github.com/aschampion/schemer.git", rev = "6726b60f43f72c6e24a18d31be0ec7d42829e5e1" }

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -64,7 +64,7 @@ and this library adheres to Rust's notion of
 ### Changed
 - MSRV is now 1.56.1.
 - Bumped dependencies to `ff 0.12`, `group 0.12`, `bls12_381 0.7`, `jubjub 0.9`,
-  `zcash_primitives 0.7`.
+  `zcash_primitives 0.8`, `orchard 0.3`.
 - `zcash_client_backend::proto`:
   - `compact_formats::CompactSpend` has been renamed to `CompactSaplingSpend`,
     and its `epk` field (and associated `set_epk` method) has been renamed to

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -29,7 +29,7 @@ hdwallet = { version = "0.3.1", optional = true }
 jubjub = "0.9"
 memuse = "0.2"
 nom = "7"
-orchard = "0.2"
+orchard = "0.3"
 percent-encoding = "2.1.0"
 proptest = { version = "1.0.0", optional = true }
 protobuf = "~2.27.1" # MSRV 1.52.1
@@ -45,7 +45,7 @@ tracing = "0.1"
 zcash_address = { version = "0.1", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.1", path = "../components/zcash_encoding" }
 zcash_note_encryption = { version = "0.2", path = "../components/zcash_note_encryption" }
-zcash_primitives = { version = "0.7", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.27.1" # MSRV 1.52.1
@@ -55,7 +55,7 @@ gumdrop = "0.8"
 proptest = "1.0.0"
 rand_xorshift = "0.3"
 tempfile = "3.1.0"
-zcash_proofs = { version = "0.7", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
 zcash_address = { version = "0.1", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     protobuf_codegen_pure::Codegen::new()
         .out_dir("src/proto")
-        .inputs(&["proto/compact_formats.proto"])
-        .includes(&["proto"])
+        .inputs(["proto/compact_formats.proto"])
+        .includes(["proto"])
         .run()
         .expect("Protobuf codegen failed");
 }

--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -612,7 +612,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     fn seed() -> Vec<u8> {
         let seed_hex = "6ef5f84def6f4b9d38f466586a8380a38593bd47c8cda77f091856176da47f26b5bd1c8d097486e5635df5a66e820d28e1d73346f499801c86228d43f390304f";
-        hex::decode(&seed_hex).unwrap()
+        hex::decode(seed_hex).unwrap()
     }
 
     #[test]

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -62,7 +62,7 @@ and this library adheres to Rust's notion of
     (and in the future, outputs to other pools). Values for this column should
     be assigned by inference from the address type in the stored data.
 - MSRV is now 1.56.1.
-- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`.
+- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`, `zcash_primitives 0.8`.
 - Renamed the following to use lower-case abbreviations (matching Rust
   naming conventions):
   - `zcash_client_sqlite::BlockDB` to `BlockDb`

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -28,14 +28,14 @@ secrecy = "0.8"
 time = "0.2"
 uuid = "1.1"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.7", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
 
 [dev-dependencies]
 proptest = "1.0.0"
 regex = "1.4"
 tempfile = "3"
-zcash_proofs = { version = "0.7", path = "../zcash_proofs" }
-zcash_primitives = { version = "0.7", path = "../zcash_primitives", features = ["test-dependencies"] }
+zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
+zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.1", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_sqlite/src/prepared.rs
+++ b/zcash_client_sqlite/src/prepared.rs
@@ -352,7 +352,7 @@ impl<'a, P> DataConnStmtCache<'a, P> {
     /// Finds the database row for the given `txid`, if the transaction is in the wallet.
     pub(crate) fn stmt_select_tx_ref(&mut self, txid: &TxId) -> Result<i64, SqliteClientError> {
         self.stmt_select_tx_ref
-            .query_row(&[&txid.as_ref()[..]], |row| row.get(0))
+            .query_row([&txid.as_ref()[..]], |row| row.get(0))
             .map_err(SqliteClientError::from)
     }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -842,7 +842,7 @@ mod tests {
             tx.write(&mut tx_bytes).unwrap();
             wdb.conn.execute(
                 "INSERT INTO transactions (block, id_tx, txid, raw) VALUES (0, 0, '', ?)",
-                &[&tx_bytes[..]],
+                [&tx_bytes[..]],
             )?;
             wdb.conn.execute(
                 "INSERT INTO sent_notes (tx, output_index, from_account, address, value)

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -11,14 +11,14 @@ rust-version = "1.56.1"
 
 [dependencies]
 blake2b_simd = "1"
-zcash_primitives = { version = "0.7", path = "../zcash_primitives", features = ["zfuture" ] }
+zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = ["zfuture" ] }
 
 [dev-dependencies]
 ff = "0.12"
 jubjub = "0.9"
 rand_core = "0.6"
 zcash_address = { version = "0.1", path = "../components/zcash_address" }
-zcash_proofs = { version = "0.7", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = []

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2022-10-19
 ### Added
 - `zcash_primitives::legacy`:
   - `impl {Copy, Eq, Ord} for TransparentAddress`
@@ -57,6 +59,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `group 0.13`.
+- Migrated to `orchard 0.3`.
 - `zcash_primitives::sapling::ViewingKey` now stores `nk` as a
   `NullifierDerivingKey` instead of as a bare `jubjub::SubgroupPoint`.
 - The signature of `zcash_primitives::sapling::Note::nf` has changed to

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -38,7 +38,7 @@ jubjub = "0.9"
 lazy_static = "1"
 memuse = "0.2.1"
 nonempty = "0.7"
-orchard = "0.2"
+orchard = "0.3"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 rand_core = "0.6"
@@ -58,7 +58,7 @@ features = ["pre-zip-212"]
 criterion = "0.3"
 proptest = "1.0.0"
 rand_xorshift = "0.3"
-orchard = { version = "0.2", features = ["test-dependencies"] }
+orchard = { version = "0.3", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.9", features = ["criterion", "flamegraph"] } # MSRV 1.56

--- a/zcash_primitives/src/legacy.rs
+++ b/zcash_primitives/src/legacy.rs
@@ -84,10 +84,10 @@ impl Shl<&[u8]> for Script {
             self.0.push(data.len() as u8);
         } else if data.len() <= 0xffff {
             self.0.push(OpCode::PushData2 as u8);
-            self.0.extend(&(data.len() as u16).to_le_bytes());
+            self.0.extend((data.len() as u16).to_le_bytes());
         } else {
             self.0.push(OpCode::PushData4 as u8);
-            self.0.extend(&(data.len() as u32).to_le_bytes());
+            self.0.extend((data.len() as u32).to_le_bytes());
         }
         self.0.extend(data);
         self

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -100,7 +100,7 @@ impl TransparentBuilder {
                 use ripemd::Ripemd160;
                 use sha2::{Digest, Sha256};
 
-                if hash[..] != Ripemd160::digest(&Sha256::digest(&pubkey))[..] {
+                if hash[..] != Ripemd160::digest(Sha256::digest(&pubkey))[..] {
                     return Err(Error::InvalidAddress);
                 }
             }
@@ -245,7 +245,7 @@ impl Bundle<Unauthorized> {
 
                 // Signature has to have "SIGHASH_ALL" appended to it
                 let mut sig_bytes: Vec<u8> = sig.serialize_der()[..].to_vec();
-                sig_bytes.extend(&[SIGHASH_ALL as u8]);
+                sig_bytes.extend([SIGHASH_ALL as u8]);
 
                 // P2PKH scriptSig
                 Script::default() << &sig_bytes[..] << &info.pubkey[..]

--- a/zcash_primitives/src/transaction/util/sha256d.rs
+++ b/zcash_primitives/src/transaction/util/sha256d.rs
@@ -60,7 +60,7 @@ impl HashWriter {
 
 impl Write for HashWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.hasher.update(&buf);
+        self.hasher.update(buf);
 
         Ok(buf.len())
     }

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.8.0] - 2022-10-19
+### Changed
+- Bumped dependencies to `zcash_primitives 0.8`.
+
 ## [0.7.1] - 2022-07-05
 ### Added
 - `zcash_proofs::sapling::BatchValidator`

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]
@@ -30,7 +30,7 @@ rand_core = "0.6"
 redjubjub = "0.5"
 tracing = "0.1"
 wagyu-zcash-parameters = { version = "0.2", optional = true }
-zcash_primitives = { version = "0.7", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -232,7 +232,7 @@ fn stream_params_downloads_to_disk(
     use std::io::{BufWriter, Read};
 
     // Fail early if the directory isn't writeable.
-    let new_params_file = File::create(&params_path)?;
+    let new_params_file = File::create(params_path)?;
     let new_params_file = BufWriter::with_capacity(1024 * 1024, new_params_file);
 
     // Set up the download requests.
@@ -441,7 +441,7 @@ fn verify_file_size(
     name: &str,
     params_source: &str,
 ) -> Result<(), io::Error> {
-    let file_size = std::fs::metadata(&params_path)?.len();
+    let file_size = std::fs::metadata(params_path)?.len();
 
     if file_size != expected_bytes {
         return Err(io::Error::new(

--- a/zcash_proofs/src/sprout.rs
+++ b/zcash_proofs/src/sprout.rs
@@ -159,8 +159,8 @@ pub fn verify_proof(
     public_input.extend(mac2);
     public_input.extend(cm1);
     public_input.extend(cm2);
-    public_input.extend(&vpub_old.to_le_bytes());
-    public_input.extend(&vpub_new.to_le_bytes());
+    public_input.extend(vpub_old.to_le_bytes());
+    public_input.extend(vpub_new.to_le_bytes());
 
     let public_input = multipack::bytes_to_bits(&public_input);
     let public_input = multipack::compute_multipacking(&public_input);


### PR DESCRIPTION
* This updates the `zcash_primitives` crate to use `orchard 0.3` which is a breaking change; we do a release of `zcash_primitives 0.8`.
* We update `zcash_proofs` to use `zcash_primitives 0.8` which is a breaking change; we do a release of `zcash_proofs 0.8`.
* We update `zcash_extensions`, `zcash_client_backend`, `zcash_client_sqlite` to use `zcash_primitives 0.8` which is a breaking change; we are not releasing these crates in this PR.
* We also update `zcash_client_backend` to use `orchard 0.3`.