### PR TITLE
zcash_client_backend: Introduce an "orchard" feature flag.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -9,13 +9,14 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `zcash_client_backend::data_api`:
-  - `BlockMetadata::orchard_tree_size`.
+  - `BlockMetadata::orchard_tree_size` (when the `orchard` feature is enabled).
   - `TransparentInputSource`
   - `SaplingInputSource`
-  - `ScannedBlock::{
-      sapling_tree_size, orchard_tree_size, orchard_nullifier_map,
-      orchard_commitments, into_commitments
-    }`
+  - `ScannedBlock::{into_commitments, sapling}`
+  - `ScannedBlock::orchard` (when the `orchard` feature is enabled.)
+  - `ScannedBlockSapling`
+  - `ScannedBlockOrchard` (when the `orchard` feature is enabled.)
+  - `ScannedBlockCommitments`
   - `Balance::{add_spendable_value, add_pending_change_value, add_pending_spendable_value}`
   - `AccountBalance::{
       with_sapling_balance_mut, 
@@ -49,12 +50,17 @@ and this library adheres to Rust's notion of
      wallet::{ReceivedSaplingNote, WalletTransparentOutput},
      wallet::input_selection::{Proposal, SaplingInputs},
    }`
+- A new `orchard` feature flag has been added to make it possible to
+  build client code without `orchard` dependendencies.
 
 ### Moved
 - `zcash_client_backend::data_api::{PoolType, ShieldedProtocol}` have
   been moved into the `zcash_client_backend` root module.
 - `zcash_client_backend::data_api::{NoteId, Recipient}` have
   been moved into the `zcash_client_backend::wallet` module.
+- `ScannedBlock::{sapling_tree_size, sapling_nullifier_map, sapling_commitments}`
+  have been moved to `ScannedBlockSapling` and in that context are now 
+  named `{tree_size, nullifier_map, commitments}` respectively.
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -68,7 +74,6 @@ and this library adheres to Rust's notion of
     `WalletShieldedOutput` change.
   - `ScannedBlock` has an additional type parameter as a consequence of the 
     `WalletTx` change.
-  - Arguments to `ScannedBlock::from_parts` have changed.
   - `ScannedBlock::metadata` has been renamed to `to_block_metadata` and now
     returns an owned value rather than a reference.
   - `ShieldedProtocol` has a new variant for `Orchard`, allowing for better
@@ -184,6 +189,18 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::address`:
   - `RecipientAddress` has been renamed to `Address`
   - `Address::Shielded` has been renamed to `Address::Sapling`
+  - `UnifiedAddress::from_receivers` no longer takes an Orchard receiver 
+    argument uless the `orchard` feature is enabled.
+  - `UnifiedAddress::orchard` is now only available when the `orchard` feature
+    is enabled.
+
+- `zcash_client_backend::keys`:
+  - `DerivationError::Orchard` is now only available when the `orchard` feature
+    is enabled.
+  - `UnifiedSpendingKey::orchard` is now only available when the `orchard`
+    feature is enabled.
+  - `UnifiedFullViewingKey::new` no longer takes an Orchard full viewing key
+    argument uless the `orchard` feature is enabled.
 
 ### Removed
 - `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by
@@ -195,6 +212,7 @@ and this library adheres to Rust's notion of
   removed without replacement as it was unused, and its functionality will be
   fully reproduced by `SaplingInputSource::select_spendable_sapling_notes` in a future
   change.
+- `zcash_client_backend::data_api::ScannedBlock::from_parts` has been made crate-private.
 - `zcash_client_backend::data_api::ScannedBlock::into_sapling_commitments` has been
   replaced by `into_commitments` which returns both Sapling and Orchard note commitments
   and associated note commitment retention information for the block.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -14,8 +14,7 @@ and this library adheres to Rust's notion of
   - `SaplingInputSource`
   - `ScannedBlock::{into_commitments, sapling}`
   - `ScannedBlock::orchard` (when the `orchard` feature is enabled.)
-  - `ScannedBlockSapling`
-  - `ScannedBlockOrchard` (when the `orchard` feature is enabled.)
+  - `ScannedBundles`
   - `ScannedBlockCommitments`
   - `Balance::{add_spendable_value, add_pending_change_value, add_pending_spendable_value}`
   - `AccountBalance::{

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -189,7 +189,7 @@ and this library adheres to Rust's notion of
   - `RecipientAddress` has been renamed to `Address`
   - `Address::Shielded` has been renamed to `Address::Sapling`
   - `UnifiedAddress::from_receivers` no longer takes an Orchard receiver 
-    argument uless the `orchard` feature is enabled.
+    argument unless the `orchard` feature is enabled.
   - `UnifiedAddress::orchard` is now only available when the `orchard` feature
     is enabled.
 
@@ -199,7 +199,7 @@ and this library adheres to Rust's notion of
   - `UnifiedSpendingKey::orchard` is now only available when the `orchard`
     feature is enabled.
   - `UnifiedFullViewingKey::new` no longer takes an Orchard full viewing key
-    argument uless the `orchard` feature is enabled.
+    argument unless the `orchard` feature is enabled.
 
 ### Removed
 - `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -59,7 +59,7 @@ subtle.workspace = true
 # - Shielded protocols
 bls12_381.workspace = true
 group.workspace = true
-orchard.workspace = true
+orchard = { workspace = true, optional = true }
 sapling.workspace = true
 
 # - Note commitment trees
@@ -109,10 +109,13 @@ lightwalletd-tonic = ["dep:tonic"]
 ## Enables receiving transparent funds and shielding them.
 transparent-inputs = ["dep:hdwallet", "zcash_primitives/transparent-inputs"]
 
+## Enables receiving and spending Orchard funds.
+orchard = ["dep:orchard"]
+
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
 test-dependencies = [
     "dep:proptest",
-    "orchard/test-dependencies",
+    "orchard?/test-dependencies",
     "zcash_primitives/test-dependencies",
     "incrementalmerkletree/test-dependencies",
 ]

--- a/zcash_client_backend/src/address.rs
+++ b/zcash_client_backend/src/address.rs
@@ -38,6 +38,7 @@ impl AddressMetadata {
 /// A Unified Address.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnifiedAddress {
+    #[cfg(feature = "orchard")]
     orchard: Option<orchard::Address>,
     sapling: Option<PaymentAddress>,
     transparent: Option<TransparentAddress>,
@@ -48,6 +49,7 @@ impl TryFrom<unified::Address> for UnifiedAddress {
     type Error = &'static str;
 
     fn try_from(ua: unified::Address) -> Result<Self, Self::Error> {
+        #[cfg(feature = "orchard")]
         let mut orchard = None;
         let mut sapling = None;
         let mut transparent = None;
@@ -58,6 +60,7 @@ impl TryFrom<unified::Address> for UnifiedAddress {
             .items_as_parsed()
             .iter()
             .filter_map(|receiver| match receiver {
+                #[cfg(feature = "orchard")]
                 unified::Receiver::Orchard(data) => {
                     Option::from(orchard::Address::from_raw_address_bytes(data))
                         .ok_or("Invalid Orchard receiver in Unified Address")
@@ -66,6 +69,10 @@ impl TryFrom<unified::Address> for UnifiedAddress {
                             None
                         })
                         .transpose()
+                }
+                #[cfg(not(feature = "orchard"))]
+                unified::Receiver::Orchard(data) => {
+                    Some(Ok((unified::Typecode::Orchard.into(), data.to_vec())))
                 }
                 unified::Receiver::Sapling(data) => PaymentAddress::from_bytes(data)
                     .ok_or("Invalid Sapling receiver in Unified Address")
@@ -89,6 +96,7 @@ impl TryFrom<unified::Address> for UnifiedAddress {
             .collect::<Result<_, _>>()?;
 
         Ok(Self {
+            #[cfg(feature = "orchard")]
             orchard,
             sapling,
             transparent,
@@ -103,12 +111,18 @@ impl UnifiedAddress {
     /// Returns `None` if the receivers would produce an invalid Unified Address (namely,
     /// if no shielded receiver is provided).
     pub fn from_receivers(
-        orchard: Option<orchard::Address>,
+        #[cfg(feature = "orchard")] orchard: Option<orchard::Address>,
         sapling: Option<PaymentAddress>,
         transparent: Option<TransparentAddress>,
     ) -> Option<Self> {
-        if orchard.is_some() || sapling.is_some() {
+        #[cfg(feature = "orchard")]
+        let has_orchard = orchard.is_some();
+        #[cfg(not(feature = "orchard"))]
+        let has_orchard = false;
+
+        if has_orchard || sapling.is_some() {
             Some(Self {
+                #[cfg(feature = "orchard")]
                 orchard,
                 sapling,
                 transparent,
@@ -121,6 +135,7 @@ impl UnifiedAddress {
     }
 
     /// Returns the Orchard receiver within this Unified Address, if any.
+    #[cfg(feature = "orchard")]
     pub fn orchard(&self) -> Option<&orchard::Address> {
         self.orchard.as_ref()
     }
@@ -136,6 +151,15 @@ impl UnifiedAddress {
     }
 
     fn to_address(&self, net: Network) -> ZcashAddress {
+        #[cfg(feature = "orchard")]
+        let orchard_receiver = self
+            .orchard
+            .as_ref()
+            .map(|addr| addr.to_raw_address_bytes())
+            .map(unified::Receiver::Orchard);
+        #[cfg(not(feature = "orchard"))]
+        let orchard_receiver = None;
+
         let ua = unified::Address::try_from_items(
             self.unknown
                 .iter()
@@ -153,12 +177,7 @@ impl UnifiedAddress {
                         .map(|pa| pa.to_bytes())
                         .map(unified::Receiver::Sapling),
                 )
-                .chain(
-                    self.orchard
-                        .as_ref()
-                        .map(|addr| addr.to_raw_address_bytes())
-                        .map(unified::Receiver::Orchard),
-                )
+                .chain(orchard_receiver)
                 .collect(),
         )
         .expect("UnifiedAddress should only be constructed safely");
@@ -259,6 +278,7 @@ mod tests {
 
     #[test]
     fn ua_round_trip() {
+        #[cfg(feature = "orchard")]
         let orchard = {
             let sk = orchard::keys::SpendingKey::from_zip32_seed(&[0; 32], 0, 0).unwrap();
             let fvk = orchard::keys::FullViewingKey::from(&sk);
@@ -273,7 +293,11 @@ mod tests {
 
         let transparent = { None };
 
+        #[cfg(feature = "orchard")]
         let ua = UnifiedAddress::from_receivers(orchard, sapling, transparent).unwrap();
+
+        #[cfg(not(feature = "orchard"))]
+        let ua = UnifiedAddress::from_receivers(sapling, transparent).unwrap();
 
         let addr = Address::Unified(ua);
         let addr_str = addr.encode(&MAIN_NETWORK);
@@ -290,6 +314,7 @@ mod tests {
                         tv.p2pkh_bytes.is_some() || tv.p2sh_bytes.is_some()
                     );
                     assert_eq!(ua.sapling().is_some(), tv.sapling_raw_addr.is_some());
+                    #[cfg(feature = "orchard")]
                     assert_eq!(ua.orchard().is_some(), tv.orchard_raw_addr.is_some());
                 }
                 Some(_) => {

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -634,8 +634,8 @@ impl<NoteCommitment, NF> ScannedBundles<NoteCommitment, NF> {
     ///
     /// The returned tuple is keyed by both transaction ID and the index of the transaction within
     /// the block, so that either the txid or the combination of the block hash available from
-    /// [`Self::block_hash`] and returned transaction index may be used to uniquely identify the
-    /// transaction, depending upon the needs of the caller.
+    /// [`ScannedBlock::block_hash`] and returned transaction index may be used to uniquely
+    /// identify the transaction, depending upon the needs of the caller.
     pub fn nullifier_map(&self) -> &[(TxId, u16, Vec<NF>)] {
         &self.nullifier_map
     }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -603,6 +603,7 @@ where
 
                                 Ok((key, note, merkle_path))
                             }
+                            #[cfg(feature = "orchard")]
                             WalletNote::Orchard(_) => {
                                 // FIXME: Implement this once `Proposal` has been refactored to
                                 // include Orchard notes.
@@ -623,8 +624,8 @@ where
         params.clone(),
         proposal.min_target_height(),
         BuildConfig::Standard {
-            sapling_anchor,
-            orchard_anchor: orchard::Anchor::empty_tree(),
+            sapling_anchor: Some(sapling_anchor),
+            orchard_anchor: None,
         },
     );
 

--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -1,5 +1,4 @@
 //! Helper functions for managing light client key material.
-use orchard;
 use zcash_address::unified::{self, Container, Encoding};
 use zcash_primitives::{
     consensus,
@@ -26,6 +25,9 @@ use {
     zcash_encoding::CompactSize,
     zcash_primitives::consensus::BranchId,
 };
+
+#[cfg(feature = "orchard")]
+use orchard;
 
 pub mod sapling {
     pub use sapling::zip32::{
@@ -84,6 +86,7 @@ fn to_transparent_child_index(j: DiversifierIndex) -> Option<u32> {
 #[derive(Debug)]
 #[doc(hidden)]
 pub enum DerivationError {
+    #[cfg(feature = "orchard")]
     Orchard(orchard::zip32::Error),
     #[cfg(feature = "transparent-inputs")]
     Transparent(hdwallet::error::Error),
@@ -144,6 +147,7 @@ pub struct UnifiedSpendingKey {
     #[cfg(feature = "transparent-inputs")]
     transparent: legacy::AccountPrivKey,
     sapling: sapling::ExtendedSpendingKey,
+    #[cfg(feature = "orchard")]
     orchard: orchard::keys::SpendingKey,
 }
 
@@ -158,6 +162,7 @@ impl UnifiedSpendingKey {
             panic!("ZIP 32 seeds MUST be at least 32 bytes");
         }
 
+        #[cfg(feature = "orchard")]
         let orchard =
             orchard::keys::SpendingKey::from_zip32_seed(seed, params.coin_type(), account.into())
                 .map_err(DerivationError::Orchard)?;
@@ -170,6 +175,7 @@ impl UnifiedSpendingKey {
             #[cfg(feature = "transparent-inputs")]
             transparent,
             sapling: sapling::spending_key(seed, params.coin_type(), account),
+            #[cfg(feature = "orchard")]
             orchard,
         })
     }
@@ -179,6 +185,7 @@ impl UnifiedSpendingKey {
             #[cfg(feature = "transparent-inputs")]
             transparent: Some(self.transparent.to_account_pubkey()),
             sapling: Some(self.sapling.to_diversifiable_full_viewing_key()),
+            #[cfg(feature = "orchard")]
             orchard: Some((&self.orchard).into()),
             unknown: vec![],
         }
@@ -197,6 +204,7 @@ impl UnifiedSpendingKey {
     }
 
     /// Returns the Orchard spending key component of this unified spending key.
+    #[cfg(feature = "orchard")]
     pub fn orchard(&self) -> &orchard::keys::SpendingKey {
         &self.orchard
     }
@@ -215,13 +223,15 @@ impl UnifiedSpendingKey {
         let mut result = vec![];
         result.write_u32::<LittleEndian>(era.id()).unwrap();
 
-        // orchard
-        let orchard_key = self.orchard();
-        CompactSize::write(&mut result, usize::try_from(Typecode::Orchard).unwrap()).unwrap();
+        #[cfg(feature = "orchard")]
+        {
+            let orchard_key = self.orchard();
+            CompactSize::write(&mut result, usize::try_from(Typecode::Orchard).unwrap()).unwrap();
 
-        let orchard_key_bytes = orchard_key.to_bytes();
-        CompactSize::write(&mut result, orchard_key_bytes.len()).unwrap();
-        result.write_all(orchard_key_bytes).unwrap();
+            let orchard_key_bytes = orchard_key.to_bytes();
+            CompactSize::write(&mut result, orchard_key_bytes.len()).unwrap();
+            result.write_all(orchard_key_bytes).unwrap();
+        }
 
         // sapling
         let sapling_key = self.sapling();
@@ -261,6 +271,7 @@ impl UnifiedSpendingKey {
             return Err(DecodingError::EraMismatch(decoded_era));
         }
 
+        #[cfg(feature = "orchard")]
         let mut orchard = None;
         let mut sapling = None;
         #[cfg(feature = "transparent-inputs")]
@@ -283,12 +294,16 @@ impl UnifiedSpendingKey {
                     source
                         .read_exact(&mut key)
                         .map_err(|_| DecodingError::InsufficientData(Typecode::Orchard))?;
-                    orchard = Some(
-                        Option::<orchard::keys::SpendingKey>::from(
-                            orchard::keys::SpendingKey::from_bytes(key),
-                        )
-                        .ok_or(DecodingError::KeyDataInvalid(Typecode::Orchard))?,
-                    );
+
+                    #[cfg(feature = "orchard")]
+                    {
+                        orchard = Some(
+                            Option::<orchard::keys::SpendingKey>::from(
+                                orchard::keys::SpendingKey::from_bytes(key),
+                            )
+                            .ok_or(DecodingError::KeyDataInvalid(Typecode::Orchard))?,
+                        );
+                    }
                 }
                 Typecode::Sapling => {
                     if len != 169 {
@@ -324,13 +339,19 @@ impl UnifiedSpendingKey {
                 }
             }
 
+            #[cfg(feature = "orchard")]
+            let has_orchard = orchard.is_some();
+            #[cfg(not(feature = "orchard"))]
+            let has_orchard = true;
+
             #[cfg(feature = "transparent-inputs")]
             let has_transparent = transparent.is_some();
             #[cfg(not(feature = "transparent-inputs"))]
             let has_transparent = true;
 
-            if orchard.is_some() && sapling.is_some() && has_transparent {
+            if has_orchard && sapling.is_some() && has_transparent {
                 return Ok(UnifiedSpendingKey {
+                    #[cfg(feature = "orchard")]
                     orchard: orchard.unwrap(),
                     sapling: sapling.unwrap(),
                     #[cfg(feature = "transparent-inputs")]
@@ -362,6 +383,7 @@ pub struct UnifiedFullViewingKey {
     #[cfg(feature = "transparent-inputs")]
     transparent: Option<legacy::AccountPubKey>,
     sapling: Option<sapling::DiversifiableFullViewingKey>,
+    #[cfg(feature = "orchard")]
     orchard: Option<orchard::keys::FullViewingKey>,
     unknown: Vec<(u32, Vec<u8>)>,
 }
@@ -372,7 +394,7 @@ impl UnifiedFullViewingKey {
     pub fn new(
         #[cfg(feature = "transparent-inputs")] transparent: Option<legacy::AccountPubKey>,
         sapling: Option<sapling::DiversifiableFullViewingKey>,
-        orchard: Option<orchard::keys::FullViewingKey>,
+        #[cfg(feature = "orchard")] orchard: Option<orchard::keys::FullViewingKey>,
     ) -> Option<UnifiedFullViewingKey> {
         if sapling.is_none() {
             None
@@ -381,6 +403,7 @@ impl UnifiedFullViewingKey {
                 #[cfg(feature = "transparent-inputs")]
                 transparent,
                 sapling,
+                #[cfg(feature = "orchard")]
                 orchard,
                 // We don't allow constructing new UFVKs with unknown items, but we store
                 // this to allow parsing such UFVKs.
@@ -402,6 +425,7 @@ impl UnifiedFullViewingKey {
             ));
         }
 
+        #[cfg(feature = "orchard")]
         let mut orchard = None;
         let mut sapling = None;
         #[cfg(feature = "transparent-inputs")]
@@ -413,6 +437,7 @@ impl UnifiedFullViewingKey {
             .items_as_parsed()
             .iter()
             .filter_map(|receiver| match receiver {
+                #[cfg(feature = "orchard")]
                 unified::Fvk::Orchard(data) => orchard::keys::FullViewingKey::from_bytes(data)
                     .ok_or("Invalid Orchard FVK in Unified FVK")
                     .map(|addr| {
@@ -420,6 +445,10 @@ impl UnifiedFullViewingKey {
                         None
                     })
                     .transpose(),
+                #[cfg(not(feature = "orchard"))]
+                unified::Fvk::Orchard(data) => {
+                    Some(Ok((unified::Typecode::Orchard.into(), data.to_vec())))
+                }
                 unified::Fvk::Sapling(data) => {
                     sapling::DiversifiableFullViewingKey::from_bytes(data)
                         .ok_or("Invalid Sapling FVK in Unified FVK")
@@ -449,6 +478,7 @@ impl UnifiedFullViewingKey {
             #[cfg(feature = "transparent-inputs")]
             transparent,
             sapling,
+            #[cfg(feature = "orchard")]
             orchard,
             unknown,
         })
@@ -457,12 +487,6 @@ impl UnifiedFullViewingKey {
     /// Returns the string encoding of this `UnifiedFullViewingKey` for the given network.
     pub fn encode<P: consensus::Parameters>(&self, params: &P) -> String {
         let items = std::iter::empty()
-            .chain(
-                self.orchard
-                    .as_ref()
-                    .map(|fvk| fvk.to_bytes())
-                    .map(unified::Fvk::Orchard),
-            )
             .chain(
                 self.sapling
                     .as_ref()
@@ -477,6 +501,13 @@ impl UnifiedFullViewingKey {
                         data: data.clone(),
                     }),
             );
+        #[cfg(feature = "orchard")]
+        let items = items.chain(
+            self.orchard
+                .as_ref()
+                .map(|fvk| fvk.to_bytes())
+                .map(unified::Fvk::Orchard),
+        );
         #[cfg(feature = "transparent-inputs")]
         let items = items.chain(
             self.transparent
@@ -503,6 +534,7 @@ impl UnifiedFullViewingKey {
     }
 
     /// Returns the Orchard full viewing key component of this unified key.
+    #[cfg(feature = "orchard")]
     pub fn orchard(&self) -> Option<&orchard::keys::FullViewingKey> {
         self.orchard.as_ref()
     }
@@ -537,7 +569,12 @@ impl UnifiedFullViewingKey {
         #[cfg(not(feature = "transparent-inputs"))]
         let transparent = None;
 
-        UnifiedAddress::from_receivers(None, sapling, transparent)
+        UnifiedAddress::from_receivers(
+            #[cfg(feature = "orchard")]
+            None,
+            sapling,
+            transparent,
+        )
     }
 
     /// Searches the diversifier space starting at diversifier index `j` for one which will
@@ -658,6 +695,7 @@ mod tests {
     fn ufvk_round_trip() {
         let account = AccountId::ZERO;
 
+        #[cfg(feature = "orchard")]
         let orchard = {
             let sk = orchard::keys::SpendingKey::from_zip32_seed(&[0; 32], 0, 0).unwrap();
             Some(orchard::keys::FullViewingKey::from(&sk))
@@ -678,19 +716,28 @@ mod tests {
             #[cfg(feature = "transparent-inputs")]
             transparent,
             sapling,
+            #[cfg(feature = "orchard")]
             orchard,
         )
         .unwrap();
 
         let encoded = ufvk.encode(&MAIN_NETWORK);
 
-        // test encoded form against known values
+        // Test encoded form against known values; these test vectors contain Orchard receivers
+        // that will be treated as unknown if the `orchard` feature is not enabled.
         let encoded_with_t = "uview1tg6rpjgju2s2j37gkgjq79qrh5lvzr6e0ed3n4sf4hu5qd35vmsh7avl80xa6mx7ryqce9hztwaqwrdthetpy4pc0kce25x453hwcmax02p80pg5savlg865sft9reat07c5vlactr6l2pxtlqtqunt2j9gmvr8spcuzf07af80h5qmut38h0gvcfa9k4rwujacwwca9vu8jev7wq6c725huv8qjmhss3hdj2vh8cfxhpqcm2qzc34msyrfxk5u6dqttt4vv2mr0aajreww5yufpk0gn4xkfm888467k7v6fmw7syqq6cceu078yw8xja502jxr0jgum43lhvpzmf7eu5dmnn6cr6f7p43yw8znzgxg598mllewnx076hljlvynhzwn5es94yrv65tdg3utuz2u3sras0wfcq4adxwdvlk387d22g3q98t5z74quw2fa4wed32escx8dwh4mw35t4jwf35xyfxnu83mk5s4kw2glkgsshmxk";
         let _encoded_no_t = "uview12z384wdq76ceewlsu0esk7d97qnd23v2qnvhujxtcf2lsq8g4hwzpx44fwxssnm5tg8skyh4tnc8gydwxefnnm0hd0a6c6etmj0pp9jqkdsllkr70u8gpf7ndsfqcjlqn6dec3faumzqlqcmtjf8vp92h7kj38ph2786zx30hq2wru8ae3excdwc8w0z3t9fuw7mt7xy5sn6s4e45kwm0cjp70wytnensgdnev286t3vew3yuwt2hcz865y037k30e428dvgne37xvyeal2vu8yjnznphf9t2rw3gdp0hk5zwq00ws8f3l3j5n3qkqgsyzrwx4qzmgq0xwwk4vz2r6vtsykgz089jncvycmem3535zjwvvtvjw8v98y0d5ydwte575gjm7a7k";
-        #[cfg(feature = "transparent-inputs")]
-        assert_eq!(encoded, encoded_with_t);
-        #[cfg(not(feature = "transparent-inputs"))]
-        assert_eq!(encoded, _encoded_no_t);
+
+        // We test the full roundtrip only with the `orchard` feature enabled, because we will
+        // not generate the `orchard` part of the encoding if the UFVK does not have an Orchard
+        // part.
+        #[cfg(feature = "orchard")]
+        {
+            #[cfg(feature = "transparent-inputs")]
+            assert_eq!(encoded, encoded_with_t);
+            #[cfg(not(feature = "transparent-inputs"))]
+            assert_eq!(encoded, _encoded_no_t);
+        }
 
         let decoded = UnifiedFullViewingKey::decode(&MAIN_NETWORK, &encoded).unwrap();
         let reencoded = decoded.encode(&MAIN_NETWORK);
@@ -705,6 +752,7 @@ mod tests {
             decoded.sapling.map(|s| s.to_bytes()),
             ufvk.sapling.map(|s| s.to_bytes()),
         );
+        #[cfg(feature = "orchard")]
         assert_eq!(
             decoded.orchard.map(|o| o.to_bytes()),
             ufvk.orchard.map(|o| o.to_bytes()),
@@ -716,7 +764,12 @@ mod tests {
             decoded_with_t.transparent.map(|t| t.serialize()),
             ufvk.transparent.as_ref().map(|t| t.serialize()),
         );
-        #[cfg(not(feature = "transparent-inputs"))]
+
+        #[cfg(all(not(feature = "orchard"), not(feature = "transparent-inputs")))]
+        assert_eq!(decoded_with_t.unknown.len(), 2);
+        #[cfg(all(feature = "transparent-inputs", not(feature = "orchard")))]
+        assert_eq!(decoded_with_t.unknown.len(), 1);
+        #[cfg(all(feature = "orchard", not(feature = "transparent-inputs")))]
         assert_eq!(decoded_with_t.unknown.len(), 1);
     }
 
@@ -771,14 +824,20 @@ mod tests {
         #[cfg(feature = "unstable")]
         fn prop_usk_roundtrip(usk in arb_unified_spending_key(Network::MainNetwork)) {
             let encoded = usk.to_bytes(Era::Orchard);
+
             #[cfg(not(feature = "transparent-inputs"))]
             assert_eq!(encoded.len(), 4 + 2 + 32 + 2 + 169);
             #[cfg(feature = "transparent-inputs")]
             assert_eq!(encoded.len(), 4 + 2 + 32 + 2 + 169 + 2 + 64);
+
             let decoded = UnifiedSpendingKey::from_bytes(Era::Orchard, &encoded);
             let decoded = decoded.unwrap_or_else(|e| panic!("Error decoding USK: {:?}", e));
+
+            #[cfg(feature = "orchard")]
             assert!(bool::from(decoded.orchard().ct_eq(usk.orchard())));
+
             assert_eq!(decoded.sapling(), usk.sapling());
+
             #[cfg(feature = "transparent-inputs")]
             assert_eq!(decoded.transparent().to_bytes(), usk.transparent().to_bytes());
         }

--- a/zcash_client_backend/src/keys.rs
+++ b/zcash_client_backend/src/keys.rs
@@ -26,9 +26,6 @@ use {
     zcash_primitives::consensus::BranchId,
 };
 
-#[cfg(feature = "orchard")]
-use orchard;
-
 pub mod sapling {
     pub use sapling::zip32::{
         DiversifiableFullViewingKey, ExtendedFullViewingKey, ExtendedSpendingKey,

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -35,7 +35,7 @@ pub use decrypt::{decrypt_transaction, DecryptedOutput, TransferType};
 #[macro_use]
 extern crate assert_matches;
 
-/// A shielded transfer protocol supported by the wallet.
+/// A shielded transfer protocol known to the wallet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ShieldedProtocol {
     /// The Sapling protocol

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -186,6 +186,7 @@ impl<A: sapling::bundle::Authorization> From<&sapling::bundle::SpendDescription<
     }
 }
 
+#[cfg(feature = "orchard")]
 impl<SpendAuth> From<&orchard::Action<SpendAuth>> for compact_formats::CompactOrchardAction {
     fn from(action: &orchard::Action<SpendAuth>) -> compact_formats::CompactOrchardAction {
         compact_formats::CompactOrchardAction {

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -18,16 +18,13 @@ use zcash_primitives::{
     zip32::{AccountId, Scope},
 };
 
-use crate::data_api::{BlockMetadata, ScannedBlock, ScannedBlockSapling};
+use crate::data_api::{BlockMetadata, ScannedBlock, ScannedBundles};
 use crate::{
     proto::compact_formats::CompactBlock,
     scan::{Batch, BatchRunner, Tasks},
     wallet::{WalletSaplingOutput, WalletSaplingSpend, WalletTx},
     ShieldedProtocol,
 };
-
-#[cfg(feature = "orchard")]
-use crate::data_api::ScannedBlockOrchard;
 
 /// A key that can be used to perform trial decryption and nullifier
 /// computation for a Sapling [`CompactSaplingOutput`]
@@ -651,13 +648,13 @@ pub(crate) fn scan_block_with_runner<
         cur_hash,
         block.time,
         wtxs,
-        ScannedBlockSapling::new(
+        ScannedBundles::new(
             sapling_commitment_tree_size,
             sapling_note_commitments,
             sapling_nullifier_map,
         ),
         #[cfg(feature = "orchard")]
-        ScannedBlockOrchard::new(
+        ScannedBundles::new(
             orchard_commitment_tree_size,
             vec![], // FIXME: collect the Orchard nullifiers
             vec![], // FIXME: collect the Orchard note commitments

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -239,6 +239,7 @@ impl<N, S> WalletSaplingOutput<N, S> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WalletNote {
     Sapling(sapling::Note),
+    #[cfg(feature = "orchard")]
     Orchard(orchard::Note),
 }
 
@@ -248,6 +249,7 @@ impl WalletNote {
             WalletNote::Sapling(n) => n.value().try_into().expect(
                 "Sapling notes must have values in the range of valid non-negative ZEC values.",
             ),
+            #[cfg(feature = "orchard")]
             WalletNote::Orchard(n) => NonNegativeAmount::from_u64(n.value().inner()).expect(
                 "Orchard notes must have values in the range of valid non-negative ZEC values.",
             ),

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -760,7 +760,12 @@ pub mod testing {
             sapling in arb_payment_address(),
             transparent in option::of(arb_transparent_addr()),
         ) -> UnifiedAddress {
-            UnifiedAddress::from_receivers(None, Some(sapling), transparent).unwrap()
+            UnifiedAddress::from_receivers(
+                #[cfg(feature = "orchard")]
+                None,
+                Some(sapling),
+                transparent
+            ).unwrap()
         }
     }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- A new `orchard` feature flag has been added to make it possible to
+  build client code without `orchard` dependendencies.
+
 ### Changed
 - `zcash_client_sqlite::error::SqliteClientError` has new error variants:
   - `SqliteClientError::UnsupportedPoolType`

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -80,6 +80,10 @@ multicore = ["maybe-rayon/threads", "zcash_primitives/multicore"]
 ## client is configured for use with the Zcash testnet.
 mainnet = []
 
+## Enables support for storing data related to the sending and receiving of 
+## Orchard funds.
+orchard = ["zcash_client_backend/orchard"]
+
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
 test-dependencies = [
     "incrementalmerkletree/test-dependencies",

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -444,8 +444,8 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                 (
                     block.height(),
                     Position::from(
-                        u64::from(block.sapling_tree_size())
-                            - u64::try_from(block.sapling_commitments().len()).unwrap(),
+                        u64::from(block.sapling().final_tree_size())
+                            - u64::try_from(block.sapling().commitments().len()).unwrap(),
                     ),
                 )
             });
@@ -466,8 +466,8 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                     block.height(),
                     block.block_hash(),
                     block.block_time(),
-                    block.sapling_tree_size(),
-                    block.sapling_commitments().len().try_into().unwrap(),
+                    block.sapling().final_tree_size(),
+                    block.sapling().commitments().len().try_into().unwrap(),
                 )?;
 
                 for tx in block.transactions() {
@@ -496,7 +496,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                     wdb.conn.0,
                     block.height(),
                     ShieldedProtocol::Sapling,
-                    block.sapling_nullifier_map(),
+                    block.sapling().nullifier_map(),
                 )?;
 
                 note_positions.extend(block.transactions().iter().flat_map(|wtx| {
@@ -506,8 +506,8 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                 }));
 
                 last_scanned_height = Some(block.height());
-                let (block_sapling_commitments, _) = block.into_commitments();
-                sapling_commitments.extend(block_sapling_commitments.into_iter().map(Some));
+                let block_commitments = block.into_commitments();
+                sapling_commitments.extend(block_commitments.sapling.into_iter().map(Some));
             }
 
             // Prune the nullifier map of entries we no longer need.

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -841,6 +841,8 @@ pub(crate) fn fake_compact_block_from_tx(
             ctx.outputs.push(output.into());
         }
     }
+
+    #[cfg(feature = "orchard")]
     if let Some(bundle) = tx.orchard_bundle() {
         for action in bundle.actions() {
             ctx.actions.push(action.into());

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -648,8 +648,8 @@ mod tests {
                 FutureNetwork,
                 height,
                 BuildConfig::Standard {
-                    sapling_anchor,
-                    orchard_anchor: orchard::Anchor::empty_tree(),
+                    sapling_anchor: Some(sapling_anchor),
+                    orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 },
             ),
             extension_id: 0,


### PR DESCRIPTION
We plan to also introduce a similar flag to gate access to Sapling functionality. Since introduction of Orchard functionality is still nascent, it's the correct time to introduce this isolation, before there's more functionality that needs to be isolated in this fashion.