### PR TITLE
Release stabilization branch for updates related to the 2.0.0 release of the light wallet SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 dependencies = [
  "assert_matches",
  "base64",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "assert_matches",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 dependencies = [
  "assert_matches",
  "bs58",

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
-## [0.8.0-rc.1] - 2023-09-08
+## [0.8.0-rc.3] - 2023-09-12
 ### Added
 - `zcash_client_sqlite::commitment_tree` Types related to management of note
   commitment trees using the `shardtree` crate.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-zcash_client_backend = { version = "=0.10.0-rc.1", path = "../zcash_client_backend" }
+zcash_client_backend = { version = "=0.10.0-rc.2", path = "../zcash_client_backend" }
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_primitives = { version = "=0.13.0-rc.1", path = "../zcash_primitives", default-features = false }
 
@@ -62,7 +62,7 @@ tempfile = "3.5.0"
 zcash_note_encryption = "0.4"
 zcash_proofs = { version = "=0.13.0-rc.1", path = "../zcash_proofs" }
 zcash_primitives = { version = "=0.13.0-rc.1", path = "../zcash_primitives", features = ["test-dependencies"] }
-zcash_client_backend = { version = "=0.10.0-rc.1", path = "../zcash_client_backend", features = ["test-dependencies", "unstable-serialization"] }
+zcash_client_backend = { version = "=0.10.0-rc.2", path = "../zcash_client_backend", features = ["test-dependencies", "unstable-serialization"] }
 zcash_address = { version = "0.3", path = "../components/zcash_address", features = ["test-dependencies"] }
 
 [features]

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-zcash_client_backend = { version = "=0.10.0-rc.2", path = "../zcash_client_backend" }
+zcash_client_backend = { version = "=0.10.0-rc.2", path = "../zcash_client_backend", features = ["unstable-serialization"]}
 zcash_encoding = { version = "0.2", path = "../components/zcash_encoding" }
 zcash_primitives = { version = "=0.13.0-rc.1", path = "../zcash_primitives", default-features = false }
 


### PR DESCRIPTION
This is the release stabilization branch for:
* `zcash_primitives 0.13.0`
* `zcash_proofs 0.13.0`
* `zcash_client_backend 0.10.0`
* `zcash_client_sqlite 0.8.0`