### PR TITLE
zcash_client_backend: Use `NonNegativeAmount` for fee and change amounts.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -22,6 +22,12 @@ and this library adheres to Rust's notion of
   - The `NoteMismatch` variant of `data_api::error::Error` now wraps a
     `data_api::NoteId` instead of a backend-specific note identifier. The
     related `NoteRef` type parameter has been removed from `data_api::error::Error`.
+  - `wallet::create_spend_to_address` now takes a `NonNegativeAmount` rather than
+    an `Amount`.
+  - All uses of `Amount` in `data_api::wallet::input_selection` have been replaced
+    with `NonNegativeAmount`.
+- All uses of `Amount` in `zcash_client_backend::fees` have been replaced
+  with `NonNegativeAmount`.
 
 ## [0.10.0] - 2023-09-25
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -640,6 +640,7 @@ impl SentTransactionOutput {
             sapling_change_to,
         }
     }
+
     /// Returns the index within the transaction that contains the recipient output.
     ///
     /// - If `recipient_address` is a Sapling address, this is an index into the Sapling

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -493,7 +493,7 @@ where
             }
         };
 
-        if balance.total() >= shielding_threshold.into() {
+        if balance.total() >= shielding_threshold {
             Ok(Proposal {
                 transaction_request: TransactionRequest::empty(),
                 transparent_inputs,
@@ -506,7 +506,7 @@ where
             })
         } else {
             Err(InputSelectorError::InsufficientFunds {
-                available: balance.total(),
+                available: balance.total().into(),
                 required: shielding_threshold.into(),
             })
         }

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -580,7 +580,7 @@ mod tests {
             value::NoteValue,
             Nullifier, SaplingIvk,
         },
-        transaction::components::Amount,
+        transaction::components::amount::NonNegativeAmount,
         zip32::{AccountId, DiversifiableFullViewingKey, ExtendedSpendingKey},
     };
 
@@ -637,7 +637,7 @@ mod tests {
         prev_hash: BlockHash,
         nf: Nullifier,
         dfvk: &DiversifiableFullViewingKey,
-        value: Amount,
+        value: NonNegativeAmount,
         tx_after: bool,
         initial_sapling_tree_size: Option<u32>,
     ) -> CompactBlock {
@@ -646,7 +646,7 @@ mod tests {
         // Create a fake Note for the account
         let mut rng = OsRng;
         let rseed = generate_random_rseed(&Network::TestNetwork, height, &mut rng);
-        let note = sapling::Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
+        let note = sapling::Note::from_parts(to, NoteValue::from(value), rseed);
         let encryptor = sapling_note_encryption::<_, Network>(
             Some(dfvk.fvk().ovk),
             note.clone(),
@@ -724,7 +724,7 @@ mod tests {
                 BlockHash([0; 32]),
                 Nullifier([0; 32]),
                 &dfvk,
-                Amount::from_u64(5).unwrap(),
+                NonNegativeAmount::const_from_u64(5),
                 false,
                 None,
             );
@@ -808,7 +808,7 @@ mod tests {
                 BlockHash([0; 32]),
                 Nullifier([0; 32]),
                 &dfvk,
-                Amount::from_u64(5).unwrap(),
+                NonNegativeAmount::const_from_u64(5),
                 true,
                 Some(0),
             );
@@ -884,7 +884,7 @@ mod tests {
             BlockHash([0; 32]),
             nf,
             &dfvk,
-            Amount::from_u64(5).unwrap(),
+            NonNegativeAmount::const_from_u64(5),
             false,
             Some(0),
         );

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -367,7 +367,7 @@ mod tests {
         let (h1, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(5).unwrap(),
+            NonNegativeAmount::const_from_u64(5),
         );
 
         // Scan the cache
@@ -377,7 +377,7 @@ mod tests {
         let (h2, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(7).unwrap(),
+            NonNegativeAmount::const_from_u64(7),
         );
 
         // Scanning should detect no inconsistencies
@@ -397,12 +397,12 @@ mod tests {
         let (h, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(5).unwrap(),
+            NonNegativeAmount::const_from_u64(5),
         );
         let (last_contiguous_height, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(7).unwrap(),
+            NonNegativeAmount::const_from_u64(7),
         );
 
         // Scanning the cache should find no inconsistencies
@@ -415,13 +415,13 @@ mod tests {
             BlockHash([1; 32]),
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(8).unwrap(),
+            NonNegativeAmount::const_from_u64(8),
             2,
         );
         st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(3).unwrap(),
+            NonNegativeAmount::const_from_u64(3),
         );
 
         // Data+cache chain should be invalid at the data/cache boundary
@@ -448,10 +448,10 @@ mod tests {
         assert_eq!(st.get_wallet_summary(0), None);
 
         // Create fake CompactBlocks sending value to the address
-        let value = NonNegativeAmount::from_u64(5).unwrap();
-        let value2 = NonNegativeAmount::from_u64(7).unwrap();
-        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
-        st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2.into());
+        let value = NonNegativeAmount::const_from_u64(5);
+        let value2 = NonNegativeAmount::const_from_u64(7);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
         // Scan the cache
         st.scan_cached_blocks(h, 2);
@@ -502,14 +502,14 @@ mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Create a block with height SAPLING_ACTIVATION_HEIGHT
-        let value = NonNegativeAmount::from_u64(50000).unwrap();
-        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(50000);
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h1, 1);
         assert_eq!(st.get_total_balance(AccountId::from(0)), value);
 
         // Create blocks to reach SAPLING_ACTIVATION_HEIGHT + 2
-        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
-        let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the later block first
         st.scan_cached_blocks(h3, 1);
@@ -560,8 +560,8 @@ mod tests {
         assert_eq!(st.get_wallet_summary(0), None);
 
         // Create a fake CompactBlock sending value to the address
-        let value = NonNegativeAmount::from_u64(5).unwrap();
-        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(5);
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the cache
         let summary = st.scan_cached_blocks(h1, 1);
@@ -573,8 +573,8 @@ mod tests {
         assert_eq!(st.get_total_balance(AccountId::from(0)), value);
 
         // Create a second fake CompactBlock sending more value to the address
-        let value2 = NonNegativeAmount::from_u64(7).unwrap();
-        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2.into());
+        let value2 = NonNegativeAmount::const_from_u64(7);
+        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
         // Scan the cache again
         let summary = st.scan_cached_blocks(h2, 1);
@@ -601,9 +601,9 @@ mod tests {
         assert_eq!(st.get_wallet_summary(0), None);
 
         // Create a fake CompactBlock sending value to the address
-        let value = NonNegativeAmount::from_u64(5).unwrap();
+        let value = NonNegativeAmount::const_from_u64(5);
         let (received_height, _, nf) =
-            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Scan the cache
         st.scan_cached_blocks(received_height, 1);
@@ -614,9 +614,8 @@ mod tests {
         // Create a second fake CompactBlock spending value from the address
         let extsk2 = ExtendedSpendingKey::master(&[0]);
         let to2 = extsk2.default_address().1;
-        let value2 = NonNegativeAmount::from_u64(2).unwrap();
-        let (spent_height, _) =
-            st.generate_next_block_spending(&dfvk, (nf, value.into()), to2, value2.into());
+        let value2 = NonNegativeAmount::const_from_u64(2);
+        let (spent_height, _) = st.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
         // Scan the cache again
         st.scan_cached_blocks(spent_height, 1);
@@ -641,16 +640,15 @@ mod tests {
         assert_eq!(st.get_wallet_summary(0), None);
 
         // Create a fake CompactBlock sending value to the address
-        let value = NonNegativeAmount::from_u64(5).unwrap();
+        let value = NonNegativeAmount::const_from_u64(5);
         let (received_height, _, nf) =
-            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
         // Create a second fake CompactBlock spending value from the address
         let extsk2 = ExtendedSpendingKey::master(&[0]);
         let to2 = extsk2.default_address().1;
-        let value2 = NonNegativeAmount::from_u64(2).unwrap();
-        let (spent_height, _) =
-            st.generate_next_block_spending(&dfvk, (nf, value.into()), to2, value2.into());
+        let value2 = NonNegativeAmount::const_from_u64(2);
+        let (spent_height, _) = st.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
         // Scan the spending block first.
         st.scan_cached_blocks(spent_height, 1);

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1135,7 +1135,9 @@ mod tests {
     use {
         crate::testing::AddressType,
         zcash_client_backend::keys::sapling,
-        zcash_primitives::{consensus::Parameters, transaction::components::Amount},
+        zcash_primitives::{
+            consensus::Parameters, transaction::components::amount::NonNegativeAmount,
+        },
     };
 
     #[test]
@@ -1194,12 +1196,12 @@ mod tests {
         let (h1, meta1, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(5).unwrap(),
+            NonNegativeAmount::const_from_u64(5),
         );
         let (h2, meta2, _) = st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::from_u64(10).unwrap(),
+            NonNegativeAmount::const_from_u64(10),
         );
 
         // The BlockMeta DB is not updated until we do so explicitly.

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -48,10 +48,7 @@ use zcash_primitives::{
         Note, Nullifier, PaymentAddress,
     },
     transaction::{
-        components::{
-            amount::{BalanceError, NonNegativeAmount},
-            Amount,
-        },
+        components::amount::{BalanceError, NonNegativeAmount},
         fees::FeeRule,
         Transaction, TxId,
     },
@@ -181,7 +178,7 @@ where
         &mut self,
         dfvk: &DiversifiableFullViewingKey,
         req: AddressType,
-        value: Amount,
+        value: NonNegativeAmount,
     ) -> (BlockHeight, Cache::InsertResult, Nullifier) {
         let (height, prev_hash, initial_sapling_tree_size) = self
             .latest_cached_block
@@ -211,7 +208,7 @@ where
         prev_hash: BlockHash,
         dfvk: &DiversifiableFullViewingKey,
         req: AddressType,
-        value: Amount,
+        value: NonNegativeAmount,
         initial_sapling_tree_size: u32,
     ) -> (Cache::InsertResult, Nullifier) {
         let (cb, nf) = fake_compact_block(
@@ -240,9 +237,9 @@ where
     pub(crate) fn generate_next_block_spending(
         &mut self,
         dfvk: &DiversifiableFullViewingKey,
-        note: (Nullifier, Amount),
+        note: (Nullifier, NonNegativeAmount),
         to: PaymentAddress,
-        value: Amount,
+        value: NonNegativeAmount,
     ) -> (BlockHeight, Cache::InsertResult) {
         let (height, prev_hash, initial_sapling_tree_size) = self
             .latest_cached_block
@@ -434,7 +431,7 @@ impl<Cache> TestState<Cache> {
         &mut self,
         usk: &UnifiedSpendingKey,
         to: &RecipientAddress,
-        amount: Amount,
+        amount: NonNegativeAmount,
         memo: Option<MemoBytes>,
         ovk_policy: OvkPolicy,
         min_confirmations: NonZeroU32,
@@ -700,7 +697,7 @@ pub(crate) fn fake_compact_block<P: consensus::Parameters>(
     prev_hash: BlockHash,
     dfvk: &DiversifiableFullViewingKey,
     req: AddressType,
-    value: Amount,
+    value: NonNegativeAmount,
     initial_sapling_tree_size: u32,
 ) -> (CompactBlock, Nullifier) {
     let to = match req {
@@ -712,7 +709,7 @@ pub(crate) fn fake_compact_block<P: consensus::Parameters>(
     // Create a fake Note for the account
     let mut rng = OsRng;
     let rseed = generate_random_rseed(params, height, &mut rng);
-    let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
+    let note = Note::from_parts(to, NoteValue::from(value), rseed);
     let encryptor = sapling_note_encryption::<_, Network>(
         Some(dfvk.fvk().ovk),
         note.clone(),
@@ -801,10 +798,10 @@ pub(crate) fn fake_compact_block_spending<P: consensus::Parameters>(
     params: &P,
     height: BlockHeight,
     prev_hash: BlockHash,
-    (nf, in_value): (Nullifier, Amount),
+    (nf, in_value): (Nullifier, NonNegativeAmount),
     dfvk: &DiversifiableFullViewingKey,
     to: PaymentAddress,
-    value: Amount,
+    value: NonNegativeAmount,
     initial_sapling_tree_size: u32,
 ) -> CompactBlock {
     let mut rng = OsRng;
@@ -820,7 +817,7 @@ pub(crate) fn fake_compact_block_spending<P: consensus::Parameters>(
 
     // Create a fake Note for the payment
     ctx.outputs.push({
-        let note = Note::from_parts(to, NoteValue::from_raw(value.into()), rseed);
+        let note = Note::from_parts(to, NoteValue::from(value), rseed);
         let encryptor = sapling_note_encryption::<_, Network>(
             Some(dfvk.fvk().ovk),
             note.clone(),
@@ -846,7 +843,7 @@ pub(crate) fn fake_compact_block_spending<P: consensus::Parameters>(
         let rseed = generate_random_rseed(params, height, &mut rng);
         let note = Note::from_parts(
             change_addr,
-            NoteValue::from_raw((in_value - value).unwrap().into()),
+            NoteValue::from((in_value - value).unwrap()),
             rseed,
         );
         let encryptor = sapling_note_encryption::<_, Network>(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2094,7 +2094,7 @@ mod tests {
 
         // Initialize the wallet with chain data that has no shielded notes for us.
         let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
-        let not_our_value = Amount::const_from_i64(10000);
+        let not_our_value = NonNegativeAmount::const_from_u64(10000);
         let (start_height, _, _) =
             st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
         for _ in 1..10 {
@@ -2160,7 +2160,9 @@ mod tests {
 
         // Shield the output.
         let input_selector = GreedyInputSelector::new(
-            fixed::SingleOutputChangeStrategy::new(FixedFeeRule::non_standard(Amount::zero())),
+            fixed::SingleOutputChangeStrategy::new(FixedFeeRule::non_standard(
+                NonNegativeAmount::ZERO,
+            )),
             DustOutputPolicy::default(),
         );
         let txid = st

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -514,8 +514,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note
-        let value = NonNegativeAmount::from_u64(60000).unwrap();
-        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(60000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h, 1);
 
         // Spendable balance matches total balance
@@ -534,7 +534,7 @@ pub(crate) mod tests {
         let to: RecipientAddress = to_extsk.default_address().1.into();
         let request = zip321::TransactionRequest::new(vec![Payment {
             recipient_address: to,
-            amount: Amount::from_u64(10000).unwrap(),
+            amount: Amount::const_from_i64(10000),
             memo: None, // this should result in the creation of an empty memo
             label: None,
             message: None,
@@ -666,7 +666,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk1,
                 &to,
-                Amount::from_u64(1).unwrap(),
+                NonNegativeAmount::const_from_u64(1),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -693,7 +693,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(1).unwrap(),
+                NonNegativeAmount::const_from_u64(1),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -713,8 +713,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note
-        let value = NonNegativeAmount::from_u64(50000).unwrap();
-        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(50000);
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h1, 1);
 
         // Spendable balance matches total balance at 1 confirmation.
@@ -736,7 +736,7 @@ pub(crate) mod tests {
         );
 
         // Add more funds to the wallet in a second note
-        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h2, 1);
 
         // Verified balance does not include the second note
@@ -759,7 +759,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(70000).unwrap(),
+                NonNegativeAmount::const_from_u64(70000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(10).unwrap(),
@@ -768,14 +768,14 @@ pub(crate) mod tests {
                 available,
                 required
             })
-            if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(80000).unwrap()
+            if available == Amount::const_from_i64(50000)
+                && required == Amount::const_from_i64(80000)
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 2 to 9 until just before the second
         // note is verified
         for _ in 2..10 {
-            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         }
         st.scan_cached_blocks(h2 + 1, 8);
 
@@ -787,7 +787,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(70000).unwrap(),
+                NonNegativeAmount::const_from_u64(70000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(10).unwrap(),
@@ -796,12 +796,12 @@ pub(crate) mod tests {
                 available,
                 required
             })
-            if available == Amount::from_u64(50000).unwrap()
-                && required == Amount::from_u64(80000).unwrap()
+            if available == Amount::const_from_i64(50000)
+                && required == Amount::const_from_i64(80000)
         );
 
         // Mine block 11 so that the second note becomes verified
-        let (h11, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let (h11, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h11, 1);
 
         // Total balance is value * number of blocks scanned (11).
@@ -819,7 +819,7 @@ pub(crate) mod tests {
             .create_spend_to_address(
                 &usk,
                 &to,
-                amount_sent.into(),
+                amount_sent,
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(10).unwrap(),
@@ -849,8 +849,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note
-        let value = NonNegativeAmount::from_u64(50000).unwrap();
-        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(50000);
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h1, 1);
 
         // Spendable balance matches total balance at 1 confirmation.
@@ -864,7 +864,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(15000).unwrap(),
+                NonNegativeAmount::const_from_u64(15000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -877,7 +877,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(2000).unwrap(),
+                NonNegativeAmount::const_from_u64(2000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -886,7 +886,7 @@ pub(crate) mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
+            if available == Amount::zero() && required == Amount::const_from_i64(12000)
         );
 
         // Mine blocks SAPLING_ACTIVATION_HEIGHT + 1 to 41 (that don't send us funds)
@@ -895,7 +895,7 @@ pub(crate) mod tests {
             st.generate_next_block(
                 &ExtendedSpendingKey::master(&[i as u8]).to_diversifiable_full_viewing_key(),
                 AddressType::DefaultExternal,
-                value.into(),
+                value,
             );
         }
         st.scan_cached_blocks(h1 + 1, 41);
@@ -905,7 +905,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(2000).unwrap(),
+                NonNegativeAmount::const_from_u64(2000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -914,14 +914,14 @@ pub(crate) mod tests {
                 available,
                 required
             })
-            if available == Amount::zero() && required == Amount::from_u64(12000).unwrap()
+            if available == Amount::zero() && required == Amount::const_from_i64(12000)
         );
 
         // Mine block SAPLING_ACTIVATION_HEIGHT + 42 so that the first transaction expires
         let (h43, _, _) = st.generate_next_block(
             &ExtendedSpendingKey::master(&[42]).to_diversifiable_full_viewing_key(),
             AddressType::DefaultExternal,
-            value.into(),
+            value,
         );
         st.scan_cached_blocks(h43, 1);
 
@@ -935,7 +935,7 @@ pub(crate) mod tests {
             .create_spend_to_address(
                 &usk,
                 &to,
-                amount_sent2.into(),
+                amount_sent2,
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -964,8 +964,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note
-        let value = NonNegativeAmount::from_u64(50000).unwrap();
-        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(50000);
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h1, 1);
 
         // Spendable balance matches total balance at 1 confirmation.
@@ -991,7 +991,7 @@ pub(crate) mod tests {
             let txid = st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(15000).unwrap(),
+                NonNegativeAmount::const_from_u64(15000),
                 None,
                 ovk_policy,
                 NonZeroU32::new(1).unwrap(),
@@ -1040,7 +1040,7 @@ pub(crate) mod tests {
             st.generate_next_block(
                 &ExtendedSpendingKey::master(&[i as u8]).to_diversifiable_full_viewing_key(),
                 AddressType::DefaultExternal,
-                value.into(),
+                value,
             );
         }
         st.scan_cached_blocks(h1 + 1, 42);
@@ -1064,8 +1064,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note
-        let value = NonNegativeAmount::from_u64(60000).unwrap();
-        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let value = NonNegativeAmount::const_from_u64(60000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h, 1);
 
         // Spendable balance matches total balance at 1 confirmation.
@@ -1078,7 +1078,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(50000).unwrap(),
+                NonNegativeAmount::const_from_u64(50000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -1098,8 +1098,8 @@ pub(crate) mod tests {
         let dfvk = st.test_account_sapling().unwrap();
 
         // Add funds to the wallet in a single note owned by the internal spending key
-        let value = NonNegativeAmount::from_u64(60000).unwrap();
-        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::Internal, value.into());
+        let value = NonNegativeAmount::const_from_u64(60000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::Internal, value);
         st.scan_cached_blocks(h, 1);
 
         // Spendable balance matches total balance at 1 confirmation.
@@ -1119,7 +1119,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(50000).unwrap(),
+                NonNegativeAmount::const_from_u64(50000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
@@ -1149,7 +1149,7 @@ pub(crate) mod tests {
 
         // Add funds to the wallet in a single note
         let value = NonNegativeAmount::from_u64(100000).unwrap();
-        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value.into());
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h, 1);
 
         // Spendable balance matches total balance
@@ -1202,8 +1202,7 @@ pub(crate) mod tests {
             )
             .unwrap();
 
-        let amount_left =
-            (value - (amount_sent + fee_rule.fixed_fee().try_into().unwrap()).unwrap()).unwrap();
+        let amount_left = (value - (amount_sent + fee_rule.fixed_fee()).unwrap()).unwrap();
         let pending_change = (amount_left - amount_legacy_change).unwrap();
 
         // The "legacy change" is not counted by get_pending_change().
@@ -1261,7 +1260,7 @@ pub(crate) mod tests {
         let (h1, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::Internal,
-            Amount::from_u64(50000).unwrap(),
+            NonNegativeAmount::const_from_u64(50000),
         );
 
         // Add 10 dust notes to the wallet
@@ -1269,14 +1268,14 @@ pub(crate) mod tests {
             st.generate_next_block(
                 &dfvk,
                 AddressType::DefaultExternal,
-                Amount::from_u64(1000).unwrap(),
+                NonNegativeAmount::const_from_u64(1000),
             );
         }
 
         st.scan_cached_blocks(h1, 11);
 
         // Spendable balance matches total balance
-        let total = NonNegativeAmount::from_u64(60000).unwrap();
+        let total = NonNegativeAmount::const_from_u64(60000);
         assert_eq!(st.get_total_balance(account), total);
         assert_eq!(st.get_spendable_balance(account, 1), total);
 
@@ -1288,7 +1287,7 @@ pub(crate) mod tests {
         // This first request will fail due to insufficient non-dust funds
         let req = TransactionRequest::new(vec![Payment {
             recipient_address: RecipientAddress::Shielded(dfvk.default_address().1),
-            amount: Amount::from_u64(50000).unwrap(),
+            amount: Amount::const_from_i64(50000),
             memo: None,
             label: None,
             message: None,
@@ -1305,15 +1304,15 @@ pub(crate) mod tests {
                 NonZeroU32::new(1).unwrap(),
             ),
             Err(Error::InsufficientFunds { available, required })
-                if available == Amount::from_u64(51000).unwrap()
-                && required == Amount::from_u64(60000).unwrap()
+                if available == Amount::const_from_i64(51000)
+                && required == Amount::const_from_i64(60000)
         );
 
         // This request will succeed, spending a single dust input to pay the 10000
         // ZAT fee in addition to the 41000 ZAT output to the recipient
         let req = TransactionRequest::new(vec![Payment {
             recipient_address: RecipientAddress::Shielded(dfvk.default_address().1),
-            amount: Amount::from_u64(41000).unwrap(),
+            amount: Amount::const_from_i64(41000),
             memo: None,
             label: None,
             message: None,
@@ -1365,14 +1364,14 @@ pub(crate) mod tests {
         let (h, _, _) = st.generate_next_block(
             &dfvk,
             AddressType::Internal,
-            Amount::from_u64(50000).unwrap(),
+            NonNegativeAmount::const_from_u64(50000),
         );
         st.scan_cached_blocks(h, 1);
 
         let utxo = WalletTransparentOutput::from_parts(
             OutPoint::new([1u8; 32], 1),
             TxOut {
-                value: Amount::from_u64(10000).unwrap(),
+                value: Amount::const_from_i64(10000),
                 script_pubkey: taddr.script(),
             },
             h,
@@ -1431,7 +1430,7 @@ pub(crate) mod tests {
 
         // Generate 9 blocks that have no value for us, starting at the birthday height.
         let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
-        let not_our_value = Amount::const_from_i64(10000);
+        let not_our_value = NonNegativeAmount::const_from_u64(10000);
         st.generate_block_at(
             birthday.height(),
             BlockHash([0; 32]),
@@ -1448,7 +1447,7 @@ pub(crate) mod tests {
         st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::const_from_i64(500000),
+            NonNegativeAmount::const_from_u64(500000),
         );
 
         // Generate some more blocks to get above our anchor height
@@ -1502,14 +1501,14 @@ pub(crate) mod tests {
         st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::const_from_i64(500000),
+            NonNegativeAmount::const_from_u64(500000),
         );
         st.scan_cached_blocks(birthday.height(), 1);
 
         // Create a gap of 10 blocks having no shielded outputs, then add a block that doesn't
         // belong to us so that we can get a checkpoint in the tree.
         let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
-        let not_our_value = Amount::const_from_i64(10000);
+        let not_our_value = NonNegativeAmount::const_from_u64(10000);
         st.generate_block_at(
             birthday.height() + 10,
             BlockHash([0; 32]),
@@ -1545,7 +1544,7 @@ pub(crate) mod tests {
             st.create_spend_to_address(
                 &usk,
                 &to,
-                Amount::from_u64(10000).unwrap(),
+                NonNegativeAmount::const_from_u64(10000),
                 None,
                 OvkPolicy::Sender,
                 NonZeroU32::new(5).unwrap(),

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -512,7 +512,7 @@ pub(crate) mod tests {
         block::BlockHash,
         consensus::{BlockHeight, NetworkUpgrade, Parameters},
         sapling::Node,
-        transaction::components::Amount,
+        transaction::components::amount::NonNegativeAmount,
         zip32::DiversifiableFullViewingKey,
     };
 
@@ -564,7 +564,7 @@ pub(crate) mod tests {
         let initial_sapling_tree_size = (0x1 << 16) * 3 + 5;
         let initial_height = sapling_activation_height + 310;
 
-        let value = Amount::from_u64(50000).unwrap();
+        let value = NonNegativeAmount::const_from_u64(50000);
         st.generate_block_at(
             initial_height,
             BlockHash([0; 32]),
@@ -578,7 +578,7 @@ pub(crate) mod tests {
             st.generate_next_block(
                 &dfvk,
                 AddressType::DefaultExternal,
-                Amount::from_u64(10000).unwrap(),
+                NonNegativeAmount::const_from_u64(10000),
             );
         }
 
@@ -845,8 +845,8 @@ pub(crate) mod tests {
             BlockHash([0u8; 32]),
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::const_from_i64(10000),
             // 1235 notes into into the second shard
+            NonNegativeAmount::const_from_u64(10000),
             u64::from(birthday.sapling_frontier().value().unwrap().position() + 1)
                 .try_into()
                 .unwrap(),
@@ -961,7 +961,7 @@ pub(crate) mod tests {
             BlockHash([0u8; 32]),
             &dfvk,
             AddressType::DefaultExternal,
-            Amount::const_from_i64(10000),
+            NonNegativeAmount::const_from_u64(10000),
             u64::from(birthday.sapling_frontier().value().unwrap().position() + 1)
                 .try_into()
                 .unwrap(),

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -847,7 +847,7 @@ mod tests {
 
         let mut builder_b = demo_builder(tx_height + 1);
         let prevout_a = (OutPoint::new(tx_a.txid(), 0), tze_a.vout[0].clone());
-        let value_xfr = (value - fee_rule.fixed_fee()).unwrap();
+        let value_xfr = (value - fee_rule.fixed_fee().into()).unwrap();
         builder_b
             .demo_transfer_to_close(prevout_a, value_xfr, preimage_1, h2)
             .map_err(|e| format!("transfer failure: {:?}", e))
@@ -873,7 +873,7 @@ mod tests {
         builder_c
             .add_transparent_output(
                 &TransparentAddress::PublicKey([0; 20]),
-                (value_xfr - fee_rule.fixed_fee()).unwrap(),
+                (value_xfr - fee_rule.fixed_fee().into()).unwrap(),
             )
             .unwrap();
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -21,16 +21,41 @@ and this library adheres to Rust's notion of
     set of closures.
 - Test helpers, behind the `test-dependencies` feature flag:
   - `zcash_primitives::prover::mock::{MockSpendProver, MockOutputProver}`
-- MARGINAL_FEE pub const Amount:
-  - `zcash_primitives::transaction::fees::zip317::MARGINAL_FEE`
+- Constants in `zcash_primitives::transaction::fees::zip317`:
+  - `MARGINAL_FEE`
+  - `GRACE_ACTIONS`
+  - `P2PKH_STANDARD_INPUT_SIZE`
+  - `P2PKH_STANDARD_OUTPUT_SIZE`
+- `zcash_primitives::transaction::builder::get_fee`
+- Additions related to `zcash_primitive::components::transaction::Amount`
+  and `zcash_primitive::components::transaction::NonNegativeAmount`
+  - `impl TryFrom<Amount> for u64`
+  - `Amount::const_from_u64`
+  - `NonNegativeAmount::const_from_u64`
+  - `NonNegativeAmount::from_nonnegative_i64_le_bytes`
+  - `NonNegativeAmount::to_i64_le_bytes`
+  - `impl From<&NonNegativeAmount> for Amount`
+  - `impl From<NonNegativeAmount> for u64`
+  - `impl From<NonNegativeAmount> for zcash_primitives::sapling::value::NoteValue`
+  - `impl Sum<NonNegativeAmount> for Option<NonNegativeAmount>`
+  - `impl<'a> Sum<&'a NonNegativeAmount> for Option<NonNegativeAmount>`
 
 ### Changed
+- `zcash_primitives::transaction::fees`:
+  - `FeeRule::fee_required` now returns the required fee as a `NonNegativeAmount` instead
+    of as an `Amount`.
+  - When using the `zfuture` feature flag, `FutureFeeRule::fee_required_zfuture` now returns
+    the required fee as a `NonNegativeAmount` instead of as an `Amount`.
+  - `fees::fixed::FeeRule::fixed_fee` now wraps a `NonNegativeAmount` instead of an `Amount`
+  - `fees::zip317::FeeRule::marginal_fee` is now represented and exposed as a
+    `NonNegativeAmount` instead of an `Amount`
 - `zcash_primitives::transaction::components::sapling`:
   - `MapAuth` trait methods now take `&mut self` instead of `&self`.
 
 ### Removed
 - `zcash_primitives::constants`:
   - All `const` values (moved to `zcash_primitives::sapling::constants`).
+- `impl From<zcash_primitive::components::transaction::Amount> for u64`
 
 ## [0.13.0] - 2023-09-25
 ### Added
@@ -55,7 +80,7 @@ and this library adheres to Rust's notion of
 ### Changed
 - Migrated to `incrementalmerkletree 0.5`, `orchard 0.6`.
 - `zcash_primitives::transaction`:
-  - `builder::Builder::{new, new_with_rng}` now take an optional `orchard_anchor` 
+  - `builder::Builder::{new, new_with_rng}` now take an optional `orchard_anchor`
     argument which must be provided in order to enable Orchard spends and recipients.
   - All `builder::Builder` methods now require the bound `R: CryptoRng` on
     `Builder<'a, P, R>`. A non-`CryptoRng` randomness source is still accepted
@@ -64,11 +89,11 @@ and this library adheres to Rust's notion of
   - `builder::Error` has several additional variants for Orchard-related errors.
   - `fees::FeeRule::fee_required` now takes an additional argument,
     `orchard_action_count`
-  - `Unauthorized`'s associated type `OrchardAuth` is now 
+  - `Unauthorized`'s associated type `OrchardAuth` is now
     `orchard::builder::InProgress<orchard::builder::Unproven, orchard::builder::Unauthorized>`
     instead of `zcash_primitives::transaction::components::orchard::Unauthorized`
 - `zcash_primitives::consensus::NetworkUpgrade` now implements `PartialEq`, `Eq`
-- `zcash_primitives::legacy::Script` now has a custom `Debug` implementation that 
+- `zcash_primitives::legacy::Script` now has a custom `Debug` implementation that
   renders script details in a much more legible fashion.
 - `zcash_primitives::sapling::redjubjub::Signature` now has a custom `Debug`
   implementation that renders details in a much more legible fashion.
@@ -76,7 +101,7 @@ and this library adheres to Rust's notion of
   implementation that renders details in a much more legible fashion.
 
 ### Removed
-- `impl {PartialEq, Eq} for transaction::builder::Error` 
+- `impl {PartialEq, Eq} for transaction::builder::Error`
   (use `assert_matches!` where error comparisons are required)
 - `zcash_primitives::transaction::components::orchard::Unauthorized`
 - `zcash_primitives::transaction::components::amount::DEFAULT_FEE` was

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{amount::Amount, transparent::fees as transparent},
+    transaction::components::{amount::NonNegativeAmount, transparent::fees as transparent},
 };
 
 #[cfg(feature = "zfuture")]
@@ -31,7 +31,7 @@ pub trait FeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
-    ) -> Result<Amount, Self::Error>;
+    ) -> Result<NonNegativeAmount, Self::Error>;
 }
 
 /// A trait that represents the ability to compute the fees that must be paid by a transaction
@@ -54,5 +54,5 @@ pub trait FutureFeeRule: FeeRule {
         sapling_output_count: usize,
         tze_inputs: &[impl tze::InputView],
         tze_outputs: &[impl tze::OutputView],
-    ) -> Result<Amount, Self::Error>;
+    ) -> Result<NonNegativeAmount, Self::Error>;
 }

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,6 +1,6 @@
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{amount::Amount, transparent::fees as transparent},
+    transaction::components::{amount::NonNegativeAmount, transparent::fees as transparent},
     transaction::fees::zip317,
 };
 
@@ -11,12 +11,12 @@ use crate::transaction::components::tze::fees as tze;
 /// the transaction being constructed.
 #[derive(Clone, Copy, Debug)]
 pub struct FeeRule {
-    fixed_fee: Amount,
+    fixed_fee: NonNegativeAmount,
 }
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
-    pub fn non_standard(fixed_fee: Amount) -> Self {
+    pub fn non_standard(fixed_fee: NonNegativeAmount) -> Self {
         Self { fixed_fee }
     }
 
@@ -40,7 +40,7 @@ impl FeeRule {
     }
 
     /// Returns the fixed fee amount which which this rule was configured.
-    pub fn fixed_fee(&self) -> Amount {
+    pub fn fixed_fee(&self) -> NonNegativeAmount {
         self.fixed_fee
     }
 }
@@ -57,7 +57,7 @@ impl super::FeeRule for FeeRule {
         _sapling_input_count: usize,
         _sapling_output_count: usize,
         _orchard_action_count: usize,
-    ) -> Result<Amount, Self::Error> {
+    ) -> Result<NonNegativeAmount, Self::Error> {
         Ok(self.fixed_fee)
     }
 }
@@ -74,7 +74,7 @@ impl super::FutureFeeRule for FeeRule {
         _sapling_output_count: usize,
         _tze_inputs: &[impl tze::InputView],
         _tze_outputs: &[impl tze::OutputView],
-    ) -> Result<Amount, Self::Error> {
+    ) -> Result<NonNegativeAmount, Self::Error> {
         Ok(self.fixed_fee)
     }
 }


### PR DESCRIPTION
It's incorrect to use the possibly-negative `Amount` type in places where values must be nonnegative.

This updates fee and change data structures to use `NonNegativeAmount` where possible.