### PR TITLE
zcash_client_backend: Move `min_confirmations` into `Proposal`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -47,6 +47,8 @@ and this library adheres to Rust's notion of
     `TransactionBalance`.
   - `wallet::create_spend_to_address` now takes an additional
     `change_memo` argument.
+  - `wallet::create_proposed_transaction` now takes its `proposal` argument
+      by reference instead of as an owned value.
 - `zcash_client_backend::fees::ChangeValue::Sapling` is now a structured variant.
   In addition to the existing change value, it now also carries an optional memo
   to be associated with the change output.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -15,6 +15,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api::error::Error` has new error variant:
   - `Error::UnsupportedPoolType(zcash_client_backend::data_api::PoolType)`
 - Added module `zcash_client_backend::fees::standard`
+- Added `zcash_client_backend::wallet::input_selection::Proposal::min_confirmations`
 - Added methods to `zcash_client_backend::wallet::ReceivedSaplingNote`:
   `{from_parts, txid, output_index, diversifier, rseed, note_commitment_tree_position}`.
 
@@ -45,10 +46,12 @@ and this library adheres to Rust's notion of
     `change_memo` argument; instead, change memos are represented in the
     individual values of the `proposed_change` field of the `Proposal`'s
     `TransactionBalance`.
+  - `wallet::create_proposed_transaction` now takes its `proposal` argument
+    by reference instead of as an owned value.
+  - `wallet::create_proposed_transaction` no longer takes a `min_confirmations`
+    argument. Instead, `min_confirmations` is stored in the `Proposal`
   - `wallet::create_spend_to_address` now takes an additional
     `change_memo` argument.
-  - `wallet::create_proposed_transaction` now takes its `proposal` argument
-      by reference instead of as an owned value.
 - `zcash_client_backend::fees::ChangeValue::Sapling` is now a structured variant.
   In addition to the existing change value, it now also carries an optional memo
   to be associated with the change output.

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -231,15 +231,7 @@ where
         change_memo,
     )?;
 
-    create_proposed_transaction(
-        wallet_db,
-        params,
-        prover,
-        usk,
-        ovk_policy,
-        &proposal,
-        min_confirmations,
-    )
+    create_proposed_transaction(wallet_db, params, prover, usk, ovk_policy, &proposal)
 }
 
 /// Constructs a transaction that sends funds as specified by the `request` argument
@@ -332,15 +324,7 @@ where
         min_confirmations,
     )?;
 
-    create_proposed_transaction(
-        wallet_db,
-        params,
-        prover,
-        usk,
-        ovk_policy,
-        &proposal,
-        min_confirmations,
-    )
+    create_proposed_transaction(wallet_db, params, prover, usk, ovk_policy, &proposal)
 }
 
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction
@@ -495,7 +479,6 @@ pub fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT>(
     usk: &UnifiedSpendingKey,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, DbT::NoteRef>,
-    min_confirmations: NonZeroU32,
 ) -> Result<
     TxId,
     Error<
@@ -546,7 +529,7 @@ where
     // are no possible transparent inputs, so we ignore those
     let mut builder = Builder::new(params.clone(), proposal.min_target_height(), None);
 
-    let checkpoint_depth = wallet_db.get_checkpoint_depth(min_confirmations)?;
+    let checkpoint_depth = wallet_db.get_checkpoint_depth(proposal.min_confirmations())?;
     wallet_db.with_sapling_tree_mut::<_, _, Error<_, _, _, _>>(|sapling_tree| {
         for selected in proposal.sapling_inputs() {
             let (note, key, merkle_path) = select_key_for_note(
@@ -815,15 +798,7 @@ where
         min_confirmations,
     )?;
 
-    create_proposed_transaction(
-        wallet_db,
-        params,
-        prover,
-        usk,
-        OvkPolicy::Sender,
-        &proposal,
-        min_confirmations,
-    )
+    create_proposed_transaction(wallet_db, params, prover, usk, OvkPolicy::Sender, &proposal)
 }
 
 #[allow(clippy::type_complexity)]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -237,7 +237,7 @@ where
         prover,
         usk,
         ovk_policy,
-        proposal,
+        &proposal,
         min_confirmations,
     )
 }
@@ -338,7 +338,7 @@ where
         prover,
         usk,
         ovk_policy,
-        proposal,
+        &proposal,
         min_confirmations,
     )
 }
@@ -494,7 +494,7 @@ pub fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT>(
     prover: impl SaplingProver,
     usk: &UnifiedSpendingKey,
     ovk_policy: OvkPolicy,
-    proposal: Proposal<FeeRuleT, DbT::NoteRef>,
+    proposal: &Proposal<FeeRuleT, DbT::NoteRef>,
     min_confirmations: NonZeroU32,
 ) -> Result<
     TxId,
@@ -821,7 +821,7 @@ where
         prover,
         usk,
         OvkPolicy::Sender,
-        proposal,
+        &proposal,
         min_confirmations,
     )
 }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -81,6 +81,7 @@ pub struct Proposal<FeeRuleT, NoteRef> {
     sapling_inputs: Vec<ReceivedSaplingNote<NoteRef>>,
     balance: TransactionBalance,
     fee_rule: FeeRuleT,
+    min_confirmations: NonZeroU32,
     min_target_height: BlockHeight,
     min_anchor_height: BlockHeight,
     is_shielding: bool,
@@ -106,6 +107,10 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// Returns the fee rule to be used by the transaction builder.
     pub fn fee_rule(&self) -> &FeeRuleT {
         &self.fee_rule
+    }
+    /// Returns the value of `min_confirmations` used in input selection.
+    pub fn min_confirmations(&self) -> NonZeroU32 {
+        self.min_confirmations
     }
     /// Returns the target height for which the proposal was prepared.
     ///
@@ -399,6 +404,7 @@ where
                         sapling_inputs,
                         balance,
                         fee_rule: (*self.change_strategy.fee_rule()).clone(),
+                        min_confirmations,
                         min_target_height: target_height,
                         min_anchor_height: anchor_height,
                         is_shielding: false,
@@ -505,6 +511,7 @@ where
                 sapling_inputs: vec![],
                 balance,
                 fee_rule: (*self.change_strategy.fee_rule()).clone(),
+                min_confirmations,
                 min_target_height: target_height,
                 min_anchor_height: latest_anchor,
                 is_shielding: true,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -600,8 +600,7 @@ impl<Cache> TestState<Cache> {
         &mut self,
         usk: &UnifiedSpendingKey,
         ovk_policy: OvkPolicy,
-        proposal: Proposal<FeeRuleT, ReceivedNoteId>,
-        min_confirmations: NonZeroU32,
+        proposal: &Proposal<FeeRuleT, ReceivedNoteId>,
     ) -> Result<
         TxId,
         data_api::error::Error<
@@ -621,8 +620,7 @@ impl<Cache> TestState<Cache> {
             test_prover(),
             usk,
             ovk_policy,
-            &proposal,
-            min_confirmations,
+            proposal,
         )
     }
 

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -621,7 +621,7 @@ impl<Cache> TestState<Cache> {
             test_prover(),
             usk,
             ovk_policy,
-            proposal,
+            &proposal,
             min_confirmations,
         )
     }


### PR DESCRIPTION
Builds upon #1018 

This fixes an API issue whereby it was possible to execute a `Proposal`
with a different value of `min_confirmations` than that with which the
`Proposal` was constructed.
