### PR TITLE
zcash_client_sqlite: Replace internal height tuples with `RangeInclusive`

### DIFF
--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -170,7 +170,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
         wallet::scan_queue_extrema(self.conn.borrow())
-            .map(|h| h.map(|(_, max)| max))
+            .map(|h| h.map(|range| *range.end()))
             .map_err(SqliteClientError::from)
     }
 

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -756,7 +756,7 @@ pub(crate) fn get_checkpoint_depth(
     min_confirmations: NonZeroU32,
 ) -> Result<Option<usize>, rusqlite::Error> {
     scan_queue_extrema(conn)?
-        .map(|(_, max)| max)
+        .map(|range| *range.end())
         .map(|chain_tip| {
             let max_checkpoint_height =
                 u32::from(chain_tip).saturating_sub(u32::from(min_confirmations) - 1);

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -346,7 +346,7 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
     };
 
     // Read the previous max scanned height from the blocks table
-    let max_scanned = block_height_extrema(conn)?.map(|(_, max_scanned)| max_scanned);
+    let max_scanned = block_height_extrema(conn)?.map(|range| *range.end());
 
     // Read the wallet birthday (if known).
     let wallet_birthday = wallet_birthday(conn)?;


### PR DESCRIPTION
We don't need to iterate over them, but the `*_extrema` internal methods are semantically returning inclusive ranges, and using `RangeInclusive` avoids bugs where the wrong half of the tuple is used (instead moving the location of the tuple handling inside the `*_extrema` methods, which cuts the number of occurrences from linear in the number of function calls to constant).