### PR TITLE
Replace `directories` dependency with `home, known-folders, xdg`

### DIFF
--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replaced internal `directories` dependency which now transitively depends on
+  MPL-licensed code.
 
 ## [0.12.0] - 2023-06-06
 ### Changed

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.1] - 2023-06-28
 ### Changed
 - Replaced internal `directories` dependency which now transitively depends on
   MPL-licensed code.

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -34,9 +34,11 @@ tracing = "0.1"
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 blake2b_simd = "1"
-directories = { version = "5", optional = true }
+home = { version = "0.5", optional = true }
+known-folders = { version = "1", optional = true }
 redjubjub = "0.7"
 wagyu-zcash-parameters = { version = "0.2", optional = true }
+xdg = { version = "2.5", optional = true }
 
 [dev-dependencies]
 byteorder = "1"
@@ -49,6 +51,7 @@ pprof = { version = "0.11", features = ["criterion", "flamegraph"] } # MSRV 1.56
 [features]
 default = ["local-prover", "multicore"]
 bundled-prover = ["wagyu-zcash-parameters"]
+directories = ["dep:home", "dep:known-folders", "dep:xdg"]
 download-params = ["minreq", "directories"]
 local-prover = ["directories"]
 multicore = ["bellman/multicore", "zcash_primitives/multicore"]


### PR DESCRIPTION
`directories 5.0.1` added a dependency on `option-ext`, which is licensed as MPL (a copyleft license), and which upstream intends to keep (dirs-dev/dirs-sys-rs#21). The replacement dependencies are all licensed as `MIT OR Apache-2.0`.