### PR TITLE
zcash_client_sqlite: Maintain a nullifier map from out-of-order scanning

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -300,6 +300,7 @@ pub struct ScannedBlock<Nf> {
     metadata: BlockMetadata,
     block_time: u32,
     transactions: Vec<WalletTx<Nf>>,
+    sapling_nullifier_map: Vec<(TxId, u16, Vec<sapling::Nullifier>)>,
     sapling_commitments: Vec<(sapling::Node, Retention<BlockHeight>)>,
 }
 
@@ -308,12 +309,14 @@ impl<Nf> ScannedBlock<Nf> {
         metadata: BlockMetadata,
         block_time: u32,
         transactions: Vec<WalletTx<Nf>>,
+        sapling_nullifier_map: Vec<(TxId, u16, Vec<sapling::Nullifier>)>,
         sapling_commitments: Vec<(sapling::Node, Retention<BlockHeight>)>,
     ) -> Self {
         Self {
             metadata,
             block_time,
             transactions,
+            sapling_nullifier_map,
             sapling_commitments,
         }
     }
@@ -336,6 +339,10 @@ impl<Nf> ScannedBlock<Nf> {
 
     pub fn transactions(&self) -> &[WalletTx<Nf>] {
         &self.transactions
+    }
+
+    pub fn sapling_nullifier_map(&self) -> &[(TxId, u16, Vec<sapling::Nullifier>)] {
+        &self.sapling_nullifier_map
     }
 
     pub fn sapling_commitments(&self) -> &[(sapling::Node, Retention<BlockHeight>)] {
@@ -498,7 +505,7 @@ pub trait WalletWrite: WalletRead {
     /// `blocks` must be sequential, in order of increasing block height
     fn put_blocks(
         &mut self,
-        block: Vec<ScannedBlock<sapling::Nullifier>>,
+        blocks: Vec<ScannedBlock<sapling::Nullifier>>,
     ) -> Result<Vec<Self::NoteRef>, Self::Error>;
 
     /// Updates the wallet's view of the blockchain.

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -414,6 +414,18 @@ mod tests {
                 sapling_tree BLOB NOT NULL ,
                 sapling_commitment_tree_size INTEGER,
                 orchard_commitment_tree_size INTEGER)",
+            "CREATE TABLE nullifier_map (
+                spend_pool INTEGER NOT NULL,
+                nf BLOB NOT NULL,
+                block_height INTEGER NOT NULL,
+                tx_index INTEGER NOT NULL,
+                CONSTRAINT tx_locator
+                    FOREIGN KEY (block_height, tx_index)
+                    REFERENCES tx_locator_map(block_height, tx_index)
+                    ON DELETE CASCADE
+                    ON UPDATE RESTRICT,
+                CONSTRAINT nf_uniq UNIQUE (spend_pool, nf)
+            )",
             "CREATE TABLE sapling_received_notes (
                 id_note INTEGER PRIMARY KEY,
                 tx INTEGER NOT NULL,
@@ -506,6 +518,12 @@ mod tests {
                 raw BLOB,
                 fee INTEGER,
                 FOREIGN KEY (block) REFERENCES blocks(height)
+            )",
+            "CREATE TABLE tx_locator_map (
+                block_height INTEGER NOT NULL,
+                tx_index INTEGER NOT NULL,
+                txid BLOB NOT NULL UNIQUE,
+                PRIMARY KEY (block_height, tx_index)
             )",
             "CREATE TABLE \"utxos\" (
                 id_utxo INTEGER PRIMARY KEY,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -2,6 +2,7 @@ mod add_transaction_views;
 mod add_utxo_account;
 mod addresses_table;
 mod initial_setup;
+mod nullifier_map;
 mod received_notes_nullable_nf;
 mod sent_notes_to_internal;
 mod shardtree_support;
@@ -30,6 +31,10 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //                    add_transaction_views
     //                       /
     //        v_transactions_net
+    //                  /
+    //      received_notes_nullable_nf
+    //            /               \
+    // shardtree_support      nullifier_map
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -48,5 +53,6 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         Box::new(v_transactions_net::Migration),
         Box::new(received_notes_nullable_nf::Migration),
         Box::new(shardtree_support::Migration),
+        Box::new(nullifier_map::Migration),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
@@ -1,0 +1,72 @@
+//! This migration adds a table for storing mappings from nullifiers to the transaction
+//! they are revealed in.
+
+use std::collections::HashSet;
+
+use schemer_rusqlite::RusqliteMigration;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::received_notes_nullable_nf;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xe2d71ac5_6a44_4c6b_a9a0_6d0a79d355f1);
+
+pub(super) struct Migration;
+
+impl schemer::Migration for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        [received_notes_nullable_nf::MIGRATION_ID]
+            .into_iter()
+            .collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds a lookup table for nullifiers we've observed on-chain that we haven't confirmed are not ours."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // We don't enforce any foreign key constraint to the blocks table, to allow
+        // loading the nullifier map separately from block scanning.
+        debug!("Creating tables for nullifier map");
+        transaction.execute_batch(
+            "CREATE TABLE tx_locator_map (
+                block_height INTEGER NOT NULL,
+                tx_index INTEGER NOT NULL,
+                txid BLOB NOT NULL UNIQUE,
+                PRIMARY KEY (block_height, tx_index)
+            );
+            CREATE TABLE nullifier_map (
+                spend_pool INTEGER NOT NULL,
+                nf BLOB NOT NULL,
+                block_height INTEGER NOT NULL,
+                tx_index INTEGER NOT NULL,
+                CONSTRAINT tx_locator
+                    FOREIGN KEY (block_height, tx_index)
+                    REFERENCES tx_locator_map(block_height, tx_index)
+                    ON DELETE CASCADE
+                    ON UPDATE RESTRICT,
+                CONSTRAINT nf_uniq UNIQUE (spend_pool, nf)
+            );",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP TABLE nullifier_map;
+            DROP TABLE tx_locator_map;",
+        )?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Also fixes the `WalletDb::block_fully_scanned` implementation, which this PR depends on.