### PR TITLE
Add derive Ord to Node

### DIFF
--- a/zcash_primitives/src/sapling/tree.rs
+++ b/zcash_primitives/src/sapling/tree.rs
@@ -64,7 +64,7 @@ pub fn merkle_hash(depth: usize, lhs: &[u8; 32], rhs: &[u8; 32]) -> [u8; 32] {
 }
 
 /// A node within the Sapling commitment tree.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord)]
 pub struct Node {
     pub(super) repr: [u8; 32],
 }


### PR DESCRIPTION
For any of the new features in incrementalmerkletree, to make a `BridgeTree ` or `ShardTree` of  `Node`s, we need an `Ord` impl