### PR TITLE
zcash_primitives: Downgrade to `bip0039 0.10`

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -9,7 +9,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `ff 0.13`, `group 0.13`,
-  `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.11`.
+  `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.10`.
 
 ## [0.10.2] - 2023-03-16
 ### Added

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -60,7 +60,7 @@ hdwallet = { version = "0.3.1", optional = true }
 secp256k1 = { version = "0.21", optional = true }
 
 # - ZIP 339
-bip0039 = { version = "0.11", features = ["std", "all-languages"] }
+bip0039 = { version = "0.10", features = ["std", "all-languages"] }
 
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)


### PR DESCRIPTION
`bip0039 0.11` switched from language function arguments to a generic parameter. We aren't ready to migrate to this yet.