### PR TITLE
zcash_client_sqlite: Ensure that target and anchor heights are relative to the chain tip.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -17,7 +17,7 @@ and this library adheres to Rust's notion of
   - `ScannedBlock`
   - `ShieldedProtocol`
   - `WalletCommitmentTrees`
-  - `WalletRead::{block_metadata, block_fully_scanned, suggest_scan_ranges}`
+  - `WalletRead::{chain_height, block_metadata, block_fully_scanned, suggest_scan_ranges}`
   - `WalletWrite::{put_blocks, update_chain_tip}`
   - `chain::CommitmentTreeRoot`
   - `scanning` A new module containing types required for `suggest_scan_ranges`
@@ -89,10 +89,13 @@ and this library adheres to Rust's notion of
 
 ### Removed
 - `zcash_client_backend::data_api`:
-  - `WalletRead::get_all_nullifiers`
-  - `WalletRead::{get_commitment_tree, get_witnesses}` have been removed 
-    without replacement. The utility of these methods is now subsumed
-    by those available from the `WalletCommitmentTrees` trait.
+  - `WalletRead::block_height_extrema` has been removed. Use `chain_height`
+    instead to obtain the wallet's view of the chain tip instead, or
+    `suggest_scan_ranges` to obtain information about blocks that need to be
+    scanned.
+  - `WalletRead::{get_all_nullifiers, get_commitment_tree, get_witnesses}` have
+    been removed without replacement. The utility of these methods is now
+    subsumed by those available from the `WalletCommitmentTrees` trait.
   - `WalletWrite::advance_by_block` (use `WalletWrite::put_blocks` instead).
   - `PrunedBlock` has been replaced by `ScannedBlock`
   - `testing::MockWalletDb`, which is available under the `test-dependencies`
@@ -107,6 +110,9 @@ and this library adheres to Rust's notion of
   have been removed as individual incremental witnesses are no longer tracked on a
   per-note basis. The global note commitment tree for the wallet should be used
   to obtain witnesses for spend operations instead.
+- Default implementations of `zcash_client_backend::data_api::WalletRead::{
+    get_target_and_anchor_heights, get_max_height_hash
+  }` have been removed. These should be implemented in a backend-specific fashion.
 
 
 ## [0.9.0] - 2023-04-28

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -66,9 +66,7 @@ where
     // for mempool transactions.
     let height = data
         .get_tx_height(tx.txid())?
-        .or(data
-            .block_height_extrema()?
-            .map(|(_, max_height)| max_height + 1))
+        .or(data.chain_height()?.map(|max_height| max_height + 1))
         .or_else(|| params.activation_height(NetworkUpgrade::Sapling))
         .expect("Sapling activation height must be known.");
 

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -370,7 +370,7 @@ mod tests {
         let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
 
         // Empty chain should return None
-        assert_matches!(db_data.get_max_height_hash(), Ok(None));
+        assert_matches!(db_data.chain_height(), Ok(None));
 
         // Create a fake CompactBlock sending value to the address
         let (cb, _) = fake_compact_block(

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -619,12 +619,12 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
     params: &P,
     new_tip: BlockHeight,
 ) -> Result<(), SqliteClientError> {
-    // Read the previous tip height from the blocks table.
+    // Read the previous max scanned height from the blocks table
     let prior_tip = block_height_extrema(conn)?.map(|(_, prior_tip)| prior_tip);
 
-    // If the chain tip is below the prior tip height, then the caller has caught the
-    // chain in the middle of a reorg. Do nothing; the caller will continue using the old
-    // scan ranges and either:
+    // If the chain tip is below the prior max scanned height, then the caller has caught
+    // the chain in the middle of a reorg. Do nothing; the caller will continue using the
+    // old scan ranges and either:
     // - encounter an error trying to fetch the blocks (and thus trigger the same handling
     //   logic as if this happened with the old linear scanning code); or
     // - encounter a discontinuity error in `scan_cached_blocks`, at which point they will


### PR DESCRIPTION
Prior to the scan-before-sync changes, the wallet was able to assume that the maximum scanned block height at the time of the spend was within a few blocks of the chain tip. However, under linear scanning after the spend-before-sync changes this invariant no longer holds, resulting in a situation where in linear sync conditions the wallet could attempt to create transactions with already-past expiry heights.

This change separates the notion of "chain tip" from "max scanned height", relying upon the `scan_queue` table to maintain the wallet's view of the consensus chain height and using information from the `blocks` table only in situations where the latest and/or earliest scanned height is required.

As part of this change, the `WalletRead` interface is also modified to disambiguate these concepts.