### PR TITLE
Add `WalletWrite::insert_address_with_diversifier_index` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "hdwallet",
  "incrementalmerkletree",
  "jubjub",
+ "libsqlite3-sys",
  "maybe-rayon",
  "orchard",
  "proptest",

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -21,6 +21,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::fees::ChangeValue::orchard`
 - `zcash_client_backend::wallet`:
   - `Note::Orchard`
+- `WalletWrite::insert_address_with_diversifier_index`
 
 ### Changed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -56,6 +56,7 @@ shardtree = { workspace = true, features = ["legacy-api"] }
 # CocoaPods, due to being bound to React Native. We need to ensure that the SQLite
 # version required for `rusqlite` is a version that is available through CocoaPods.
 rusqlite = { version = "0.29.0", features = ["bundled", "time", "array"] }
+libsqlite3-sys = { version = "0.26.0", features = ["bundled"] }
 schemer = "0.2"
 schemer-rusqlite = "0.2.2"
 time = "0.3.22"


### PR DESCRIPTION
This enables use cases where the diversifier index is prescribed instead of sequentially assigned.