### PR TITLE
zcash_primitives: Re-export language types in `zip339` module

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,10 +6,30 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_primitives::zip339`:
+  - Language types that implement the `Language` trait:
+    - `ChineseSimplified`
+    - `ChineseTraditional`
+    - `Czech`
+    - `English`
+    - `French`
+    - `Italian`
+    - `Japanese`
+    - `Korean`
+    - `Portuguese`
+    - `Spanish`
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `ff 0.13`, `group 0.13`,
   `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.11`.
+- `zcash_primitives::zip339` changes due to `bip0039 0.11`:
+  - `Language` is now a trait instead of an enum.
+  - `Mnemonic` has a generic parameter (that defaults to `English`).
+
+### Removed
+- `zcash_primitives::zip339`:
+  - `Mnemonic::{*_in}` methods that previously took a language parameter.
 
 ## [0.10.2] - 2023-03-16
 ### Added

--- a/zcash_primitives/src/zip339.rs
+++ b/zcash_primitives/src/zip339.rs
@@ -2,4 +2,9 @@
 //!
 //! [ZIP 339]: https://zips.z.cash/zip-0339
 
-pub use bip0039::{Count, Error, Language, Mnemonic};
+pub use bip0039::{Count, English, Error, Language, Mnemonic};
+
+pub use bip0039::{
+    ChineseSimplified, ChineseTraditional, Czech, French, Italian, Japanese, Korean, Portuguese,
+    Spanish,
+};


### PR DESCRIPTION
`bip0039 0.11` switched from language function arguments to a generic parameter.