### PR TITLE
fix: Avoid a redundant check containing curve point multiplication

### DIFF
--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -667,9 +667,7 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
         }
     }
 
-    if let NoteValidity::Valid =
-        check_note_validity::<D>(&note, &ephemeral_key, &output.cmstar_bytes())
-    {
+    if D::ExtractedCommitmentBytes::from(&D::cmstar(&note)) == output.cmstar_bytes() {
         Some((note, to, memo))
     } else {
         None


### PR DESCRIPTION
## Motivation

The function [try_output_recovery_with_ock](https://github.com/zcash/librustzcash/blob/bc558932679247b56d69c508c4172abda8b8d1f6/components/zcash_note_encryption/src/lib.rs#L614) calls [parse_note_plaintext_without_memo_ovk](https://github.com/zcash/librustzcash/blob/bc558932679247b56d69c508c4172abda8b8d1f6/zcash_primitives/src/sapling/note_encryption.rs#L254) from [here](https://github.com/zcash/librustzcash/blob/bc558932679247b56d69c508c4172abda8b8d1f6/components/zcash_note_encryption/src/lib.rs#L659). The second function validates the ephemeral keys. The first function then calls [check_note_validity](https://github.com/zcash/librustzcash/blob/bc558932679247b56d69c508c4172abda8b8d1f6/components/zcash_note_encryption/src/lib.rs#L514), which also contains the same check of the same ephemeral keys. These checks both contain a curve point multiplication.

Closes #802.

## Solution

- Don't call `check_note_validity`, but still check the commitment bytes.

As mentioned in https://github.com/ZcashFoundation/zebra/issues/6392#issuecomment-1520405426, I initially thought of refactoring `check_note_validity` directly, which wouldn't be worth it since it's called in other places. Only then I thought of not calling `check_note_validity` at all, which is a much simpler solution that avoids the redundant check.
