### PR TITLE
Improve wallet tests

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Trait implementation `Mul<usize>` for `NonNegativeAmount`.
 
 ## [0.13.0-rc.1] - 2023-09-08
 ### Added

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -306,6 +306,14 @@ impl Sub<NonNegativeAmount> for Option<NonNegativeAmount> {
     }
 }
 
+impl Mul<usize> for NonNegativeAmount {
+    type Output = Option<Self>;
+
+    fn mul(self, rhs: usize) -> Option<NonNegativeAmount> {
+        (self.0 * rhs).map(NonNegativeAmount)
+    }
+}
+
 /// A type for balance violations in amount addition and subtraction
 /// (overflow and underflow of allowed ranges)
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This was originally going to test #899, and then it was going to test and fix #936. These tasks ended up being more complicated than we thought given the inconsistent use of the `sent_notes` table, and the introduction of out-of-order scanning (which can cause us not to know which spent notes are ours during the process of trying to categorize outputs). Now the PR just improves the existing wallet tests, provides support for resetting a wallet in the test framework, and checks that resetting a wallet works at all.