### PR TITLE
Replace SaplingInputSource and TransparentInputSource with InputSource

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,8 +10,7 @@ and this library adheres to Rust's notion of
 ### Added
 - `zcash_client_backend::data_api`:
   - `BlockMetadata::orchard_tree_size` (when the `orchard` feature is enabled).
-  - `TransparentInputSource`
-  - `SaplingInputSource`
+  - `InputSource`
   - `ScannedBlock::{into_commitments, sapling}`
   - `ScannedBlock::orchard` (when the `orchard` feature is enabled.)
   - `ScannedBundles`
@@ -112,15 +111,11 @@ and this library adheres to Rust's notion of
     - `wallet::create_spend_to_address`
     - `wallet::shield_transparent_funds`
     - `wallet::spend`
-  - In order to support better reusability for input selection code, two new
-    traits have been factored out from `WalletRead`:
-    - `zcash_client_backend::data_api::TransparentInputSource`
-    - `zcash_client_backend::data_api::SaplingInputSource`
   - `wallet::input_selection::InputSelector::propose_shielding`,
     has been moved out to the newly-created `ShieldingSelector` trait.
     - `ShieldingSelector::propose_shielding` has been altered such that it takes
       an explicit `target_height` in order to minimize the capabilities that the
-      `data_api::TransparentInputSource` trait must expose. Also, it now takes its
+      `data_api::InputSource` trait must expose. Also, it now takes its
       `min_confirmations` argument as `u32` instead of `NonZeroU32`.
   - The `wallet::input_selection::InputSelector::DataSource`
     associated type has been renamed to `InputSource`.
@@ -128,7 +123,7 @@ and this library adheres to Rust's notion of
     has been altered such that it longer takes `min_confirmations` as an
     argument, instead taking explicit `target_height` and `anchor_height`
     arguments. This helps to minimize the set of capabilities that the
-    `data_api::SaplingInputSource` must expose.
+    `data_api::InputSource` must expose.
   - `WalletRead::get_checkpoint_depth` has been removed without replacement. This
     is no longer needed given the change to use the stored anchor height for transaction
     proposal execution.
@@ -207,10 +202,11 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api::WalletRead::is_valid_account_extfvk` has been
   removed; it was unused in the ECC mobile wallet SDKs and has been superseded by
   `get_account_for_ufvk`.
-- `zcash_client_backend::data_api::WalletRead::get_spendable_sapling_notes` has been
-  removed without replacement as it was unused, and its functionality will be
-  fully reproduced by `SaplingInputSource::select_spendable_sapling_notes` in a future
-  change.
+- `zcash_client_backend::data_api::WalletRead::{
+     get_spendable_sapling_notes
+     select_spendable_sapling_notes,
+     get_unspent_transparent_outputs,
+   }` - use `data_api::InputSource` instead.
 - `zcash_client_backend::data_api::ScannedBlock::from_parts` has been made crate-private.
 - `zcash_client_backend::data_api::ScannedBlock::into_sapling_commitments` has been
   replaced by `into_commitments` which returns both Sapling and Orchard note commitments

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -61,7 +61,7 @@ use zcash_client_backend::{
         self,
         chain::{BlockSource, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
-        AccountBirthday, BlockMetadata, DecryptedTransaction, NullifierQuery, SaplingInputSource,
+        AccountBirthday, BlockMetadata, DecryptedTransaction, InputSource, NullifierQuery,
         ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
         WalletWrite, SAPLING_SHARD_HEIGHT,
     },
@@ -74,10 +74,7 @@ use zcash_client_backend::{
 use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore};
 
 #[cfg(feature = "transparent-inputs")]
-use {
-    zcash_client_backend::data_api::TransparentInputSource,
-    zcash_primitives::transaction::components::OutPoint,
-};
+use zcash_primitives::transaction::components::OutPoint;
 
 #[cfg(feature = "unstable")]
 use {
@@ -164,24 +161,24 @@ impl<P: consensus::Parameters + Clone> WalletDb<Connection, P> {
     }
 }
 
-impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> SaplingInputSource
-    for WalletDb<C, P>
-{
+impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for WalletDb<C, P> {
     type Error = SqliteClientError;
     type NoteRef = ReceivedNoteId;
 
-    fn get_spendable_sapling_note(
+    fn get_spendable_note(
         &self,
         txid: &TxId,
+        _protocol: ShieldedProtocol,
         index: u32,
     ) -> Result<Option<ReceivedNote<Self::NoteRef>>, Self::Error> {
         wallet::sapling::get_spendable_sapling_note(self.conn.borrow(), &self.params, txid, index)
     }
 
-    fn select_spendable_sapling_notes(
+    fn select_spendable_notes(
         &self,
         account: AccountId,
         target_value: Amount,
+        _sources: &[ShieldedProtocol],
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<Vec<ReceivedNote<Self::NoteRef>>, Self::Error> {
@@ -194,14 +191,8 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> SaplingInputSour
             exclude,
         )
     }
-}
 
-#[cfg(feature = "transparent-inputs")]
-impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> TransparentInputSource
-    for WalletDb<C, P>
-{
-    type Error = SqliteClientError;
-
+    #[cfg(feature = "transparent-inputs")]
     fn get_unspent_transparent_output(
         &self,
         outpoint: &OutPoint,
@@ -209,6 +200,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> TransparentInput
         wallet::get_unspent_transparent_output(self.conn.borrow(), outpoint)
     }
 
+    #[cfg(feature = "transparent-inputs")]
     fn get_unspent_transparent_outputs(
         &self,
         address: &TransparentAddress,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -41,6 +41,7 @@ use zcash_client_backend::{
     proto::compact_formats::{
         self as compact, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },
+    proto::proposal,
     wallet::OvkPolicy,
     zip321,
 };
@@ -71,11 +72,8 @@ use super::BlockDb;
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    zcash_client_backend::{
-        data_api::wallet::{
-            input_selection::ShieldingSelector, propose_shielding, shield_transparent_funds,
-        },
-        proto::proposal,
+    zcash_client_backend::data_api::wallet::{
+        input_selection::ShieldingSelector, propose_shielding, shield_transparent_funds,
     },
     zcash_primitives::legacy::TransparentAddress,
 };
@@ -571,7 +569,6 @@ impl<Cache> TestState<Cache> {
             change_memo,
         );
 
-        #[cfg(feature = "transparent-inputs")]
         if let Ok(proposal) = &result {
             check_proposal_serialization_roundtrip(self.wallet(), proposal);
         }
@@ -1075,7 +1072,6 @@ pub(crate) fn input_selector(
 
 // Checks that a protobuf proposal serialized from the provided proposal value correctly parses to
 // the same proposal value.
-#[cfg(feature = "transparent-inputs")]
 pub(crate) fn check_proposal_serialization_roundtrip(
     db_data: &WalletDb<rusqlite::Connection, Network>,
     proposal: &Proposal<StandardFeeRule, ReceivedNoteId>,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1993,9 +1993,7 @@ mod tests {
         },
         sapling::zip32::ExtendedSpendingKey,
         zcash_client_backend::{
-            data_api::{
-                wallet::input_selection::GreedyInputSelector, TransparentInputSource, WalletWrite,
-            },
+            data_api::{wallet::input_selection::GreedyInputSelector, InputSource, WalletWrite},
             encoding::AddressCodec,
             fees::{fixed, DustOutputPolicy},
             wallet::WalletTransparentOutput,


### PR DESCRIPTION
This unification allows us to better isolate transparent-input dependent functionality. Previously, `TransparentInputSource` could not be placed under a feature flag because the interface was needed for proposal deserialization; by instead making the transparent input source methods flag-dependent, we can correctly produce an error when proposal deserializaiton attempts to select transparent inputs and the feature flag is off.