### PR TITLE
Upgrade to redjubjub 0.7.0

### DIFF
--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `jubjub 0.10`,
-  `bellman 0.14`
+  `bellman 0.14`, `redjubjub 0.7`
 
 ## [0.10.0] - 2023-02-01
 ### Added

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -34,7 +34,7 @@ tracing = "0.1"
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 blake2b_simd = "1"
 directories = { version = "4", optional = true }
-redjubjub = "0.5"
+redjubjub = "0.7"
 wagyu-zcash-parameters = { version = "0.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This removes our reliance on the following out-of-date transitive dependencies that are duplicative of more recent versions of crates we depend on:
- bls12_381 v0.7
- ff v0.12
- group v0.12
- jubjub v0.9
- pasta_curves v0.4
- reddsa v0.3