### PR TITLE
zcash_note_encryption: remove `recipient` parameter from `Domain::note_plaintext_bytes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ codegen-units = 1
 
 [patch.crates-io]
 zcash_encoding = { path = "components/zcash_encoding" }
-zcash_note_encryption = { path = "components/zcash_note_encryption" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "6cbde279e90974201bedbd9b5ddf155e8f8b1e8e" }
 halo2_gadgets = { git = "https://github.com/zcash/halo2.git", rev = "642924d614305d882cc122739c59144109f4bd3f" }
 halo2_proofs = { git = "https://github.com/zcash/halo2.git", rev = "642924d614305d882cc122739c59144109f4bd3f" }

--- a/components/zcash_note_encryption/CHANGELOG.md
+++ b/components/zcash_note_encryption/CHANGELOG.md
@@ -7,6 +7,13 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `recipient` parameter has been removed from `Domain::note_plaintext_bytes`.
+- The `recipient` parameter has been removed from `NoteEncryption::new`. Since 
+  the `Domain::Note` type is now expected to contain information about the
+  recipient of the note, there is no longer any need to pass this information
+  in via the encryption context.
+
 ## [0.2.0] - 2022-10-13
 ### Added
 - `zcash_note_encryption::Domain`:

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_note_encryption"
 description = "Note encryption for Zcash transactions"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -22,7 +22,7 @@ development = ["zcash_proofs"]
 [dependencies]
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
-zcash_note_encryption = { version = "0.2", path = "../components/zcash_note_encryption" }
+zcash_note_encryption = "0.2"
 zcash_primitives = { version = "0.10", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -50,7 +50,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 regex = "1.4"
 tempfile = "3"
-zcash_note_encryption = { version = "0.2", path = "../components/zcash_note_encryption" }
+zcash_note_encryption = "0.2"
 zcash_proofs = { version = "0.10", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.10", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -81,7 +81,6 @@ fpe = "0.5"
 
 [dependencies.zcash_note_encryption]
 version = "0.2"
-path = "../components/zcash_note_encryption"
 features = ["pre-zip-212"]
 
 [dev-dependencies]


### PR DESCRIPTION
This then updates the `zcash_note_encryption` crate for a version 0.3.0 release.