### PR TITLE
zcash_client_backend: Fix missing `test-dependencies` feature dependency.

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -126,6 +126,7 @@ orchard = ["dep:orchard", "zcash_keys/orchard"]
 test-dependencies = [
     "dep:proptest",
     "orchard?/test-dependencies",
+    "zcash_keys/test-dependencies",
     "zcash_primitives/test-dependencies",
     "incrementalmerkletree/test-dependencies",
 ]


### PR DESCRIPTION
This fixes a current issue with `cargo check --tests --all-features -p zcash_client_backend`.