### PR TITLE
[Impacts API versioning] Update dependencies to resolve RUSTSEC-2022-0090

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -29,7 +29,7 @@ zcash_primitives = { version = "0.12", path = "../zcash_primitives", default-fea
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 # - Data Access API
-time = "0.2"
+time = "0.3.22"
 
 # - Encodings
 base64 = "0.21"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -36,10 +36,10 @@ secrecy = "0.8"
 # - SQLite databases
 group = "0.13"
 jubjub = "0.10"
-rusqlite = { version = "0.25", features = ["bundled", "time", "array"] }
+rusqlite = { version = "0.29.0", features = ["bundled", "time", "array"] }
 schemer = "0.2"
-schemer-rusqlite = "0.2.1"
-time = "0.2"
+schemer-rusqlite = "0.2.2"
+time = "0.3.22"
 uuid = "1.1"
 
 # Dependencies used internally:


### PR DESCRIPTION
This resolves [RUSTSEC-2022-0090](https://rustsec.org/advisories/RUSTSEC-2022-0090), and with both this patch and after I remembered to also run `cargo update`, there are now no `cargo audit` reports.

Note that this updates dependencies that are re-exported in the public interface, so I'm not super clear on if that's invasive for dependent crates or not. If it were invasive, it may imply something about our release versioning and semver, which I haven't thought about too carefully.