### PR TITLE
Return the empty memo when memo is not present.

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,14 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.7.1] - 2023-05-17
+
+### Fixed
+- Fixes a potential crash that could occur when attempting to read a memo from 
+  sqlite when the memo value is `NULL`. At present, we return the empty memo
+  in this case; in the future, the `get_memo` API will be updated to reflect
+  the potential absence of memo data.
+
 ## [0.7.0] - 2023-04-28
 ### Changed
 - Bumped dependencies to `zcash_client_backend 0.9`.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -196,6 +196,7 @@ impl<P: consensus::Parameters> WalletRead for WalletDb<P> {
             NoteId::SentNoteId(id_note) => wallet::get_sent_memo(self, id_note),
             NoteId::ReceivedNoteId(id_note) => wallet::get_received_memo(self, id_note),
         }
+        .map(|m| m.unwrap_or(Memo::Empty))
     }
 
     fn get_commitment_tree(


### PR DESCRIPTION
Memos may be absent for both sent and received notes in cases where only compact block information has been used to populate the wallet database. This fixes a potential crash in the case that we attempt to decode a SQLite `NULL` as a byte array.

Fixes #384

(cherry picked from commit d99b4d4d6ec1126447159ffe649a3edac2f322d5)