### PR TITLE
Release zcash_client_sqlite 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_matches",
  "bs58",

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2023-10-18
+
+### Fixed
+- Fixed a bug in `v_transactions` that was omitting value from identically-valued notes
+
 ## [Unreleased]
 
 ## [0.8.0] - 2023-09-25

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"


### PR DESCRIPTION
This is a special hotfix release to fix a high impact bug fixed by #1020. This branch is based off of the `zcash_client_sqlite-0.8.0` tag. We'll tag this after review and merge. (We'll have to manually merge though because of changelog conflicts...)

The alternative would be to release what's on `main` now, which also contains the bugfix, but that will be very intense process as `main` is not currently in a releasable state.