### PR TITLE
Update memo retrieval API to reflect that memos may not be present.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,6 +8,9 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - Bumped dependencies to `hdwallet 0.4`.
+- `WalletRead::get_memo` now returns `Result<Option<Memo>, Self::Error>`
+  instead of `Result<Memo, Self::Error>` in order to make representable
+  wallet states where the full note plaintext is not available.
 
 ## [0.9.0] - 2023-04-28
 ### Added
@@ -19,7 +22,7 @@ and this library adheres to Rust's notion of
   to allow reuse of the data structure for non-Sapling contexts.
 - `data_api::SentTransactionOutput` must now be constructed using
   `SentTransactionOutput::from_parts`. The internal state of `SentTransactionOutput`
-  is now private, and accessible via methods that have the same names as the 
+  is now private, and accessible via methods that have the same names as the
   previously exposed fields.
 
 ### Renamed

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -155,8 +155,10 @@ pub trait WalletRead {
     /// Returns the memo for a note.
     ///
     /// Implementations of this method must return an error if the note identifier
-    /// does not appear in the backing data store.
-    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Memo, Self::Error>;
+    /// does not appear in the backing data store. Returns `Ok(None)` if the note
+    /// is known to the wallet but memo data has not yet been populated for that
+    /// note.
+    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error>;
 
     /// Returns a transaction.
     fn get_transaction(&self, id_tx: Self::TxRef) -> Result<Transaction, Self::Error>;
@@ -512,8 +514,8 @@ pub mod testing {
             Ok(Amount::zero())
         }
 
-        fn get_memo(&self, _id_note: Self::NoteRef) -> Result<Memo, Self::Error> {
-            Ok(Memo::Empty)
+        fn get_memo(&self, _id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error> {
+            Ok(None)
         }
 
         fn get_transaction(&self, _id_tx: Self::TxRef) -> Result<Transaction, Self::Error> {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -190,7 +190,7 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
         wallet::get_transaction(self, id_tx)
     }
 
-    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Memo, Self::Error> {
+    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error> {
         match id_note {
             NoteId::SentNoteId(id_note) => wallet::get_sent_memo(self, id_note),
             NoteId::ReceivedNoteId(id_note) => wallet::get_received_memo(self, id_note),
@@ -349,7 +349,7 @@ impl<'a, P: consensus::Parameters> WalletRead for DataConnStmtCache<'a, P> {
         self.wallet_db.get_transaction(id_tx)
     }
 
-    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Memo, Self::Error> {
+    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error> {
         self.wallet_db.get_memo(id_note)
     }
 


### PR DESCRIPTION
Memos may be absent for both sent and received notes in cases where only compact block information has been used to populate the wallet database. This fixes a potential crash in the case that we attempt to decode a SQLite `NULL` as a byte array. It does, however, introduce a slight semantic confusion that will need to be considered in the case of future updates where a note may not have an associated memo; at present, the only reason we might not have the memo is that we might not have retrieved the full transaction information from the chain, but in the future there might be other possible reasons for this absence.

Fixes #384