### PR TITLE
Add `shielding_threshold` argument to `shield_transparent_funds`.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,10 +13,6 @@ and this library adheres to Rust's notion of
   minimum value allowed as input to a shielding transaction. Previously 
   the shielding threshold was fixed at 100000 zatoshis.
 
-### Fixed
-- An error that could occur when querying the transparent balance when the
-  wallet database contains no transparent UTXOs has been fixed.
-
 ## [0.6.1] - 2022-12-06
 ### Added
 - `zcash_client_backend::data_api::chain::scan_cached_blocks` now generates

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- `zcash_client_backend::data_api::wallet::shield_transparent_funds` now
+  takes a `shielding_threshold` argument that can be used to specify the 
+  minimum value allowed as input to a shielding transaction. Previously 
+  the shielding threshold was fixed at 100000 zatoshis.
+
+### Fixed
+- An error that could occur when querying the transparent balance when the
+  wallet database contains no transparent UTXOs has been fixed.
+
 ## [0.6.1] - 2022-12-06
 ### Added
 - `zcash_client_backend::data_api::chain::scan_cached_blocks` now generates

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -471,6 +471,7 @@ pub fn shield_transparent_funds<DbT, ParamsT, InputsT>(
     params: &ParamsT,
     prover: impl SaplingProver,
     input_selector: &InputsT,
+    shielding_threshold: NonNegativeAmount,
     usk: &UnifiedSpendingKey,
     from_addrs: &[TransparentAddress],
     memo: &MemoBytes,
@@ -508,7 +509,7 @@ where
     let proposal = input_selector.propose_shielding(
         params,
         wallet_db,
-        NonNegativeAmount::from_u64(100000).unwrap(),
+        shielding_threshold,
         from_addrs,
         latest_anchor,
         target_height,

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -116,7 +116,7 @@ impl TransparentBuilder {
         #[cfg(not(feature = "transparent-inputs"))]
         {
             let invalid: &[InvalidTransparentInput] = &[];
-            return invalid;
+            invalid
         }
     }
 


### PR DESCRIPTION
Previously, the shielding threshold was fixed to 100000 zatoshis.

Fixes #726