### PR TITLE
Add Network Upgrade 6 to `consensus::NetworkUpgrade`

### DIFF
--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -23,6 +23,7 @@ zcash_proofs.workspace = true
 
 [features]
 transparent-inputs = []
+unstable-nu6 = ["zcash_primitives/unstable-nu6"]
 
 [lib]
 bench = false

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -513,6 +513,7 @@ mod tests {
                 NetworkUpgrade::Heartwood => Some(BlockHeight::from_u32(903_800)),
                 NetworkUpgrade::Canopy => Some(BlockHeight::from_u32(1_028_500)),
                 NetworkUpgrade::Nu5 => Some(BlockHeight::from_u32(1_200_000)),
+                NetworkUpgrade::Nu6 => Some(BlockHeight::from_u32(1_300_000)),
                 NetworkUpgrade::ZFuture => Some(BlockHeight::from_u32(1_400_000)),
             }
         }

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -513,6 +513,7 @@ mod tests {
                 NetworkUpgrade::Heartwood => Some(BlockHeight::from_u32(903_800)),
                 NetworkUpgrade::Canopy => Some(BlockHeight::from_u32(1_028_500)),
                 NetworkUpgrade::Nu5 => Some(BlockHeight::from_u32(1_200_000)),
+                #[cfg(feature = "unstable-nu6")]
                 NetworkUpgrade::Nu6 => Some(BlockHeight::from_u32(1_300_000)),
                 NetworkUpgrade::ZFuture => Some(BlockHeight::from_u32(1_400_000)),
             }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -106,6 +106,7 @@ multicore = ["orchard/multicore"]
 transparent-inputs = ["hdwallet", "ripemd", "secp256k1"]
 temporary-zcashd = []
 test-dependencies = ["proptest", "orchard/test-dependencies"]
+unstable-nu6 = []
 zfuture = []
 
 [lib]

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -212,6 +212,7 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_000)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_046_400)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_687_104)),
+            #[cfg(feature = "unstable-nu6")]
             NetworkUpgrade::Nu6 => None,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
@@ -264,6 +265,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
+            #[cfg(feature = "unstable-nu6")]
             NetworkUpgrade::Nu6 => None,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
@@ -398,6 +400,7 @@ pub enum NetworkUpgrade {
     /// The [Nu6] network upgrade.
     ///
     /// [Nu6]: https://z.cash/upgrade/nu6/
+    #[cfg(feature = "unstable-nu6")]
     Nu6,
     /// The ZFUTURE network upgrade.
     ///
@@ -419,6 +422,7 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Heartwood => write!(f, "Heartwood"),
             NetworkUpgrade::Canopy => write!(f, "Canopy"),
             NetworkUpgrade::Nu5 => write!(f, "Nu5"),
+            #[cfg(feature = "unstable-nu6")]
             NetworkUpgrade::Nu6 => write!(f, "Nu6"),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => write!(f, "ZFUTURE"),
@@ -435,6 +439,7 @@ impl NetworkUpgrade {
             NetworkUpgrade::Heartwood => BranchId::Heartwood,
             NetworkUpgrade::Canopy => BranchId::Canopy,
             NetworkUpgrade::Nu5 => BranchId::Nu5,
+            #[cfg(feature = "unstable-nu6")]
             NetworkUpgrade::Nu6 => BranchId::Nu6,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => BranchId::ZFuture,
@@ -453,6 +458,7 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Heartwood,
     NetworkUpgrade::Canopy,
     NetworkUpgrade::Nu5,
+    #[cfg(feature = "unstable-nu6")]
     NetworkUpgrade::Nu6,
 ];
 
@@ -488,6 +494,7 @@ pub enum BranchId {
     /// The consensus rules deployed by [`NetworkUpgrade::Nu5`].
     Nu5,
     /// The consensus rules deployed by [`NetworkUpgrade::Nu6`].
+    #[cfg(feature = "unstable-nu6")]
     Nu6,
     /// Candidates for future consensus rules; this branch will never
     /// activate on mainnet.
@@ -509,6 +516,7 @@ impl TryFrom<u32> for BranchId {
             0xf5b9_230b => Ok(BranchId::Heartwood),
             0xe9ff_75a6 => Ok(BranchId::Canopy),
             0xc2d6_d0b4 => Ok(BranchId::Nu5),
+            #[cfg(feature = "unstable-nu6")]
             0xc8e71055 => Ok(BranchId::Nu6),
             #[cfg(feature = "zfuture")]
             0xffff_ffff => Ok(BranchId::ZFuture),
@@ -527,6 +535,7 @@ impl From<BranchId> for u32 {
             BranchId::Heartwood => 0xf5b9_230b,
             BranchId::Canopy => 0xe9ff_75a6,
             BranchId::Nu5 => 0xc2d6_d0b4,
+            #[cfg(feature = "unstable-nu6")]
             BranchId::Nu6 => 0xc8e71055,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => 0xffff_ffff,
@@ -593,16 +602,15 @@ impl BranchId {
             BranchId::Canopy => params
                 .activation_height(NetworkUpgrade::Canopy)
                 .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu5))),
-            BranchId::Nu5 => params
-                .activation_height(NetworkUpgrade::Nu5)
-                .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu6))),
-            BranchId::Nu6 => params.activation_height(NetworkUpgrade::Nu6).map(|lower| {
+            BranchId::Nu5 => params.activation_height(NetworkUpgrade::Nu5).map(|lower| {
                 #[cfg(feature = "zfuture")]
                 let upper = params.activation_height(NetworkUpgrade::ZFuture);
                 #[cfg(not(feature = "zfuture"))]
                 let upper = None;
                 (lower, upper)
             }),
+            #[cfg(feature = "unstable-nu6")]
+            BranchId::Nu6 => None,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => params
                 .activation_height(NetworkUpgrade::ZFuture)
@@ -631,6 +639,7 @@ pub mod testing {
             BranchId::Heartwood,
             BranchId::Canopy,
             BranchId::Nu5,
+            #[cfg(feature = "unstable-nu6")]
             BranchId::Nu6,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture,
@@ -726,12 +735,8 @@ mod tests {
             BranchId::Nu5,
         );
         assert_eq!(
-            BranchId::for_height(&MAIN_NETWORK, BlockHeight(2_726_400)),
-            BranchId::Nu6,
-        );
-        assert_eq!(
             BranchId::for_height(&MAIN_NETWORK, BlockHeight(5_000_000)),
-            BranchId::Nu6,
+            BranchId::Nu5,
         );
     }
 }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -264,7 +264,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
-            NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
+            NetworkUpgrade::Nu6 => None,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -212,6 +212,7 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_000)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_046_400)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_687_104)),
+            NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
@@ -263,6 +264,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
+            NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
@@ -393,6 +395,10 @@ pub enum NetworkUpgrade {
     ///
     /// [Nu5]: https://z.cash/upgrade/nu5/
     Nu5,
+    /// The [Nu6] network upgrade.
+    ///
+    /// [Nu6]: https://z.cash/upgrade/nu6/
+    Nu6,
     /// The ZFUTURE network upgrade.
     ///
     /// This upgrade is expected never to activate on mainnet;
@@ -413,6 +419,7 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Heartwood => write!(f, "Heartwood"),
             NetworkUpgrade::Canopy => write!(f, "Canopy"),
             NetworkUpgrade::Nu5 => write!(f, "Nu5"),
+            NetworkUpgrade::Nu6 => write!(f, "Nu6"),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => write!(f, "ZFUTURE"),
         }
@@ -428,6 +435,7 @@ impl NetworkUpgrade {
             NetworkUpgrade::Heartwood => BranchId::Heartwood,
             NetworkUpgrade::Canopy => BranchId::Canopy,
             NetworkUpgrade::Nu5 => BranchId::Nu5,
+            NetworkUpgrade::Nu6 => BranchId::Nu6,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => BranchId::ZFuture,
         }
@@ -445,6 +453,7 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Heartwood,
     NetworkUpgrade::Canopy,
     NetworkUpgrade::Nu5,
+    NetworkUpgrade::Nu6,
 ];
 
 pub const ZIP212_GRACE_PERIOD: u32 = 32256;
@@ -478,6 +487,8 @@ pub enum BranchId {
     Canopy,
     /// The consensus rules deployed by [`NetworkUpgrade::Nu5`].
     Nu5,
+    /// The consensus rules deployed by [`NetworkUpgrade::Nu6`].
+    Nu6,
     /// Candidates for future consensus rules; this branch will never
     /// activate on mainnet.
     #[cfg(feature = "zfuture")]
@@ -498,6 +509,7 @@ impl TryFrom<u32> for BranchId {
             0xf5b9_230b => Ok(BranchId::Heartwood),
             0xe9ff_75a6 => Ok(BranchId::Canopy),
             0xc2d6_d0b4 => Ok(BranchId::Nu5),
+            0xc8e71055 => Ok(BranchId::Nu6),
             #[cfg(feature = "zfuture")]
             0xffff_ffff => Ok(BranchId::ZFuture),
             _ => Err("Unknown consensus branch ID"),
@@ -515,6 +527,7 @@ impl From<BranchId> for u32 {
             BranchId::Heartwood => 0xf5b9_230b,
             BranchId::Canopy => 0xe9ff_75a6,
             BranchId::Nu5 => 0xc2d6_d0b4,
+            BranchId::Nu6 => 0xc8e71055,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => 0xffff_ffff,
         }
@@ -580,7 +593,10 @@ impl BranchId {
             BranchId::Canopy => params
                 .activation_height(NetworkUpgrade::Canopy)
                 .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu5))),
-            BranchId::Nu5 => params.activation_height(NetworkUpgrade::Nu5).map(|lower| {
+            BranchId::Nu5 => params
+                .activation_height(NetworkUpgrade::Nu5)
+                .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu6))),
+            BranchId::Nu6 => params.activation_height(NetworkUpgrade::Nu6).map(|lower| {
                 #[cfg(feature = "zfuture")]
                 let upper = params.activation_height(NetworkUpgrade::ZFuture);
                 #[cfg(not(feature = "zfuture"))]
@@ -615,6 +631,7 @@ pub mod testing {
             BranchId::Heartwood,
             BranchId::Canopy,
             BranchId::Nu5,
+            BranchId::Nu6,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture,
         ])
@@ -709,8 +726,12 @@ mod tests {
             BranchId::Nu5,
         );
         assert_eq!(
+            BranchId::for_height(&MAIN_NETWORK, BlockHeight(2_726_400)),
+            BranchId::Nu6,
+        );
+        assert_eq!(
             BranchId::for_height(&MAIN_NETWORK, BlockHeight(5_000_000)),
-            BranchId::Nu5,
+            BranchId::Nu6,
         );
     }
 }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -517,7 +517,7 @@ impl TryFrom<u32> for BranchId {
             0xe9ff_75a6 => Ok(BranchId::Canopy),
             0xc2d6_d0b4 => Ok(BranchId::Nu5),
             #[cfg(feature = "unstable-nu6")]
-            0xc8e71055 => Ok(BranchId::Nu6),
+            0xc8e7_1055 => Ok(BranchId::Nu6),
             #[cfg(feature = "zfuture")]
             0xffff_ffff => Ok(BranchId::ZFuture),
             _ => Err("Unknown consensus branch ID"),
@@ -536,7 +536,7 @@ impl From<BranchId> for u32 {
             BranchId::Canopy => 0xe9ff_75a6,
             BranchId::Nu5 => 0xc2d6_d0b4,
             #[cfg(feature = "unstable-nu6")]
-            BranchId::Nu6 => 0xc8e71055,
+            BranchId::Nu6 => 0xc8e7_1055,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => 0xffff_ffff,
         }

--- a/zcash_primitives/src/consensus.rs
+++ b/zcash_primitives/src/consensus.rs
@@ -212,7 +212,7 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_000)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_046_400)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_687_104)),
-            NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
+            NetworkUpgrade::Nu6 => None,
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -238,7 +238,7 @@ impl TxVersion {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 TxVersion::Sapling
             }
-            BranchId::Nu5 => TxVersion::Zip225,
+            BranchId::Nu5 | BranchId::Nu6 => TxVersion::Zip225,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
         }
@@ -969,7 +969,7 @@ pub mod testing {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 Just(TxVersion::Sapling).boxed()
             }
-            BranchId::Nu5 => Just(TxVersion::Zip225).boxed(),
+            BranchId::Nu5 | BranchId::Nu6 => Just(TxVersion::Zip225).boxed(),
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => Just(TxVersion::ZFuture).boxed(),
         }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -238,7 +238,9 @@ impl TxVersion {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 TxVersion::Sapling
             }
-            BranchId::Nu5 | BranchId::Nu6 => TxVersion::Zip225,
+            BranchId::Nu5 => TxVersion::Zip225,
+            #[cfg(feature = "unstable-nu6")]
+            BranchId::Nu6 => TxVersion::Zip225,
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
         }
@@ -969,7 +971,9 @@ pub mod testing {
             BranchId::Sapling | BranchId::Blossom | BranchId::Heartwood | BranchId::Canopy => {
                 Just(TxVersion::Sapling).boxed()
             }
-            BranchId::Nu5 | BranchId::Nu6 => Just(TxVersion::Zip225).boxed(),
+            BranchId::Nu5 => Just(TxVersion::Zip225).boxed(),
+            #[cfg(feature = "unstable-nu6")]
+            BranchId::Nu6 => Just(TxVersion::Zip225).boxed(),
             #[cfg(feature = "zfuture")]
             BranchId::ZFuture => Just(TxVersion::ZFuture).boxed(),
         }


### PR DESCRIPTION
I've started working on adding Network Upgrade 6 to Zebra. I need to add it to `zcash_primitives` as well as `zebra-chain` and `zebra-scan` both depend on it.

In this code NU6 references Tx V5. This will need to be updated to reference Tx V6 and ZIP-230 once Tx V6 is implemented.

Let me know if this is not the right way to proceed here.

cc @teor2345 