### PR TITLE
Temporarily re-expose ability to construct invalid Sapling bundles

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.10.1] - 2023-03-08
+### Added
+- Sapling bundle component constructors, behind the `temporary-zcashd` feature
+  flag. These temporarily re-expose the ability to construct invalid Sapling
+  bundles (that was removed in 0.10.0), and will be removed in a future release:
+  - `zcash_primitives::transaction::components::sapling`:
+    - `Bundle::temporary_zcashd_from_parts`
+    - `SpendDescription::temporary_zcashd_from_parts`
+    - `OutputDescription::temporary_zcashd_from_parts`
+
 ## [0.10.0] - 2023-02-01
 ### Added
 - `zcash_primitives::sapling`:

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -98,6 +98,7 @@ inferno = ">=0.11, <0.11.5" # MSRV 1.59
 
 [features]
 transparent-inputs = ["hdwallet", "ripemd", "secp256k1"]
+temporary-zcashd = []
 test-dependencies = ["proptest", "orchard/test-dependencies"]
 zfuture = []
 


### PR DESCRIPTION
Until zcash/zcash#6397 is closed, this ability is needed by `zcashd` for crossing the FFI.