### PR TITLE
zcash_client_sqlite: Only select notes for which witnesses can be constructed.

### DIFF
--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -9,6 +9,7 @@ mod sent_notes_to_internal;
 mod shardtree_support;
 mod ufvk_support;
 mod utxos_table;
+mod v_sapling_shard_unscanned_ranges;
 mod v_transactions_net;
 
 use schemer_rusqlite::RusqliteMigration;
@@ -36,6 +37,8 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //                  received_notes_nullable_nf
     //                 /          |           \
     // shardtree_support    nullifier_map    sapling_memo_consistency
+    //         |
+    // v_sapling_shard_unscanned_ranges
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -56,6 +59,9 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         Box::new(shardtree_support::Migration),
         Box::new(nullifier_map::Migration),
         Box::new(sapling_memo_consistency::Migration {
+            params: params.clone(),
+        }),
+        Box::new(v_sapling_shard_unscanned_ranges::Migration {
             params: params.clone(),
         }),
     ]

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
@@ -1,0 +1,75 @@
+//! This migration adds a view that returns the un-scanned ranges associated with each sapling note
+//! commitment tree shard.
+
+use std::collections::HashSet;
+
+use schemer_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_client_backend::data_api::scanning::ScanPriority;
+use zcash_primitives::consensus;
+
+use crate::wallet::{init::WalletMigrationError, scanning::priority_code};
+
+use super::shardtree_support;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xfa934bdc_97b6_4980_8a83_b2cb1ac465fd);
+
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
+
+impl<P> schemer::Migration for Migration<P> {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        [shardtree_support::MIGRATION_ID].into_iter().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds a view that returns the un-scanned ranges associated with each sapling note commitment tree shard."
+    }
+}
+
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            &format!(
+                "CREATE VIEW v_sapling_shard_unscanned_ranges AS
+                SELECT
+                    shard.shard_index,
+                    shard.shard_index << 16 AS start_position,
+                    (shard.shard_index + 1) << 16 AS end_position_exclusive,
+                    IFNULL(prev_shard.subtree_end_height, {}) AS subtree_start_height,
+                    shard.subtree_end_height AS subtree_end_height,
+                    shard.contains_marked,
+                    scan_queue.block_range_start,
+                    scan_queue.block_range_end,
+                    scan_queue.priority
+                FROM sapling_tree_shards shard
+                LEFT OUTER JOIN sapling_tree_shards prev_shard
+                    ON shard.shard_index = prev_shard.shard_index + 1
+                INNER JOIN scan_queue ON 
+                    (scan_queue.block_range_start BETWEEN subtree_start_height AND shard.subtree_end_height) OR
+                    ((scan_queue.block_range_end - 1) BETWEEN subtree_start_height AND shard.subtree_end_height) OR
+                    (
+                        scan_queue.block_range_start <= prev_shard.subtree_end_height
+                        AND (scan_queue.block_range_end - 1) >= shard.subtree_end_height
+                    )
+                WHERE scan_queue.priority != {}",
+                u32::from(self.params.activation_height(consensus::NetworkUpgrade::Sapling).unwrap()),
+                priority_code(&ScanPriority::Scanned),
+            )
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch("DROP VIEW v_sapling_shard_unscanned_ranges;")?;
+        Ok(())
+    }
+}

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -150,6 +150,7 @@ pub(crate) fn get_spendable_sapling_notes(
          FROM sapling_received_notes
          INNER JOIN transactions ON transactions.id_tx = sapling_received_notes.tx
          WHERE account = :account
+         AND commitment_tree_position IS NOT NULL
          AND spent IS NULL
          AND transactions.block <= :anchor_height
          AND id_note NOT IN rarray(:exclude)
@@ -223,6 +224,7 @@ pub(crate) fn select_spendable_sapling_notes(
              INNER JOIN transactions
                 ON transactions.id_tx = sapling_received_notes.tx
              WHERE account = :account
+             AND commitment_tree_position IS NOT NULL
              AND spent IS NULL
              AND transactions.block <= :anchor_height
              AND id_note NOT IN rarray(:exclude)


### PR DESCRIPTION
This change modifies the implementation of `get_spendable_sapling_notes` and `select_spendable_sapling_notes` to only return notes at positions where the associated note commitment tree shard has been fully scanned. This is slightly more conservative than it needs to be, because there could be cases where witnesses imported into the tree in the `shardtree_support` migration cover the complete range of a subtree (and hence that subtree doesn't need to be re-scanned). However, we can't detect or depend upon that condition in general without attempting to create a witness for each note retrieved.

A possible alternative to this approach would be to not bound our query results on the requested total, and instead attempt to construct a witness for each note we retrieve, skipping the note if we cannot construct a witness. However, given that accessing the note commitment tree can be a costly operation requiring nontrivial deserialization costs, the more conservative database-oriented approach is perhaps better.