### PR TITLE
Adds `limit` parameter to `validate_chain()`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -25,26 +25,21 @@ and this library adheres to Rust's notion of
   - `validate_chain` now requires a non-optional `validate_from` parameter that
     indicates the starting point of the `BlockSourceT` validation. An Optional
     `limit` can be specified as well.  This allows callers to validate smaller
-    intervals of the given `BlockSourceT` shortening processing times of the
-    function call at the expense of obtaining a partial result on a given
-    section of interest of the block source. 
+    intervals of blocks already present on the provided `BlockSource` shortening
+    processing times of the function call at the expense of obtaining a partial
+    result. 
 
   - `params: &ParamsT` has been removed from the arguments since they were only
     needed to fall back to `sapling_activation_height` when `None` as passed as
-    the `validate_from` argument. Passing `None` as validation start point on a
-    pre-populated `block_source` would result in an error
-    `ChainError::block_height_discontinuity(sapling_activation_height - 1, current_height)` 
+    the `validate_from` argument. Implementors of `BlockSource` are resposible
+    of definining how they will fall back to a suitable value when `validate_from`
+    is `None`. 
 
-  - With this new API callers must specify a concrete `validate_from` argument
-    and assume that `validate_chain` will not take any default fallbacks to
-    chain `ParamsT`.
-
-  - The addition of a `limit` to the chain validation function changes the
-    meaning of its successful output, being now a `BlockHeight, BlockHash)`
-    tuple indicating the block height and block has up to which the chain as
-    been validated on its continuity of heights and hashes. Callers providing a
-    `limit` aregumente are responsible of subsequent calls to
-    `validate_chain()` to complete validating the totality of the block_source. 
+  - When passing a `limit` to the chain validation function, a successful output,
+    indicates that the chain has been validated on its continuity of heights and hashes
+    within the limits of the range `[validate_from, validate_from + limit)`. 
+    Callers providing a `limit` argument are responsible for making subsequent calls to
+    `validate_chain()` in order to complete validating the totality of the block_source. 
 
 ### Removed 
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -9,20 +9,47 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.60.0.
+
 - `zcash_client_backend::data_api::wallet::shield_transparent_funds` now
   takes a `shielding_threshold` argument that can be used to specify the 
   minimum value allowed as input to a shielding transaction. Previously 
   the shielding threshold was fixed at 100000 zatoshis.
+
 - Note commitments now use
   `zcash_primitives::sapling::note::ExtractedNoteCommitment` instead of
   `bls12_381::Scalar` in the following places:
   - The `cmu` field of `zcash_client_backend::wallet::WalletShieldedOutput`.
   - `zcash_client_backend::proto::compact_formats::CompactSaplingOutput::cmu`.
 
+- **breaking changes** to `zcash_client_backend::data_api::chain::validate_chain`
+  - `validate_chain` now requires a non-optional `validate_from` parameter that
+    indicates the starting point of the `BlockSourceT` validation. An Optional
+    `limit` can be specified as well.  This allows callers to validate smaller
+    intervals of the given `BlockSourceT` shortening processing times of the
+    function call at the expense of obtaining a partial result on a given
+    section of interest of the block source. 
+
+  - `params: &ParamsT` has been removed from the arguments since they were only
+    needed to fall back to `sapling_activation_height` when `None` as passed as
+    the `validate_from` argument. Passing `None` as validation start point on a
+    pre-populated `block_source` would result in an error
+    `ChainError::block_height_discontinuity(sapling_activation_height - 1, current_height)` 
+
+  - With this new API callers must specify a concrete `validate_from` argument
+    and assume that `validate_chain` will not take any default fallbacks to
+    chain `ParamsT`.
+
+  - The addition of a `limit` to the chain validation function changes the
+    meaning of its successful output, being now a `BlockHeight, BlockHash)`
+    tuple indicating the block height and block has up to which the chain as
+    been validated on its continuity of heights and hashes. Callers providing a
+    `limit` aregumente are responsible of subsequent calls to
+    `validate_chain()` to complete validating the totality of the block_source. 
 
 ### Removed 
 - `zcash_client_backend::data_api`:
   - `WalletWrite::remove_unmined_tx` (was behind the `unstable` feature flag).
+
 ## [0.6.1] - 2022-12-06
 ### Added
 - `zcash_client_backend::data_api::chain::scan_cached_blocks` now generates

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -135,25 +135,21 @@ pub trait BlockSource {
 /// block source is more likely to be accurate than the previously-scanned information.
 /// This follows from the design (and trust) assumption that the `lightwalletd` server
 /// provides accurate block information as of the time it was requested.
-/// The addition of a `limit` to the chain validation function changes the meaning of
-/// its successful output, being now a `BlockHeight, BlockHash)` tuple indicating the
-/// block height and block hash up to which the chain as been validated on its continuity
-/// of heights and hashes. Callers providing a `limit` argument are responsible of
-/// making subsequent calls to `validate_chain()` to complete validating the remaining
-/// blocks stored on the `block_source`.
 ///
 /// Arguments:
 /// - `block_source` Source of compact blocks
 /// - `validate_from` Height & hash of last validated block;
-/// - `limit` Maximum number of blocks that should be validated in this call.
+/// - `limit` specified number of blocks that will be valididated. Callers providing
+/// a `limit` argument are responsible of making subsequent calls to `validate_chain()`
+/// to complete validating the remaining blocks stored on the `block_source`. If `none`
+/// is provided, there will be no limit set to the validation and upper bound of the
+/// validation range will be the latest height present in the `block_source`.
 ///
 /// Returns:
 /// - `Ok(())` if the combined chain is valid up to the given height
 /// and block hash.
 /// - `Err(Error::Chain(cause))` if the combined chain is invalid.
 /// - `Err(e)` if there was an error during validation unrelated to chain validity.
-///
-/// This function does not mutate either of the databases.
 pub fn validate_chain<BlockSourceT>(
     block_source: &BlockSourceT,
     mut validate_from: Option<(BlockHeight, BlockHash)>,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -18,8 +18,32 @@ and this library adheres to Rust's notion of
 ### Changed
 - MSRV is now 1.60.0.
 
+- **breaking changes** to `validate_chain`. 
+  - `zcash_client_backend::data_api::chain::validate_chain` now requires a
+    non-optional `validate_from` parameter that indicates the starting point of
+    the `BlockSourceT` validation. An Optional `limit` can be specified as
+    well. This allows callers to validate smaller intervals of the given
+    `BlockSourceT` shortening processing times of the function call at the
+    expense of obtaining a partial result on a given section of interest of the
+    block source. 
+  - `params: &ParamsT` has been removed from the arguments since they were only needed 
+    to fall back to `sapling_activation_height` when `None` as passed as the
+    `validate_from` argument. Passing `None` as validation start point on a
+    pre-populated `block_source` would result in an error
+    `ChainError::block_height_discontinuity(sapling_activation_height - 1, current_height)` 
+  - With this new API callers must specify a concrete `validate_from` argument and
+    assume that `validate_chain` will not take any default fallbacks to chain
+    `ParamsT`.
+  - The addition of a `limit` to the chain validation function changes the
+    meaning of its successful output, being now a `BlockHeight, BlockHash)` tuple
+    indicating the block height and block has up to which the chain as been
+    validated on its continuity of heights and hashes. Callers providing a
+    `limit` aregumente are responsible of subsequent calls to `validate_chain()`
+    to complete validating the totality of the block_source. 
+
 ### Removed
 - implementation of unstable function `WalletWrite::remove_unmined_tx`,
+
 ## [0.4.2] - 2022-12-13
 ### Fixed
 - `zcash_client_sqlite::WalletDb::get_transparent_balances` no longer returns an

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -28,7 +28,7 @@ pub mod migrations;
 /// blocks are traversed up to the maximum height.
 pub(crate) fn blockdb_with_blocks<F, DbErrT, NoteRef>(
     block_source: &BlockDb,
-    last_scanned_height: BlockHeight,
+    last_scanned_height: Option<BlockHeight>,
     limit: Option<u32>,
     mut with_row: F,
 ) -> Result<(), Error<DbErrT, SqliteClientError, NoteRef>>
@@ -51,7 +51,7 @@ where
 
     let mut rows = stmt_blocks
         .query(params![
-            u32::from(last_scanned_height),
+            last_scanned_height.map_or(0u32, u32::from),
             limit.unwrap_or(u32::max_value()),
         ])
         .map_err(to_chain_error)?;
@@ -197,7 +197,7 @@ pub(crate) fn blockmetadb_find_block(
 #[cfg(feature = "unstable")]
 pub(crate) fn fsblockdb_with_blocks<F, DbErrT, NoteRef>(
     cache: &FsBlockDb,
-    last_scanned_height: BlockHeight,
+    last_scanned_height: Option<BlockHeight>,
     limit: Option<u32>,
     mut with_block: F,
 ) -> Result<(), Error<DbErrT, FsBlockDbError, NoteRef>>
@@ -213,16 +213,16 @@ where
         .conn
         .prepare(
             "SELECT height, blockhash, time, sapling_outputs_count, orchard_actions_count
-         FROM compactblocks_meta
-         WHERE height > ?
-         ORDER BY height ASC LIMIT ?",
+             FROM compactblocks_meta
+             WHERE height > ?
+             ORDER BY height ASC LIMIT ?",
         )
         .map_err(to_chain_error)?;
 
     let rows = stmt_blocks
         .query_map(
             params![
-                u32::from(last_scanned_height),
+                last_scanned_height.map_or(0u32, u32::from),
                 limit.unwrap_or(u32::max_value()),
             ],
             |row| {
@@ -319,25 +319,20 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Cache-only chain should be valid
-        let validate_chain_result =
-            validate_chain(&db_cache, (fake_block_height, fake_block_hash), Some(1));
-
-        assert_matches!(
-            validate_chain_result,
-            Ok((_fake_block_height, _fake_block_hash))
+        let validate_chain_result = validate_chain(
+            &db_cache,
+            Some((fake_block_height, fake_block_hash)),
+            Some(1),
         );
+
+        assert_matches!(validate_chain_result, Ok(()));
 
         // Scan the cache
         let mut db_write = db_data.get_update_ops().unwrap();
         scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
 
         // Data-only chain should be valid
-        validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        )
-        .unwrap();
+        validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None).unwrap();
 
         // Create a second fake CompactBlock sending more value to the address
         let (cb2, _) = fake_compact_block(
@@ -350,23 +345,13 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Data+cache chain should be valid
-        validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        )
-        .unwrap();
+        validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None).unwrap();
 
         // Scan the cache again
         scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
 
         // Data-only chain should be valid
-        validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        )
-        .unwrap();
+        validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None).unwrap();
     }
 
     #[test]
@@ -405,12 +390,7 @@ mod tests {
         scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
 
         // Data-only chain should be valid
-        validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        )
-        .unwrap();
+        validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None).unwrap();
 
         // Create more fake CompactBlocks that don't connect to the scanned ones
         let (cb3, _) = fake_compact_block(
@@ -431,11 +411,7 @@ mod tests {
         insert_into_cache(&db_cache, &cb4);
 
         // Data+cache chain should be invalid at the data/cache boundary
-        let val_result = validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        );
+        let val_result = validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None);
 
         assert_matches!(val_result, Err(Error::Chain(e)) if e.at_height() == sapling_activation_height() + 2);
     }
@@ -476,12 +452,7 @@ mod tests {
         scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
 
         // Data-only chain should be valid
-        validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        )
-        .unwrap();
+        validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None).unwrap();
 
         // Create more fake CompactBlocks that contain a reorg
         let (cb3, _) = fake_compact_block(
@@ -502,11 +473,7 @@ mod tests {
         insert_into_cache(&db_cache, &cb4);
 
         // Data+cache chain should be invalid inside the cache
-        let val_result = validate_chain(
-            &db_cache,
-            db_data.get_max_height_hash().unwrap().unwrap(),
-            None,
-        );
+        let val_result = validate_chain(&db_cache, db_data.get_max_height_hash().unwrap(), None);
 
         assert_matches!(val_result, Err(Error::Chain(e)) if e.at_height() == sapling_activation_height() + 3);
     }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -723,7 +723,7 @@ impl BlockSource for BlockDb {
 
     fn with_blocks<F, DbErrT, NoteRef>(
         &self,
-        from_height: BlockHeight,
+        from_height: Option<BlockHeight>,
         limit: Option<u32>,
         with_row: F,
     ) -> Result<(), data_api::chain::error::Error<DbErrT, Self::Error, NoteRef>>
@@ -904,7 +904,7 @@ impl BlockSource for FsBlockDb {
 
     fn with_blocks<F, DbErrT, NoteRef>(
         &self,
-        from_height: BlockHeight,
+        from_height: Option<BlockHeight>,
         limit: Option<u32>,
         with_row: F,
     ) -> Result<(), data_api::chain::error::Error<DbErrT, Self::Error, NoteRef>>


### PR DESCRIPTION
Closes zcash/librustzcash#705

This change adds a `limit` parameter to `validate_chain()` function and also makes the `validate_from` parameters non-optional to avoid falling back to `sapling_activation_height` which is an implicit default parameter that is visible to the caller and I consider it hurts the "locality" of the function itself. 

I have empirical reasons to suspect that these assumptions on DB state don’t hold up and it can trigger a DB rewind on clients using validate_chain without specifying a concrete `validate_from` value and that might make the clients delete the whole database.

If you pass None to the validate_from  parameter to a BlockSourceT that has blocks on it and does not start in sapling_activation  this will fail with a weird state that would signal a gap of sapling_activation_height - 1 and first_existing_block_in_block_source regardless of it’s valid state.

I might have seen this bug in action in debug environments.

I also cleaned up the side-effects of the Optional `validate_from` parameter which results in the removal of the `ParamsT` argument since it's no longer needed because there is no more fallback to `sapling_activation_height`  when no value is provided. The `if () else` structure resulting of this change as been simplified as well. 

I only have one doubt I'd like to run by @str4d and @nuttycom:  Is it possible that there's no `prev_hash` to be provided?