### PR TITLE
Add protobuf representation for transaction proposals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 zcash_client_backend/src/proto/compact_formats.rs linguist-generated=true
 zcash_client_backend/src/proto/service.rs linguist-generated=true
+zcash_client_backend/src/proto/proposal.rs linguist-generated=true

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -15,6 +15,7 @@ and this library adheres to Rust's notion of
   - `ScannedBlock::sapling_tree_size`.
   - `ScannedBlock::orchard_tree_size`.
   - `wallet::propose_standard_transfer_to_address`
+  - `wallet::input_selection::Proposal::from_parts`
   - `wallet::input_selection::SaplingInputs`
   - `wallet::input_selection::ShieldingSelector` has been
     factored out from the `InputSelector` trait to separate out transparent
@@ -23,6 +24,22 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::wallet`:
   - `ReceivedSaplingNote::from_parts`
   - `ReceivedSaplingNote::{txid, output_index, diversifier, rseed, note_commitment_tree_position}`
+- `zcash_client_backend::zip321::TransactionRequest::total`
+- `zcash_client_backend::proto::`
+  - `PROPOSAL_SER_V1`
+  - `ProposalError`
+  - `proposal::Proposal::{from_standard_proposal, try_into_standard_proposal}`
+  - `proposal::ProposedInput::parse_txid`
+- `impl Clone for zcash_client_backend::{
+     zip321::{Payment, TransactionRequest, Zip321Error, parse::Param, parse::IndexedParam},
+     wallet::{ReceivedSaplingNote, WalletTransparentOutput},
+     wallet::input_selection::{Proposal, SaplingInputs},
+   }`
+- `impl {PartialEq, Eq} for zcash_client_backend::{
+     zip321::{Zip321Error, parse::Param, parse::IndexedParam},
+     wallet::{ReceivedSaplingNote, WalletTransparentOutput},
+     wallet::input_selection::{Proposal, SaplingInputs},
+   }`
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -42,11 +59,11 @@ and this library adheres to Rust's notion of
       backend-specific note identifier. The related `NoteRef` type parameter has
       been removed from `error::Error`.
     - A new variant `UnsupportedPoolType` has been added.
-  - `wallet::shield_transparent_funds` no longer
-    takes a `memo` argument; instead, memos to be associated with the shielded
-    outputs should be specified in the construction of the value of the
-    `input_selector` argument, which is used to construct the proposed shielded
-    values as internal "change" outputs.
+  - `wallet::shield_transparent_funds` no longer takes a `memo` argument;
+    instead, memos to be associated with the shielded outputs should be
+    specified in the construction of the value of the `input_selector`
+    argument, which is used to construct the proposed shielded values as
+    internal "change" outputs.
   - `wallet::create_proposed_transaction` no longer takes a
     `change_memo` argument; instead, change memos are represented in the
     individual values of the `proposed_change` field of the `Proposal`'s

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -28,8 +28,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::proto::`
   - `PROPOSAL_SER_V1`
   - `ProposalError`
-  - `proposal::Proposal::{from_standard_proposal, try_into_standard_proposal}`
-  - `proposal::ProposedInput::parse_txid`
+  - `proposal` module, for parsing and serializing transaction proposals.
 - `impl Clone for zcash_client_backend::{
      zip321::{Payment, TransactionRequest, Zip321Error, parse::Param, parse::IndexedParam},
      wallet::{ReceivedSaplingNote, WalletTransparentOutput},

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -25,6 +25,7 @@ and this library adheres to Rust's notion of
   - `ReceivedSaplingNote::from_parts`
   - `ReceivedSaplingNote::{txid, output_index, diversifier, rseed, note_commitment_tree_position}`
 - `zcash_client_backend::zip321::TransactionRequest::total`
+- `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proto::`
   - `PROPOSAL_SER_V1`
   - `ProposalError`

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -4,6 +4,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 const COMPACT_FORMATS_PROTO: &str = "proto/compact_formats.proto";
+
+const PROPOSAL_PROTO: &str = "proto/proposal.proto";
+
 const SERVICE_PROTO: &str = "proto/service.proto";
 
 fn main() -> io::Result<()> {
@@ -70,6 +73,15 @@ fn build() -> io::Result<()> {
             "crate::proto::compact_formats::CompactOrchardAction",
         )
         .compile(&[SERVICE_PROTO], &["proto/"])?;
+
+    // Build the proposal types.
+    tonic_build::compile_protos(PROPOSAL_PROTO)?;
+
+    // Copy the generated types into the source tree so changes can be committed.
+    fs::copy(
+        out.join("cash.z.wallet.sdk.ffi.rs"),
+        "src/proto/proposal.rs",
+    )?;
 
     // Copy the generated types into the source tree so changes can be committed. The
     // file has the same name as for the compact format types because they have the

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+syntax = "proto3";
+package cash.z.wallet.sdk.ffi;
+
+// A data structure that describes the inputs to be consumed and outputs to
+// be produced in a proposed transaction.
+message Proposal {
+    uint32 protoVersion = 1;
+    // ZIP 321 serialized transaction request
+    string transactionRequest = 2;
+    // The transparent UTXOs to use as inputs to the transaction.
+    repeated ProposedInput transparentInputs = 3;
+    // The Sapling input notes and anchor height to be used in creating the transaction.
+    SaplingInputs saplingInputs = 4;
+    // The total value, fee amount, and change outputs of the proposed
+    // transaction
+    TransactionBalance balance = 5;
+    // The fee rule used in constructing this proposal
+    FeeRule feeRule = 6;
+    // The target height for which the proposal was constructed
+    //
+    // The chain must contain at least this many blocks in order for the proposal to
+    // be executed.
+    uint32 minTargetHeight = 7;
+    // A flag indicating whether the proposal is for a shielding transaction,
+    // used for determining which OVK to select for wallet-internal outputs.
+    bool isShielding = 8;
+}
+
+message SaplingInputs {
+    // Returns the Sapling anchor height to be used in creating the transaction.
+    uint32 anchorHeight = 1;
+    // The unique identifier and amount for each proposed Sapling input
+    repeated ProposedInput inputs = 2;
+}
+
+// The unique identifier and amount for each proposed input.
+message ProposedInput {
+    bytes txid = 1;
+    uint32 index = 2;
+    uint64 value = 3;
+}
+
+// The fee rule used in constructing a Proposal
+enum FeeRule {
+    // Protobuf requires that enums have a zero descriminant as the default
+    // value. However, we need to require that a known fee rule is selected,
+    // and we do not want to fall back to any default, so sending the
+    // FeeRuleNotSpecified value will be treated as an error.
+    FeeRuleNotSpecified = 0;
+    // 10000 ZAT
+    PreZip313 = 1;
+    // 1000 ZAT
+    Zip313 = 2;
+    // MAX(10000, 5000 * logical_actions) ZAT
+    Zip317 = 3;
+}
+
+// The proposed change outputs and fee amount.
+message TransactionBalance {
+    repeated ChangeValue proposedChange = 1;
+    uint64 feeRequired = 2;
+}
+
+// An enumeration of change value types.
+message ChangeValue {
+    oneof value {
+        SaplingChange saplingValue = 1;
+    }
+}
+
+// An object wrapper for memo bytes, to facilitate representing the
+// `change_memo == None` case.
+message MemoBytes {
+    bytes value = 1;
+}
+
+// The amount and memo for a proposed Sapling change output.
+message SaplingChange {
+    uint64 amount = 1;
+    MemoBytes memo = 2;
+}
+

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -31,7 +31,7 @@ message Proposal {
 }
 
 message SaplingInputs {
-    // Returns the Sapling anchor height to be used in creating the transaction.
+    // The Sapling anchor height to be used in creating the transaction
     uint32 anchorHeight = 1;
     // The unique identifier and amount for each proposed Sapling input
     repeated ProposedInput inputs = 2;
@@ -46,7 +46,7 @@ message ProposedInput {
 
 // The fee rule used in constructing a Proposal
 enum FeeRule {
-    // Protobuf requires that enums have a zero descriminant as the default
+    // Protobuf requires that enums have a zero discriminant as the default
     // value. However, we need to require that a known fee rule is selected,
     // and we do not want to fall back to any default, so sending the
     // FeeRuleNotSpecified value will be treated as an error.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -17,7 +17,10 @@ use zcash_primitives::{
     memo::{Memo, MemoBytes},
     sapling::{self, Node, NOTE_COMMITMENT_TREE_DEPTH},
     transaction::{
-        components::amount::{Amount, NonNegativeAmount},
+        components::{
+            amount::{Amount, NonNegativeAmount},
+            OutPoint,
+        },
         Transaction, TxId,
     },
     zip32::AccountId,
@@ -30,9 +33,6 @@ use crate::{
     proto::service::TreeState,
     wallet::{ReceivedSaplingNote, WalletTransparentOutput, WalletTx},
 };
-
-#[cfg(feature = "transparent-inputs")]
-use zcash_primitives::transaction::components::OutPoint;
 
 use self::chain::CommitmentTreeRoot;
 use self::scanning::ScanRange;
@@ -222,6 +222,14 @@ pub trait SaplingInputSource {
     /// or a UUID.
     type NoteRef: Copy + Debug + Eq + Ord;
 
+    /// Returns a received Sapling note, or Ok(None) if the note is not known to belong to the
+    /// wallet or if the note is not spendable.
+    fn get_spendable_sapling_note(
+        &self,
+        txid: &TxId,
+        index: u32,
+    ) -> Result<Option<ReceivedSaplingNote<Self::NoteRef>>, Self::Error>;
+
     /// Returns a list of spendable Sapling notes sufficient to cover the specified target value,
     /// if possible.
     fn select_spendable_sapling_notes(
@@ -235,10 +243,16 @@ pub trait SaplingInputSource {
 
 /// A trait representing the capability to query a data store for unspent transparent UTXOs
 /// belonging to a wallet.
-#[cfg(feature = "transparent-inputs")]
 pub trait TransparentInputSource {
     /// The type of errors produced by a wallet backend.
     type Error;
+
+    /// Returns a received transparent UTXO, or Ok(None) if the UTXO is not known to belong to the
+    /// wallet or is not spendable.
+    fn get_unspent_transparent_output(
+        &self,
+        outpoint: &OutPoint,
+    ) -> Result<Option<WalletTransparentOutput>, Self::Error>;
 
     /// Returns a list of unspent transparent UTXOs that appear in the chain at heights up to and
     /// including `max_height`.
@@ -1008,6 +1022,14 @@ pub mod testing {
         type Error = ();
         type NoteRef = u32;
 
+        fn get_spendable_sapling_note(
+            &self,
+            _txid: &TxId,
+            _index: u32,
+        ) -> Result<Option<ReceivedSaplingNote<Self::NoteRef>>, Self::Error> {
+            Ok(None)
+        }
+
         fn select_spendable_sapling_notes(
             &self,
             _account: AccountId,
@@ -1022,6 +1044,13 @@ pub mod testing {
     #[cfg(feature = "transparent-inputs")]
     impl TransparentInputSource for MockWalletDb {
         type Error = ();
+
+        fn get_unspent_transparent_output(
+            &self,
+            _outpoint: &OutPoint,
+        ) -> Result<Option<WalletTransparentOutput>, Self::Error> {
+            Ok(None)
+        }
 
         fn get_unspent_transparent_outputs(
             &self,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -222,8 +222,11 @@ pub trait SaplingInputSource {
     /// or a UUID.
     type NoteRef: Copy + Debug + Eq + Ord;
 
-    /// Returns a received Sapling note, or Ok(None) if the note is not known to belong to the
-    /// wallet or if the note is not spendable.
+    /// Fetches a spendable Sapling note by indexing into the specified transaction's
+    /// [`sapling::Bundle::shielded_outputs`].
+    ///
+    /// Returns `Ok(None)` if the note is not known to belong to the wallet or if the note
+    /// is not spendable.
     fn get_spendable_sapling_note(
         &self,
         txid: &TxId,
@@ -247,8 +250,10 @@ pub trait TransparentInputSource {
     /// The type of errors produced by a wallet backend.
     type Error;
 
-    /// Returns a received transparent UTXO, or Ok(None) if the UTXO is not known to belong to the
-    /// wallet or is not spendable.
+    /// Fetches a spendable transparent output.
+    ///
+    /// Returns `Ok(None)` if the UTXO is not known to belong to the wallet or is not
+    /// spendable.
     fn get_unspent_transparent_output(
         &self,
         outpoint: &OutPoint,

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -81,7 +81,7 @@ where
     FE: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self {
+        match self {
             Error::DataSource(e) => {
                 write!(
                     f,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -145,7 +145,7 @@ impl std::error::Error for ProposalError {}
 impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// Constructs a validated [`Proposal`] from its constituent parts.
     ///
-    /// This operation validaes the proposal for balance consistency and agreement between
+    /// This operation validates the proposal for balance consistency and agreement between
     /// the `is_shielding` flag and the structure of the proposal.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
@@ -167,9 +167,8 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
             .iter()
             .flat_map(|s_in| s_in.notes().iter())
             .map(|out| out.value())
-            .fold(Ok(NonNegativeAmount::ZERO), |acc, a| {
-                (acc? + a).ok_or(ProposalError::Overflow)
-            })?;
+            .fold(Some(NonNegativeAmount::ZERO), |acc, a| (acc? + a))
+            .ok_or(ProposalError::Overflow)?;
         let input_total =
             (transparent_input_total + sapling_input_total).ok_or(ProposalError::Overflow)?;
 

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -54,6 +54,9 @@ impl ChangeValue {
 pub struct TransactionBalance {
     proposed_change: Vec<ChangeValue>,
     fee_required: NonNegativeAmount,
+
+    // A cache for the sum of proposed change and fee; we compute it on construction anyway, so we
+    // cache the resulting value.
     total: NonNegativeAmount,
 }
 

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -3,15 +3,31 @@
 use std::io;
 
 use incrementalmerkletree::frontier::CommitmentTree;
+
+use nonempty::NonEmpty;
 use zcash_primitives::{
     block::{BlockHash, BlockHeader},
-    consensus::BlockHeight,
+    consensus::{self, BlockHeight, Parameters},
+    memo::{self, MemoBytes},
     merkle_tree::read_commitment_tree,
     sapling::{self, note::ExtractedNoteCommitment, Node, Nullifier, NOTE_COMMITMENT_TREE_DEPTH},
-    transaction::TxId,
+    transaction::{
+        components::{amount::NonNegativeAmount, OutPoint},
+        fees::StandardFeeRule,
+        TxId,
+    },
 };
 
 use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
+
+use crate::{
+    data_api::{
+        wallet::input_selection::{Proposal, SaplingInputs},
+        PoolType, SaplingInputSource, ShieldedProtocol, TransparentInputSource,
+    },
+    fees::{ChangeValue, TransactionBalance},
+    zip321::{TransactionRequest, Zip321Error},
+};
 
 #[rustfmt::skip]
 #[allow(unknown_lints)]
@@ -186,5 +202,225 @@ impl service::TreeState {
             )
         })?;
         read_commitment_tree::<Node, _, NOTE_COMMITMENT_TREE_DEPTH>(&sapling_tree_bytes[..])
+    }
+}
+
+pub const PROPOSAL_SER_V1: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProposalError<DbError> {
+    Zip321(Zip321Error),
+    TxIdInvalid(Vec<u8>),
+    InputRetrieval(DbError),
+    InputNotFound(TxId, PoolType, u32),
+    BalanceInvalid,
+    MemoInvalid(memo::Error),
+    VersionInvalid(u32),
+    ZeroMinConf,
+    FeeRuleNotSpecified,
+}
+
+impl<E> From<Zip321Error> for ProposalError<E> {
+    fn from(value: Zip321Error) -> Self {
+        Self::Zip321(value)
+    }
+}
+
+impl proposal::ProposedInput {
+    pub fn parse_txid(&self) -> Result<TxId, Vec<u8>> {
+        Ok(TxId::from_bytes(self.txid.clone().try_into()?))
+    }
+}
+
+impl proposal::Proposal {
+    /// Serializes a [`Proposal`] based upon a supported [`StandardFeeRule`] to its protobuf
+    /// representation.
+    pub fn from_standard_proposal<P: Parameters, NoteRef>(
+        params: &P,
+        value: &Proposal<StandardFeeRule, NoteRef>,
+    ) -> Option<Self> {
+        let transaction_request = value.transaction_request().to_uri(params)?;
+
+        let transparent_inputs = value
+            .transparent_inputs()
+            .iter()
+            .map(|utxo| proposal::ProposedInput {
+                txid: utxo.outpoint().hash().to_vec(),
+                index: utxo.outpoint().n(),
+                value: utxo.txout().value.into(),
+            })
+            .collect();
+
+        let sapling_inputs = value
+            .sapling_inputs()
+            .map(|sapling_inputs| proposal::SaplingInputs {
+                anchor_height: sapling_inputs.anchor_height().into(),
+                inputs: sapling_inputs
+                    .notes()
+                    .iter()
+                    .map(|rec_note| proposal::ProposedInput {
+                        txid: rec_note.txid().as_ref().to_vec(),
+                        index: rec_note.output_index().into(),
+                        value: rec_note.value().into(),
+                    })
+                    .collect(),
+            });
+
+        let balance = Some(proposal::TransactionBalance {
+            proposed_change: value
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|cv| match cv {
+                    ChangeValue::Sapling { value, memo } => proposal::ChangeValue {
+                        value: Some(proposal::change_value::Value::SaplingValue(
+                            proposal::SaplingChange {
+                                amount: (*value).into(),
+                                memo: memo.as_ref().map(|memo_bytes| proposal::MemoBytes {
+                                    value: memo_bytes.as_slice().to_vec(),
+                                }),
+                            },
+                        )),
+                    },
+                })
+                .collect(),
+            fee_required: value.balance().fee_required().into(),
+        });
+
+        #[allow(deprecated)]
+        Some(proposal::Proposal {
+            proto_version: PROPOSAL_SER_V1,
+            transaction_request,
+            transparent_inputs,
+            sapling_inputs,
+            balance,
+            fee_rule: match value.fee_rule() {
+                StandardFeeRule::PreZip313 => proposal::FeeRule::PreZip313,
+                StandardFeeRule::Zip313 => proposal::FeeRule::Zip313,
+                StandardFeeRule::Zip317 => proposal::FeeRule::Zip317,
+            }
+            .into(),
+            min_target_height: value.min_target_height().into(),
+            is_shielding: value.is_shielding(),
+        })
+    }
+
+    /// Attempts to parse a [`Proposal`] based upon a supported [`StandardFeeRule`] from its
+    /// protobuf representation.
+    pub fn try_into_standard_proposal<P: consensus::Parameters, DbT, DbError>(
+        &self,
+        params: &P,
+        wallet_db: &DbT,
+    ) -> Result<Proposal<StandardFeeRule, DbT::NoteRef>, ProposalError<DbError>>
+    where
+        DbT: TransparentInputSource<Error = DbError> + SaplingInputSource<Error = DbError>,
+    {
+        match self.proto_version {
+            PROPOSAL_SER_V1 => {
+                #[allow(deprecated)]
+                let fee_rule = match self.fee_rule() {
+                    proposal::FeeRule::PreZip313 => StandardFeeRule::PreZip313,
+                    proposal::FeeRule::Zip313 => StandardFeeRule::Zip313,
+                    proposal::FeeRule::Zip317 => StandardFeeRule::Zip317,
+                    proposal::FeeRule::NotSpecified => {
+                        return Err(ProposalError::FeeRuleNotSpecified);
+                    }
+                };
+
+                let transaction_request =
+                    TransactionRequest::from_uri(params, &self.transaction_request)?;
+                let transparent_inputs = self
+                    .transparent_inputs
+                    .iter()
+                    .map(|t_in| {
+                        let txid = t_in.parse_txid().map_err(ProposalError::TxIdInvalid)?;
+                        let outpoint = OutPoint::new(txid.into(), t_in.index);
+
+                        wallet_db
+                            .get_unspent_transparent_output(&outpoint)
+                            .map_err(ProposalError::InputRetrieval)?
+                            .ok_or_else(|| {
+                                ProposalError::InputNotFound(
+                                    txid,
+                                    PoolType::Transparent,
+                                    t_in.index,
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let sapling_inputs = self.sapling_inputs.as_ref().and_then(|s_in| {
+                    s_in.inputs
+                        .iter()
+                        .map(|s_in| {
+                            let txid = s_in.parse_txid().map_err(ProposalError::TxIdInvalid)?;
+
+                            wallet_db
+                                .get_spendable_sapling_note(&txid, s_in.index)
+                                .map_err(ProposalError::InputRetrieval)
+                                .and_then(|opt| {
+                                    opt.ok_or_else(|| {
+                                        ProposalError::InputNotFound(
+                                            txid,
+                                            PoolType::Shielded(ShieldedProtocol::Sapling),
+                                            s_in.index,
+                                        )
+                                    })
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                        .map(|notes| {
+                            NonEmpty::from_vec(notes).map(|notes| {
+                                SaplingInputs::from_parts(s_in.anchor_height.into(), notes)
+                            })
+                        })
+                        .transpose()
+                });
+
+                let balance = self.balance.as_ref().ok_or(ProposalError::BalanceInvalid)?;
+                let balance = TransactionBalance::new(
+                    balance
+                        .proposed_change
+                        .iter()
+                        .filter_map(|cv| {
+                            cv.value
+                                .as_ref()
+                                .map(|cv| -> Result<ChangeValue, ProposalError<_>> {
+                                    match cv {
+                                        proposal::change_value::Value::SaplingValue(sc) => {
+                                            Ok(ChangeValue::sapling(
+                                                NonNegativeAmount::from_u64(sc.amount)
+                                                    .map_err(|_| ProposalError::BalanceInvalid)?,
+                                                sc.memo
+                                                    .as_ref()
+                                                    .map(|bytes| {
+                                                        MemoBytes::from_bytes(&bytes.value)
+                                                            .map_err(ProposalError::MemoInvalid)
+                                                    })
+                                                    .transpose()?,
+                                            ))
+                                        }
+                                    }
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    NonNegativeAmount::from_u64(balance.fee_required)
+                        .map_err(|_| ProposalError::BalanceInvalid)?,
+                )
+                .map_err(|_| ProposalError::BalanceInvalid)?;
+
+                Proposal::from_parts(
+                    transaction_request,
+                    transparent_inputs,
+                    sapling_inputs.transpose()?,
+                    balance,
+                    fee_rule,
+                    self.min_target_height.into(),
+                    self.is_shielding,
+                )
+                .map_err(|_| ProposalError::BalanceInvalid)
+            }
+            other => Err(ProposalError::VersionInvalid(other)),
+        }
     }
 }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -21,6 +21,11 @@ pub mod compact_formats;
 #[rustfmt::skip]
 #[allow(unknown_lints)]
 #[allow(clippy::derive_partial_eq_without_eq)]
+pub mod proposal;
+
+#[rustfmt::skip]
+#[allow(unknown_lints)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod service;
 
 impl compact_formats::CompactBlock {

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -1,0 +1,137 @@
+/// A data structure that describes the inputs to be consumed and outputs to
+/// be produced in a proposed transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Proposal {
+    #[prost(uint32, tag = "1")]
+    pub proto_version: u32,
+    /// ZIP 321 serialized transaction request
+    #[prost(string, tag = "2")]
+    pub transaction_request: ::prost::alloc::string::String,
+    /// The transparent UTXOs to use as inputs to the transaction.
+    #[prost(message, repeated, tag = "3")]
+    pub transparent_inputs: ::prost::alloc::vec::Vec<ProposedInput>,
+    /// The Sapling input notes and anchor height to be used in creating the transaction.
+    #[prost(message, optional, tag = "4")]
+    pub sapling_inputs: ::core::option::Option<SaplingInputs>,
+    /// The total value, fee amount, and change outputs of the proposed
+    /// transaction
+    #[prost(message, optional, tag = "5")]
+    pub balance: ::core::option::Option<TransactionBalance>,
+    /// The fee rule used in constructing this proposal
+    #[prost(enumeration = "FeeRule", tag = "6")]
+    pub fee_rule: i32,
+    /// The target height for which the proposal was constructed
+    ///
+    /// The chain must contain at least this many blocks in order for the proposal to
+    /// be executed.
+    #[prost(uint32, tag = "7")]
+    pub min_target_height: u32,
+    /// A flag indicating whether the proposal is for a shielding transaction,
+    /// used for determining which OVK to select for wallet-internal outputs.
+    #[prost(bool, tag = "8")]
+    pub is_shielding: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SaplingInputs {
+    /// Returns the Sapling anchor height to be used in creating the transaction.
+    #[prost(uint32, tag = "1")]
+    pub anchor_height: u32,
+    /// The unique identifier and amount for each proposed Sapling input
+    #[prost(message, repeated, tag = "2")]
+    pub inputs: ::prost::alloc::vec::Vec<ProposedInput>,
+}
+/// The unique identifier and amount for each proposed input.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProposedInput {
+    #[prost(bytes = "vec", tag = "1")]
+    pub txid: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "2")]
+    pub index: u32,
+    #[prost(uint64, tag = "3")]
+    pub value: u64,
+}
+/// The proposed change outputs and fee amount.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionBalance {
+    #[prost(message, repeated, tag = "1")]
+    pub proposed_change: ::prost::alloc::vec::Vec<ChangeValue>,
+    #[prost(uint64, tag = "2")]
+    pub fee_required: u64,
+}
+/// An enumeration of change value types.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChangeValue {
+    #[prost(oneof = "change_value::Value", tags = "1")]
+    pub value: ::core::option::Option<change_value::Value>,
+}
+/// Nested message and enum types in `ChangeValue`.
+pub mod change_value {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(message, tag = "1")]
+        SaplingValue(super::SaplingChange),
+    }
+}
+/// An object wrapper for memo bytes, to facilitate representing the
+/// `change_memo == None` case.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MemoBytes {
+    #[prost(bytes = "vec", tag = "1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// The amount and memo for a proposed Sapling change output.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SaplingChange {
+    #[prost(uint64, tag = "1")]
+    pub amount: u64,
+    #[prost(message, optional, tag = "2")]
+    pub memo: ::core::option::Option<MemoBytes>,
+}
+/// The fee rule used in constructing a Proposal
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FeeRule {
+    /// Protobuf requires that enums have a zero descriminant as the default
+    /// value. However, we need to require that a known fee rule is selected,
+    /// and we do not want to fall back to any default, so sending the
+    /// FeeRuleNotSpecified value will be treated as an error.
+    NotSpecified = 0,
+    /// 10000 ZAT
+    PreZip313 = 1,
+    /// 1000 ZAT
+    Zip313 = 2,
+    /// MAX(10000, 5000 * logical_actions) ZAT
+    Zip317 = 3,
+}
+impl FeeRule {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FeeRule::NotSpecified => "FeeRuleNotSpecified",
+            FeeRule::PreZip313 => "PreZip313",
+            FeeRule::Zip313 => "Zip313",
+            FeeRule::Zip317 => "Zip317",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FeeRuleNotSpecified" => Some(Self::NotSpecified),
+            "PreZip313" => Some(Self::PreZip313),
+            "Zip313" => Some(Self::Zip313),
+            "Zip317" => Some(Self::Zip317),
+            _ => None,
+        }
+    }
+}

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -29,7 +29,7 @@ pub struct WalletTx<N> {
     pub sapling_outputs: Vec<WalletSaplingOutput<N>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WalletTransparentOutput {
     outpoint: OutPoint,
     txout: TxOut,
@@ -175,7 +175,7 @@ impl<N> WalletSaplingOutput<N> {
 
 /// Information about a note that is tracked by the wallet that is available for spending,
 /// with sufficient information for use in note selection.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReceivedSaplingNote<NoteRef> {
     note_id: NoteRef,
     txid: TxId,

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -5,7 +5,10 @@
 //!
 //! The specification for ZIP 321 URIs may be found at <https://zips.z.cash/zip-0321>
 use core::fmt::Debug;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{self, Display},
+};
 
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use nom::{
@@ -43,6 +46,51 @@ pub enum Zip321Error {
     RecipientMissing(usize),
     /// The ZIP 321 URI was malformed and failed to parse.
     ParseError(String),
+}
+
+impl Display for Zip321Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Zip321Error::InvalidBase64(err) => {
+                write!(f, "Memo value was not correctly base64 encoded: {:?}", err)
+            }
+            Zip321Error::MemoBytesError(err) => write!(
+                f,
+                "Memo exceeded maximum length or violated utf-8 encodiding restrictions: {:?}.",
+                err
+            ),
+            Zip321Error::TooManyPayments(n) => write!(
+                f,
+                "Cannot create a Zcash transaction containing {} payments",
+                n
+            ),
+            Zip321Error::DuplicateParameter(param, idx) => write!(
+                f,
+                "There is a duplicate {} parameter at index {}",
+                param.name(),
+                idx
+            ),
+            Zip321Error::TransparentMemo(idx) => write!(
+                f,
+                "Payment {} is invalid: cannot send a memo to a transparent recipient address.",
+                idx
+            ),
+            Zip321Error::RecipientMissing(idx) => {
+                write!(f, "Payment {} is missing its recipient address.", idx)
+            }
+            Zip321Error::ParseError(s) => write!(f, "Parse failure: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for Zip321Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Zip321Error::InvalidBase64(err) => Some(err),
+            Zip321Error::MemoBytesError(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 /// Converts a [`MemoBytes`] value to a ZIP 321 compatible base64-encoded string.
@@ -439,6 +487,20 @@ mod parse {
         Label(String),
         Message(String),
         Other(String, String),
+    }
+
+    impl Param {
+        /// Returns the name of the parameter from which this value was parsed.
+        pub fn name(&self) -> String {
+            match self {
+                Param::Addr(_) => "address".to_owned(),
+                Param::Amount(_) => "amount".to_owned(),
+                Param::Memo(_) => "memo".to_owned(),
+                Param::Label(_) => "label".to_owned(),
+                Param::Message(_) => "message".to_owned(),
+                Param::Other(name, _) => name.clone(),
+            }
+        }
     }
 
     /// A [`Param`] value with its associated index.

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -154,8 +154,8 @@ impl TransactionRequest {
 
     /// Returns the total value of payments to be made.
     ///
-    /// Returns `Err` in the case of overflow, if payment values are negative, or the value is
-    /// outside the valid range of Zcash values. .
+    /// Returns `Err` in the case of overflow, or the value is
+    /// outside the range `0..=MAX_MONEY` zatoshis.
     pub fn total(&self) -> Result<NonNegativeAmount, ()> {
         if self.payments.is_empty() {
             Ok(NonNegativeAmount::ZERO)

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -52,11 +52,11 @@ impl Display for Zip321Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Zip321Error::InvalidBase64(err) => {
-                write!(f, "Memo value was not correctly base64 encoded: {:?}", err)
+                write!(f, "Memo value was not correctly base64-encoded: {:?}", err)
             }
             Zip321Error::MemoBytesError(err) => write!(
                 f,
-                "Memo exceeded maximum length or violated utf-8 encodiding restrictions: {:?}.",
+                "Memo exceeded maximum length or violated UTF-8 encoding restrictions: {:?}",
                 err
             ),
             Zip321Error::TooManyPayments(n) => write!(
@@ -72,11 +72,11 @@ impl Display for Zip321Error {
             ),
             Zip321Error::TransparentMemo(idx) => write!(
                 f,
-                "Payment {} is invalid: cannot send a memo to a transparent recipient address.",
+                "Payment {} is invalid: cannot send a memo to a transparent recipient address",
                 idx
             ),
             Zip321Error::RecipientMissing(idx) => {
-                write!(f, "Payment {} is missing its recipient address.", idx)
+                write!(f, "Payment {} is missing its recipient address", idx)
             }
             Zip321Error::ParseError(s) => write!(f, "Parse failure: {}", s),
         }
@@ -202,7 +202,7 @@ impl TransactionRequest {
 
     /// Returns the total value of payments to be made.
     ///
-    /// Returns `Err` in the case of overflow, or the value is
+    /// Returns `Err` in the case of overflow, or if the value is
     /// outside the range `0..=MAX_MONEY` zatoshis.
     pub fn total(&self) -> Result<NonNegativeAmount, ()> {
         if self.payments.is_empty() {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -173,6 +173,14 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> SaplingInputSour
     type Error = SqliteClientError;
     type NoteRef = ReceivedNoteId;
 
+    fn get_spendable_sapling_note(
+        &self,
+        txid: &TxId,
+        index: u32,
+    ) -> Result<Option<ReceivedSaplingNote<Self::NoteRef>>, Self::Error> {
+        wallet::sapling::get_spendable_sapling_note(self.conn.borrow(), txid, index)
+    }
+
     fn select_spendable_sapling_notes(
         &self,
         account: AccountId,
@@ -195,6 +203,19 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> TransparentInput
     for WalletDb<C, P>
 {
     type Error = SqliteClientError;
+
+    fn get_unspent_transparent_output(
+        &self,
+        _outpoint: &OutPoint,
+    ) -> Result<Option<WalletTransparentOutput>, Self::Error> {
+        #[cfg(feature = "transparent-inputs")]
+        return wallet::get_unspent_transparent_output(self.conn.borrow(), _outpoint);
+
+        #[cfg(not(feature = "transparent-inputs"))]
+        panic!(
+            "The wallet must be compiled with the transparent-inputs feature to use this method."
+        );
+    }
 
     fn get_unspent_transparent_outputs(
         &self,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -206,15 +206,9 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> TransparentInput
 
     fn get_unspent_transparent_output(
         &self,
-        _outpoint: &OutPoint,
+        outpoint: &OutPoint,
     ) -> Result<Option<WalletTransparentOutput>, Self::Error> {
-        #[cfg(feature = "transparent-inputs")]
-        return wallet::get_unspent_transparent_output(self.conn.borrow(), _outpoint);
-
-        #[cfg(not(feature = "transparent-inputs"))]
-        panic!(
-            "The wallet must be compiled with the transparent-inputs feature to use this method."
-        );
+        wallet::get_unspent_transparent_output(self.conn.borrow(), outpoint)
     }
 
     fn get_unspent_transparent_outputs(

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1071,6 +1071,8 @@ pub(crate) fn input_selector(
     GreedyInputSelector::new(change_strategy, DustOutputPolicy::default())
 }
 
+// Checks that a protobuf proposal serialized from the provided proposal value correctly parses to
+// the same proposal value.
 pub(crate) fn check_proposal_serialization_roundtrip(
     db_data: &WalletDb<rusqlite::Connection, Network>,
     proposal: &Proposal<StandardFeeRule, ReceivedNoteId>,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -135,8 +135,8 @@ fn to_spendable_note(row: &Row) -> Result<ReceivedSaplingNote<ReceivedNoteId>, S
     ))
 }
 
-// The `clippy::let_and_return` lint is explicitly allowed here because a bug in the Rust compiler
-// (https://github.com/rust-lang/rust/issues/114633) fails to identify that the `result` temporary
+// The `clippy::let_and_return` lint is explicitly allowed here because a bug in Clippy
+// (https://github.com/rust-lang/rust-clippy/issues/11308) means it fails to identify that the `result` temporary
 // is required in order to resolve the borrows involved in the `query_and_then` call.
 #[allow(clippy::let_and_return)]
 pub(crate) fn get_spendable_sapling_note(

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -135,6 +135,38 @@ fn to_spendable_note(row: &Row) -> Result<ReceivedSaplingNote<ReceivedNoteId>, S
     ))
 }
 
+// The `clippy::let_and_return` lint is explicitly allowed here because a bug in the Rust compiler
+// (https://github.com/rust-lang/rust/issues/114633) fails to identify that the `result` temporary
+// is required in order to resolve the borrows involved in the `query_and_then` call.
+#[allow(clippy::let_and_return)]
+pub(crate) fn get_spendable_sapling_note(
+    conn: &Connection,
+    txid: &TxId,
+    index: u32,
+) -> Result<Option<ReceivedSaplingNote<ReceivedNoteId>>, SqliteClientError> {
+    let mut stmt_select_note = conn.prepare_cached(
+        "SELECT id_note, txid, output_index, diversifier, value, rcm, commitment_tree_position
+         FROM sapling_received_notes
+         INNER JOIN transactions ON transactions.id_tx = sapling_received_notes.tx
+         WHERE txid = :txid
+         AND output_index = :output_index
+         AND spent IS NULL",
+    )?;
+
+    let result = stmt_select_note
+        .query_and_then(
+            named_params![
+               ":txid": txid.as_ref(),
+               ":output_index": index,
+            ],
+            to_spendable_note,
+        )?
+        .next()
+        .transpose();
+
+    result
+}
+
 /// Utility method for determining whether we have any spendable notes
 ///
 /// If the tip shard has unscanned ranges below the anchor height and greater than or equal to

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -82,6 +82,9 @@ and this library adheres to Rust's notion of
   - `impl From<NonNegativeAmount> for zcash_primitives::sapling::value::NoteValue`
   - `impl Sum<NonNegativeAmount> for Option<NonNegativeAmount>`
   - `impl<'a> Sum<&'a NonNegativeAmount> for Option<NonNegativeAmount>`
+- `impl {Clone, PartialEq, Eq} for zcash_primitives::memo::Error`
+- `impl {PartialEq, Eq} for zcash_primitives::sapling::note::Rseed`
+- `impl From<TxId> for [u8; 32]`
 
 ### Changed
 - `zcash_primitives::sapling`:

--- a/zcash_primitives/src/memo.rs
+++ b/zcash_primitives/src/memo.rs
@@ -28,7 +28,7 @@ where
 }
 
 /// Errors that may result from attempting to construct an invalid memo.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     InvalidUtf8(std::str::Utf8Error),
     TooLong(usize),

--- a/zcash_primitives/src/sapling/note.rs
+++ b/zcash_primitives/src/sapling/note.rs
@@ -16,7 +16,7 @@ pub(super) mod nullifier;
 /// Before ZIP 212, the note commitment trapdoor `rcm` must be a scalar value.
 /// After ZIP 212, the note randomness `rseed` is a 32-byte sequence, used to derive
 /// both the note commitment trapdoor `rcm` and the ephemeral private key `esk`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Rseed {
     BeforeZip212(jubjub::Fr),
     AfterZip212([u8; 32]),


### PR DESCRIPTION
In order to make complete information about proposed transactions readily available to wallets, it's necessary to provide a mechanism to pass a `TransactionProposal` across the FFI. This PR adds a Protobuf representation for proposed transactions and implements conversions back and forth between the protobuf representation and the native type.