### PR TITLE
zcash_client_backend: Factor out `InputSource` from `WalletRead`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        run: cargo doc --all --document-private-items
+        run: cargo doc --all --all-features --document-private-items
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19f96dde3a8693874f7e7c53d95616569b4009379a903789efbd448f4ea9cc7"
+checksum = "dbf20c7a2747d9083092e3a3eeb9a7ed75577ae364896bebbc5e0bdcd4e97735"
 dependencies = [
  "assert_matches",
  "bitflags 2.4.0",
@@ -2963,6 +2963,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nom",
+ "nonempty",
  "orchard",
  "percent-encoding",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zcash_proofs = { version = "0.13", path = "zcash_proofs", default-features = fal
 ff = "0.13"
 group = "0.13"
 incrementalmerkletree = "0.5"
-shardtree = "0.1"
+shardtree = "0.2"
 
 # Payment protocols
 # - Sapling

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,6 +30,7 @@ zcash_primitives.workspace = true
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 # - Data Access API
 time = "0.3.22"
+nonempty.workspace = true
 
 # - Encodings
 base64.workspace = true
@@ -87,6 +88,7 @@ gumdrop = "0.8"
 jubjub.workspace = true
 proptest.workspace = true
 rand_core.workspace = true
+shardtree = { workspace = true, features = ["test-dependencies"] }
 zcash_proofs.workspace = true
 zcash_address = { workspace = true, features = ["test-dependencies"] }
 

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -112,7 +112,7 @@ pub enum ChangeError<E, NoteRefT> {
     DustInputs {
         /// The outpoints corresponding to transparent inputs having no current economic value.
         transparent: Vec<OutPoint>,
-        /// The identifiers for Sapling inputs having not current economic value
+        /// The identifiers for Sapling inputs having no current economic value
         sapling: Vec<NoteRefT>,
     },
     /// An error occurred that was specific to the change selection strategy in use.

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -70,7 +70,9 @@ use super::BlockDb;
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    zcash_client_backend::data_api::wallet::{propose_shielding, shield_transparent_funds},
+    zcash_client_backend::data_api::wallet::{
+        input_selection::ShieldingSelector, propose_shielding, shield_transparent_funds,
+    },
     zcash_primitives::legacy::TransparentAddress,
 };
 
@@ -483,7 +485,7 @@ impl<Cache> TestState<Cache> {
         >,
     >
     where
-        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+        InputsT: InputSelector<InputSource = WalletDb<Connection, Network>>,
     {
         let params = self.network();
         let prover = test_prover();
@@ -518,7 +520,7 @@ impl<Cache> TestState<Cache> {
         >,
     >
     where
-        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+        InputsT: InputSelector<InputSource = WalletDb<Connection, Network>>,
     {
         let params = self.network();
         propose_transfer::<_, _, _, Infallible>(
@@ -575,9 +577,9 @@ impl<Cache> TestState<Cache> {
         input_selector: &InputsT,
         shielding_threshold: NonNegativeAmount,
         from_addrs: &[TransparentAddress],
-        min_confirmations: NonZeroU32,
+        min_confirmations: u32,
     ) -> Result<
-        Proposal<InputsT::FeeRule, ReceivedNoteId>,
+        Proposal<InputsT::FeeRule, Infallible>,
         data_api::error::Error<
             SqliteClientError,
             Infallible,
@@ -586,7 +588,7 @@ impl<Cache> TestState<Cache> {
         >,
     >
     where
-        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+        InputsT: ShieldingSelector<InputSource = WalletDb<Connection, Network>>,
     {
         let params = self.network();
         propose_shielding::<_, _, _, Infallible>(
@@ -639,7 +641,7 @@ impl<Cache> TestState<Cache> {
         shielding_threshold: NonNegativeAmount,
         usk: &UnifiedSpendingKey,
         from_addrs: &[TransparentAddress],
-        min_confirmations: NonZeroU32,
+        min_confirmations: u32,
     ) -> Result<
         TxId,
         data_api::error::Error<
@@ -650,7 +652,7 @@ impl<Cache> TestState<Cache> {
         >,
     >
     where
-        InputsT: InputSelector<DataSource = WalletDb<Connection, Network>>,
+        InputsT: ShieldingSelector<InputSource = WalletDb<Connection, Network>>,
     {
         let params = self.network();
         let prover = test_prover();

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -5,7 +5,7 @@ use super::{
     components::{
         amount::NonNegativeAmount,
         sapling::{self, GrothProofBytes},
-        transparent, Amount,
+        transparent,
     },
     sighash_v4::v4_signature_hash,
     sighash_v5::v5_signature_hash,
@@ -13,7 +13,7 @@ use super::{
 };
 
 #[cfg(feature = "zfuture")]
-use crate::extensions::transparent::Precondition;
+use {super::components::Amount, crate::extensions::transparent::Precondition};
 
 pub const SIGHASH_ALL: u8 = 0x01;
 pub const SIGHASH_NONE: u8 = 0x02;


### PR DESCRIPTION
Prior to this change, it's necessary to implement the entirety of the `WalletRead` trait in order to be able to use the input selection functionality provided by `zcash_client_backend::data_api::input_selection`. This change factors out the minimal operations required for transaction proposal construction to better reflect the principle of least authority and make the input selection code reusable in more contexts.