### PR TITLE
zcash_client_sqlite: Ensure that re-adding the same checkpoint information does not cause a database conflict.

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,6 +12,8 @@ and this library adheres to Rust's notion of
 - A new default-enabled feature flag `multicore`. This allows users to disable
   multicore support by setting `default_features = false` on their
   `zcash_primitives`, `zcash_proofs`, and `zcash_client_sqlite` dependencies.
+- `zcash_client_sqlite::wallet::commitment_tree` A new module containing a
+  sqlite-backed implementation of `shardtree::store::ShardStore`.
 
 ### Changed
 - MSRV is now 1.65.0.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -32,7 +32,6 @@ tracing = "0.1"
 # - Serialization
 byteorder = "1"
 prost = "0.11"
-either = "1.8"
 group = "0.13"
 jubjub = "0.10"
 

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -1,14 +1,13 @@
 //! Error types for problems that may arise when reading or storing wallet data to SQLite.
 
-use either::Either;
 use std::error;
 use std::fmt;
-use std::io;
 
 use shardtree::error::ShardTreeError;
 use zcash_client_backend::encoding::{Bech32DecodeError, TransparentCodecError};
 use zcash_primitives::{consensus::BlockHeight, zip32::AccountId};
 
+use crate::wallet::commitment_tree;
 use crate::PRUNING_DEPTH;
 
 #[cfg(feature = "transparent-inputs")]
@@ -85,7 +84,7 @@ pub enum SqliteClientError {
 
     /// An error occurred in inserting data into or accessing data from one of the wallet's note
     /// commitment trees.
-    CommitmentTree(ShardTreeError<Either<io::Error, rusqlite::Error>>),
+    CommitmentTree(ShardTreeError<commitment_tree::Error>),
 }
 
 impl error::Error for SqliteClientError {
@@ -176,8 +175,8 @@ impl From<zcash_primitives::memo::Error> for SqliteClientError {
     }
 }
 
-impl From<ShardTreeError<Either<io::Error, rusqlite::Error>>> for SqliteClientError {
-    fn from(e: ShardTreeError<Either<io::Error, rusqlite::Error>>) -> Self {
+impl From<ShardTreeError<commitment_tree::Error>> for SqliteClientError {
+    fn from(e: ShardTreeError<commitment_tree::Error>) -> Self {
         SqliteClientError::CommitmentTree(e)
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -38,7 +38,7 @@ use maybe_rayon::{
 };
 use rusqlite::{self, Connection};
 use secrecy::{ExposeSecret, SecretVec};
-use std::{borrow::Borrow, collections::HashMap, convert::AsRef, fmt, io, ops::Range, path::Path};
+use std::{borrow::Borrow, collections::HashMap, convert::AsRef, fmt, ops::Range, path::Path};
 
 use incrementalmerkletree::Position;
 use shardtree::{error::ShardTreeError, ShardTree};
@@ -76,8 +76,8 @@ use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore}
 #[cfg(feature = "unstable")]
 use {
     crate::chain::{fsblockdb_with_blocks, BlockMeta},
-    std::fs,
     std::path::PathBuf,
+    std::{fs, io},
 };
 
 pub mod chain;

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -111,7 +111,7 @@ use {
     },
 };
 
-pub(crate) mod commitment_tree;
+pub mod commitment_tree;
 pub mod init;
 pub(crate) mod sapling;
 pub(crate) mod scanning;

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -1,7 +1,7 @@
 //! Functions for initializing the various databases.
-use either::Either;
+
 use incrementalmerkletree::Retention;
-use std::{collections::HashMap, fmt, io};
+use std::{collections::HashMap, fmt};
 use tracing::debug;
 
 use rusqlite::{self, types::ToSql};
@@ -24,7 +24,7 @@ use zcash_client_backend::{data_api::SAPLING_SHARD_HEIGHT, keys::UnifiedFullView
 
 use crate::{error::SqliteClientError, wallet, WalletDb, PRUNING_DEPTH, SAPLING_TABLES_PREFIX};
 
-use super::commitment_tree::SqliteShardStore;
+use super::commitment_tree::{self, SqliteShardStore};
 
 mod migrations;
 
@@ -43,7 +43,7 @@ pub enum WalletMigrationError {
     BalanceError(BalanceError),
 
     /// Wrapper for commitment tree invariant violations
-    CommitmentTree(ShardTreeError<Either<io::Error, rusqlite::Error>>),
+    CommitmentTree(ShardTreeError<commitment_tree::Error>),
 }
 
 impl From<rusqlite::Error> for WalletMigrationError {
@@ -58,8 +58,8 @@ impl From<BalanceError> for WalletMigrationError {
     }
 }
 
-impl From<ShardTreeError<Either<io::Error, rusqlite::Error>>> for WalletMigrationError {
-    fn from(e: ShardTreeError<Either<io::Error, rusqlite::Error>>) -> Self {
+impl From<ShardTreeError<commitment_tree::Error>> for WalletMigrationError {
+    fn from(e: ShardTreeError<commitment_tree::Error>) -> Self {
         WalletMigrationError::CommitmentTree(e)
     }
 }

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -454,7 +454,8 @@ mod tests {
                 checkpoint_id INTEGER NOT NULL,
                 mark_removed_position INTEGER NOT NULL,
                 FOREIGN KEY (checkpoint_id) REFERENCES sapling_tree_checkpoints(checkpoint_id)
-                ON DELETE CASCADE
+                ON DELETE CASCADE,
+                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
             )",
             "CREATE TABLE sapling_tree_checkpoints (
                 checkpoint_id INTEGER PRIMARY KEY,

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -99,7 +99,8 @@ impl RusqliteMigration for Migration {
                 checkpoint_id INTEGER NOT NULL,
                 mark_removed_position INTEGER NOT NULL,
                 FOREIGN KEY (checkpoint_id) REFERENCES sapling_tree_checkpoints(checkpoint_id)
-                ON DELETE CASCADE
+                ON DELETE CASCADE,
+                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
             );",
         )?;
 


### PR DESCRIPTION
The `add_checkpoint` method is intended to be idempotent. In the case that we add a checkpoint at an already-checkpointed block height, we should only raise an error in the case that the note commitment tree position or the set of notes spent in the checkpointed block has changed.