### PR TITLE
`zcash_client_sqlite`: Introduce `TestBuilder` and `TestRunner`

### DIFF
--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -348,7 +348,7 @@ mod tests {
 
     use crate::{
         chain::init::init_cache_database,
-        tests::{
+        testing::{
             self, fake_compact_block, fake_compact_block_spending, init_test_accounts_table,
             insert_into_cache, sapling_activation_height, AddressType,
         },
@@ -363,7 +363,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -386,7 +386,7 @@ mod tests {
 
         // Scan the cache
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -409,7 +409,7 @@ mod tests {
         // Scanning should detect no inconsistencies
         assert_matches!(
             scan_cached_blocks(
-                &tests::network(),
+                &testing::network(),
                 &db_cache,
                 &mut db_data,
                 sapling_activation_height() + 1,
@@ -426,7 +426,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -455,7 +455,7 @@ mod tests {
         // Scanning the cache should find no inconsistencies
         assert_matches!(
             scan_cached_blocks(
-                &tests::network(),
+                &testing::network(),
                 &db_cache,
                 &mut db_data,
                 sapling_activation_height(),
@@ -487,7 +487,7 @@ mod tests {
         // Data+cache chain should be invalid at the data/cache boundary
         assert_matches!(
             scan_cached_blocks(
-                &tests::network(),
+                &testing::network(),
                 &db_cache,
                 &mut db_data,
                 sapling_activation_height() + 2,
@@ -505,7 +505,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -542,7 +542,7 @@ mod tests {
 
         // Scan the cache
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -584,7 +584,7 @@ mod tests {
 
         // Scan the cache again
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -606,7 +606,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -626,7 +626,7 @@ mod tests {
         );
         insert_into_cache(&db_cache, &cb1);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -660,7 +660,7 @@ mod tests {
         insert_into_cache(&db_cache, &cb3);
         assert_matches!(
             scan_cached_blocks(
-                &tests::network(),
+                &testing::network(),
                 &db_cache,
                 &mut db_data,
                 sapling_activation_height() + 2,
@@ -672,7 +672,7 @@ mod tests {
         // If we add a block of height SAPLING_ACTIVATION_HEIGHT + 1, we can now scan that
         insert_into_cache(&db_cache, &cb2);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -701,7 +701,7 @@ mod tests {
         assert_matches!(
             spend(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 crate::wallet::sapling::tests::test_prover(),
                 &input_selector,
                 &usk,
@@ -720,7 +720,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -746,7 +746,7 @@ mod tests {
 
         // Scan the cache
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -774,7 +774,7 @@ mod tests {
 
         // Scan the cache again
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -796,7 +796,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -822,7 +822,7 @@ mod tests {
 
         // Scan the cache
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -855,7 +855,7 @@ mod tests {
 
         // Scan the cache again
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -877,7 +877,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -920,7 +920,7 @@ mod tests {
 
         // Scan the spending block first.
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -936,7 +936,7 @@ mod tests {
 
         // Now scan the block in which we received the note that was spent.
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -325,7 +325,6 @@ mod tests {
     use std::num::NonZeroU32;
 
     use secrecy::Secret;
-    use tempfile::NamedTempFile;
 
     use zcash_primitives::{
         block::BlockHash,
@@ -336,9 +335,8 @@ mod tests {
     use zcash_client_backend::{
         address::RecipientAddress,
         data_api::{
-            chain::{error::Error, scan_cached_blocks},
-            wallet::{input_selection::GreedyInputSelector, spend},
-            WalletRead, WalletWrite,
+            chain::error::Error, wallet::input_selection::GreedyInputSelector, WalletRead,
+            WalletWrite,
         },
         fees::{zip317::SingleOutputChangeStrategy, DustOutputPolicy},
         scanning::ScanError,
@@ -347,340 +345,192 @@ mod tests {
     };
 
     use crate::{
-        chain::init::init_cache_database,
-        testing::{
-            self, fake_compact_block, fake_compact_block_spending, init_test_accounts_table,
-            insert_into_cache, sapling_activation_height, AddressType,
-        },
-        wallet::{get_balance, init::init_wallet_db, truncate_to_height},
-        AccountId, BlockDb, WalletDb,
+        testing::{AddressType, TestBuilder},
+        wallet::{get_balance, truncate_to_height},
+        AccountId,
     };
 
     #[test]
     fn valid_chain_states() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Empty chain should return None
-        assert_matches!(db_data.chain_height(), Ok(None));
+        assert_matches!(test.wallet().chain_height(), Ok(None));
 
         // Create a fake CompactBlock sending value to the address
-        let (cb, _) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
+        let (h1, _, _) = test.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(5).unwrap(),
-            0,
         );
 
-        insert_into_cache(&db_cache, &cb);
-
         // Scan the cache
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(h1, 1);
 
         // Create a second fake CompactBlock sending more value to the address
-        let (cb2, _) = fake_compact_block(
-            sapling_activation_height() + 1,
-            cb.hash(),
+        let (h2, _, _) = test.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(7).unwrap(),
-            1,
         );
-
-        insert_into_cache(&db_cache, &cb2);
 
         // Scanning should detect no inconsistencies
-        assert_matches!(
-            scan_cached_blocks(
-                &testing::network(),
-                &db_cache,
-                &mut db_data,
-                sapling_activation_height() + 1,
-                1,
-            ),
-            Ok(())
-        );
+        test.scan_cached_blocks(h2, 1);
     }
 
     #[test]
     fn invalid_chain_cache_disconnected() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Create some fake CompactBlocks
-        let (cb, _) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
+        let (h, _, _) = test.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(5).unwrap(),
-            0,
         );
-        let (cb2, _) = fake_compact_block(
-            sapling_activation_height() + 1,
-            cb.hash(),
+        let (last_contiguous_height, _, _) = test.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(7).unwrap(),
-            1,
         );
-        insert_into_cache(&db_cache, &cb);
-        insert_into_cache(&db_cache, &cb2);
 
         // Scanning the cache should find no inconsistencies
-        assert_matches!(
-            scan_cached_blocks(
-                &testing::network(),
-                &db_cache,
-                &mut db_data,
-                sapling_activation_height(),
-                2,
-            ),
-            Ok(())
-        );
+        test.scan_cached_blocks(h, 2);
 
         // Create more fake CompactBlocks that don't connect to the scanned ones
-        let (cb3, _) = fake_compact_block(
-            sapling_activation_height() + 2,
+        let disconnect_height = last_contiguous_height + 1;
+        test.generate_block_at(
+            disconnect_height,
             BlockHash([1; 32]),
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(8).unwrap(),
             2,
         );
-        let (cb4, _) = fake_compact_block(
-            sapling_activation_height() + 3,
-            cb3.hash(),
+        test.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
             Amount::from_u64(3).unwrap(),
-            3,
         );
-        insert_into_cache(&db_cache, &cb3);
-        insert_into_cache(&db_cache, &cb4);
 
         // Data+cache chain should be invalid at the data/cache boundary
         assert_matches!(
-            scan_cached_blocks(
-                &testing::network(),
-                &db_cache,
-                &mut db_data,
-                sapling_activation_height() + 2,
+            test.try_scan_cached_blocks(
+                disconnect_height,
                 2
             ),
             Err(Error::Scan(ScanError::PrevHashMismatch { at_height }))
-                if at_height == sapling_activation_height() + 2
+                if at_height == disconnect_height
         );
     }
 
     #[test]
     fn data_db_truncation() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Account balance should be zero
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
 
         // Create fake CompactBlocks sending value to the address
         let value = Amount::from_u64(5).unwrap();
         let value2 = Amount::from_u64(7).unwrap();
-        let (cb, _) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            0,
-        );
-
-        let (cb2, _) = fake_compact_block(
-            sapling_activation_height() + 1,
-            cb.hash(),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value2,
-            1,
-        );
-        insert_into_cache(&db_cache, &cb);
-        insert_into_cache(&db_cache, &cb2);
+        let (h, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        test.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
         // Scan the cache
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            2,
-        )
-        .unwrap();
+        test.scan_cached_blocks(h, 2);
 
         // Account balance should reflect both received notes
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value + value2).unwrap()
         );
 
         // "Rewind" to height of last scanned block
-        db_data
-            .transactionally(|wdb| {
-                truncate_to_height(wdb.conn.0, &wdb.params, sapling_activation_height() + 1)
-            })
+        test.wallet_mut()
+            .transactionally(|wdb| truncate_to_height(wdb.conn.0, &wdb.params, h + 1))
             .unwrap();
 
         // Account balance should be unaltered
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value + value2).unwrap()
         );
 
         // Rewind so that one block is dropped
-        db_data
-            .transactionally(|wdb| {
-                truncate_to_height(wdb.conn.0, &wdb.params, sapling_activation_height())
-            })
+        test.wallet_mut()
+            .transactionally(|wdb| truncate_to_height(wdb.conn.0, &wdb.params, h))
             .unwrap();
 
         // Account balance should only contain the first received note
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             value
         );
 
         // Scan the cache again
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            2,
-        )
-        .unwrap();
+        test.scan_cached_blocks(h, 2);
 
         // Account balance should again reflect both received notes
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value + value2).unwrap()
         );
     }
 
     #[test]
     fn scan_cached_blocks_allows_blocks_out_of_order() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
-
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .build();
 
         // Add an account to the wallet
         let seed = Secret::new([0u8; 32].to_vec());
-        let (_, usk) = db_data.create_account(&seed).unwrap();
+        let (_, usk) = test.wallet_mut().create_account(&seed).unwrap();
         let dfvk = usk.sapling().to_diversifiable_full_viewing_key();
 
         // Create a block with height SAPLING_ACTIVATION_HEIGHT
         let value = Amount::from_u64(50000).unwrap();
-        let (cb1, _) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            0,
-        );
-        insert_into_cache(&db_cache, &cb1);
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            1,
-        )
-        .unwrap();
+        let (h1, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        test.scan_cached_blocks(h1, 1);
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             value
         );
 
         // Create blocks to reach SAPLING_ACTIVATION_HEIGHT + 2
-        let (cb2, _) = fake_compact_block(
-            sapling_activation_height() + 1,
-            cb1.hash(),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            1,
-        );
-        let (cb3, _) = fake_compact_block(
-            sapling_activation_height() + 2,
-            cb2.hash(),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            2,
-        );
+        let (h2, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        let (h3, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the later block first
-        insert_into_cache(&db_cache, &cb3);
-        assert_matches!(
-            scan_cached_blocks(
-                &testing::network(),
-                &db_cache,
-                &mut db_data,
-                sapling_activation_height() + 2,
-                1
-            ),
-            Ok(_)
-        );
+        test.scan_cached_blocks(h3, 1);
 
-        // If we add a block of height SAPLING_ACTIVATION_HEIGHT + 1, we can now scan that
-        insert_into_cache(&db_cache, &cb2);
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height() + 1,
-            1,
-        )
-        .unwrap();
+        // Now scan the block of height SAPLING_ACTIVATION_HEIGHT + 1
+        test.scan_cached_blocks(h2, 1);
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::from_u64(150_000).unwrap()
         );
 
@@ -699,10 +549,7 @@ mod tests {
             DustOutputPolicy::default(),
         );
         assert_matches!(
-            spend(
-                &mut db_data,
-                &testing::network(),
-                crate::wallet::sapling::tests::test_prover(),
+            test.spend(
                 &input_selector,
                 &usk,
                 req,
@@ -715,124 +562,74 @@ mod tests {
 
     #[test]
     fn scan_cached_blocks_finds_received_notes() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Account balance should be zero
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
 
         // Create a fake CompactBlock sending value to the address
         let value = Amount::from_u64(5).unwrap();
-        let (cb, _) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            0,
-        );
-        insert_into_cache(&db_cache, &cb);
+        let (h1, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the cache
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(h1, 1);
 
         // Account balance should reflect the received note
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             value
         );
 
         // Create a second fake CompactBlock sending more value to the address
         let value2 = Amount::from_u64(7).unwrap();
-        let (cb2, _) = fake_compact_block(
-            sapling_activation_height() + 1,
-            cb.hash(),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value2,
-            1,
-        );
-        insert_into_cache(&db_cache, &cb2);
+        let (h2, _, _) = test.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
         // Scan the cache again
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height() + 1,
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(h2, 1);
 
         // Account balance should reflect both received notes
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value + value2).unwrap()
         );
     }
 
     #[test]
     fn scan_cached_blocks_finds_change_notes() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Account balance should be zero
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
 
         // Create a fake CompactBlock sending value to the address
         let value = Amount::from_u64(5).unwrap();
-        let (cb, nf) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            0,
-        );
-        insert_into_cache(&db_cache, &cb);
+        let (received_height, _, nf) =
+            test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the cache
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(received_height, 1);
 
         // Account balance should reflect the received note
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             value
         );
 
@@ -840,113 +637,60 @@ mod tests {
         let extsk2 = ExtendedSpendingKey::master(&[0]);
         let to2 = extsk2.default_address().1;
         let value2 = Amount::from_u64(2).unwrap();
-        insert_into_cache(
-            &db_cache,
-            &fake_compact_block_spending(
-                sapling_activation_height() + 1,
-                cb.hash(),
-                (nf, value),
-                &dfvk,
-                to2,
-                value2,
-                1,
-            ),
-        );
+        let (spent_height, _) = test.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
         // Scan the cache again
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height() + 1,
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(spent_height, 1);
 
         // Account balance should equal the change
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value - value2).unwrap()
         );
     }
 
     #[test]
     fn scan_cached_blocks_detects_spends_out_of_order() {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
-        init_cache_database(&db_cache).unwrap();
+        let mut test = TestBuilder::new()
+            .with_block_cache()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        let (dfvk, _taddr) = init_test_accounts_table(&mut db_data);
+        let dfvk = test.test_account_sapling().unwrap();
 
         // Account balance should be zero
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
 
         // Create a fake CompactBlock sending value to the address
         let value = Amount::from_u64(5).unwrap();
-        let (cb, nf) = fake_compact_block(
-            sapling_activation_height(),
-            BlockHash([0; 32]),
-            &dfvk,
-            AddressType::DefaultExternal,
-            value,
-            0,
-        );
-        insert_into_cache(&db_cache, &cb);
+        let (received_height, _, nf) =
+            test.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Create a second fake CompactBlock spending value from the address
         let extsk2 = ExtendedSpendingKey::master(&[0]);
         let to2 = extsk2.default_address().1;
         let value2 = Amount::from_u64(2).unwrap();
-        insert_into_cache(
-            &db_cache,
-            &fake_compact_block_spending(
-                sapling_activation_height() + 1,
-                cb.hash(),
-                (nf, value),
-                &dfvk,
-                to2,
-                value2,
-                1,
-            ),
-        );
+        let (spent_height, _) = test.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
         // Scan the spending block first.
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height() + 1,
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(spent_height, 1);
 
         // Account balance should equal the change
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value - value2).unwrap()
         );
 
         // Now scan the block in which we received the note that was spent.
-        scan_cached_blocks(
-            &testing::network(),
-            &db_cache,
-            &mut db_data,
-            sapling_activation_height(),
-            1,
-        )
-        .unwrap();
+        test.scan_cached_blocks(received_height, 1);
 
         // Account balance should be the same.
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             (value - value2).unwrap()
         );
     }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -90,6 +90,9 @@ pub mod serialization;
 pub mod wallet;
 use wallet::commitment_tree::{self, put_shard_roots};
 
+#[cfg(test)]
+mod testing;
+
 /// The maximum number of blocks the wallet is allowed to rewind. This is
 /// consistent with the bound in zcashd, and allows block data deeper than
 /// this delta from the chain tip to be pruned.
@@ -1082,317 +1085,33 @@ extern crate assert_matches;
 
 #[cfg(test)]
 mod tests {
-    use prost::Message;
-    use rand_core::{OsRng, RngCore};
-    use rusqlite::params;
-    use std::collections::HashMap;
-
-    #[cfg(feature = "unstable")]
-    use std::{fs::File, path::Path};
-
-    #[cfg(feature = "transparent-inputs")]
-    use zcash_primitives::{legacy, legacy::keys::IncomingViewingKey};
-
-    use zcash_note_encryption::Domain;
-    use zcash_primitives::{
-        block::BlockHash,
-        consensus::{BlockHeight, Network, NetworkUpgrade, Parameters},
-        legacy::TransparentAddress,
-        memo::MemoBytes,
-        sapling::{
-            note_encryption::{sapling_note_encryption, SaplingDomain},
-            util::generate_random_rseed,
-            value::NoteValue,
-            Note, Nullifier, PaymentAddress,
-        },
-        transaction::components::Amount,
-        zip32::{sapling::DiversifiableFullViewingKey, DiversifierIndex},
-    };
-
-    use zcash_client_backend::{
-        data_api::{WalletRead, WalletWrite},
-        keys::{sapling, UnifiedFullViewingKey},
-        proto::compact_formats::{
-            self as compact, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
-        },
-    };
+    use zcash_client_backend::data_api::{WalletRead, WalletWrite};
 
     use crate::{
-        wallet::init::{init_accounts_table, init_wallet_db},
+        testing::{init_test_accounts_table_ufvk, network},
+        wallet::init::init_wallet_db,
         AccountId, WalletDb,
     };
 
-    use super::BlockDb;
+    #[cfg(feature = "unstable")]
+    use zcash_primitives::{
+        block::BlockHash,
+        consensus::{BlockHeight, Parameters},
+        transaction::components::Amount,
+    };
 
     #[cfg(feature = "unstable")]
-    use super::{
-        chain::{init::init_blockmeta_db, BlockMeta},
+    use zcash_client_backend::keys::sapling;
+
+    #[cfg(feature = "unstable")]
+    use crate::{
+        chain::init::init_blockmeta_db,
+        testing::{fake_compact_block, store_in_fsblockdb, AddressType},
         FsBlockDb,
     };
 
-    #[cfg(feature = "mainnet")]
-    pub(crate) fn network() -> Network {
-        Network::MainNetwork
-    }
-
-    #[cfg(not(feature = "mainnet"))]
-    pub(crate) fn network() -> Network {
-        Network::TestNetwork
-    }
-
-    #[cfg(feature = "mainnet")]
-    pub(crate) fn sapling_activation_height() -> BlockHeight {
-        Network::MainNetwork
-            .activation_height(NetworkUpgrade::Sapling)
-            .unwrap()
-    }
-
-    #[cfg(not(feature = "mainnet"))]
-    pub(crate) fn sapling_activation_height() -> BlockHeight {
-        Network::TestNetwork
-            .activation_height(NetworkUpgrade::Sapling)
-            .unwrap()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn init_test_accounts_table(
-        db_data: &mut WalletDb<rusqlite::Connection, Network>,
-    ) -> (DiversifiableFullViewingKey, Option<TransparentAddress>) {
-        let (ufvk, taddr) = init_test_accounts_table_ufvk(db_data);
-        (ufvk.sapling().unwrap().clone(), taddr)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn init_test_accounts_table_ufvk(
-        db_data: &mut WalletDb<rusqlite::Connection, Network>,
-    ) -> (UnifiedFullViewingKey, Option<TransparentAddress>) {
-        let seed = [0u8; 32];
-        let account = AccountId::from(0);
-        let extsk = sapling::spending_key(&seed, network().coin_type(), account);
-        let dfvk = extsk.to_diversifiable_full_viewing_key();
-
-        #[cfg(feature = "transparent-inputs")]
-        let (tkey, taddr) = {
-            let tkey = legacy::keys::AccountPrivKey::from_seed(&network(), &seed, account)
-                .unwrap()
-                .to_account_pubkey();
-            let taddr = tkey.derive_external_ivk().unwrap().default_address().0;
-            (Some(tkey), Some(taddr))
-        };
-
-        #[cfg(not(feature = "transparent-inputs"))]
-        let taddr = None;
-
-        let ufvk = UnifiedFullViewingKey::new(
-            #[cfg(feature = "transparent-inputs")]
-            tkey,
-            Some(dfvk),
-            None,
-        )
-        .unwrap();
-
-        let ufvks = HashMap::from([(account, ufvk.clone())]);
-        init_accounts_table(db_data, &ufvks).unwrap();
-
-        (ufvk, taddr)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) enum AddressType {
-        DefaultExternal,
-        DiversifiedExternal(DiversifierIndex),
-        Internal,
-    }
-
-    /// Create a fake CompactBlock at the given height, containing a single output paying
-    /// an address. Returns the CompactBlock and the nullifier for the new note.
-    pub(crate) fn fake_compact_block(
-        height: BlockHeight,
-        prev_hash: BlockHash,
-        dfvk: &DiversifiableFullViewingKey,
-        req: AddressType,
-        value: Amount,
-        initial_sapling_tree_size: u32,
-    ) -> (CompactBlock, Nullifier) {
-        let to = match req {
-            AddressType::DefaultExternal => dfvk.default_address().1,
-            AddressType::DiversifiedExternal(idx) => dfvk.find_address(idx).unwrap().1,
-            AddressType::Internal => dfvk.change_address().1,
-        };
-
-        // Create a fake Note for the account
-        let mut rng = OsRng;
-        let rseed = generate_random_rseed(&network(), height, &mut rng);
-        let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
-        let encryptor = sapling_note_encryption::<_, Network>(
-            Some(dfvk.fvk().ovk),
-            note.clone(),
-            MemoBytes::empty(),
-            &mut rng,
-        );
-        let cmu = note.cmu().to_bytes().to_vec();
-        let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
-            .0
-            .to_vec();
-        let enc_ciphertext = encryptor.encrypt_note_plaintext();
-
-        // Create a fake CompactBlock containing the note
-        let cout = CompactSaplingOutput {
-            cmu,
-            ephemeral_key,
-            ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
-        };
-        let mut ctx = CompactTx::default();
-        let mut txid = vec![0; 32];
-        rng.fill_bytes(&mut txid);
-        ctx.hash = txid;
-        ctx.outputs.push(cout);
-        let mut cb = CompactBlock {
-            hash: {
-                let mut hash = vec![0; 32];
-                rng.fill_bytes(&mut hash);
-                hash
-            },
-            height: height.into(),
-            ..Default::default()
-        };
-        cb.prev_hash.extend_from_slice(&prev_hash.0);
-        cb.vtx.push(ctx);
-        cb.chain_metadata = Some(compact::ChainMetadata {
-            sapling_commitment_tree_size: initial_sapling_tree_size
-                + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
-            ..Default::default()
-        });
-        (cb, note.nf(&dfvk.fvk().vk.nk, 0))
-    }
-
-    /// Create a fake CompactBlock at the given height, spending a single note from the
-    /// given address.
-    pub(crate) fn fake_compact_block_spending(
-        height: BlockHeight,
-        prev_hash: BlockHash,
-        (nf, in_value): (Nullifier, Amount),
-        dfvk: &DiversifiableFullViewingKey,
-        to: PaymentAddress,
-        value: Amount,
-        initial_sapling_tree_size: u32,
-    ) -> CompactBlock {
-        let mut rng = OsRng;
-        let rseed = generate_random_rseed(&network(), height, &mut rng);
-
-        // Create a fake CompactBlock containing the note
-        let cspend = CompactSaplingSpend { nf: nf.to_vec() };
-        let mut ctx = CompactTx::default();
-        let mut txid = vec![0; 32];
-        rng.fill_bytes(&mut txid);
-        ctx.hash = txid;
-        ctx.spends.push(cspend);
-
-        // Create a fake Note for the payment
-        ctx.outputs.push({
-            let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
-            let encryptor = sapling_note_encryption::<_, Network>(
-                Some(dfvk.fvk().ovk),
-                note.clone(),
-                MemoBytes::empty(),
-                &mut rng,
-            );
-            let cmu = note.cmu().to_bytes().to_vec();
-            let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
-                .0
-                .to_vec();
-            let enc_ciphertext = encryptor.encrypt_note_plaintext();
-
-            CompactSaplingOutput {
-                cmu,
-                ephemeral_key,
-                ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
-            }
-        });
-
-        // Create a fake Note for the change
-        ctx.outputs.push({
-            let change_addr = dfvk.default_address().1;
-            let rseed = generate_random_rseed(&network(), height, &mut rng);
-            let note = Note::from_parts(
-                change_addr,
-                NoteValue::from_raw((in_value - value).unwrap().into()),
-                rseed,
-            );
-            let encryptor = sapling_note_encryption::<_, Network>(
-                Some(dfvk.fvk().ovk),
-                note.clone(),
-                MemoBytes::empty(),
-                &mut rng,
-            );
-            let cmu = note.cmu().to_bytes().to_vec();
-            let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
-                .0
-                .to_vec();
-            let enc_ciphertext = encryptor.encrypt_note_plaintext();
-
-            CompactSaplingOutput {
-                cmu,
-                ephemeral_key,
-                ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
-            }
-        });
-
-        let mut cb = CompactBlock {
-            hash: {
-                let mut hash = vec![0; 32];
-                rng.fill_bytes(&mut hash);
-                hash
-            },
-            height: height.into(),
-            ..Default::default()
-        };
-        cb.prev_hash.extend_from_slice(&prev_hash.0);
-        cb.vtx.push(ctx);
-        cb.chain_metadata = Some(compact::ChainMetadata {
-            sapling_commitment_tree_size: initial_sapling_tree_size
-                + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
-            ..Default::default()
-        });
-        cb
-    }
-
-    /// Insert a fake CompactBlock into the cache DB.
-    pub(crate) fn insert_into_cache(db_cache: &BlockDb, cb: &CompactBlock) {
-        let cb_bytes = cb.encode_to_vec();
-        db_cache
-            .0
-            .prepare("INSERT INTO compactblocks (height, data) VALUES (?, ?)")
-            .unwrap()
-            .execute(params![u32::from(cb.height()), cb_bytes,])
-            .unwrap();
-    }
-
     #[cfg(feature = "unstable")]
-    pub(crate) fn store_in_fsblockdb<P: AsRef<Path>>(
-        fsblockdb_root: P,
-        cb: &CompactBlock,
-    ) -> BlockMeta {
-        use std::io::Write;
-
-        let meta = BlockMeta {
-            height: cb.height(),
-            block_hash: cb.hash(),
-            block_time: cb.time,
-            sapling_outputs_count: cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum(),
-            orchard_actions_count: cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum(),
-        };
-
-        let blocks_dir = fsblockdb_root.as_ref().join("blocks");
-        let block_path = meta.block_file_path(&blocks_dir);
-
-        File::create(block_path)
-            .unwrap()
-            .write_all(&cb.encode_to_vec())
-            .unwrap();
-
-        meta
-    }
+    use super::BlockDb;
 
     #[test]
     pub(crate) fn get_next_available_address() {
@@ -1422,7 +1141,9 @@ mod tests {
         use secrecy::Secret;
         use tempfile::NamedTempFile;
 
-        use crate::{chain::init::init_cache_database, wallet::init::init_wallet_db};
+        use crate::{
+            chain::init::init_cache_database, testing::network, wallet::init::init_wallet_db,
+        };
 
         let cache_file = NamedTempFile::new().unwrap();
         let db_cache = BlockDb::for_path(cache_file.path()).unwrap();

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -518,14 +518,6 @@ pub(crate) fn sapling_activation_height() -> BlockHeight {
 }
 
 #[cfg(test)]
-pub(crate) fn init_test_accounts_table(
-    db_data: &mut WalletDb<rusqlite::Connection, Network>,
-) -> (DiversifiableFullViewingKey, Option<TransparentAddress>) {
-    let (ufvk, taddr) = init_test_accounts_table_ufvk(db_data);
-    (ufvk.sapling().unwrap().clone(), taddr)
-}
-
-#[cfg(test)]
 pub(crate) fn init_test_accounts_table_ufvk(
     db_data: &mut WalletDb<rusqlite::Connection, Network>,
 ) -> (UnifiedFullViewingKey, Option<TransparentAddress>) {

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1,0 +1,304 @@
+use std::collections::HashMap;
+
+#[cfg(feature = "unstable")]
+use std::{fs::File, path::Path};
+
+use prost::Message;
+use rand_core::{OsRng, RngCore};
+use rusqlite::params;
+
+use zcash_client_backend::{
+    keys::{sapling, UnifiedFullViewingKey},
+    proto::compact_formats::{
+        self as compact, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
+    },
+};
+use zcash_note_encryption::Domain;
+use zcash_primitives::{
+    block::BlockHash,
+    consensus::{BlockHeight, Network, NetworkUpgrade, Parameters},
+    legacy::TransparentAddress,
+    memo::MemoBytes,
+    sapling::{
+        note_encryption::{sapling_note_encryption, SaplingDomain},
+        util::generate_random_rseed,
+        value::NoteValue,
+        Note, Nullifier, PaymentAddress,
+    },
+    transaction::components::Amount,
+    zip32::{sapling::DiversifiableFullViewingKey, DiversifierIndex},
+};
+
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::{legacy, legacy::keys::IncomingViewingKey};
+
+use crate::{wallet::init::init_accounts_table, AccountId, WalletDb};
+
+use super::BlockDb;
+
+#[cfg(feature = "unstable")]
+use super::chain::BlockMeta;
+
+#[cfg(feature = "mainnet")]
+pub(crate) fn network() -> Network {
+    Network::MainNetwork
+}
+
+#[cfg(not(feature = "mainnet"))]
+pub(crate) fn network() -> Network {
+    Network::TestNetwork
+}
+
+#[cfg(feature = "mainnet")]
+pub(crate) fn sapling_activation_height() -> BlockHeight {
+    Network::MainNetwork
+        .activation_height(NetworkUpgrade::Sapling)
+        .unwrap()
+}
+
+#[cfg(not(feature = "mainnet"))]
+pub(crate) fn sapling_activation_height() -> BlockHeight {
+    Network::TestNetwork
+        .activation_height(NetworkUpgrade::Sapling)
+        .unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn init_test_accounts_table(
+    db_data: &mut WalletDb<rusqlite::Connection, Network>,
+) -> (DiversifiableFullViewingKey, Option<TransparentAddress>) {
+    let (ufvk, taddr) = init_test_accounts_table_ufvk(db_data);
+    (ufvk.sapling().unwrap().clone(), taddr)
+}
+
+#[cfg(test)]
+pub(crate) fn init_test_accounts_table_ufvk(
+    db_data: &mut WalletDb<rusqlite::Connection, Network>,
+) -> (UnifiedFullViewingKey, Option<TransparentAddress>) {
+    let seed = [0u8; 32];
+    let account = AccountId::from(0);
+    let extsk = sapling::spending_key(&seed, network().coin_type(), account);
+    let dfvk = extsk.to_diversifiable_full_viewing_key();
+
+    #[cfg(feature = "transparent-inputs")]
+    let (tkey, taddr) = {
+        let tkey = legacy::keys::AccountPrivKey::from_seed(&network(), &seed, account)
+            .unwrap()
+            .to_account_pubkey();
+        let taddr = tkey.derive_external_ivk().unwrap().default_address().0;
+        (Some(tkey), Some(taddr))
+    };
+
+    #[cfg(not(feature = "transparent-inputs"))]
+    let taddr = None;
+
+    let ufvk = UnifiedFullViewingKey::new(
+        #[cfg(feature = "transparent-inputs")]
+        tkey,
+        Some(dfvk),
+        None,
+    )
+    .unwrap();
+
+    let ufvks = HashMap::from([(account, ufvk.clone())]);
+    init_accounts_table(db_data, &ufvks).unwrap();
+
+    (ufvk, taddr)
+}
+
+#[allow(dead_code)]
+pub(crate) enum AddressType {
+    DefaultExternal,
+    DiversifiedExternal(DiversifierIndex),
+    Internal,
+}
+
+/// Create a fake CompactBlock at the given height, containing a single output paying
+/// an address. Returns the CompactBlock and the nullifier for the new note.
+pub(crate) fn fake_compact_block(
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    dfvk: &DiversifiableFullViewingKey,
+    req: AddressType,
+    value: Amount,
+    initial_sapling_tree_size: u32,
+) -> (CompactBlock, Nullifier) {
+    let to = match req {
+        AddressType::DefaultExternal => dfvk.default_address().1,
+        AddressType::DiversifiedExternal(idx) => dfvk.find_address(idx).unwrap().1,
+        AddressType::Internal => dfvk.change_address().1,
+    };
+
+    // Create a fake Note for the account
+    let mut rng = OsRng;
+    let rseed = generate_random_rseed(&network(), height, &mut rng);
+    let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
+    let encryptor = sapling_note_encryption::<_, Network>(
+        Some(dfvk.fvk().ovk),
+        note.clone(),
+        MemoBytes::empty(),
+        &mut rng,
+    );
+    let cmu = note.cmu().to_bytes().to_vec();
+    let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
+        .0
+        .to_vec();
+    let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+    // Create a fake CompactBlock containing the note
+    let cout = CompactSaplingOutput {
+        cmu,
+        ephemeral_key,
+        ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
+    };
+    let mut ctx = CompactTx::default();
+    let mut txid = vec![0; 32];
+    rng.fill_bytes(&mut txid);
+    ctx.hash = txid;
+    ctx.outputs.push(cout);
+    let mut cb = CompactBlock {
+        hash: {
+            let mut hash = vec![0; 32];
+            rng.fill_bytes(&mut hash);
+            hash
+        },
+        height: height.into(),
+        ..Default::default()
+    };
+    cb.prev_hash.extend_from_slice(&prev_hash.0);
+    cb.vtx.push(ctx);
+    cb.chain_metadata = Some(compact::ChainMetadata {
+        sapling_commitment_tree_size: initial_sapling_tree_size
+            + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
+        ..Default::default()
+    });
+    (cb, note.nf(&dfvk.fvk().vk.nk, 0))
+}
+
+/// Create a fake CompactBlock at the given height, spending a single note from the
+/// given address.
+pub(crate) fn fake_compact_block_spending(
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    (nf, in_value): (Nullifier, Amount),
+    dfvk: &DiversifiableFullViewingKey,
+    to: PaymentAddress,
+    value: Amount,
+    initial_sapling_tree_size: u32,
+) -> CompactBlock {
+    let mut rng = OsRng;
+    let rseed = generate_random_rseed(&network(), height, &mut rng);
+
+    // Create a fake CompactBlock containing the note
+    let cspend = CompactSaplingSpend { nf: nf.to_vec() };
+    let mut ctx = CompactTx::default();
+    let mut txid = vec![0; 32];
+    rng.fill_bytes(&mut txid);
+    ctx.hash = txid;
+    ctx.spends.push(cspend);
+
+    // Create a fake Note for the payment
+    ctx.outputs.push({
+        let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
+        let encryptor = sapling_note_encryption::<_, Network>(
+            Some(dfvk.fvk().ovk),
+            note.clone(),
+            MemoBytes::empty(),
+            &mut rng,
+        );
+        let cmu = note.cmu().to_bytes().to_vec();
+        let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
+            .0
+            .to_vec();
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+        CompactSaplingOutput {
+            cmu,
+            ephemeral_key,
+            ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
+        }
+    });
+
+    // Create a fake Note for the change
+    ctx.outputs.push({
+        let change_addr = dfvk.default_address().1;
+        let rseed = generate_random_rseed(&network(), height, &mut rng);
+        let note = Note::from_parts(
+            change_addr,
+            NoteValue::from_raw((in_value - value).unwrap().into()),
+            rseed,
+        );
+        let encryptor = sapling_note_encryption::<_, Network>(
+            Some(dfvk.fvk().ovk),
+            note.clone(),
+            MemoBytes::empty(),
+            &mut rng,
+        );
+        let cmu = note.cmu().to_bytes().to_vec();
+        let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
+            .0
+            .to_vec();
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+        CompactSaplingOutput {
+            cmu,
+            ephemeral_key,
+            ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
+        }
+    });
+
+    let mut cb = CompactBlock {
+        hash: {
+            let mut hash = vec![0; 32];
+            rng.fill_bytes(&mut hash);
+            hash
+        },
+        height: height.into(),
+        ..Default::default()
+    };
+    cb.prev_hash.extend_from_slice(&prev_hash.0);
+    cb.vtx.push(ctx);
+    cb.chain_metadata = Some(compact::ChainMetadata {
+        sapling_commitment_tree_size: initial_sapling_tree_size
+            + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
+        ..Default::default()
+    });
+    cb
+}
+
+/// Insert a fake CompactBlock into the cache DB.
+pub(crate) fn insert_into_cache(db_cache: &BlockDb, cb: &CompactBlock) {
+    let cb_bytes = cb.encode_to_vec();
+    db_cache
+        .0
+        .prepare("INSERT INTO compactblocks (height, data) VALUES (?, ?)")
+        .unwrap()
+        .execute(params![u32::from(cb.height()), cb_bytes,])
+        .unwrap();
+}
+
+#[cfg(feature = "unstable")]
+pub(crate) fn store_in_fsblockdb<P: AsRef<Path>>(
+    fsblockdb_root: P,
+    cb: &CompactBlock,
+) -> BlockMeta {
+    use std::io::Write;
+
+    let meta = BlockMeta {
+        height: cb.height(),
+        block_hash: cb.hash(),
+        block_time: cb.time,
+        sapling_outputs_count: cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum(),
+        orchard_actions_count: cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum(),
+    };
+
+    let blocks_dir = fsblockdb_root.as_ref().join("blocks");
+    let block_path = meta.block_file_path(&blocks_dir);
+
+    File::create(block_path)
+        .unwrap()
+        .write_all(&cb.encode_to_vec())
+        .unwrap();
+
+    meta
+}

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -55,7 +55,7 @@ use zcash_primitives::{
 };
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_client_backend::data_api::wallet::shield_transparent_funds;
+use zcash_client_backend::data_api::wallet::{propose_shielding, shield_transparent_funds};
 #[cfg(feature = "transparent-inputs")]
 use zcash_primitives::{
     legacy, legacy::keys::IncomingViewingKey, transaction::components::amount::NonNegativeAmount,
@@ -418,6 +418,38 @@ impl<Cache> TestState<Cache> {
             spend_from_account,
             input_selector,
             request,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`propose_shielding`] with the given arguments.
+    #[cfg(feature = "transparent-inputs")]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn propose_shielding<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        shielding_threshold: NonNegativeAmount,
+        from_addrs: &[TransparentAddress],
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        Proposal<InputsT::FeeRule, ReceivedNoteId>,
+        data_api::error::Error<
+            SqliteClientError,
+            Infallible,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+            ReceivedNoteId,
+        >,
+    >
+    where
+        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+    {
+        propose_shielding::<_, _, _, Infallible>(
+            &mut self.db_data,
+            &self.params,
+            input_selector,
+            shielding_threshold,
+            from_addrs,
             min_confirmations,
         )
     }

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -129,8 +129,8 @@ impl<Cache> TestBuilder<Cache> {
         self
     }
 
-    /// Builds the runner for this test.
-    pub(crate) fn build(self) -> TestRunner<Cache> {
+    /// Builds the state for this test.
+    pub(crate) fn build(self) -> TestState<Cache> {
         let params = network();
 
         let data_file = NamedTempFile::new().unwrap();
@@ -144,7 +144,7 @@ impl<Cache> TestBuilder<Cache> {
             None
         };
 
-        TestRunner {
+        TestState {
             params,
             cache: self.cache,
             latest_cached_block: None,
@@ -155,8 +155,8 @@ impl<Cache> TestBuilder<Cache> {
     }
 }
 
-/// A `zcash_client_sqlite` test runner.
-pub(crate) struct TestRunner<Cache> {
+/// The state for a `zcash_client_sqlite` test.
+pub(crate) struct TestState<Cache> {
     params: Network,
     cache: Cache,
     latest_cached_block: Option<(BlockHeight, BlockHash, u32)>,
@@ -165,7 +165,7 @@ pub(crate) struct TestRunner<Cache> {
     test_account: Option<(UnifiedFullViewingKey, Option<TransparentAddress>)>,
 }
 
-impl<Cache: TestCache> TestRunner<Cache>
+impl<Cache: TestCache> TestState<Cache>
 where
     <Cache::BlockSource as BlockSource>::Error: fmt::Debug,
 {
@@ -297,7 +297,7 @@ where
     }
 }
 
-impl<Cache> TestRunner<Cache> {
+impl<Cache> TestState<Cache> {
     /// Exposes an immutable reference to the test's [`WalletDb`].
     pub(crate) fn wallet(&self) -> &WalletDb<Connection, Network> {
         &self.db_data

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1,17 +1,38 @@
-use std::collections::HashMap;
+use std::convert::Infallible;
+use std::fmt;
+use std::{collections::HashMap, num::NonZeroU32};
 
 #[cfg(feature = "unstable")]
-use std::{fs::File, path::Path};
+use std::fs::File;
 
 use prost::Message;
 use rand_core::{OsRng, RngCore};
-use rusqlite::params;
+use rusqlite::{params, Connection};
+use secrecy::SecretVec;
+use tempfile::NamedTempFile;
 
+#[cfg(feature = "unstable")]
+use tempfile::TempDir;
+
+#[allow(deprecated)]
+use zcash_client_backend::data_api::wallet::create_spend_to_address;
 use zcash_client_backend::{
-    keys::{sapling, UnifiedFullViewingKey},
+    address::RecipientAddress,
+    data_api::{
+        self,
+        chain::{scan_cached_blocks, BlockSource},
+        wallet::{
+            create_proposed_transaction,
+            input_selection::{GreedyInputSelectorError, InputSelector, Proposal},
+            propose_transfer, spend,
+        },
+    },
+    keys::{sapling, UnifiedFullViewingKey, UnifiedSpendingKey},
     proto::compact_formats::{
         self as compact, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },
+    wallet::OvkPolicy,
+    zip321,
 };
 use zcash_note_encryption::Domain;
 use zcash_primitives::{
@@ -25,19 +46,452 @@ use zcash_primitives::{
         value::NoteValue,
         Note, Nullifier, PaymentAddress,
     },
-    transaction::components::Amount,
+    transaction::{
+        components::{amount::BalanceError, Amount},
+        fees::FeeRule,
+        TxId,
+    },
     zip32::{sapling::DiversifiableFullViewingKey, DiversifierIndex},
 };
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::{legacy, legacy::keys::IncomingViewingKey};
+use zcash_client_backend::data_api::wallet::shield_transparent_funds;
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::{
+    legacy, legacy::keys::IncomingViewingKey, transaction::components::amount::NonNegativeAmount,
+};
 
-use crate::{wallet::init::init_accounts_table, AccountId, WalletDb};
+use crate::{
+    chain::init::init_cache_database,
+    error::SqliteClientError,
+    wallet::{
+        commitment_tree,
+        init::{init_accounts_table, init_wallet_db},
+        sapling::tests::test_prover,
+    },
+    AccountId, ReceivedNoteId, WalletDb,
+};
 
 use super::BlockDb;
 
 #[cfg(feature = "unstable")]
-use super::chain::BlockMeta;
+use crate::{
+    chain::{init::init_blockmeta_db, BlockMeta},
+    FsBlockDb,
+};
+/// A builder for a `zcash_client_sqlite` test.
+pub(crate) struct TestBuilder<Cache> {
+    cache: Cache,
+    seed: Option<SecretVec<u8>>,
+    with_test_account: bool,
+}
+
+impl TestBuilder<()> {
+    /// Constructs a new test.
+    pub(crate) fn new() -> Self {
+        TestBuilder {
+            cache: (),
+            seed: None,
+            with_test_account: false,
+        }
+    }
+
+    /// Adds a [`BlockDb`] cache to the test.
+    pub(crate) fn with_block_cache(self) -> TestBuilder<BlockCache> {
+        TestBuilder {
+            cache: BlockCache::new(),
+            seed: self.seed,
+            with_test_account: self.with_test_account,
+        }
+    }
+
+    /// Adds a [`FsBlockDb`] cache to the test.
+    #[cfg(feature = "unstable")]
+    pub(crate) fn with_fs_block_cache(self) -> TestBuilder<FsBlockCache> {
+        TestBuilder {
+            cache: FsBlockCache::new(),
+            seed: self.seed,
+            with_test_account: self.with_test_account,
+        }
+    }
+}
+
+impl<Cache> TestBuilder<Cache> {
+    /// Gives the test knowledge of the wallet seed for initialization.
+    pub(crate) fn with_seed(mut self, seed: SecretVec<u8>) -> Self {
+        // TODO remove
+        self.seed = Some(seed);
+        self
+    }
+
+    pub(crate) fn with_test_account(mut self) -> Self {
+        self.with_test_account = true;
+        self
+    }
+
+    /// Builds the runner for this test.
+    pub(crate) fn build(self) -> TestRunner<Cache> {
+        let params = network();
+
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), params).unwrap();
+        init_wallet_db(&mut db_data, self.seed).unwrap();
+
+        let test_account = if self.with_test_account {
+            // Add an account to the wallet
+            Some(init_test_accounts_table_ufvk(&mut db_data))
+        } else {
+            None
+        };
+
+        TestRunner {
+            params,
+            cache: self.cache,
+            latest_cached_block: None,
+            _data_file: data_file,
+            db_data,
+            test_account,
+        }
+    }
+}
+
+/// A `zcash_client_sqlite` test runner.
+pub(crate) struct TestRunner<Cache> {
+    params: Network,
+    cache: Cache,
+    latest_cached_block: Option<(BlockHeight, BlockHash, u32)>,
+    _data_file: NamedTempFile,
+    db_data: WalletDb<Connection, Network>,
+    test_account: Option<(UnifiedFullViewingKey, Option<TransparentAddress>)>,
+}
+
+impl<Cache: TestCache> TestRunner<Cache>
+where
+    <Cache::BlockSource as BlockSource>::Error: fmt::Debug,
+{
+    /// Exposes an immutable reference to the test's [`BlockSource`].
+    #[cfg(feature = "unstable")]
+    pub(crate) fn cache(&self) -> &Cache::BlockSource {
+        self.cache.block_source()
+    }
+
+    /// Creates a fake block at the expected next height containing a single output of the
+    /// given value, and inserts it into the cache.
+    pub(crate) fn generate_next_block(
+        &mut self,
+        dfvk: &DiversifiableFullViewingKey,
+        req: AddressType,
+        value: Amount,
+    ) -> (BlockHeight, Cache::InsertResult, Nullifier) {
+        let (height, prev_hash, initial_sapling_tree_size) = self
+            .latest_cached_block
+            .map(|(prev_height, prev_hash, end_size)| (prev_height + 1, prev_hash, end_size))
+            .unwrap_or_else(|| (sapling_activation_height(), BlockHash([0; 32]), 0));
+
+        let (res, nf) = self.generate_block_at(
+            height,
+            prev_hash,
+            dfvk,
+            req,
+            value,
+            initial_sapling_tree_size,
+        );
+
+        (height, res, nf)
+    }
+
+    /// Creates a fake block with the given height and hash containing a single output of
+    /// the given value, and inserts it into the cache.
+    ///
+    /// This generated block will be treated as the latest block, and subsequent calls to
+    /// [`Self::generate_next_block`] will build on it.
+    pub(crate) fn generate_block_at(
+        &mut self,
+        height: BlockHeight,
+        prev_hash: BlockHash,
+        dfvk: &DiversifiableFullViewingKey,
+        req: AddressType,
+        value: Amount,
+        initial_sapling_tree_size: u32,
+    ) -> (Cache::InsertResult, Nullifier) {
+        let (cb, nf) = fake_compact_block(
+            height,
+            prev_hash,
+            dfvk,
+            req,
+            value,
+            initial_sapling_tree_size,
+        );
+        let res = self.cache.insert(&cb);
+
+        self.latest_cached_block = Some((
+            height,
+            cb.hash(),
+            initial_sapling_tree_size
+                + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
+        ));
+
+        (res, nf)
+    }
+
+    /// Creates a fake block at the expected next height spending the given note, and
+    /// inserts it into the cache.
+    pub(crate) fn generate_next_block_spending(
+        &mut self,
+        dfvk: &DiversifiableFullViewingKey,
+        note: (Nullifier, Amount),
+        to: PaymentAddress,
+        value: Amount,
+    ) -> (BlockHeight, Cache::InsertResult) {
+        let (height, prev_hash, initial_sapling_tree_size) = self
+            .latest_cached_block
+            .map(|(prev_height, prev_hash, end_size)| (prev_height + 1, prev_hash, end_size))
+            .unwrap_or_else(|| (sapling_activation_height(), BlockHash([0; 32]), 0));
+
+        let cb = fake_compact_block_spending(
+            height,
+            prev_hash,
+            note,
+            dfvk,
+            to,
+            value,
+            initial_sapling_tree_size,
+        );
+        let res = self.cache.insert(&cb);
+
+        self.latest_cached_block = Some((
+            height,
+            cb.hash(),
+            initial_sapling_tree_size
+                + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
+        ));
+
+        (height, res)
+    }
+
+    /// Invokes [`scan_cached_blocks`] with the given arguments, expecting success.
+    pub(crate) fn scan_cached_blocks(&mut self, from_height: BlockHeight, limit: usize) {
+        self.try_scan_cached_blocks(from_height, limit)
+            .expect("should succeed for this test");
+    }
+
+    /// Invokes [`scan_cached_blocks`] with the given arguments.
+    pub(crate) fn try_scan_cached_blocks(
+        &mut self,
+        from_height: BlockHeight,
+        limit: usize,
+    ) -> Result<
+        (),
+        data_api::chain::error::Error<
+            SqliteClientError,
+            <Cache::BlockSource as BlockSource>::Error,
+        >,
+    > {
+        scan_cached_blocks(
+            &self.params,
+            self.cache.block_source(),
+            &mut self.db_data,
+            from_height,
+            limit,
+        )
+    }
+}
+
+impl<Cache> TestRunner<Cache> {
+    /// Exposes an immutable reference to the test's [`WalletDb`].
+    pub(crate) fn wallet(&self) -> &WalletDb<Connection, Network> {
+        &self.db_data
+    }
+
+    /// Exposes a mutable reference to the test's [`WalletDb`].
+    pub(crate) fn wallet_mut(&mut self) -> &mut WalletDb<Connection, Network> {
+        &mut self.db_data
+    }
+
+    /// Exposes the test account, if enabled via [`TestBuilder::with_test_account`].
+    #[cfg(feature = "unstable")]
+    pub(crate) fn test_account(
+        &self,
+    ) -> Option<(UnifiedFullViewingKey, Option<TransparentAddress>)> {
+        self.test_account.as_ref().cloned()
+    }
+
+    /// Exposes the test account's Sapling DFVK, if enabled via [`TestBuilder::with_test_account`].
+    pub(crate) fn test_account_sapling(&self) -> Option<DiversifiableFullViewingKey> {
+        self.test_account
+            .as_ref()
+            .map(|(ufvk, _)| ufvk.sapling().unwrap().clone())
+    }
+
+    /// Invokes [`create_spend_to_address`] with the given arguments.
+    #[allow(deprecated)]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn create_spend_to_address(
+        &mut self,
+        usk: &UnifiedSpendingKey,
+        to: &RecipientAddress,
+        amount: Amount,
+        memo: Option<MemoBytes>,
+        ovk_policy: OvkPolicy,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        TxId,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            GreedyInputSelectorError<BalanceError, ReceivedNoteId>,
+            Infallible,
+            ReceivedNoteId,
+        >,
+    > {
+        create_spend_to_address(
+            &mut self.db_data,
+            &self.params,
+            test_prover(),
+            usk,
+            to,
+            amount,
+            memo,
+            ovk_policy,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`spend`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn spend<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        usk: &UnifiedSpendingKey,
+        request: zip321::TransactionRequest,
+        ovk_policy: OvkPolicy,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        TxId,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+            ReceivedNoteId,
+        >,
+    >
+    where
+        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+    {
+        spend(
+            &mut self.db_data,
+            &self.params,
+            test_prover(),
+            input_selector,
+            usk,
+            request,
+            ovk_policy,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`propose_transfer`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn propose_transfer<InputsT>(
+        &mut self,
+        spend_from_account: AccountId,
+        input_selector: &InputsT,
+        request: zip321::TransactionRequest,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        Proposal<InputsT::FeeRule, ReceivedNoteId>,
+        data_api::error::Error<
+            SqliteClientError,
+            Infallible,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+            ReceivedNoteId,
+        >,
+    >
+    where
+        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+    {
+        propose_transfer::<_, _, _, Infallible>(
+            &mut self.db_data,
+            &self.params,
+            spend_from_account,
+            input_selector,
+            request,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`create_proposed_transaction`] with the given arguments.
+    pub(crate) fn create_proposed_transaction<FeeRuleT>(
+        &mut self,
+        usk: &UnifiedSpendingKey,
+        ovk_policy: OvkPolicy,
+        proposal: Proposal<FeeRuleT, ReceivedNoteId>,
+        min_confirmations: NonZeroU32,
+        change_memo: Option<MemoBytes>,
+    ) -> Result<
+        TxId,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            Infallible,
+            FeeRuleT::Error,
+            ReceivedNoteId,
+        >,
+    >
+    where
+        FeeRuleT: FeeRule,
+    {
+        create_proposed_transaction::<_, _, Infallible, _>(
+            &mut self.db_data,
+            &self.params,
+            test_prover(),
+            usk,
+            ovk_policy,
+            proposal,
+            min_confirmations,
+            change_memo,
+        )
+    }
+
+    /// Invokes [`shield_transparent_funds`] with the given arguments.
+    #[cfg(feature = "transparent-inputs")]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn shield_transparent_funds<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        shielding_threshold: NonNegativeAmount,
+        usk: &UnifiedSpendingKey,
+        from_addrs: &[TransparentAddress],
+        memo: &MemoBytes,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        TxId,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+            ReceivedNoteId,
+        >,
+    >
+    where
+        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+    {
+        shield_transparent_funds(
+            &mut self.db_data,
+            &self.params,
+            test_prover(),
+            input_selector,
+            shielding_threshold,
+            usk,
+            from_addrs,
+            memo,
+            min_confirmations,
+        )
+    }
+}
 
 #[cfg(feature = "mainnet")]
 pub(crate) fn network() -> Network {
@@ -266,39 +720,103 @@ pub(crate) fn fake_compact_block_spending(
     cb
 }
 
-/// Insert a fake CompactBlock into the cache DB.
-pub(crate) fn insert_into_cache(db_cache: &BlockDb, cb: &CompactBlock) {
-    let cb_bytes = cb.encode_to_vec();
-    db_cache
-        .0
-        .prepare("INSERT INTO compactblocks (height, data) VALUES (?, ?)")
-        .unwrap()
-        .execute(params![u32::from(cb.height()), cb_bytes,])
-        .unwrap();
+/// Trait used by tests that require a block cache.
+pub(crate) trait TestCache {
+    type BlockSource: BlockSource;
+    type InsertResult;
+
+    /// Exposes the block cache as a [`BlockSource`].
+    fn block_source(&self) -> &Self::BlockSource;
+
+    /// Inserts a CompactBlock into the cache DB.
+    fn insert(&self, cb: &CompactBlock) -> Self::InsertResult;
+}
+
+pub(crate) struct BlockCache {
+    _cache_file: NamedTempFile,
+    db_cache: BlockDb,
+}
+
+impl BlockCache {
+    fn new() -> Self {
+        let cache_file = NamedTempFile::new().unwrap();
+        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
+        init_cache_database(&db_cache).unwrap();
+
+        BlockCache {
+            _cache_file: cache_file,
+            db_cache,
+        }
+    }
+}
+
+impl TestCache for BlockCache {
+    type BlockSource = BlockDb;
+    type InsertResult = ();
+
+    fn block_source(&self) -> &Self::BlockSource {
+        &self.db_cache
+    }
+
+    fn insert(&self, cb: &CompactBlock) {
+        let cb_bytes = cb.encode_to_vec();
+        self.db_cache
+            .0
+            .prepare("INSERT INTO compactblocks (height, data) VALUES (?, ?)")
+            .unwrap()
+            .execute(params![u32::from(cb.height()), cb_bytes,])
+            .unwrap();
+    }
 }
 
 #[cfg(feature = "unstable")]
-pub(crate) fn store_in_fsblockdb<P: AsRef<Path>>(
-    fsblockdb_root: P,
-    cb: &CompactBlock,
-) -> BlockMeta {
-    use std::io::Write;
+pub(crate) struct FsBlockCache {
+    fsblockdb_root: TempDir,
+    db_meta: FsBlockDb,
+}
 
-    let meta = BlockMeta {
-        height: cb.height(),
-        block_hash: cb.hash(),
-        block_time: cb.time,
-        sapling_outputs_count: cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum(),
-        orchard_actions_count: cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum(),
-    };
+#[cfg(feature = "unstable")]
+impl FsBlockCache {
+    fn new() -> Self {
+        let fsblockdb_root = tempfile::tempdir().unwrap();
+        let mut db_meta = FsBlockDb::for_path(&fsblockdb_root).unwrap();
+        init_blockmeta_db(&mut db_meta).unwrap();
 
-    let blocks_dir = fsblockdb_root.as_ref().join("blocks");
-    let block_path = meta.block_file_path(&blocks_dir);
+        FsBlockCache {
+            fsblockdb_root,
+            db_meta,
+        }
+    }
+}
 
-    File::create(block_path)
-        .unwrap()
-        .write_all(&cb.encode_to_vec())
-        .unwrap();
+#[cfg(feature = "unstable")]
+impl TestCache for FsBlockCache {
+    type BlockSource = FsBlockDb;
+    type InsertResult = BlockMeta;
 
-    meta
+    fn block_source(&self) -> &Self::BlockSource {
+        &self.db_meta
+    }
+
+    fn insert(&self, cb: &CompactBlock) -> Self::InsertResult {
+        use std::io::Write;
+
+        let meta = BlockMeta {
+            height: cb.height(),
+            block_hash: cb.hash(),
+            block_time: cb.time,
+            sapling_outputs_count: cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum(),
+            orchard_actions_count: cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum(),
+        };
+
+        let blocks_dir = self.fsblockdb_root.as_ref().join("blocks");
+        let block_path = meta.block_file_path(&blocks_dir);
+
+        File::create(block_path)
+            .unwrap()
+            .write_all(&cb.encode_to_vec())
+            .unwrap();
+
+        meta
+    }
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1579,7 +1579,7 @@ mod tests {
     use zcash_client_backend::data_api::WalletRead;
 
     use crate::{
-        tests,
+        testing,
         wallet::{get_current_address, init::init_wallet_db},
         AccountId, WalletDb,
     };
@@ -1600,11 +1600,11 @@ mod tests {
     #[test]
     fn empty_database_has_no_balance() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
-        tests::init_test_accounts_table(&mut db_data);
+        testing::init_test_accounts_table(&mut db_data);
 
         // The account should be empty
         assert_eq!(
@@ -1635,7 +1635,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     fn put_received_transparent_utxo() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1572,17 +1572,12 @@ mod tests {
     use std::num::NonZeroU32;
 
     use secrecy::Secret;
-    use tempfile::NamedTempFile;
 
     use zcash_primitives::transaction::components::Amount;
 
     use zcash_client_backend::data_api::WalletRead;
 
-    use crate::{
-        testing,
-        wallet::{get_current_address, init::init_wallet_db},
-        AccountId, WalletDb,
-    };
+    use crate::{testing::TestBuilder, AccountId};
 
     use super::get_balance;
 
@@ -1599,22 +1594,20 @@ mod tests {
 
     #[test]
     fn empty_database_has_no_balance() {
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
-
-        // Add an account to the wallet
-        testing::init_test_accounts_table(&mut db_data);
+        let test = TestBuilder::new()
+            .with_seed(Secret::new(vec![]))
+            .with_test_account()
+            .build();
 
         // The account should be empty
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
 
         // We can't get an anchor height, as we have not scanned any blocks.
         assert_eq!(
-            db_data
+            test.wallet()
                 .get_target_and_anchor_heights(NonZeroU32::new(10).unwrap())
                 .unwrap(),
             None
@@ -1622,11 +1615,11 @@ mod tests {
 
         // An invalid account has zero balance
         assert_matches!(
-            get_current_address(&db_data.conn, &db_data.params, AccountId::from(1)),
+            test.wallet().get_current_address(AccountId::from(1)),
             Ok(None)
         );
         assert_eq!(
-            get_balance(&db_data.conn, AccountId::from(0)).unwrap(),
+            get_balance(&test.wallet().conn, AccountId::from(0)).unwrap(),
             Amount::zero()
         );
     }
@@ -1634,17 +1627,20 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn put_received_transparent_utxo() {
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
-        init_wallet_db(&mut db_data, None).unwrap();
+        let mut test = TestBuilder::new().build();
 
         // Add an account to the wallet
         let seed = Secret::new([0u8; 32].to_vec());
-        let (account_id, _usk) = db_data.create_account(&seed).unwrap();
-        let uaddr = db_data.get_current_address(account_id).unwrap().unwrap();
+        let (account_id, _usk) = test.wallet_mut().create_account(&seed).unwrap();
+        let uaddr = test
+            .wallet()
+            .get_current_address(account_id)
+            .unwrap()
+            .unwrap();
         let taddr = uaddr.transparent().unwrap();
 
-        let bal_absent = db_data
+        let bal_absent = test
+            .wallet()
             .get_transparent_balances(account_id, BlockHeight::from_u32(12345))
             .unwrap();
         assert!(bal_absent.is_empty());
@@ -1659,7 +1655,7 @@ mod tests {
         )
         .unwrap();
 
-        let res0 = super::put_received_transparent_utxo(&db_data.conn, &db_data.params, &utxo);
+        let res0 = test.wallet_mut().put_received_transparent_utxo(&utxo);
         assert_matches!(res0, Ok(_));
 
         // Change the mined height of the UTXO and upsert; we should get back
@@ -1673,13 +1669,11 @@ mod tests {
             BlockHeight::from_u32(34567),
         )
         .unwrap();
-        let res1 = super::put_received_transparent_utxo(&db_data.conn, &db_data.params, &utxo2);
+        let res1 = test.wallet_mut().put_received_transparent_utxo(&utxo2);
         assert_matches!(res1, Ok(id) if id == res0.unwrap());
 
         assert_matches!(
-            super::get_unspent_transparent_outputs(
-                &db_data.conn,
-                &db_data.params,
+            test.wallet().get_unspent_transparent_outputs(
                 taddr,
                 BlockHeight::from_u32(12345),
                 &[]
@@ -1688,9 +1682,7 @@ mod tests {
         );
 
         assert_matches!(
-            super::get_unspent_transparent_outputs(
-                &db_data.conn,
-                &db_data.params,
+            test.wallet().get_unspent_transparent_outputs(
                 taddr,
                 BlockHeight::from_u32(34567),
                 &[]
@@ -1702,21 +1694,21 @@ mod tests {
         );
 
         assert_matches!(
-            db_data.get_transparent_balances(account_id, BlockHeight::from_u32(34567)),
+            test.wallet().get_transparent_balances(account_id, BlockHeight::from_u32(34567)),
             Ok(h) if h.get(taddr) == Amount::from_u64(100000).ok().as_ref()
         );
 
         // Artificially delete the address from the addresses table so that
         // we can ensure the update fails if the join doesn't work.
-        db_data
+        test.wallet()
             .conn
             .execute(
                 "DELETE FROM addresses WHERE cached_transparent_receiver_address = ?",
-                [Some(taddr.encode(&db_data.params))],
+                [Some(taddr.encode(&test.wallet().params))],
             )
             .unwrap();
 
-        let res2 = super::put_received_transparent_utxo(&db_data.conn, &db_data.params, &utxo2);
+        let res2 = test.wallet_mut().put_received_transparent_utxo(&utxo2);
         assert_matches!(res2, Err(_));
     }
 }

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -988,11 +988,11 @@ mod tests {
     use zcash_primitives::consensus::BlockHeight;
 
     use super::SqliteShardStore;
-    use crate::{tests, wallet::init::init_wallet_db, WalletDb, SAPLING_TABLES_PREFIX};
+    use crate::{testing, wallet::init::init_wallet_db, WalletDb, SAPLING_TABLES_PREFIX};
 
     fn new_tree(m: usize) -> ShardTree<SqliteShardStore<rusqlite::Connection, String, 3>, 4, 3> {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         data_file.keep().unwrap();
 
         init_wallet_db(&mut db_data, None).unwrap();
@@ -1040,7 +1040,7 @@ mod tests {
     #[test]
     fn put_shard_roots() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         data_file.keep().unwrap();
 
         init_wallet_db(&mut db_data, None).unwrap();

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -393,7 +393,7 @@ mod tests {
 
     use crate::{
         error::SqliteClientError,
-        tests::{self, network},
+        testing::{self, network},
         wallet::scanning::priority_code,
         AccountId, WalletDb,
     };
@@ -415,7 +415,7 @@ mod tests {
     #[test]
     fn verify_schema() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         use regex::Regex;
@@ -609,7 +609,7 @@ mod tests {
                         AND (scan_queue.block_range_end - 1) >= shard.subtree_end_height
                     )
                 WHERE scan_queue.priority > {}",
-                u32::from(tests::network().activation_height(NetworkUpgrade::Sapling).unwrap()),
+                u32::from(testing::network().activation_height(NetworkUpgrade::Sapling).unwrap()),
                 priority_code(&ScanPriority::Scanned),
             ),
             // v_transactions
@@ -852,11 +852,11 @@ mod tests {
             )?;
 
             let address = encode_payment_address(
-                tests::network().hrp_sapling_payment_address(),
+                testing::network().hrp_sapling_payment_address(),
                 &extfvk.default_address().1,
             );
             let extfvk = encode_extended_full_viewing_key(
-                tests::network().hrp_sapling_extended_full_viewing_key(),
+                testing::network().hrp_sapling_extended_full_viewing_key(),
                 extfvk,
             );
             wdb.conn.execute(
@@ -874,10 +874,10 @@ mod tests {
 
         let seed = [0xab; 32];
         let account = AccountId::from(0);
-        let secret_key = sapling::spending_key(&seed, tests::network().coin_type(), account);
+        let secret_key = sapling::spending_key(&seed, testing::network().coin_type(), account);
         let extfvk = secret_key.to_extended_full_viewing_key();
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_0_3_0(&mut db_data, &extfvk, account).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(seed.to_vec()))).unwrap();
     }
@@ -984,11 +984,11 @@ mod tests {
             )?;
 
             let address = encode_payment_address(
-                tests::network().hrp_sapling_payment_address(),
+                testing::network().hrp_sapling_payment_address(),
                 &extfvk.default_address().1,
             );
             let extfvk = encode_extended_full_viewing_key(
-                tests::network().hrp_sapling_extended_full_viewing_key(),
+                testing::network().hrp_sapling_extended_full_viewing_key(),
                 extfvk,
             );
             wdb.conn.execute(
@@ -1040,10 +1040,10 @@ mod tests {
 
         let seed = [0xab; 32];
         let account = AccountId::from(0);
-        let secret_key = sapling::spending_key(&seed, tests::network().coin_type(), account);
+        let secret_key = sapling::spending_key(&seed, testing::network().coin_type(), account);
         let extfvk = secret_key.to_extended_full_viewing_key();
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_autoshielding(&mut db_data, &extfvk, account).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(seed.to_vec()))).unwrap();
     }
@@ -1150,9 +1150,9 @@ mod tests {
                 [],
             )?;
 
-            let ufvk_str = ufvk.encode(&tests::network());
+            let ufvk_str = ufvk.encode(&testing::network());
             let address_str =
-                RecipientAddress::Unified(ufvk.default_address().0).encode(&tests::network());
+                RecipientAddress::Unified(ufvk.default_address().0).encode(&testing::network());
             wdb.conn.execute(
                 "INSERT INTO accounts (account, ufvk, address, transparent_address)
                 VALUES (?, ?, ?, '')",
@@ -1168,7 +1168,7 @@ mod tests {
             {
                 let taddr =
                     RecipientAddress::Transparent(*ufvk.default_address().0.transparent().unwrap())
-                        .encode(&tests::network());
+                        .encode(&testing::network());
                 wdb.conn.execute(
                     "INSERT INTO blocks (height, hash, time, sapling_tree) VALUES (0, 0, 0, x'000000')",
                     [],
@@ -1188,9 +1188,10 @@ mod tests {
 
         let seed = [0xab; 32];
         let account = AccountId::from(0);
-        let secret_key = UnifiedSpendingKey::from_seed(&tests::network(), &seed, account).unwrap();
+        let secret_key =
+            UnifiedSpendingKey::from_seed(&testing::network(), &seed, account).unwrap();
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_main(
             &mut db_data,
             &secret_key.to_unified_full_viewing_key(),
@@ -1203,7 +1204,7 @@ mod tests {
     #[test]
     fn init_accounts_table_only_works_once() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // We can call the function as many times as we want with no data
@@ -1272,7 +1273,7 @@ mod tests {
     #[test]
     fn init_blocks_table_only_works_once() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // First call with data should initialise the blocks table
@@ -1299,14 +1300,14 @@ mod tests {
     #[test]
     fn init_accounts_table_stores_correct_address() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         let seed = [0u8; 32];
 
         // Add an account to the wallet
         let account_id = AccountId::from(0);
-        let usk = UnifiedSpendingKey::from_seed(&tests::network(), &seed, account_id).unwrap();
+        let usk = UnifiedSpendingKey::from_seed(&testing::network(), &seed, account_id).unwrap();
         let ufvk = usk.to_unified_full_viewing_key();
         let expected_address = ufvk.sapling().unwrap().default_address().1;
         let ufvks = HashMap::from([(account_id, ufvk)]);

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -286,7 +286,7 @@ mod tests {
     use zcash_primitives::zip32::AccountId;
 
     use crate::{
-        tests,
+        testing,
         wallet::init::{init_wallet_db_internal, migrations::addresses_table},
         WalletDb,
     };
@@ -311,10 +311,10 @@ mod tests {
     #[test]
     fn transaction_views() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db_internal(&mut db_data, None, &[addresses_table::MIGRATION_ID]).unwrap();
         let usk =
-            UnifiedSpendingKey::from_seed(&tests::network(), &[0u8; 32][..], AccountId::from(0))
+            UnifiedSpendingKey::from_seed(&testing::network(), &[0u8; 32][..], AccountId::from(0))
                 .unwrap();
         let ufvk = usk.to_unified_full_viewing_key();
 
@@ -322,7 +322,7 @@ mod tests {
             .conn
             .execute(
                 "INSERT INTO accounts (account, ufvk) VALUES (0, ?)",
-                params![ufvk.encode(&tests::network())],
+                params![ufvk.encode(&testing::network())],
             )
             .unwrap();
 
@@ -403,7 +403,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     fn migrate_from_wm2() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db_internal(
             &mut db_data,
             None,
@@ -440,7 +440,7 @@ mod tests {
         tx.write(&mut tx_bytes).unwrap();
 
         let usk =
-            UnifiedSpendingKey::from_seed(&tests::network(), &[0u8; 32][..], AccountId::from(0))
+            UnifiedSpendingKey::from_seed(&testing::network(), &[0u8; 32][..], AccountId::from(0))
                 .unwrap();
         let ufvk = usk.to_unified_full_viewing_key();
         let (ua, _) = ufvk.default_address();
@@ -451,11 +451,11 @@ mod tests {
                     .ok()
                     .map(|k| k.derive_address(0).unwrap())
             })
-            .map(|a| a.encode(&tests::network()));
+            .map(|a| a.encode(&testing::network()));
 
         db_data.conn.execute(
             "INSERT INTO accounts (account, ufvk, address, transparent_address) VALUES (0, ?, ?, ?)",
-            params![ufvk.encode(&tests::network()), ua.encode(&tests::network()), &taddr]
+            params![ufvk.encode(&testing::network()), ua.encode(&testing::network()), &taddr]
         ).unwrap();
         db_data
             .conn

--- a/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
@@ -236,7 +236,7 @@ mod tests {
     use zcash_primitives::zip32::AccountId;
 
     use crate::{
-        tests,
+        testing,
         wallet::init::{init_wallet_db_internal, migrations::v_transactions_net},
         WalletDb,
     };
@@ -244,19 +244,19 @@ mod tests {
     #[test]
     fn received_notes_nullable_migration() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db_internal(&mut db_data, None, &[v_transactions_net::MIGRATION_ID]).unwrap();
 
         // Create an account in the wallet
         let usk0 =
-            UnifiedSpendingKey::from_seed(&tests::network(), &[0u8; 32][..], AccountId::from(0))
+            UnifiedSpendingKey::from_seed(&testing::network(), &[0u8; 32][..], AccountId::from(0))
                 .unwrap();
         let ufvk0 = usk0.to_unified_full_viewing_key();
         db_data
             .conn
             .execute(
                 "INSERT INTO accounts (account, ufvk) VALUES (0, ?)",
-                params![ufvk0.encode(&tests::network())],
+                params![ufvk0.encode(&testing::network())],
             )
             .unwrap();
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -215,7 +215,7 @@ mod tests {
     use zcash_primitives::zip32::AccountId;
 
     use crate::{
-        tests,
+        testing,
         wallet::init::{init_wallet_db_internal, migrations::add_transaction_views},
         WalletDb,
     };
@@ -223,32 +223,32 @@ mod tests {
     #[test]
     fn v_transactions_net() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db_internal(&mut db_data, None, &[add_transaction_views::MIGRATION_ID])
             .unwrap();
 
         // Create two accounts in the wallet.
         let usk0 =
-            UnifiedSpendingKey::from_seed(&tests::network(), &[0u8; 32][..], AccountId::from(0))
+            UnifiedSpendingKey::from_seed(&testing::network(), &[0u8; 32][..], AccountId::from(0))
                 .unwrap();
         let ufvk0 = usk0.to_unified_full_viewing_key();
         db_data
             .conn
             .execute(
                 "INSERT INTO accounts (account, ufvk) VALUES (0, ?)",
-                params![ufvk0.encode(&tests::network())],
+                params![ufvk0.encode(&testing::network())],
             )
             .unwrap();
 
         let usk1 =
-            UnifiedSpendingKey::from_seed(&tests::network(), &[1u8; 32][..], AccountId::from(1))
+            UnifiedSpendingKey::from_seed(&testing::network(), &[1u8; 32][..], AccountId::from(1))
                 .unwrap();
         let ufvk1 = usk1.to_unified_full_viewing_key();
         db_data
             .conn
             .execute(
                 "INSERT INTO accounts (account, ufvk) VALUES (1, ?)",
-                params![ufvk1.encode(&tests::network())],
+                params![ufvk1.encode(&testing::network())],
             )
             .unwrap();
 

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -448,7 +448,7 @@ pub(crate) mod tests {
     use crate::{
         chain::init::init_cache_database,
         error::SqliteClientError,
-        tests::{
+        testing::{
             self, fake_compact_block, insert_into_cache, network, sapling_activation_height,
             AddressType,
         },
@@ -480,7 +480,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -500,7 +500,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -540,7 +540,7 @@ pub(crate) mod tests {
             &GreedyInputSelector::new(change_strategy, DustOutputPolicy::default());
         let proposal_result = propose_transfer::<_, _, _, Infallible>(
             &mut db_data,
-            &tests::network(),
+            &testing::network(),
             account,
             input_selector,
             request,
@@ -551,7 +551,7 @@ pub(crate) mod tests {
         let change_memo = "Test change memo".parse::<Memo>().unwrap();
         let create_proposed_result = create_proposed_transaction::<_, _, Infallible, _>(
             &mut db_data,
-            &tests::network(),
+            &testing::network(),
             test_prover(),
             &usk,
             OvkPolicy::Sender,
@@ -571,7 +571,7 @@ pub(crate) mod tests {
             .into_iter()
             .collect();
         let decrypted_outputs = decrypt_transaction(
-            &tests::network(),
+            &testing::network(),
             sapling_activation_height() + 1,
             &tx,
             &ufvks,
@@ -650,7 +650,7 @@ pub(crate) mod tests {
     #[test]
     fn create_to_address_fails_on_incorrect_usk() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -667,7 +667,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk1,
                 &to,
@@ -683,7 +683,7 @@ pub(crate) mod tests {
     #[test]
     fn create_to_address_fails_with_no_blocks() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -702,7 +702,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -722,7 +722,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -742,7 +742,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -776,7 +776,7 @@ pub(crate) mod tests {
         .0;
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -804,7 +804,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -836,7 +836,7 @@ pub(crate) mod tests {
             insert_into_cache(&db_cache, &cb);
         }
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 2,
@@ -848,7 +848,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -877,7 +877,7 @@ pub(crate) mod tests {
         .0;
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 10,
@@ -889,7 +889,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -909,7 +909,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet
@@ -929,7 +929,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -947,7 +947,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -963,7 +963,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -994,7 +994,7 @@ pub(crate) mod tests {
             insert_into_cache(&db_cache, &cb);
         }
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 1,
@@ -1006,7 +1006,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -1034,7 +1034,7 @@ pub(crate) mod tests {
         .0;
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height() + 42,
@@ -1045,7 +1045,7 @@ pub(crate) mod tests {
         // Second spend should now succeed
         create_spend_to_address(
             &mut db_data,
-            &tests::network(),
+            &testing::network(),
             test_prover(),
             &usk,
             &to,
@@ -1059,7 +1059,7 @@ pub(crate) mod tests {
 
     #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
-        let network = tests::network();
+        let network = testing::network();
         let cache_file = NamedTempFile::new().unwrap();
         let db_cache = BlockDb(Connection::open(cache_file.path()).unwrap());
         init_cache_database(&db_cache).unwrap();
@@ -1085,7 +1085,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -1116,7 +1116,7 @@ pub(crate) mod tests {
         > {
             let txid = create_spend_to_address(
                 db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -1200,7 +1200,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -1220,7 +1220,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -1246,7 +1246,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -1266,7 +1266,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -1286,7 +1286,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -1312,7 +1312,7 @@ pub(crate) mod tests {
         assert_matches!(
             create_spend_to_address(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &usk,
                 &to,
@@ -1332,7 +1332,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -1366,7 +1366,7 @@ pub(crate) mod tests {
         }
 
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -1408,7 +1408,7 @@ pub(crate) mod tests {
         assert_matches!(
             spend(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &input_selector,
                 &usk,
@@ -1436,7 +1436,7 @@ pub(crate) mod tests {
         assert_matches!(
             spend(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &input_selector,
                 &usk,
@@ -1456,7 +1456,7 @@ pub(crate) mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, None).unwrap();
 
         // Add an account to the wallet
@@ -1495,7 +1495,7 @@ pub(crate) mod tests {
         );
         insert_into_cache(&db_cache, &cb);
         scan_cached_blocks(
-            &tests::network(),
+            &testing::network(),
             &db_cache,
             &mut db_data,
             sapling_activation_height(),
@@ -1506,7 +1506,7 @@ pub(crate) mod tests {
         assert_matches!(
             shield_transparent_funds(
                 &mut db_data,
-                &tests::network(),
+                &testing::network(),
                 test_prover(),
                 &input_selector,
                 NonNegativeAmount::from_u64(10000).unwrap(),

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -755,7 +755,7 @@ mod tests {
 
     use crate::{
         chain::init::init_cache_database,
-        tests::{
+        testing::{
             self, fake_compact_block, init_test_accounts_table, insert_into_cache,
             sapling_activation_height, AddressType,
         },
@@ -1098,7 +1098,7 @@ mod tests {
         init_cache_database(&db_cache).unwrap();
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         // Add an account to the wallet.
@@ -1159,7 +1159,7 @@ mod tests {
 
         assert_matches!(
             scan_cached_blocks(
-                &tests::network(),
+                &testing::network(),
                 &db_cache,
                 &mut db_data,
                 initial_height,
@@ -1226,7 +1226,7 @@ mod tests {
         use ScanPriority::*;
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), tests::network()).unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), testing::network()).unwrap();
         init_wallet_db(&mut db_data, Some(Secret::new(vec![]))).unwrap();
 
         let sap_active = db_data


### PR DESCRIPTION
These provide a standard way to set up tests, and helper methods for performing common test actions.

Closes #917.