### PR TITLE
zcash_client_backend: Reduce scope of `lightwalletd-tonic` feature flag

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -87,8 +87,12 @@ and this library adheres to Rust's notion of
   method now takes an optional `BlockMetadata` argument instead of a base commitment
   tree and incremental witnesses for each previously-known note. In addition, the
   return type has now been updated to return a `Result<ScannedBlock, ScanError>`.
-- `proto/service.proto` has been updated to include the new GRPC endpoints
-  supported by lightwalletd v0.4.15
+- `zcash_client_backend::proto::service`:
+  - The module is no longer behind the `lightwalletd-tonic` feature flag; that
+    now only gates the `service::compact_tx_streamer_client` submodule. This
+    exposes the service types to parse messages received by other gRPC clients.
+  - The module has been updated to include the new gRPC endpoints supported by
+    `lightwalletd` v0.4.15.
 
 ### Removed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -38,45 +38,43 @@ fn build() -> io::Result<()> {
         "src/proto/compact_formats.rs",
     )?;
 
-    {
-        // Build the gRPC types and client.
-        tonic_build::configure()
-            .build_server(false)
-            .client_mod_attribute(
-                "cash.z.wallet.sdk.rpc",
-                r#"#[cfg(feature = "lightwalletd-tonic")]"#,
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.ChainMetadata",
-                "crate::proto::compact_formats::ChainMetadata",
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.CompactBlock",
-                "crate::proto::compact_formats::CompactBlock",
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.CompactTx",
-                "crate::proto::compact_formats::CompactTx",
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.CompactSaplingSpend",
-                "crate::proto::compact_formats::CompactSaplingSpend",
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.CompactSaplingOutput",
-                "crate::proto::compact_formats::CompactSaplingOutput",
-            )
-            .extern_path(
-                ".cash.z.wallet.sdk.rpc.CompactOrchardAction",
-                "crate::proto::compact_formats::CompactOrchardAction",
-            )
-            .compile(&[SERVICE_PROTO], &["proto/"])?;
+    // Build the gRPC types and client.
+    tonic_build::configure()
+        .build_server(false)
+        .client_mod_attribute(
+            "cash.z.wallet.sdk.rpc",
+            r#"#[cfg(feature = "lightwalletd-tonic")]"#,
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.ChainMetadata",
+            "crate::proto::compact_formats::ChainMetadata",
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.CompactBlock",
+            "crate::proto::compact_formats::CompactBlock",
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.CompactTx",
+            "crate::proto::compact_formats::CompactTx",
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.CompactSaplingSpend",
+            "crate::proto::compact_formats::CompactSaplingSpend",
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.CompactSaplingOutput",
+            "crate::proto::compact_formats::CompactSaplingOutput",
+        )
+        .extern_path(
+            ".cash.z.wallet.sdk.rpc.CompactOrchardAction",
+            "crate::proto::compact_formats::CompactOrchardAction",
+        )
+        .compile(&[SERVICE_PROTO], &["proto/"])?;
 
-        // Copy the generated types into the source tree so changes can be committed. The
-        // file has the same name as for the compact format types because they have the
-        // same package, but we've set things up so this only contains the service types.
-        fs::copy(out.join("cash.z.wallet.sdk.rpc.rs"), "src/proto/service.rs")?;
-    }
+    // Copy the generated types into the source tree so changes can be committed. The
+    // file has the same name as for the compact format types because they have the
+    // same package, but we've set things up so this only contains the service types.
+    fs::copy(out.join("cash.z.wallet.sdk.rpc.rs"), "src/proto/service.rs")?;
 
     Ok(())
 }

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -4,8 +4,6 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 const COMPACT_FORMATS_PROTO: &str = "proto/compact_formats.proto";
-
-#[cfg(feature = "lightwalletd-tonic")]
 const SERVICE_PROTO: &str = "proto/service.proto";
 
 fn main() -> io::Result<()> {
@@ -40,11 +38,14 @@ fn build() -> io::Result<()> {
         "src/proto/compact_formats.rs",
     )?;
 
-    #[cfg(feature = "lightwalletd-tonic")]
     {
         // Build the gRPC types and client.
         tonic_build::configure()
             .build_server(false)
+            .client_mod_attribute(
+                "cash.z.wallet.sdk.rpc",
+                r#"#[cfg(feature = "lightwalletd-tonic")]"#,
+            )
             .extern_path(
                 ".cash.z.wallet.sdk.rpc.ChainMetadata",
                 "crate::proto::compact_formats::ChainMetadata",

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -14,7 +14,6 @@ use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
 #[allow(clippy::derive_partial_eq_without_eq)]
 pub mod compact_formats;
 
-#[cfg(feature = "lightwalletd-tonic")]
 #[rustfmt::skip]
 #[allow(unknown_lints)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zcash_client_backend/src/proto/service.rs
+++ b/zcash_client_backend/src/proto/service.rs
@@ -275,6 +275,7 @@ impl ShieldedProtocol {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "lightwalletd-tonic")]
 pub mod compact_tx_streamer_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;


### PR DESCRIPTION
The `zcash_client_backend::proto::service::compact_tx_streamer_client` is now the only module controlled by that feature flag, exposing the service types for use by parsers.