### PR TITLE
CI: Replace most unmaintained `actions-rs/*` actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -16,10 +16,7 @@ jobs:
           override: true
 
       - name: Build latest rustdocs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --workspace --all-features
+        run: cargo doc --no-deps --workspace --all-features
         env:
           RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
-
       - name: Fetch path to Zcash parameters
         working-directory: ./zcash_proofs
         shell: bash
@@ -33,16 +28,9 @@ jobs:
         run: cargo run --release --example download-params --features download-params
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --verbose --release --all
+        run: cargo test  --all-features --verbose --release --all
       - name: Run slow tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --verbose --release --all -- --ignored
-
+        run: cargo test --all-features --verbose --release --all -- --ignored
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -56,16 +44,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
       - name: Add target
         run: rustup target add ${{ matrix.target }}
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: Build zcash_proofs for target
         working-directory: ./zcash_proofs
         run: cargo build --verbose --no-default-features --target ${{ matrix.target }}
@@ -76,35 +57,22 @@ jobs:
   bitrot:
     name: Bitrot check
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --benches
+        run: cargo build --all --benches
 
   clippy:
-    name: Clippy (1.60.0)
+    name: Clippy (MSRV)
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          components: clippy
-          override: true
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.60.0)
+          name: Clippy (MSRV)
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 
@@ -131,21 +99,12 @@ jobs:
   codecov:
     name: Code coverage
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
 
     steps:
       - uses: actions/checkout@v3
-      # Use stable for this to ensure that cargo-tarpaulin can be built and has the source
-      # coverage features released in 1.60.0.
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install cargo-tarpaulin
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-tarpaulin
-
       - name: Fetch path to Zcash parameters
         working-directory: ./zcash_proofs
         shell: bash
@@ -162,35 +121,19 @@ jobs:
         run: cargo run --release --example download-params --features download-params
 
       - name: Generate coverage report
-        uses: actions-rs/cargo@v1
-        with:
-          command: tarpaulin
-          args: --engine llvm --all-features --release --timeout 600 --out Xml
+        run: cargo tarpaulin --engine llvm --all-features --release --timeout 600 --out Xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1
 
   doc-links:
     name: Intra-doc links
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-
-      # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crates.
+      - run: cargo fetch
+      # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all --document-private-items
+        run: cargo doc --all --document-private-items
 
   fmt:
     name: Rustfmt
@@ -198,15 +141,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.60.0
-          override: true
-
-      # Ensure all code has been formatted with rustfmt
-      - run: rustup component add rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.60.0"
+components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
The `actions-rs/*` actions are unmaintained. See actions-rs/toolchain#216 for more information.

- `actions-rs/toolchain` is replaced by `rust-toolchain.toml`.
- `actions-rs/cargo` is replaced by direct cargo usage.
- `actions-rs/tarpaulin` is replaced by the `cargo-tarpaulin` container.

We currently retain a few usages due to a current lack of alternatives:

- `actions-rs/toolchain` to enable beta (for Clippy warnings) and nightly (for building the book).
- `actions-rs/clippy-check` so Clippy results are published as annotations on PRs.

We also now require via `rust-toolchain.toml` that people building from the repo have the `clippy` and `rustfmt` components installed. This is fine because they will need to ensure these pass when making PRs.