### PR TITLE
Show feature flags in documentation

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -20,6 +20,10 @@ exclude = ["*.proto"]
 [package.metadata.cargo-udeps.ignore]
 development = ["zcash_proofs"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 zcash_address.workspace = true
 zcash_encoding.workspace = true

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -7,6 +7,8 @@
 #![doc = document_features::document_features!()]
 //!
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 // Temporary until we have addressed all Result<T, ()> cases.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -14,6 +14,10 @@ edition.workspace = true
 rust-version.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 zcash_client_backend = { workspace = true, features = ["unstable-serialization", "unstable-spanning-tree"] }
 zcash_encoding.workspace = true

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -27,6 +27,8 @@
 //! [`CompactBlock`]: zcash_client_backend::proto::compact_formats::CompactBlock
 //! [`init_cache_database`]: crate::chain::init::init_cache_database
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -10,6 +10,10 @@ edition.workspace = true
 rust-version.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 blake2b_simd.workspace = true
 zcash_primitives = { workspace = true, features = ["zfuture" ] }

--- a/zcash_extensions/src/lib.rs
+++ b/zcash_extensions/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -16,6 +16,7 @@ categories.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 equihash.workspace = true

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 // Temporary until we have addressed all Result<T, ()> cases.

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -452,7 +452,6 @@ impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<
 
     /// Adds a transparent coin to be spent in this transaction.
     #[cfg(feature = "transparent-inputs")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "transparent-inputs")))]
     pub fn add_transparent_input(
         &mut self,
         sk: secp256k1::SecretKey,

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -203,7 +203,6 @@ impl TransparentBuilder {
 
 impl TxIn<Unauthorized> {
     #[cfg(feature = "transparent-inputs")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "transparent-inputs")))]
     pub fn new(prevout: OutPoint) -> Self {
         TxIn {
             prevout,

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 zcash_primitives.workspace = true

--- a/zcash_proofs/src/lib.rs
+++ b/zcash_proofs/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 // Temporary until we have addressed all Result<T, ()> cases.
@@ -31,14 +32,9 @@ mod hashreader;
 pub mod sprout;
 
 #[cfg(any(feature = "local-prover", feature = "bundled-prover"))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(feature = "local-prover", feature = "bundled-prover")))
-)]
 pub mod prover;
 
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 mod downloadreader;
 
 // Circuit names
@@ -67,7 +63,6 @@ const DOWNLOAD_URL: &str = "https://download.z.cash/downloads";
 
 /// The paths to the Sapling parameter files.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SaplingParameterPaths {
     /// The path to the Sapling spend parameter file.
@@ -79,7 +74,6 @@ pub struct SaplingParameterPaths {
 
 /// Returns the default folder that the Zcash proving parameters are located in.
 #[cfg(feature = "directories")]
-#[cfg_attr(docsrs, doc(cfg(feature = "directories")))]
 pub fn default_params_folder() -> Option<PathBuf> {
     #[cfg(windows)]
     {
@@ -107,7 +101,6 @@ pub fn default_params_folder() -> Option<PathBuf> {
 ///
 /// This mirrors the behaviour of the `fetch-params.sh` script from `zcashd`.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 #[deprecated(
     since = "0.6.0",
     note = "please replace with `download_sapling_parameters`, and use `download_sprout_parameters` if needed"
@@ -126,7 +119,6 @@ pub fn download_parameters() -> Result<(), minreq::Error> {
 ///
 /// Returns the paths to the downloaded files.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 pub fn download_sapling_parameters(
     timeout: Option<u64>,
 ) -> Result<SaplingParameterPaths, minreq::Error> {
@@ -156,7 +148,6 @@ pub fn download_sapling_parameters(
 ///
 /// Returns the path to the downloaded file.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 pub fn download_sprout_parameters(timeout: Option<u64>) -> Result<PathBuf, minreq::Error> {
     fetch_params(SPROUT_NAME, SPROUT_HASH, SPROUT_BYTES, timeout)
 }
@@ -166,7 +157,6 @@ pub fn download_sprout_parameters(timeout: Option<u64>) -> Result<PathBuf, minre
 ///
 /// See [`download_sapling_parameters`] for details.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 fn fetch_params(
     name: &str,
     expected_hash: &str,
@@ -234,7 +224,6 @@ fn fetch_params(
 ///
 /// See [`download_sapling_parameters`] for details.
 #[cfg(feature = "download-params")]
-#[cfg_attr(docsrs, doc(cfg(feature = "download-params")))]
 fn stream_params_downloads_to_disk(
     params_path: &Path,
     name: &str,

--- a/zcash_proofs/src/prover.rs
+++ b/zcash_proofs/src/prover.rs
@@ -97,7 +97,6 @@ impl LocalTxProver {
     /// This function will panic if the parameters in the default local location do not
     /// have the expected hashes.
     #[cfg(feature = "local-prover")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "local-prover")))]
     pub fn with_default_location() -> Option<Self> {
         let params_dir = default_params_folder()?;
         let (spend_path, output_path) = if params_dir.exists() {
@@ -120,7 +119,6 @@ impl LocalTxProver {
     /// This requires the `bundled-prover` feature, which will increase the binary size by
     /// around 50 MiB.
     #[cfg(feature = "bundled-prover")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bundled-prover")))]
     pub fn bundled() -> Self {
         let (spend_buf, output_buf) = wagyu_zcash_parameters::load_sapling_parameters();
         let p = parse_parameters(&spend_buf[..], &output_buf[..], None);


### PR DESCRIPTION
This can be rendered locally with:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --workspace --all-features
```