### PR TITLE
Fix API doc comment on UnifiedSpendingKey

### DIFF
--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -133,7 +133,7 @@ impl Era {
     }
 }
 
-/// A set of viewing keys that are all associated with a single
+/// A set of spending keys that are all associated with a single
 /// ZIP-0032 account identifier.
 #[derive(Clone, Debug)]
 #[doc(hidden)]


### PR DESCRIPTION
This fixes a simple copy/paste error of the docs from the unified viewing key.