### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ at your option.
 
 Downstream code forks should note that some (but not all) of these crates
 and components depend on the 'orchard' crate, which is licensed under the
-[Bootstrap Open Source License](https://github.com/zcash/orchard/blob/main/LICENSE-BOSL).
+[Bootstrap Open Source License]([https://github.com/zcash/orchard/blob/main/LICENSE-BOSL](https://github.com/zcash/orchard?tab=readme-ov-file#license)).
 A license exception is provided allowing some derived works that are linked or
 combined with the 'orchard' crate to be copied or distributed under the original
 licenses (in this case MIT / Apache 2.0), provided that the included portions of

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ at your option.
 
 Downstream code forks should note that some (but not all) of these crates
 and components depend on the 'orchard' crate, which is licensed under the
-[Bootstrap Open Source License]([https://github.com/zcash/orchard/blob/main/LICENSE-BOSL](https://github.com/zcash/orchard?tab=readme-ov-file#license]).
+[Bootstrap Open Source License](https://github.com/zcash/orchard?tab=readme-ov-file#license).
 A license exception is provided allowing some derived works that are linked or
 combined with the 'orchard' crate to be copied or distributed under the original
 licenses (in this case MIT / Apache 2.0), provided that the included portions of

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ at your option.
 
 Downstream code forks should note that some (but not all) of these crates
 and components depend on the 'orchard' crate, which is licensed under the
-[Bootstrap Open Source License]([https://github.com/zcash/orchard/blob/main/LICENSE-BOSL](https://github.com/zcash/orchard?tab=readme-ov-file#license)).
+[Bootstrap Open Source License]([https://github.com/zcash/orchard/blob/main/LICENSE-BOSL](https://github.com/zcash/orchard?tab=readme-ov-file#license]).
 A license exception is provided allowing some derived works that are linked or
 combined with the 'orchard' crate to be copied or distributed under the original
 licenses (in this case MIT / Apache 2.0), provided that the included portions of


### PR DESCRIPTION
The link pointing to the Orchard license has been corrected.
