### PR TITLE
zcash_primitives: Rename `TransparentAddress` variants.

### DIFF
--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -1154,7 +1154,7 @@ pub(crate) mod tests {
         let fee_rule = StandardFeeRule::PreZip313;
 
         // TODO: generate_next_block_from_tx does not currently support transparent outputs.
-        let to = TransparentAddress::PublicKey([7; 20]).into();
+        let to = TransparentAddress::PublicKeyHash([7; 20]).into();
         let min_confirmations = NonZeroU32::new(1).unwrap();
         let proposal = st
             .propose_standard_transfer::<Infallible>(
@@ -1216,7 +1216,7 @@ pub(crate) mod tests {
         let fee_rule = StandardFeeRule::PreZip313;
 
         // TODO: generate_next_block_from_tx does not currently support transparent outputs.
-        let to = TransparentAddress::PublicKey([7; 20]).into();
+        let to = TransparentAddress::PublicKeyHash([7; 20]).into();
         let min_confirmations = NonZeroU32::new(1).unwrap();
         let proposal = st
             .propose_standard_transfer::<Infallible>(

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -890,7 +890,7 @@ mod tests {
 
         builder_c
             .add_transparent_output(
-                &TransparentAddress::PublicKey([0; 20]),
+                &TransparentAddress::PublicKeyHash([0; 20]),
                 (value_xfr - fee_rule.fixed_fee()).unwrap(),
             )
             .unwrap();

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -82,11 +82,11 @@ impl TryFrom<unified::Address> for UnifiedAddress {
                     })
                     .transpose(),
                 unified::Receiver::P2pkh(data) => {
-                    transparent = Some(TransparentAddress::PublicKey(*data));
+                    transparent = Some(TransparentAddress::PublicKeyHash(*data));
                     None
                 }
                 unified::Receiver::P2sh(data) => {
-                    transparent = Some(TransparentAddress::Script(*data));
+                    transparent = Some(TransparentAddress::ScriptHash(*data));
                     None
                 }
                 unified::Receiver::Unknown { typecode, data } => {
@@ -173,8 +173,8 @@ impl UnifiedAddress {
                     data: data.clone(),
                 })
                 .chain(self.transparent.as_ref().map(|taddr| match taddr {
-                    TransparentAddress::PublicKey(data) => unified::Receiver::P2pkh(*data),
-                    TransparentAddress::Script(data) => unified::Receiver::P2sh(*data),
+                    TransparentAddress::PublicKeyHash(data) => unified::Receiver::P2pkh(*data),
+                    TransparentAddress::ScriptHash(data) => unified::Receiver::P2sh(*data),
                 }))
                 .chain(
                     self.sapling
@@ -241,11 +241,11 @@ impl TryFromRawAddress for Address {
     fn try_from_raw_transparent_p2pkh(
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
-        Ok(TransparentAddress::PublicKey(data).into())
+        Ok(TransparentAddress::PublicKeyHash(data).into())
     }
 
     fn try_from_raw_transparent_p2sh(data: [u8; 20]) -> Result<Self, ConversionError<Self::Error>> {
-        Ok(TransparentAddress::Script(data).into())
+        Ok(TransparentAddress::ScriptHash(data).into())
     }
 }
 
@@ -262,10 +262,12 @@ impl Address {
         match self {
             Address::Sapling(pa) => ZcashAddress::from_sapling(net, pa.to_bytes()),
             Address::Transparent(addr) => match addr {
-                TransparentAddress::PublicKey(data) => {
+                TransparentAddress::PublicKeyHash(data) => {
                     ZcashAddress::from_transparent_p2pkh(net, *data)
                 }
-                TransparentAddress::Script(data) => ZcashAddress::from_transparent_p2sh(net, *data),
+                TransparentAddress::ScriptHash(data) => {
+                    ZcashAddress::from_transparent_p2sh(net, *data)
+                }
             },
             Address::Unified(ua) => ua.to_address(net),
         }

--- a/zcash_keys/src/encoding.rs
+++ b/zcash_keys/src/encoding.rs
@@ -348,7 +348,7 @@ pub fn decode_payment_address(
 ///     encode_transparent_address(
 ///         &TEST_NETWORK.b58_pubkey_address_prefix(),
 ///         &TEST_NETWORK.b58_script_address_prefix(),
-///         &TransparentAddress::PublicKey([0; 20]),
+///         &TransparentAddress::PublicKeyHash([0; 20]),
 ///     ),
 ///     "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma",
 /// );
@@ -357,7 +357,7 @@ pub fn decode_payment_address(
 ///     encode_transparent_address(
 ///         &TEST_NETWORK.b58_pubkey_address_prefix(),
 ///         &TEST_NETWORK.b58_script_address_prefix(),
-///         &TransparentAddress::Script([0; 20]),
+///         &TransparentAddress::ScriptHash([0; 20]),
 ///     ),
 ///     "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2",
 /// );
@@ -369,13 +369,13 @@ pub fn encode_transparent_address(
     addr: &TransparentAddress,
 ) -> String {
     let decoded = match addr {
-        TransparentAddress::PublicKey(key_id) => {
+        TransparentAddress::PublicKeyHash(key_id) => {
             let mut decoded = vec![0; pubkey_version.len() + 20];
             decoded[..pubkey_version.len()].copy_from_slice(pubkey_version);
             decoded[pubkey_version.len()..].copy_from_slice(key_id);
             decoded
         }
-        TransparentAddress::Script(script_id) => {
+        TransparentAddress::ScriptHash(script_id) => {
             let mut decoded = vec![0; script_version.len() + 20];
             decoded[..script_version.len()].copy_from_slice(script_version);
             decoded[script_version.len()..].copy_from_slice(script_id);
@@ -418,7 +418,7 @@ pub fn encode_transparent_address_p<P: consensus::Parameters>(
 ///         &TEST_NETWORK.b58_script_address_prefix(),
 ///         "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma",
 ///     ),
-///     Ok(Some(TransparentAddress::PublicKey([0; 20]))),
+///     Ok(Some(TransparentAddress::PublicKeyHash([0; 20]))),
 /// );
 ///
 /// assert_eq!(
@@ -427,7 +427,7 @@ pub fn encode_transparent_address_p<P: consensus::Parameters>(
 ///         &TEST_NETWORK.b58_script_address_prefix(),
 ///         "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2",
 ///     ),
-///     Ok(Some(TransparentAddress::Script([0; 20]))),
+///     Ok(Some(TransparentAddress::ScriptHash([0; 20]))),
 /// );
 /// ```
 /// [`TransparentAddress`]: zcash_primitives::legacy::TransparentAddress
@@ -441,12 +441,12 @@ pub fn decode_transparent_address(
             decoded[pubkey_version.len()..]
                 .try_into()
                 .ok()
-                .map(TransparentAddress::PublicKey)
+                .map(TransparentAddress::PublicKeyHash)
         } else if decoded.starts_with(script_version) {
             decoded[script_version.len()..]
                 .try_into()
                 .ok()
-                .map(TransparentAddress::Script)
+                .map(TransparentAddress::ScriptHash)
         } else {
             None
         }

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -64,6 +64,9 @@ and this library adheres to Rust's notion of
     defaults to `constants::regtest::` for everything else. 
 
 ### Changed
+- `zcash_primitives::legacy::TransparentAddress` variants have changed:
+  - `TransparentAddress::PublicKey` has been renamed to `PublicKeyHash`
+  - `TransparentAddress::Script` has been renamed to `ScriptHash`
 - `zcash_primitives::transaction`:
   - `builder::Builder` now has a generic parameter for the type of progress
     notifier, which needs to implement `sapling::builder::ProverProgress` in

--- a/zcash_primitives/src/constants/mainnet.rs
+++ b/zcash_primitives/src/constants/mainnet.rs
@@ -5,7 +5,7 @@
 /// [SLIP 44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 pub const COIN_TYPE: u32 = 133;
 
-/// The HRP for a Bech32-encoded mainnet [`ExtendedSpendingKey`].
+/// The HRP for a Bech32-encoded mainnet Sapling [`ExtendedSpendingKey`].
 ///
 /// Defined in [ZIP 32].
 ///
@@ -21,7 +21,7 @@ pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-main";
 /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviews";
 
-/// The HRP for a Bech32-encoded mainnet [`PaymentAddress`].
+/// The HRP for a Bech32-encoded mainnet Sapling [`PaymentAddress`].
 ///
 /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
 ///
@@ -29,12 +29,12 @@ pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviews";
 /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
 pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "zs";
 
-/// The prefix for a Base58Check-encoded mainnet [`TransparentAddress::PublicKey`].
+/// The prefix for a Base58Check-encoded mainnet [`PublicKeyHash`].
 ///
-/// [`TransparentAddress::PublicKey`]: crate::legacy::TransparentAddress::PublicKey
+/// [`PublicKeyHash`]: crate::legacy::TransparentAddress::PublicKeyHash
 pub const B58_PUBKEY_ADDRESS_PREFIX: [u8; 2] = [0x1c, 0xb8];
 
-/// The prefix for a Base58Check-encoded mainnet [`TransparentAddress::Script`].
+/// The prefix for a Base58Check-encoded mainnet [`ScriptHash`].
 ///
-/// [`TransparentAddress::Script`]: crate::legacy::TransparentAddress::Script
+/// [`ScriptHash`]: crate::legacy::TransparentAddress::ScriptHash
 pub const B58_SCRIPT_ADDRESS_PREFIX: [u8; 2] = [0x1c, 0xbd];

--- a/zcash_primitives/src/constants/regtest.rs
+++ b/zcash_primitives/src/constants/regtest.rs
@@ -9,7 +9,7 @@
 /// The regtest cointype reuses the testnet cointype
 pub const COIN_TYPE: u32 = 1;
 
-/// The HRP for a Bech32-encoded regtest [`ExtendedSpendingKey`].
+/// The HRP for a Bech32-encoded regtest Sapling [`ExtendedSpendingKey`].
 ///
 /// It is defined in [the `zcashd` codebase].
 ///
@@ -17,7 +17,7 @@ pub const COIN_TYPE: u32 = 1;
 /// [the `zcashd` codebase]: <https://github.com/zcash/zcash/blob/128d863fb8be39ee294fda397c1ce3ba3b889cb2/src/chainparams.cpp#L496>
 pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-regtest";
 
-/// The HRP for a Bech32-encoded regtest [`ExtendedFullViewingKey`].
+/// The HRP for a Bech32-encoded regtest Sapling [`ExtendedFullViewingKey`].
 ///
 /// It is defined in [the `zcashd` codebase].
 ///
@@ -25,7 +25,7 @@ pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-regtest
 /// [the `zcashd` codebase]: <https://github.com/zcash/zcash/blob/128d863fb8be39ee294fda397c1ce3ba3b889cb2/src/chainparams.cpp#L494>
 pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewregtestsapling";
 
-/// The HRP for a Bech32-encoded regtest [`PaymentAddress`].
+/// The HRP for a Bech32-encoded regtest Sapling [`PaymentAddress`].
 ///
 /// It is defined in [the `zcashd` codebase].
 ///
@@ -33,14 +33,14 @@ pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewregtestsapling";
 /// [the `zcashd` codebase]: <https://github.com/zcash/zcash/blob/128d863fb8be39ee294fda397c1ce3ba3b889cb2/src/chainparams.cpp#L493>
 pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "zregtestsapling";
 
-/// The prefix for a Base58Check-encoded regtest [`TransparentAddress::PublicKey`].
+/// The prefix for a Base58Check-encoded regtest transparent [`PublicKeyHash`].
 /// Same as the testnet prefix.
 ///
-/// [`TransparentAddress::PublicKey`]: crate::legacy::TransparentAddress::PublicKey
+/// [`PublicKeyHash`]: crate::legacy::TransparentAddress::PublicKeyHash
 pub const B58_PUBKEY_ADDRESS_PREFIX: [u8; 2] = [0x1d, 0x25];
 
-/// The prefix for a Base58Check-encoded regtest [`TransparentAddress::Script`].
+/// The prefix for a Base58Check-encoded regtest transparent [`ScriptHash`].
 /// Same as the testnet prefix.
 ///
-/// [`TransparentAddress::Script`]: crate::legacy::TransparentAddress::Script
+/// [`ScriptHash`]: crate::legacy::TransparentAddress::ScriptHash
 pub const B58_SCRIPT_ADDRESS_PREFIX: [u8; 2] = [0x1c, 0xba];

--- a/zcash_primitives/src/constants/testnet.rs
+++ b/zcash_primitives/src/constants/testnet.rs
@@ -5,7 +5,7 @@
 /// [SLIP 44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 pub const COIN_TYPE: u32 = 1;
 
-/// The HRP for a Bech32-encoded testnet [`ExtendedSpendingKey`].
+/// The HRP for a Bech32-encoded testnet Sapling [`ExtendedSpendingKey`].
 ///
 /// Defined in [ZIP 32].
 ///
@@ -13,7 +13,7 @@ pub const COIN_TYPE: u32 = 1;
 /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-test";
 
-/// The HRP for a Bech32-encoded testnet [`ExtendedFullViewingKey`].
+/// The HRP for a Bech32-encoded testnet Sapling [`ExtendedFullViewingKey`].
 ///
 /// Defined in [ZIP 32].
 ///
@@ -21,7 +21,7 @@ pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-test";
 /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewtestsapling";
 
-/// The HRP for a Bech32-encoded testnet [`PaymentAddress`].
+/// The HRP for a Bech32-encoded testnet Sapling [`PaymentAddress`].
 ///
 /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
 ///
@@ -29,12 +29,12 @@ pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewtestsapling";
 /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
 pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "ztestsapling";
 
-/// The prefix for a Base58Check-encoded testnet [`TransparentAddress::PublicKey`].
+/// The prefix for a Base58Check-encoded testnet transparent [`PublicKeyHash`].
 ///
-/// [`TransparentAddress::PublicKey`]: crate::legacy::TransparentAddress::PublicKey
+/// [`PublicKeyHash`]: crate::legacy::TransparentAddress::PublicKeyHash
 pub const B58_PUBKEY_ADDRESS_PREFIX: [u8; 2] = [0x1d, 0x25];
 
-/// The prefix for a Base58Check-encoded testnet [`TransparentAddress::Script`].
+/// The prefix for a Base58Check-encoded testnet transparent [`ScriptHash`].
 ///
-/// [`TransparentAddress::Script`]: crate::legacy::TransparentAddress::Script
+/// [`ScriptHash`]: crate::legacy::TransparentAddress::ScriptHash
 pub const B58_SCRIPT_ADDRESS_PREFIX: [u8; 2] = [0x1c, 0xba];

--- a/zcash_primitives/src/legacy/keys.rs
+++ b/zcash_primitives/src/legacy/keys.rs
@@ -153,7 +153,7 @@ impl AccountPubKey {
 /// Derives the P2PKH transparent address corresponding to the given pubkey.
 #[deprecated(note = "This function will be removed from the public API in an upcoming refactor.")]
 pub fn pubkey_to_address(pubkey: &secp256k1::PublicKey) -> TransparentAddress {
-    TransparentAddress::PublicKey(
+    TransparentAddress::PublicKeyHash(
         *ripemd::Ripemd160::digest(Sha256::digest(pubkey.serialize())).as_ref(),
     )
 }

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -999,7 +999,7 @@ mod tests {
         // Create a tx with only t output. No binding_sig should be present
         builder
             .add_transparent_output(
-                &TransparentAddress::PublicKey([0; 20]),
+                &TransparentAddress::PublicKeyHash([0; 20]),
                 NonNegativeAmount::const_from_u64(40000),
             )
             .unwrap();
@@ -1043,7 +1043,7 @@ mod tests {
 
         builder
             .add_transparent_output(
-                &TransparentAddress::PublicKey([0; 20]),
+                &TransparentAddress::PublicKeyHash([0; 20]),
                 NonNegativeAmount::const_from_u64(40000),
             )
             .unwrap();
@@ -1116,7 +1116,7 @@ mod tests {
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
                 .add_transparent_output(
-                    &TransparentAddress::PublicKey([0; 20]),
+                    &TransparentAddress::PublicKeyHash([0; 20]),
                     NonNegativeAmount::const_from_u64(50000),
                 )
                 .unwrap();
@@ -1157,7 +1157,7 @@ mod tests {
                 .unwrap();
             builder
                 .add_transparent_output(
-                    &TransparentAddress::PublicKey([0; 20]),
+                    &TransparentAddress::PublicKeyHash([0; 20]),
                     NonNegativeAmount::const_from_u64(20000),
                 )
                 .unwrap();
@@ -1200,7 +1200,7 @@ mod tests {
                 .unwrap();
             builder
                 .add_transparent_output(
-                    &TransparentAddress::PublicKey([0; 20]),
+                    &TransparentAddress::PublicKeyHash([0; 20]),
                     NonNegativeAmount::const_from_u64(20000),
                 )
                 .unwrap();

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -117,7 +117,7 @@ impl TransparentBuilder {
         // output may be spent.
         let pubkey = secp256k1::PublicKey::from_secret_key(&self.secp, &sk).serialize();
         match coin.script_pubkey.address() {
-            Some(TransparentAddress::PublicKey(hash)) => {
+            Some(TransparentAddress::PublicKeyHash(hash)) => {
                 use ripemd::Ripemd160;
                 use sha2::Sha256;
 

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -156,7 +156,7 @@ impl super::FeeRule for FeeRule {
         let non_p2pkh_inputs: Vec<_> = transparent_inputs
             .iter()
             .filter_map(|t_in| match t_in.coin().script_pubkey.address() {
-                Some(TransparentAddress::PublicKey(_)) => None,
+                Some(TransparentAddress::PublicKeyHash(_)) => None,
                 _ => Some(t_in.outpoint()),
             })
             .cloned()


### PR DESCRIPTION
This resolves an old TODO.