### PR TITLE
CI: Don't test `unstable-nu6` and `zfuture` feature flags on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
         include:
           - extra_flags: orchard
             rustflags: '--cfg zcash_unstable="orchard"'
+        exclude:
+          - os: macOS-latest
+            extra_flags: unstable-nu6
+          - os: macOS-latest
+            extra_flags: zfuture
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
 


### PR DESCRIPTION
This reduces the number of macOS runner jobs in each PR from 10 to 6, or from 5 to 3 for external PRs. GitHub's macOS runners are noticeably slower than their other runners, and our available free runner slots are being quickly exhausted when we have multiple PRs open.