### PR TITLE
Add write_as_raw_encoding method to UnifiedAddress

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_client_backend::address::UnifiedAddress::write_as_raw_encoding`
 
 ## [0.6.0] - 2022-11-12
 ### Added

--- a/zcash_client_backend/src/address.rs
+++ b/zcash_client_backend/src/address.rs
@@ -135,8 +135,8 @@ impl UnifiedAddress {
         self.transparent.as_ref()
     }
 
-    fn to_address(&self, net: Network) -> ZcashAddress {
-        let ua = unified::Address::try_from_items(
+    fn to_unified(&self) -> unified::Address {
+        unified::Address::try_from_items(
             self.unknown
                 .iter()
                 .map(|(typecode, data)| unified::Receiver::Unknown {
@@ -161,8 +161,40 @@ impl UnifiedAddress {
                 )
                 .collect(),
         )
-        .expect("UnifiedAddress should only be constructed safely");
-        ZcashAddress::from_unified(net, ua)
+        .expect("UnifiedAddress should only be constructed safely")
+    }
+
+    fn to_address(&self, net: Network) -> ZcashAddress {
+        ZcashAddress::from_unified(net, self.to_unified())
+    }
+
+    /// Returns the raw encoding of this `UnifiedAddress` as specified in ZIP 316
+    pub fn write_as_raw_encoding<W: std::io::Write>(&self, mut writer: W) -> std::io::Result<()> {
+        for item in self.to_unified().items() {
+            match item {
+                unified::Receiver::Orchard(data) => {
+                    writer.write(&[3])?;
+                    writer.write(&data)?;
+                }
+                unified::Receiver::Sapling(data) => {
+                    writer.write(&[2])?;
+                    writer.write(&data)?;
+                }
+                unified::Receiver::P2sh(data) => {
+                    writer.write(&[1])?;
+                    writer.write(&data)?;
+                }
+                unified::Receiver::P2pkh(data) => {
+                    writer.write(&[0])?;
+                    writer.write(&data)?;
+                }
+                unified::Receiver::Unknown { typecode, data } => {
+                    zcash_encoding::CompactSize::write(&mut writer, typecode as usize)?;
+                    writer.write(&data)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Returns the string encoding of this `UnifiedAddress` for the given network.

--- a/zcash_client_backend/src/address.rs
+++ b/zcash_client_backend/src/address.rs
@@ -173,24 +173,24 @@ impl UnifiedAddress {
         for item in self.to_unified().items() {
             match item {
                 unified::Receiver::Orchard(data) => {
-                    writer.write(&[3])?;
-                    writer.write(&data)?;
+                    writer.write_all(&[3])?;
+                    writer.write_all(&data)?;
                 }
                 unified::Receiver::Sapling(data) => {
-                    writer.write(&[2])?;
-                    writer.write(&data)?;
+                    writer.write_all(&[2])?;
+                    writer.write_all(&data)?;
                 }
                 unified::Receiver::P2sh(data) => {
-                    writer.write(&[1])?;
-                    writer.write(&data)?;
+                    writer.write_all(&[1])?;
+                    writer.write_all(&data)?;
                 }
                 unified::Receiver::P2pkh(data) => {
-                    writer.write(&[0])?;
-                    writer.write(&data)?;
+                    writer.write_all(&[0])?;
+                    writer.write_all(&data)?;
                 }
                 unified::Receiver::Unknown { typecode, data } => {
                     zcash_encoding::CompactSize::write(&mut writer, typecode as usize)?;
-                    writer.write(&data)?;
+                    writer.write_all(&data)?;
                 }
             }
         }


### PR DESCRIPTION
Adds a `write_as_raw_encoding` method to `UnifiedAddress`. Right now, `Receiver`s can be read, turned into a `zcash_address::unified::Address`, and converted to a `UnifiedAddress`, but the reverse operation isn't possible. 