### PR TITLE
Bump versions for f4jumble, zcash_address, zcash_encoding and zcash_history crates

### DIFF
--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2022-10-19
 ### Added
 - `zcash_address::ConversionError`
 - `zcash_address::TryFromAddress`

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_address"
 description = "Zcash address parsing and serialization"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
@@ -18,7 +18,7 @@ keywords = ["zcash", "address", "sapling", "unified"]
 bech32 = "0.8"
 bs58 = { version = "0.4", features = ["check"] }
 f4jumble = { version = "0.1", path = "../f4jumble" }
-zcash_encoding = { version = "0.1", path = "../zcash_encoding" }
+zcash_encoding = { version = "0.2", path = "../zcash_encoding" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-10-19
 ### Changed
 - MSRV is now 1.56.1
 

--- a/components/zcash_encoding/Cargo.toml
+++ b/components/zcash_encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_encoding"
 description = "Binary encodings used throughout the Zcash ecosystem."
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -42,8 +42,8 @@ sha2 = { version = "0.10.1", optional = true }
 subtle = "2.2.3"
 time = "0.2"
 tracing = "0.1"
-zcash_address = { version = "0.1", path = "../components/zcash_address" }
-zcash_encoding = { version = "0.1", path = "../components/zcash_encoding" }
+zcash_address = { version = "0.2", path = "../components/zcash_address" }
+zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_note_encryption = { version = "0.2", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
 
@@ -56,7 +56,7 @@ proptest = "1.0.0"
 rand_xorshift = "0.3"
 tempfile = "3.1.0"
 zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
-zcash_address = { version = "0.1", path = "../components/zcash_address", features = ["test-dependencies"] }
+zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]
 transparent-inputs = ["ripemd", "hdwallet", "sha2", "secp256k1", "zcash_primitives/transparent-inputs"]

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.4"
 tempfile = "3"
 zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = ["test-dependencies"] }
-zcash_address = { version = "0.1", path = "../components/zcash_address", features = ["test-dependencies"] }
+zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]
 mainnet = []

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -17,7 +17,7 @@ zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = [
 ff = "0.12"
 jubjub = "0.9"
 rand_core = "0.6"
-zcash_address = { version = "0.1", path = "../components/zcash_address" }
+zcash_address = { version = "0.2", path = "../components/zcash_address" }
 zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
 
 [features]

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -83,7 +83,8 @@ and this library adheres to Rust's notion of
   `zcash_primitives::transaction::components::transparent::TxOut::recipient_address`
 
 ## [0.8.0] - 2022-10-19
-This release was yanked.
+This release was yanked because it depended on the wrong versions of `zcash_address`
+and `zcash_encoding`.
 
 ## [0.7.0] - 2022-06-24
 ### Changed

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
-## [0.8.0] - 2022-10-19
+## [0.8.1] - 2022-10-19
 ### Added
 - `zcash_primitives::legacy`:
   - `impl {Copy, Eq, Ord} for TransparentAddress`
@@ -58,8 +58,7 @@ and this library adheres to Rust's notion of
   - `zcash_primitives::zip32::AccountId`
 
 ### Changed
-- Migrated to `group 0.13`.
-- Migrated to `orchard 0.3`.
+- Migrated to `group 0.13`, `orchard 0.3`, `zcash_address 0.2`, `zcash_encoding 0.2`.
 - `zcash_primitives::sapling::ViewingKey` now stores `nk` as a
   `NullifierDerivingKey` instead of as a bare `jubjub::SubgroupPoint`.
 - The signature of `zcash_primitives::sapling::Note::nf` has changed to
@@ -82,6 +81,9 @@ and this library adheres to Rust's notion of
   safe to use on arbitrary scripts, only on script_pubkey values. Its
   functionality is now available via
   `zcash_primitives::transaction::components::transparent::TxOut::recipient_address`
+
+## [0.8.0] - 2022-10-19
+This release was yanked.
 
 ## [0.7.0] - 2022-06-24
 ### Changed

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -46,8 +46,8 @@ ripemd = { version = "0.1", optional = true }
 secp256k1 = { version = "0.21", optional = true }
 sha2 = "0.9"
 subtle = "2.2.3"
-zcash_address = { version = "0.1", path = "../components/zcash_address" }
-zcash_encoding = { version = "0.1", path = "../components/zcash_encoding" }
+zcash_address = { version = "0.2", path = "../components/zcash_address" }
+zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 
 [dependencies.zcash_note_encryption]
 version = "0.2"


### PR DESCRIPTION
This bumps `zcash_address` and `zcash_encoding` versions to 0.2. Then, it bumps `zcash_primitives` to `0.8.1` (which now depend on the new versions of `zcash_address` and `zcash_encoding`) with the goal to yank `0.8.0` which was mistakenly published prior to the version bumps of `zcash_address` and `zcash_encoding`.