### PR TITLE
zcash_client_sqlite: Consider utxos unspent if the spending transaction expired.

### DIFF
--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -716,12 +716,15 @@ pub(crate) fn get_wallet_summary(
         let mut stmt_transparent_balances = conn.prepare(
             "SELECT u.received_by_account, SUM(u.value_zat)
              FROM utxos u
+             LEFT OUTER JOIN transactions tx ON tx.id_tx = u.spent_in_tx
              WHERE u.height <= :max_height
-             AND u.spent_in_tx IS NULL
+             AND (u.spent_in_tx IS NULL OR (tx.block IS NULL AND tx.expiry_height < :stable_height))
              GROUP BY u.received_by_account",
         )?;
-        let mut rows = stmt_transparent_balances
-            .query(named_params![":max_height": u32::from(zero_conf_height)])?;
+        let mut rows = stmt_transparent_balances.query(named_params![
+            ":max_height": u32::from(zero_conf_height),
+            ":stable_height": u32::from(chain_tip_height - PRUNING_DEPTH)
+        ])?;
 
         while let Some(row) = rows.next()? {
             let account = AccountId::from(row.get::<_, u32>(0)?);
@@ -1300,23 +1303,25 @@ pub(crate) fn get_unspent_transparent_outputs<P: consensus::Parameters>(
     max_height: BlockHeight,
     exclude: &[OutPoint],
 ) -> Result<Vec<WalletTransparentOutput>, SqliteClientError> {
+    let chain_tip_height = scan_queue_extrema(conn)?.map(|(_, max)| max);
     let mut stmt_blocks = conn.prepare(
-        "SELECT u.prevout_txid, u.prevout_idx, u.script,
-                u.value_zat, u.height
+        "SELECT u.prevout_txid, u.prevout_idx, u.script, u.value_zat, u.height
          FROM utxos u
+         LEFT OUTER JOIN transactions tx ON tx.id_tx = u.spent_in_tx
          WHERE u.address = :address
          AND u.height <= :max_height
-         AND u.spent_in_tx IS NULL",
+         AND (u.spent_in_tx IS NULL OR (tx.block IS NULL AND tx.expiry_height < :stable_height))",
     )?;
 
     let addr_str = address.encode(params);
-
-    let mut utxos = Vec::<WalletTransparentOutput>::new();
     let mut rows = stmt_blocks.query(named_params![
         ":address": addr_str,
-        ":max_height": u32::from(max_height)
+        ":max_height": u32::from(max_height),
+        ":stable_height": u32::from(chain_tip_height.unwrap_or(max_height).saturating_sub(PRUNING_DEPTH)),
     ])?;
+
     let excluded: BTreeSet<OutPoint> = exclude.iter().cloned().collect();
+    let mut utxos = Vec::<WalletTransparentOutput>::new();
     while let Some(row) = rows.next()? {
         let txid: Vec<u8> = row.get(0)?;
         let mut txid_bytes = [0u8; 32];
@@ -1363,19 +1368,22 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     account: AccountId,
     max_height: BlockHeight,
 ) -> Result<HashMap<TransparentAddress, Amount>, SqliteClientError> {
+    let chain_tip_height = scan_queue_extrema(conn)?.map(|(_, max)| max);
     let mut stmt_blocks = conn.prepare(
         "SELECT u.address, SUM(u.value_zat)
          FROM utxos u
+         LEFT OUTER JOIN transactions tx ON tx.id_tx = u.spent_in_tx
          WHERE u.received_by_account = :account_id
          AND u.height <= :max_height
-         AND u.spent_in_tx IS NULL
+         AND (u.spent_in_tx IS NULL OR (tx.block IS NULL AND tx.expiry_height < :stable_height))
          GROUP BY u.address",
     )?;
 
     let mut res = HashMap::new();
     let mut rows = stmt_blocks.query(named_params![
         ":account_id": u32::from(account),
-        ":max_height": u32::from(max_height)
+        ":max_height": u32::from(max_height),
+        ":stable_height": u32::from(chain_tip_height.unwrap_or(max_height).saturating_sub(PRUNING_DEPTH))
     ])?;
     while let Some(row) = rows.next()? {
         let taddr_str: String = row.get(0)?;
@@ -2053,6 +2061,8 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn transparent_balance_across_shielding() {
+        use crate::PRUNING_DEPTH;
+
         let mut st = TestBuilder::new()
             .with_block_cache()
             .with_test_account(AccountBirthday::from_sapling_activation)
@@ -2174,17 +2184,15 @@ mod tests {
         check_balance(&st, 1, NonNegativeAmount::ZERO);
         check_balance(&st, 2, NonNegativeAmount::ZERO);
 
-        // Expire the shielding transaction.
+        // Expire the shielding transaction, and let the chain advance past the pruning depth.
         let expiry_height = st.wallet().get_transaction(txid).unwrap().expiry_height();
-        st.wallet_mut().update_chain_tip(expiry_height).unwrap();
+        st.wallet_mut()
+            .update_chain_tip(expiry_height + 1 + PRUNING_DEPTH)
+            .unwrap();
 
         // The transparent output should be spendable again, with more confirmations.
-        /*
-        TODO: Handle expiration of shielding transactions.
-        https://github.com/zcash/librustzcash/issues/986
         check_balance(&st, 0, value);
         check_balance(&st, 1, value);
         check_balance(&st, 2, value);
-        */
     }
 }


### PR DESCRIPTION
If a shielding transaction is expired as of the current chain tip, its input utxos should be considered unspent.