### PR TITLE
Document `zcash_note_encryption` non-local dependency rationale & doc work-around.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ working with Zcash.
 
 These libraries are currently under development and have not been fully-reviewed.
 
+## Cross-Workspace Dependency Cycle
+
+There is a complication in crate dependencies documented in
+[`components/zcash_note_encryption/README.md`](./components/zcash_note_encryption/README.md)
+and [issue #768](https://github.com/zcash/librustzcash/issues/768).
+
 ## License
 
 All code in this workspace is licensed under either of

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ There is a complication in crate dependencies documented in
 [`components/zcash_note_encryption/README.md`](./components/zcash_note_encryption/README.md)
 and [issue #768](https://github.com/zcash/librustzcash/issues/768).
 
+### `cargo doc` Warning
+
+A consequence of the cross-workspace dependency above is that there's a name collision for the
+two distinct `zcash_note_encryption` crates when running `cargo doc`:
+
+```
+warning: output filename collision.
+The lib target `zcash_note_encryption` in package `zcash_note_encryption v0.4.0` has the same output filename as the lib target `zcash_note_encryption` in package `zcash_note_encryption v0.4.0 (/home/user/src/gi
+thub.com/zcash/librustzcash/components/zcash_note_encryption)`.
+Colliding filename is: /home/user/src/github.com/zcash/librustzcash/target/doc/zcash_note_encryption/index.html
+```
+
+**Workarounds:**
+
+- To view rendered docs for the local crate run: `cargo doc -p zcash_note_encryption --open`
+- To view docs for the released crate, see [docs.rs/zcash_note_encryption](https://docs.rs/zcash_note_encryption/).
+
 ## License
 
 All code in this workspace is licensed under either of

--- a/components/zcash_note_encryption/README.md
+++ b/components/zcash_note_encryption/README.md
@@ -12,6 +12,15 @@ users with their own existing types can similarly implement the trait themselves
 [`zcash_primitives`]: https://crates.io/crates/zcash_primitives
 [`orchard`]: https://crates.io/crates/orchard
 
+## Cross-Workspace Dependency Cycle
+
+There is a cross-workspace cyclic dependency: `zcash_client_backend` (local)
+depends on [`orchard`](https://github.com/zcash/orchard) which depends on this crate
+`zcash_note_encryption`. For this reason `zcash_client_backend` does not depend on the local
+`zcash_note_encryption` crate, but rather the published crate release.
+
+This issue is tracked in [#768](https://github.com/zcash/librustzcash/issues/768).
+
 ## License
 
 Licensed under either of

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -23,6 +23,7 @@ development = ["zcash_proofs"]
 incrementalmerkletree = { version = "0.4", features = ["legacy-api"] }
 zcash_address = { version = "0.3", path = "../components/zcash_address" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
+# Note: this is not the local workspace crate! See `components/zcash_note_encryption/README.md` for rationale:
 zcash_note_encryption = "0.4"
 zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-features = false }
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -51,6 +51,7 @@ proptest = "1.0.0"
 rand_core = "0.6"
 regex = "1.4"
 tempfile = "3.5.0"
+# Note: this is not the local workspace crate! See `components/zcash_note_encryption/README.md` for rationale:
 zcash_note_encryption = "0.4"
 zcash_proofs = { version = "0.12", path = "../zcash_proofs" }
 zcash_primitives = { version = "0.12", path = "../zcash_primitives", features = ["test-dependencies"] }


### PR DESCRIPTION
I had forgotten about the issue in #768 and just ran `cargo doc` and was confused by the warning. It took me a bit to track down via `cargo tree -i zcash_note_encryption`, then I rediscovered #768.

So I figured many devs/consumers who are poking around here may also get confused and I added in-band docs about the issue.