### PR TITLE
zcash_client_sqlite: Remove use of boolean constants from `v_tx_outputs`

### DIFF
--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -553,7 +553,7 @@ mod tests {
                    utxos.received_by_account   AS to_account,
                    utxos.address               AS to_address,
                    utxos.value_zat             AS value,
-                   false                       AS is_change,
+                   0                           AS is_change,
                    NULL                        AS memo
             FROM utxos
             UNION
@@ -564,7 +564,7 @@ mod tests {
                    sapling_received_notes.account AS to_account,
                    sent_notes.to_address          AS to_address,
                    sent_notes.value               AS value,
-                   false                          AS is_change,
+                   0                              AS is_change,
                    sent_notes.memo                AS memo
             FROM sent_notes
             JOIN transactions

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -13,6 +13,7 @@ mod utxos_table;
 mod v_sapling_shard_unscanned_ranges;
 mod v_transactions_net;
 mod v_transactions_transparent_history;
+mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
 
 use schemer_rusqlite::RusqliteMigration;
@@ -47,6 +48,8 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //         |                                        |
     // wallet_summaries                                 |
     //                                   v_transactions_transparent_history
+    //                                                  |
+    //                                     v_tx_outputs_use_legacy_false
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -79,5 +82,6 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         }),
         Box::new(wallet_summaries::Migration),
         Box::new(v_transactions_transparent_history::Migration),
+        Box::new(v_tx_outputs_use_legacy_false::Migration),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
@@ -1,0 +1,92 @@
+//! This migration revises the `v_tx_outputs` view to support SQLite 3.19.x
+//! which did not define `TRUE` and `FALSE` constants. This is required in
+//! order to support Android API 27
+
+use std::collections::HashSet;
+
+use schemer_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::v_transactions_transparent_history;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xb3e21434_286f_41f3_8d71_44cce968ab2b);
+
+pub(super) struct Migration;
+
+impl schemer::Migration for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        [v_transactions_transparent_history::MIGRATION_ID]
+            .into_iter()
+            .collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Updates v_tx_outputs to remove use of `true` and `false` constants for legacy SQLite version support."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_tx_outputs;
+            CREATE VIEW v_tx_outputs AS
+            SELECT transactions.txid                   AS txid,
+                   2                                   AS output_pool,
+                   sapling_received_notes.output_index AS output_index,
+                   sent_notes.from_account             AS from_account,
+                   sapling_received_notes.account      AS to_account,
+                   NULL                                AS to_address,
+                   sapling_received_notes.value        AS value,
+                   sapling_received_notes.is_change    AS is_change,
+                   sapling_received_notes.memo         AS memo
+            FROM sapling_received_notes
+            JOIN transactions
+                 ON transactions.id_tx = sapling_received_notes.tx
+            LEFT JOIN sent_notes
+                      ON (sent_notes.tx, sent_notes.output_pool, sent_notes.output_index) =
+                         (sapling_received_notes.tx, 2, sent_notes.output_index)
+            UNION
+            SELECT utxos.prevout_txid          AS txid,
+                   0                           AS output_pool,
+                   utxos.prevout_idx           AS output_index,
+                   NULL                        AS from_account,
+                   utxos.received_by_account   AS to_account,
+                   utxos.address               AS to_address,
+                   utxos.value_zat             AS value,
+                   0                           AS is_change,
+                   NULL                        AS memo
+            FROM utxos
+            UNION
+            SELECT transactions.txid              AS txid,
+                   sent_notes.output_pool         AS output_pool,
+                   sent_notes.output_index        AS output_index,
+                   sent_notes.from_account        AS from_account,
+                   sapling_received_notes.account AS to_account,
+                   sent_notes.to_address          AS to_address,
+                   sent_notes.value               AS value,
+                   0                              AS is_change,
+                   sent_notes.memo                AS memo
+            FROM sent_notes
+            JOIN transactions
+                 ON transactions.id_tx = sent_notes.tx
+            LEFT JOIN sapling_received_notes
+                      ON (sent_notes.tx, sent_notes.output_pool, sent_notes.output_index) =
+                         (sapling_received_notes.tx, 2, sapling_received_notes.output_index)
+            WHERE COALESCE(sapling_received_notes.is_change, 0) = 0;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        panic!("This migration cannot be reverted.");
+    }
+}


### PR DESCRIPTION
At present, [zcash/zcash-android-wallet-sdk] supports Android API 27, which bundles SQLite 3.19. SQLite support for the `TRUE` and `FALSE` constants were introduced in SQLite 3.23, so we cannot currently use these constants and retain support for Android API 27.

This version support limitation applies only to the `v_transactions` and `v_tx_outputs` views, which are considered part of the public API of this crate; other use of more recent SQLite features is fine because they rely upon the SQLite bundled via our use of the `rusqlite` crate and feature compatibility is verified via the unit tests of this crate.