### PR TITLE
Release `zcash_client_sqlite 0.4.0` and dependencies

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -85,7 +85,7 @@ and this library adheres to Rust's notion of
 ### Changed
 - MSRV is now 1.56.1.
 - Bumped dependencies to `ff 0.12`, `group 0.12`, `bls12_381 0.7`
-  `zcash_primitives 0.8`, `orchard 0.3`.
+  `zcash_primitives 0.9`, `orchard 0.3`.
 - `zcash_client_backend::proto`:
   - The Protocol Buffers bindings are now generated for `prost 0.11` instead of
     `protobuf 2`.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.6.0] - 2022-11-12
 ### Added
 - Functionality that enables the receiving and spending of transparent funds,
   behind the new `transparent-inputs` feature flag.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -118,6 +118,10 @@ and this library adheres to Rust's notion of
     - The `WalletRead::NoteRef` and `WalletRead::TxRef` associated types are now
       required to implement `Eq` and `Ord`
   - `WalletWrite::store_received_tx` has been renamed to `store_decrypted_tx`.
+  - `wallet::decrypt_and_store_transaction` now always stores the transaction by
+    calling `WalletWrite::store_decrypted_tx`, even if no outputs could be
+    decrypted. The error type produced by the provided `WalletWrite` instance is
+    also now returned directly.
   - The `SentTransaction` type has been substantially modified to accommodate
     handling of transparent inputs. Per-output data has been split out into a
     new struct `SentTransactionOutput`, and `SentTransaction` can now contain
@@ -136,9 +140,6 @@ and this library adheres to Rust's notion of
     the block source and wallet database to which these methods delegate IO
     operations directly, which simplifies error handling in cases where callback
     functions are involved.
-  - The error type of `wallet::decrypt_and_store_transaction` has been changed;
-    the error type produced by the provided `WalletWrite` instance is returned
-    directly.
   - `error::ChainInvalid` has been moved to `chain::error`.
   - `error::Error` has been substantially modified. It now wraps database,
     note selection, builder, and other errors.

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -23,7 +23,7 @@ development = ["zcash_proofs"]
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_note_encryption = { version = "0.2", path = "../components/zcash_note_encryption" }
-zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.9", path = "../zcash_primitives" }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -84,7 +84,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 rand_xorshift = "0.3"
 tempfile = "3.1.0"
-zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.9", path = "../zcash_proofs" }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -65,7 +65,8 @@ and this library adheres to Rust's notion of
     (and in the future, outputs to other pools). Values for this column should
     be assigned by inference from the address type in the stored data.
 - MSRV is now 1.56.1.
-- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`, `zcash_primitives 0.9`.
+- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`,
+  `zcash_primitives 0.9`, `zcash_client_backend 0.6`.
 - Renamed the following to use lower-case abbreviations (matching Rust
   naming conventions):
   - `zcash_client_sqlite::BlockDB` to `BlockDb`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-11-12
 ### Added
 - Implementations of `zcash_client_backend::data_api::WalletReadTransparent`
   and `WalletWriteTransparent` have been added. These implementations

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -75,32 +75,30 @@ and this library adheres to Rust's notion of
 - The SQLite implementations of `zcash_client_backend::data_api::WalletRead`
   and `WalletWrite` have been updated to reflect the changes to those
   traits.
-- Renamed the following to reflect their Sapling-specific nature:
-  - `zcash_client_sqlite::wallet`:
-    - `get_spendable_notes` to `get_spendable_sapling_notes`.
-    - `select_spendable_notes` to `select_spendable_sapling_notes`.
-- `zcash_client_sqlite::wallet::{get_spendable_sapling_notes, select_spendable_sapling_notes}`
-  have also been changed to take a parameter that permits the caller to
-  specify a set of notes to exclude from consideration.
-- `zcash_client_sqlite::wallet::init_wallet_db` has been modified to
-  take the wallet seed as an argument so that it can correctly perform
-  migrations that require re-deriving key material. In particular for
-  this upgrade, the seed is used to derive UFVKs to replace the currently
-  stored Sapling extfvks (without loss of information) as part of the
-  migration process.
+- `zcash_client_sqlite::wallet`:
+  - `get_spendable_notes` has been renamed to `get_spendable_sapling_notes`.
+  - `select_spendable_notes` has been renamed to `select_spendable_sapling_notes`.
+  - `get_spendable_sapling_notes` and `select_spendable_sapling_notes` have also
+    been changed to take a parameter that permits the caller to specify a set of
+    notes to exclude from consideration.
+  - `init_wallet_db` has been modified to take the wallet seed as an argument so
+    that it can correctly perform migrations that require re-deriving key
+    material. In particular for this upgrade, the seed is used to derive UFVKs
+    to replace the currently stored Sapling ExtFVKs (without losing information)
+    as part of the migration process.
 
 ### Removed
 - The following functions have been removed from the public interface of
   `zcash_client_sqlite::wallet`. Prefer methods defined on
   `zcash_client_backend::data_api::{WalletRead, WalletWrite}` instead.
   - `get_extended_full_viewing_keys` (use `WalletRead::get_unified_full_viewing_keys` instead).
-  - `insert_sent_note` (use `WalletWrite::store_sent_tx` instead)
-  - `insert_sent_utxo` (use `WalletWrite::store_sent_tx` instead)
-  - `put_sent_note` (use `WalletWrite::store_decrypted_tx` instead)
-  - `put_sent_utxo` (use `WalletWrite::store_decrypted_tx` instead)
-  - `delete_utxos_above` (use `WalletWrite::rewind_to_height` instead)
+  - `insert_sent_note` (use `WalletWrite::store_sent_tx` instead).
+  - `insert_sent_utxo` (use `WalletWrite::store_sent_tx` instead).
+  - `put_sent_note` (use `WalletWrite::store_decrypted_tx` instead).
+  - `put_sent_utxo` (use `WalletWrite::store_decrypted_tx` instead).
+  - `delete_utxos_above` (use `WalletWrite::rewind_to_height` instead).
 - `zcash_client_sqlite::with_blocks` (use
-  `zcash_client_backend::data_api::BlockSource::with_blocks` instead)
+  `zcash_client_backend::data_api::BlockSource::with_blocks` instead).
 - `zcash_client_sqlite::error::SqliteClientError` variants:
   - `SqliteClientError::IncorrectHrpExtFvk`
   - `SqliteClientError::Base58`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -65,7 +65,7 @@ and this library adheres to Rust's notion of
     (and in the future, outputs to other pools). Values for this column should
     be assigned by inference from the address type in the stored data.
 - MSRV is now 1.56.1.
-- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`, `zcash_primitives 0.8`.
+- Bumped dependencies to `ff 0.12`, `group 0.12`, `jubjub 0.9`, `zcash_primitives 0.9`.
 - Renamed the following to use lower-case abbreviations (matching Rust
   naming conventions):
   - `zcash_client_sqlite::BlockDB` to `BlockDb`

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
+zcash_client_backend = { version = "0.6", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.9", path = "../zcash_primitives" }
 
 # Dependencies exposed in a public API:

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 regex = "1.4"
 tempfile = "3"
-zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.9", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.9", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.56.1"
 
 [dependencies]
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.9", path = "../zcash_primitives" }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
@@ -48,7 +48,7 @@ rand_core = "0.6"
 regex = "1.4"
 tempfile = "3"
 zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
-zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = ["test-dependencies"] }
+zcash_primitives = { version = "0.9", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.56.1"
 
 [dependencies]
 blake2b_simd = "1"
-zcash_primitives = { version = "0.8", path = "../zcash_primitives", features = ["zfuture" ] }
+zcash_primitives = { version = "0.9", path = "../zcash_primitives", features = ["zfuture" ] }
 
 [dev-dependencies]
 ff = "0.12"

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -18,7 +18,7 @@ ff = "0.12"
 jubjub = "0.9"
 rand_core = "0.6"
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
-zcash_proofs = { version = "0.8", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.9", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = []

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,80 +8,75 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
-- Added in `zcash_primitives::zip32`
-  - An implementation of `TryFrom<DiversifierIndex>` for `u32`
-- `zcash_primitives::transaction::components::amount::NonNegativeAmount`
-- Added to `zcash_primitives::transaction::builder`
-  - `Error::InsufficientFunds`
-  - `Error::ChangeRequired`
-  - `Error::Balance`
-  - `Error::Fee`
+- Added to `zcash_primitives::transaction::builder`:
+  - `Error::{InsufficientFunds, ChangeRequired, Balance, Fee}`
   - `Builder` state accessor methods:
-    - `Builder::params()`
-    - `Builder::target_height()`
-    - `Builder::transparent_inputs()`
-    - `Builder::transparent_outputs()`
-    - `Builder::sapling_inputs()`
-    - `Builder::sapling_outputs()`
-- `zcash_primitives::transaction::fees` a new module containing abstractions
+    - `Builder::{params, target_height}`
+    - `Builder::{transparent_inputs, transparent_outputs}`
+    - `Builder::{sapling_inputs, sapling_outputs}`
+- `zcash_primitives::transaction::fees`, a new module containing abstractions
   and types related to fee calculations.
-  - `FeeRule` a trait that describes how to compute the fee required for a
+  - `FeeRule`, a trait that describes how to compute the fee required for a
     transaction given inputs and outputs to the transaction.
-  - `fixed`, a new module containing an implementation of the existing fixed
-    fee rule.
-  - `zip317`, a new module containing an implementation of the ZIP 317 fee
-    rules.
-- Added to `zcash_primitives::transaction::components::orchard`:
-  - `impl MapAuth<orchard::bundle::Authorized, orchard::bundle::Authorized> for ()`
-    (the identity map).
-- Added to `zcash_primitives::transaction::components::sapling`:
-  - `impl MapAuth<Authorized, Authorized> for ()` (the identity map).
-  - `builder::SaplingBuilder::{inputs, outputs}`: accessors for Sapling builder
-    state.
-- `zcash_primitives::transaction::components::sapling::fees`
-- Added to `zcash_primitives::transaction::components::transparent::builder`
-  - `TransparentBuilder::{inputs, outputs}`: accessors for transparent builder state.
-- `zcash_primitives::transaction::components::transparent::fees`
-- `zcash_primitives::sapling::Note::commitment`
-- Added to `zcash_primitives::zip32::sapling::DiversifiableFullViewingKey`
-  - `DiversifiableFullViewingKey::{diversified_address, diversified_change_address}`
-- `impl Eq for zcash_primitves::sapling::PaymentAddress`
-- `impl {PartialOrd, Ord} for zcash_primitves::transaction::components::transparent::OutPoint`
+  - `fixed`, a module containing an implementation of the old fixed fee rule.
+  - `zip317`, a module containing an implementation of the ZIP 317 fee rules.
+- Added to `zcash_primitives::transaction::components`:
+  - `amount::NonNegativeAmount`
+  - Added to the `orchard` module:
+    - `impl MapAuth<orchard::bundle::Authorized, orchard::bundle::Authorized> for ()`
+      (the identity map).
+  - Added to the `sapling` module:
+    - `impl MapAuth<Authorized, Authorized> for ()` (the identity map).
+    - `builder::SaplingBuilder::{inputs, outputs}`: accessors for Sapling
+      builder state.
+    - `fees`, a module with Sapling-specific fee traits.
+  - Added to the `transparent` module:
+    - `impl {PartialOrd, Ord} for OutPoint`
+    - `builder::TransparentBuilder::{inputs, outputs}`: accessors for
+      transparent builder state.
+    - `fees`, a module with transparent-specific fee traits.
+- Added to `zcash_primitives::sapling`:
+  - `Note::commitment`
+  - `impl Eq for PaymentAddress`
+- Added to `zcash_primitives::zip32`:
+  - `impl TryFrom<DiversifierIndex> for u32`
+  - `sapling::DiversifiableFullViewingKey::{diversified_address, diversified_change_address}`
 
 ### Changed
-- `zcash_primitives::transaction::builder::Builder::build` now takes a `FeeRule`
-  argument which is used to compute the fee for the transaction as part of the
-  build process.
-- `zcash_primitives::transaction::builder::Builder::value_balance` now
-  returns `Result<Amount, BalanceError>` instead of `Option<Amount>`.
-- `zcash_primitives::transaction::builder::Builder::{new, new_with_rng}` no
-  longer fixes the fee for transactions to 0.00001 ZEC; the builder instead
-  computes the fee using a `FeeRule` implementation at build time.
-- `zcash_primitives::transaction::builder::Error` now is parameterized by the
-  types that can now be produced by fee calculation.
+- `zcash_primitives::transaction::builder`:
+  - `Builder::build` now takes a `FeeRule` argument which is used to compute the
+    fee for the transaction as part of the build process.
+  - `Builder::value_balance` now returns `Result<Amount, BalanceError>` instead
+    of `Option<Amount>`.
+  - `Builder::{new, new_with_rng}` no longer fixes the fee for transactions to
+    0.00001 ZEC; the builder instead computes the fee using a `FeeRule`
+    implementation at build time.
+  - `Error` now is parameterized by the types that can now be produced by fee
+    calculation.
 - `zcash_primitives::transaction::components::tze::builder::Builder::value_balance` now
   returns `Result<Amount, BalanceError>` instead of `Option<Amount>`.
 
 ### Deprecated
-- `zcash_primitives::zip32::sapling::to_extended_full_viewing_key` Use
-  `to_diversifiable_full_viewing_key` instead.
+- `zcash_primitives::zip32::sapling::to_extended_full_viewing_key` (use
+  `to_diversifiable_full_viewing_key` instead).
 
 ### Removed
-- Removed from `zcash_primitives::transaction::builder::Builder`
+- Removed from `zcash_primitives::transaction::builder`:
   - `Builder::{new_with_fee, new_with_rng_and_fee`} (use `Builder::{new, new_with_rng}`
     instead along with a `FeeRule` implementation passed to `Builder::build`.)
-  - `Builder::send_change_to` has been removed. Change outputs must be added to the
-    builder by the caller, just like any other output.
-- Removed from `zcash_primitives::transaction::builder::Error`
+  - `Builder::send_change_to` (change outputs must be added to the builder by
+    the caller, just like any other output).
   - `Error::ChangeIsNegative`
   - `Error::NoChangeAddress`
-  - `Error::InvalidAmount` (replaced by `Error::BalanceError`)
-- `zcash_primitives::transaction::components::sapling::builder::SaplingBuilder::get_candidate_change_address`
-   has been removed; change outputs must now be added by the caller.
-- The `From<&ExtendedSpendingKey>` instance for `ExtendedFullViewingKey` has been
-  removed. Use `ExtendedSpendingKey::to_diversifiable_full_viewing_key` instead.
-- `zcash_primitives::sapling::Node::new` has been removed. Use
-  `Node::from_scalar` or (preferably) `Note::commitment` instead.
+  - `Error::InvalidAmount` (replaced by `Error::BalanceError`).
+- Removed from `zcash_primitives::transaction::components::sapling::builder`:
+  - `SaplingBuilder::get_candidate_change_address` (change outputs must now be
+    added by the caller).
+- Removed from `zcash_primitives::zip32::sapling`:
+  - `impl From<&ExtendedSpendingKey> for ExtendedFullViewingKey` (use
+    `ExtendedSpendingKey::to_diversifiable_full_viewing_key` instead).
+- `zcash_primitives::sapling::Node::new` (use `Node::from_scalar` or preferably
+  `Note::commitment` instead).
 
 ## [0.8.1] - 2022-10-19
 ### Added

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.9.0] - 2022-11-12
 ### Added
 - Added to `zcash_primitives::transaction::builder`:
   - `Error::{InsufficientFunds, ChangeRequired, Balance, Fee}`

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.8.1"
+version = "0.9.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bumped dependencies to `zcash_primitives 0.9`.
 
 ## [0.8.0] - 2022-10-19
 ### Changed

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.0] - 2022-11-12
 ### Changed
 - Bumped dependencies to `zcash_primitives 0.9`.
 

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 all-features = true
 
 [dependencies]
-zcash_primitives = { version = "0.8", path = "../zcash_primitives" }
+zcash_primitives = { version = "0.9", path = "../zcash_primitives" }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]


### PR DESCRIPTION
Closes #487.
Closes #488.
Closes #497.