### PR TITLE
CI: Build `wasm32-wasi` in a synthetic crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: crates
+      # We use a synthetic crate to ensure no dev-dependencies are enabled, which can
+      # be incompatible with some of these targets.
+      - name: Create synthetic crate for testing
+        run: cargo init --lib ci-build
+      - name: Copy Rust version into synthetic crate
+        run: cp crates/rust-toolchain.toml ci-build/
+      - name: Add zcash_proofs as a dependency of the synthetic crate
+        working-directory: ./ci-build
+        run: cargo add --no-default-features --path ../crates/zcash_proofs
+      - name: Add zcash_client_backend as a dependency of the synthetic crate
+        working-directory: ./ci-build
+        run: cargo add --no-default-features --path ../crates/zcash_client_backend
+      - name: Copy pinned dependencies into synthetic crate
+        run: cp crates/Cargo.lock ci-build/
       - name: Add target
+        working-directory: ./ci-build
         run: rustup target add ${{ matrix.target }}
-      - run: cargo fetch
-      - name: Build zcash_proofs for target
-        working-directory: ./zcash_proofs
-        run: cargo build --verbose --no-default-features --target ${{ matrix.target }}
-      - name: Build zcash_client_backend for target
-        working-directory: ./zcash_client_backend
-        run: cargo build --verbose --no-default-features --target ${{ matrix.target }}
+      - name: Build for target
+        working-directory: ./ci-build
+        run: cargo build --verbose --target ${{ matrix.target }}
 
   bitrot:
     name: Bitrot check


### PR DESCRIPTION
This target is incompatible with various crates that we use for testing. However, when those crates are enabled via dev-dependencies, they become part of the build graph and prevent us from building the regular code.

Downstream crates don't inherit dev-dependencies, so we simulate this directly in CI.