### PR TITLE
Drop unused `mainnet` feature

### DIFF
--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -80,10 +80,6 @@ default = ["multicore"]
 ## Enables multithreading support for creating proofs and building subtrees.
 multicore = ["maybe-rayon/threads", "zcash_primitives/multicore"]
 
-## Configures the light client for use with the Zcash mainnet. By default, the light
-## client is configured for use with the Zcash testnet.
-mainnet = []
-
 ## Enables support for storing data related to the sending and receiving of 
 ## Orchard funds.
 orchard = ["zcash_client_backend/orchard"]


### PR DESCRIPTION
Nothing seems to have depended on it, and my testing suggests the same build of this crate can work on both networks.