### PR TITLE
Update generated protobufs

### DIFF
--- a/zcash_client_backend/src/proto/compact_formats.rs
+++ b/zcash_client_backend/src/proto/compact_formats.rs
@@ -1,6 +1,3 @@
-// Remember that proto3 fields are all optional. A field that is not present will be set to its zero value.
-// bytes fields of hashes are in canonical little-endian format.
-
 /// CompactBlock is a packaging of ONLY the data from a block that's needed to:
 ///    1. Detect a payment to your shielded Sapling address
 ///    2. Detect a spend of your shielded Sapling notes
@@ -8,25 +5,25 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactBlock {
     /// the version of this wire format, for storage
-    #[prost(uint32, tag="1")]
+    #[prost(uint32, tag = "1")]
     pub proto_version: u32,
     /// the height of this block
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub height: u64,
     /// the ID (hash) of this block, same as in block explorers
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
     /// the ID (hash) of this block's predecessor
-    #[prost(bytes="vec", tag="4")]
+    #[prost(bytes = "vec", tag = "4")]
     pub prev_hash: ::prost::alloc::vec::Vec<u8>,
     /// Unix epoch time when the block was mined
-    #[prost(uint32, tag="5")]
+    #[prost(uint32, tag = "5")]
     pub time: u32,
     /// (hash, prevHash, and time) OR (full header)
-    #[prost(bytes="vec", tag="6")]
+    #[prost(bytes = "vec", tag = "6")]
     pub header: ::prost::alloc::vec::Vec<u8>,
     /// zero or more compact transactions from this block
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub vtx: ::prost::alloc::vec::Vec<CompactTx>,
 }
 /// CompactTx contains the minimum information for a wallet to know if this transaction
@@ -39,23 +36,23 @@ pub struct CompactTx {
     /// about this transaction.
     ///
     /// the index within the full block
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub index: u64,
     /// the ID (hash) of this transaction, same as in block explorers
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
     /// The transaction fee: present if server can provide. In the case of a
     /// stateless server and a transaction with transparent inputs, this will be
     /// unset because the calculation requires reference to prior transactions.
     /// If there are no transparent inputs, the fee will be calculable as:
     ///     valueBalanceSapling + valueBalanceOrchard + sum(vPubNew) - sum(vPubOld) - sum(tOut)
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub fee: u32,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub spends: ::prost::alloc::vec::Vec<CompactSaplingSpend>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub outputs: ::prost::alloc::vec::Vec<CompactSaplingOutput>,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub actions: ::prost::alloc::vec::Vec<CompactOrchardAction>,
 }
 /// CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash
@@ -63,7 +60,7 @@ pub struct CompactTx {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactSaplingSpend {
     /// nullifier (see the Zcash protocol specification)
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub nf: ::prost::alloc::vec::Vec<u8>,
 }
 /// output encodes the `cmu` field, `ephemeralKey` field, and a 52-byte prefix of the
@@ -74,13 +71,13 @@ pub struct CompactSaplingSpend {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactSaplingOutput {
     /// note commitment u-coordinate
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub cmu: ::prost::alloc::vec::Vec<u8>,
     /// ephemeral public key
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub ephemeral_key: ::prost::alloc::vec::Vec<u8>,
     /// first 52 bytes of ciphertext
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }
 /// <https://github.com/zcash/zips/blob/main/zip-0225.rst#orchard-action-description-orchardaction>
@@ -88,15 +85,15 @@ pub struct CompactSaplingOutput {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactOrchardAction {
     /// \[32\] The nullifier of the input note
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub nullifier: ::prost::alloc::vec::Vec<u8>,
     /// \[32\] The x-coordinate of the note commitment for the output note
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub cmx: ::prost::alloc::vec::Vec<u8>,
     /// \[32\] An encoding of an ephemeral Pallas public key
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub ephemeral_key: ::prost::alloc::vec::Vec<u8>,
     /// \[52\] The first 52 bytes of the encCiphertext field
-    #[prost(bytes="vec", tag="4")]
+    #[prost(bytes = "vec", tag = "4")]
     pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/zcash_client_backend/src/proto/service.rs
+++ b/zcash_client_backend/src/proto/service.rs
@@ -2,18 +2,18 @@
 /// hash. Specification by hash is not implemented, but may be in the future.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockId {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub height: u64,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// BlockRange specifies a series of blocks from start to end inclusive.
 /// Both BlockIDs must be heights; specification by hash is not yet supported.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockRange {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub start: ::core::option::Option<BlockId>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub end: ::core::option::Option<BlockId>,
 }
 /// A TxFilter contains the information needed to identify a particular
@@ -22,25 +22,25 @@ pub struct BlockRange {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxFilter {
     /// block identifier, height or hash
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub block: ::core::option::Option<BlockId>,
     /// index within the block
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub index: u64,
     /// transaction ID (hash, txid)
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
 }
-/// RawTransaction contains the complete transaction data. It also optionally includes 
+/// RawTransaction contains the complete transaction data. It also optionally includes
 /// the block height in which the transaction was included, or, when returned
 /// by GetMempoolStream(), the latest block height.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RawTransaction {
     /// exact data returned by Zcash 'getrawtransaction'
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub data: ::prost::alloc::vec::Vec<u8>,
     /// height that the transaction was mined (or -1)
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub height: u64,
 }
 /// A SendResponse encodes an error code and a string. It is currently used
@@ -48,58 +48,56 @@ pub struct RawTransaction {
 /// successful; if non-zero, it and the message specify the failure.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendResponse {
-    #[prost(int32, tag="1")]
+    #[prost(int32, tag = "1")]
     pub error_code: i32,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }
 /// Chainspec is a placeholder to allow specification of a particular chain fork.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ChainSpec {
-}
+pub struct ChainSpec {}
 /// Empty is for gRPCs that take no arguments, currently only GetLightdInfo.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Empty {
-}
+pub struct Empty {}
 /// LightdInfo returns various information about this lightwalletd instance
 /// and the state of the blockchain.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LightdInfo {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub version: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub vendor: ::prost::alloc::string::String,
     /// true
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub taddr_support: bool,
     /// either "main" or "test"
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub chain_name: ::prost::alloc::string::String,
     /// depends on mainnet or testnet
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub sapling_activation_height: u64,
     /// protocol identifier, see consensus/upgrades.cpp
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub consensus_branch_id: ::prost::alloc::string::String,
     /// latest block on the best chain
-    #[prost(uint64, tag="7")]
+    #[prost(uint64, tag = "7")]
     pub block_height: u64,
-    #[prost(string, tag="8")]
+    #[prost(string, tag = "8")]
     pub git_commit: ::prost::alloc::string::String,
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     pub branch: ::prost::alloc::string::String,
-    #[prost(string, tag="10")]
+    #[prost(string, tag = "10")]
     pub build_date: ::prost::alloc::string::String,
-    #[prost(string, tag="11")]
+    #[prost(string, tag = "11")]
     pub build_user: ::prost::alloc::string::String,
     /// less than tip height if zcashd is syncing
-    #[prost(uint64, tag="12")]
+    #[prost(uint64, tag = "12")]
     pub estimated_height: u64,
     /// example: "v4.1.1-877212414"
-    #[prost(string, tag="13")]
+    #[prost(string, tag = "13")]
     pub zcashd_build: ::prost::alloc::string::String,
     /// example: "/MagicBean:4.1.1/"
-    #[prost(string, tag="14")]
+    #[prost(string, tag = "14")]
     pub zcashd_subversion: ::prost::alloc::string::String,
 }
 /// TransparentAddressBlockFilter restricts the results to the given address
@@ -107,10 +105,10 @@ pub struct LightdInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransparentAddressBlockFilter {
     /// t-address
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub address: ::prost::alloc::string::String,
     /// start, end heights
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub range: ::core::option::Option<BlockRange>,
 }
 /// Duration is currently used only for testing, so that the Ping rpc
@@ -118,7 +116,7 @@ pub struct TransparentAddressBlockFilter {
 /// are microseconds.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub interval_us: i64,
 }
 /// PingResponse is used to indicate concurrency, how many Ping rpcs
@@ -126,83 +124,83 @@ pub struct Duration {
 /// This rpc is used for testing only.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PingResponse {
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub entry: i64,
-    #[prost(int64, tag="2")]
+    #[prost(int64, tag = "2")]
     pub exit: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub address: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddressList {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Balance {
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub value_zat: i64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Exclude {
-    #[prost(bytes="vec", repeated, tag="1")]
+    #[prost(bytes = "vec", repeated, tag = "1")]
     pub txid: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// The TreeState is derived from the Zcash z_gettreestate rpc.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TreeState {
     /// "main" or "test"
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub network: ::prost::alloc::string::String,
     /// block height
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub height: u64,
     /// block id
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub hash: ::prost::alloc::string::String,
     /// Unix epoch time when the block was mined
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub time: u32,
     /// sapling commitment tree state
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub sapling_tree: ::prost::alloc::string::String,
     /// orchard commitment tree state
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub orchard_tree: ::prost::alloc::string::String,
 }
 /// Results are sorted by height, which makes it easy to issue another
 /// request that picks up from where the previous left off.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressUtxosArg {
-    #[prost(string, repeated, tag="1")]
+    #[prost(string, repeated, tag = "1")]
     pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub start_height: u64,
     /// zero means unlimited
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub max_entries: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressUtxosReply {
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub address: ::prost::alloc::string::String,
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub txid: ::prost::alloc::vec::Vec<u8>,
-    #[prost(int32, tag="2")]
+    #[prost(int32, tag = "2")]
     pub index: i32,
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub script: ::prost::alloc::vec::Vec<u8>,
-    #[prost(int64, tag="4")]
+    #[prost(int64, tag = "4")]
     pub value_zat: i64,
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub height: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressUtxosReplyList {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub address_utxos: ::prost::alloc::vec::Vec<GetAddressUtxosReply>,
 }
 /// Generated client implementations.


### PR DESCRIPTION
`prost 0.11.2` added code formatting support, so the generated files now better match what rustfmt produces.