### PR TITLE
Add `zcash_unstable` to `RUSTFLAGS` for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+    "rust-analyzer.cargo.extraEnv": {
+        "RUSTFLAGS": "--cfg zcash_unstable=\"orchard\""
+    },
     "rust-analyzer.cargo.features": "all"
 }


### PR DESCRIPTION
Necessary for the `--all-features` to work, allowing all code to be compiled by `rust-analyzer`.