### PR TITLE
zcash_primitives: Use sapling::NoteValue instead of bare u64

### DIFF
--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -815,7 +815,10 @@ mod tests {
         // create some inputs to spend
         let extsk = ExtendedSpendingKey::master(&[]);
         let to = extsk.default_address().1;
-        let note1 = to.create_note(110000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(
+            sapling::value::NoteValue::from_raw(110000),
+            Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)),
+        );
         let cm1 = Node::from_cmu(&note1.cmu());
         let mut tree = sapling::CommitmentTree::empty();
         // fake that the note appears in some previous

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -39,6 +39,10 @@ and this library adheres to Rust's notion of
   - `impl From<NonNegativeAmount> for zcash_primitives::sapling::value::NoteValue`
   - `impl Sum<NonNegativeAmount> for Option<NonNegativeAmount>`
   - `impl<'a> Sum<&'a NonNegativeAmount> for Option<NonNegativeAmount>`
+- `zcash_primitives::sapling::circuit::ValueCommitmentOpening::value` is
+  now represented as a `NoteValue` instead of as a bare `u64`.
+- `zcash_primitives::sapling::address::PaymentAddress::create_note` now
+  takes its `value` argument as a `NoteValue` instead of as a bare `u64`.
 
 ### Changed
 - `zcash_primitives::transaction::fees`:

--- a/zcash_primitives/src/sapling/address.rs
+++ b/zcash_primitives/src/sapling/address.rs
@@ -93,8 +93,8 @@ impl PaymentAddress {
         self.diversifier.g_d().expect("checked at construction")
     }
 
-    pub fn create_note(&self, value: u64, rseed: Rseed) -> Note {
-        Note::from_parts(*self, NoteValue::from_raw(value), rseed)
+    pub fn create_note(&self, value: NoteValue, rseed: Rseed) -> Note {
+        Note::from_parts(*self, value, rseed)
     }
 }
 

--- a/zcash_primitives/src/sapling/note_encryption.rs
+++ b/zcash_primitives/src/sapling/note_encryption.rs
@@ -108,7 +108,7 @@ where
 
     // `diversifier` was checked by `get_pk_d`.
     let to = PaymentAddress::from_parts_unchecked(diversifier, pk_d)?;
-    let note = to.create_note(value.try_into().unwrap(), rseed);
+    let note = to.create_note(value.into(), rseed);
     Some((note, to))
 }
 
@@ -369,7 +369,7 @@ impl<P: consensus::Parameters> BatchDomain for SaplingDomain<P> {
 /// let cv = ValueCommitment::derive(value, rcv);
 /// let height = TEST_NETWORK.activation_height(NetworkUpgrade::Canopy).unwrap();
 /// let rseed = generate_random_rseed(&TEST_NETWORK, height, &mut rng);
-/// let note = to.create_note(value.inner(), rseed);
+/// let note = to.create_note(value, rseed);
 /// let cmu = note.cmu();
 ///
 /// let mut enc = sapling_note_encryption::<_, TestNetwork>(ovk, note, MemoBytes::empty(), &mut rng);
@@ -589,7 +589,7 @@ mod tests {
 
         let rseed = generate_random_rseed(&TEST_NETWORK, height, &mut rng);
 
-        let note = pa.create_note(value.inner(), rseed);
+        let note = pa.create_note(value, rseed);
         let cmu = note.cmu();
 
         let ovk = OutgoingViewingKey([0; 32]);
@@ -1421,7 +1421,7 @@ mod tests {
             assert_eq!(ock.as_ref(), tv.ock);
 
             let to = PaymentAddress::from_parts(Diversifier(tv.default_d), pk_d).unwrap();
-            let note = to.create_note(tv.v, Rseed::BeforeZip212(rcm));
+            let note = to.create_note(NoteValue::from_raw(tv.v), Rseed::BeforeZip212(rcm));
             assert_eq!(note.cmu(), cmu);
 
             let output = OutputDescription::from_parts(

--- a/zcash_primitives/src/sapling/prover.rs
+++ b/zcash_primitives/src/sapling/prover.rs
@@ -170,7 +170,7 @@ pub mod mock {
                 .to_payment_address(diversifier);
             Some(sapling::circuit::Spend {
                 value_commitment_opening: Some(ValueCommitmentOpening {
-                    value: value.inner(),
+                    value,
                     randomness: rcv.inner(),
                 }),
                 proof_generation_key: Some(proof_generation_key),
@@ -209,7 +209,7 @@ pub mod mock {
         ) -> sapling::circuit::Output {
             sapling::circuit::Output {
                 value_commitment_opening: Some(ValueCommitmentOpening {
-                    value: value.inner(),
+                    value,
                     randomness: rcv.inner(),
                 }),
                 payment_address: Some(payment_address),

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -12,7 +12,7 @@ use crate::{
     keys::OutgoingViewingKey,
     legacy::TransparentAddress,
     memo::MemoBytes,
-    sapling::{self, prover::TxProver, value::NoteValue, Diversifier, Note, PaymentAddress},
+    sapling::{self, prover::TxProver, Diversifier, Note, PaymentAddress},
     transaction::{
         components::{
             amount::{Amount, BalanceError},
@@ -344,7 +344,7 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R> {
             &mut self.rng,
             ovk,
             to,
-            NoteValue::from_raw(value.into()),
+            sapling::value::NoteValue::from_raw(value.into()),
             memo,
         )
     }
@@ -709,7 +709,7 @@ mod tests {
         consensus::{NetworkUpgrade, Parameters, TEST_NETWORK},
         legacy::TransparentAddress,
         memo::MemoBytes,
-        sapling::{Node, Rseed},
+        sapling::{self, Node, Rseed},
         transaction::components::{
             amount::{Amount, NonNegativeAmount},
             sapling::builder::{self as sapling_builder},
@@ -802,7 +802,10 @@ mod tests {
 
         let mut rng = OsRng;
 
-        let note1 = to.create_note(50000, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(
+            sapling::value::NoteValue::from_raw(50000),
+            Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)),
+        );
         let cmu1 = Node::from_cmu(&note1.cmu());
         let mut tree = CommitmentTree::<Node, 32>::empty();
         tree.append(cmu1).unwrap();
@@ -895,7 +898,10 @@ mod tests {
             );
         }
 
-        let note1 = to.create_note(59999, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note1 = to.create_note(
+            sapling::value::NoteValue::from_raw(59999),
+            Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)),
+        );
         let cmu1 = Node::from_cmu(&note1.cmu());
         let mut tree = CommitmentTree::<Node, 32>::empty();
         tree.append(cmu1).unwrap();
@@ -933,7 +939,10 @@ mod tests {
             );
         }
 
-        let note2 = to.create_note(1, Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)));
+        let note2 = to.create_note(
+            sapling::value::NoteValue::from_raw(1),
+            Rseed::BeforeZip212(jubjub::Fr::random(&mut rng)),
+        );
         let cmu2 = Node::from_cmu(&note2.cmu());
         tree.append(cmu2).unwrap();
         witness1.append(cmu2).unwrap();

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 use memuse::DynamicUsage;
 use orchard::value as orchard;
 
-use crate::sapling::value::NoteValue;
+use crate::sapling;
 
 pub const COIN: i64 = 1_0000_0000;
 pub const MAX_MONEY: i64 = 21_000_000 * COIN;
@@ -316,9 +316,9 @@ impl From<NonNegativeAmount> for u64 {
     }
 }
 
-impl From<NonNegativeAmount> for NoteValue {
+impl From<NonNegativeAmount> for sapling::value::NoteValue {
     fn from(n: NonNegativeAmount) -> Self {
-        NoteValue::from_raw(n.0.try_into().unwrap())
+        sapling::value::NoteValue::from_raw(n.into())
     }
 }
 

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -31,7 +31,7 @@ impl SpendProver for SpendParameters {
     ) -> Option<Spend> {
         // Construct the value commitment
         let value_commitment_opening = ValueCommitmentOpening {
-            value: value.inner(),
+            value,
             randomness: rcv.inner(),
         };
 
@@ -86,7 +86,7 @@ impl OutputProver for OutputParameters {
     ) -> Output {
         // Construct the value commitment for the proof instance
         let value_commitment_opening = ValueCommitmentOpening {
-            value: value.inner(),
+            value,
             randomness: rcv.inner(),
         };
 


### PR DESCRIPTION
Builds upon #1014