### PR TITLE
Use mermaid for migrations graph

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "bierner.markdown-mermaid"
+    ]
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations.md
+++ b/zcash_client_sqlite/src/wallet/init/migrations.md
@@ -1,0 +1,44 @@
+This graph can be rendered on github.com or with the `bierner.markdown-mermaid` extension in VS Code.
+
+```mermaid
+graph TD;
+    initial_setup-->utxos_table;
+
+    initial_setup-->ufvk_support;
+
+    ufvk_support-->addresses_table;
+
+    ufvk_support-->sent_notes_to_internal;
+
+    utxos_table-->add_utxo_account;
+    addresses_table-->add_utxo_account;
+
+    sent_notes_to_internal-->add_transaction_views;
+    add_utxo_account-->add_transaction_views;
+
+    add_transaction_views-->v_transactions_net;
+
+    v_transactions_net-->received_notes_nullable_nf;
+
+    received_notes_nullable_nf-->shardtree_support;
+
+    received_notes_nullable_nf-->nullifier_map;
+
+    received_notes_nullable_nf-->sapling_memo_consistency;
+
+    shardtree_support-->add_account_birthdays;
+
+    shardtree_support-->receiving_key_scopes;
+
+    sapling_memo_consistency-->v_transactions_transparent_history;
+
+    add_account_birthdays-->v_sapling_shard_unscanned_ranges;
+
+    v_transactions_transparent_history-->v_tx_outputs_use_legacy_false;
+
+    v_tx_outputs_use_legacy_false-->v_transactions_shielding_balance;
+
+    v_transactions_shielding_balance-->v_transactions_note_uniqueness;
+
+    v_sapling_shard_unscanned_ranges-->wallet_summaries;
+```

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -29,30 +29,8 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     params: &P,
     seed: Option<SecretVec<u8>>,
 ) -> Vec<Box<dyn RusqliteMigration<Error = WalletMigrationError>>> {
-    //                         initial_setup
-    //                         /           \
-    //                utxos_table         ufvk_support
-    //                   |                 /         \
-    //                   |    addresses_table   sent_notes_to_internal
-    //                   |          /                /
-    //                 add_utxo_account             /
-    //                              \              /
-    //                           add_transaction_views
-    //                                     |
-    //                             v_transactions_net
-    //                                     |
-    //                                  received_notes_nullable_nf
-    //                                 /            |             \
-    //                 shardtree_support      nullifier_map       sapling_memo_consistency
-    //                  /              \                                      |
-    //      add_account_birthdays   receiving_key_scopes      v_transactions_transparent_history
-    //                  |                                                     |
-    // v_sapling_shard_unscanned_ranges                         v_tx_outputs_use_legacy_false
-    //                  |                                                     |
-    //        wallet_summaries                                 v_transactions_shielding_balance
-    //                                                                        |
-    //                                                          v_transactions_note_uniqueness
     vec![
+        // Update migrations.md with each new migration.
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
         Box::new(ufvk_support::Migration {


### PR DESCRIPTION
The migrations ASCII art previously used was somewhat hard to read and much harder to maintain over time. Mermaid markdown provides a very easy way to add new nodes to the graph, and the result is far more visually parseable.

Mermaid can be rendered on GitHub or via a local extension such as in VS Code. I've added an extension recommendation for VS Code as part of this change.

Here is what it looks like in VS Code:
<img width="1581" alt="image" src="https://github.com/zcash/librustzcash/assets/3548/e05a10d5-d6de-451c-a697-f314ab458d9c">

And right here in the PR, github will render the graphic with the click of a button on the introduced file.