### PR TITLE
Add `WalletRead::get_account_ids` function

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.md]
+indent_style = space

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -140,7 +140,7 @@ and this library adheres to Rust's notion of
     - `get_spendable_sapling_notes`, `select_spendable_sapling_notes`, and
       `get_unspent_transparent_outputs` have been removed; use
       `data_api::InputSource` instead.
-    - Added `get_account_ids`
+    - Added `get_account_ids`.
   - `wallet::{propose_shielding, shield_transparent_funds}` now takes their
     `min_confirmations` arguments as `u32` rather than a `NonZeroU32` to permit
     implmentations to enable zero-conf shielding.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -140,6 +140,7 @@ and this library adheres to Rust's notion of
     - `get_spendable_sapling_notes`, `select_spendable_sapling_notes`, and
       `get_unspent_transparent_outputs` have been removed; use
       `data_api::InputSource` instead.
+    - Added `get_account_ids`
   - `wallet::{propose_shielding, shield_transparent_funds}` now takes their
     `min_confirmations` arguments as `u32` rather than a `NonZeroU32` to permit
     implmentations to enable zero-conf shielding.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -560,6 +560,9 @@ pub trait WalletRead {
         account: AccountId,
         max_height: BlockHeight,
     ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error>;
+
+    /// Returns a vector with the IDs of all accounts known to this wallet.
+    fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error>;
 }
 
 /// Metadata describing the sizes of the zcash note commitment trees as of a particular block.
@@ -1282,6 +1285,10 @@ pub mod testing {
             _max_height: BlockHeight,
         ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
             Ok(HashMap::new())
+        }
+
+        fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error> {
+            Ok(Vec::new())
         }
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -372,6 +372,10 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
     ) -> Result<Vec<(AccountId, orchard::note::Nullifier)>, Self::Error> {
         todo!()
     }
+
+    fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error> {
+        wallet::get_account_ids(self.conn.borrow())
+    }
 }
 
 impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P> {


### PR DESCRIPTION
As per our [discord discussion](https://discord.com/channels/809218587167293450/972649509651906711/1193920166598287421), this needs to be exposed via the API since the sqlite 'public API' is said to not include most of the tables, including the accounts table.