### PR TITLE
Enable unstable features when editing in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "rust-analyzer.cargo.features": ["unstable"]
+    "rust-analyzer.cargo.features": "all"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": ["unstable"]
+}


### PR DESCRIPTION
This improves the editing experience by 'enabling' all the code that otherwise is turned off because of the `unstable` flag.