### PR TITLE
WIP: Add CI to do daily `cargo audit` checks.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: cargo audit
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+
+jobs:
+  cargo-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo install cargo-audit
+      - run: cargo audit


### PR DESCRIPTION
This is an untested attempt at the "preventative solution" to #816.

It attempts to run `cargo audit` every 24 hours. I'm calling it WIP because I don't have confidence it will work well as-is:

- How are failing "cron-like" CI workflows represented? Do they mark `main` with a red flag or block other merges?
- Are these run steps correct?
- Is there a `rustsec` action we can use to cut down on run time by skipping the `cargo-audit` install?
- How can we test that this workflow functions correctly prior to merging (if at all)?