### PR TITLE
zcash_client_sqlite: Build subtrees from new commitments in a threadpool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "bae25ad89c0c192bee625252d2d419bd56638e48" }
-shardtree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "bae25ad89c0c192bee625252d2d419bd56638e48" }
+incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "2a667f500958d517c6b2ea608477140afd907fd8" }
+shardtree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "2a667f500958d517c6b2ea608477140afd907fd8" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "6ef89d5f154de2cf7b7dd87edb8d8c49158beebb" }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -9,6 +9,9 @@ and this library adheres to Rust's notion of
 ### Added
 - `zcash_client_sqlite::serialization` Serialization formats for data stored
   as SQLite BLOBs in the wallet database.
+- A new default-enabled feature flag `multicore`. This allows users to disable
+  multicore support by setting `default_features = false` on their
+  `zcash_primitives`, `zcash_proofs`, and `zcash_client_sqlite` dependencies.
 
 ### Changed
 - MSRV is now 1.65.0.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -48,6 +48,7 @@ uuid = "1.1"
 
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
+maybe-rayon = {version = "0.1.0", default-features = false}
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -63,6 +64,8 @@ zcash_primitives = { version = "0.12", path = "../zcash_primitives", features = 
 zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]
+default = ["multicore"]
+multicore = ["maybe-rayon/threads", "zcash_primitives/multicore"]
 mainnet = []
 test-dependencies = [
     "incrementalmerkletree/test-dependencies",


### PR DESCRIPTION
The new `multicore` feature flag can be used to disable this behaviour.

Depends on https://github.com/zcash/incrementalmerkletree/pull/88.