### PR TITLE
zcash_primitives: Make `value_balance` generic in `sapling::Bundle`

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -96,6 +96,8 @@ and this library adheres to Rust's notion of
   - `SaplingVerificationContext::{check_spend, check_output}` now take
     the `PreparedSpendVerifyingKey` and `PreparedOutputVerifyingKey`
     newtypes.
+  - `SaplingVerificationContext::final_check` now takes its `value_balance`
+    argument as `V: Into<i64>` instead of `Amount`.
   - `address::PaymentAddress::create_note` now takes its `value` argument as a
     `NoteValue` instead of as a bare `u64`.
   - `builder::SaplingBuilder` no longer has a `P: consensus::Parameters` type
@@ -112,6 +114,9 @@ and this library adheres to Rust's notion of
     - `Error::DuplicateSignature`
     - `Error::InvalidExternalSignature`
     - `Error::MissingSignatures`
+  - `bundle::Bundle` now has a second generic parameter `V`.
+  - `bundle::Bundle::value_balance` now returns `&V` instead of `&Amount`.
+  - `bundle::testing::arb_bundle` now takes a `value_balance: V` argument.
   - `bundle::MapAuth` trait methods now take `&mut self` instead of `&self`.
   - `circuit::ValueCommitmentOpening::value` is now represented as a `NoteValue`
     instead of as a bare `u64`.

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -17,6 +17,7 @@ use zcash_primitives::{
         value::NoteValue,
         Diversifier, SaplingIvk,
     },
+    transaction::components::Amount,
 };
 
 #[cfg(unix)]
@@ -46,7 +47,7 @@ fn bench_note_decryption(c: &mut Criterion) {
             )
             .unwrap();
         let (bundle, _) = builder
-            .build::<MockSpendProver, MockOutputProver, _>(&mut rng)
+            .build::<MockSpendProver, MockOutputProver, _, Amount>(&mut rng)
             .unwrap()
             .unwrap();
         bundle.shielded_outputs()[0].clone()

--- a/zcash_primitives/src/sapling/note_encryption.rs
+++ b/zcash_primitives/src/sapling/note_encryption.rs
@@ -23,10 +23,9 @@ use crate::{
             DiversifiedTransmissionKey, EphemeralPublicKey, EphemeralSecretKey, OutgoingViewingKey,
             SharedSecret,
         },
-        value::ValueCommitment,
+        value::{NoteValue, ValueCommitment},
         Diversifier, Note, PaymentAddress, Rseed,
     },
-    transaction::components::amount::NonNegativeAmount,
 };
 
 use super::note::ExtractedNoteCommitment;
@@ -93,12 +92,11 @@ where
             .try_into()
             .expect("Note plaintext is checked to have length >= COMPACT_NOTE_SIZE."),
     );
-    let value = NonNegativeAmount::from_u64_le_bytes(
+    let value = NoteValue::from_bytes(
         plaintext[12..20]
             .try_into()
             .expect("Note plaintext is checked to have length >= COMPACT_NOTE_SIZE."),
-    )
-    .ok()?;
+    );
     let r: [u8; 32] = plaintext[20..COMPACT_NOTE_SIZE]
         .try_into()
         .expect("Note plaintext is checked to have length >= COMPACT_NOTE_SIZE.");
@@ -114,7 +112,7 @@ where
 
     // `diversifier` was checked by `get_pk_d`.
     let to = PaymentAddress::from_parts_unchecked(diversifier, pk_d)?;
-    let note = to.create_note(value.into(), rseed);
+    let note = to.create_note(value, rseed);
     Some((note, to))
 }
 

--- a/zcash_primitives/src/sapling/value.rs
+++ b/zcash_primitives/src/sapling/value.rs
@@ -69,6 +69,10 @@ impl NoteValue {
         NoteValue(value)
     }
 
+    pub(crate) fn from_bytes(bytes: [u8; 8]) -> Self {
+        NoteValue(u64::from_le_bytes(bytes))
+    }
+
     pub(crate) fn to_le_bits(self) -> BitArray<[u8; 8], Lsb0> {
         BitArray::<_, Lsb0>::new(self.0.to_le_bytes())
     }

--- a/zcash_primitives/src/sapling/verifier.rs
+++ b/zcash_primitives/src/sapling/verifier.rs
@@ -2,13 +2,10 @@ use bellman::{gadgets::multipack, groth16::Proof};
 use bls12_381::Bls12;
 use group::{ff::PrimeField, Curve, GroupEncoding};
 
-use crate::{
-    sapling::{
-        note::ExtractedNoteCommitment,
-        redjubjub::{PublicKey, Signature},
-        value::{CommitmentSum, ValueCommitment},
-    },
-    transaction::components::Amount,
+use crate::sapling::{
+    note::ExtractedNoteCommitment,
+    redjubjub::{PublicKey, Signature},
+    value::{CommitmentSum, ValueCommitment},
 };
 
 mod single;
@@ -145,9 +142,9 @@ impl SaplingVerificationContextInner {
     /// Perform consensus checks on the valueBalance and bindingSig parts of a
     /// Sapling transaction. All SpendDescriptions and OutputDescriptions must
     /// have been checked before calling this function.
-    fn final_check(
+    fn final_check<V: Into<i64>>(
         &self,
-        value_balance: Amount,
+        value_balance: V,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
         binding_sig_verifier: impl FnOnce(PublicKey, [u8; 64], Signature) -> bool,

--- a/zcash_primitives/src/sapling/verifier/batch.rs
+++ b/zcash_primitives/src/sapling/verifier/batch.rs
@@ -45,7 +45,11 @@ impl BatchValidator {
     /// `BatchValidator` can continue to be used regardless, but some or all of the proofs
     /// and signatures from this bundle may have already been added to the batch even if
     /// it fails other consensus rules.
-    pub fn check_bundle(&mut self, bundle: Bundle<Authorized>, sighash: [u8; 32]) -> bool {
+    pub fn check_bundle<V: Copy + Into<i64>>(
+        &mut self,
+        bundle: Bundle<Authorized, V>,
+        sighash: [u8; 32],
+    ) -> bool {
         self.bundles_added = true;
 
         let mut ctx = SaplingVerificationContextInner::new();

--- a/zcash_primitives/src/sapling/verifier/single.rs
+++ b/zcash_primitives/src/sapling/verifier/single.rs
@@ -2,15 +2,12 @@ use bellman::groth16::{verify_proof, Proof};
 use bls12_381::Bls12;
 
 use super::SaplingVerificationContextInner;
-use crate::{
-    sapling::{
-        circuit::{PreparedOutputVerifyingKey, PreparedSpendVerifyingKey},
-        constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
-        note::ExtractedNoteCommitment,
-        redjubjub::{PublicKey, Signature},
-        value::ValueCommitment,
-    },
-    transaction::components::Amount,
+use crate::sapling::{
+    circuit::{PreparedOutputVerifyingKey, PreparedSpendVerifyingKey},
+    constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
+    note::ExtractedNoteCommitment,
+    redjubjub::{PublicKey, Signature},
+    value::ValueCommitment,
 };
 
 /// A context object for verifying the Sapling components of a single Zcash transaction.
@@ -80,9 +77,9 @@ impl SaplingVerificationContext {
     /// Perform consensus checks on the valueBalance and bindingSig parts of a
     /// Sapling transaction. All SpendDescriptions and OutputDescriptions must
     /// have been checked before calling this function.
-    pub fn final_check(
+    pub fn final_check<V: Into<i64>>(
         &self,
-        value_balance: Amount,
+        value_balance: V,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
     ) -> bool {

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -513,7 +513,7 @@ impl<'a, P: consensus::Parameters, R: RngCore + CryptoRng> Builder<'a, P, R> {
         let mut rng = self.rng;
         let (sapling_bundle, tx_metadata) = match self
             .sapling_builder
-            .build::<SP, OP, _>(&mut rng)
+            .build::<SP, OP, _, _>(&mut rng)
             .map_err(Error::SaplingBuild)?
             .map(|(bundle, tx_metadata)| {
                 // We need to create proofs before signatures, because we still support

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -286,7 +286,7 @@ pub(crate) fn read_v4_components<R: Read>(
 #[cfg(feature = "temporary-zcashd")]
 pub fn temporary_zcashd_write_v4_components<W: Write>(
     writer: W,
-    bundle: Option<&Bundle<Authorized>>,
+    bundle: Option<&Bundle<Authorized, Amount>>,
     tx_has_sapling: bool,
 ) -> io::Result<()> {
     write_v4_components(writer, bundle, tx_has_sapling)
@@ -295,7 +295,7 @@ pub fn temporary_zcashd_write_v4_components<W: Write>(
 /// Writes the Sapling components of a v4 transaction.
 pub(crate) fn write_v4_components<W: Write>(
     mut writer: W,
-    bundle: Option<&Bundle<Authorized>>,
+    bundle: Option<&Bundle<Authorized, Amount>>,
     tx_has_sapling: bool,
 ) -> io::Result<()> {
     if tx_has_sapling {
@@ -326,7 +326,9 @@ pub(crate) fn write_v4_components<W: Write>(
 
 /// Reads a [`Bundle`] from a v5 transaction format.
 #[allow(clippy::redundant_closure)]
-pub(crate) fn read_v5_bundle<R: Read>(mut reader: R) -> io::Result<Option<Bundle<Authorized>>> {
+pub(crate) fn read_v5_bundle<R: Read>(
+    mut reader: R,
+) -> io::Result<Option<Bundle<Authorized, Amount>>> {
     let sd_v5s = Vector::read(&mut reader, read_spend_v5)?;
     let od_v5s = Vector::read(&mut reader, read_output_v5)?;
     let n_spends = sd_v5s.len();
@@ -385,7 +387,7 @@ pub(crate) fn read_v5_bundle<R: Read>(mut reader: R) -> io::Result<Option<Bundle
 /// Writes a [`Bundle`] in the v5 transaction format.
 pub(crate) fn write_v5_bundle<W: Write>(
     mut writer: W,
-    sapling_bundle: Option<&Bundle<Authorized>>,
+    sapling_bundle: Option<&Bundle<Authorized, Amount>>,
 ) -> io::Result<()> {
     if let Some(bundle) = sapling_bundle {
         Vector::write(&mut writer, bundle.shielded_spends(), |w, e| {
@@ -436,13 +438,26 @@ pub mod testing {
     use proptest::prelude::*;
 
     use crate::{
-        sapling::bundle::{testing::arb_bundle, Authorized, Bundle},
-        transaction::TxVersion,
+        sapling::bundle::{testing as t_sap, Authorized, Bundle},
+        transaction::{
+            components::{amount::testing::arb_amount, Amount},
+            TxVersion,
+        },
     };
+
+    prop_compose! {
+        fn arb_bundle()(
+            value_balance in arb_amount()
+        )(
+            bundle in t_sap::arb_bundle(value_balance)
+        ) -> Option<Bundle<Authorized, Amount>> {
+            bundle
+        }
+    }
 
     pub fn arb_bundle_for_version(
         v: TxVersion,
-    ) -> impl Strategy<Value = Option<Bundle<Authorized>>> {
+    ) -> impl Strategy<Value = Option<Bundle<Authorized, Amount>>> {
         if v.has_sapling() {
             Strategy::boxed(arb_bundle())
         } else {

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -309,7 +309,7 @@ pub struct TransactionData<A: Authorization> {
     expiry_height: BlockHeight,
     transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
     sprout_bundle: Option<sprout::Bundle>,
-    sapling_bundle: Option<sapling::Bundle<A::SaplingAuth>>,
+    sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
     orchard_bundle: Option<orchard::bundle::Bundle<A::OrchardAuth, Amount>>,
     #[cfg(feature = "zfuture")]
     tze_bundle: Option<tze::Bundle<A::TzeAuth>>,
@@ -324,7 +324,7 @@ impl<A: Authorization> TransactionData<A> {
         expiry_height: BlockHeight,
         transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
         sprout_bundle: Option<sprout::Bundle>,
-        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth>>,
+        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
         orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount>>,
     ) -> Self {
         TransactionData {
@@ -350,7 +350,7 @@ impl<A: Authorization> TransactionData<A> {
         expiry_height: BlockHeight,
         transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
         sprout_bundle: Option<sprout::Bundle>,
-        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth>>,
+        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
         orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount>>,
         tze_bundle: Option<tze::Bundle<A::TzeAuth>>,
     ) -> Self {
@@ -391,7 +391,7 @@ impl<A: Authorization> TransactionData<A> {
         self.sprout_bundle.as_ref()
     }
 
-    pub fn sapling_bundle(&self) -> Option<&sapling::Bundle<A::SaplingAuth>> {
+    pub fn sapling_bundle(&self) -> Option<&sapling::Bundle<A::SaplingAuth, Amount>> {
         self.sapling_bundle.as_ref()
     }
 
@@ -460,8 +460,8 @@ impl<A: Authorization> TransactionData<A> {
             Option<transparent::Bundle<A::TransparentAuth>>,
         ) -> Option<transparent::Bundle<B::TransparentAuth>>,
         f_sapling: impl FnOnce(
-            Option<sapling::Bundle<A::SaplingAuth>>,
-        ) -> Option<sapling::Bundle<B::SaplingAuth>>,
+            Option<sapling::Bundle<A::SaplingAuth, Amount>>,
+        ) -> Option<sapling::Bundle<B::SaplingAuth, Amount>>,
         f_orchard: impl FnOnce(
             Option<orchard::bundle::Bundle<A::OrchardAuth, Amount>>,
         ) -> Option<orchard::bundle::Bundle<B::OrchardAuth, Amount>>,
@@ -727,7 +727,7 @@ impl Transaction {
     #[cfg(feature = "temporary-zcashd")]
     pub fn temporary_zcashd_read_v5_sapling<R: Read>(
         reader: R,
-    ) -> io::Result<Option<sapling::Bundle<sapling::bundle::Authorized>>> {
+    ) -> io::Result<Option<sapling::Bundle<sapling::bundle::Authorized, Amount>>> {
         sapling_serialization::read_v5_bundle(reader)
     }
 
@@ -836,7 +836,7 @@ impl Transaction {
 
     #[cfg(feature = "temporary-zcashd")]
     pub fn temporary_zcashd_write_v5_sapling<W: Write>(
-        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized>>,
+        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, Amount>>,
         writer: W,
     ) -> io::Result<()> {
         sapling_serialization::write_v5_bundle(writer, sapling_bundle)
@@ -915,7 +915,7 @@ pub trait TransactionDigest<A: Authorization> {
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth>>,
+        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, Amount>>,
     ) -> Self::SaplingDigest;
 
     fn digest_orchard(

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -256,7 +256,7 @@ pub(crate) fn hash_transparent_txid_data(
 
 /// Implements [ZIP 244 section T.3](https://zips.z.cash/zip-0244#t-3-sapling-digest)
 fn hash_sapling_txid_data<A: sapling::bundle::Authorization>(
-    bundle: &sapling::Bundle<A>,
+    bundle: &sapling::Bundle<A, Amount>,
 ) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_HASH_PERSONALIZATION);
     if !(bundle.shielded_spends().is_empty() && bundle.shielded_outputs().is_empty()) {
@@ -328,7 +328,7 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth>>,
+        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, Amount>>,
     ) -> Self::SaplingDigest {
         sapling_bundle.map(hash_sapling_txid_data)
     }
@@ -467,7 +467,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized>>,
+        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, Amount>>,
     ) -> Blake2bHash {
         let mut h = hasher(ZCASH_SAPLING_SIGS_HASH_PERSONALIZATION);
         if let Some(bundle) = sapling_bundle {


### PR DESCRIPTION
This removes the dependency on `Amount`, and matches how we handle this in the `orchard` crate.

Part of zcash/librustzcash#1044.