### PR TITLE
Release zcash_address 0.3.0, zcash_primitives 0.12.0 and zcash_proofs 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,3 @@ members = [
 lto = true
 panic = 'abort'
 codegen-units = 1
-
-[patch.crates-io]
-zcash_encoding = { path = "components/zcash_encoding" }
-zcash_note_encryption = { path = "components/zcash_note_encryption" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "2dbdd345670ea22337a0efa6734272d54551285f" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "35054e85b85dc144b4572ed0fd57ea164f50c26a" }

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-06-06
 ### Changed
 - Bumped bs58 dependency to `0.5`.
 

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Bumped bs58 dependency to `0.5`.
+
 ## [0.2.1] - 2023-04-15
 ### Changed
 - Bumped internal dependency to `bech32 0.9`.

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_address"
 description = "Zcash address parsing and serialization"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["zcash", "address", "sapling", "unified"]
 
 [dependencies]
 bech32 = "0.9"
-bs58 = { version = "0.4", features = ["check"] }
+bs58 = { version = "0.5", features = ["check"] }
 f4jumble = { version = "0.1", path = "../f4jumble" }
 zcash_encoding = { version = "0.2", path = "../zcash_encoding" }
 

--- a/components/zcash_note_encryption/CHANGELOG.md
+++ b/components/zcash_note_encryption/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-06-06
 ### Changed
 - The `esk` and `ephemeral_key` arguments have been removed from 
   `Domain::parse_note_plaintext_without_memo_ovk`. It is therefore no longer

--- a/components/zcash_note_encryption/Cargo.toml
+++ b/components/zcash_note_encryption/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_note_encryption"
 description = "Note encryption for Zcash transactions"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,7 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `hdwallet 0.4`, `zcash_note_encryption 0.4`,
+- Bumped dependencies to `hdwallet 0.4`, `zcash_primitives 0.12`, `zcash_note_encryption 0.4`,
   `incrementalmerkletree 0.4`, `orchard 0.5`, `bs58 0.5`
 - `WalletRead::get_memo` now returns `Result<Option<Memo>, Self::Error>`
   instead of `Result<Memo, Self::Error>` in order to make representable

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -14,7 +14,7 @@ and this library adheres to Rust's notion of
 ### Changed
 - MSRV is now 1.65.0.
 - Bumped dependencies to `hdwallet 0.4`, `zcash_note_encryption 0.4`,
-  `incrementalmerkletree 0.4`, `orchard 0.5`
+  `incrementalmerkletree 0.4`, `orchard 0.5`, `bs58 0.5`
 - `WalletRead::get_memo` now returns `Result<Option<Memo>, Self::Error>`
   instead of `Result<Memo, Self::Error>` in order to make representable
   wallet states where the full note plaintext is not available.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -9,13 +9,21 @@ and this library adheres to Rust's notion of
 ### Added
 - `impl Eq for zcash_client_backend::address::RecipientAddress`
 - `impl Eq for zcash_client_backend::zip321::{Payment, TransactionRequest}`
+- `data_api::NullifierQuery` for use with `WalletRead::get_sapling_nullifiers`
 
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `hdwallet 0.4`.
+- Bumped dependencies to `hdwallet 0.4`, `zcash_note_encryption 0.4`,
+  `incrementalmerkletree 0.4`, `orchard 0.5`
 - `WalletRead::get_memo` now returns `Result<Option<Memo>, Self::Error>`
   instead of `Result<Memo, Self::Error>` in order to make representable
   wallet states where the full note plaintext is not available.
+- `WalletRead::get_nullifiers` has been renamed to `WalletRead::get_sapling_nullifiers`
+  and its signature has changed; it now subsumes the removed `WalletRead::get_all_nullifiers`.
+- `wallet::SpendableNote` has been renamed to `wallet::ReceivedSaplingNote`.
+
+### Removed
+- `WalletRead::get_all_nullifiers`
 
 ## [0.9.0] - 2023-04-28
 ### Added

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -24,7 +24,7 @@ incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 zcash_address = { version = "0.3", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_note_encryption = "0.4"
-zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -20,10 +20,10 @@ exclude = ["*.proto"]
 development = ["zcash_proofs"]
 
 [dependencies]
-incrementalmerkletree = { version = "0.3", features = ["legacy-api"] }
+incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
-zcash_note_encryption = "0.3"
+zcash_note_encryption = "0.4"
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
@@ -54,7 +54,7 @@ subtle = "2.2.3"
 # - Shielded protocols
 bls12_381 = "0.8"
 group = "0.13"
-orchard = { version = "0.4", default-features = false }
+orchard = { version = "0.5", default-features = false }
 
 # - Test dependencies
 proptest = { version = "1.0.0", optional = true }

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -21,7 +21,7 @@ development = ["zcash_proofs"]
 
 [dependencies]
 incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
-zcash_address = { version = "0.2", path = "../components/zcash_address" }
+zcash_address = { version = "0.3", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_note_encryption = "0.4"
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
@@ -86,7 +86,7 @@ rand_core = "0.6"
 rand_xorshift = "0.3"
 tempfile = "3.5.0"
 zcash_proofs = { version = "0.11", path = "../zcash_proofs", default-features = false }
-zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
+zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]
 lightwalletd-tonic = ["tonic"]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -34,7 +34,7 @@ time = "0.2"
 # - Encodings
 base64 = "0.21"
 bech32 = "0.9"
-bs58 = { version = "0.4", features = ["check"] }
+bs58 = { version = "0.5", features = ["check"] }
 
 # - Errors
 hdwallet = { version = "0.4", optional = true }

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -85,7 +85,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 rand_xorshift = "0.3"
 tempfile = "3.5.0"
-zcash_proofs = { version = "0.11", path = "../zcash_proofs", default-features = false }
+zcash_proofs = { version = "0.12", path = "../zcash_proofs", default-features = false }
 zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_backend/src/welding_rig.rs
+++ b/zcash_client_backend/src/welding_rig.rs
@@ -91,7 +91,7 @@ impl ScanningKey for DiversifiableFullViewingKey {
     ) -> Self::Nf {
         note.nf(
             key,
-            u64::try_from(witness.tip_position())
+            u64::try_from(witness.position())
                 .expect("Sapling note commitment tree position must fit into a u64"),
         )
     }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,7 +8,8 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `hdwallet 0.4`, `incrementalmerkletree 0.4`, `bs58 0.5`
+- Bumped dependencies to `hdwallet 0.4`, `incrementalmerkletree 0.4`, `bs58 0.5`,
+  `zcash_primitives 0.12`
 
 ### Removed
 - The empty `wallet::transact` module has been removed.
@@ -16,7 +17,7 @@ and this library adheres to Rust's notion of
 ## [0.7.1] - 2023-05-17
 
 ### Fixed
-- Fixes a potential crash that could occur when attempting to read a memo from 
+- Fixes a potential crash that could occur when attempting to read a memo from
   sqlite when the memo value is `NULL`. At present, we return the empty memo
   in this case; in the future, the `get_memo` API will be updated to reflect
   the potential absence of memo data.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `hdwallet 0.4`, `incrementalmerkletree 0.4`
+- Bumped dependencies to `hdwallet 0.4`, `incrementalmerkletree 0.4`, `bs58 0.5`
 
 ### Removed
 - The empty `wallet::transact` module has been removed.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `hdwallet 0.4`.
+- Bumped dependencies to `hdwallet 0.4`, `incrementalmerkletree 0.4`
 
 ### Removed
 - The empty `wallet::transact` module has been removed.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-incrementalmerkletree = { version = "0.3", features = ["legacy-api"] }
+incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 zcash_client_backend = { version = "0.9", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
 
@@ -51,7 +51,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 regex = "1.4"
 tempfile = "3.5.0"
-zcash_note_encryption = "0.3"
+zcash_note_encryption = "0.4"
 zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 [dependencies]
 incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 zcash_client_backend = { version = "0.9", path = "../zcash_client_backend" }
-zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
@@ -53,7 +53,7 @@ regex = "1.4"
 tempfile = "3.5.0"
 zcash_note_encryption = "0.4"
 zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
-zcash_primitives = { version = "0.11", path = "../zcash_primitives", features = ["test-dependencies"] }
+zcash_primitives = { version = "0.12", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -21,7 +21,7 @@ zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-fea
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 # - Errors
-bs58 = { version = "0.4", features = ["check"] }
+bs58 = { version = "0.5", features = ["check"] }
 hdwallet = { version = "0.4", optional = true }
 
 # - Logging and metrics

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -52,7 +52,7 @@ rand_core = "0.6"
 regex = "1.4"
 tempfile = "3.5.0"
 zcash_note_encryption = "0.4"
-zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.12", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.12", path = "../zcash_primitives", features = ["test-dependencies"] }
 zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -54,7 +54,7 @@ tempfile = "3.5.0"
 zcash_note_encryption = "0.4"
 zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.11", path = "../zcash_primitives", features = ["test-dependencies"] }
-zcash_address = { version = "0.2", path = "../components/zcash_address", features = ["test-dependencies"] }
+zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]
 mainnet = []

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.65"
 
 [dependencies]
 blake2b_simd = "1"
-zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false, features = ["zfuture" ] }
+zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-features = false, features = ["zfuture" ] }
 
 [dev-dependencies]
 ff = "0.13"

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -17,7 +17,7 @@ zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-fea
 ff = "0.13"
 jubjub = "0.10"
 rand_core = "0.6"
-zcash_address = { version = "0.2", path = "../components/zcash_address" }
+zcash_address = { version = "0.3", path = "../components/zcash_address" }
 zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
 
 [features]

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -18,7 +18,7 @@ ff = "0.13"
 jubjub = "0.10"
 rand_core = "0.6"
 zcash_address = { version = "0.3", path = "../components/zcash_address" }
-zcash_proofs = { version = "0.11", path = "../zcash_proofs" }
+zcash_proofs = { version = "0.12", path = "../zcash_proofs" }
 
 [features]
 transparent-inputs = []

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -17,7 +17,8 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.65.0.
-- Bumped dependencies to `secp256k1 0.26`, `hdwallet 0.4`.
+- Bumped dependencies to `secp256k1 0.26`, `hdwallet 0.4`, `incrementalmerkletree 0.4`
+  `zcash_note_encryption 0.4`, `orchard 0.5`
 
 ### Removed
 - `merkle_tree::Hashable` has been removed and its uses have been replaced by

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.0] - 2023-06-06
 ### Added
 - `zcash_primitives::transaction`:
   - `Transaction::temporary_zcashd_read_v5_sapling`

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -44,10 +44,10 @@ ff = "0.13"
 group = { version = "0.13", features = ["wnaf-memuse"] }
 jubjub = "0.10"
 nonempty = "0.7"
-orchard = { version = "0.4", default-features = false }
+orchard = { version = "0.5", default-features = false }
 
 # - Note Commitment Trees
-incrementalmerkletree = { version = "0.3", features = ["legacy-api"] }
+incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 
 # - Static constants
 lazy_static = "1"
@@ -82,17 +82,17 @@ aes = "0.8"
 fpe = "0.6"
 
 [dependencies.zcash_note_encryption]
-version = "0.3"
+version = "0.4"
 features = ["pre-zip-212"]
 
 [dev-dependencies]
 chacha20poly1305 = "0.10"
 criterion = "0.4"
-incrementalmerkletree = { version = "0.3", features = ["legacy-api", "test-dependencies"] }
+incrementalmerkletree = { version = "0.4", features = ["legacy-api", "test-dependencies"] }
 proptest = "1.0.0"
 assert_matches = "1.3.0"
 rand_xorshift = "0.3"
-orchard = { version = "0.4", default-features = false, features = ["test-dependencies"] }
+orchard = { version = "0.5", default-features = false, features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.11", features = ["criterion", "flamegraph"] } # MSRV 1.56

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [dependencies]
 equihash = { version = "0.2", path = "../components/equihash" }
-zcash_address = { version = "0.2", path = "../components/zcash_address" }
+zcash_address = { version = "0.3", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 
 # Dependencies exposed in a public API:

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
+- Bumped dependencies to `incrementalmerkletree 0.4`, `zcash_primitives 0.12`
 - MSRV is now 1.65.0.
 
 ### Removed

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.0] - 2023-06-06
 ### Changed
 - Bumped dependencies to `incrementalmerkletree 0.4`, `zcash_primitives 0.12`
 - MSRV is now 1.65.0.

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -24,7 +24,7 @@ zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-fea
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }
 bls12_381 = "0.8"
 group = "0.13"
-incrementalmerkletree = { version = "0.3", features = ["legacy-api"] }
+incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 jubjub = "0.10"
 lazy_static = "1"
 minreq = { version = "2", features = ["https"], optional = true }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 all-features = true
 
 [dependencies]
-zcash_primitives = { version = "0.11", path = "../zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-features = false }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)


### PR DESCRIPTION
Upgrades to:
- `bs58 0.5`
- `incrementalmerkletree 0.4`
- `orchard 0.5`
Fixes #785 