### PR TITLE
Add an enumeration of standard fee rules.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -14,6 +14,7 @@ and this library adheres to Rust's notion of
   before it is fully supported.
 - `zcash_client_backend::data_api::error::Error` has new error variant:
   - `Error::UnsupportedPoolType(zcash_client_backend::data_api::PoolType)`
+- Added module `zcash_client_backend::fees::standard`
 - Added methods to `zcash_client_backend::wallet::ReceivedSaplingNote`:
   `{from_parts, txid, output_index, diversifier, rseed, note_commitment_tree_position}`.
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
+
 use zcash_primitives::{
     consensus::{self, BlockHeight, NetworkUpgrade},
     memo::MemoBytes,
@@ -212,29 +213,31 @@ where
     DbT: WalletWrite + WalletCommitmentTrees,
     DbT::NoteRef: Copy + Eq + Ord,
 {
-    let req = zip321::TransactionRequest::new(vec![Payment {
-        recipient_address: to.clone(),
-        amount,
-        memo,
-        label: None,
-        message: None,
-        other_params: vec![],
-    }])
-    .expect(
-        "It should not be possible for this to violate ZIP 321 request construction invariants.",
-    );
+    let account = wallet_db
+        .get_account_for_ufvk(&usk.to_unified_full_viewing_key())
+        .map_err(Error::DataSource)?
+        .ok_or(Error::KeyNotRecognized)?;
 
     #[allow(deprecated)]
-    let fee_rule = StandardFeeRule::PreZip313;
-    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(fee_rule, change_memo);
-    spend(
+    let proposal = propose_standard_transfer_to_address(
+        wallet_db,
+        params,
+        StandardFeeRule::PreZip313,
+        account,
+        min_confirmations,
+        to,
+        amount,
+        memo,
+        change_memo,
+    )?;
+
+    create_proposed_transaction(
         wallet_db,
         params,
         prover,
-        &GreedyInputSelector::<DbT, _>::new(change_strategy, DustOutputPolicy::default()),
         usk,
-        req,
         ovk_policy,
+        proposal,
         min_confirmations,
     )
 }
@@ -371,6 +374,77 @@ where
             min_confirmations,
         )
         .map_err(Error::from)
+}
+
+/// Proposes a transaction paying the specified address from the given account.
+///
+/// Returns the proposal, which may then be executed using [`create_proposed_transaction`]
+///
+/// Parameters:
+/// * `wallet_db`: A read/write reference to the wallet database
+/// * `params`: Consensus parameters
+/// * `fee_rule`: The fee rule to use in creating the transaction.
+/// * `spend_from_account`: The unified account that controls the funds that will be spent
+///   in the resulting transaction. This procedure will return an error if the
+///   account ID does not correspond to an account known to the wallet.
+/// * `min_confirmations`: The minimum number of confirmations that a previously
+///   received note must have in the blockchain in order to be considered for being
+///   spent. A value of 10 confirmations is recommended and 0-conf transactions are
+///   not supported.
+/// * `to`: The address to which `amount` will be paid.
+/// * `amount`: The amount to send.
+/// * `memo`: A memo to be included in the output to the recipient.
+/// * `change_memo`: A memo to be included in any change output that is created.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    fee_rule: StandardFeeRule,
+    spend_from_account: AccountId,
+    min_confirmations: NonZeroU32,
+    to: &RecipientAddress,
+    amount: NonNegativeAmount,
+    memo: Option<MemoBytes>,
+    change_memo: Option<MemoBytes>,
+) -> Result<
+    Proposal<StandardFeeRule, DbT::NoteRef>,
+    Error<
+        DbT::Error,
+        CommitmentTreeErrT,
+        GreedyInputSelectorError<Zip317FeeError, DbT::NoteRef>,
+        Zip317FeeError,
+    >,
+>
+where
+    ParamsT: consensus::Parameters + Clone,
+    DbT: WalletWrite,
+    DbT::NoteRef: Copy + Eq + Ord,
+{
+    let request = zip321::TransactionRequest::new(vec![Payment {
+        recipient_address: to.clone(),
+        amount,
+        memo,
+        label: None,
+        message: None,
+        other_params: vec![],
+    }])
+    .expect(
+        "It should not be possible for this to violate ZIP 321 request construction invariants.",
+    );
+
+    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(fee_rule, change_memo);
+    let input_selector =
+        GreedyInputSelector::<DbT, _>::new(change_strategy, DustOutputPolicy::default());
+
+    propose_transfer(
+        wallet_db,
+        params,
+        spend_from_account,
+        &input_selector,
+        request,
+        min_confirmations,
+    )
 }
 
 #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -381,8 +381,8 @@ where
 /// Returns the proposal, which may then be executed using [`create_proposed_transaction`]
 ///
 /// Parameters:
-/// * `wallet_db`: A read/write reference to the wallet database
-/// * `params`: Consensus parameters
+/// * `wallet_db`: A read/write reference to the wallet database.
+/// * `params`: Consensus parameters.
 /// * `fee_rule`: The fee rule to use in creating the transaction.
 /// * `spend_from_account`: The unified account that controls the funds that will be spent
 ///   in the resulting transaction. This procedure will return an error if the

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -15,6 +15,7 @@ use zcash_primitives::{
 };
 
 pub mod fixed;
+pub mod standard;
 pub mod zip317;
 
 /// A proposed change amount and output pool.
@@ -116,6 +117,28 @@ pub enum ChangeError<E, NoteRefT> {
     },
     /// An error occurred that was specific to the change selection strategy in use.
     StrategyError(E),
+}
+
+impl<E, NoteRefT> ChangeError<E, NoteRefT> {
+    pub fn map<E0, F: FnOnce(E) -> E0>(self, f: F) -> ChangeError<E0, NoteRefT> {
+        match self {
+            ChangeError::InsufficientFunds {
+                available,
+                required,
+            } => ChangeError::InsufficientFunds {
+                available,
+                required,
+            },
+            ChangeError::DustInputs {
+                transparent,
+                sapling,
+            } => ChangeError::DustInputs {
+                transparent,
+                sapling,
+            },
+            ChangeError::StrategyError(e) => ChangeError::StrategyError(f(e)),
+        }
+    }
 }
 
 impl<CE: fmt::Display, N: fmt::Display> fmt::Display for ChangeError<CE, N> {

--- a/zcash_client_backend/src/fees/standard.rs
+++ b/zcash_client_backend/src/fees/standard.rs
@@ -17,7 +17,7 @@ use zcash_primitives::{
 
 use super::{fixed, zip317, ChangeError, ChangeStrategy, DustOutputPolicy, TransactionBalance};
 
-/// A change strategy that and proposes change as a single output to the most current supported
+/// A change strategy that proposes change as a single output to the most current supported
 /// shielded pool and delegates fee calculation to the provided fee rule.
 pub struct SingleOutputChangeStrategy {
     fee_rule: StandardFeeRule,

--- a/zcash_client_backend/src/fees/standard.rs
+++ b/zcash_client_backend/src/fees/standard.rs
@@ -1,0 +1,101 @@
+//! Change strategies designed for use with a standard fee.
+
+use zcash_primitives::{
+    consensus::{self, BlockHeight},
+    memo::MemoBytes,
+    transaction::{
+        components::{
+            amount::NonNegativeAmount, sapling::fees as sapling, transparent::fees as transparent,
+        },
+        fees::{
+            fixed::FeeRule as FixedFeeRule,
+            zip317::{FeeError as Zip317FeeError, FeeRule as Zip317FeeRule},
+            StandardFeeRule,
+        },
+    },
+};
+
+use super::{fixed, zip317, ChangeError, ChangeStrategy, DustOutputPolicy, TransactionBalance};
+
+/// A change strategy that and proposes change as a single output to the most current supported
+/// shielded pool and delegates fee calculation to the provided fee rule.
+pub struct SingleOutputChangeStrategy {
+    fee_rule: StandardFeeRule,
+    change_memo: Option<MemoBytes>,
+}
+
+impl SingleOutputChangeStrategy {
+    /// Constructs a new [`SingleOutputChangeStrategy`] with the specified ZIP 317
+    /// fee parameters.
+    pub fn new(fee_rule: StandardFeeRule, change_memo: Option<MemoBytes>) -> Self {
+        Self {
+            fee_rule,
+            change_memo,
+        }
+    }
+}
+
+impl ChangeStrategy for SingleOutputChangeStrategy {
+    type FeeRule = StandardFeeRule;
+    type Error = Zip317FeeError;
+
+    fn fee_rule(&self) -> &Self::FeeRule {
+        &self.fee_rule
+    }
+
+    fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
+        &self,
+        params: &P,
+        target_height: BlockHeight,
+        transparent_inputs: &[impl transparent::InputView],
+        transparent_outputs: &[impl transparent::OutputView],
+        sapling_inputs: &[impl sapling::InputView<NoteRefT>],
+        sapling_outputs: &[impl sapling::OutputView],
+        dust_output_policy: &DustOutputPolicy,
+    ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
+        #[allow(deprecated)]
+        match self.fee_rule() {
+            StandardFeeRule::PreZip313 => fixed::SingleOutputChangeStrategy::new(
+                FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(10000)),
+                self.change_memo.clone(),
+            )
+            .compute_balance(
+                params,
+                target_height,
+                transparent_inputs,
+                transparent_outputs,
+                sapling_inputs,
+                sapling_outputs,
+                dust_output_policy,
+            )
+            .map_err(|e| e.map(Zip317FeeError::Balance)),
+            StandardFeeRule::Zip313 => fixed::SingleOutputChangeStrategy::new(
+                FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(1000)),
+                self.change_memo.clone(),
+            )
+            .compute_balance(
+                params,
+                target_height,
+                transparent_inputs,
+                transparent_outputs,
+                sapling_inputs,
+                sapling_outputs,
+                dust_output_policy,
+            )
+            .map_err(|e| e.map(Zip317FeeError::Balance)),
+            StandardFeeRule::Zip317 => zip317::SingleOutputChangeStrategy::new(
+                Zip317FeeRule::standard(),
+                self.change_memo.clone(),
+            )
+            .compute_balance(
+                params,
+                target_height,
+                transparent_inputs,
+                transparent_outputs,
+                sapling_inputs,
+                sapling_outputs,
+                dust_output_policy,
+            ),
+        }
+    }
+}

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -549,7 +549,7 @@ impl<Cache> TestState<Cache> {
         >,
     > {
         let params = self.network();
-        let result = propose_standard_transfer_to_address::<_, _, CommitmentTreeErrT>(
+        propose_standard_transfer_to_address::<_, _, CommitmentTreeErrT>(
             &mut self.db_data,
             &params,
             fee_rule,
@@ -559,9 +559,7 @@ impl<Cache> TestState<Cache> {
             amount,
             memo,
             change_memo,
-        );
-
-        result
+        )
     }
 
     /// Invokes [`propose_shielding`] with the given arguments.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -80,6 +80,7 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `transaction::fees::StandardFeeRule`
+
 ## [0.13.0] - 2023-09-25
 ### Added
 - `zcash_primitives::consensus::BlockHeight::saturating_sub`

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -78,6 +78,8 @@ and this library adheres to Rust's notion of
   - All `const` values (moved to `zcash_primitives::sapling::constants`).
 - `impl From<zcash_primitive::components::transaction::Amount> for u64`
 
+### Added
+- `transaction::fees::StandardFeeRule`
 ## [0.13.0] - 2023-09-25
 ### Added
 - `zcash_primitives::consensus::BlockHeight::saturating_sub`

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -60,9 +60,13 @@ pub trait FutureFeeRule: FeeRule {
 /// An enumeration of the standard fee rules supported by the wallet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StandardFeeRule {
-    #[deprecated(note = "It is recommended to use `StandardFeeRule::Zip317` instead.")]
+    #[deprecated(
+        note = "Using this fee rule violates ZIP 317, and might cause transactions built with it to fail. Use `StandardFeeRule::Zip317` instead."
+    )]
     PreZip313,
-    #[deprecated(note = "It is recommended to use `StandardFeeRule::Zip317` instead.")]
+    #[deprecated(
+        note = "Using this fee rule violates ZIP 317, and might cause transactions built with it to fail. Use `StandardFeeRule::Zip317` instead."
+    )]
     Zip313,
     Zip317,
 }

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -56,3 +56,43 @@ pub trait FutureFeeRule: FeeRule {
         tze_outputs: &[impl tze::OutputView],
     ) -> Result<NonNegativeAmount, Self::Error>;
 }
+
+/// An enumeration of the standard fee rules supported by the wallet.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum StandardFeeRule {
+    #[deprecated(note = "It is recommended to use `StandardFeeRule::Zip317` instead.")]
+    PreZip313,
+    #[deprecated(note = "It is recommended to use `StandardFeeRule::Zip317` instead.")]
+    Zip313,
+    Zip317,
+}
+
+impl FeeRule for StandardFeeRule {
+    type Error = zip317::FeeError;
+
+    fn fee_required<P: consensus::Parameters>(
+        &self,
+        params: &P,
+        target_height: BlockHeight,
+        transparent_inputs: &[impl transparent::InputView],
+        transparent_outputs: &[impl transparent::OutputView],
+        sapling_input_count: usize,
+        sapling_output_count: usize,
+        orchard_action_count: usize,
+    ) -> Result<NonNegativeAmount, Self::Error> {
+        #[allow(deprecated)]
+        match self {
+            Self::PreZip313 => Ok(zip317::MINIMUM_FEE),
+            Self::Zip313 => Ok(NonNegativeAmount::const_from_u64(1000)),
+            Self::Zip317 => zip317::FeeRule::standard().fee_required(
+                params,
+                target_height,
+                transparent_inputs,
+                transparent_outputs,
+                sapling_input_count,
+                sapling_output_count,
+                orchard_action_count,
+            ),
+        }
+    }
+}


### PR DESCRIPTION
In order to pass a `FeeRule` across a serialization boundary, it is necessary for the type of the fee rule to be known. The simplest approach to this is to add serialization for a fixed set of types. `StandardFeeRule` provides such a set of known fee rules, so that we can serialize and deserialize them.

Extracted from #891 