### PR TITLE
Factor out a transaction proposal API from `spend`.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::wallet`:
+  - `propose_transfer`
+  - `propose_shielding`
+  - `create_proposed_transaction`
+
 ### Changed
 - MSRV is now 1.60.0.
 - `zcash_client_backend::data_api::wallet::shield_transparent_funds` now


### PR DESCRIPTION
This change makes it possible for wallets using the `zcash_client_backend::data_api::wallet` module to perform transaction preparation, including input selection and fee calculation, as an independent step prior to creating proofs and signatures. This can be used to improve user experience by making it possible to report the proposed effects of the transaction to the wallet user (including privacy implications) prior to authorizing the transaction.