### PR TITLE
`zcash_primitives 0.11.0`, `zcash_proofs 0.11.0`, `zcash_client_backend 0.8.0`, `zcash_client_sqlite 0.6.0`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -17,6 +17,11 @@ and this library adheres to Rust's notion of
   `zcash_primitives/multicore` feature if they did not already depend
   upon `zcash_primitives` with default features enabled.
 
+### Fixed
+- `zcash_client_backend::fees::zip317::SingleOutputChangeStrategy` now takes
+  into account the Sapling output padding behaviour of
+  `zcash_primitives::transaction::components::sapling::builder::SaplingBuilder`.
+
 ## [0.7.0] - 2023-02-01
 ### Added
 - `zcash_client_backend::data_api::wallet`:

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-04-15
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `orchard 0.4`,
   `tonic 0.9`, `base64 0.21`, `bech32 0.9`, `zcash_primitives 0.11`.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -9,7 +9,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `orchard 0.4`,
-  `tonic 0.9`, `base64 0.21`, `bech32 0.9`.
+  `tonic 0.9`, `base64 0.21`, `bech32 0.9`, `zcash_primitives 0.11`.
 - The dependency on `zcash_primitives` no longer enables the `multicore` feature
   by default in order to support compilation under `wasm32-wasi`. Users of other
   platforms may need to include an explicit dependency on `zcash_primitives`

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -84,7 +84,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 rand_xorshift = "0.3"
 tempfile = "3.1.0"
-zcash_proofs = { version = "0.10", path = "../zcash_proofs", default-features = false }
+zcash_proofs = { version = "0.11", path = "../zcash_proofs", default-features = false }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -23,7 +23,7 @@ development = ["zcash_proofs"]
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_note_encryption = "0.3"
-zcash_primitives = { version = "0.10", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -6,6 +6,21 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- SQLite view `v_tx_outputs`, exposing the history of transaction outputs sent
+  from and received by the wallet. See `zcash_client_sqlite::wallet` for view
+  documentation.
+
+### Fixed
+- In a previous crate release, `WalletDb` was modified to start tracking Sapling
+  change notes in both the `sent_notes` and `received_notes` tables, as a form
+  of double-entry accounting. This broke assumptions in the `v_transactions`
+  SQLite view, and also left the `sent_notes` table in an inconsistent state. A
+  migration has been added to this release which fixes the `sent_notes` table to
+  consistently store Sapling change notes.
+- The SQLite view `v_transactions` had several bugs independently from the above
+  issue, and has been rewritten. See `zcash_client_sqlite::wallet` for view
+  documentation.
 
 ### Changed
 - Bumped dependencies to `group 0.13`, `jubjub 0.10`
@@ -15,6 +30,9 @@ and this library adheres to Rust's notion of
   without `default-features = false` or otherwise explicitly enable the
   `zcash_primitives/multicore` feature if they did not already depend
   upon `zcash_primitives` with default features enabled.
+
+### Removed
+- SQLite views `v_tx_received` and `v_tx_sent` (use `v_tx_outputs` instead).
 
 ## [0.7.0] - 2023-02-01
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -23,7 +23,7 @@ and this library adheres to Rust's notion of
   documentation.
 
 ### Changed
-- Bumped dependencies to `group 0.13`, `jubjub 0.10`
+- Bumped dependencies to `group 0.13`, `jubjub 0.10`, `zcash_primitives 0.11`.
 - The dependency on `zcash_primitives` no longer enables the `multicore` feature
   by default in order to support compilation under `wasm32-wasi`. Users of other
   platforms may need to include an explicit dependency on `zcash_primitives`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -23,7 +23,8 @@ and this library adheres to Rust's notion of
   documentation.
 
 ### Changed
-- Bumped dependencies to `group 0.13`, `jubjub 0.10`, `zcash_primitives 0.11`.
+- Bumped dependencies to `group 0.13`, `jubjub 0.10`, `zcash_primitives 0.11`,
+  `zcash_client_backend 0.8`.
 - The dependency on `zcash_primitives` no longer enables the `multicore` feature
   by default in order to support compilation under `wasm32-wasi`. Users of other
   platforms may need to include an explicit dependency on `zcash_primitives`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2023-04-15
 ### Added
 - SQLite view `v_tx_outputs`, exposing the history of transaction outputs sent
   from and received by the wallet. See `zcash_client_sqlite::wallet` for view
@@ -35,7 +37,7 @@ and this library adheres to Rust's notion of
 ### Removed
 - SQLite views `v_tx_received` and `v_tx_sent` (use `v_tx_outputs` instead).
 
-## [0.7.0] - 2023-02-01
+## [0.5.0] - 2023-02-01
 ### Added
 - `zcash_client_sqlite::FsBlockDb::rewind_to_height` rewinds the BlockMeta Db
  to the specified height following the same logic as homonymous functions on

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-zcash_client_backend = { version = "0.7", path = "../zcash_client_backend" }
+zcash_client_backend = { version = "0.8", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -51,7 +51,7 @@ rand_core = "0.6"
 regex = "1.4"
 tempfile = "3"
 zcash_note_encryption = "0.3"
-zcash_proofs = { version = "0.10", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60"
 
 [dependencies]
 zcash_client_backend = { version = "0.7", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.10", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
@@ -52,7 +52,7 @@ regex = "1.4"
 tempfile = "3"
 zcash_note_encryption = "0.3"
 zcash_proofs = { version = "0.10", path = "../zcash_proofs" }
-zcash_primitives = { version = "0.10", path = "../zcash_primitives", features = ["test-dependencies"] }
+zcash_primitives = { version = "0.11", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60"
 
 [dependencies]
 blake2b_simd = "1"
-zcash_primitives = { version = "0.10", path = "../zcash_primitives", default-features = false, features = ["zfuture" ] }
+zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false, features = ["zfuture" ] }
 
 [dev-dependencies]
 ff = "0.13"

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -18,7 +18,7 @@ ff = "0.13"
 jubjub = "0.10"
 rand_core = "0.6"
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
-zcash_proofs = { version = "0.10", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = []

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.0] - 2023-04-15
 ### Added
 - `zcash_primitives::zip32::fingerprint` module, containing types for deriving
   ZIP 32 Seed Fingerprints.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,10 +6,14 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_primitives::zip32::fingerprint` module, containing types for deriving
+  ZIP 32 Seed Fingerprints.
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `ff 0.13`, `group 0.13`,
-  `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.10`.
+  `jubjub 0.10`, `orchard 0.4`, `sha2 0.10`, `bip0039 0.10`,
+  `zcash_note_encryption 0.3`.
 
 ## [0.10.2] - 2023-03-16
 ### Added

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.10.2"
+version = "0.11.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `jubjub 0.10`,
-  `bellman 0.14`, `redjubjub 0.7`
+  `bellman 0.14`, `redjubjub 0.7`.
 
 ## [0.10.0] - 2023-02-01
 ### Added

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `jubjub 0.10`,
-  `bellman 0.14`, `redjubjub 0.7`.
+  `bellman 0.14`, `redjubjub 0.7`, `zcash_primitives 0.11`.
 
 ## [0.10.0] - 2023-02-01
 ### Added

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.11.0] - 2023-04-15
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `jubjub 0.10`,
   `bellman 0.14`, `redjubjub 0.7`, `zcash_primitives 0.11`.

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 all-features = true
 
 [dependencies]
-zcash_primitives = { version = "0.10", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)


### PR DESCRIPTION
Closes #765.