### PR TITLE
zcash_history: Migrate to `primitive-types 0.12`

### DIFF
--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.60.0.
+- Bumped dependencies to `primitive-types 0.12`.
 
 ## [0.3.0] - 2022-05-11
 ### Added

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -14,13 +14,10 @@ assert_matches = "1.3.0"
 proptest = "1.0.0"
 
 [dependencies]
-primitive-types = "0.11"
+primitive-types = { version = "0.12", default-features = false }
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "1" }
 proptest = { version = "1.0.0", optional = true }
-
-# pin the winnow dependency due to MSRV of 1.64 in 0.4.2
-winnow = { version = "=0.4.1" }
 
 [features]
 test-dependencies = ["proptest"]


### PR DESCRIPTION
We also disable the default `std` feature, to remove transitive dependencies we don't use.