### PR TITLE
CI: Replace `actions-rs/toolchain` with `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - name: Build latest rustdocs
         run: cargo doc --no-deps --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@beta
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Run Clippy (beta)
         uses: actions-rs/clippy-check@v1
         continue-on-error: true


### PR DESCRIPTION
Now that dtolnay/rust-toolchain#53 has been closed, we can migrate away from the unmaintained actions-rs/toolchain.