### PR TITLE
Allow insertion of UTXOs associated with the legacy taddr.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -25,6 +25,7 @@ and this library adheres to Rust's notion of
   in any release.
 - `zcash_client_backend::address`:
   - `RecipientAddress::Unified`
+  - `AddressMetadata`
 - `zcash_client_backend::data_api`:
   - `PoolType`
   - `Recipient`
@@ -102,9 +103,17 @@ and this library adheres to Rust's notion of
   `store_decrypted_tx`.
 - `data_api::ReceivedTransaction` has been renamed to `DecryptedTransaction`,
   and its `outputs` field has been renamed to `sapling_outputs`.
-- An `Error::MemoForbidden` error has been added to the
-  `data_api::error::Error` enum to report the condition where a memo was
-  specified to be sent to a transparent recipient.
+- `data_api::error::Error` has the following additional cases:
+  - `Error::MemoForbidden` to report the condition where a memo was
+    specified to be sent to a transparent recipient.
+  - `Error::TransparentInputsNotSupported` to represent the condition
+    where a transparent spend has been requested of a wallet compiled without
+    the `transparent-inputs` feature.
+  - `Error::AddressNotRecognized` to indicate that a transparent address from
+    which funds are being requested to be spent does not appear to be associated
+    with this wallet.
+  - `Error::ChildIndexOutOfRange` to indicate that a diversifier index for an
+    address is out of range for valid transparent child indices.
 - `zcash_client_backend::decrypt`:
   - `decrypt_transaction` now takes a `HashMap<_, UnifiedFullViewingKey>`
     instead of `HashMap<_, ExtendedFullViewingKey>`.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -36,6 +36,7 @@ and this library adheres to Rust's notion of
   - `WalletRead::get_all_nullifiers`
   - `WalletRead::get_transparent_receivers`
   - `WalletRead::get_unspent_transparent_outputs`
+  - `WalletRead::get_transparent_balances`
   - `WalletWrite::create_account`
   - `WalletWrite::remove_unmined_tx` (behind the `unstable` feature flag).
   - `WalletWrite::get_next_available_address`

--- a/zcash_client_backend/src/address.rs
+++ b/zcash_client_backend/src/address.rs
@@ -6,7 +6,34 @@ use zcash_address::{
     unified::{self, Container, Encoding},
     ConversionError, Network, ToAddress, TryFromRawAddress, ZcashAddress,
 };
-use zcash_primitives::{consensus, legacy::TransparentAddress, sapling::PaymentAddress};
+use zcash_primitives::{
+    consensus,
+    legacy::TransparentAddress,
+    sapling::PaymentAddress,
+    zip32::{AccountId, DiversifierIndex},
+};
+
+pub struct AddressMetadata {
+    account: AccountId,
+    diversifier_index: DiversifierIndex,
+}
+
+impl AddressMetadata {
+    pub fn new(account: AccountId, diversifier_index: DiversifierIndex) -> Self {
+        Self {
+            account,
+            diversifier_index,
+        }
+    }
+
+    pub fn account(&self) -> AccountId {
+        self.account
+    }
+
+    pub fn diversifier_index(&self) -> &DiversifierIndex {
+        &self.diversifier_index
+    }
+}
 
 /// A Unified Address.
 #[derive(Clone, Debug, PartialEq)]

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -216,6 +216,14 @@ pub trait WalletRead {
         address: &TransparentAddress,
         max_height: BlockHeight,
     ) -> Result<Vec<WalletTransparentOutput>, Self::Error>;
+
+    /// Returns a mapping from transparent receiver to not-yet-shielded UTXO balance,
+    /// for each address associated with a nonzero balance.
+    fn get_transparent_balances(
+        &self,
+        account: AccountId,
+        max_height: BlockHeight,
+    ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error>;
 }
 
 /// The subset of information that is relevant to this wallet that has been
@@ -562,6 +570,14 @@ pub mod testing {
             _anchor_height: BlockHeight,
         ) -> Result<Vec<WalletTransparentOutput>, Self::Error> {
             Ok(Vec::new())
+        }
+
+        fn get_transparent_balances(
+            &self,
+            _account: AccountId,
+            _max_height: BlockHeight,
+        ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
+            Ok(HashMap::new())
         }
     }
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1,7 +1,7 @@
 //! Interfaces for wallet data persistence & low-level wallet utilities.
 
 use std::cmp;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use secrecy::SecretVec;
@@ -17,7 +17,7 @@ use zcash_primitives::{
 };
 
 use crate::{
-    address::UnifiedAddress,
+    address::{AddressMetadata, UnifiedAddress},
     decrypt::DecryptedOutput,
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
     proto::compact_formats::CompactBlock,
@@ -207,7 +207,7 @@ pub trait WalletRead {
     fn get_transparent_receivers(
         &self,
         account: AccountId,
-    ) -> Result<HashSet<TransparentAddress>, Self::Error>;
+    ) -> Result<HashMap<TransparentAddress, AddressMetadata>, Self::Error>;
 
     /// Returns a list of unspent transparent UTXOs that appear in the chain at heights up to and
     /// including `max_height`.
@@ -400,9 +400,6 @@ pub mod testing {
     use secrecy::{ExposeSecret, SecretVec};
     use std::collections::HashMap;
 
-    #[cfg(feature = "transparent-inputs")]
-    use std::collections::HashSet;
-
     use zcash_primitives::{
         block::BlockHash,
         consensus::{BlockHeight, Network},
@@ -415,7 +412,7 @@ pub mod testing {
     };
 
     use crate::{
-        address::UnifiedAddress,
+        address::{AddressMetadata, UnifiedAddress},
         keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
         proto::compact_formats::CompactBlock,
         wallet::{SpendableNote, WalletTransparentOutput},
@@ -555,8 +552,8 @@ pub mod testing {
         fn get_transparent_receivers(
             &self,
             _account: AccountId,
-        ) -> Result<HashSet<TransparentAddress>, Self::Error> {
-            Ok(HashSet::new())
+        ) -> Result<HashMap<TransparentAddress, AddressMetadata>, Self::Error> {
+            Ok(HashMap::new())
         }
 
         fn get_unspent_transparent_outputs(

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -10,6 +10,9 @@ use zcash_primitives::{
     zip32::AccountId,
 };
 
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::{legacy::TransparentAddress, zip32::DiversifierIndex};
+
 #[derive(Debug)]
 pub enum ChainInvalid {
     /// The hash of the parent block given by a proposed new chain tip does
@@ -83,6 +86,12 @@ pub enum Error<NoteId> {
     /// support
     #[cfg(not(feature = "transparent-inputs"))]
     TransparentInputsNotSupported,
+
+    #[cfg(feature = "transparent-inputs")]
+    AddressNotRecognized(TransparentAddress),
+
+    #[cfg(feature = "transparent-inputs")]
+    ChildIndexOutOfRange(DiversifierIndex),
 }
 
 impl ChainInvalid {
@@ -142,6 +151,14 @@ impl<N: fmt::Display> fmt::Display for Error<N> {
             #[cfg(not(feature = "transparent-inputs"))]
             Error::TransparentInputsNotSupported => {
                 write!(f, "This wallet does not support spending or manipulating transparent UTXOs.")
+            }
+            #[cfg(feature = "transparent-inputs")]
+            Error::AddressNotRecognized(_) => {
+                write!(f, "The specified transparent address was not recognized as belonging to the wallet.")
+            }
+            #[cfg(feature = "transparent-inputs")]
+            Error::ChildIndexOutOfRange(i) => {
+                write!(f, "The diversifier index {:?} is out of range for transparent addresses.", i)
             }
         }
     }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -23,7 +23,10 @@ use crate::{
 };
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::{legacy::TransparentAddress, sapling::keys::OutgoingViewingKey};
+use {
+    crate::wallet::WalletTransparentOutput,
+    zcash_primitives::{legacy::TransparentAddress, sapling::keys::OutgoingViewingKey},
+};
 
 /// Scans a [`Transaction`] for any information that can be decrypted by the accounts in
 /// the wallet, and saves it to the wallet.
@@ -440,7 +443,7 @@ pub fn shield_transparent_funds<E, N, P, D, R, U>(
     params: &P,
     prover: impl TxProver,
     usk: &UnifiedSpendingKey,
-    from_addr: &TransparentAddress,
+    from_addrs: &[TransparentAddress],
     memo: &MemoBytes,
     min_confirmations: u32,
 ) -> Result<D::TxRef, E>
@@ -466,8 +469,13 @@ where
     let account_pubkey = usk.transparent().to_account_pubkey();
     let ovk = OutgoingViewingKey(account_pubkey.internal_ovk().as_bytes());
 
-    // get UTXOs from DB
-    let utxos = wallet_db.get_unspent_transparent_outputs(from_addr, latest_anchor)?;
+    // get UTXOs from DB for each address
+    let mut utxos: Vec<WalletTransparentOutput> = vec![];
+    for from_addr in from_addrs {
+        let mut outputs = wallet_db.get_unspent_transparent_outputs(from_addr, latest_anchor)?;
+        utxos.append(&mut outputs);
+    }
+
     let total_amount = utxos
         .iter()
         .map(|utxo| utxo.txout().value)
@@ -481,23 +489,22 @@ where
 
     let amount_to_shield = (total_amount - fee).ok_or_else(|| E::from(Error::InvalidAmount))?;
 
+    let addr_metadata = wallet_db.get_transparent_receivers(account)?;
     let mut builder = Builder::new_with_fee(params.clone(), latest_scanned_height, fee);
-
-    let diversifier_index = *wallet_db
-        .get_transparent_receivers(account)?
-        .get(from_addr)
-        .ok_or(Error::AddressNotRecognized(*from_addr))?
-        .diversifier_index();
-
-    let child_index = u32::try_from(diversifier_index)
-        .map_err(|_| Error::ChildIndexOutOfRange(diversifier_index))?;
-
-    let secret_key = usk
-        .transparent()
-        .derive_external_secret_key(child_index)
-        .unwrap();
-
     for utxo in &utxos {
+        let diversifier_index = addr_metadata
+            .get(utxo.recipient_address())
+            .ok_or_else(|| Error::AddressNotRecognized(*utxo.recipient_address()))?
+            .diversifier_index();
+
+        let child_index = u32::try_from(*diversifier_index)
+            .map_err(|_| Error::ChildIndexOutOfRange(*diversifier_index))?;
+
+        let secret_key = usk
+            .transparent()
+            .derive_external_secret_key(child_index)
+            .unwrap();
+
         builder
             .add_transparent_input(secret_key, utxo.outpoint().clone(), utxo.txout().clone())
             .map_err(Error::Builder)?;

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -4,6 +4,7 @@ use std::error;
 use std::fmt;
 
 use zcash_client_backend::{
+    address::RecipientAddress,
     data_api,
     encoding::{Bech32DecodeError, TransparentCodecError},
 };
@@ -80,6 +81,10 @@ pub enum SqliteClientError {
 
     /// A caller attempted to construct a new account with an invalid account identifier.
     AccountIdOutOfRange,
+
+    /// The address associated with a record being inserted was not recognized as
+    /// belonging to the wallet
+    AddressNotRecognized(RecipientAddress),
 }
 
 impl error::Error for SqliteClientError {
@@ -122,6 +127,7 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::KeyDerivationError(acct_id) => write!(f, "Key derivation failed for account {:?}", acct_id),
             SqliteClientError::AccountIdDiscontinuity => write!(f, "Wallet account identifiers must be sequential."),
             SqliteClientError::AccountIdOutOfRange => write!(f, "Wallet account identifiers must be less than 0x7FFFFFFF."),
+            SqliteClientError::AddressNotRecognized(_) => write!(f, "The address associated with a received txo is not identifiable as belonging to the wallet."),
         }
     }
 }

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -4,13 +4,15 @@ use std::error;
 use std::fmt;
 
 use zcash_client_backend::{
-    address::RecipientAddress,
     data_api,
     encoding::{Bech32DecodeError, TransparentCodecError},
 };
 use zcash_primitives::{consensus::BlockHeight, zip32::AccountId};
 
 use crate::{NoteId, PRUNING_HEIGHT};
+
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::legacy::TransparentAddress;
 
 #[cfg(feature = "unstable")]
 use zcash_primitives::transaction::TxId;
@@ -44,6 +46,7 @@ pub enum SqliteClientError {
     /// Base58 decoding error
     Base58(bs58::decode::Error),
 
+    ///
     #[cfg(feature = "transparent-inputs")]
     HdwalletError(hdwallet::error::Error),
 
@@ -84,7 +87,8 @@ pub enum SqliteClientError {
 
     /// The address associated with a record being inserted was not recognized as
     /// belonging to the wallet
-    AddressNotRecognized(RecipientAddress),
+    #[cfg(feature = "transparent-inputs")]
+    AddressNotRecognized(TransparentAddress),
 }
 
 impl error::Error for SqliteClientError {
@@ -127,6 +131,7 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::KeyDerivationError(acct_id) => write!(f, "Key derivation failed for account {:?}", acct_id),
             SqliteClientError::AccountIdDiscontinuity => write!(f, "Wallet account identifiers must be sequential."),
             SqliteClientError::AccountIdOutOfRange => write!(f, "Wallet account identifiers must be less than 0x7FFFFFFF."),
+            #[cfg(feature = "transparent-inputs")]
             SqliteClientError::AddressNotRecognized(_) => write!(f, "The address associated with a received txo is not identifiable as belonging to the wallet."),
         }
     }

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -168,6 +168,12 @@ impl From<hdwallet::error::Error> for SqliteClientError {
     }
 }
 
+impl From<TransparentCodecError> for SqliteClientError {
+    fn from(e: TransparentCodecError) -> Self {
+        SqliteClientError::TransparentAddress(e)
+    }
+}
+
 impl From<zcash_primitives::memo::Error> for SqliteClientError {
     fn from(e: zcash_primitives::memo::Error) -> Self {
         SqliteClientError::InvalidMemo(e)

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -271,6 +271,20 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
             Error::TransparentInputsNotSupported,
         ));
     }
+
+    fn get_transparent_balances(
+        &self,
+        _account: AccountId,
+        _max_height: BlockHeight,
+    ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
+        #[cfg(feature = "transparent-inputs")]
+        return wallet::get_transparent_balances(self, _account, _max_height);
+
+        #[cfg(not(feature = "transparent-inputs"))]
+        return Err(SqliteClientError::BackendError(
+            Error::TransparentInputsNotSupported,
+        ));
+    }
 }
 
 impl<'a, P: consensus::Parameters> WalletRead for DataConnStmtCache<'a, P> {
@@ -390,6 +404,14 @@ impl<'a, P: consensus::Parameters> WalletRead for DataConnStmtCache<'a, P> {
     ) -> Result<Vec<WalletTransparentOutput>, Self::Error> {
         self.wallet_db
             .get_unspent_transparent_outputs(address, max_height)
+    }
+
+    fn get_transparent_balances(
+        &self,
+        account: AccountId,
+        max_height: BlockHeight,
+    ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
+        self.wallet_db.get_transparent_balances(account, max_height)
     }
 }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -34,7 +34,7 @@
 
 use rusqlite::Connection;
 use secrecy::{ExposeSecret, SecretVec};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
@@ -50,7 +50,7 @@ use zcash_primitives::{
 };
 
 use zcash_client_backend::{
-    address::UnifiedAddress,
+    address::{AddressMetadata, UnifiedAddress},
     data_api::{
         BlockSource, DecryptedTransaction, PoolType, PrunedBlock, Recipient, SentTransaction,
         WalletRead, WalletWrite,
@@ -248,7 +248,7 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
     fn get_transparent_receivers(
         &self,
         _account: AccountId,
-    ) -> Result<HashSet<TransparentAddress>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, AddressMetadata>, Self::Error> {
         #[cfg(feature = "transparent-inputs")]
         return wallet::get_transparent_receivers(&self.params, &self.conn, _account);
 
@@ -379,7 +379,7 @@ impl<'a, P: consensus::Parameters> WalletRead for DataConnStmtCache<'a, P> {
     fn get_transparent_receivers(
         &self,
         account: AccountId,
-    ) -> Result<HashSet<TransparentAddress>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, AddressMetadata>, Self::Error> {
         self.wallet_db.get_transparent_receivers(account)
     }
 
@@ -1187,10 +1187,10 @@ mod tests {
         let receivers = db_data.get_transparent_receivers(0.into()).unwrap();
 
         // The receiver for the default UA should be in the set.
-        assert!(receivers.contains(ufvk.default_address().0.transparent().unwrap()));
+        assert!(receivers.contains_key(ufvk.default_address().0.transparent().unwrap()));
 
         // The default t-addr should be in the set.
-        assert!(receivers.contains(&taddr));
+        assert!(receivers.contains_key(&taddr));
     }
 
     #[cfg(feature = "unstable")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -236,9 +236,7 @@ pub(crate) fn get_current_address<P: consensus::Parameters>(
 
     addr.map(|(addr_str, di_vec)| {
         let mut di_be: [u8; 11] = di_vec.try_into().map_err(|_| {
-            SqliteClientError::CorruptedData(
-                "Diversifier index is not an 11-byte value".to_owned(),
-            )
+            SqliteClientError::CorruptedData("Diversifier index is not an 11-byte value".to_owned())
         })?;
         di_be.reverse();
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -79,7 +79,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                             )),
                         })?;
 
-                for taddr in taddrs {
+                for (taddr, _) in taddrs {
                     stmt_update_utxo_account.execute(named_params![
                         ":account": &account,
                         ":address": &taddr.encode(&self._params),

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- Added in `zcash_primitives::zip32`
+  - An implementation of `TryFrom<DiversifierIndex>` for `u32`
+
 ## [0.8.1] - 2022-10-19
 ### Added
 - `zcash_primitives::legacy`:

--- a/zcash_primitives/src/zip32.rs
+++ b/zcash_primitives/src/zip32.rs
@@ -105,6 +105,16 @@ impl From<u64> for DiversifierIndex {
     }
 }
 
+impl TryFrom<DiversifierIndex> for u32 {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(di: DiversifierIndex) -> Result<u32, Self::Error> {
+        let mut u128_bytes = [0u8; 16];
+        u128_bytes[0..11].copy_from_slice(&di.0[..]);
+        u128::from_le_bytes(u128_bytes).try_into()
+    }
+}
+
 impl DiversifierIndex {
     pub fn new() -> Self {
         DiversifierIndex([0; 11])
@@ -144,3 +154,26 @@ pub enum Scope {
 }
 
 memuse::impl_no_dynamic_usage!(Scope);
+
+#[cfg(test)]
+mod tests {
+    use super::DiversifierIndex;
+
+    #[test]
+    fn diversifier_index_to_u32() {
+        let two = DiversifierIndex([
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(u32::try_from(two), Ok(2));
+
+        let max_u32 = DiversifierIndex([
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(u32::try_from(max_u32), Ok(u32::MAX));
+
+        let too_big = DiversifierIndex([
+            0xff, 0xff, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert!(matches!(u32::try_from(too_big), Err(_)));
+    }
+}


### PR DESCRIPTION
The legacy transparent address is never added to the `addresses` table, but we still need to be able to receive UTXOs sent to that address. So, we add a special case for when a UTXO matches that legacy address, and set the account ID to 0 manually.