### PR TITLE
get_transparent_balances fails with `no such column`

### DIFF
--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1016,7 +1016,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
          FROM utxos u
          LEFT OUTER JOIN transactions tx
          ON tx.id_tx = u.spent_in_tx
-         WHERE u.received_by_accountt = ?
+         WHERE u.received_by_account = ?
          AND u.height <= ?
          AND tx.block IS NULL",
     )?;


### PR DESCRIPTION
Error message:

"Error while fetching transparent balances for AccountId(0): no such column: u.received_by_accountt"

Closes #686