### PR TITLE
Remove esk and ephemeral_key arguments from `parse_note_plaintext_ovk`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ codegen-units = 1
 zcash_encoding = { path = "components/zcash_encoding" }
 zcash_note_encryption = { path = "components/zcash_note_encryption" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "62f0c9039b0bee94c16c40c272e19c5922290664" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "11b6858ac81a79675de205980155a49d6f92b71e" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "2a4f27c937fbcbdb66163e1bb426ce1fcb5bc4f8" }

--- a/components/zcash_note_encryption/CHANGELOG.md
+++ b/components/zcash_note_encryption/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `esk` and `ephemeral_key` arguments have been removed from 
+  `Domain::parse_note_plaintext_without_memo_ovk`. It is therefore no longer
+  necessary (or possible) to ensure that `ephemeral_key` is derived from `esk`
+  and the diversifier within the note plaintext. We have analyzed the safety of
+  this change in the context of callers within `zcash_note_encryption` and
+  `orchard`. See https://github.com/zcash/librustzcash/pull/848 and the
+  associated issue https://github.com/zcash/librustzcash/issues/802 for
+  additional detail.
+
 ## [0.3.0] - 2023-03-22
 ### Changed
 - The `recipient` parameter has been removed from `Domain::note_plaintext_bytes`.

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -651,8 +651,7 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
         )
         .ok()?;
 
-    let (note, to) =
-        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &plaintext)?;
+    let (note, to) = domain.parse_note_plaintext_without_memo_ovk(&pk_d, &plaintext)?;
     let memo = domain.extract_memo(&plaintext);
 
     // ZIP 212: Check that the esk provided to this function is consistent with the esk we

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -237,8 +237,6 @@ pub trait Domain {
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
-        esk: &Self::EphemeralSecretKey,
-        ephemeral_key: &EphemeralKeyBytes,
         plaintext: &NotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
@@ -654,7 +652,7 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
         .ok()?;
 
     let (note, to) =
-        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &plaintext)?;
+        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &plaintext)?;
     let memo = domain.extract_memo(&plaintext);
 
     // ZIP 212: Check that the esk provided to this function is consistent with the esk we

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -513,6 +513,8 @@ fn check_note_validity<D: Domain>(
     cmstar_bytes: &D::ExtractedCommitmentBytes,
 ) -> NoteValidity {
     if &D::ExtractedCommitmentBytes::from(&D::cmstar(note)) == cmstar_bytes {
+        // In the case corresponding to specification section 4.19.3, we check that `esk` is equal
+        // to `D::derive_esk(note)` prior to calling this method.
         if let Some(derived_esk) = D::derive_esk(note) {
             if D::epk_bytes(&D::ka_derive_public(note, &derived_esk))
                 .ct_eq(ephemeral_key)
@@ -654,8 +656,9 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
     let (note, to) = domain.parse_note_plaintext_without_memo_ovk(&pk_d, &plaintext)?;
     let memo = domain.extract_memo(&plaintext);
 
-    // ZIP 212: Check that the esk provided to this function is consistent with the esk we
-    // can derive from the note.
+    // ZIP 212: Check that the esk provided to this function is consistent with the esk we can
+    // derive from the note. This check corresponds to `ToScalar(PRF^{expand}_{rseed}([4]) = esk`
+    // in https://zips.z.cash/protocol/protocol.pdf#decryptovk. (`ρ^opt = []` for Sapling.)
     if let Some(derived_esk) = D::derive_esk(&note) {
         if (!derived_esk.ct_eq(&esk)).into() {
             return None;

--- a/zcash_primitives/src/sapling/note_encryption.rs
+++ b/zcash_primitives/src/sapling/note_encryption.rs
@@ -257,8 +257,6 @@ impl<P: consensus::Parameters> Domain for SaplingDomain<P> {
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
-        _esk: &Self::EphemeralSecretKey,
-        _ephemeral_key: &EphemeralKeyBytes,
         plaintext: &NotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)> {
         sapling_parse_note_plaintext_without_memo(self, &plaintext.0, |diversifier| {


### PR DESCRIPTION
Requires https://github.com/zcash/orchard/pull/396

Fixes #850