### PR TITLE
Remove deprecated APIs & rename Sapling-specific data structures to include "Sapling".

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,14 +8,15 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Added
 - `data_api::SentTransactionOutput::from_parts`
-- `data_api::SentTransactionOutput::sapling_change_to`
 - `data_api::WalletRead::get_min_unspent_height`
 
 ### Changed
 - `decrypt::DecryptedOutput` is now parameterized by a `Note` type parameter,
   to allow reuse of the data structure for non-Sapling contexts.
 - `data_api::SentTransactionOutput` must now be constructed using
-  `SentTransactionOutput::from_parts`
+  `SentTransactionOutput::from_parts`. The internal state of `SentTransactionOutput`
+  is now private, and accessible via methods that have the same names as the 
+  previously exposed fields.
 
 ### Renamed
 - The following types and fields have been renamed in preparation for supporting

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -6,17 +6,25 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `data_api::SentTransactionOutput::from_parts`
+- `data_api::SentTransactionOutput::sapling_change_to`
+
 ### Changed
 - `decrypt::DecryptedOutput` is now parameterized by a `Note` type parameter,
   to allow reuse of the data structure for non-Sapling contexts.
+- `data_api::SentTransactionOutput` must now be constructed using 
+  `SentTransactionOutput::from_parts`
 
 ### Renamed
 - The following types and fields have been renamed in preparation for supporting
   `orchard` in wallet APIs:
   - `WalletTx::shielded_spends`  -> `WalletTx::sapling_spends`
   - `WalletTx::shielded_outputs` -> `WalletTx::sapling_outputs`
-  - `WalletShieldedSpend` -> `WalletSaplingSpend`
-  - `WalletShieldedOutput` -> `WalletSaplingOutput`
+  - `WalletShieldedSpend` -> `WalletSaplingSpend`. Also, the internals of this
+    data structure have been made private.
+  - `WalletShieldedOutput` -> `WalletSaplingOutput`. Also, the internals of this
+    data structure have been made private.
 
 ### Removed
   - `wallet::WalletTx::num_spends`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -18,6 +18,11 @@ and this library adheres to Rust's notion of
 ### Removed
   - `wallet::WalletTx::num_spends`
   - `wallet::WalletTx::num_outputs`
+  - `wallet::WalletSaplingOutput::to` is redundant and has been removed; the
+    recipient address can be obtained from the note.
+  - `decrypt::DecryptedOutput::to` is redundant and has been removed; the
+    recipient address can be obtained from the note.
+
 ## [0.8.0] - 2023-04-15
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `orchard 0.4`,

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,17 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Renamed
+- The following types and fields have been renamed in preparation for supporting
+  `orchard` in wallet APIs:
+  - `WalletTx::shielded_spends`  -> `WalletTx::sapling_spends`
+  - `WalletTx::shielded_outputs` -> `WalletTx::sapling_outputs`
+  - `WalletShieldedSpend` -> `WalletSaplingSpend`
+  - `WalletShieldedOutput` -> `WalletSaplingOutput`
+
+### Removed
+  - `wallet::WalletTx::num_spends`
+  - `wallet::WalletTx::num_outputs`
 ## [0.8.0] - 2023-04-15
 ### Changed
 - Bumped dependencies to `bls12_381 0.8`, `group 0.13`, `orchard 0.4`,

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `decrypt::DecryptedOutput` is now parameterized by a `Note` type parameter,
+  to allow reuse of the data structure for non-Sapling contexts.
 
 ### Renamed
 - The following types and fields have been renamed in preparation for supporting

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -9,11 +9,12 @@ and this library adheres to Rust's notion of
 ### Added
 - `data_api::SentTransactionOutput::from_parts`
 - `data_api::SentTransactionOutput::sapling_change_to`
+- `data_api::WalletRead::get_min_unspent_height`
 
 ### Changed
 - `decrypt::DecryptedOutput` is now parameterized by a `Note` type parameter,
   to allow reuse of the data structure for non-Sapling contexts.
-- `data_api::SentTransactionOutput` must now be constructed using 
+- `data_api::SentTransactionOutput` must now be constructed using
   `SentTransactionOutput::from_parts`
 
 ### Renamed
@@ -25,6 +26,8 @@ and this library adheres to Rust's notion of
     data structure have been made private.
   - `WalletShieldedOutput` -> `WalletSaplingOutput`. Also, the internals of this
     data structure have been made private.
+- The `data_api::WalletWrite::rewind_to_height` method has been renamed to
+  `truncate_to_height` to better reflect its semantics.
 
 ### Removed
   - `wallet::WalletTx::num_spends`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -291,20 +291,49 @@ pub enum Recipient {
 }
 
 pub struct SentTransactionOutput {
-    /// The index within the transaction that contains the recipient output.
+    output_index: usize,
+    recipient: Recipient,
+    value: Amount,
+    memo: Option<MemoBytes>,
+}
+
+impl SentTransactionOutput {
+    pub fn from_parts(
+        output_index: usize,
+        recipient: Recipient,
+        value: Amount,
+        memo: Option<MemoBytes>,
+    ) -> Self {
+        Self {
+            output_index,
+            recipient,
+            value,
+            memo,
+        }
+    }
+
+    /// Returns the index within the transaction that contains the recipient output.
     ///
     /// - If `recipient_address` is a Sapling address, this is an index into the Sapling
     ///   outputs of the transaction.
     /// - If `recipient_address` is a transparent address, this is an index into the
     ///   transparent outputs of the transaction.
-    pub output_index: usize,
-    /// The recipient address of the transaction, or the account
-    /// id for wallet-internal transactions.
-    pub recipient: Recipient,
-    /// The value of the newly created output
-    pub value: Amount,
-    /// The memo that was attached to the output, if any
-    pub memo: Option<MemoBytes>,
+    pub fn output_index(&self) -> usize {
+        self.output_index
+    }
+    /// Returns the recipient address of the transaction, or the account id for wallet-internal
+    /// transactions.
+    pub fn recipient(&self) -> &Recipient {
+        &self.recipient
+    }
+    /// Returns the value of the newly created output.
+    pub fn value(&self) -> Amount {
+        self.value
+    }
+    /// Returns the memo that was attached to the output, if any.
+    pub fn memo(&self) -> Option<&MemoBytes> {
+        self.memo.as_ref()
+    }
 }
 
 /// This trait encapsulates the write capabilities required to update stored

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -11,7 +11,7 @@ use zcash_primitives::{
     legacy::TransparentAddress,
     memo::{Memo, MemoBytes},
     merkle_tree::{CommitmentTree, IncrementalWitness},
-    sapling::{Node, Nullifier, PaymentAddress},
+    sapling::{self, Node, Nullifier, PaymentAddress},
     transaction::{
         components::{amount::Amount, OutPoint},
         Transaction, TxId,
@@ -247,7 +247,7 @@ pub struct PrunedBlock<'a> {
 /// wallet database when transactions are successfully decrypted.
 pub struct DecryptedTransaction<'a> {
     pub tx: &'a Transaction,
-    pub sapling_outputs: &'a Vec<DecryptedOutput>,
+    pub sapling_outputs: &'a Vec<DecryptedOutput<sapling::Note>>,
 }
 
 /// A transaction that was constructed and sent by the wallet.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -83,6 +83,9 @@ pub trait WalletRead {
         })
     }
 
+    /// Returns the minimum block height corresponding to an unspent note in the wallet.
+    fn get_min_unspent_height(&self) -> Result<Option<BlockHeight>, Self::Error>;
+
     /// Returns the block hash for the block at the given height, if the
     /// associated block data is available. Returns `Ok(None)` if the hash
     /// is not found in the database.
@@ -361,7 +364,7 @@ pub trait WalletWrite: WalletRead {
     /// persistent wallet store.
     fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<Self::TxRef, Self::Error>;
 
-    /// Rewinds the wallet database to the specified height.
+    /// Truncates the wallet database to the specified height.
     ///
     /// This method assumes that the state of the underlying data store is
     /// consistent up to a particular block height. Since it is possible that
@@ -373,8 +376,8 @@ pub trait WalletWrite: WalletRead {
     /// most recent block and all other operations will treat this block
     /// as the chain tip for balance determination purposes.
     ///
-    /// There may be restrictions on how far it is possible to rewind.
-    fn rewind_to_height(&mut self, block_height: BlockHeight) -> Result<(), Self::Error>;
+    /// There may be restrictions on heights to which it is possible to truncate.
+    fn truncate_to_height(&mut self, block_height: BlockHeight) -> Result<(), Self::Error>;
 
     /// Adds a transparent UTXO received by the wallet to the data store.
     fn put_received_transparent_utxo(
@@ -420,6 +423,10 @@ pub mod testing {
         type TxRef = TxId;
 
         fn block_height_extrema(&self) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_min_unspent_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
             Ok(None)
         }
 
@@ -588,7 +595,7 @@ pub mod testing {
             Ok(TxId::from_bytes([0u8; 32]))
         }
 
-        fn rewind_to_height(&mut self, _block_height: BlockHeight) -> Result<(), Self::Error> {
+        fn truncate_to_height(&mut self, _block_height: BlockHeight) -> Result<(), Self::Error> {
             Ok(())
         }
 

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -55,7 +55,7 @@
 //!             let rewind_height = e.at_height() - 10;
 //!
 //!             // b) Rewind scanned block information.
-//!             db_data.rewind_to_height(rewind_height);
+//!             db_data.truncate_to_height(rewind_height);
 //!
 //!             // c) Delete cached blocks from rewind_height onwards.
 //!             //

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -323,7 +323,7 @@ where
                     }
                 }
                 for tx in &txs {
-                    for output in tx.shielded_outputs.iter() {
+                    for output in tx.sapling_outputs.iter() {
                         if output.witness.root() != cur_root {
                             return Err(ChainError::invalid_new_witness_anchor(
                                 current_height,
@@ -352,12 +352,12 @@ where
 
             let spent_nf: Vec<Nullifier> = txs
                 .iter()
-                .flat_map(|tx| tx.shielded_spends.iter().map(|spend| spend.nf))
+                .flat_map(|tx| tx.sapling_spends.iter().map(|spend| spend.nf))
                 .collect();
             nullifiers.retain(|(_, nf)| !spent_nf.contains(nf));
             nullifiers.extend(
                 txs.iter()
-                    .flat_map(|tx| tx.shielded_outputs.iter().map(|out| (out.account, out.nf))),
+                    .flat_map(|tx| tx.sapling_outputs.iter().map(|out| (out.account, out.nf))),
             );
 
             witnesses.extend(new_witnesses);

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -324,12 +324,12 @@ where
                 }
                 for tx in &txs {
                     for output in tx.sapling_outputs.iter() {
-                        if output.witness.root() != cur_root {
+                        if output.witness().root() != cur_root {
                             return Err(ChainError::invalid_new_witness_anchor(
                                 current_height,
                                 tx.txid,
-                                output.index,
-                                output.witness.root(),
+                                output.index(),
+                                output.witness().root(),
                             )
                             .into());
                         }
@@ -350,15 +350,16 @@ where
                 )
                 .map_err(Error::Wallet)?;
 
-            let spent_nf: Vec<Nullifier> = txs
+            let spent_nf: Vec<&Nullifier> = txs
                 .iter()
-                .flat_map(|tx| tx.sapling_spends.iter().map(|spend| spend.nf))
+                .flat_map(|tx| tx.sapling_spends.iter().map(|spend| spend.nf()))
                 .collect();
-            nullifiers.retain(|(_, nf)| !spent_nf.contains(nf));
-            nullifiers.extend(
-                txs.iter()
-                    .flat_map(|tx| tx.sapling_outputs.iter().map(|out| (out.account, out.nf))),
-            );
+            nullifiers.retain(|(_, nf)| !spent_nf.contains(&nf));
+            nullifiers.extend(txs.iter().flat_map(|tx| {
+                tx.sapling_outputs
+                    .iter()
+                    .map(|out| (out.account(), *out.nf()))
+            }));
 
             witnesses.extend(new_witnesses);
 

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -7,7 +7,7 @@ use zcash_primitives::{
         note_encryption::{
             try_sapling_note_decryption, try_sapling_output_recovery, PreparedIncomingViewingKey,
         },
-        Note, PaymentAddress,
+        Note,
     },
     transaction::Transaction,
     zip32::{AccountId, Scope},
@@ -39,8 +39,6 @@ pub struct DecryptedOutput {
     pub note: Note,
     /// The account that decrypted the note.
     pub account: AccountId,
-    /// The address the note was sent to.
-    pub to: PaymentAddress,
     /// The memo bytes included with the note.
     pub memo: MemoBytes,
     /// True if this output was recovered using an [`OutgoingViewingKey`], meaning that
@@ -94,11 +92,10 @@ pub fn decrypt_transaction<P: consensus::Parameters>(
                                         .map(|ret| (ret, TransferType::Outgoing))
                                 })
                                 .into_iter()
-                                .map(move |((note, to, memo), transfer_type)| DecryptedOutput {
+                                .map(move |((note, _, memo), transfer_type)| DecryptedOutput {
                                     index,
                                     note,
                                     account,
-                                    to,
                                     memo,
                                     transfer_type,
                                 })

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -4,10 +4,10 @@ use zcash_primitives::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     sapling::{
+        self,
         note_encryption::{
             try_sapling_note_decryption, try_sapling_output_recovery, PreparedIncomingViewingKey,
         },
-        Note,
     },
     transaction::Transaction,
     zip32::{AccountId, Scope},
@@ -30,7 +30,7 @@ pub enum TransferType {
 }
 
 /// A decrypted shielded output.
-pub struct DecryptedOutput {
+pub struct DecryptedOutput<Note> {
     /// The index of the output within [`shielded_outputs`].
     ///
     /// [`shielded_outputs`]: zcash_primitives::transaction::TransactionData
@@ -55,7 +55,7 @@ pub fn decrypt_transaction<P: consensus::Parameters>(
     height: BlockHeight,
     tx: &Transaction,
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
-) -> Vec<DecryptedOutput> {
+) -> Vec<DecryptedOutput<sapling::Note>> {
     tx.sapling_bundle()
         .iter()
         .flat_map(|bundle| {

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -7,12 +7,10 @@ use zcash_primitives::{
     keys::OutgoingViewingKey,
     legacy::TransparentAddress,
     merkle_tree::IncrementalWitness,
-    sapling::{
-        note::ExtractedNoteCommitment, Diversifier, Node, Note, Nullifier, PaymentAddress, Rseed,
-    },
+    sapling,
     transaction::{
         components::{
-            sapling,
+            sapling::fees as sapling_fees,
             transparent::{self, OutPoint, TxOut},
             Amount,
         },
@@ -27,10 +25,8 @@ use zcash_primitives::{
 pub struct WalletTx<N> {
     pub txid: TxId,
     pub index: usize,
-    pub num_spends: usize,
-    pub num_outputs: usize,
-    pub shielded_spends: Vec<WalletShieldedSpend>,
-    pub shielded_outputs: Vec<WalletShieldedOutput<N>>,
+    pub sapling_spends: Vec<WalletSaplingSpend>,
+    pub sapling_outputs: Vec<WalletSaplingOutput<N>>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,24 +86,24 @@ impl transparent::fees::InputView for WalletTransparentOutput {
 /// A subset of a [`SpendDescription`] relevant to wallets and light clients.
 ///
 /// [`SpendDescription`]: zcash_primitives::transaction::components::SpendDescription
-pub struct WalletShieldedSpend {
+pub struct WalletSaplingSpend {
     pub index: usize,
-    pub nf: Nullifier,
+    pub nf: sapling::Nullifier,
     pub account: AccountId,
 }
 
 /// A subset of an [`OutputDescription`] relevant to wallets and light clients.
 ///
 /// [`OutputDescription`]: zcash_primitives::transaction::components::OutputDescription
-pub struct WalletShieldedOutput<N> {
+pub struct WalletSaplingOutput<N> {
     pub index: usize,
-    pub cmu: ExtractedNoteCommitment,
+    pub cmu: sapling::note::ExtractedNoteCommitment,
     pub ephemeral_key: EphemeralKeyBytes,
     pub account: AccountId,
-    pub note: Note,
-    pub to: PaymentAddress,
+    pub note: sapling::Note,
+    pub to: sapling::PaymentAddress,
     pub is_change: bool,
-    pub witness: IncrementalWitness<Node>,
+    pub witness: IncrementalWitness<sapling::Node>,
     pub nf: N,
 }
 
@@ -115,13 +111,13 @@ pub struct WalletShieldedOutput<N> {
 /// with sufficient information for use in note selection.
 pub struct SpendableNote<NoteRef> {
     pub note_id: NoteRef,
-    pub diversifier: Diversifier,
+    pub diversifier: sapling::Diversifier,
     pub note_value: Amount,
-    pub rseed: Rseed,
-    pub witness: IncrementalWitness<Node>,
+    pub rseed: sapling::Rseed,
+    pub witness: IncrementalWitness<sapling::Node>,
 }
 
-impl<NoteRef> sapling::fees::InputView<NoteRef> for SpendableNote<NoteRef> {
+impl<NoteRef> sapling_fees::InputView<NoteRef> for SpendableNote<NoteRef> {
     fn note_id(&self) -> &NoteRef {
         &self.note_id
     }

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -101,7 +101,6 @@ pub struct WalletSaplingOutput<N> {
     pub ephemeral_key: EphemeralKeyBytes,
     pub account: AccountId,
     pub note: sapling::Note,
-    pub to: sapling::PaymentAddress,
     pub is_change: bool,
     pub witness: IncrementalWitness<sapling::Node>,
     pub nf: N,

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -87,23 +87,93 @@ impl transparent::fees::InputView for WalletTransparentOutput {
 ///
 /// [`SpendDescription`]: zcash_primitives::transaction::components::SpendDescription
 pub struct WalletSaplingSpend {
-    pub index: usize,
-    pub nf: sapling::Nullifier,
-    pub account: AccountId,
+    index: usize,
+    nf: sapling::Nullifier,
+    account: AccountId,
+}
+
+impl WalletSaplingSpend {
+    pub fn from_parts(index: usize, nf: sapling::Nullifier, account: AccountId) -> Self {
+        Self { index, nf, account }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+    pub fn nf(&self) -> &sapling::Nullifier {
+        &self.nf
+    }
+    pub fn account(&self) -> AccountId {
+        self.account
+    }
 }
 
 /// A subset of an [`OutputDescription`] relevant to wallets and light clients.
 ///
 /// [`OutputDescription`]: zcash_primitives::transaction::components::OutputDescription
 pub struct WalletSaplingOutput<N> {
-    pub index: usize,
-    pub cmu: sapling::note::ExtractedNoteCommitment,
-    pub ephemeral_key: EphemeralKeyBytes,
-    pub account: AccountId,
-    pub note: sapling::Note,
-    pub is_change: bool,
-    pub witness: IncrementalWitness<sapling::Node>,
-    pub nf: N,
+    index: usize,
+    cmu: sapling::note::ExtractedNoteCommitment,
+    ephemeral_key: EphemeralKeyBytes,
+    account: AccountId,
+    note: sapling::Note,
+    is_change: bool,
+    witness: IncrementalWitness<sapling::Node>,
+    nf: N,
+}
+
+impl<N> WalletSaplingOutput<N> {
+    /// Constructs a new `WalletSaplingOutput` value from its constituent parts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        index: usize,
+        cmu: sapling::note::ExtractedNoteCommitment,
+        ephemeral_key: EphemeralKeyBytes,
+        account: AccountId,
+        note: sapling::Note,
+        is_change: bool,
+        witness: IncrementalWitness<sapling::Node>,
+        nf: N,
+    ) -> Self {
+        Self {
+            index,
+            cmu,
+            ephemeral_key,
+            account,
+            note,
+            is_change,
+            witness,
+            nf,
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+    pub fn cmu(&self) -> &sapling::note::ExtractedNoteCommitment {
+        &self.cmu
+    }
+    pub fn ephemeral_key(&self) -> &EphemeralKeyBytes {
+        &self.ephemeral_key
+    }
+    pub fn account(&self) -> AccountId {
+        self.account
+    }
+    pub fn note(&self) -> &sapling::Note {
+        &self.note
+    }
+    pub fn is_change(&self) -> bool {
+        self.is_change
+    }
+    pub fn witness(&self) -> &IncrementalWitness<sapling::Node> {
+        &self.witness
+    }
+    pub fn witness_mut(&mut self) -> &mut IncrementalWitness<sapling::Node> {
+        &mut self.witness
+    }
+    pub fn nf(&self) -> &N {
+        &self.nf
+    }
 }
 
 /// Information about a note that is tracked by the wallet that is available for spending,

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -344,7 +344,7 @@ pub(crate) fn scan_block_with_runner<
                 }
                 tree.append(node).unwrap();
 
-                if let Some(((note, to), account, nk)) = dec_output {
+                if let Some(((note, _), account, nk)) = dec_output {
                     // A note is marked as "change" if the account that received it
                     // also spent notes in the same transaction. This will catch,
                     // for instance:
@@ -361,7 +361,6 @@ pub(crate) fn scan_block_with_runner<
                         ephemeral_key: output.ephemeral_key.clone(),
                         account,
                         note,
-                        to,
                         is_change,
                         witness,
                         nf,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,37 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Removed
+- The following deprecated types and methods have been removed from the public API:
+  - `wallet::ShieldedOutput`
+  - `wallet::block_height_extrema`
+  - `wallet::get_address`
+  - `wallet::get_all_nullifiers`
+  - `wallet::get_balance`
+  - `wallet::get_balance_at`
+  - `wallet::get_block_hash`
+  - `wallet::get_commitment_tree`
+  - `wallet::get_nullifiers`
+  - `wallet::get_received_memo`
+  - `wallet::get_rewind_height`
+  - `wallet::get_sent_memo`
+  - `wallet::get_spendable_sapling_notes`
+  - `wallet::get_transaction`
+  - `wallet::get_tx_height`
+  - `wallet::get_unified_full_viewing_keys`
+  - `wallet::get_witnesses`
+  - `wallet::insert_block`
+  - `wallet::insert_witnesses`
+  - `wallet::is_valid_account_extfvk`
+  - `wallet::mark_sapling_note_spent`
+  - `wallet::put_tx_data`
+  - `wallet::put_tx_meta`
+  - `wallet::prune_witnesses`
+  - `wallet::select_spendable_sapling_notes`
+  - `wallet::update_expired_notes`
+  - `wallet::transact::get_spendable_sapling_notes`
+  - `wallet::transact::select_spendable_sapling_notes`
+
 ## [0.6.0] - 2023-04-15
 ### Added
 - SQLite view `v_tx_outputs`, exposing the history of transaction outputs sent

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -141,7 +141,7 @@ pub(crate) fn blockmetadb_insert(
 }
 
 #[cfg(feature = "unstable")]
-pub(crate) fn blockmetadb_rewind_to_height(
+pub(crate) fn blockmetadb_truncate_to_height(
     conn: &Connection,
     block_height: BlockHeight,
 ) -> Result<(), rusqlite::Error> {
@@ -284,7 +284,7 @@ mod tests {
             self, fake_compact_block, fake_compact_block_spending, init_test_accounts_table,
             insert_into_cache, sapling_activation_height, AddressType,
         },
-        wallet::{get_balance, init::init_wallet_db, rewind_to_height},
+        wallet::{get_balance, init::init_wallet_db, truncate_to_height},
         AccountId, BlockDb, WalletDb,
     };
 
@@ -479,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn data_db_rewinding() {
+    fn data_db_truncation() {
         let cache_file = NamedTempFile::new().unwrap();
         let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
         init_cache_database(&db_cache).unwrap();
@@ -529,7 +529,7 @@ mod tests {
         );
 
         // "Rewind" to height of last scanned block
-        rewind_to_height(&db_data, sapling_activation_height() + 1).unwrap();
+        truncate_to_height(&db_data, sapling_activation_height() + 1).unwrap();
 
         // Account balance should be unaltered
         assert_eq!(
@@ -538,7 +538,7 @@ mod tests {
         );
 
         // Rewind so that one block is dropped
-        rewind_to_height(&db_data, sapling_activation_height()).unwrap();
+        truncate_to_height(&db_data, sapling_activation_height()).unwrap();
 
         // Account balance should only contain the first received note
         assert_eq!(get_balance(&db_data, AccountId::from(0)).unwrap(), value);

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -136,24 +136,20 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
     type TxRef = i64;
 
     fn block_height_extrema(&self) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
-        #[allow(deprecated)]
         wallet::block_height_extrema(self).map_err(SqliteClientError::from)
     }
 
     fn get_block_hash(&self, block_height: BlockHeight) -> Result<Option<BlockHash>, Self::Error> {
-        #[allow(deprecated)]
         wallet::get_block_hash(self, block_height).map_err(SqliteClientError::from)
     }
 
     fn get_tx_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
-        #[allow(deprecated)]
         wallet::get_tx_height(self, txid).map_err(SqliteClientError::from)
     }
 
     fn get_unified_full_viewing_keys(
         &self,
     ) -> Result<HashMap<AccountId, UnifiedFullViewingKey>, Self::Error> {
-        #[allow(deprecated)]
         wallet::get_unified_full_viewing_keys(self)
     }
 
@@ -176,7 +172,6 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         account: AccountId,
         extfvk: &ExtendedFullViewingKey,
     ) -> Result<bool, Self::Error> {
-        #[allow(deprecated)]
         wallet::is_valid_account_extfvk(self, account, extfvk)
     }
 
@@ -185,17 +180,14 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         account: AccountId,
         anchor_height: BlockHeight,
     ) -> Result<Amount, Self::Error> {
-        #[allow(deprecated)]
         wallet::get_balance_at(self, account, anchor_height)
     }
 
     fn get_transaction(&self, id_tx: i64) -> Result<Transaction, Self::Error> {
-        #[allow(deprecated)]
         wallet::get_transaction(self, id_tx)
     }
 
     fn get_memo(&self, id_note: Self::NoteRef) -> Result<Memo, Self::Error> {
-        #[allow(deprecated)]
         match id_note {
             NoteId::SentNoteId(id_note) => wallet::get_sent_memo(self, id_note),
             NoteId::ReceivedNoteId(id_note) => wallet::get_received_memo(self, id_note),
@@ -206,8 +198,7 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         &self,
         block_height: BlockHeight,
     ) -> Result<Option<CommitmentTree<Node>>, Self::Error> {
-        #[allow(deprecated)]
-        wallet::get_commitment_tree(self, block_height)
+        wallet::get_sapling_commitment_tree(self, block_height)
     }
 
     #[allow(clippy::type_complexity)]
@@ -215,18 +206,15 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         &self,
         block_height: BlockHeight,
     ) -> Result<Vec<(Self::NoteRef, IncrementalWitness<Node>)>, Self::Error> {
-        #[allow(deprecated)]
-        wallet::get_witnesses(self, block_height)
+        wallet::get_sapling_witnesses(self, block_height)
     }
 
     fn get_nullifiers(&self) -> Result<Vec<(AccountId, Nullifier)>, Self::Error> {
-        #[allow(deprecated)]
-        wallet::get_nullifiers(self)
+        wallet::get_sapling_nullifiers(self)
     }
 
     fn get_all_nullifiers(&self) -> Result<Vec<(AccountId, Nullifier)>, Self::Error> {
-        #[allow(deprecated)]
-        wallet::get_all_nullifiers(self)
+        wallet::get_all_sapling_nullifiers(self)
     }
 
     fn get_spendable_sapling_notes(
@@ -235,7 +223,6 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<Vec<SpendableNote<Self::NoteRef>>, Self::Error> {
-        #[allow(deprecated)]
         wallet::transact::get_spendable_sapling_notes(self, account, anchor_height, exclude)
     }
 
@@ -246,7 +233,6 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<Vec<SpendableNote<Self::NoteRef>>, Self::Error> {
-        #[allow(deprecated)]
         wallet::transact::select_spendable_sapling_notes(
             self,
             account,
@@ -458,7 +444,6 @@ impl<'a, P: consensus::Parameters> DataConnStmtCache<'a, P> {
     }
 }
 
-#[allow(deprecated)]
 impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
     type UtxoRef = UtxoId;
 
@@ -540,11 +525,11 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
                 let tx_row = wallet::put_tx_meta(up, tx, block.block_height)?;
 
                 // Mark notes as spent and remove them from the scanning cache
-                for spend in &tx.shielded_spends {
+                for spend in &tx.sapling_spends {
                     wallet::mark_sapling_note_spent(up, tx_row, &spend.nf)?;
                 }
 
-                for output in &tx.shielded_outputs {
+                for output in &tx.sapling_outputs {
                     let received_note_id = wallet::put_received_note(up, output, tx_row)?;
 
                     // Save witness for note.
@@ -968,7 +953,6 @@ impl std::fmt::Display for FsBlockDbError {
 extern crate assert_matches;
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use prost::Message;
     use rand_core::{OsRng, RngCore};

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -569,7 +569,7 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
                 match output.transfer_type {
                     TransferType::Outgoing | TransferType::WalletInternal => {
                         let recipient = if output.transfer_type == TransferType::Outgoing {
-                            Recipient::Sapling(output.to)
+                            Recipient::Sapling(output.note.recipient())
                         } else {
                             Recipient::InternalAccount(output.account, PoolType::Sapling)
                         };

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -526,14 +526,14 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
 
                 // Mark notes as spent and remove them from the scanning cache
                 for spend in &tx.sapling_spends {
-                    wallet::mark_sapling_note_spent(up, tx_row, &spend.nf)?;
+                    wallet::mark_sapling_note_spent(up, tx_row, spend.nf())?;
                 }
 
                 for output in &tx.sapling_outputs {
                     let received_note_id = wallet::put_received_note(up, output, tx_row)?;
 
                     // Save witness for note.
-                    new_witnesses.push((received_note_id, output.witness.clone()));
+                    new_witnesses.push((received_note_id, output.witness().clone()));
                 }
             }
 

--- a/zcash_client_sqlite/src/prepared.rs
+++ b/zcash_client_sqlite/src/prepared.rs
@@ -684,7 +684,7 @@ impl<'a, P> DataConnStmtCache<'a, P> {
         diversifier: &Diversifier,
         value: u64,
         rcm: [u8; 32],
-        nf: &Option<Nullifier>,
+        nf: Option<&Nullifier>,
         memo: Option<&MemoBytes>,
         is_change: Option<bool>,
     ) -> Result<NoteId, SqliteClientError> {
@@ -695,7 +695,7 @@ impl<'a, P> DataConnStmtCache<'a, P> {
             (":diversifier", &diversifier.0.as_ref()),
             (":value", &(value as i64)),
             (":rcm", &rcm.as_ref()),
-            (":nf", &nf.as_ref().map(|nf| nf.0.as_ref())),
+            (":nf", &nf.map(|nf| nf.0.as_ref())),
             (
                 ":memo",
                 &memo
@@ -726,7 +726,7 @@ impl<'a, P> DataConnStmtCache<'a, P> {
         diversifier: &Diversifier,
         value: u64,
         rcm: [u8; 32],
-        nf: &Option<Nullifier>,
+        nf: Option<&Nullifier>,
         memo: Option<&MemoBytes>,
         is_change: Option<bool>,
         tx_ref: i64,
@@ -737,7 +737,7 @@ impl<'a, P> DataConnStmtCache<'a, P> {
             (":diversifier", &diversifier.0.as_ref()),
             (":value", &(value as i64)),
             (":rcm", &rcm.as_ref()),
-            (":nf", &nf.as_ref().map(|nf| nf.0.as_ref())),
+            (":nf", &nf.map(|nf| nf.0.as_ref())),
             (
                 ":memo",
                 &memo

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -86,7 +86,7 @@ use zcash_client_backend::{
     address::{RecipientAddress, UnifiedAddress},
     data_api::{PoolType, Recipient, SentTransactionOutput},
     keys::UnifiedFullViewingKey,
-    wallet::{WalletShieldedOutput, WalletTx},
+    wallet::{WalletSaplingOutput, WalletTx},
     DecryptedOutput,
 };
 
@@ -123,8 +123,7 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
 }
 
 /// This trait provides a generalization over shielded output representations.
-#[deprecated(note = "This trait will be removed in a future release.")]
-pub trait ShieldedOutput {
+pub(crate) trait SaplingOutput {
     fn index(&self) -> usize;
     fn account(&self) -> AccountId;
     fn to(&self) -> &PaymentAddress;
@@ -134,8 +133,7 @@ pub trait ShieldedOutput {
     fn nullifier(&self) -> Option<Nullifier>;
 }
 
-#[allow(deprecated)]
-impl ShieldedOutput for WalletShieldedOutput<Nullifier> {
+impl SaplingOutput for WalletSaplingOutput<Nullifier> {
     fn index(&self) -> usize {
         self.index
     }
@@ -160,8 +158,7 @@ impl ShieldedOutput for WalletShieldedOutput<Nullifier> {
     }
 }
 
-#[allow(deprecated)]
-impl ShieldedOutput for DecryptedOutput {
+impl SaplingOutput for DecryptedOutput {
     fn index(&self) -> usize {
         self.index
     }
@@ -183,53 +180,6 @@ impl ShieldedOutput for DecryptedOutput {
     fn nullifier(&self) -> Option<Nullifier> {
         None
     }
-}
-
-/// Returns the address for the account.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::{
-///     consensus::{self, Network},
-///     zip32::AccountId,
-/// };
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_address,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let addr = get_address(&db, AccountId::from(0));
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_address instead."
-)]
-pub fn get_address<P: consensus::Parameters>(
-    wdb: &WalletDb<P>,
-    account: AccountId,
-) -> Result<Option<PaymentAddress>, SqliteClientError> {
-    // This returns the most recently generated address.
-    let addr: String = wdb.conn.query_row(
-        "SELECT address
-        FROM addresses WHERE account = ?
-        ORDER BY diversifier_index_be DESC
-        LIMIT 1",
-        [u32::from(account)],
-        |row| row.get(0),
-    )?;
-
-    RecipientAddress::decode(&wdb.params, &addr)
-        .ok_or_else(|| {
-            SqliteClientError::CorruptedData("Not a valid Zcash recipient address".to_owned())
-        })
-        .map(|addr| match addr {
-            // TODO: Return the UA, not its Sapling component.
-            RecipientAddress::Unified(ua) => ua.sapling().cloned(),
-            _ => None,
-        })
 }
 
 pub(crate) fn get_max_account_id<P>(
@@ -451,10 +401,7 @@ pub(crate) fn get_account_for_ufvk<P: consensus::Parameters>(
 /// specified account.
 ///
 /// [`ExtendedFullViewingKey`]: zcash_primitives::zip32::ExtendedFullViewingKey
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::is_valid_account_extfvk instead."
-)]
-pub fn is_valid_account_extfvk<P: consensus::Parameters>(
+pub(crate) fn is_valid_account_extfvk<P: consensus::Parameters>(
     wdb: &WalletDb<P>,
     account: AccountId,
     extfvk: &ExtendedFullViewingKey,
@@ -488,28 +435,11 @@ pub fn is_valid_account_extfvk<P: consensus::Parameters>(
 /// to chain reorgs. You should generally not show this balance to users without some
 /// caveat. Use [`get_balance_at`] where you need a more reliable indication of the
 /// wallet balance.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::{
-///     consensus::Network,
-///     zip32::AccountId,
-/// };
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_balance,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let addr = get_balance(&db, AccountId::from(0));
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_balance_at instead."
-)]
-pub fn get_balance<P>(wdb: &WalletDb<P>, account: AccountId) -> Result<Amount, SqliteClientError> {
+#[cfg(test)]
+pub(crate) fn get_balance<P>(
+    wdb: &WalletDb<P>,
+    account: AccountId,
+) -> Result<Amount, SqliteClientError> {
     let balance = wdb.conn.query_row(
         "SELECT SUM(value) FROM received_notes
         INNER JOIN transactions ON transactions.id_tx = received_notes.tx
@@ -529,28 +459,7 @@ pub fn get_balance<P>(wdb: &WalletDb<P>, account: AccountId) -> Result<Amount, S
 /// Returns the verified balance for the account at the specified height,
 /// This may be used to obtain a balance that ignores notes that have been
 /// received so recently that they are not yet deemed spendable.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::{
-///     consensus::{BlockHeight, Network},
-///     zip32::AccountId,
-/// };
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_balance_at,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let addr = get_balance_at(&db, AccountId::from(0), BlockHeight::from_u32(0));
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_balance_at instead."
-)]
-pub fn get_balance_at<P>(
+pub(crate) fn get_balance_at<P>(
     wdb: &WalletDb<P>,
     account: AccountId,
     anchor_height: BlockHeight,
@@ -575,26 +484,10 @@ pub fn get_balance_at<P>(
 ///
 /// The note is identified by its row index in the `received_notes` table within the wdb
 /// database.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::Network;
-/// use zcash_client_sqlite::{
-///     NoteId,
-///     WalletDb,
-///     wallet::get_received_memo,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let memo = get_received_memo(&db, 27);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_memo instead."
-)]
-pub fn get_received_memo<P>(wdb: &WalletDb<P>, id_note: i64) -> Result<Memo, SqliteClientError> {
+pub(crate) fn get_received_memo<P>(
+    wdb: &WalletDb<P>,
+    id_note: i64,
+) -> Result<Memo, SqliteClientError> {
     let memo_bytes: Vec<_> = wdb.conn.query_row(
         "SELECT memo FROM received_notes
         WHERE id_note = ?",
@@ -633,26 +526,7 @@ pub(crate) fn get_transaction<P: Parameters>(
 ///
 /// The note is identified by its row index in the `sent_notes` table within the wdb
 /// database.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::Network;
-/// use zcash_client_sqlite::{
-///     NoteId,
-///     WalletDb,
-///     wallet::get_sent_memo,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let memo = get_sent_memo(&db, 12);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_memo instead."
-)]
-pub fn get_sent_memo<P>(wdb: &WalletDb<P>, id_note: i64) -> Result<Memo, SqliteClientError> {
+pub(crate) fn get_sent_memo<P>(wdb: &WalletDb<P>, id_note: i64) -> Result<Memo, SqliteClientError> {
     let memo_bytes: Vec<_> = wdb.conn.query_row(
         "SELECT memo FROM sent_notes
         WHERE id_note = ?",
@@ -666,25 +540,7 @@ pub fn get_sent_memo<P>(wdb: &WalletDb<P>, id_note: i64) -> Result<Memo, SqliteC
 }
 
 /// Returns the minimum and maximum heights for blocks stored in the wallet database.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::Network;
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::block_height_extrema,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let bounds = block_height_extrema(&db);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::block_height_extrema instead."
-)]
-pub fn block_height_extrema<P>(
+pub(crate) fn block_height_extrema<P>(
     wdb: &WalletDb<P>,
 ) -> Result<Option<(BlockHeight, BlockHeight)>, rusqlite::Error> {
     wdb.conn
@@ -703,26 +559,7 @@ pub fn block_height_extrema<P>(
 
 /// Returns the block height at which the specified transaction was mined,
 /// if any.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::Network;
-/// use zcash_primitives::transaction::TxId;
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_tx_height,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let height = get_tx_height(&db, TxId::from_bytes([0u8; 32]));
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_tx_height instead."
-)]
-pub fn get_tx_height<P>(
+pub(crate) fn get_tx_height<P>(
     wdb: &WalletDb<P>,
     txid: TxId,
 ) -> Result<Option<BlockHeight>, rusqlite::Error> {
@@ -737,25 +574,7 @@ pub fn get_tx_height<P>(
 
 /// Returns the block hash for the block at the specified height,
 /// if any.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::{H0, Network};
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_block_hash,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let hash = get_block_hash(&db, H0);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_block_hash instead."
-)]
-pub fn get_block_hash<P>(
+pub(crate) fn get_block_hash<P>(
     wdb: &WalletDb<P>,
     block_height: BlockHeight,
 ) -> Result<Option<BlockHash>, rusqlite::Error> {
@@ -773,8 +592,9 @@ pub fn get_block_hash<P>(
 
 /// Gets the height to which the database must be rewound if any rewind greater than the pruning
 /// height is attempted.
-#[deprecated(note = "This function will be removed in a future release.")]
-pub fn get_rewind_height<P>(wdb: &WalletDb<P>) -> Result<Option<BlockHeight>, SqliteClientError> {
+pub(crate) fn get_rewind_height<P>(
+    wdb: &WalletDb<P>,
+) -> Result<Option<BlockHeight>, SqliteClientError> {
     wdb.conn
         .query_row(
             "SELECT MIN(tx.block)
@@ -815,7 +635,6 @@ pub(crate) fn rewind_to_height<P: consensus::Parameters>(
         })?;
 
     if block_height < last_scanned_height - PRUNING_HEIGHT {
-        #[allow(deprecated)]
         if let Some(h) = get_rewind_height(wdb)? {
             if block_height > h {
                 return Err(SqliteClientError::RequestedRewindInvalid(h, block_height));
@@ -872,25 +691,7 @@ pub(crate) fn rewind_to_height<P: consensus::Parameters>(
 
 /// Returns the commitment tree for the block at the specified height,
 /// if any.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::{Network, H0};
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_commitment_tree,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let tree = get_commitment_tree(&db, H0);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_commitment_tree instead."
-)]
-pub fn get_commitment_tree<P>(
+pub(crate) fn get_sapling_commitment_tree<P>(
     wdb: &WalletDb<P>,
     block_height: BlockHeight,
 ) -> Result<Option<CommitmentTree<Node>>, SqliteClientError> {
@@ -915,25 +716,7 @@ pub fn get_commitment_tree<P>(
 
 /// Returns the incremental witnesses for the block at the specified height,
 /// if any.
-///
-/// # Examples
-///
-/// ```
-/// use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::{Network, H0};
-/// use zcash_client_sqlite::{
-///     WalletDb,
-///     wallet::get_witnesses,
-/// };
-///
-/// let data_file = NamedTempFile::new().unwrap();
-/// let db = WalletDb::for_path(data_file, Network::TestNetwork).unwrap();
-/// let witnesses = get_witnesses(&db, H0);
-/// ```
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_witnesses instead."
-)]
-pub fn get_witnesses<P>(
+pub(crate) fn get_sapling_witnesses<P>(
     wdb: &WalletDb<P>,
     block_height: BlockHeight,
 ) -> Result<Vec<(NoteId, IncrementalWitness<Node>)>, SqliteClientError> {
@@ -956,10 +739,7 @@ pub fn get_witnesses<P>(
 /// Retrieve the nullifiers for notes that the wallet is tracking
 /// that have not yet been confirmed as a consequence of the spending
 /// transaction being included in a block.
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletRead::get_nullifiers instead."
-)]
-pub fn get_nullifiers<P>(
+pub(crate) fn get_sapling_nullifiers<P>(
     wdb: &WalletDb<P>,
 ) -> Result<Vec<(AccountId, Nullifier)>, SqliteClientError> {
     // Get the nullifiers for the notes we are tracking
@@ -984,7 +764,7 @@ pub fn get_nullifiers<P>(
 }
 
 /// Returns the nullifiers for the notes that this wallet is tracking.
-pub(crate) fn get_all_nullifiers<P>(
+pub(crate) fn get_all_sapling_nullifiers<P>(
     wdb: &WalletDb<P>,
 ) -> Result<Vec<(AccountId, Nullifier)>, SqliteClientError> {
     // Get the nullifiers for the notes we are tracking
@@ -1101,10 +881,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
 }
 
 /// Inserts information about a scanned block into the database.
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::advance_by_block instead."
-)]
-pub fn insert_block<'a, P>(
+pub(crate) fn insert_block<'a, P>(
     stmts: &mut DataConnStmtCache<'a, P>,
     block_height: BlockHeight,
     block_hash: BlockHash,
@@ -1116,10 +893,7 @@ pub fn insert_block<'a, P>(
 
 /// Inserts information about a mined transaction that was observed to
 /// contain a note related to this wallet into the database.
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::advance_by_block instead."
-)]
-pub fn put_tx_meta<'a, P, N>(
+pub(crate) fn put_tx_meta<'a, P, N>(
     stmts: &mut DataConnStmtCache<'a, P>,
     tx: &WalletTx<N>,
     height: BlockHeight,
@@ -1134,10 +908,7 @@ pub fn put_tx_meta<'a, P, N>(
 }
 
 /// Inserts full transaction data into the database.
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::store_decrypted_tx instead."
-)]
-pub fn put_tx_data<'a, P>(
+pub(crate) fn put_tx_data<'a, P>(
     stmts: &mut DataConnStmtCache<'a, P>,
     tx: &Transaction,
     fee: Option<Amount>,
@@ -1162,10 +933,7 @@ pub fn put_tx_data<'a, P>(
 ///
 /// Marking a note spent in this fashion does NOT imply that the
 /// spending transaction has been mined.
-#[deprecated(
-    note = "This function will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::store_sent_tx instead."
-)]
-pub fn mark_sapling_note_spent<'a, P>(
+pub(crate) fn mark_sapling_note_spent<'a, P>(
     stmts: &mut DataConnStmtCache<'a, P>,
     tx_ref: i64,
     nf: &Nullifier,
@@ -1233,11 +1001,7 @@ pub(crate) fn put_received_transparent_utxo<'a, P: consensus::Parameters>(
 /// This implementation relies on the facts that:
 /// - A transaction will not contain more than 2^63 shielded outputs.
 /// - A note value will never exceed 2^63 zatoshis.
-#[deprecated(
-    note = "This method will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::store_decrypted_tx instead."
-)]
-#[allow(deprecated)]
-pub fn put_received_note<'a, P, T: ShieldedOutput>(
+pub(crate) fn put_received_note<'a, P, T: SaplingOutput>(
     stmts: &mut DataConnStmtCache<'a, P>,
     output: &T,
     tx_ref: i64,
@@ -1283,10 +1047,7 @@ pub fn put_received_note<'a, P, T: ShieldedOutput>(
 
 /// Records the incremental witness for the specified note,
 /// as of the given block height.
-#[deprecated(
-    note = "This method will be removed in a future release. Use zcash_client_backend::data_api::WalletWrite::store_decrypted_tx instead."
-)]
-pub fn insert_witness<'a, P>(
+pub(crate) fn insert_witness<'a, P>(
     stmts: &mut DataConnStmtCache<'a, P>,
     note_id: i64,
     witness: &IncrementalWitness<Node>,
@@ -1296,10 +1057,7 @@ pub fn insert_witness<'a, P>(
 }
 
 /// Removes old incremental witnesses up to the given block height.
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletWrite::advance_by_block instead."
-)]
-pub fn prune_witnesses<P>(
+pub(crate) fn prune_witnesses<P>(
     stmts: &mut DataConnStmtCache<'_, P>,
     below_height: BlockHeight,
 ) -> Result<(), SqliteClientError> {
@@ -1308,10 +1066,7 @@ pub fn prune_witnesses<P>(
 
 /// Marks notes that have not been mined in transactions
 /// as expired, up to the given block height.
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletWrite::advance_by_block instead."
-)]
-pub fn update_expired_notes<P>(
+pub(crate) fn update_expired_notes<P>(
     stmts: &mut DataConnStmtCache<'_, P>,
     height: BlockHeight,
 ) -> Result<(), SqliteClientError> {
@@ -1365,7 +1120,6 @@ pub(crate) fn put_sent_output<'a, P: consensus::Parameters>(
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use secrecy::Secret;
     use tempfile::NamedTempFile;
@@ -1374,9 +1128,13 @@ mod tests {
 
     use zcash_client_backend::data_api::WalletRead;
 
-    use crate::{tests, wallet::init::init_wallet_db, AccountId, WalletDb};
+    use crate::{
+        tests,
+        wallet::{get_current_address, init::init_wallet_db},
+        AccountId, WalletDb,
+    };
 
-    use super::{get_address, get_balance};
+    use super::get_balance;
 
     #[cfg(feature = "transparent-inputs")]
     use {
@@ -1408,7 +1166,7 @@ mod tests {
         assert_eq!(db_data.get_target_and_anchor_heights(10).unwrap(), None);
 
         // An invalid account has zero balance
-        assert!(get_address(&db_data, AccountId::from(1)).is_err());
+        assert_matches!(get_current_address(&db_data, AccountId::from(1)), Ok(None));
         assert_eq!(
             get_balance(&db_data, AccountId::from(0)).unwrap(),
             Amount::zero()

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1078,11 +1078,11 @@ pub(crate) fn insert_sent_output<'a, P: consensus::Parameters>(
 ) -> Result<(), SqliteClientError> {
     stmts.stmt_insert_sent_output(
         tx_ref,
-        output.output_index,
+        output.output_index(),
         from_account,
-        &output.recipient,
-        output.value,
-        output.memo.as_ref(),
+        output.recipient(),
+        output.value(),
+        output.memo(),
     )
 }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -129,28 +129,28 @@ pub(crate) trait SaplingOutput {
     fn note(&self) -> &Note;
     fn memo(&self) -> Option<&MemoBytes>;
     fn is_change(&self) -> Option<bool>;
-    fn nullifier(&self) -> Option<Nullifier>;
+    fn nullifier(&self) -> Option<&Nullifier>;
 }
 
 impl SaplingOutput for WalletSaplingOutput<Nullifier> {
     fn index(&self) -> usize {
-        self.index
+        self.index()
     }
     fn account(&self) -> AccountId {
-        self.account
+        WalletSaplingOutput::account(self)
     }
     fn note(&self) -> &Note {
-        &self.note
+        WalletSaplingOutput::note(self)
     }
     fn memo(&self) -> Option<&MemoBytes> {
         None
     }
     fn is_change(&self) -> Option<bool> {
-        Some(self.is_change)
+        Some(WalletSaplingOutput::is_change(self))
     }
 
-    fn nullifier(&self) -> Option<Nullifier> {
-        Some(self.nf)
+    fn nullifier(&self) -> Option<&Nullifier> {
+        Some(self.nf())
     }
 }
 
@@ -170,7 +170,7 @@ impl SaplingOutput for DecryptedOutput<Note> {
     fn is_change(&self) -> Option<bool> {
         None
     }
-    fn nullifier(&self) -> Option<Nullifier> {
+    fn nullifier(&self) -> Option<&Nullifier> {
         None
     }
 }
@@ -1015,7 +1015,7 @@ pub(crate) fn put_received_note<'a, P, T: SaplingOutput>(
         diversifier,
         value.inner(),
         rcm,
-        &nf,
+        nf,
         memo,
         is_change,
         tx_ref,
@@ -1029,7 +1029,7 @@ pub(crate) fn put_received_note<'a, P, T: SaplingOutput>(
             diversifier,
             value.inner(),
             rcm,
-            &nf,
+            nf,
             memo,
             is_change,
         )

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -74,7 +74,7 @@ use zcash_primitives::{
     consensus::{self, BlockHeight, BranchId, NetworkUpgrade, Parameters},
     memo::{Memo, MemoBytes},
     merkle_tree::{CommitmentTree, IncrementalWitness},
-    sapling::{Node, Note, Nullifier, PaymentAddress},
+    sapling::{Node, Note, Nullifier},
     transaction::{components::Amount, Transaction, TxId},
     zip32::{
         sapling::{DiversifiableFullViewingKey, ExtendedFullViewingKey},
@@ -126,7 +126,6 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
 pub(crate) trait SaplingOutput {
     fn index(&self) -> usize;
     fn account(&self) -> AccountId;
-    fn to(&self) -> &PaymentAddress;
     fn note(&self) -> &Note;
     fn memo(&self) -> Option<&MemoBytes>;
     fn is_change(&self) -> Option<bool>;
@@ -139,9 +138,6 @@ impl SaplingOutput for WalletSaplingOutput<Nullifier> {
     }
     fn account(&self) -> AccountId {
         self.account
-    }
-    fn to(&self) -> &PaymentAddress {
-        &self.to
     }
     fn note(&self) -> &Note {
         &self.note
@@ -164,9 +160,6 @@ impl SaplingOutput for DecryptedOutput {
     }
     fn account(&self) -> AccountId {
         self.account
-    }
-    fn to(&self) -> &PaymentAddress {
-        &self.to
     }
     fn note(&self) -> &Note {
         &self.note
@@ -1008,7 +1001,8 @@ pub(crate) fn put_received_note<'a, P, T: SaplingOutput>(
 ) -> Result<NoteId, SqliteClientError> {
     let rcm = output.note().rcm().to_repr();
     let account = output.account();
-    let diversifier = output.to().diversifier();
+    let to = output.note().recipient();
+    let diversifier = to.diversifier();
     let value = output.note().value();
     let memo = output.memo();
     let is_change = output.is_change();

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -154,7 +154,7 @@ impl SaplingOutput for WalletSaplingOutput<Nullifier> {
     }
 }
 
-impl SaplingOutput for DecryptedOutput {
+impl SaplingOutput for DecryptedOutput<Note> {
     fn index(&self) -> usize {
         self.index
     }

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -158,11 +158,11 @@ fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
 /// [`WalletWrite::create_account`]: zcash_client_backend::data_api::WalletWrite::create_account
 ///
 /// The [`UnifiedFullViewingKey`]s are stored internally and used by other APIs such as
-/// [`get_address`], [`scan_cached_blocks`], and [`create_spend_to_address`]. Account identifiers
-/// in `keys` **MUST** form a consecutive sequence beginning at account 0, and the
-/// [`UnifiedFullViewingKey`] corresponding to a given account identifier **MUST** be derived from
-/// the wallet's mnemonic seed at the BIP-44 `account` path level as described by
-/// [ZIP 316](https://zips.z.cash/zip-0316)
+/// [`scan_cached_blocks`], and [`create_spend_to_address`]. Account identifiers in `keys` **MUST**
+/// form a consecutive sequence beginning at account 0, and the [`UnifiedFullViewingKey`]
+/// corresponding to a given account identifier **MUST** be derived from the wallet's mnemonic seed
+/// at the BIP-44 `account` path level as described by [ZIP
+/// 316](https://zips.z.cash/zip-0316)
 ///
 /// # Examples
 ///
@@ -301,6 +301,7 @@ mod tests {
 
     use zcash_client_backend::{
         address::RecipientAddress,
+        data_api::WalletRead,
         encoding::{encode_extended_full_viewing_key, encode_payment_address},
         keys::{sapling, UnifiedFullViewingKey, UnifiedSpendingKey},
     };
@@ -315,7 +316,6 @@ mod tests {
     use crate::{
         error::SqliteClientError,
         tests::{self, network},
-        wallet::get_address,
         AccountId, WalletDb,
     };
 
@@ -1142,8 +1142,8 @@ mod tests {
         init_accounts_table(&db_data, &ufvks).unwrap();
 
         // The account's address should be in the data DB
-        let pa = get_address(&db_data, AccountId::from(0)).unwrap();
-        assert_eq!(pa.unwrap(), expected_address);
+        let ua = db_data.get_current_address(AccountId::from(0)).unwrap();
+        assert_eq!(ua.unwrap().sapling().unwrap(), &expected_address);
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -62,10 +62,7 @@ fn to_spendable_note(row: &Row) -> Result<SpendableNote<NoteId>, SqliteClientErr
     })
 }
 
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletRead::get_spendable_sapling_notes instead."
-)]
-pub fn get_spendable_sapling_notes<P>(
+pub(crate) fn get_spendable_sapling_notes<P>(
     wdb: &WalletDb<P>,
     account: AccountId,
     anchor_height: BlockHeight,
@@ -104,10 +101,7 @@ pub fn get_spendable_sapling_notes<P>(
     notes.collect::<Result<_, _>>()
 }
 
-#[deprecated(
-    note = "This method will be removed in a future update. Use zcash_client_backend::data_api::WalletRead::select_spendable_sapling_notes instead."
-)]
-pub fn select_spendable_sapling_notes<P>(
+pub(crate) fn select_spendable_sapling_notes<P>(
     wdb: &WalletDb<P>,
     account: AccountId,
     target_value: Amount,


### PR DESCRIPTION
This helps to clarify the Sapling-specific nature of a number of operations in wallet code.