### PR TITLE
`zcash_address 0.2.1`

### DIFF
--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-04-15
+### Changed
+- Bumped internal dependency to `bech32 0.9`.
+
 ## [0.2.0] - 2022-10-19
 ### Added
 - `zcash_address::ConversionError`

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_address"
 description = "Zcash address parsing and serialization"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]


### PR DESCRIPTION
This is just so we don't have two `bech32` versions in `zcashd`.