### PR TITLE
zcash_client_backend: Enable `zcash_keys/unstable` feature flag

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -133,7 +133,7 @@ test-dependencies = [
 #! ### Experimental features
 
 ## Exposes unstable APIs. Their behaviour may change at any time.
-unstable = ["dep:byteorder"]
+unstable = ["dep:byteorder", "zcash_keys/unstable"]
 
 ## Exposes APIs for unstable serialization formats. These may change at any time.
 unstable-serialization = ["dep:byteorder"]


### PR DESCRIPTION
Due to `zcash_keys` being in `zcash_client_backend`'s public API, their unstable APIs are a common API surface (as they were before `zcash_keys` was extracted).

This can be reverted once `zcash_keys` types with unstable APIs are not being re-exported from `zcash_client_backend`.