### PR TITLE
zcash_client_backend: Make scan range bounds required in `data_api::chain::scan_cached_blocks`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -36,7 +36,8 @@ and this library adheres to Rust's notion of
     and its signature has changed; it now subsumes the removed `WalletRead::get_all_nullifiers`.
   - `WalletRead::get_target_and_anchor_heights` now takes its argument as a `NonZeroU32`
   - `chain::scan_cached_blocks` now takes a `from_height` argument that
-    permits the caller to control the starting position of the scan range.
+    permits the caller to control the starting position of the scan range
+    In addition, the `limit` parameter is now required.
   - A new `CommitmentTree` variant has been added to `data_api::error::Error`
   - `data_api::wallet::{create_spend_to_address, create_proposed_transaction,
     shield_transparent_funds}` all now require that `WalletCommitmentTrees` be

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,14 +11,15 @@ and this library adheres to Rust's notion of
 - `impl Eq for zcash_client_backend::zip321::{Payment, TransactionRequest}`
 - `impl Debug` for `zcash_client_backend::{data_api::wallet::input_selection::Proposal, wallet::ReceivedSaplingNote}`
 - `zcash_client_backend::data_api`:
+  - `BlockMetadata`
+  - `NullifierQuery` for use with `WalletRead::get_sapling_nullifiers`
+  - `ScannedBlock`
+  - `ShieldedProtocol`
   - `WalletRead::{block_metadata, block_fully_scanned, suggest_scan_ranges}`
   - `WalletWrite::put_block`
   - `WalletCommitmentTrees`
-  - `testing::MockWalletDb::new`
-  - `NullifierQuery` for use with `WalletRead::get_sapling_nullifiers`
-  - `BlockMetadata`
-  - `ScannedBlock`
   - `chain::CommitmentTreeRoot`
+  - `testing::MockWalletDb::new`
   - `wallet::input_sellection::Proposal::{min_target_height, min_anchor_height}`:
 - `zcash_client_backend::wallet::WalletSaplingOutput::note_commitment_tree_position`
 - `zcash_client_backend::scanning::ScanError`
@@ -49,6 +50,8 @@ and this library adheres to Rust's notion of
     now take their respective `min_confirmations` arguments as `NonZeroU32`
   - A new `Scan` variant has been added to `data_api::chain::error::Error`.
   - A new `SyncRequired` variant has been added to `data_api::wallet::input_selection::InputSelectorError`.
+  - The variants of the `PoolType` enum have changed; the `PoolType::Sapling` variant has been 
+    removed in favor of a `PoolType::Shielded` variant that wraps a `ShieldedProtocol` value.
 - `zcash_client_backend::wallet`:
   - `SpendableNote` has been renamed to `ReceivedSaplingNote`.
   - Arguments to `WalletSaplingOutput::from_parts` have changed.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -372,14 +372,21 @@ pub struct SentTransaction<'a> {
     pub utxos_spent: Vec<OutPoint>,
 }
 
+/// A shielded transfer protocol supported by the wallet.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ShieldedProtocol {
+    /// The Sapling protocol
+    Sapling,
+    // TODO: Orchard
+}
+
 /// A value pool to which the wallet supports sending transaction outputs.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PoolType {
     /// The transparent value pool
     Transparent,
-    /// The Sapling value pool
-    Sapling,
-    // TODO: Orchard
+    /// A shielded value pool.
+    Shielded(ShieldedProtocol),
 }
 
 /// A type that represents the recipient of a transaction output; a recipient address (and, for

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -494,7 +494,6 @@ pub trait WalletWrite: WalletRead {
     /// Updates the state of the wallet database by persisting the provided block information,
     /// along with the note commitments that were detected when scanning the block for transactions
     /// pertaining to this wallet.
-    #[allow(clippy::type_complexity)]
     fn put_block(
         &mut self,
         block: ScannedBlock<sapling::Nullifier>,

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -45,7 +45,7 @@
 //! // At this point, the cache and scanned data are locally consistent (though not
 //! // necessarily consistent with the latest chain tip - this would be discovered the
 //! // next time this codepath is executed after new blocks are received).
-//! scan_cached_blocks(&network, &block_source, &mut db_data, None, None)
+//! scan_cached_blocks(&network, &block_source, &mut db_data, BlockHeight::from(0), 10)
 //! # }
 //! # }
 //! ```
@@ -60,8 +60,10 @@ use crate::{
     data_api::{NullifierQuery, WalletWrite},
     proto::compact_formats::CompactBlock,
     scan::BatchRunner,
-    scanning::{add_block_to_runner, scan_block_with_runner},
+    scanning::{add_block_to_runner, check_continuity, scan_block_with_runner},
 };
+
+use super::BlockMetadata;
 
 pub mod error;
 use error::Error;
@@ -141,8 +143,8 @@ pub fn scan_cached_blocks<ParamsT, DbT, BlockSourceT>(
     params: &ParamsT,
     block_source: &BlockSourceT,
     data_db: &mut DbT,
-    from_height: Option<BlockHeight>,
-    limit: Option<u32>,
+    from_height: BlockHeight,
+    limit: u32,
 ) -> Result<(), Error<DbT::Error, BlockSourceT::Error>>
 where
     ParamsT: consensus::Parameters + Send + 'static,
@@ -178,61 +180,81 @@ where
             .map(|(tag, ivk)| (tag, PreparedIncomingViewingKey::new(&ivk))),
     );
 
-    // Start at either the provided height, or where we synced up to previously.
-    let (scan_from, mut prior_block_metadata) = match from_height {
-        Some(h) => {
-            // if we are provided with a starting height, obtain the metadata for the previous
-            // block (if any is available)
-            (
-                Some(h),
-                if h > BlockHeight::from(0) {
-                    data_db.block_metadata(h - 1).map_err(Error::Wallet)?
-                } else {
-                    None
-                },
-            )
-        }
-        None => {
-            let last_scanned = data_db.block_fully_scanned().map_err(Error::Wallet)?;
-            last_scanned.map_or_else(|| (None, None), |m| (Some(m.block_height + 1), Some(m)))
-        }
+    let mut prior_block_metadata = if from_height > BlockHeight::from(0) {
+        data_db
+            .block_metadata(from_height - 1)
+            .map_err(Error::Wallet)?
+    } else {
+        None
     };
 
-    block_source.with_blocks::<_, DbT::Error>(scan_from, limit, |block: CompactBlock| {
-        add_block_to_runner(params, block, &mut batch_runner);
-        Ok(())
-    })?;
+    let mut continuity_check_metadata = prior_block_metadata;
+    block_source.with_blocks::<_, DbT::Error>(
+        Some(from_height),
+        Some(limit),
+        |block: CompactBlock| {
+            // check block continuity
+            if let Some(scan_error) = check_continuity(&block, continuity_check_metadata.as_ref()) {
+                return Err(Error::Scan(scan_error));
+            }
+            continuity_check_metadata = continuity_check_metadata.as_ref().map(|m| {
+                BlockMetadata::from_parts(
+                    block.height(),
+                    block.hash(),
+                    block
+                        .chain_metadata
+                        .as_ref()
+                        .map(|m| m.sapling_commitment_tree_size)
+                        .unwrap_or_else(|| {
+                            m.sapling_tree_size()
+                                + u32::try_from(
+                                    block.vtx.iter().map(|tx| tx.outputs.len()).sum::<usize>(),
+                                )
+                                .unwrap()
+                        }),
+                )
+            });
+
+            add_block_to_runner(params, block, &mut batch_runner);
+
+            Ok(())
+        },
+    )?;
 
     batch_runner.flush();
 
-    block_source.with_blocks::<_, DbT::Error>(scan_from, limit, |block: CompactBlock| {
-        let scanned_block = scan_block_with_runner(
-            params,
-            block,
-            &dfvks,
-            &sapling_nullifiers,
-            prior_block_metadata.as_ref(),
-            Some(&mut batch_runner),
-        )
-        .map_err(Error::Scan)?;
+    block_source.with_blocks::<_, DbT::Error>(
+        Some(from_height),
+        Some(limit),
+        |block: CompactBlock| {
+            let scanned_block = scan_block_with_runner(
+                params,
+                block,
+                &dfvks,
+                &sapling_nullifiers,
+                prior_block_metadata.as_ref(),
+                Some(&mut batch_runner),
+            )
+            .map_err(Error::Scan)?;
 
-        let spent_nf: Vec<&sapling::Nullifier> = scanned_block
-            .transactions
-            .iter()
-            .flat_map(|tx| tx.sapling_spends.iter().map(|spend| spend.nf()))
-            .collect();
-
-        sapling_nullifiers.retain(|(_, nf)| !spent_nf.contains(&nf));
-        sapling_nullifiers.extend(scanned_block.transactions.iter().flat_map(|tx| {
-            tx.sapling_outputs
+            let spent_nf: Vec<&sapling::Nullifier> = scanned_block
+                .transactions
                 .iter()
-                .map(|out| (out.account(), *out.nf()))
-        }));
+                .flat_map(|tx| tx.sapling_spends.iter().map(|spend| spend.nf()))
+                .collect();
 
-        prior_block_metadata = Some(*scanned_block.metadata());
-        data_db.put_block(scanned_block).map_err(Error::Wallet)?;
-        Ok(())
-    })?;
+            sapling_nullifiers.retain(|(_, nf)| !spent_nf.contains(&nf));
+            sapling_nullifiers.extend(scanned_block.transactions.iter().flat_map(|tx| {
+                tx.sapling_outputs
+                    .iter()
+                    .map(|out| (out.account(), *out.nf()))
+            }));
+
+            prior_block_metadata = Some(*scanned_block.metadata());
+            data_db.put_block(scanned_block).map_err(Error::Wallet)?;
+            Ok(())
+        },
+    )?;
 
     Ok(())
 }

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -153,7 +153,7 @@ impl fmt::Display for ScanError {
                 write!(f, "Block height discontinuity at height {}; next height is : {}", prev_height, new_height)
             }
             ScanError::TreeSizeMismatch { protocol, at_height, given, computed } => {
-                write!(f, "The the {:?} note commitment tree size provided by a compact block did not match the expected size at height {}; given {}, expected {}", protocol, at_height, given, computed)
+                write!(f, "The {:?} note commitment tree size provided by a compact block did not match the expected size at height {}; given {}, expected {}", protocol, at_height, given, computed)
             }
             ScanError::TreeSizeUnknown { protocol, at_height } => {
                 write!(f, "Unable to determine {:?} note commitment tree size at height {}", protocol, at_height)

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -330,7 +330,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Create a second fake CompactBlock sending more value to the address
         let (cb2, _) = fake_compact_block(
@@ -344,7 +351,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            1,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -381,7 +395,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            2,
+        )
+        .unwrap();
 
         // Create more fake CompactBlocks that don't connect to the scanned ones
         let (cb3, _) = fake_compact_block(
@@ -405,7 +426,13 @@ mod tests {
 
         // Data+cache chain should be invalid at the data/cache boundary
         assert_matches!(
-            scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None),
+            scan_cached_blocks(
+                &tests::network(),
+                &db_cache,
+                &mut db_data,
+                sapling_activation_height() + 2,
+                2
+            ),
             Err(_) // FIXME: check error result more closely
         );
     }
@@ -444,7 +471,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            2,
+        )
+        .unwrap();
 
         // Create more fake CompactBlocks that contain a reorg
         let (cb3, _) = fake_compact_block(
@@ -468,7 +502,13 @@ mod tests {
 
         // Data+cache chain should be invalid inside the cache
         assert_matches!(
-            scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None),
+            scan_cached_blocks(
+                &tests::network(),
+                &db_cache,
+                &mut db_data,
+                sapling_activation_height() + 2,
+                2
+            ),
             Err(_) // FIXME: check error result more closely
         );
     }
@@ -516,7 +556,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            2,
+        )
+        .unwrap();
 
         // Account balance should reflect both received notes
         assert_eq!(
@@ -551,7 +598,14 @@ mod tests {
         );
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            2,
+        )
+        .unwrap();
 
         // Account balance should again reflect both received notes
         assert_eq!(
@@ -586,7 +640,14 @@ mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb1);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
         assert_eq!(
             get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
             value
@@ -617,8 +678,8 @@ mod tests {
                 &tests::network(),
                 &db_cache,
                 &mut db_data,
-                Some(sapling_activation_height() + 2),
-                None
+                sapling_activation_height() + 2,
+                1
             ),
             Ok(_)
         );
@@ -629,8 +690,8 @@ mod tests {
             &tests::network(),
             &db_cache,
             &mut db_data,
-            Some(sapling_activation_height() + 1),
-            Some(1),
+            sapling_activation_height() + 1,
+            1,
         )
         .unwrap();
         assert_eq!(
@@ -699,7 +760,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Account balance should reflect the received note
         assert_eq!(
@@ -720,7 +788,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            1,
+        )
+        .unwrap();
 
         // Account balance should reflect both received notes
         assert_eq!(
@@ -761,7 +836,14 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Scan the cache
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Account balance should reflect the received note
         assert_eq!(
@@ -787,7 +869,14 @@ mod tests {
         );
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            1,
+        )
+        .unwrap();
 
         // Account balance should equal the change
         assert_eq!(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -59,7 +59,8 @@ use zcash_client_backend::{
         self,
         chain::{BlockSource, CommitmentTreeRoot},
         BlockMetadata, DecryptedTransaction, NullifierQuery, PoolType, Recipient, ScannedBlock,
-        SentTransaction, WalletCommitmentTrees, WalletRead, WalletWrite, SAPLING_SHARD_HEIGHT,
+        SentTransaction, ShieldedProtocol, WalletCommitmentTrees, WalletRead, WalletWrite,
+        SAPLING_SHARD_HEIGHT,
     },
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
     proto::compact_formats::CompactBlock,
@@ -459,7 +460,10 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                         let recipient = if output.transfer_type == TransferType::Outgoing {
                             Recipient::Sapling(output.note.recipient())
                         } else {
-                            Recipient::InternalAccount(output.account, PoolType::Sapling)
+                            Recipient::InternalAccount(
+                                output.account,
+                                PoolType::Shielded(ShieldedProtocol::Sapling)
+                            )
                         };
 
                         wallet::put_sent_output(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -66,8 +66,11 @@
 
 use rusqlite::{self, named_params, OptionalExtension, ToSql};
 use std::convert::TryFrom;
-use std::io::Cursor;
-use std::{collections::HashMap, io};
+use std::{
+    collections::HashMap,
+    io::{self, Cursor},
+};
+use zcash_client_backend::data_api::ShieldedProtocol;
 
 use zcash_primitives::{
     block::BlockHash,
@@ -116,7 +119,7 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
     // implementation detail.
     match pool_type {
         PoolType::Transparent => 0i64,
-        PoolType::Sapling => 2i64,
+        PoolType::Shielded(ShieldedProtocol::Sapling) => 2i64,
     }
 }
 
@@ -1119,7 +1122,11 @@ fn recipient_params<P: consensus::Parameters>(
 ) -> (Option<String>, Option<u32>, PoolType) {
     match to {
         Recipient::Transparent(addr) => (Some(addr.encode(params)), None, PoolType::Transparent),
-        Recipient::Sapling(addr) => (Some(addr.encode(params)), None, PoolType::Sapling),
+        Recipient::Sapling(addr) => (
+            Some(addr.encode(params)),
+            None,
+            PoolType::Shielded(ShieldedProtocol::Sapling),
+        ),
         Recipient::Unified(addr, pool) => (Some(addr.encode(params)), None, *pool),
         Recipient::InternalAccount(id, pool) => (None, Some(u32::from(*id)), *pool),
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -65,11 +65,9 @@
 //! - `memo` the shielded memo associated with the output, if any.
 
 use rusqlite::{self, named_params, OptionalExtension, ToSql};
+use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::{
-    collections::HashMap,
-    io::{self, Cursor},
-};
+use std::io::{self, Cursor};
 use zcash_client_backend::data_api::ShieldedProtocol;
 
 use zcash_primitives::{

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -8,7 +8,9 @@ use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
 
 use zcash_client_backend::{
-    address::RecipientAddress, data_api::PoolType, keys::UnifiedSpendingKey,
+    address::RecipientAddress,
+    data_api::{PoolType, ShieldedProtocol},
+    keys::UnifiedSpendingKey,
 };
 use zcash_primitives::{consensus, zip32::AccountId};
 
@@ -229,7 +231,9 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                         ))
                     })?;
                 let output_pool = match decoded_address {
-                    RecipientAddress::Shielded(_) => Ok(pool_code(PoolType::Sapling)),
+                    RecipientAddress::Shielded(_) => {
+                        Ok(pool_code(PoolType::Shielded(ShieldedProtocol::Sapling)))
+                    }
                     RecipientAddress::Transparent(_) => Ok(pool_code(PoolType::Transparent)),
                     RecipientAddress::Unified(_) => Err(WalletMigrationError::CorruptedData(
                         "Unified addresses should not yet appear in the sent_notes table."

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -6,9 +6,10 @@ use rusqlite::{self, named_params};
 use schemer;
 use schemer_rusqlite::RusqliteMigration;
 use uuid::Uuid;
+use zcash_client_backend::data_api::{PoolType, ShieldedProtocol};
 
 use super::add_transaction_views;
-use crate::wallet::{init::WalletMigrationError, pool_code, PoolType};
+use crate::wallet::{init::WalletMigrationError, pool_code};
 
 pub(super) const MIGRATION_ID: Uuid = Uuid::from_fields(
     0x2aa4d24f,
@@ -48,7 +49,7 @@ impl RusqliteMigration for Migration {
              SELECT tx, :output_pool, output_index, from_account, from_account, value
              FROM sent_notes",
              named_params![
-                ":output_pool": &pool_code(PoolType::Sapling)
+                ":output_pool": &pool_code(PoolType::Shielded(ShieldedProtocol::Sapling))
              ]
         )?;
 

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -571,7 +571,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Verified balance matches total balance
         let (_, anchor_height) = db_data
@@ -598,7 +605,14 @@ pub(crate) mod tests {
         )
         .0;
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            1,
+        )
+        .unwrap();
 
         // Verified balance does not include the second note
         let (_, anchor_height2) = db_data
@@ -651,7 +665,14 @@ pub(crate) mod tests {
             .0;
             insert_into_cache(&db_cache, &cb);
         }
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 2,
+            8,
+        )
+        .unwrap();
 
         // Second spend still fails
         assert_matches!(
@@ -681,11 +702,18 @@ pub(crate) mod tests {
             &dfvk,
             AddressType::DefaultExternal,
             value,
-            11,
+            10,
         )
         .0;
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 10,
+            1,
+        )
+        .unwrap();
 
         // Second spend should now succeed
         assert_matches!(
@@ -730,7 +758,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
         assert_eq!(
             get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
             value
@@ -788,7 +823,14 @@ pub(crate) mod tests {
             .0;
             insert_into_cache(&db_cache, &cb);
         }
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            41,
+        )
+        .unwrap();
 
         // Second spend still fails
         assert_matches!(
@@ -821,7 +863,14 @@ pub(crate) mod tests {
         )
         .0;
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 42,
+            1,
+        )
+        .unwrap();
 
         // Second spend should now succeed
         create_spend_to_address(
@@ -865,7 +914,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
         assert_eq!(
             get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
             value
@@ -938,7 +994,14 @@ pub(crate) mod tests {
             .0;
             insert_into_cache(&db_cache, &cb);
         }
-        scan_cached_blocks(&network, &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &network,
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height() + 1,
+            42,
+        )
+        .unwrap();
 
         // Send the funds again, discarding history.
         // Neither transaction output is decryptable by the sender.
@@ -971,7 +1034,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Verified balance matches total balance
         let (_, anchor_height) = db_data
@@ -1030,7 +1100,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         // Verified balance matches total balance
         let (_, anchor_height) = db_data
@@ -1103,7 +1180,14 @@ pub(crate) mod tests {
             insert_into_cache(&db_cache, &cb);
         }
 
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            11,
+        )
+        .unwrap();
 
         // Verified balance matches total balance
         let total = Amount::from_u64(60000).unwrap();
@@ -1225,7 +1309,14 @@ pub(crate) mod tests {
             0,
         );
         insert_into_cache(&db_cache, &cb);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_data, None, None).unwrap();
+        scan_cached_blocks(
+            &tests::network(),
+            &db_cache,
+            &mut db_data,
+            sapling_activation_height(),
+            1,
+        )
+        .unwrap();
 
         assert_matches!(
             shield_transparent_funds(


### PR DESCRIPTION
Builds on #861 