### PR TITLE
Revert #830 and instead modify `zcash_primitives::transaction::fees::fixed::FeeRule::standard()`

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -184,7 +184,9 @@ where
 /// [`sapling::TxProver`]: zcash_primitives::sapling::prover::TxProver
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
-#[deprecated(note = "Use `spend` instead.")]
+#[deprecated(
+    note = "Use `spend` instead. Note that this uses a fixed fee of 10000 zatoshis, which is not compliant with ZIP 317."
+)]
 pub fn create_spend_to_address<DbT, ParamsT>(
     wallet_db: &mut DbT,
     params: &ParamsT,
@@ -221,7 +223,9 @@ where
         "It should not be possible for this to violate ZIP 321 request construction invariants.",
     );
 
-    let change_strategy = fees::fixed::SingleOutputChangeStrategy::new(fixed::FeeRule::standard());
+    #[allow(deprecated)]
+    let fee_rule = fixed::FeeRule::standard();
+    let change_strategy = fees::fixed::SingleOutputChangeStrategy::new(fee_rule);
     spend(
         wallet_db,
         params,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -185,7 +185,7 @@ where
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[deprecated(
-    note = "Use `spend` instead. Note that this uses a fixed fee of 10000 zatoshis, which is not compliant with ZIP 317."
+    note = "Use `spend` instead. `create_spend_to_address` uses a fixed fee of 10000 zatoshis, which is not compliant with ZIP 317."
 )]
 pub fn create_spend_to_address<DbT, ParamsT>(
     wallet_db: &mut DbT,

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -185,7 +185,7 @@ mod tests {
             &Vec::<TxOut>::new(),
             &[TestSaplingInput {
                 note_id: 0,
-                value: Amount::from_u64(60000).unwrap(),
+                value: Amount::from_u64(45000).unwrap(),
             }],
             &[SaplingPayment::new(Amount::from_u64(40000).unwrap())],
             &DustOutputPolicy::default(),
@@ -193,8 +193,8 @@ mod tests {
 
         assert_matches!(
             result,
-            Ok(balance) if balance.proposed_change() == [ChangeValue::Sapling(Amount::from_u64(10000).unwrap())]
-                && balance.fee_required() == Amount::from_u64(10000).unwrap()
+            Ok(balance) if balance.proposed_change() == [ChangeValue::Sapling(Amount::from_u64(4000).unwrap())]
+                && balance.fee_required() == Amount::from_u64(1000).unwrap()
         );
     }
 
@@ -218,7 +218,7 @@ mod tests {
                 // enough to pay a fee, plus dust
                 TestSaplingInput {
                     note_id: 0,
-                    value: Amount::from_u64(10100).unwrap(),
+                    value: Amount::from_u64(1100).unwrap(),
                 },
             ],
             &[SaplingPayment::new(Amount::from_u64(40000).unwrap())],
@@ -228,7 +228,7 @@ mod tests {
         assert_matches!(
             result,
             Err(ChangeError::InsufficientFunds { available, required })
-            if available == Amount::from_u64(50100).unwrap() && required == Amount::from_u64(60000).unwrap()
+            if available == Amount::from_u64(41100).unwrap() && required == Amount::from_u64(42000).unwrap()
         );
     }
 }

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -185,7 +185,7 @@ mod tests {
             &Vec::<TxOut>::new(),
             &[TestSaplingInput {
                 note_id: 0,
-                value: Amount::from_u64(45000).unwrap(),
+                value: Amount::from_u64(60000).unwrap(),
             }],
             &[SaplingPayment::new(Amount::from_u64(40000).unwrap())],
             &DustOutputPolicy::default(),
@@ -193,8 +193,8 @@ mod tests {
 
         assert_matches!(
             result,
-            Ok(balance) if balance.proposed_change() == [ChangeValue::Sapling(Amount::from_u64(4000).unwrap())]
-                && balance.fee_required() == Amount::from_u64(1000).unwrap()
+            Ok(balance) if balance.proposed_change() == [ChangeValue::Sapling(Amount::from_u64(10000).unwrap())]
+                && balance.fee_required() == Amount::from_u64(10000).unwrap()
         );
     }
 
@@ -218,7 +218,7 @@ mod tests {
                 // enough to pay a fee, plus dust
                 TestSaplingInput {
                     note_id: 0,
-                    value: Amount::from_u64(1100).unwrap(),
+                    value: Amount::from_u64(10100).unwrap(),
                 },
             ],
             &[SaplingPayment::new(Amount::from_u64(40000).unwrap())],
@@ -228,7 +228,7 @@ mod tests {
         assert_matches!(
             result,
             Err(ChangeError::InsufficientFunds { available, required })
-            if available == Amount::from_u64(41100).unwrap() && required == Amount::from_u64(42000).unwrap()
+            if available == Amount::from_u64(50100).unwrap() && required == Amount::from_u64(60000).unwrap()
         );
     }
 }

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -173,7 +173,9 @@ mod tests {
 
     #[test]
     fn change_without_dust() {
-        let change_strategy = SingleOutputChangeStrategy::new(FixedFeeRule::standard());
+        #[allow(deprecated)]
+        let fee_rule = FixedFeeRule::standard();
+        let change_strategy = SingleOutputChangeStrategy::new(fee_rule);
 
         // spend a single Sapling note that is sufficient to pay the fee
         let result = change_strategy.compute_balance(
@@ -200,7 +202,9 @@ mod tests {
 
     #[test]
     fn dust_change() {
-        let change_strategy = SingleOutputChangeStrategy::new(FixedFeeRule::standard());
+        #[allow(deprecated)]
+        let fee_rule = FixedFeeRule::standard();
+        let change_strategy = SingleOutputChangeStrategy::new(fee_rule);
 
         // spend a single Sapling note that is sufficient to pay the fee
         let result = change_strategy.compute_balance(

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -354,7 +354,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(10001).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(1001).unwrap()
         );
     }
 
@@ -437,7 +437,7 @@ mod tests {
                 required
             })
             if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(80000).unwrap()
+                && required == Amount::from_u64(71000).unwrap()
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 2 to 9 until just before the second
@@ -472,7 +472,7 @@ mod tests {
                 required
             })
             if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(80000).unwrap()
+                && required == Amount::from_u64(71000).unwrap()
         );
 
         // Mine block 11 so that the second note becomes verified
@@ -568,7 +568,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(3000).unwrap()
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 1 to 21 (that don't send us funds)
@@ -602,7 +602,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(3000).unwrap()
         );
 
         // Mine block SAPLING_ACTIVATION_HEIGHT + 22 so that the first transaction expires
@@ -752,7 +752,7 @@ mod tests {
         let dfvk = usk.sapling().to_diversifiable_full_viewing_key();
 
         // Add funds to the wallet in a single note
-        let value = Amount::from_u64(60000).unwrap();
+        let value = Amount::from_u64(51000).unwrap();
         let (cb, _) = fake_compact_block(
             sapling_activation_height(),
             BlockHash([0; 32]),
@@ -806,7 +806,7 @@ mod tests {
         let dfvk = usk.sapling().to_diversifiable_full_viewing_key();
 
         // Add funds to the wallet in a single note
-        let value = Amount::from_u64(60000).unwrap();
+        let value = Amount::from_u64(51000).unwrap();
         let (cb, _) = fake_compact_block(
             sapling_activation_height(),
             BlockHash([0; 32]),

--- a/zcash_client_sqlite/src/wallet/transact.rs
+++ b/zcash_client_sqlite/src/wallet/transact.rs
@@ -354,7 +354,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(1001).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(10001).unwrap()
         );
     }
 
@@ -437,7 +437,7 @@ mod tests {
                 required
             })
             if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(71000).unwrap()
+                && required == Amount::from_u64(80000).unwrap()
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 2 to 9 until just before the second
@@ -472,7 +472,7 @@ mod tests {
                 required
             })
             if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(71000).unwrap()
+                && required == Amount::from_u64(80000).unwrap()
         );
 
         // Mine block 11 so that the second note becomes verified
@@ -568,7 +568,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(3000).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 1 to 21 (that don't send us funds)
@@ -602,7 +602,7 @@ mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(3000).unwrap()
+            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
         );
 
         // Mine block SAPLING_ACTIVATION_HEIGHT + 22 so that the first transaction expires
@@ -752,7 +752,7 @@ mod tests {
         let dfvk = usk.sapling().to_diversifiable_full_viewing_key();
 
         // Add funds to the wallet in a single note
-        let value = Amount::from_u64(51000).unwrap();
+        let value = Amount::from_u64(60000).unwrap();
         let (cb, _) = fake_compact_block(
             sapling_activation_height(),
             BlockHash([0; 32]),
@@ -806,7 +806,7 @@ mod tests {
         let dfvk = usk.sapling().to_diversifiable_full_viewing_key();
 
         // Add funds to the wallet in a single note
-        let value = Amount::from_u64(51000).unwrap();
+        let value = Amount::from_u64(60000).unwrap();
         let (cb, _) = fake_compact_block(
             sapling_activation_height(),
             BlockHash([0; 32]),

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -812,7 +812,7 @@ mod tests {
         // create some inputs to spend
         let extsk = ExtendedSpendingKey::master(&[]);
         let to = extsk.default_address().1;
-        let note1 = to.create_note(110000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(101000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
         let cm1 = Node::from_cmu(&note1.cmu());
         let mut tree = sapling::CommitmentTree::empty();
         // fake that the note appears in some previous

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -812,7 +812,7 @@ mod tests {
         // create some inputs to spend
         let extsk = ExtendedSpendingKey::master(&[]);
         let to = extsk.default_address().1;
-        let note1 = to.create_note(101000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(110000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
         let cm1 = Node::from_cmu(&note1.cmu());
         let mut tree = sapling::CommitmentTree::empty();
         // fake that the note appears in some previous

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -807,6 +807,9 @@ mod tests {
         //
 
         let mut rng = OsRng;
+
+        // FIXME: implement zcash_primitives::transaction::fees::FutureFeeRule for zip317::FeeRule.
+        #[allow(deprecated)]
         let fee_rule = fixed::FeeRule::standard();
 
         // create some inputs to spend

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -67,6 +67,10 @@ and this library adheres to Rust's notion of
 - `merkle_tree::read_incremental_witness` replaces `merkle_tree::IncrementalWitness::read`
 - `merkle_tree::merkle_path_from_slice` replaces `merkle_tree::MerklePath::from_slice`
 - `sapling::{CommitmentTree, IncrementalWitness, MerklePath, NOTE_COMMITMENT_TREE_DEPTH}`
+- `transaction::fees::zip317::MINIMUM_FEE`, reflecting the minimum possible
+  [ZIP 317](https://zips.z.cash/zip-0317) conventional fee.
+- `transaction::components::amount::Amount::const_from_i64`, intended for constructing
+  a constant `Amount`.
 
 ### Changed
 - The bounds on the `H` parameter to the following methods have changed:

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -78,6 +78,9 @@ and this library adheres to Rust's notion of
   - `merkle_tree::incremental::read_auth_fragment_v1`
 - The depth of the `merkle_tree::{CommitmentTree, IncrementalWitness, and MerklePath}` 
   data types are now statically constrained using const generic type parameters.
+- `transaction::fees::fixed::FeeRule::standard()` now uses the ZIP 317 minimum fee
+  (10000 zatoshis rather than 1000 zatoshis) as the fixed fee. To be compliant with
+  ZIP 317, use `transaction::fees::zip317::FeeRule::standard()` instead.
 
 ## [0.11.0] - 2023-04-15
 ### Added

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,8 +8,6 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - Bumped dependencies to `secp256k1 0.26`, `hdwallet 0.4`.
-- `zcash_primitives::transactions::component::amount::DEFAULT_FEE` increased zip317 
-  minimum possible fee.
 
 ### Removed
 - `merkle_tree::Hashable` has been removed and its uses have been replaced by

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -82,6 +82,14 @@ and this library adheres to Rust's notion of
   (10000 zatoshis rather than 1000 zatoshis) as the fixed fee. To be compliant with
   ZIP 317, use `transaction::fees::zip317::FeeRule::standard()` instead.
 
+### Deprecated
+- `transaction::components::amount::DEFAULT_FEE` has been deprecated. Depending on
+  context, you may want to use `transaction::fees::zip317::MINIMUM_FEE`, or calculate
+  the ZIP 317 conventional fee using `transaction::fees::zip317::FeeRule` instead.
+- `transaction::fees::fixed::FeeRule::standard()` has been deprecated.
+  Use either `transaction::fees::zip317::FeeRule::standard()` or
+  `transaction::fees::fixed::FeeRule::non_standard`.
+
 ## [0.11.0] - 2023-04-15
 ### Added
 - `zcash_primitives::zip32::fingerprint` module, containing types for deriving

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -646,7 +646,7 @@ mod tests {
         builder
             .add_transparent_output(
                 &TransparentAddress::PublicKey([0; 20]),
-                Amount::from_u64(40000).unwrap(),
+                Amount::from_u64(49000).unwrap(),
             )
             .unwrap();
 
@@ -682,7 +682,7 @@ mod tests {
         builder
             .add_transparent_output(
                 &TransparentAddress::PublicKey([0; 20]),
-                Amount::from_u64(40000).unwrap(),
+                Amount::from_u64(49000).unwrap(),
             )
             .unwrap();
 
@@ -771,7 +771,7 @@ mod tests {
             );
         }
 
-        let note1 = to.create_note(59999, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(50999, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
         let cmu1 = Node::from_cmu(&note1.cmu());
         let mut tree = CommitmentTree::<Node, 32>::empty();
         tree.append(cmu1).unwrap();

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -533,6 +533,7 @@ mod testing {
         }
 
         pub fn mock_build(self) -> Result<(Transaction, SaplingMetadata), Error<Infallible>> {
+            #[allow(deprecated)]
             self.build(&MockTxProver, &fixed::FeeRule::standard())
         }
     }

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -32,6 +32,14 @@ impl Amount {
         Amount(0)
     }
 
+    /// Creates a constant Amount from an i64.
+    ///
+    /// Panics: if the amount is outside the range `{-MAX_MONEY..MAX_MONEY}`.
+    pub const fn const_from_i64(amount: i64) -> Self {
+        assert!(-MAX_MONEY <= amount && amount <= MAX_MONEY); // contains is not const
+        Amount(amount)
+    }
+
     /// Creates an Amount from an i64.
     ///
     /// Returns an error if the amount is outside the range `{-MAX_MONEY..MAX_MONEY}`.

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -8,6 +8,12 @@ use orchard::value as orchard;
 pub const COIN: i64 = 1_0000_0000;
 pub const MAX_MONEY: i64 = 21_000_000 * COIN;
 
+#[deprecated(
+    since = "0.12.0",
+    note = "To calculate the ZIP 317 fee, use `transaction::fees::zip317::FeeRule`.
+For a constant representing the minimum ZIP 317 fee, use `transaction::fees::zip317::MINIMUM_FEE`.
+For the constant amount 1000 zatoshis, use `Amount::const_from_i64(1000)`."
+)]
 pub const DEFAULT_FEE: Amount = Amount(1000);
 
 /// A type-safe representation of some quantity of Zcash.

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -8,7 +8,7 @@ use orchard::value as orchard;
 pub const COIN: i64 = 1_0000_0000;
 pub const MAX_MONEY: i64 = 21_000_000 * COIN;
 
-pub const DEFAULT_FEE: Amount = Amount(10_000);
+pub const DEFAULT_FEE: Amount = Amount(1000);
 
 /// A type-safe representation of some quantity of Zcash.
 ///

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -24,10 +24,15 @@ impl FeeRule {
     /// i.e. 10000 zatoshis.
     ///
     /// Note that using a fixed fee is not compliant with [ZIP 317]; consider
-    /// using [`zcash_primitives::transaction::fees::zip317::FeeRule`] instead.
+    /// using [`zcash_primitives::transaction::fees::zip317::FeeRule::standard()`]
+    /// instead.
     ///
-    /// [`zcash_primitives::transaction::fees::zip317::FeeRule`]: crate::transaction::fees::zip317::FeeRule
+    /// [`zcash_primitives::transaction::fees::zip317::FeeRule::standard()`]: crate::transaction::fees::zip317::FeeRule::standard
     /// [ZIP 317]: https://zips.z.cash/zip-0317
+    #[deprecated(
+        since = "0.12.0",
+        note = "To calculate the ZIP 317 fee, use `transaction::fees::zip317::FeeRule::standard()`. For a fixed fee, use the `non_standard` constructor."
+    )]
     pub fn standard() -> Self {
         Self {
             fixed_fee: zip317::MINIMUM_FEE,

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,9 +1,7 @@
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{
-        amount::{Amount, DEFAULT_FEE},
-        transparent::fees as transparent,
-    },
+    transaction::components::{amount::Amount, transparent::fees as transparent},
+    transaction::fees::zip317,
 };
 
 #[cfg(feature = "zfuture")]
@@ -22,10 +20,17 @@ impl FeeRule {
         Self { fixed_fee }
     }
 
-    /// Creates a new fixed fee rule with the standard default fee.
+    /// Creates a new fixed fee rule with the minimum possible [ZIP 317] fee,
+    /// i.e. 10000 zatoshis.
+    ///
+    /// Note that using a fixed fee is not compliant with [ZIP 317]; consider
+    /// using [`zcash_primitives::transaction::fees::zip317::FeeRule`] instead.
+    ///
+    /// [`zcash_primitives::transaction::fees::zip317::FeeRule`]: crate::transaction::fees::zip317::FeeRule
+    /// [ZIP 317]: https://zips.z.cash/zip-0317
     pub fn standard() -> Self {
         Self {
-            fixed_fee: DEFAULT_FEE,
+            fixed_fee: zip317::MINIMUM_FEE,
         }
     }
 

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -13,6 +13,13 @@ use crate::{
     },
 };
 
+/// The minimum conventional fee using the standard [ZIP 317] constants. Equivalent to
+/// `(FeeRule::standard().marginal_fee() * FeeRule::standard().grace_actions()).unwrap()`,
+/// but as a constant.
+///
+/// [ZIP 317]: https//zips.z.cash/zip-0317
+pub const MINIMUM_FEE: Amount = Amount::const_from_i64(10_000);
+
 /// A [`FeeRule`] implementation that implements the [ZIP 317] fee rule.
 ///
 /// This fee rule supports only P2pkh transparent inputs; an error will be returned if a coin


### PR DESCRIPTION
#830 updated `zcash_primitives::components::amount::DEFAULT_FEE` to be 10000 zatoshis. This is not consistent with the value of `LEGACY_DEFAULT_FEE` in zcashd, and might have unintended side effects in code that uses it. Also, the effect on the behaviour of `zcash_primitives::transaction::fees::fixed::FeeRule::standard()` was not documented in the release notes.

This PR reverts #830 (as the first commit) and instead updates `zcash_primitives::transaction::fees::fixed::FeeRule::standard()` to use a new constant, `zcash_primitives::transaction::fees::zip317::MINIMUM_FEE`. It also deprecates `zcash_primitives::components::amount::DEFAULT_FEE` and `zcash_primitives::transaction::fees::fixed::FeeRule::standard()`. (You can still use `fixed::FeeRule` via its `non_standard` constructor, which is correct because any fixed fee is by definition non-standard.)