### PR TITLE
zcash_client_sqlite: Only import recent frontiers into `ShardTree`

### DIFF
--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -265,7 +265,7 @@ impl RusqliteMigration for Migration {
                 transaction,
                 Some(ScanRange::from_parts(
                     start..chain_end,
-                    ScanPriority::Historic,
+                    ScanPriority::Scanned,
                 ))
                 .iter(),
             )?;


### PR DESCRIPTION
We only need to load frontiers into the ShardTree that are close enough to the wallet's known chain tip to fill `PRUNING_DEPTH` checkpoints, so that ShardTree's witness generation will be able to correctly handle anchor depths. Loading frontiers further back than this doesn't add any useful nodes to the ShardTree (as we don't support rollbacks beyond `PRUNING_DEPTH`, and we won't be finding notes in earlier blocks), and hurts performance (as frontier importing has a significant Merkle tree hashing cost).

Closes zcash/librustzcash#877.