### PR TITLE
zcash_client_backend: Return summary information from `scan_cached_blocks`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,9 +7,13 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
-## [0.10.0] - 2023-09-25
-### Notable Changes
+### Changed
+- `zcash_client_backend::data_api::chain::scan_cached_blocks` now returns
+  a `ScanSummary` containing metadata about the scanned blocks on success.
 
+## [0.10.0] - 2023-09-25
+
+### Notable Changes
 - `zcash_client_backend` now supports out-of-order scanning of blockchain history.
   See the module documentation for `zcash_client_backend::data_api::chain`
   for details on how to make use of the new scanning capabilities.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -61,7 +61,7 @@ rand_core.workspace = true
 regex = "1.4"
 tempfile = "3.5.0"
 zcash_note_encryption.workspace = true
-zcash_proofs.workspace = true
+zcash_proofs = { workspace = true, features = ["local-prover"] }
 zcash_primitives = { workspace = true, features = ["test-dependencies"] }
 zcash_client_backend = { workspace = true, features = ["test-dependencies", "unstable-serialization", "unstable-spanning-tree"] }
 zcash_address = { workspace = true, features = ["test-dependencies"] }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -564,7 +564,10 @@ mod tests {
         let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
 
         // Scan the cache
-        st.scan_cached_blocks(h1, 1);
+        let summary = st.scan_cached_blocks(h1, 1);
+        assert_eq!(summary.scanned_range().start, h1);
+        assert_eq!(summary.scanned_range().end, h1 + 1);
+        assert_eq!(summary.received_sapling_note_count(), 1);
 
         // Account balance should reflect the received note
         assert_eq!(st.get_total_balance(AccountId::from(0)), value);
@@ -574,7 +577,10 @@ mod tests {
         let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2.into());
 
         // Scan the cache again
-        st.scan_cached_blocks(h2, 1);
+        let summary = st.scan_cached_blocks(h2, 1);
+        assert_eq!(summary.scanned_range().start, h2);
+        assert_eq!(summary.scanned_range().end, h2 + 1);
+        assert_eq!(summary.received_sapling_note_count(), 1);
 
         // Account balance should reflect both received notes
         assert_eq!(

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -14,6 +14,7 @@ use tempfile::NamedTempFile;
 #[cfg(feature = "unstable")]
 use tempfile::TempDir;
 
+use zcash_client_backend::data_api::chain::ScanSummary;
 use zcash_client_backend::data_api::{AccountBalance, WalletRead};
 #[allow(deprecated)]
 use zcash_client_backend::{
@@ -326,8 +327,14 @@ where
     }
 
     /// Invokes [`scan_cached_blocks`] with the given arguments, expecting success.
-    pub(crate) fn scan_cached_blocks(&mut self, from_height: BlockHeight, limit: usize) {
-        assert_matches!(self.try_scan_cached_blocks(from_height, limit), Ok(_));
+    pub(crate) fn scan_cached_blocks(
+        &mut self,
+        from_height: BlockHeight,
+        limit: usize,
+    ) -> ScanSummary {
+        let result = self.try_scan_cached_blocks(from_height, limit);
+        assert_matches!(result, Ok(_));
+        result.unwrap()
     }
 
     /// Invokes [`scan_cached_blocks`] with the given arguments.
@@ -336,7 +343,7 @@ where
         from_height: BlockHeight,
         limit: usize,
     ) -> Result<
-        (),
+        ScanSummary,
         data_api::chain::error::Error<
             SqliteClientError,
             <Cache::BlockSource as BlockSource>::Error,


### PR DESCRIPTION
When scanning, a wallet only needs to update balance and transaction information shown to users when the scan has resulted in a change to wallet state. This modifies `scan_cached_blocks` to return the range of block heights actually scanned, along with the counts of notes spent and received by the wallet in that range.

Fixes #918