### PR TITLE
Restrict use of backend-specific note identifiers.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -37,7 +37,8 @@ and this library adheres to Rust's notion of
   - `WalletRead::TxRef` has been removed in favor of consistently using `TxId` instead. 
   - `WalletRead::get_transaction` now takes a `TxId` as its argument.
   - `WalletWrite::{store_decrypted_tx, store_sent_tx}` now return `Result<(), Self::Error>` 
-    as the `WalletRead::TxRef` associated type has been removed. Use `TxId` instead.
+    as the `WalletRead::TxRef` associated type has been removed. Use
+    `WalletRead::get_transaction` with the transaction's `TxId` instead.
   - `WalletRead::get_memo` now takes a `NoteId` as its argument instead of `Self::NoteRef`
     and returns `Result<Option<Memo>, Self::Error>` instead of `Result<Memo,
     Self::Error>` in order to make representable wallet states where the full

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,7 @@ and this library adheres to Rust's notion of
 - `impl Debug` for `zcash_client_backend::{data_api::wallet::input_selection::Proposal, wallet::ReceivedSaplingNote}`
 - `zcash_client_backend::data_api`:
   - `BlockMetadata`
+  - `NoteId`
   - `NullifierQuery` for use with `WalletRead::get_sapling_nullifiers`
   - `ScannedBlock`
   - `ShieldedProtocol`
@@ -33,9 +34,14 @@ and this library adheres to Rust's notion of
 - Bumped dependencies to `hdwallet 0.4`, `zcash_primitives 0.12`, `zcash_note_encryption 0.4`,
   `incrementalmerkletree 0.4`, `orchard 0.5`, `bs58 0.5`
 - `zcash_client_backend::data_api`:
-  - `WalletRead::get_memo` now returns `Result<Option<Memo>, Self::Error>`
-    instead of `Result<Memo, Self::Error>` in order to make representable
-    wallet states where the full note plaintext is not available.
+  - `WalletRead::TxRef` has been removed in favor of consistently using `TxId` instead. 
+  - `WalletRead::get_transaction` now takes a `TxId` as its argument.
+  - `WalletWrite::{store_decrypted_tx, store_sent_tx}` now return `Result<(), Self::Error>` 
+    as the `WalletRead::TxRef` associated type has been removed. Use `TxId` instead.
+  - `WalletRead::get_memo` now takes a `NoteId` as its argument instead of `Self::NoteRef`
+    and returns `Result<Option<Memo>, Self::Error>` instead of `Result<Memo,
+    Self::Error>` in order to make representable wallet states where the full
+    note plaintext is not available.
   - `WalletRead::get_nullifiers` has been renamed to `WalletRead::get_sapling_nullifiers`
     and its signature has changed; it now subsumes the removed `WalletRead::get_all_nullifiers`.
   - `WalletRead::get_target_and_anchor_heights` now takes its argument as a `NonZeroU32`
@@ -45,15 +51,15 @@ and this library adheres to Rust's notion of
   - `chain::BlockSource::with_blocks` now takes its limit as an `Option<usize>`
     instead of `Option<u32>`.
   - A new `CommitmentTree` variant has been added to `data_api::error::Error`
-  - `data_api::wallet::{create_spend_to_address, create_proposed_transaction,
+  - `wallet::{create_spend_to_address, create_proposed_transaction,
     shield_transparent_funds}` all now require that `WalletCommitmentTrees` be
     implemented for the type passed to them for the `wallet_db` parameter.
-  - `data_api::wallet::create_proposed_transaction` now takes an additional 
+  - `wallet::create_proposed_transaction` now takes an additional 
     `min_confirmations` argument.
-  - `data_api::wallet::{spend, create_spend_to_address, shield_transparent_funds, 
+  - `wallet::{spend, create_spend_to_address, shield_transparent_funds, 
     propose_transfer, propose_shielding, create_proposed_transaction}` now take their
     respective `min_confirmations` arguments as `NonZeroU32`
-  - `data_api::wallet::input_selection::InputSelector::{propose_transaction, propose_shielding}`
+  - `wallet::input_selection::InputSelector::{propose_transaction, propose_shielding}`
     now take their respective `min_confirmations` arguments as `NonZeroU32`
   - A new `Scan` variant has been added to `data_api::chain::error::Error`.
   - A new `SyncRequired` variant has been added to `data_api::wallet::input_selection::InputSelectorError`.
@@ -64,6 +70,9 @@ and this library adheres to Rust's notion of
   - Arguments to `WalletSaplingOutput::from_parts` have changed.
 - `zcash_client_backend::data_api::wallet::input_selection::InputSelector`:
   - Arguments to `{propose_transaction, propose_shielding}` have changed. 
+- `zcash_client_backend::data_api::wallet::{create_spend_to_address, spend,
+  create_proposed_transaction, shield_transparent_funds}` now return the `TxId`
+  for the newly created transaction instead an internal database identifier.
 - `zcash_client_backend::wallet::ReceivedSaplingNote::note_commitment_tree_position`
   has replaced the `witness` field in the same struct.
 - `zcash_client_backend::welding_rig` has been renamed to `zcash_client_backend::scanning`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -386,11 +386,12 @@ pub enum ShieldedProtocol {
 pub struct NoteId {
     txid: TxId,
     protocol: ShieldedProtocol,
-    output_index: u32,
+    output_index: u16,
 }
 
 impl NoteId {
-    pub fn new(txid: TxId, protocol: ShieldedProtocol, output_index: u32) -> Self {
+    /// Constructs a new `NoteId` from its parts.
+    pub fn new(txid: TxId, protocol: ShieldedProtocol, output_index: u16) -> Self {
         Self {
             txid,
             protocol,
@@ -398,15 +399,19 @@ impl NoteId {
         }
     }
 
+    /// Returns the ID of the transaction containing this note.
     pub fn txid(&self) -> &TxId {
         &self.txid
     }
 
+    /// Returns the shielded protocol used by this note.
     pub fn protocol(&self) -> ShieldedProtocol {
         self.protocol
     }
 
-    pub fn output_index(&self) -> u32 {
+    /// Returns the index of this note within its transaction's corresponding list of
+    /// shielded outputs.
+    pub fn output_index(&self) -> u16 {
         self.output_index
     }
 }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -38,6 +38,8 @@ pub mod wallet;
 
 pub const SAPLING_SHARD_HEIGHT: u8 = sapling::NOTE_COMMITMENT_TREE_DEPTH / 2;
 
+/// An enumeration of constraints that can be applied when querying for nullifiers for notes
+/// belonging to the wallet.
 pub enum NullifierQuery {
     Unspent,
     All,
@@ -57,13 +59,6 @@ pub trait WalletRead {
     /// For example, this might be a database identifier type
     /// or a UUID.
     type NoteRef: Copy + Debug + Eq + Ord;
-
-    /// Backend-specific transaction identifier.
-    ///
-    /// For example, this might be a database identifier type
-    /// or a TxId if the backend is able to support that type
-    /// directly.
-    type TxRef: Copy + Debug + Eq + Ord;
 
     /// Returns the minimum and maximum block heights for stored blocks.
     ///
@@ -189,14 +184,13 @@ pub trait WalletRead {
 
     /// Returns the memo for a note.
     ///
-    /// Implementations of this method must return an error if the note identifier
-    /// does not appear in the backing data store. Returns `Ok(None)` if the note
-    /// is known to the wallet but memo data has not yet been populated for that
-    /// note.
-    fn get_memo(&self, id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error>;
+    /// Returns `Ok(None)` if the note is known to the wallet but memo data has not yet been
+    /// populated for that note, or if the note identifier does not correspond to a note
+    /// that is known to the wallet.
+    fn get_memo(&self, note_id: NoteId) -> Result<Option<Memo>, Self::Error>;
 
     /// Returns a transaction.
-    fn get_transaction(&self, id_tx: Self::TxRef) -> Result<Transaction, Self::Error>;
+    fn get_transaction(&self, txid: TxId) -> Result<Transaction, Self::Error>;
 
     /// Returns the nullifiers for notes that the wallet is tracking, along with their associated
     /// account IDs, that are either unspent or have not yet been confirmed as spent (in that a
@@ -206,7 +200,7 @@ pub trait WalletRead {
         query: NullifierQuery,
     ) -> Result<Vec<(AccountId, sapling::Nullifier)>, Self::Error>;
 
-    /// Return all unspent Sapling notes.
+    /// Return all unspent Sapling notes, excluding the specified note IDs.
     fn get_spendable_sapling_notes(
         &self,
         account: AccountId,
@@ -380,11 +374,41 @@ pub struct SentTransaction<'a> {
 }
 
 /// A shielded transfer protocol supported by the wallet.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ShieldedProtocol {
     /// The Sapling protocol
     Sapling,
     // TODO: Orchard
+}
+
+/// A unique identifier for a shielded transaction output
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NoteId {
+    txid: TxId,
+    protocol: ShieldedProtocol,
+    output_index: u32,
+}
+
+impl NoteId {
+    pub fn new(txid: TxId, protocol: ShieldedProtocol, output_index: u32) -> Self {
+        Self {
+            txid,
+            protocol,
+            output_index,
+        }
+    }
+
+    pub fn txid(&self) -> &TxId {
+        &self.txid
+    }
+
+    pub fn protocol(&self) -> ShieldedProtocol {
+        self.protocol
+    }
+
+    pub fn output_index(&self) -> u32 {
+        self.output_index
+    }
 }
 
 /// A value pool to which the wallet supports sending transaction outputs.
@@ -508,7 +532,7 @@ pub trait WalletWrite: WalletRead {
     fn put_blocks(
         &mut self,
         blocks: Vec<ScannedBlock<sapling::Nullifier>>,
-    ) -> Result<Vec<Self::NoteRef>, Self::Error>;
+    ) -> Result<(), Self::Error>;
 
     /// Updates the wallet's view of the blockchain.
     ///
@@ -520,14 +544,11 @@ pub trait WalletWrite: WalletRead {
     fn update_chain_tip(&mut self, tip_height: BlockHeight) -> Result<(), Self::Error>;
 
     /// Caches a decrypted transaction in the persistent wallet store.
-    fn store_decrypted_tx(
-        &mut self,
-        received_tx: DecryptedTransaction,
-    ) -> Result<Self::TxRef, Self::Error>;
+    fn store_decrypted_tx(&mut self, received_tx: DecryptedTransaction) -> Result<(), Self::Error>;
 
     /// Saves information about a transaction that was constructed and sent by the wallet to the
     /// persistent wallet store.
-    fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<Self::TxRef, Self::Error>;
+    fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<(), Self::Error>;
 
     /// Truncates the wallet database to the specified height.
     ///
@@ -610,7 +631,7 @@ pub mod testing {
 
     use super::{
         chain::CommitmentTreeRoot, scanning::ScanRange, BlockMetadata, DecryptedTransaction,
-        NullifierQuery, ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead,
+        NoteId, NullifierQuery, ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead,
         WalletWrite, SAPLING_SHARD_HEIGHT,
     };
 
@@ -635,7 +656,6 @@ pub mod testing {
     impl WalletRead for MockWalletDb {
         type Error = ();
         type NoteRef = u32;
-        type TxRef = TxId;
 
         fn block_height_extrema(&self) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
             Ok(None)
@@ -707,11 +727,11 @@ pub mod testing {
             Ok(Amount::zero())
         }
 
-        fn get_memo(&self, _id_note: Self::NoteRef) -> Result<Option<Memo>, Self::Error> {
+        fn get_memo(&self, _id_note: NoteId) -> Result<Option<Memo>, Self::Error> {
             Ok(None)
         }
 
-        fn get_transaction(&self, _id_tx: Self::TxRef) -> Result<Transaction, Self::Error> {
+        fn get_transaction(&self, _txid: TxId) -> Result<Transaction, Self::Error> {
             Err(())
         }
 
@@ -790,8 +810,8 @@ pub mod testing {
         fn put_blocks(
             &mut self,
             _blocks: Vec<ScannedBlock<sapling::Nullifier>>,
-        ) -> Result<Vec<Self::NoteRef>, Self::Error> {
-            Ok(vec![])
+        ) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn update_chain_tip(&mut self, _tip_height: BlockHeight) -> Result<(), Self::Error> {
@@ -801,15 +821,12 @@ pub mod testing {
         fn store_decrypted_tx(
             &mut self,
             _received_tx: DecryptedTransaction,
-        ) -> Result<Self::TxRef, Self::Error> {
-            Ok(TxId::from_bytes([0u8; 32]))
+        ) -> Result<(), Self::Error> {
+            Ok(())
         }
 
-        fn store_sent_tx(
-            &mut self,
-            _sent_tx: &SentTransaction,
-        ) -> Result<Self::TxRef, Self::Error> {
-            Ok(TxId::from_bytes([0u8; 32]))
+        fn store_sent_tx(&mut self, _sent_tx: &SentTransaction) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn truncate_to_height(&mut self, _block_height: BlockHeight) -> Result<(), Self::Error> {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,6 +12,7 @@ and this library adheres to Rust's notion of
 - A new default-enabled feature flag `multicore`. This allows users to disable
   multicore support by setting `default_features = false` on their
   `zcash_primitives`, `zcash_proofs`, and `zcash_client_sqlite` dependencies.
+- `zcash_client_sqlite::ReceivedNoteId`
 - `zcash_client_sqlite::wallet::commitment_tree` A new module containing a
   sqlite-backed implementation of `shardtree::store::ShardStore`.
 
@@ -30,6 +31,9 @@ and this library adheres to Rust's notion of
 
 ### Removed
 - The empty `wallet::transact` module has been removed.
+- `zcash_client_sqlite::NoteId` has been replaced with `zcash_client_sqlite::ReceivedNoteId`
+  as the `SentNoteId` variant of is now unused following changes to 
+  `zcash_client_backend::data_api::WalletRead`.
 
 ### Fixed
 - Fixed an off-by-one error in the `BlockSource` implementation for the SQLite-backed

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -505,7 +505,7 @@ pub(crate) fn get_received_memo(
         .transpose()
 }
 
-/// Looks up a transaction by its internal database identifier.
+/// Looks up a transaction by its [`TxId`].
 ///
 /// Returns the decoded transaction, along with the block height that was used in its decoding.
 /// This is either the block height at which the transaction was mined, or the expiry height if the

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -346,7 +346,7 @@ pub fn init_blocks_table<P: consensus::Parameters>(
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
-    use rusqlite::{self, ToSql};
+    use rusqlite::{self, named_params, ToSql};
     use secrecy::Secret;
     use std::collections::HashMap;
     use tempfile::NamedTempFile;
@@ -969,8 +969,11 @@ mod tests {
             let mut tx_bytes = vec![];
             tx.write(&mut tx_bytes).unwrap();
             wdb.conn.execute(
-                "INSERT INTO transactions (block, id_tx, txid, raw) VALUES (0, 0, '', ?)",
-                [&tx_bytes[..]],
+                "INSERT INTO transactions (block, id_tx, txid, raw) VALUES (0, 0, :txid, :tx_bytes)",
+                named_params![
+                    ":txid": tx.txid().as_ref(), 
+                    ":tx_bytes": &tx_bytes[..]
+                ],
             )?;
             wdb.conn.execute(
                 "INSERT INTO sent_notes (tx, output_index, from_account, address, value)


### PR DESCRIPTION
This builds atop #886 