### PR TITLE
zcash_client_sqlite: Prevent scan range fragmentation.

### DIFF
--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -38,7 +38,6 @@ use zcash_note_encryption::Domain;
 use zcash_primitives::{
     block::BlockHash,
     consensus::{self, BlockHeight, Network, NetworkUpgrade, Parameters},
-    legacy::TransparentAddress,
     memo::MemoBytes,
     sapling::{
         note_encryption::{sapling_note_encryption, SaplingDomain},
@@ -66,7 +65,9 @@ use super::BlockDb;
 #[cfg(feature = "transparent-inputs")]
 use {
     zcash_client_backend::data_api::wallet::{propose_shielding, shield_transparent_funds},
-    zcash_primitives::transaction::components::amount::NonNegativeAmount,
+    zcash_primitives::{
+        legacy::TransparentAddress, transaction::components::amount::NonNegativeAmount,
+    },
 };
 
 #[cfg(feature = "unstable")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1571,8 +1571,6 @@ pub(crate) fn prune_nullifier_map(
 mod tests {
     use std::num::NonZeroU32;
 
-    use secrecy::Secret;
-
     use zcash_primitives::transaction::components::Amount;
 
     use zcash_client_backend::data_api::WalletRead;
@@ -1586,6 +1584,7 @@ mod tests {
 
     #[cfg(feature = "transparent-inputs")]
     use {
+        secrecy::Secret,
         zcash_client_backend::{
             data_api::WalletWrite, encoding::AddressCodec, wallet::WalletTransparentOutput,
         },

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -735,7 +735,7 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
 
 #[cfg(test)]
 mod tests {
-    use std::{mem::replace, ops::Range};
+    use std::ops::Range;
 
     use incrementalmerkletree::{Hashable, Level};
     use secrecy::Secret;

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -453,7 +453,7 @@ pub(crate) fn replace_queue_entries(
             "SELECT block_range_start, block_range_end, priority
             FROM scan_queue
             WHERE (
-                -- the start is contained within the range
+                -- the start is contained within or adjacent to the range
                 :start >= block_range_start
                 AND :start <= block_range_end
             )


### PR DESCRIPTION
Fixes #922