### PR TITLE
Avoid redundant checks during note decryption

### DIFF
--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -229,8 +229,6 @@ pub trait Domain {
     ///   which may be passed via `self`).
     /// - The note plaintext contains valid encodings of its various fields.
     /// - Any domain-specific requirements are satisfied.
-    /// - `ephemeral_key` can be derived from `esk` and the diversifier within the note
-    ///   plaintext.
     ///
     /// `&self` is passed here to enable the implementation to enforce contextual checks,
     /// such as rules like [ZIP 212] that become active at a specific block height.

--- a/zcash_primitives/src/sapling/address.rs
+++ b/zcash_primitives/src/sapling/address.rs
@@ -36,6 +36,17 @@ impl PaymentAddress {
         // Check that the diversifier is valid
         diversifier.g_d()?;
 
+        Self::from_parts_unchecked(diversifier, pk_d)
+    }
+
+    /// Constructs a PaymentAddress from a diversifier and a Jubjub point.
+    ///
+    /// Returns None if `pk_d` is the identity. The caller must check that `diversifier`
+    /// is valid for Sapling.
+    pub(crate) fn from_parts_unchecked(
+        diversifier: Diversifier,
+        pk_d: DiversifiedTransmissionKey,
+    ) -> Option<Self> {
         if pk_d.is_identity() {
             None
         } else {


### PR DESCRIPTION
Replaces #840.