### PR TITLE
Replace `SaplingReceivedNote` with `ReceivedNote`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -30,8 +30,8 @@ and this library adheres to Rust's notion of
     functionality and move it behind the `transparent-inputs` feature flag.
 - `zcash_client_backend::fees::standard`
 - `zcash_client_backend::wallet`:
-  - `ReceivedSaplingNote::from_parts`
-  - `ReceivedSaplingNote::{txid, output_index, diversifier, rseed, note_commitment_tree_position}`
+  - `WalletNote`
+  - `ReceivedNote`
 - `zcash_client_backend::zip321::TransactionRequest::total`
 - `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proto::`
@@ -60,6 +60,13 @@ and this library adheres to Rust's notion of
   - Arguments to `BlockMetadata::from_parts` have changed to include Orchard.
   - `BlockMetadata::sapling_tree_size` now returns an `Option<u32>` instead of
     a `u32` for consistency with Orchard.
+  - `WalletShieldedOutput` has an additiona type parameter which is used for
+    key scope. `WalletShieldedOutput::from_parts` now takes an additional
+    argument of this type.
+  - `WalletTx` has an additional type parameter as a consequence of the 
+    `WalletShieldedOutput` change.
+  - `ScannedBlock` has an additional type parameter as a consequence of the 
+    `WalletTx` change.
   - Arguments to `ScannedBlock::from_parts` have changed.
   - `ScannedBlock::metadata` has been renamed to `to_block_metadata` and now
     returns an owned value rather than a reference.
@@ -174,6 +181,8 @@ and this library adheres to Rust's notion of
     - `WalletTransparentOutput::value`
 
 ### Removed
+- `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by
+  `zcash_client_backend::ReceivedNote.
 - `zcash_client_backend::data_api::WalletRead::is_valid_account_extfvk` has been
   removed; it was unused in the ECC mobile wallet SDKs and has been superseded by
   `get_account_for_ufvk`.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -49,6 +49,12 @@ and this library adheres to Rust's notion of
      wallet::input_selection::{Proposal, SaplingInputs},
    }`
 
+### Moved
+- `zcash_client_backend::data_api::{PoolType, ShieldedProtocol}` have
+  been moved into the `zcash_client_backend` root module.
+- `zcash_client_backend::data_api::{NoteId, Recipient}` have
+  been moved into the `zcash_client_backend::wallet` module.
+
 ### Changed
 - `zcash_client_backend::data_api`:
   - Arguments to `BlockMetadata::from_parts` have changed to include Orchard.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -32,6 +32,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::wallet`:
   - `WalletNote`
   - `ReceivedNote`
+  - `WalletSaplingOutput::recipient_key_scope`
 - `zcash_client_backend::zip321::TransactionRequest::total`
 - `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proto::`
@@ -60,7 +61,7 @@ and this library adheres to Rust's notion of
   - Arguments to `BlockMetadata::from_parts` have changed to include Orchard.
   - `BlockMetadata::sapling_tree_size` now returns an `Option<u32>` instead of
     a `u32` for consistency with Orchard.
-  - `WalletShieldedOutput` has an additiona type parameter which is used for
+  - `WalletShieldedOutput` has an additional type parameter which is used for
     key scope. `WalletShieldedOutput::from_parts` now takes an additional
     argument of this type.
   - `WalletTx` has an additional type parameter as a consequence of the 
@@ -182,7 +183,7 @@ and this library adheres to Rust's notion of
 
 ### Removed
 - `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by
-  `zcash_client_backend::ReceivedNote.
+  `zcash_client_backend::ReceivedNote`.
 - `zcash_client_backend::data_api::WalletRead::is_valid_account_extfvk` has been
   removed; it was unused in the ECC mobile wallet SDKs and has been superseded by
   `get_account_for_ufvk`.

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -15,12 +15,12 @@ use zcash_primitives::{
 };
 
 use crate::data_api::wallet::input_selection::InputSelectorError;
-use crate::data_api::PoolType;
+use crate::PoolType;
 
 #[cfg(feature = "transparent-inputs")]
 use zcash_primitives::{legacy::TransparentAddress, zip32::DiversifierIndex};
 
-use super::NoteId;
+use crate::wallet::NoteId;
 
 /// Errors that can occur as a consequence of wallet operations.
 #[derive(Debug)]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -600,6 +600,8 @@ where
                         builder.add_sapling_spend(key, note.clone(), merkle_path)?;
                     }
                     WalletNote::Orchard(_) => {
+                        // FIXME: Implement this once `Proposal` has been refactored to
+                        // include Orchard notes.
                         panic!("Orchard spends are not yet supported");
                     }
                 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -24,15 +24,16 @@ use zcash_primitives::{
 use crate::{
     address::RecipientAddress,
     data_api::{
-        error::Error, wallet::input_selection::Proposal, DecryptedTransaction, PoolType, Recipient,
-        SentTransaction, SentTransactionOutput, WalletCommitmentTrees, WalletRead, WalletWrite,
+        error::Error, wallet::input_selection::Proposal, DecryptedTransaction, SentTransaction,
+        SentTransactionOutput, WalletCommitmentTrees, WalletRead, WalletWrite,
         SAPLING_SHARD_HEIGHT,
     },
     decrypt_transaction,
     fees::{self, ChangeValue, DustOutputPolicy},
     keys::UnifiedSpendingKey,
-    wallet::{OvkPolicy, ReceivedSaplingNote},
+    wallet::{NoteId, OvkPolicy, ReceivedSaplingNote, Recipient},
     zip321::{self, Payment},
+    PoolType, ShieldedProtocol,
 };
 
 pub mod input_selection;
@@ -40,7 +41,7 @@ use input_selection::{
     GreedyInputSelector, GreedyInputSelectorError, InputSelector, InputSelectorError,
 };
 
-use super::{NoteId, SaplingInputSource, ShieldedProtocol};
+use super::SaplingInputSource;
 
 #[cfg(feature = "transparent-inputs")]
 use {
@@ -597,11 +598,11 @@ where
                     sapling_inputs.anchor_height(),
                 )?
                 .ok_or_else(|| {
-                    Error::NoteMismatch(NoteId {
-                        txid: *selected.txid(),
-                        protocol: ShieldedProtocol::Sapling,
-                        output_index: selected.output_index(),
-                    })
+                    Error::NoteMismatch(NoteId::new(
+                        *selected.txid(),
+                        ShieldedProtocol::Sapling,
+                        selected.output_index(),
+                    ))
                 })?;
 
                 let key = match scope {

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -22,7 +22,7 @@ use crate::{
     address::{RecipientAddress, UnifiedAddress},
     data_api::SaplingInputSource,
     fees::{ChangeError, ChangeStrategy, DustOutputPolicy, TransactionBalance},
-    wallet::{ReceivedSaplingNote, WalletTransparentOutput},
+    wallet::{ReceivedNote, WalletTransparentOutput},
     zip321::TransactionRequest,
 };
 
@@ -263,15 +263,12 @@ impl<FeeRuleT, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
 #[derive(Clone, PartialEq, Eq)]
 pub struct SaplingInputs<NoteRef> {
     anchor_height: BlockHeight,
-    notes: NonEmpty<ReceivedSaplingNote<NoteRef>>,
+    notes: NonEmpty<ReceivedNote<NoteRef>>,
 }
 
 impl<NoteRef> SaplingInputs<NoteRef> {
     /// Constructs a [`SaplingInputs`] from its constituent parts.
-    pub fn from_parts(
-        anchor_height: BlockHeight,
-        notes: NonEmpty<ReceivedSaplingNote<NoteRef>>,
-    ) -> Self {
+    pub fn from_parts(anchor_height: BlockHeight, notes: NonEmpty<ReceivedNote<NoteRef>>) -> Self {
         Self {
             anchor_height,
             notes,
@@ -285,7 +282,7 @@ impl<NoteRef> SaplingInputs<NoteRef> {
     }
 
     /// Returns the list of Sapling notes to be used as inputs to the proposed transaction.
-    pub fn notes(&self) -> &NonEmpty<ReceivedSaplingNote<NoteRef>> {
+    pub fn notes(&self) -> &NonEmpty<ReceivedNote<NoteRef>> {
         &self.notes
     }
 }
@@ -534,7 +531,7 @@ where
             }
         }
 
-        let mut sapling_inputs: Vec<ReceivedSaplingNote<DbT::NoteRef>> = vec![];
+        let mut sapling_inputs: Vec<ReceivedNote<DbT::NoteRef>> = vec![];
         let mut prior_available = NonNegativeAmount::ZERO;
         let mut amount_required = NonNegativeAmount::ZERO;
         let mut exclude: Vec<DbT::NoteRef> = vec![];
@@ -654,7 +651,7 @@ where
             target_height,
             &transparent_inputs,
             &Vec::<TxOut>::new(),
-            &Vec::<ReceivedSaplingNote<Infallible>>::new(),
+            &Vec::<ReceivedNote<Infallible>>::new(),
             &Vec::<SaplingPayment>::new(),
             &self.dust_output_policy,
         );
@@ -670,7 +667,7 @@ where
                     target_height,
                     &transparent_inputs,
                     &Vec::<TxOut>::new(),
-                    &Vec::<ReceivedSaplingNote<Infallible>>::new(),
+                    &Vec::<ReceivedNote<Infallible>>::new(),
                     &Vec::<SaplingPayment>::new(),
                     &self.dust_output_policy,
                 )?

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -23,8 +23,38 @@ pub mod zip321;
 #[cfg(feature = "unstable-serialization")]
 pub mod serialization;
 
+use std::fmt;
+
 pub use decrypt::{decrypt_transaction, DecryptedOutput, TransferType};
 
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
+
+/// A shielded transfer protocol supported by the wallet.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ShieldedProtocol {
+    /// The Sapling protocol
+    Sapling,
+    /// The Orchard protocol
+    Orchard,
+}
+
+/// A value pool to which the wallet supports sending transaction outputs.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PoolType {
+    /// The transparent value pool
+    Transparent,
+    /// A shielded value pool.
+    Shielded(ShieldedProtocol),
+}
+
+impl fmt::Display for PoolType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PoolType::Transparent => f.write_str("Transparent"),
+            PoolType::Shielded(ShieldedProtocol::Sapling) => f.write_str("Sapling"),
+            PoolType::Shielded(ShieldedProtocol::Orchard) => f.write_str("Orchard"),
+        }
+    }
+}

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -27,10 +27,11 @@ use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
 use crate::{
     data_api::{
         wallet::input_selection::{Proposal, ProposalError, SaplingInputs},
-        PoolType, SaplingInputSource, ShieldedProtocol, TransparentInputSource,
+        SaplingInputSource, TransparentInputSource,
     },
     fees::{ChangeValue, TransactionBalance},
     zip321::{TransactionRequest, Zip321Error},
+    PoolType, ShieldedProtocol,
 };
 
 #[rustfmt::skip]

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -19,11 +19,12 @@ use zcash_primitives::{
     zip32::{AccountId, Scope},
 };
 
-use crate::data_api::{BlockMetadata, ScannedBlock, ShieldedProtocol};
+use crate::data_api::{BlockMetadata, ScannedBlock};
 use crate::{
     proto::compact_formats::CompactBlock,
     scan::{Batch, BatchRunner, Tasks},
     wallet::{WalletSaplingOutput, WalletSaplingSpend, WalletTx},
+    ShieldedProtocol,
 };
 
 /// A key that can be used to perform trial decryption and nullifier

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -258,7 +258,7 @@ pub fn scan_block<P: consensus::Parameters + Send + 'static, K: ScanningKey>(
     vks: &[(&AccountId, &K)],
     sapling_nullifiers: &[(AccountId, sapling::Nullifier)],
     prior_block_metadata: Option<&BlockMetadata>,
-) -> Result<ScannedBlock<K::Nf>, ScanError> {
+) -> Result<ScannedBlock<K::Nf, K::Scope>, ScanError> {
     scan_block_with_runner::<_, _, ()>(
         params,
         block,
@@ -341,7 +341,7 @@ pub(crate) fn scan_block_with_runner<
     nullifiers: &[(AccountId, sapling::Nullifier)],
     prior_block_metadata: Option<&BlockMetadata>,
     mut batch_runner: Option<&mut TaggedBatchRunner<K::Scope, T>>,
-) -> Result<ScannedBlock<K::Nf>, ScanError> {
+) -> Result<ScannedBlock<K::Nf, K::Scope>, ScanError> {
     if let Some(scan_error) = check_hash_continuity(&block, prior_block_metadata) {
         return Err(scan_error);
     }
@@ -441,7 +441,7 @@ pub(crate) fn scan_block_with_runner<
     )?;
 
     let compact_block_tx_count = block.vtx.len();
-    let mut wtxs: Vec<WalletTx<K::Nf>> = vec![];
+    let mut wtxs: Vec<WalletTx<K::Nf, K::Scope>> = vec![];
     let mut sapling_nullifier_map = Vec::with_capacity(block.vtx.len());
     let mut sapling_note_commitments: Vec<(sapling::Node, Retention<BlockHeight>)> = vec![];
     for (tx_idx, tx) in block.vtx.into_iter().enumerate() {
@@ -495,7 +495,7 @@ pub(crate) fn scan_block_with_runner<
             u32::try_from(tx.actions.len()).expect("Orchard action count cannot exceed a u32");
 
         // Check for incoming notes while incrementing tree and witnesses
-        let mut shielded_outputs: Vec<WalletSaplingOutput<K::Nf>> = vec![];
+        let mut shielded_outputs: Vec<WalletSaplingOutput<K::Nf, K::Scope>> = vec![];
         {
             let decoded = &tx
                 .outputs
@@ -528,7 +528,7 @@ pub(crate) fn scan_block_with_runner<
                                 "The batch runner and scan_block must use the same set of IVKs.",
                             );
 
-                            (d_note.note, a, (*nk).clone())
+                            (d_note.note, a, d_note.ivk_tag.1, (*nk).clone())
                         })
                     })
                     .collect()
@@ -538,13 +538,13 @@ pub(crate) fn scan_block_with_runner<
                     .flat_map(|(a, k)| {
                         k.to_sapling_keys()
                             .into_iter()
-                            .map(move |(_, ivk, nk)| (**a, ivk, nk))
+                            .map(move |(scope, ivk, nk)| (**a, scope, ivk, nk))
                     })
                     .collect::<Vec<_>>();
 
                 let ivks = vks
                     .iter()
-                    .map(|(_, ivk, _)| ivk)
+                    .map(|(_, _, ivk, _)| ivk)
                     .map(PreparedIncomingViewingKey::new)
                     .collect::<Vec<_>>();
 
@@ -552,8 +552,8 @@ pub(crate) fn scan_block_with_runner<
                     .into_iter()
                     .map(|v| {
                         v.map(|((note, _), ivk_idx)| {
-                            let (account, _, nk) = &vks[ivk_idx];
-                            (note, *account, (*nk).clone())
+                            let (account, scope, _, nk) = &vks[ivk_idx];
+                            (note, *account, scope.clone(), (*nk).clone())
                         })
                     })
                     .collect()
@@ -574,7 +574,7 @@ pub(crate) fn scan_block_with_runner<
                     (false, false) => Retention::Ephemeral,
                 };
 
-                if let Some((note, account, nk)) = dec_output {
+                if let Some((note, account, scope, nk)) = dec_output {
                     // A note is marked as "change" if the account that received it
                     // also spent notes in the same transaction. This will catch,
                     // for instance:
@@ -596,6 +596,7 @@ pub(crate) fn scan_block_with_runner<
                         is_change,
                         note_commitment_tree_position,
                         nf,
+                        scope,
                     ));
                 }
 

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -55,8 +55,8 @@ impl NoteId {
     }
 }
 
-/// A type that represents the recipient of a transaction output; a recipient address (and, for
-/// unified addresses, the pool to which the payment is sent) in the case of outgoing output, or an
+/// A type that represents the recipient of a transaction output: a recipient address (and, for
+/// unified addresses, the pool to which the payment is sent) in the case of an outgoing output, or an
 /// internal account ID and the pool to which funds were sent in the case of a wallet-internal
 /// output.
 #[derive(Debug, Clone)]
@@ -157,6 +157,15 @@ impl WalletSaplingSpend {
 }
 
 /// A subset of an [`OutputDescription`] relevant to wallets and light clients.
+///
+/// The type parameter `<N>` is used to specify the nullifier type, which may vary between
+/// `Sapling` and `Orchard`, and also may vary depending upon the type of key that was used to
+/// decrypt this output; incoming viewing keys do not have the capability to derive the nullifier
+/// for a note, and the `<N>` will be `()` in these cases.
+///
+/// The type parameter `<S>` is used to specify the type of the scope of the key used to recover
+/// this output; this will usually be [`zcash_primitives::zip32::Scope`] for received notes, and
+/// `()` for sent notes.
 ///
 /// [`OutputDescription`]: zcash_primitives::transaction::components::OutputDescription
 pub struct WalletSaplingOutput<N, S> {

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -18,6 +18,55 @@ use zcash_primitives::{
     zip32::AccountId,
 };
 
+use crate::{address::UnifiedAddress, PoolType, ShieldedProtocol};
+
+/// A unique identifier for a shielded transaction output
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NoteId {
+    txid: TxId,
+    protocol: ShieldedProtocol,
+    output_index: u16,
+}
+
+impl NoteId {
+    /// Constructs a new `NoteId` from its parts.
+    pub fn new(txid: TxId, protocol: ShieldedProtocol, output_index: u16) -> Self {
+        Self {
+            txid,
+            protocol,
+            output_index,
+        }
+    }
+
+    /// Returns the ID of the transaction containing this note.
+    pub fn txid(&self) -> &TxId {
+        &self.txid
+    }
+
+    /// Returns the shielded protocol used by this note.
+    pub fn protocol(&self) -> ShieldedProtocol {
+        self.protocol
+    }
+
+    /// Returns the index of this note within its transaction's corresponding list of
+    /// shielded outputs.
+    pub fn output_index(&self) -> u16 {
+        self.output_index
+    }
+}
+
+/// A type that represents the recipient of a transaction output; a recipient address (and, for
+/// unified addresses, the pool to which the payment is sent) in the case of outgoing output, or an
+/// internal account ID and the pool to which funds were sent in the case of a wallet-internal
+/// output.
+#[derive(Debug, Clone)]
+pub enum Recipient {
+    Transparent(TransparentAddress),
+    Sapling(sapling::PaymentAddress),
+    Unified(UnifiedAddress, PoolType),
+    InternalAccount(AccountId, PoolType),
+}
+
 /// A subset of a [`Transaction`] relevant to wallets and light clients.
 ///
 /// [`Transaction`]: zcash_primitives::transaction::Transaction

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -4,10 +4,13 @@ use std::error;
 use std::fmt;
 
 use shardtree::error::ShardTreeError;
-use zcash_client_backend::data_api::PoolType;
-use zcash_client_backend::encoding::{Bech32DecodeError, TransparentCodecError};
-use zcash_primitives::transaction::components::amount::BalanceError;
-use zcash_primitives::{consensus::BlockHeight, zip32::AccountId};
+use zcash_client_backend::{
+    encoding::{Bech32DecodeError, TransparentCodecError},
+    PoolType,
+};
+use zcash_primitives::{
+    consensus::BlockHeight, transaction::components::amount::BalanceError, zip32::AccountId,
+};
 
 use crate::wallet::commitment_tree;
 use crate::PRUNING_DEPTH;

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -64,14 +64,14 @@ use zcash_client_backend::{
         self,
         chain::{BlockSource, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
-        AccountBirthday, BlockMetadata, DecryptedTransaction, NoteId, NullifierQuery, PoolType,
-        Recipient, SaplingInputSource, ScannedBlock, SentTransaction, ShieldedProtocol,
-        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, SAPLING_SHARD_HEIGHT,
+        AccountBirthday, BlockMetadata, DecryptedTransaction, NullifierQuery, SaplingInputSource,
+        ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
+        WalletWrite, SAPLING_SHARD_HEIGHT,
     },
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
     proto::compact_formats::CompactBlock,
-    wallet::{ReceivedSaplingNote, WalletTransparentOutput},
-    DecryptedOutput, TransferType,
+    wallet::{NoteId, ReceivedSaplingNote, Recipient, WalletTransparentOutput},
+    DecryptedOutput, PoolType, ShieldedProtocol, TransferType,
 };
 
 use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore};

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -178,7 +178,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> SaplingInputSour
         txid: &TxId,
         index: u32,
     ) -> Result<Option<ReceivedSaplingNote<Self::NoteRef>>, Self::Error> {
-        wallet::sapling::get_spendable_sapling_note(self.conn.borrow(), txid, index)
+        wallet::sapling::get_spendable_sapling_note(self.conn.borrow(), &self.params, txid, index)
     }
 
     fn select_spendable_sapling_notes(
@@ -190,6 +190,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> SaplingInputSour
     ) -> Result<Vec<ReceivedSaplingNote<Self::NoteRef>>, Self::Error> {
         wallet::sapling::select_spendable_sapling_notes(
             self.conn.borrow(),
+            &self.params,
             account,
             target_value,
             anchor_height,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -143,6 +143,14 @@ pub(crate) fn scope_code(scope: Scope) -> i64 {
     }
 }
 
+pub(crate) fn parse_scope(code: i64) -> Option<Scope> {
+    match code {
+        0i64 => Some(Scope::External),
+        1i64 => Some(Scope::Internal),
+        _ => None,
+    }
+}
+
 pub(crate) fn memo_repr(memo: Option<&MemoBytes>) -> Option<&[u8]> {
     memo.map(|m| {
         if m == &MemoBytes::empty() {
@@ -1509,9 +1517,9 @@ pub(crate) fn put_block(
 
 /// Inserts information about a mined transaction that was observed to
 /// contain a note related to this wallet into the database.
-pub(crate) fn put_tx_meta<N>(
+pub(crate) fn put_tx_meta<N, S>(
     conn: &rusqlite::Connection,
-    tx: &WalletTx<N>,
+    tx: &WalletTx<N, S>,
     height: BlockHeight,
 ) -> Result<i64, SqliteClientError> {
     // It isn't there, so insert our transaction into the database.
@@ -1890,7 +1898,7 @@ pub(crate) fn insert_nullifier_map<N: AsRef<[u8]>>(
 
 /// Returns the row of the `transactions` table corresponding to the transaction in which
 /// this nullifier is revealed, if any.
-pub(crate) fn query_nullifier_map<N: AsRef<[u8]>>(
+pub(crate) fn query_nullifier_map<N: AsRef<[u8]>, S>(
     conn: &rusqlite::Transaction<'_>,
     spend_pool: ShieldedProtocol,
     nf: &N,
@@ -1928,7 +1936,7 @@ pub(crate) fn query_nullifier_map<N: AsRef<[u8]>>(
     // change or explicit in-wallet recipient.
     put_tx_meta(
         conn,
-        &WalletTx::<N> {
+        &WalletTx::<N, S> {
             txid,
             index,
             sapling_spends: vec![],

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -75,6 +75,7 @@ use std::ops::RangeInclusive;
 use tracing::debug;
 use zcash_client_backend::data_api::{AccountBalance, Ratio, WalletSummary};
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
+use zcash_primitives::zip32::Scope;
 
 use zcash_client_backend::data_api::{
     scanning::{ScanPriority, ScanRange},
@@ -134,6 +135,13 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
         PoolType::Transparent => 0i64,
         PoolType::Shielded(ShieldedProtocol::Sapling) => 2i64,
         PoolType::Shielded(ShieldedProtocol::Orchard) => 3i64,
+    }
+}
+
+pub(crate) fn scope_code(scope: Scope) -> i64 {
+    match scope {
+        Scope::External => 0i64,
+        Scope::Internal => 1i64,
     }
 }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -77,27 +77,25 @@ use zcash_client_backend::data_api::{AccountBalance, Ratio, WalletSummary};
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::zip32::Scope;
 
-use zcash_client_backend::data_api::{
-    scanning::{ScanPriority, ScanRange},
-    AccountBirthday, NoteId, ShieldedProtocol, SAPLING_SHARD_HEIGHT,
-};
-use zcash_primitives::transaction::TransactionData;
-
 use zcash_primitives::{
     block::BlockHash,
     consensus::{self, BlockHeight, BranchId, NetworkUpgrade, Parameters},
     memo::{Memo, MemoBytes},
     merkle_tree::read_commitment_tree,
-    transaction::{components::Amount, Transaction, TxId},
+    transaction::{components::Amount, Transaction, TransactionData, TxId},
     zip32::{AccountId, DiversifierIndex},
 };
 
 use zcash_client_backend::{
     address::{RecipientAddress, UnifiedAddress},
-    data_api::{BlockMetadata, PoolType, Recipient, SentTransactionOutput},
+    data_api::{
+        scanning::{ScanPriority, ScanRange},
+        AccountBirthday, BlockMetadata, SentTransactionOutput, SAPLING_SHARD_HEIGHT,
+    },
     encoding::AddressCodec,
     keys::UnifiedFullViewingKey,
-    wallet::WalletTx,
+    wallet::{NoteId, Recipient, WalletTx},
+    PoolType, ShieldedProtocol,
 };
 
 use crate::wallet::commitment_tree::{get_max_checkpointed_height, SqliteShardStore};

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -248,6 +248,7 @@ mod tests {
                 memo BLOB,
                 spent INTEGER,
                 commitment_tree_position INTEGER,
+                recipient_key_scope INTEGER NOT NULL DEFAULT 0,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account) REFERENCES accounts(account),
                 FOREIGN KEY (spent) REFERENCES transactions(id_tx),

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -5,6 +5,7 @@ mod addresses_table;
 mod initial_setup;
 mod nullifier_map;
 mod received_notes_nullable_nf;
+mod receiving_key_scopes;
 mod sapling_memo_consistency;
 mod sent_notes_to_internal;
 mod shardtree_support;
@@ -40,17 +41,17 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //                                     |
     //                             v_transactions_net
     //                                     |
-    //                         received_notes_nullable_nf
-    //                        /            |             \
-    //        shardtree_support      nullifier_map       sapling_memo_consistency
-    //                |                                             |
-    //      add_account_birthdays                   v_transactions_transparent_history
-    //                |                                             |
-    // v_sapling_shard_unscanned_ranges               v_tx_outputs_use_legacy_false
-    //                |                                             |
-    //        wallet_summaries                       v_transactions_shielding_balance
-    //                                                              |
-    //                                               v_transactions_note_uniqueness
+    //                                  received_notes_nullable_nf
+    //                                 /            |             \
+    //                 shardtree_support      nullifier_map       sapling_memo_consistency
+    //                  /              \                                      |
+    //      add_account_birthdays   receiving_key_scopes      v_transactions_transparent_history
+    //                  |                                                     |
+    // v_sapling_shard_unscanned_ranges                         v_tx_outputs_use_legacy_false
+    //                  |                                                     |
+    //        wallet_summaries                                 v_transactions_shielding_balance
+    //                                                                        |
+    //                                                          v_transactions_note_uniqueness
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -86,5 +87,8 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         Box::new(v_tx_outputs_use_legacy_false::Migration),
         Box::new(v_transactions_shielding_balance::Migration),
         Box::new(v_transactions_note_uniqueness::Migration),
+        Box::new(receiving_key_scopes::Migration {
+            params: params.clone(),
+        }),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -1,0 +1,111 @@
+//! This migration adds support for the Orchard protocol to `zcash_client_sqlite`
+
+use std::collections::HashSet;
+
+use rusqlite::{self, named_params};
+use schemer;
+use schemer_rusqlite::RusqliteMigration;
+
+use tracing::debug;
+use uuid::Uuid;
+
+use zcash_client_backend::{keys::UnifiedFullViewingKey, scanning::ScanningKey};
+use zcash_primitives::{
+    consensus::{self, sapling_zip212_enforcement, BlockHeight, BranchId},
+    sapling::note_encryption::{try_sapling_note_decryption, PreparedIncomingViewingKey},
+    transaction::Transaction,
+    zip32::Scope,
+};
+
+use crate::wallet::{
+    init::{migrations::shardtree_support, WalletMigrationError},
+    scope_code,
+};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xee89ed2b_c1c2_421e_9e98_c1e3e54a7fc2);
+
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
+
+impl<P> schemer::Migration for Migration<P> {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        [shardtree_support::MIGRATION_ID].into_iter().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Add support for receiving storage of note commitment tree data using the `shardtree` crate."
+    }
+}
+
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // Add commitment tree sizes to block metadata.
+        debug!("Adding new columns");
+        transaction.execute_batch(
+            &format!(
+                "ALTER TABLE sapling_received_notes ADD COLUMN recipient_key_scope INTEGER NOT NULL DEFAULT {};",
+                scope_code(Scope::External)
+            )
+        )?;
+
+        // For all notes marked as change, we have to determine whether they were actually sent to
+        // the internal key or the external key for the account, so we trial-decrypt the original
+        // output with both and pick the scope of whichever worked.
+        let mut stmt_select_notes = transaction.prepare(
+            "SELECT id_note, output_index, transactions.raw, transactions.expiry_height, accounts.ufvk
+             FROM sapling_received_notes
+             INNER JOIN accounts on accounts.account = sapling_received_notes.account
+             INNER JOIN transactions ON transactions.id_tx = sapling_received_notes.tx
+             WHERE is_change = 1"
+        )?;
+
+        let mut rows = stmt_select_notes.query([])?;
+        while let Some(row) = rows.next()? {
+            let note_id: i64 = row.get(0)?;
+            let output_index: usize = row.get(1)?;
+            let tx_data: Vec<u8> = row.get(2)?;
+
+            let tx = Transaction::read(&tx_data[..], BranchId::Canopy)
+                .expect("Transaction must be valid");
+            let output = tx
+                .sapling_bundle()
+                .and_then(|b| b.shielded_outputs().get(output_index))
+                .unwrap_or_else(|| panic!("A Sapling output must exist at index {}", output_index));
+            let tx_expiry_height = BlockHeight::from(row.get::<_, u32>(3)?);
+            let zip212_enforcement = sapling_zip212_enforcement(&self.params, tx_expiry_height);
+
+            let ufvk_str: String = row.get(4)?;
+            let ufvk = UnifiedFullViewingKey::decode(&self.params, &ufvk_str)
+                .expect("Stored UFVKs must be valid");
+            let dfvk = ufvk
+                .sapling()
+                .expect("UFVK must have a Sapling component to have received Sapling notes");
+            let keys = dfvk.to_sapling_keys();
+
+            for (scope, ivk, _) in keys {
+                let pivk = PreparedIncomingViewingKey::new(&ivk);
+                if try_sapling_note_decryption(&pivk, output, zip212_enforcement).is_some() {
+                    transaction.execute(
+                        "UPDATE sapling_received_notes SET recipient_key_scope = :scope
+                         WHERE id_note = :note_id",
+                        named_params! {":scope": scope_code(scope), ":note_id": note_id},
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // TODO: something better than just panic?
+        panic!("Cannot revert this migration.");
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -8,9 +8,7 @@ use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
 
 use zcash_client_backend::{
-    address::RecipientAddress,
-    data_api::{PoolType, ShieldedProtocol},
-    keys::UnifiedSpendingKey,
+    address::RecipientAddress, keys::UnifiedSpendingKey, PoolType, ShieldedProtocol,
 };
 use zcash_primitives::{consensus, zip32::AccountId};
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -6,7 +6,7 @@ use rusqlite::{self, named_params};
 use schemer;
 use schemer_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_client_backend::data_api::{PoolType, ShieldedProtocol};
+use zcash_client_backend::{PoolType, ShieldedProtocol};
 
 use super::add_transaction_views;
 use crate::wallet::{init::WalletMigrationError, pool_code};

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -483,14 +483,14 @@ pub(crate) mod tests {
             chain::CommitmentTreeRoot,
             error::Error,
             wallet::input_selection::{GreedyInputSelector, GreedyInputSelectorError},
-            AccountBirthday, Ratio, ShieldedProtocol, WalletCommitmentTrees, WalletRead,
-            WalletWrite,
+            AccountBirthday, Ratio, WalletCommitmentTrees, WalletRead, WalletWrite,
         },
         decrypt_transaction,
         fees::{fixed, standard, DustOutputPolicy},
         keys::UnifiedSpendingKey,
         wallet::OvkPolicy,
         zip321::{self, Payment, TransactionRequest},
+        ShieldedProtocol,
     };
 
     use crate::{

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -95,6 +95,7 @@ and this library adheres to Rust's notion of
   - `impl From<NonNegativeAmount> for zcash_primitives::sapling::value::NoteValue`
   - `impl Sum<NonNegativeAmount> for Option<NonNegativeAmount>`
   - `impl<'a> Sum<&'a NonNegativeAmount> for Option<NonNegativeAmount>`
+  - `impl TryFrom<sapling::value::NoteValue> for NonNegativeAmount`
 - `impl {Clone, PartialEq, Eq} for zcash_primitives::memo::Error`
 - `impl {PartialEq, Eq} for zcash_primitives::sapling::note::Rseed`
 - `impl From<TxId> for [u8; 32]`

--- a/zcash_primitives/src/transaction/components/amount.rs
+++ b/zcash_primitives/src/transaction/components/amount.rs
@@ -323,6 +323,14 @@ impl From<NonNegativeAmount> for sapling::value::NoteValue {
     }
 }
 
+impl TryFrom<sapling::value::NoteValue> for NonNegativeAmount {
+    type Error = ();
+
+    fn try_from(value: sapling::value::NoteValue) -> Result<Self, Self::Error> {
+        Self::from_u64(value.inner())
+    }
+}
+
 impl TryFrom<Amount> for NonNegativeAmount {
     type Error = ();
 


### PR DESCRIPTION
This generalizes the data structure used to represent spendable notes to handle both Sapling and Orchard notes.