### PR TITLE
`zcash_client_backend`: Updates to the `Proposal` data structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,8 +2105,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5de898a7cdb7f6d9c8fb888341b6ae6e2aeae88227b7f435f1dda49ecf9e62"
+source = "git+https://github.com/zcash/sapling-crypto?rev=346a6507413eb2388b2967c014672cd83199648a#346a6507413eb2388b2967c014672cd83199648a"
 dependencies = [
  "aes",
  "bellman",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,8 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.1.0"
-source = "git+https://github.com/zcash/sapling-crypto?rev=346a6507413eb2388b2967c014672cd83199648a#346a6507413eb2388b2967c014672cd83199648a"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d183012062dfdde85f7e3e758328fcf6e9846d8dd3fce35b04d0efcb6677b0e0"
 dependencies = [
  "aes",
  "bellman",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,6 +3062,7 @@ dependencies = [
  "incrementalmerkletree",
  "jubjub",
  "maybe-rayon",
+ "nonempty",
  "orchard",
  "proptest",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,6 @@ zip32 = "0.1"
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+[patch.crates-io]
+sapling = { package = "sapling-crypto", git = "https://github.com/zcash/sapling-crypto", rev = "346a6507413eb2388b2967c014672cd83199648a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bitvec = "1"
 blake2s_simd = "1"
 bls12_381 = "0.8"
 jubjub = "0.10"
-sapling = { package = "sapling-crypto", version = "0.1" }
+sapling = { package = "sapling-crypto", version = "0.1.1" }
 
 # - Orchard
 nonempty = "0.7"
@@ -115,6 +115,3 @@ zip32 = "0.1"
 lto = true
 panic = 'abort'
 codegen-units = 1
-
-[patch.crates-io]
-sapling = { package = "sapling-crypto", git = "https://github.com/zcash/sapling-crypto", rev = "346a6507413eb2388b2967c014672cd83199648a" }

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -35,6 +35,7 @@ and this library adheres to Rust's notion of
 ## [0.11.0-pre-release] Unreleased
 
 ### Added
+- `zcash_client_backend::PoolType::is_receiver`
 - `zcash_client_backend::data_api`:
   - `InputSource`
   - `ScannedBlock::{into_commitments, sapling}`
@@ -206,6 +207,11 @@ and this library adheres to Rust's notion of
     it possible to represent multi-step transactions, such as a deshielding
     transaction followed by a zero-conf transfer as required by ZIP 320. Individual
     transaction proposals are now represented by the `proposal::Step` type.
+  - `ProposalError` has new variants:
+    - `ReferenceError`
+    - `StepDoubleSpend`
+    - `ChainDoubleSpend`
+    - `PaymentPoolsMismatch`
 
 - `zcash_client_backend::fees`:
   - `ChangeStrategy::compute_balance` arguments have changed.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -47,7 +47,6 @@ and this library adheres to Rust's notion of
     }`
   - `WalletSummary::next_sapling_subtree_index`
   - `wallet::propose_standard_transfer_to_address`
-  - `wallet::input_selection::Proposal::{from_parts, shielded_inputs, payment_pools}`
   - `wallet::input_selection::ShieldedInputs`
   - `wallet::input_selection::ShieldingSelector` has been
     factored out from the `InputSelector` trait to separate out transparent
@@ -59,6 +58,10 @@ and this library adheres to Rust's notion of
   - `ReceivedNote`
   - `WalletSaplingOutput::recipient_key_scope`
   - `wallet::TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
+- `zcash_client_backend::zip321::TransactionRequest::total`
+- `zcash_client_backend::zip321::parse::Param::name`
+- `zcash_client_backend::proposal`
+  - `Proposal::{from_parts, shielded_inputs, payment_pools}`
 - `zcash_client_backend::proto::`
   - `PROPOSAL_SER_V1`
   - `ProposalDecodingError`
@@ -66,12 +69,12 @@ and this library adheres to Rust's notion of
 - `impl Clone for zcash_client_backend::{
      zip321::{Payment, TransactionRequest, Zip321Error, parse::Param, parse::IndexedParam},
      wallet::{ReceivedSaplingNote, WalletTransparentOutput},
-     wallet::input_selection::{Proposal, SaplingInputs},
+     proposal::{Proposal, SaplingInputs},
    }`
 - `impl {PartialEq, Eq} for zcash_client_backend::{
      zip321::{Zip321Error, parse::Param, parse::IndexedParam},
      wallet::{ReceivedSaplingNote, WalletTransparentOutput},
-     wallet::input_selection::{Proposal, SaplingInputs},
+     proposal::{Proposal, SaplingInputs},
    }`
 - `zcash_client_backend::zip321
   ` `TransactionRequest::{total, from_indexed}`
@@ -85,6 +88,8 @@ and this library adheres to Rust's notion of
 - `ScannedBlock::{sapling_tree_size, sapling_nullifier_map, sapling_commitments}`
   have been moved to `ScannedBlockSapling` and in that context are now
   named `{tree_size, nullifier_map, commitments}` respectively.
+- `zcash_client_backend::::wallet::input_selection::{Proposal, ShieldedInputs, ProposalError}`
+  have been moved to `zcash_client_backend::proposal`.
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -115,6 +120,7 @@ and this library adheres to Rust's notion of
     - A new variant `UnsupportedPoolType` has been added.
     - A new variant `NoSupportedReceivers` has been added.
     - A new variant `NoSpendingKey` has been added.
+    - A new variant `Proposal` has been added.
     - Variant `ChildIndexOutOfRange` has been removed.
   - `wallet::shield_transparent_funds` no longer takes a `memo` argument;
     instead, memos to be associated with the shielded outputs should be
@@ -148,6 +154,7 @@ and this library adheres to Rust's notion of
       `min_confirmations` argument as `u32` instead of `NonZeroU32`.
   - The `wallet::input_selection::InputSelector::DataSource`
     associated type has been renamed to `InputSource`.
+  - `wallet::input_selection::InputSelectorError` has added variant `Proposal`
   - The signature of `wallet:input_selection::InputSelector::propose_transaction`
     has been altered such that it longer takes `min_confirmations` as an
     argument, instead taking explicit `target_height` and `anchor_height`
@@ -175,11 +182,14 @@ and this library adheres to Rust's notion of
   - `wallet::create_proposed_transaction` now forces implementations to ignore
     the database identifiers for its contained notes by universally quantifying
     the `NoteRef` type parameter.
-  - Arguments to `wallet::input_selection::Proposal::from_parts` have changed.
-  - `wallet::input_selection::Proposal::min_anchor_height` has been removed in
-    favor of storing this value in `SaplingInputs`.
   - `wallet::input_selection::GreedyInputSelector` now has relaxed requirements
     for its `InputSource` associated type.
+
+- `zcash_client_backend::proposal`:
+  - Arguments to `Proposal::from_parts` have changed.
+  - `Proposal::min_anchor_height` has been removed in favor of storing this
+    value in `SaplingInputs`.
+  - `Proposal::sapling_inputs` has been replaced by `Proposal::shielded_inputs`
 
 - `zcash_client_backend::fees`:
   - `ChangeStrategy::compute_balance` arguments have changed.
@@ -230,8 +240,7 @@ and this library adheres to Rust's notion of
 ### Removed
 - `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by
   `zcash_client_backend::ReceivedNote`.
-- `zcash_client_backend::wallet::input_selection::Proposal::sapling_inputs` has
-  been replaced by `Proposal::shielded_inputs`
+- `zcash_client_backend::wallet::input_selection::Proposal`
 - `zcash_client_backend::data_api`
 - `zcash_client_backend::data_api::ScannedBlock::from_parts` has been made crate-private.
 - `zcash_client_backend::data_api::ScannedBlock::into_sapling_commitments` has been

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -47,7 +47,7 @@ and this library adheres to Rust's notion of
     }`
   - `WalletSummary::next_sapling_subtree_index`
   - `wallet::propose_standard_transfer_to_address`
-  - `wallet::input_selection::Proposal::{from_parts, shielded_inputs}`
+  - `wallet::input_selection::Proposal::{from_parts, shielded_inputs, payment_pools}`
   - `wallet::input_selection::ShieldedInputs`
   - `wallet::input_selection::ShieldingSelector` has been
     factored out from the `InputSelector` trait to separate out transparent
@@ -59,8 +59,6 @@ and this library adheres to Rust's notion of
   - `ReceivedNote`
   - `WalletSaplingOutput::recipient_key_scope`
   - `wallet::TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
-- `zcash_client_backend::zip321::TransactionRequest::total`
-- `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proto::`
   - `PROPOSAL_SER_V1`
   - `ProposalDecodingError`
@@ -75,8 +73,9 @@ and this library adheres to Rust's notion of
      wallet::{ReceivedSaplingNote, WalletTransparentOutput},
      wallet::input_selection::{Proposal, SaplingInputs},
    }`
-- `zcash_client_backend::zip321::to_uri` now returns a `String` rather than an
-  `Option<String>` and provides canonical serialization for the empty proposal.
+- `zcash_client_backend::zip321
+  ` `TransactionRequest::{total, from_indexed}`
+  - `parse::Param::name`
 
 ### Moved
 - `zcash_client_backend::data_api::{PoolType, ShieldedProtocol}` have
@@ -196,6 +195,11 @@ and this library adheres to Rust's notion of
     `ReceivedSaplingNote::from_parts` for construction instead. Accessor methods
     are provided for each previously public field.
 - `zcash_client_backend::scanning::ScanError` has a new variant, `TreeSizeInvalid`.
+- `zcash_client_backend::zip321::TransactionRequest::payments` now returns a
+  `BTreeMap<usize, Payment>` instead of `&[Payment]` so that parameter
+  indices may be preserved.
+- `zcash_client_backend::zip321::to_uri` now returns a `String` rather than an
+  `Option<String>` and provides canonical serialization for the empty proposal.
 - The following fields now have type `NonNegativeAmount` instead of `Amount`:
   - `zcash_client_backend::data_api`:
     - `error::Error::InsufficientFunds.{available, required}`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -52,13 +52,15 @@ and this library adheres to Rust's notion of
   - `wallet::input_selection::ShieldingSelector` has been
     factored out from the `InputSelector` trait to separate out transparent
     functionality and move it behind the `transparent-inputs` feature flag.
+  - `impl std::error::Error for wallet::input_selection::InputSelectorError`
 - `zcash_client_backend::fees::{standard, sapling}`
 - `zcash_client_backend::fees::ChangeValue::new`
 - `zcash_client_backend::wallet`:
   - `Note`
   - `ReceivedNote`
   - `WalletSaplingOutput::recipient_key_scope`
-  - `wallet::TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
+  - `TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
+  - `impl {Debug, Clone} for OvkPolicy`
 - `zcash_client_backend::zip321::TransactionRequest::total`
 - `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proposal`:
@@ -90,8 +92,6 @@ and this library adheres to Rust's notion of
 - `ScannedBlock::{sapling_tree_size, sapling_nullifier_map, sapling_commitments}`
   have been moved to `ScannedBlockSapling` and in that context are now
   named `{tree_size, nullifier_map, commitments}` respectively.
-- `zcash_client_backend::::wallet::input_selection::{Proposal, ShieldedInputs, ProposalError}`
-  have been moved to `zcash_client_backend::proposal`.
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -119,7 +119,7 @@ and this library adheres to Rust's notion of
     - The `NoteMismatch` variant now wraps a `NoteId` instead of a
       backend-specific note identifier. The related `NoteRef` type parameter has
       been removed from `error::Error`.
-    - New variants have been added: 
+    - New variants have been added:
       - `Error::UnsupportedPoolType`
       - `Error::NoSupportedReceivers`
       - `Error::NoSpendingKey`
@@ -146,7 +146,7 @@ and this library adheres to Rust's notion of
       the database identifiers for its contained notes by universally quantifying
       the `NoteRef` type parameter.
     - It returns a `NonEmpty<TxId>` instead of a single `TxId` value.
-  - `wallet::create_spend_to_address` now takes an additional `change_memo` 
+  - `wallet::create_spend_to_address` now takes an additional `change_memo`
     argument. It also returns its result as a `NonEmpty<TxId>` instead of a
     single `TxId`.
   - `wallet::spend` returns its result as a `NonEmpty<TxId>` instead of a
@@ -226,6 +226,9 @@ and this library adheres to Rust's notion of
   indices may be preserved.
 - `zcash_client_backend::zip321::to_uri` now returns a `String` rather than an
   `Option<String>` and provides canonical serialization for the empty proposal.
+- `zcash_client_backend::zip321::from_uri` previously stripped payment indices,
+  meaning that round-trip serialization was not supported. Payment indices are
+  now retained.
 - The following fields now have type `NonNegativeAmount` instead of `Amount`:
   - `zcash_client_backend::data_api`:
     - `error::Error::InsufficientFunds.{available, required}`
@@ -256,7 +259,8 @@ and this library adheres to Rust's notion of
 ### Removed
 - `zcash_client_backend::wallet::ReceivedSaplingNote` has been replaced by
   `zcash_client_backend::ReceivedNote`.
-- `zcash_client_backend::wallet::input_selection::Proposal`
+- `zcash_client_backend::::wallet::input_selection::{Proposal, ShieldedInputs, ProposalError}`
+  have been moved to `zcash_client_backend::proposal`.
 - `zcash_client_backend::data_api`
 - `zcash_client_backend::data_api::ScannedBlock::from_parts` has been made crate-private.
 - `zcash_client_backend::data_api::ScannedBlock::into_sapling_commitments` has been

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -52,13 +52,13 @@ and this library adheres to Rust's notion of
   - `wallet::input_selection::ShieldingSelector` has been
     factored out from the `InputSelector` trait to separate out transparent
     functionality and move it behind the `transparent-inputs` feature flag.
-  - `TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
 - `zcash_client_backend::fees::{standard, sapling}`
 - `zcash_client_backend::fees::ChangeValue::new`
 - `zcash_client_backend::wallet`:
   - `Note`
   - `ReceivedNote`
   - `WalletSaplingOutput::recipient_key_scope`
+  - `wallet::TransparentAddressMetadata` (which replaces `zcash_keys::address::AddressMetadata`).
 - `zcash_client_backend::zip321::TransactionRequest::total`
 - `zcash_client_backend::zip321::parse::Param::name`
 - `zcash_client_backend::proto::`
@@ -164,9 +164,12 @@ and this library adheres to Rust's notion of
       `get_unspent_transparent_outputs` have been removed; use
       `data_api::InputSource` instead.
     - Added `get_account_ids`.
+    - `get_transparent_receivers` and `get_transparent_balances` are now
+      guarded by the `transparent-inputs` feature flag, with noop default
+      implementations provided.
     - `get_transparent_receivers` now returns
-      `zcash_client_backend::data_api::TransparentAddressMetadata` instead of
-      `zcash_keys::address::AddressMetadata`.
+      `Option<zcash_client_backend::wallet::TransparentAddressMetadata>` as part of
+      its result where previously it returned `zcash_keys::address::AddressMetadata`.
   - `wallet::{propose_shielding, shield_transparent_funds}` now takes their
     `min_confirmations` arguments as `u32` rather than a `NonZeroU32` to permit
     implmentations to enable zero-conf shielding.

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -5,7 +5,7 @@
 syntax = "proto3";
 package cash.z.wallet.sdk.ffi;
 
-// A data structure that describes the a series of transactions to be created.
+// A data structure that describes a series of transactions to be created.
 message Proposal {
     // The version of this serialization format.
     uint32 protoVersion = 1;

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -11,25 +11,28 @@ message Proposal {
     uint32 protoVersion = 1;
     // ZIP 321 serialized transaction request
     string transactionRequest = 2;
+    // The vector of selected payment index / output pool mappings. Payment index
+    // 0 corresponds to the payment with no explicit index.
+    repeated PaymentOutputPool paymentOutputPools = 3;
     // The anchor height to be used in creating the transaction, if any.
     // Setting the anchor height to zero will disallow the use of any shielded
     // inputs.
-    uint32 anchorHeight = 3;
+    uint32 anchorHeight = 4;
     // The inputs to be used in creating the transaction.
-    repeated ProposedInput inputs = 4;
+    repeated ProposedInput inputs = 5;
     // The total value, fee value, and change outputs of the proposed
     // transaction
-    TransactionBalance balance = 5;
+    TransactionBalance balance = 6;
     // The fee rule used in constructing this proposal
-    FeeRule feeRule = 6;
+    FeeRule feeRule = 7;
     // The target height for which the proposal was constructed
     //
     // The chain must contain at least this many blocks in order for the proposal to
     // be executed.
-    uint32 minTargetHeight = 7;
+    uint32 minTargetHeight = 8;
     // A flag indicating whether the proposal is for a shielding transaction,
     // used for determining which OVK to select for wallet-internal outputs.
-    bool isShielding = 8;
+    bool isShielding = 9;
 }
 
 enum ValuePool {
@@ -44,6 +47,14 @@ enum ValuePool {
     Sapling = 2;
     // The Orchard value pool
     Orchard = 3;
+}
+
+// A mapping from ZIP 321 payment index to the output pool that has been chosen
+// for that payment, based upon the payment address and the selected inputs to
+// the transaction.
+message PaymentOutputPool {
+    uint32 paymentIndex = 1;
+    ValuePool valuePool = 2;
 }
 
 // The unique identifier and value for each proposed input.

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -5,34 +5,41 @@
 syntax = "proto3";
 package cash.z.wallet.sdk.ffi;
 
-// A data structure that describes the inputs to be consumed and outputs to
-// be produced in a proposed transaction.
+// A data structure that describes the a series of transactions to be created.
 message Proposal {
+    // The version of this serialization format.
     uint32 protoVersion = 1;
-    // ZIP 321 serialized transaction request
-    string transactionRequest = 2;
-    // The vector of selected payment index / output pool mappings. Payment index
-    // 0 corresponds to the payment with no explicit index.
-    repeated PaymentOutputPool paymentOutputPools = 3;
-    // The anchor height to be used in creating the transaction, if any.
-    // Setting the anchor height to zero will disallow the use of any shielded
-    // inputs.
-    uint32 anchorHeight = 4;
-    // The inputs to be used in creating the transaction.
-    repeated ProposedInput inputs = 5;
-    // The total value, fee value, and change outputs of the proposed
-    // transaction
-    TransactionBalance balance = 6;
     // The fee rule used in constructing this proposal
-    FeeRule feeRule = 7;
+    FeeRule feeRule = 2;
     // The target height for which the proposal was constructed
     //
     // The chain must contain at least this many blocks in order for the proposal to
     // be executed.
-    uint32 minTargetHeight = 8;
-    // A flag indicating whether the proposal is for a shielding transaction,
+    uint32 minTargetHeight = 3;
+    // The series of transactions to be created.
+    repeated ProposalStep steps = 4;
+}
+
+// A data structure that describes the inputs to be consumed and outputs to
+// be produced in a proposed transaction.
+message ProposalStep {
+    // ZIP 321 serialized transaction request
+    string transactionRequest = 1;
+    // The vector of selected payment index / output pool mappings. Payment index
+    // 0 corresponds to the payment with no explicit index.
+    repeated PaymentOutputPool paymentOutputPools = 2;
+    // The anchor height to be used in creating the transaction, if any.
+    // Setting the anchor height to zero will disallow the use of any shielded
+    // inputs.
+    uint32 anchorHeight = 3;
+    // The inputs to be used in creating the transaction.
+    repeated ProposedInput inputs = 4;
+    // The total value, fee value, and change outputs of the proposed
+    // transaction
+    TransactionBalance balance = 5;
+    // A flag indicating whether the step is for a shielding transaction,
     // used for determining which OVK to select for wallet-internal outputs.
-    bool isShielding = 9;
+    bool isShielding = 6;
 }
 
 enum ValuePool {
@@ -57,12 +64,35 @@ message PaymentOutputPool {
     ValuePool valuePool = 2;
 }
 
-// The unique identifier and value for each proposed input.
-message ProposedInput {
+// The unique identifier and value for each proposed input that does not
+// require a back-reference to a prior step of the proposal.
+message ReceivedOutput {
     bytes txid = 1;
     ValuePool valuePool = 2;
     uint32 index = 3;
     uint64 value = 4;
+}
+
+// A reference a payment in a prior step of the proposal. This payment must
+// belong to the wallet.
+message PriorStepOutput {
+    uint32 stepIndex = 1;
+    uint32 paymentIndex = 2;
+}
+
+// A reference a change output from a prior step of the proposal.
+message PriorStepChange {
+    uint32 stepIndex = 1;
+    uint32 changeIndex = 2;
+}
+
+// The unique identifier and value for an input to be used in the transaction.
+message ProposedInput {
+    oneof value {
+        ReceivedOutput receivedOutput = 1;
+        PriorStepOutput priorStepOutput = 2;
+        PriorStepChange priorStepChange = 3;
+    }
 }
 
 // The fee rule used in constructing a Proposal
@@ -82,15 +112,21 @@ enum FeeRule {
 
 // The proposed change outputs and fee value.
 message TransactionBalance {
+    // A list of change output values.
     repeated ChangeValue proposedChange = 1;
+    // The fee to be paid by the proposed transaction, in zatoshis.
     uint64 feeRequired = 2;
 }
 
 // A proposed change output. If the transparent value pool is selected,
 // the `memo` field must be null.
 message ChangeValue {
+    // The value of a change output to be created, in zatoshis.
     uint64 value = 1;
+    // The value pool in which the change output should be created.
     ValuePool valuePool = 2;
+    // The optional memo that should be associated with the newly created change output.
+    // Memos must not be present for transparent change outputs.
     MemoBytes memo = 3;
 }
 

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -37,6 +37,10 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError> {
     /// An error in transaction proposal construction
     Proposal(ProposalError),
 
+    /// The proposal was structurally valid, but spending shielded outputs of prior multi-step
+    /// transaction steps is not yet supported.
+    ProposalNotSupported,
+
     /// No account could be found corresponding to a provided spending key.
     KeyNotRecognized,
 
@@ -106,6 +110,12 @@ where
             }
             Error::Proposal(e) => {
                 write!(f, "Input selection attempted to construct an invalid proposal: {}", e)
+            }
+            Error::ProposalNotSupported => {
+                write!(
+                    f,
+                    "The proposal was valid, but spending shielded outputs of prior transaction steps is not yet supported."
+                )
             }
             Error::KeyNotRecognized => {
                 write!(

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -14,6 +14,7 @@ use zcash_primitives::{
 };
 
 use crate::data_api::wallet::input_selection::InputSelectorError;
+use crate::proposal::ProposalError;
 use crate::PoolType;
 
 #[cfg(feature = "transparent-inputs")]
@@ -32,6 +33,9 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError> {
 
     /// An error in note selection
     NoteSelection(SelectionError),
+
+    /// An error in transaction proposal construction
+    Proposal(ProposalError),
 
     /// No account could be found corresponding to a provided spending key.
     KeyNotRecognized,
@@ -100,6 +104,9 @@ where
             Error::NoteSelection(e) => {
                 write!(f, "Note selection encountered the following error: {}", e)
             }
+            Error::Proposal(e) => {
+                write!(f, "Input selection attempted to construct an invalid proposal: {}", e)
+            }
             Error::KeyNotRecognized => {
                 write!(
                     f,
@@ -148,6 +155,7 @@ where
             Error::DataSource(e) => Some(e),
             Error::CommitmentTree(e) => Some(e),
             Error::NoteSelection(e) => Some(e),
+            Error::Proposal(e) => Some(e),
             Error::Builder(e) => Some(e),
             _ => None,
         }
@@ -171,6 +179,7 @@ impl<DE, CE, SE, FE> From<InputSelectorError<DE, SE>> for Error<DE, CE, SE, FE> 
         match e {
             InputSelectorError::DataSource(e) => Error::DataSource(e),
             InputSelectorError::Selection(e) => Error::NoteSelection(e),
+            InputSelectorError::Proposal(e) => Error::Proposal(e),
             InputSelectorError::InsufficientFunds {
                 available,
                 required,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -661,7 +661,7 @@ where
 
     let mut sapling_output_meta = vec![];
     let mut transparent_output_meta = vec![];
-    for payment in proposal.transaction_request().payments() {
+    for payment in proposal.transaction_request().payments().values() {
         match &payment.recipient_address {
             Address::Unified(ua) => {
                 let memo = payment

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -20,12 +20,13 @@ use zcash_primitives::{
 use crate::{
     address::Address,
     data_api::{
-        error::Error, wallet::input_selection::Proposal, DecryptedTransaction, SentTransaction,
-        SentTransactionOutput, WalletCommitmentTrees, WalletRead, WalletWrite,
+        error::Error, DecryptedTransaction, SentTransaction, SentTransactionOutput,
+        WalletCommitmentTrees, WalletRead, WalletWrite,
     },
     decrypt_transaction,
     fees::{self, DustOutputPolicy},
     keys::UnifiedSpendingKey,
+    proposal::Proposal,
     wallet::{Note, OvkPolicy, Recipient},
     zip321::{self, Payment},
     PoolType, ShieldedProtocol,
@@ -710,7 +711,7 @@ where
                 } else {
                     builder.add_transparent_output(to, payment.amount)?;
                 }
-                transparent_output_meta.push((*to, payment.amount));
+                transparent_output_meta.push((to, payment.amount));
             }
         }
     }
@@ -805,7 +806,7 @@ where
 
         SentTransactionOutput::from_parts(
             output_index,
-            Recipient::Transparent(addr),
+            Recipient::Transparent(*addr),
             value,
             None,
             None,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -11,7 +11,10 @@ use zcash_primitives::{
     memo::MemoBytes,
     transaction::{
         builder::{BuildConfig, BuildResult, Builder},
-        components::amount::{Amount, NonNegativeAmount},
+        components::{
+            amount::{Amount, NonNegativeAmount},
+            TxOut,
+        },
         fees::{zip317::FeeError as Zip317FeeError, FeeRule, StandardFeeRule},
         Transaction, TxId,
     },
@@ -721,9 +724,9 @@ where
             .map_err(Error::DataSource)?;
 
         let mut utxos_spent: Vec<OutPoint> = vec![];
-        let mut add_transparent_input = |addr,
+        let mut add_transparent_input = |addr: &TransparentAddress,
                                          outpoint: OutPoint,
-                                         utxo|
+                                         utxo: TxOut|
          -> Result<
             (),
             Error<

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -5,7 +5,6 @@ use sapling::{
     note_encryption::{try_sapling_note_decryption, PreparedIncomingViewingKey},
     prover::{OutputProver, SpendProver},
 };
-use zcash_keys::encoding::AddressCodec;
 use zcash_primitives::{
     consensus::{self, NetworkUpgrade},
     memo::MemoBytes,
@@ -43,7 +42,7 @@ use super::InputSource;
 use {
     crate::wallet::WalletTransparentOutput, input_selection::ShieldingSelector,
     sapling::keys::OutgoingViewingKey, std::convert::Infallible,
-    zcash_primitives::legacy::TransparentAddress,
+    zcash_keys::encoding::AddressCodec, zcash_primitives::legacy::TransparentAddress,
 };
 
 /// Scans a [`Transaction`] for any information that can be decrypted by the accounts in
@@ -644,9 +643,7 @@ where
                 .get(utxo.recipient_address())
                 .ok_or_else(|| Error::AddressNotRecognized(*utxo.recipient_address()))?
                 .clone()
-                .ok_or_else(|| {
-                    Error::NoSpendingKey(utxo.recipient_address().encode(params))
-                })?;
+                .ok_or_else(|| Error::NoSpendingKey(utxo.recipient_address().encode(params)))?;
 
             let secret_key = usk
                 .transparent()

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -647,7 +647,7 @@ where
 
             let secret_key = usk
                 .transparent()
-                .derive_external_secret_key(address_metadata.address_index())
+                .derive_secret_key(address_metadata.scope(), address_metadata.address_index())
                 .unwrap();
 
             builder.add_transparent_input(

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -10,7 +10,6 @@ use std::{
 use nonempty::NonEmpty;
 use zcash_primitives::{
     consensus::{self, BlockHeight},
-    legacy::TransparentAddress,
     transaction::{
         components::{
             amount::{BalanceError, NonNegativeAmount},
@@ -31,11 +30,12 @@ use crate::{
     PoolType, ShieldedProtocol,
 };
 
-#[cfg(any(feature = "transparent-inputs"))]
-use std::convert::Infallible;
-
 #[cfg(feature = "transparent-inputs")]
-use {std::collections::BTreeSet, zcash_primitives::transaction::components::OutPoint};
+use {
+    std::collections::BTreeSet, std::convert::Infallible,
+    zcash_primitives::legacy::TransparentAddress,
+    zcash_primitives::transaction::components::OutPoint,
+};
 
 #[cfg(feature = "orchard")]
 use crate::fees::orchard as orchard_fees;
@@ -433,7 +433,7 @@ where
 
             match balance {
                 Ok(balance) => {
-                    return Proposal::from_parts(
+                    return Proposal::single_step(
                         transaction_request,
                         payment_pools,
                         vec![],
@@ -582,7 +582,7 @@ where
         };
 
         if balance.total() >= shielding_threshold {
-            Proposal::from_parts(
+            Proposal::single_step(
                 TransactionRequest::empty(),
                 BTreeMap::new(),
                 transparent_inputs,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -3,6 +3,7 @@
 use core::marker::PhantomData;
 use std::{
     collections::BTreeMap,
+    error,
     fmt::{self, Debug, Display},
 };
 
@@ -23,7 +24,8 @@ use zcash_primitives::{
 use crate::{
     address::{Address, UnifiedAddress},
     data_api::InputSource,
-    fees::{sapling, ChangeError, ChangeStrategy, DustOutputPolicy, TransactionBalance},
+    fees::{sapling, ChangeError, ChangeStrategy, DustOutputPolicy},
+    proposal::{Proposal, ProposalError, ShieldedInputs},
     wallet::{Note, ReceivedNote, WalletTransparentOutput},
     zip321::TransactionRequest,
     PoolType, ShieldedProtocol,
@@ -39,11 +41,14 @@ use {std::collections::BTreeSet, zcash_primitives::transaction::components::OutP
 use crate::fees::orchard as orchard_fees;
 
 /// The type of errors that may be produced in input selection.
+#[derive(Debug)]
 pub enum InputSelectorError<DbErrT, SelectorErrT> {
     /// An error occurred accessing the underlying data store.
     DataSource(DbErrT),
     /// An error occurred specific to the provided input selector's selection rules.
     Selection(SelectorErrT),
+    /// Input selection attempted to generate an invalid transaction proposal.
+    Proposal(ProposalError),
     /// Insufficient funds were available to satisfy the payment request that inputs were being
     /// selected to attempt to satisfy.
     InsufficientFunds {
@@ -68,6 +73,13 @@ impl<DE: fmt::Display, SE: fmt::Display> fmt::Display for InputSelectorError<DE,
             InputSelectorError::Selection(e) => {
                 write!(f, "Note selection encountered the following error: {}", e)
             }
+            InputSelectorError::Proposal(e) => {
+                write!(
+                    f,
+                    "Input selection attempted to generate an invalid proposal: {}",
+                    e
+                )
+            }
             InputSelectorError::InsufficientFunds {
                 available,
                 required,
@@ -84,235 +96,18 @@ impl<DE: fmt::Display, SE: fmt::Display> fmt::Display for InputSelectorError<DE,
     }
 }
 
-/// The inputs to be consumed and outputs to be produced in a proposed transaction.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Proposal<FeeRuleT, NoteRef> {
-    transaction_request: TransactionRequest,
-    payment_pools: BTreeMap<usize, PoolType>,
-    transparent_inputs: Vec<WalletTransparentOutput>,
-    shielded_inputs: Option<ShieldedInputs<NoteRef>>,
-    balance: TransactionBalance,
-    fee_rule: FeeRuleT,
-    min_target_height: BlockHeight,
-    is_shielding: bool,
-}
-
-/// Errors that can occur in construction of a [`Proposal`].
-#[derive(Debug, Clone)]
-pub enum ProposalError {
-    /// The total output value of the transaction request is not a valid Zcash amount.
-    RequestTotalInvalid,
-    /// The total of transaction inputs overflows the valid range of Zcash values.
-    Overflow,
-    /// The input total and output total of the payment request are not equal to one another. The
-    /// sum of transaction outputs, change, and fees is required to be exactly equal to the value
-    /// of provided inputs.
-    BalanceError {
-        input_total: NonNegativeAmount,
-        output_total: NonNegativeAmount,
-    },
-    /// The `is_shielding` flag may only be set to `true` under the following conditions:
-    /// * The total of transparent inputs is nonzero
-    /// * There exist no Sapling inputs
-    /// * There provided transaction request is empty; i.e. the only output values specified
-    ///   are change and fee amounts.
-    ShieldingInvalid,
-}
-
-impl Display for ProposalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProposalError::RequestTotalInvalid => write!(
-                f,
-                "The total requested output value is not a valid Zcash amount."
-            ),
-            ProposalError::Overflow => write!(
-                f,
-                "The total of transaction inputs overflows the valid range of Zcash values."
-            ),
-            ProposalError::BalanceError {
-                input_total,
-                output_total,
-            } => write!(
-                f,
-                "Balance error: the output total {} was not equal to the input total {}",
-                u64::from(*output_total),
-                u64::from(*input_total)
-            ),
-            ProposalError::ShieldingInvalid => write!(
-                f,
-                "The proposal violates the rules for a shielding transaction."
-            ),
+impl<DE, SE> error::Error for InputSelectorError<DE, SE>
+where
+    DE: Debug + Display + error::Error + 'static,
+    SE: Debug + Display + error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self {
+            Self::DataSource(e) => Some(e),
+            Self::Selection(e) => Some(e),
+            Self::Proposal(e) => Some(e),
+            _ => None,
         }
-    }
-}
-
-impl std::error::Error for ProposalError {}
-
-impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
-    /// Constructs a validated [`Proposal`] from its constituent parts.
-    ///
-    /// This operation validates the proposal for balance consistency and agreement between
-    /// the `is_shielding` flag and the structure of the proposal.
-    ///
-    /// Parameters:
-    /// * `transaction_request`: The ZIP 321 transaction request describing the payments
-    ///   to be made.
-    /// * `payment_pools`: A map from payment index to pool type.
-    /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
-    /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
-    /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
-    /// * `fee_rule`: The fee rule observed by the proposed transaction.
-    /// * `min_target_height`: The minimum block height at which the transaction may be created.
-    /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
-    ///   transaction.
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_parts(
-        transaction_request: TransactionRequest,
-        payment_pools: BTreeMap<usize, PoolType>,
-        transparent_inputs: Vec<WalletTransparentOutput>,
-        shielded_inputs: Option<ShieldedInputs<NoteRef>>,
-        balance: TransactionBalance,
-        fee_rule: FeeRuleT,
-        min_target_height: BlockHeight,
-        is_shielding: bool,
-    ) -> Result<Self, ProposalError> {
-        let transparent_input_total = transparent_inputs
-            .iter()
-            .map(|out| out.txout().value)
-            .fold(Ok(NonNegativeAmount::ZERO), |acc, a| {
-                (acc? + a).ok_or(ProposalError::Overflow)
-            })?;
-        let shielded_input_total = shielded_inputs
-            .iter()
-            .flat_map(|s_in| s_in.notes().iter())
-            .map(|out| out.note().value())
-            .fold(Some(NonNegativeAmount::ZERO), |acc, a| (acc? + a))
-            .ok_or(ProposalError::Overflow)?;
-        let input_total =
-            (transparent_input_total + shielded_input_total).ok_or(ProposalError::Overflow)?;
-
-        let request_total = transaction_request
-            .total()
-            .map_err(|_| ProposalError::RequestTotalInvalid)?;
-        let output_total = (request_total + balance.total()).ok_or(ProposalError::Overflow)?;
-
-        if is_shielding
-            && (transparent_input_total == NonNegativeAmount::ZERO
-                || shielded_input_total > NonNegativeAmount::ZERO
-                || request_total > NonNegativeAmount::ZERO)
-        {
-            return Err(ProposalError::ShieldingInvalid);
-        }
-
-        if input_total == output_total {
-            Ok(Self {
-                transaction_request,
-                payment_pools,
-                transparent_inputs,
-                shielded_inputs,
-                balance,
-                fee_rule,
-                min_target_height,
-                is_shielding,
-            })
-        } else {
-            Err(ProposalError::BalanceError {
-                input_total,
-                output_total,
-            })
-        }
-    }
-
-    /// Returns the transaction request that describes the payments to be made.
-    pub fn transaction_request(&self) -> &TransactionRequest {
-        &self.transaction_request
-    }
-    /// Returns the map from payment index to the pool that has been selected
-    /// for the output that will fulfill that payment.
-    pub fn payment_pools(&self) -> &BTreeMap<usize, PoolType> {
-        &self.payment_pools
-    }
-    /// Returns the transparent inputs that have been selected to fund the transaction.
-    pub fn transparent_inputs(&self) -> &[WalletTransparentOutput] {
-        &self.transparent_inputs
-    }
-    /// Returns the Sapling inputs that have been selected to fund the transaction.
-    pub fn shielded_inputs(&self) -> Option<&ShieldedInputs<NoteRef>> {
-        self.shielded_inputs.as_ref()
-    }
-    /// Returns the change outputs to be added to the transaction and the fee to be paid.
-    pub fn balance(&self) -> &TransactionBalance {
-        &self.balance
-    }
-    /// Returns the fee rule to be used by the transaction builder.
-    pub fn fee_rule(&self) -> &FeeRuleT {
-        &self.fee_rule
-    }
-    /// Returns the target height for which the proposal was prepared.
-    ///
-    /// The chain must contain at least this many blocks in order for the proposal to
-    /// be executed.
-    pub fn min_target_height(&self) -> BlockHeight {
-        self.min_target_height
-    }
-    /// Returns a flag indicating whether or not the proposed transaction
-    /// is exclusively wallet-internal (if it does not involve any external
-    /// recipients).
-    pub fn is_shielding(&self) -> bool {
-        self.is_shielding
-    }
-}
-
-impl<FeeRuleT, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Proposal")
-            .field("transaction_request", &self.transaction_request)
-            .field("transparent_inputs", &self.transparent_inputs)
-            .field(
-                "shielded_inputs",
-                &self.shielded_inputs().map(|i| i.notes.len()),
-            )
-            .field(
-                "anchor_height",
-                &self.shielded_inputs().map(|i| i.anchor_height),
-            )
-            .field("balance", &self.balance)
-            //.field("fee_rule", &self.fee_rule)
-            .field("min_target_height", &self.min_target_height)
-            .field("is_shielding", &self.is_shielding)
-            .finish_non_exhaustive()
-    }
-}
-
-/// The Sapling inputs to a proposed transaction.
-#[derive(Clone, PartialEq, Eq)]
-pub struct ShieldedInputs<NoteRef> {
-    anchor_height: BlockHeight,
-    notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
-}
-
-impl<NoteRef> ShieldedInputs<NoteRef> {
-    /// Constructs a [`ShieldedInputs`] from its constituent parts.
-    pub fn from_parts(
-        anchor_height: BlockHeight,
-        notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
-    ) -> Self {
-        Self {
-            anchor_height,
-            notes,
-        }
-    }
-
-    /// Returns the anchor height for Sapling inputs that should be used when constructing the
-    /// proposed transaction.
-    pub fn anchor_height(&self) -> BlockHeight {
-        self.anchor_height
-    }
-
-    /// Returns the list of Sapling notes to be used as inputs to the proposed transaction.
-    pub fn notes(&self) -> &NonEmpty<ReceivedNote<NoteRef, Note>> {
-        &self.notes
     }
 }
 
@@ -638,21 +433,18 @@ where
 
             match balance {
                 Ok(balance) => {
-                    return Ok(Proposal {
+                    return Proposal::from_parts(
                         transaction_request,
                         payment_pools,
-                        transparent_inputs: vec![],
-                        shielded_inputs: NonEmpty::from_vec(shielded_inputs).map(|notes| {
-                            ShieldedInputs {
-                                anchor_height,
-                                notes,
-                            }
-                        }),
+                        vec![],
+                        NonEmpty::from_vec(shielded_inputs)
+                            .map(|notes| ShieldedInputs::from_parts(anchor_height, notes)),
                         balance,
-                        fee_rule: (*self.change_strategy.fee_rule()).clone(),
-                        min_target_height: target_height,
-                        is_shielding: false,
-                    });
+                        (*self.change_strategy.fee_rule()).clone(),
+                        target_height,
+                        false,
+                    )
+                    .map_err(InputSelectorError::Proposal);
                 }
                 Err(ChangeError::DustInputs { mut sapling, .. }) => {
                     exclude.append(&mut sapling);
@@ -790,16 +582,17 @@ where
         };
 
         if balance.total() >= shielding_threshold {
-            Ok(Proposal {
-                transaction_request: TransactionRequest::empty(),
-                payment_pools: BTreeMap::new(),
+            Proposal::from_parts(
+                TransactionRequest::empty(),
+                BTreeMap::new(),
                 transparent_inputs,
-                shielded_inputs: None,
+                None,
                 balance,
-                fee_rule: (*self.change_strategy.fee_rule()).clone(),
-                min_target_height: target_height,
-                is_shielding: true,
-            })
+                (*self.change_strategy.fee_rule()).clone(),
+                target_height,
+                true,
+            )
+            .map_err(InputSelectorError::Proposal)
         } else {
             Err(InputSelectorError::InsufficientFunds {
                 available: balance.total(),

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -101,7 +101,7 @@ pub enum ShieldedProtocol {
 }
 
 /// A value pool to which the wallet supports sending transaction outputs.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PoolType {
     /// The transparent value pool
     Transparent,

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -67,6 +67,7 @@ mod decrypt;
 pub use zcash_keys::encoding;
 pub mod fees;
 pub use zcash_keys::keys;
+pub mod proposal;
 pub mod proto;
 pub mod scan;
 pub mod scanning;

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -1,0 +1,248 @@
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug, Display},
+};
+
+use nonempty::NonEmpty;
+use zcash_primitives::{
+    consensus::BlockHeight, transaction::components::amount::NonNegativeAmount,
+};
+
+use crate::{
+    fees::TransactionBalance,
+    wallet::{Note, ReceivedNote, WalletTransparentOutput},
+    zip321::TransactionRequest,
+    PoolType,
+};
+
+/// Errors that can occur in construction of a [`Proposal`].
+#[derive(Debug, Clone)]
+pub enum ProposalError {
+    /// The total output value of the transaction request is not a valid Zcash amount.
+    RequestTotalInvalid,
+    /// The total of transaction inputs overflows the valid range of Zcash values.
+    Overflow,
+    /// The input total and output total of the payment request are not equal to one another. The
+    /// sum of transaction outputs, change, and fees is required to be exactly equal to the value
+    /// of provided inputs.
+    BalanceError {
+        input_total: NonNegativeAmount,
+        output_total: NonNegativeAmount,
+    },
+    /// The `is_shielding` flag may only be set to `true` under the following conditions:
+    /// * The total of transparent inputs is nonzero
+    /// * There exist no Sapling inputs
+    /// * There provided transaction request is empty; i.e. the only output values specified
+    ///   are change and fee amounts.
+    ShieldingInvalid,
+}
+
+impl Display for ProposalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProposalError::RequestTotalInvalid => write!(
+                f,
+                "The total requested output value is not a valid Zcash amount."
+            ),
+            ProposalError::Overflow => write!(
+                f,
+                "The total of transaction inputs overflows the valid range of Zcash values."
+            ),
+            ProposalError::BalanceError {
+                input_total,
+                output_total,
+            } => write!(
+                f,
+                "Balance error: the output total {} was not equal to the input total {}",
+                u64::from(*output_total),
+                u64::from(*input_total)
+            ),
+            ProposalError::ShieldingInvalid => write!(
+                f,
+                "The proposal violates the rules for a shielding transaction."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProposalError {}
+
+/// The Sapling inputs to a proposed transaction.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ShieldedInputs<NoteRef> {
+    anchor_height: BlockHeight,
+    notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
+}
+
+impl<NoteRef> ShieldedInputs<NoteRef> {
+    /// Constructs a [`ShieldedInputs`] from its constituent parts.
+    pub fn from_parts(
+        anchor_height: BlockHeight,
+        notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
+    ) -> Self {
+        Self {
+            anchor_height,
+            notes,
+        }
+    }
+
+    /// Returns the anchor height for Sapling inputs that should be used when constructing the
+    /// proposed transaction.
+    pub fn anchor_height(&self) -> BlockHeight {
+        self.anchor_height
+    }
+
+    /// Returns the list of Sapling notes to be used as inputs to the proposed transaction.
+    pub fn notes(&self) -> &NonEmpty<ReceivedNote<NoteRef, Note>> {
+        &self.notes
+    }
+}
+
+/// The inputs to be consumed and outputs to be produced in a proposed transaction.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Proposal<FeeRuleT, NoteRef> {
+    transaction_request: TransactionRequest,
+    payment_pools: BTreeMap<usize, PoolType>,
+    transparent_inputs: Vec<WalletTransparentOutput>,
+    shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+    balance: TransactionBalance,
+    fee_rule: FeeRuleT,
+    min_target_height: BlockHeight,
+    is_shielding: bool,
+}
+
+impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
+    /// Constructs a validated [`Proposal`] from its constituent parts.
+    ///
+    /// This operation validates the proposal for balance consistency and agreement between
+    /// the `is_shielding` flag and the structure of the proposal.
+    ///
+    /// Parameters:
+    /// * `transaction_request`: The ZIP 321 transaction request describing the payments
+    ///   to be made.
+    /// * `payment_pools`: A map from payment index to pool type.
+    /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
+    /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
+    /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
+    /// * `fee_rule`: The fee rule observed by the proposed transaction.
+    /// * `min_target_height`: The minimum block height at which the transaction may be created.
+    /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
+    ///   transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        transaction_request: TransactionRequest,
+        payment_pools: BTreeMap<usize, PoolType>,
+        transparent_inputs: Vec<WalletTransparentOutput>,
+        shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+        balance: TransactionBalance,
+        fee_rule: FeeRuleT,
+        min_target_height: BlockHeight,
+        is_shielding: bool,
+    ) -> Result<Self, ProposalError> {
+        let transparent_input_total = transparent_inputs
+            .iter()
+            .map(|out| out.txout().value)
+            .fold(Ok(NonNegativeAmount::ZERO), |acc, a| {
+                (acc? + a).ok_or(ProposalError::Overflow)
+            })?;
+        let shielded_input_total = shielded_inputs
+            .iter()
+            .flat_map(|s_in| s_in.notes().iter())
+            .map(|out| out.note().value())
+            .fold(Some(NonNegativeAmount::ZERO), |acc, a| (acc? + a))
+            .ok_or(ProposalError::Overflow)?;
+        let input_total =
+            (transparent_input_total + shielded_input_total).ok_or(ProposalError::Overflow)?;
+
+        let request_total = transaction_request
+            .total()
+            .map_err(|_| ProposalError::RequestTotalInvalid)?;
+        let output_total = (request_total + balance.total()).ok_or(ProposalError::Overflow)?;
+
+        if is_shielding
+            && (transparent_input_total == NonNegativeAmount::ZERO
+                || shielded_input_total > NonNegativeAmount::ZERO
+                || request_total > NonNegativeAmount::ZERO)
+        {
+            return Err(ProposalError::ShieldingInvalid);
+        }
+
+        if input_total == output_total {
+            Ok(Self {
+                transaction_request,
+                payment_pools,
+                transparent_inputs,
+                shielded_inputs,
+                balance,
+                fee_rule,
+                min_target_height,
+                is_shielding,
+            })
+        } else {
+            Err(ProposalError::BalanceError {
+                input_total,
+                output_total,
+            })
+        }
+    }
+
+    /// Returns the transaction request that describes the payments to be made.
+    pub fn transaction_request(&self) -> &TransactionRequest {
+        &self.transaction_request
+    }
+    /// Returns the map from payment index to the pool that has been selected
+    /// for the output that will fulfill that payment.
+    pub fn payment_pools(&self) -> &BTreeMap<usize, PoolType> {
+        &self.payment_pools
+    }
+    /// Returns the transparent inputs that have been selected to fund the transaction.
+    pub fn transparent_inputs(&self) -> &[WalletTransparentOutput] {
+        &self.transparent_inputs
+    }
+    /// Returns the Sapling inputs that have been selected to fund the transaction.
+    pub fn shielded_inputs(&self) -> Option<&ShieldedInputs<NoteRef>> {
+        self.shielded_inputs.as_ref()
+    }
+    /// Returns the change outputs to be added to the transaction and the fee to be paid.
+    pub fn balance(&self) -> &TransactionBalance {
+        &self.balance
+    }
+    /// Returns the fee rule to be used by the transaction builder.
+    pub fn fee_rule(&self) -> &FeeRuleT {
+        &self.fee_rule
+    }
+    /// Returns the target height for which the proposal was prepared.
+    ///
+    /// The chain must contain at least this many blocks in order for the proposal to
+    /// be executed.
+    pub fn min_target_height(&self) -> BlockHeight {
+        self.min_target_height
+    }
+    /// Returns a flag indicating whether or not the proposed transaction
+    /// is exclusively wallet-internal (if it does not involve any external
+    /// recipients).
+    pub fn is_shielding(&self) -> bool {
+        self.is_shielding
+    }
+}
+
+impl<FeeRuleT, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Proposal")
+            .field("transaction_request", &self.transaction_request)
+            .field("transparent_inputs", &self.transparent_inputs)
+            .field(
+                "shielded_inputs",
+                &self.shielded_inputs().map(|i| i.notes.len()),
+            )
+            .field(
+                "anchor_height",
+                &self.shielded_inputs().map(|i| i.anchor_height),
+            )
+            .field("balance", &self.balance)
+            //.field("fee_rule", &self.fee_rule)
+            .field("min_target_height", &self.min_target_height)
+            .field("is_shielding", &self.is_shielding)
+            .finish_non_exhaustive()
+    }
+}

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -1,3 +1,5 @@
+//! Types related to the construction and evaluation of transaction proposals.
+
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Display},
@@ -372,7 +374,7 @@ impl<NoteRef> Step<NoteRef> {
     pub fn transparent_inputs(&self) -> &[WalletTransparentOutput] {
         &self.transparent_inputs
     }
-    /// Returns the Sapling inputs that have been selected to fund the transaction.
+    /// Returns the shielded inputs that have been selected to fund the transaction.
     pub fn shielded_inputs(&self) -> Option<&ShieldedInputs<NoteRef>> {
         self.shielded_inputs.as_ref()
     }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -15,7 +15,7 @@ use crate::{
     PoolType,
 };
 
-/// Errors that can occur in construction of a [`Proposal`].
+/// Errors that can occur in construction of a [`Step`].
 #[derive(Debug, Clone)]
 pub enum ProposalError {
     /// The total output value of the transaction request is not a valid Zcash amount.
@@ -35,6 +35,8 @@ pub enum ProposalError {
     /// * There provided transaction request is empty; i.e. the only output values specified
     ///   are change and fee amounts.
     ShieldingInvalid,
+    /// A reference to the output of a prior step is invalid.
+    ReferenceError(StepOutput),
 }
 
 impl Display for ProposalError {
@@ -61,6 +63,7 @@ impl Display for ProposalError {
                 f,
                 "The proposal violates the rules for a shielding transaction."
             ),
+            ProposalError::ReferenceError(r) => write!(f, "No prior step output found for {:?}", r),
         }
     }
 }
@@ -98,21 +101,165 @@ impl<NoteRef> ShieldedInputs<NoteRef> {
     }
 }
 
-/// The inputs to be consumed and outputs to be produced in a proposed transaction.
+/// A proposal for a series of transactions to be created.
+///
+/// Each step of the proposal represents a separate transaction to be created. At present, only
+/// transparent outputs of earlier steps may be spent in later steps; the ability to chain shielded
+/// transaction steps may be added in a future update.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Proposal<FeeRuleT, NoteRef> {
+    fee_rule: FeeRuleT,
+    min_target_height: BlockHeight,
+    steps: NonEmpty<Step<NoteRef>>,
+}
+
+impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
+    /// Constructs a validated multi-step [`Proposal`].
+    ///
+    /// This operation validates the proposal for agreement between outputs and inputs
+    /// in the case of multi-step proposals, and ensures that no double-spends are being
+    /// proposed.
+    ///
+    /// Parameters:
+    /// * `fee_rule`: The fee rule observed by the proposed transaction.
+    /// * `min_target_height`: The minimum block height at which the transaction may be created.
+    /// * `steps`: A vector of steps that make up the proposal.
+    pub fn multi_step(
+        fee_rule: FeeRuleT,
+        min_target_height: BlockHeight,
+        steps: NonEmpty<Step<NoteRef>>,
+    ) -> Result<Self, ProposalError> {
+        // TODO: actually perform the validation described in the documentation.
+
+        Ok(Self {
+            fee_rule,
+            min_target_height,
+            steps,
+        })
+    }
+
+    /// Constructs a validated [`Proposal`] having only a single step from its constituent parts.
+    ///
+    /// This operation validates the proposal for balance consistency and agreement between
+    /// the `is_shielding` flag and the structure of the proposal.
+    ///
+    /// Parameters:
+    /// * `transaction_request`: The ZIP 321 transaction request describing the payments to be
+    ///    made.
+    /// * `payment_pools`: A map from payment index to pool type.
+    /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
+    /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
+    /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
+    /// * `fee_rule`: The fee rule observed by the proposed transaction.
+    /// * `min_target_height`: The minimum block height at which the transaction may be created.
+    /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
+    ///    transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn single_step(
+        transaction_request: TransactionRequest,
+        payment_pools: BTreeMap<usize, PoolType>,
+        transparent_inputs: Vec<WalletTransparentOutput>,
+        shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+        balance: TransactionBalance,
+        fee_rule: FeeRuleT,
+        min_target_height: BlockHeight,
+        is_shielding: bool,
+    ) -> Result<Self, ProposalError> {
+        Ok(Self {
+            fee_rule,
+            min_target_height,
+            steps: NonEmpty::singleton(Step::from_parts(
+                &[],
+                transaction_request,
+                payment_pools,
+                transparent_inputs,
+                shielded_inputs,
+                vec![],
+                balance,
+                is_shielding,
+            )?),
+        })
+    }
+
+    /// Returns the fee rule to be used by the transaction builder.
+    pub fn fee_rule(&self) -> &FeeRuleT {
+        &self.fee_rule
+    }
+
+    /// Returns the target height for which the proposal was prepared.
+    ///
+    /// The chain must contain at least this many blocks in order for the proposal to
+    /// be executed.
+    pub fn min_target_height(&self) -> BlockHeight {
+        self.min_target_height
+    }
+
+    /// Returns the steps of the proposal. Each step corresponds to an independent transaction to
+    /// be generated as a result of this proposal.
+    pub fn steps(&self) -> &NonEmpty<Step<NoteRef>> {
+        &self.steps
+    }
+}
+
+impl<FeeRuleT: Debug, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Proposal")
+            .field("fee_rule", &self.fee_rule)
+            .field("min_target_height", &self.min_target_height)
+            .field("steps", &self.steps)
+            .finish()
+    }
+}
+
+/// A reference to either a payment or change output within a step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepOutputIndex {
+    Payment(usize),
+    Change(usize),
+}
+
+/// A reference to the output of a step in a proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StepOutput {
+    step_index: usize,
+    output_index: StepOutputIndex,
+}
+
+impl StepOutput {
+    /// Constructs a new [`StepOutput`] from its constituent parts.
+    pub fn new(step_index: usize, output_index: StepOutputIndex) -> Self {
+        Self {
+            step_index,
+            output_index,
+        }
+    }
+
+    /// Returns the step index to which this reference refers.
+    pub fn step_index(&self) -> usize {
+        self.step_index
+    }
+
+    /// Returns the identifier for the payment or change output within
+    /// the referenced step.
+    pub fn output_index(&self) -> StepOutputIndex {
+        self.output_index
+    }
+}
+
+/// The inputs to be consumed and outputs to be produced in a proposed transaction.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Step<NoteRef> {
     transaction_request: TransactionRequest,
     payment_pools: BTreeMap<usize, PoolType>,
     transparent_inputs: Vec<WalletTransparentOutput>,
     shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+    prior_step_inputs: Vec<StepOutput>,
     balance: TransactionBalance,
-    fee_rule: FeeRuleT,
-    min_target_height: BlockHeight,
     is_shielding: bool,
 }
 
-impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
-    /// Constructs a validated [`Proposal`] from its constituent parts.
+impl<NoteRef> Step<NoteRef> {
+    /// Constructs a validated [`Step`] from its constituent parts.
     ///
     /// This operation validates the proposal for balance consistency and agreement between
     /// the `is_shielding` flag and the structure of the proposal.
@@ -124,19 +271,17 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
     /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
     /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
-    /// * `fee_rule`: The fee rule observed by the proposed transaction.
-    /// * `min_target_height`: The minimum block height at which the transaction may be created.
     /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
     ///   transaction.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
+        prior_steps: &[Step<NoteRef>],
         transaction_request: TransactionRequest,
         payment_pools: BTreeMap<usize, PoolType>,
         transparent_inputs: Vec<WalletTransparentOutput>,
         shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+        prior_step_inputs: Vec<StepOutput>,
         balance: TransactionBalance,
-        fee_rule: FeeRuleT,
-        min_target_height: BlockHeight,
         is_shielding: bool,
     ) -> Result<Self, ProposalError> {
         let transparent_input_total = transparent_inputs
@@ -145,14 +290,43 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
             .fold(Ok(NonNegativeAmount::ZERO), |acc, a| {
                 (acc? + a).ok_or(ProposalError::Overflow)
             })?;
+
         let shielded_input_total = shielded_inputs
             .iter()
             .flat_map(|s_in| s_in.notes().iter())
             .map(|out| out.note().value())
             .fold(Some(NonNegativeAmount::ZERO), |acc, a| (acc? + a))
             .ok_or(ProposalError::Overflow)?;
-        let input_total =
-            (transparent_input_total + shielded_input_total).ok_or(ProposalError::Overflow)?;
+
+        let prior_step_input_total = prior_step_inputs
+            .iter()
+            .map(|s_ref| {
+                let step = prior_steps
+                    .get(s_ref.step_index)
+                    .ok_or(ProposalError::ReferenceError(*s_ref))?;
+                Ok(match s_ref.output_index {
+                    StepOutputIndex::Payment(i) => {
+                        step.transaction_request
+                            .payments()
+                            .get(&i)
+                            .ok_or(ProposalError::ReferenceError(*s_ref))?
+                            .amount
+                    }
+                    StepOutputIndex::Change(i) => step
+                        .balance
+                        .proposed_change()
+                        .get(i)
+                        .ok_or(ProposalError::ReferenceError(*s_ref))?
+                        .value(),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .fold(Some(NonNegativeAmount::ZERO), |acc, a| (acc? + a))
+            .ok_or(ProposalError::Overflow)?;
+
+        let input_total = (transparent_input_total + shielded_input_total + prior_step_input_total)
+            .ok_or(ProposalError::Overflow)?;
 
         let request_total = transaction_request
             .total()
@@ -173,9 +347,8 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
                 payment_pools,
                 transparent_inputs,
                 shielded_inputs,
+                prior_step_inputs,
                 balance,
-                fee_rule,
-                min_target_height,
                 is_shielding,
             })
         } else {
@@ -203,20 +376,14 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     pub fn shielded_inputs(&self) -> Option<&ShieldedInputs<NoteRef>> {
         self.shielded_inputs.as_ref()
     }
+    /// Returns the inputs that should be obtained from the outputs of the transaction
+    /// created to satisfy a previous step of the proposal.
+    pub fn prior_step_inputs(&self) -> &[StepOutput] {
+        self.prior_step_inputs.as_ref()
+    }
     /// Returns the change outputs to be added to the transaction and the fee to be paid.
     pub fn balance(&self) -> &TransactionBalance {
         &self.balance
-    }
-    /// Returns the fee rule to be used by the transaction builder.
-    pub fn fee_rule(&self) -> &FeeRuleT {
-        &self.fee_rule
-    }
-    /// Returns the target height for which the proposal was prepared.
-    ///
-    /// The chain must contain at least this many blocks in order for the proposal to
-    /// be executed.
-    pub fn min_target_height(&self) -> BlockHeight {
-        self.min_target_height
     }
     /// Returns a flag indicating whether or not the proposed transaction
     /// is exclusively wallet-internal (if it does not involve any external
@@ -226,9 +393,9 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     }
 }
 
-impl<FeeRuleT, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
+impl<NoteRef> Debug for Step<NoteRef> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Proposal")
+        f.debug_struct("Step")
             .field("transaction_request", &self.transaction_request)
             .field("transparent_inputs", &self.transparent_inputs)
             .field(
@@ -240,8 +407,6 @@ impl<FeeRuleT, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
                 &self.shielded_inputs().map(|i| i.anchor_height),
             )
             .field("balance", &self.balance)
-            //.field("fee_rule", &self.fee_rule)
-            .field("min_target_height", &self.min_target_height)
             .field("is_shielding", &self.is_shielding)
             .finish_non_exhaustive()
     }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -22,11 +22,9 @@ use zcash_primitives::{
 use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
 
 use crate::{
-    data_api::{
-        wallet::input_selection::{Proposal, ProposalError, ShieldedInputs},
-        InputSource,
-    },
+    data_api::InputSource,
     fees::{ChangeValue, TransactionBalance},
+    proposal::{Proposal, ProposalError, ShieldedInputs},
     zip321::{TransactionRequest, Zip321Error},
     PoolType, ShieldedProtocol,
 };

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -24,7 +24,7 @@ use zcash_note_encryption::{EphemeralKeyBytes, COMPACT_NOTE_SIZE};
 use crate::{
     data_api::InputSource,
     fees::{ChangeValue, TransactionBalance},
-    proposal::{Proposal, ProposalError, ShieldedInputs},
+    proposal::{Proposal, ProposalError, ShieldedInputs, Step, StepOutput, StepOutputIndex},
     zip321::{TransactionRequest, Zip321Error},
     PoolType, ShieldedProtocol,
 };
@@ -216,8 +216,12 @@ pub const PROPOSAL_SER_V1: u32 = 1;
 /// representation.
 #[derive(Debug, Clone)]
 pub enum ProposalDecodingError<DbError> {
+    /// The encoded proposal contained no steps
+    NoSteps,
     /// The ZIP 321 transaction request URI was invalid.
     Zip321(Zip321Error),
+    /// A proposed input was null.
+    NullInput(usize),
     /// A transaction identifier string did not decode to a valid transaction ID.
     TxIdInvalid(TryFromSliceError),
     /// An invalid value pool identifier was encountered.
@@ -252,7 +256,11 @@ impl<E> From<Zip321Error> for ProposalDecodingError<E> {
 impl<E: Display> Display for ProposalDecodingError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ProposalDecodingError::NoSteps => write!(f, "The proposal had no steps."),
             ProposalDecodingError::Zip321(err) => write!(f, "Transaction request invalid: {}", err),
+            ProposalDecodingError::NullInput(i) => {
+                write!(f, "Proposed input was null at index {}", i)
+            }
             ProposalDecodingError::TxIdInvalid(err) => {
                 write!(f, "Invalid transaction id: {:?}", err)
             }
@@ -317,7 +325,7 @@ fn pool_type<T>(pool_id: i32) -> Result<PoolType, ProposalDecodingError<T>> {
     }
 }
 
-impl proposal::ProposedInput {
+impl proposal::ReceivedOutput {
     pub fn parse_txid(&self) -> Result<TxId, TryFromSliceError> {
         Ok(TxId::from_bytes(self.txid[..].try_into()?))
     }
@@ -359,64 +367,112 @@ impl proposal::Proposal {
         params: &P,
         value: &Proposal<StandardFeeRule, NoteRef>,
     ) -> Self {
-        let transaction_request = value.transaction_request().to_uri(params);
-
-        let anchor_height = value
-            .shielded_inputs()
-            .map_or_else(|| 0, |i| u32::from(i.anchor_height()));
-
-        let inputs = value
-            .transparent_inputs()
+        use proposal::proposed_input;
+        use proposal::{PriorStepChange, PriorStepOutput, ReceivedOutput};
+        let steps = value
+            .steps()
             .iter()
-            .map(|utxo| proposal::ProposedInput {
-                txid: utxo.outpoint().hash().to_vec(),
-                value_pool: proposal::ValuePool::Transparent.into(),
-                index: utxo.outpoint().n(),
-                value: utxo.txout().value.into(),
-            })
-            .chain(value.shielded_inputs().iter().flat_map(|s_in| {
-                s_in.notes().iter().map(|rec_note| proposal::ProposedInput {
-                    txid: rec_note.txid().as_ref().to_vec(),
-                    value_pool: proposal::ValuePool::from(rec_note.note().protocol()).into(),
-                    index: rec_note.output_index().into(),
-                    value: rec_note.note().value().into(),
-                })
-            }))
-            .collect();
+            .map(|step| {
+                let transaction_request = step.transaction_request().to_uri(params);
 
-        let payment_output_pools = value
-            .payment_pools()
-            .iter()
-            .map(|(idx, pool_type)| proposal::PaymentOutputPool {
-                payment_index: u32::try_from(*idx).expect("Payment index fits into a u32"),
-                value_pool: proposal::ValuePool::from(*pool_type).into(),
+                let anchor_height = step
+                    .shielded_inputs()
+                    .map_or_else(|| 0, |i| u32::from(i.anchor_height()));
+
+                let inputs = step
+                    .transparent_inputs()
+                    .iter()
+                    .map(|utxo| proposal::ProposedInput {
+                        value: Some(proposed_input::Value::ReceivedOutput(ReceivedOutput {
+                            txid: utxo.outpoint().hash().to_vec(),
+                            value_pool: proposal::ValuePool::Transparent.into(),
+                            index: utxo.outpoint().n(),
+                            value: utxo.txout().value.into(),
+                        })),
+                    })
+                    .chain(step.shielded_inputs().iter().flat_map(|s_in| {
+                        s_in.notes().iter().map(|rec_note| proposal::ProposedInput {
+                            value: Some(proposed_input::Value::ReceivedOutput(ReceivedOutput {
+                                txid: rec_note.txid().as_ref().to_vec(),
+                                value_pool: proposal::ValuePool::from(rec_note.note().protocol())
+                                    .into(),
+                                index: rec_note.output_index().into(),
+                                value: rec_note.note().value().into(),
+                            })),
+                        })
+                    }))
+                    .chain(step.prior_step_inputs().iter().map(|p_in| {
+                        match p_in.output_index() {
+                            StepOutputIndex::Payment(i) => proposal::ProposedInput {
+                                value: Some(proposed_input::Value::PriorStepOutput(
+                                    PriorStepOutput {
+                                        step_index: p_in
+                                            .step_index()
+                                            .try_into()
+                                            .expect("Step index fits into a u32"),
+                                        payment_index: i
+                                            .try_into()
+                                            .expect("Payment index fits into a u32"),
+                                    },
+                                )),
+                            },
+                            StepOutputIndex::Change(i) => proposal::ProposedInput {
+                                value: Some(proposed_input::Value::PriorStepChange(
+                                    PriorStepChange {
+                                        step_index: p_in
+                                            .step_index()
+                                            .try_into()
+                                            .expect("Step index fits into a u32"),
+                                        change_index: i
+                                            .try_into()
+                                            .expect("Payment index fits into a u32"),
+                                    },
+                                )),
+                            },
+                        }
+                    }))
+                    .collect();
+
+                let payment_output_pools = step
+                    .payment_pools()
+                    .iter()
+                    .map(|(idx, pool_type)| proposal::PaymentOutputPool {
+                        payment_index: u32::try_from(*idx).expect("Payment index fits into a u32"),
+                        value_pool: proposal::ValuePool::from(*pool_type).into(),
+                    })
+                    .collect();
+
+                let balance = Some(proposal::TransactionBalance {
+                    proposed_change: step
+                        .balance()
+                        .proposed_change()
+                        .iter()
+                        .map(|change| proposal::ChangeValue {
+                            value: change.value().into(),
+                            value_pool: proposal::ValuePool::from(change.output_pool()).into(),
+                            memo: change.memo().map(|memo_bytes| proposal::MemoBytes {
+                                value: memo_bytes.as_slice().to_vec(),
+                            }),
+                        })
+                        .collect(),
+                    fee_required: step.balance().fee_required().into(),
+                });
+
+                #[allow(deprecated)]
+                proposal::ProposalStep {
+                    transaction_request,
+                    payment_output_pools,
+                    anchor_height,
+                    inputs,
+                    balance,
+                    is_shielding: step.is_shielding(),
+                }
             })
             .collect();
-
-        let balance = Some(proposal::TransactionBalance {
-            proposed_change: value
-                .balance()
-                .proposed_change()
-                .iter()
-                .map(|change| proposal::ChangeValue {
-                    value: change.value().into(),
-                    value_pool: proposal::ValuePool::from(change.output_pool()).into(),
-                    memo: change.memo().map(|memo_bytes| proposal::MemoBytes {
-                        value: memo_bytes.as_slice().to_vec(),
-                    }),
-                })
-                .collect(),
-            fee_required: value.balance().fee_required().into(),
-        });
 
         #[allow(deprecated)]
         proposal::Proposal {
             proto_version: PROPOSAL_SER_V1,
-            transaction_request,
-            payment_output_pools,
-            anchor_height,
-            inputs,
-            balance,
             fee_rule: match value.fee_rule() {
                 StandardFeeRule::PreZip313 => proposal::FeeRule::PreZip313,
                 StandardFeeRule::Zip313 => proposal::FeeRule::Zip313,
@@ -424,7 +480,7 @@ impl proposal::Proposal {
             }
             .into(),
             min_target_height: value.min_target_height().into(),
-            is_shielding: value.is_shielding(),
+            steps,
         }
     }
 
@@ -438,6 +494,7 @@ impl proposal::Proposal {
     where
         DbT: InputSource<Error = DbError>,
     {
+        use self::proposal::proposed_input::Value::*;
         match self.proto_version {
             PROPOSAL_SER_V1 => {
                 #[allow(deprecated)]
@@ -450,116 +507,166 @@ impl proposal::Proposal {
                     }
                 };
 
-                let transaction_request =
-                    TransactionRequest::from_uri(params, &self.transaction_request)?;
+                let mut steps = Vec::with_capacity(self.steps.len());
+                for step in &self.steps {
+                    let transaction_request =
+                        TransactionRequest::from_uri(params, &step.transaction_request)?;
 
-                let payment_pools = self
-                    .payment_output_pools
-                    .iter()
-                    .map(|pop| {
-                        Ok((
-                            usize::try_from(pop.payment_index)
-                                .expect("Payment index fits into a usize"),
-                            pool_type(pop.value_pool)?,
-                        ))
-                    })
-                    .collect::<Result<BTreeMap<usize, PoolType>, ProposalDecodingError<DbError>>>(
-                    )?;
+                    let payment_pools = step
+                        .payment_output_pools
+                        .iter()
+                        .map(|pop| {
+                            Ok((
+                                usize::try_from(pop.payment_index)
+                                    .expect("Payment index fits into a usize"),
+                                pool_type(pop.value_pool)?,
+                            ))
+                        })
+                        .collect::<Result<BTreeMap<usize, PoolType>, ProposalDecodingError<DbError>>>()?;
 
-                #[cfg(not(feature = "transparent-inputs"))]
-                let transparent_inputs = vec![];
-                #[cfg(feature = "transparent-inputs")]
-                let mut transparent_inputs = vec![];
+                    #[cfg(not(feature = "transparent-inputs"))]
+                    let transparent_inputs = vec![];
+                    #[cfg(feature = "transparent-inputs")]
+                    let mut transparent_inputs = vec![];
+                    let mut received_notes = vec![];
+                    let mut prior_step_inputs = vec![];
+                    for (i, input) in step.inputs.iter().enumerate() {
+                        match input
+                            .value
+                            .as_ref()
+                            .ok_or(ProposalDecodingError::NullInput(i))?
+                        {
+                            ReceivedOutput(out) => {
+                                let txid = out
+                                    .parse_txid()
+                                    .map_err(ProposalDecodingError::TxIdInvalid)?;
 
-                let mut received_notes = vec![];
-                for input in self.inputs.iter() {
-                    let txid = input
-                        .parse_txid()
-                        .map_err(ProposalDecodingError::TxIdInvalid)?;
+                                match out.pool_type()? {
+                                    PoolType::Transparent => {
+                                        #[cfg(not(feature = "transparent-inputs"))]
+                                        return Err(ProposalDecodingError::ValuePoolNotSupported(
+                                            1,
+                                        ));
 
-                    match input.pool_type()? {
-                        PoolType::Transparent => {
-                            #[cfg(not(feature = "transparent-inputs"))]
-                            return Err(ProposalDecodingError::ValuePoolNotSupported(1));
-
-                            #[cfg(feature = "transparent-inputs")]
-                            {
-                                let outpoint = OutPoint::new(txid.into(), input.index);
-                                transparent_inputs.push(
-                                    wallet_db
-                                        .get_unspent_transparent_output(&outpoint)
-                                        .map_err(ProposalDecodingError::InputRetrieval)?
-                                        .ok_or({
-                                            ProposalDecodingError::InputNotFound(
-                                                txid,
-                                                PoolType::Transparent,
-                                                input.index,
-                                            )
-                                        })?,
-                                );
+                                        #[cfg(feature = "transparent-inputs")]
+                                        {
+                                            let outpoint = OutPoint::new(txid.into(), out.index);
+                                            transparent_inputs.push(
+                                                wallet_db
+                                                    .get_unspent_transparent_output(&outpoint)
+                                                    .map_err(ProposalDecodingError::InputRetrieval)?
+                                                    .ok_or({
+                                                        ProposalDecodingError::InputNotFound(
+                                                            txid,
+                                                            PoolType::Transparent,
+                                                            out.index,
+                                                        )
+                                                    })?,
+                                            );
+                                        }
+                                    }
+                                    PoolType::Shielded(protocol) => received_notes.push(
+                                        wallet_db
+                                            .get_spendable_note(&txid, protocol, out.index)
+                                            .map_err(ProposalDecodingError::InputRetrieval)
+                                            .and_then(|opt| {
+                                                opt.ok_or({
+                                                    ProposalDecodingError::InputNotFound(
+                                                        txid,
+                                                        PoolType::Shielded(protocol),
+                                                        out.index,
+                                                    )
+                                                })
+                                            })?,
+                                    ),
+                                }
+                            }
+                            PriorStepOutput(s_ref) => {
+                                prior_step_inputs.push(StepOutput::new(
+                                    s_ref
+                                        .step_index
+                                        .try_into()
+                                        .expect("Step index fits into a usize"),
+                                    StepOutputIndex::Payment(
+                                        s_ref
+                                            .payment_index
+                                            .try_into()
+                                            .expect("Payment index fits into a usize"),
+                                    ),
+                                ));
+                            }
+                            PriorStepChange(s_ref) => {
+                                prior_step_inputs.push(StepOutput::new(
+                                    s_ref
+                                        .step_index
+                                        .try_into()
+                                        .expect("Step index fits into a usize"),
+                                    StepOutputIndex::Change(
+                                        s_ref
+                                            .change_index
+                                            .try_into()
+                                            .expect("Payment index fits into a usize"),
+                                    ),
+                                ));
                             }
                         }
-                        PoolType::Shielded(protocol) => received_notes.push(
-                            wallet_db
-                                .get_spendable_note(&txid, protocol, input.index)
-                                .map_err(ProposalDecodingError::InputRetrieval)
-                                .and_then(|opt| {
-                                    opt.ok_or({
-                                        ProposalDecodingError::InputNotFound(
-                                            txid,
-                                            PoolType::Shielded(protocol),
-                                            input.index,
-                                        )
-                                    })
-                                })?,
-                        ),
                     }
+
+                    let shielded_inputs = NonEmpty::from_vec(received_notes)
+                        .map(|notes| ShieldedInputs::from_parts(step.anchor_height.into(), notes));
+
+                    let proto_balance = step
+                        .balance
+                        .as_ref()
+                        .ok_or(ProposalDecodingError::BalanceInvalid)?;
+                    let balance = TransactionBalance::new(
+                        proto_balance
+                            .proposed_change
+                            .iter()
+                            .map(|cv| -> Result<ChangeValue, ProposalDecodingError<_>> {
+                                match cv.pool_type()? {
+                                    PoolType::Shielded(ShieldedProtocol::Sapling) => {
+                                        Ok(ChangeValue::sapling(
+                                            NonNegativeAmount::from_u64(cv.value).map_err(
+                                                |_| ProposalDecodingError::BalanceInvalid,
+                                            )?,
+                                            cv.memo
+                                                .as_ref()
+                                                .map(|bytes| {
+                                                    MemoBytes::from_bytes(&bytes.value)
+                                                        .map_err(ProposalDecodingError::MemoInvalid)
+                                                })
+                                                .transpose()?,
+                                        ))
+                                    }
+                                    t => Err(ProposalDecodingError::InvalidChangeRecipient(t)),
+                                }
+                            })
+                            .collect::<Result<Vec<_>, _>>()?,
+                        NonNegativeAmount::from_u64(proto_balance.fee_required)
+                            .map_err(|_| ProposalDecodingError::BalanceInvalid)?,
+                    )
+                    .map_err(|_| ProposalDecodingError::BalanceInvalid)?;
+
+                    let step = Step::from_parts(
+                        &steps,
+                        transaction_request,
+                        payment_pools,
+                        transparent_inputs,
+                        shielded_inputs,
+                        prior_step_inputs,
+                        balance,
+                        step.is_shielding,
+                    )
+                    .map_err(ProposalDecodingError::ProposalInvalid)?;
+
+                    steps.push(step);
                 }
 
-                let shielded_inputs = NonEmpty::from_vec(received_notes)
-                    .map(|notes| ShieldedInputs::from_parts(self.anchor_height.into(), notes));
-
-                let proto_balance = self
-                    .balance
-                    .as_ref()
-                    .ok_or(ProposalDecodingError::BalanceInvalid)?;
-                let balance = TransactionBalance::new(
-                    proto_balance
-                        .proposed_change
-                        .iter()
-                        .map(|cv| -> Result<ChangeValue, ProposalDecodingError<_>> {
-                            match cv.pool_type()? {
-                                PoolType::Shielded(ShieldedProtocol::Sapling) => {
-                                    Ok(ChangeValue::sapling(
-                                        NonNegativeAmount::from_u64(cv.value)
-                                            .map_err(|_| ProposalDecodingError::BalanceInvalid)?,
-                                        cv.memo
-                                            .as_ref()
-                                            .map(|bytes| {
-                                                MemoBytes::from_bytes(&bytes.value)
-                                                    .map_err(ProposalDecodingError::MemoInvalid)
-                                            })
-                                            .transpose()?,
-                                    ))
-                                }
-                                t => Err(ProposalDecodingError::InvalidChangeRecipient(t)),
-                            }
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                    NonNegativeAmount::from_u64(proto_balance.fee_required)
-                        .map_err(|_| ProposalDecodingError::BalanceInvalid)?,
-                )
-                .map_err(|_| ProposalDecodingError::BalanceInvalid)?;
-
-                Proposal::from_parts(
-                    transaction_request,
-                    payment_pools,
-                    transparent_inputs,
-                    shielded_inputs,
-                    balance,
+                Proposal::multi_step(
                     fee_rule,
                     self.min_target_height.into(),
-                    self.is_shielding,
+                    NonEmpty::from_vec(steps).ok_or(ProposalDecodingError::NoSteps)?,
                 )
                 .map_err(ProposalDecodingError::ProposalInvalid)
             }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -458,7 +458,6 @@ impl proposal::Proposal {
                     fee_required: step.balance().fee_required().into(),
                 });
 
-                #[allow(deprecated)]
                 proposal::ProposalStep {
                     transaction_request,
                     payment_output_pools,

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -1,4 +1,4 @@
-/// A data structure that describes the a series of transactions to be created.
+/// A data structure that describes a series of transactions to be created.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proposal {

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -8,31 +8,46 @@ pub struct Proposal {
     /// ZIP 321 serialized transaction request
     #[prost(string, tag = "2")]
     pub transaction_request: ::prost::alloc::string::String,
+    /// The vector of selected payment index / output pool mappings. Payment index
+    /// 0 corresponds to the payment with no explicit index.
+    #[prost(message, repeated, tag = "3")]
+    pub payment_output_pools: ::prost::alloc::vec::Vec<PaymentOutputPool>,
     /// The anchor height to be used in creating the transaction, if any.
     /// Setting the anchor height to zero will disallow the use of any shielded
     /// inputs.
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag = "4")]
     pub anchor_height: u32,
     /// The inputs to be used in creating the transaction.
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag = "5")]
     pub inputs: ::prost::alloc::vec::Vec<ProposedInput>,
     /// The total value, fee value, and change outputs of the proposed
     /// transaction
-    #[prost(message, optional, tag = "5")]
+    #[prost(message, optional, tag = "6")]
     pub balance: ::core::option::Option<TransactionBalance>,
     /// The fee rule used in constructing this proposal
-    #[prost(enumeration = "FeeRule", tag = "6")]
+    #[prost(enumeration = "FeeRule", tag = "7")]
     pub fee_rule: i32,
     /// The target height for which the proposal was constructed
     ///
     /// The chain must contain at least this many blocks in order for the proposal to
     /// be executed.
-    #[prost(uint32, tag = "7")]
+    #[prost(uint32, tag = "8")]
     pub min_target_height: u32,
     /// A flag indicating whether the proposal is for a shielding transaction,
     /// used for determining which OVK to select for wallet-internal outputs.
-    #[prost(bool, tag = "8")]
+    #[prost(bool, tag = "9")]
     pub is_shielding: bool,
+}
+/// A mapping from ZIP 321 payment index to the output pool that has been chosen
+/// for that payment, based upon the payment address and the selected inputs to
+/// the transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaymentOutputPool {
+    #[prost(uint32, tag = "1")]
+    pub payment_index: u32,
+    #[prost(enumeration = "ValuePool", tag = "2")]
+    pub value_pool: i32,
 }
 /// The unique identifier and value for each proposed input.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -378,6 +378,7 @@ impl<NoteRef> orchard_fees::InputView<NoteRef> for ReceivedNote<NoteRef, orchard
 /// viewing key, refer to [ZIP 310].
 ///
 /// [ZIP 310]: https://zips.z.cash/zip-0310
+#[derive(Debug, Clone)]
 pub enum OvkPolicy {
     /// Use the outgoing viewing key from the sender's [`ExtendedFullViewingKey`].
     ///

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -22,6 +22,9 @@ use crate::{address::UnifiedAddress, fees::sapling as sapling_fees, PoolType, Sh
 #[cfg(feature = "orchard")]
 use crate::fees::orchard as orchard_fees;
 
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::legacy::keys::{NonHardenedChildIndex, TransparentKeyScope};
+
 /// A unique identifier for a shielded transaction output
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoteId {
@@ -394,4 +397,30 @@ pub enum OvkPolicy {
     /// Use no outgoing viewing key. Transaction outputs will be decryptable by their
     /// recipients, but not by the sender.
     Discard,
+}
+
+/// Metadata related to the ZIP 32 derivation of a transparent address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "transparent-inputs")]
+pub struct TransparentAddressMetadata {
+    scope: TransparentKeyScope,
+    address_index: NonHardenedChildIndex,
+}
+
+#[cfg(feature = "transparent-inputs")]
+impl TransparentAddressMetadata {
+    pub fn new(scope: TransparentKeyScope, address_index: NonHardenedChildIndex) -> Self {
+        Self {
+            scope,
+            address_index,
+        }
+    }
+
+    pub fn scope(&self) -> TransparentKeyScope {
+        self.scope
+    }
+
+    pub fn address_index(&self) -> NonHardenedChildIndex {
+        self.address_index
+    }
 }

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -70,6 +70,7 @@ maybe-rayon.workspace = true
 assert_matches.workspace = true
 incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
 shardtree = { workspace = true, features = ["legacy-api", "test-dependencies"] }
+nonempty.workspace = true
 proptest.workspace = true
 rand_core.workspace = true
 regex = "1.4"

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -48,7 +48,6 @@ use shardtree::{error::ShardTreeError, ShardTree};
 use zcash_primitives::{
     block::BlockHash,
     consensus::{self, BlockHeight},
-    legacy::TransparentAddress,
     memo::{Memo, MemoBytes},
     transaction::{
         components::amount::{Amount, NonNegativeAmount},
@@ -64,8 +63,8 @@ use zcash_client_backend::{
         chain::{BlockSource, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
         AccountBirthday, BlockMetadata, DecryptedTransaction, InputSource, NullifierQuery,
-        ScannedBlock, SentTransaction, TransparentAddressMetadata, WalletCommitmentTrees,
-        WalletRead, WalletSummary, WalletWrite, SAPLING_SHARD_HEIGHT,
+        ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
+        WalletWrite, SAPLING_SHARD_HEIGHT,
     },
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
     proto::compact_formats::CompactBlock,
@@ -76,7 +75,10 @@ use zcash_client_backend::{
 use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore};
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::transaction::components::OutPoint;
+use {
+    zcash_client_backend::wallet::TransparentAddressMetadata,
+    zcash_primitives::{legacy::TransparentAddress, transaction::components::OutPoint},
+};
 
 #[cfg(feature = "unstable")]
 use {
@@ -343,36 +345,21 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         }
     }
 
+    #[cfg(feature = "transparent-inputs")]
     fn get_transparent_receivers(
         &self,
         _account: AccountId,
     ) -> Result<HashMap<TransparentAddress, Option<TransparentAddressMetadata>>, Self::Error> {
-        #[cfg(feature = "transparent-inputs")]
-        return wallet::get_transparent_receivers(self.conn.borrow(), &self.params, _account);
-
-        #[cfg(not(feature = "transparent-inputs"))]
-        panic!(
-            "The wallet must be compiled with the transparent-inputs feature to use this method."
-        );
+        wallet::get_transparent_receivers(self.conn.borrow(), &self.params, _account)
     }
 
+    #[cfg(feature = "transparent-inputs")]
     fn get_transparent_balances(
         &self,
         _account: AccountId,
         _max_height: BlockHeight,
     ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
-        #[cfg(feature = "transparent-inputs")]
-        return wallet::get_transparent_balances(
-            self.conn.borrow(),
-            &self.params,
-            _account,
-            _max_height,
-        );
-
-        #[cfg(not(feature = "transparent-inputs"))]
-        panic!(
-            "The wallet must be compiled with the transparent-inputs feature to use this method."
-        );
+        wallet::get_transparent_balances(self.conn.borrow(), &self.params, _account, _max_height)
     }
 
     #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -30,14 +30,13 @@ use zcash_client_backend::{
         chain::{scan_cached_blocks, BlockSource, ScanSummary},
         wallet::{
             create_proposed_transaction, create_spend_to_address,
-            input_selection::{
-                GreedyInputSelector, GreedyInputSelectorError, InputSelector, Proposal,
-            },
+            input_selection::{GreedyInputSelector, GreedyInputSelectorError, InputSelector},
             propose_standard_transfer_to_address, propose_transfer, spend,
         },
         AccountBalance, AccountBirthday, WalletRead, WalletSummary, WalletWrite,
     },
     keys::UnifiedSpendingKey,
+    proposal::Proposal,
     proto::compact_formats::{
         self as compact, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroU32;
 #[cfg(feature = "unstable")]
 use std::fs::File;
 
+use nonempty::NonEmpty;
 use prost::Message;
 use rand_core::{OsRng, RngCore};
 use rusqlite::{params, Connection};
@@ -29,7 +30,7 @@ use zcash_client_backend::{
         self,
         chain::{scan_cached_blocks, BlockSource, ScanSummary},
         wallet::{
-            create_proposed_transaction, create_spend_to_address,
+            create_proposed_transactions, create_spend_to_address,
             input_selection::{GreedyInputSelector, GreedyInputSelectorError, InputSelector},
             propose_standard_transfer_to_address, propose_transfer, spend,
         },
@@ -442,7 +443,7 @@ impl<Cache> TestState<Cache> {
         min_confirmations: NonZeroU32,
         change_memo: Option<MemoBytes>,
     ) -> Result<
-        TxId,
+        NonEmpty<TxId>,
         data_api::error::Error<
             SqliteClientError,
             commitment_tree::Error,
@@ -477,7 +478,7 @@ impl<Cache> TestState<Cache> {
         ovk_policy: OvkPolicy,
         min_confirmations: NonZeroU32,
     ) -> Result<
-        TxId,
+        NonEmpty<TxId>,
         data_api::error::Error<
             SqliteClientError,
             commitment_tree::Error,
@@ -608,14 +609,14 @@ impl<Cache> TestState<Cache> {
         )
     }
 
-    /// Invokes [`create_proposed_transaction`] with the given arguments.
-    pub(crate) fn create_proposed_transaction<InputsErrT, FeeRuleT>(
+    /// Invokes [`create_proposed_transactions`] with the given arguments.
+    pub(crate) fn create_proposed_transactions<InputsErrT, FeeRuleT>(
         &mut self,
         usk: &UnifiedSpendingKey,
         ovk_policy: OvkPolicy,
         proposal: &Proposal<FeeRuleT, ReceivedNoteId>,
     ) -> Result<
-        TxId,
+        NonEmpty<TxId>,
         data_api::error::Error<
             SqliteClientError,
             commitment_tree::Error,
@@ -628,7 +629,7 @@ impl<Cache> TestState<Cache> {
     {
         let params = self.network();
         let prover = test_prover();
-        create_proposed_transaction(
+        create_proposed_transactions(
             &mut self.db_data,
             &params,
             &prover,
@@ -650,7 +651,7 @@ impl<Cache> TestState<Cache> {
         from_addrs: &[TransparentAddress],
         min_confirmations: u32,
     ) -> Result<
-        TxId,
+        NonEmpty<TxId>,
         data_api::error::Error<
             SqliteClientError,
             commitment_tree::Error,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2316,7 +2316,7 @@ mod tests {
         );
         let txid = st
             .shield_transparent_funds(&input_selector, value, &usk, &[*taddr], 1)
-            .unwrap();
+            .unwrap()[0];
 
         // The wallet should have zero transparent balance, because the shielding
         // transaction can be mined.

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -112,9 +112,12 @@ use {
     crate::UtxoId,
     rusqlite::Row,
     std::collections::BTreeSet,
-    zcash_client_backend::{data_api::TransparentAddressMetadata, wallet::WalletTransparentOutput},
+    zcash_client_backend::wallet::{TransparentAddressMetadata, WalletTransparentOutput},
     zcash_primitives::{
-        legacy::{keys::IncomingViewingKey, NonHardenedChildIndex, Script, TransparentAddress},
+        legacy::{
+            keys::{IncomingViewingKey, NonHardenedChildIndex},
+            Script, TransparentAddress,
+        },
         transaction::components::{OutPoint, TxOut},
     },
 };
@@ -395,7 +398,10 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
 
             ret.insert(
                 *taddr,
-                Some(TransparentAddressMetadata::new(Scope::External, index)),
+                Some(TransparentAddressMetadata::new(
+                    Scope::External.into(),
+                    index,
+                )),
             );
         }
     }
@@ -404,7 +410,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
         ret.insert(
             taddr,
             Some(TransparentAddressMetadata::new(
-                Scope::External,
+                Scope::External.into(),
                 child_index,
             )),
         );

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -2,7 +2,6 @@
 use std::collections::HashSet;
 
 use rusqlite::{self, types::ToSql, OptionalExtension};
-use schemer;
 use schemer_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -2,7 +2,7 @@
 use std::collections::HashSet;
 
 use rusqlite::{self, types::ToSql, OptionalExtension};
-use schemer::{self};
+use schemer;
 use schemer_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 
@@ -397,7 +397,7 @@ mod tests {
     fn migrate_from_wm2() {
         use zcash_client_backend::keys::UnifiedAddressRequest;
         use zcash_primitives::{
-            legacy::NonHardenedChildIndex, transaction::components::amount::NonNegativeAmount,
+            legacy::keys::NonHardenedChildIndex, transaction::components::amount::NonNegativeAmount,
         };
 
         use crate::UA_TRANSPARENT;

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -292,7 +292,7 @@ mod tests {
     use zcash_primitives::{
         block::BlockHash,
         consensus::{BlockHeight, Network, NetworkUpgrade, Parameters},
-        legacy::{keys::IncomingViewingKey, NonHardenedChildIndex},
+        legacy::keys::{IncomingViewingKey, NonHardenedChildIndex},
         memo::MemoBytes,
         transaction::{
             builder::{BuildConfig, BuildResult, Builder},

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -589,10 +589,10 @@ pub(crate) mod tests {
             .unwrap();
 
         let create_proposed_result =
-            st.create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal);
-        assert_matches!(create_proposed_result, Ok(_));
+            st.create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal);
+        assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
 
-        let sent_tx_id = create_proposed_result.unwrap();
+        let sent_tx_id = create_proposed_result.unwrap()[0];
 
         // Verify that the sent transaction was stored and that we can decrypt the memos
         let tx = st
@@ -864,8 +864,8 @@ pub(crate) mod tests {
 
         // Executing the proposal should succeed
         let txid = st
-            .create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal)
-            .unwrap();
+            .create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal)
+            .unwrap()[0];
 
         let (h, _) = st.generate_next_block_including(txid);
         st.scan_cached_blocks(h, 1);
@@ -921,8 +921,8 @@ pub(crate) mod tests {
 
         // Executing the proposal should succeed
         assert_matches!(
-            st.create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal,),
-            Ok(_)
+            st.create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal,),
+            Ok(txids) if txids.len() == 1
         );
 
         // A second proposal fails because there are no usable notes
@@ -1000,8 +1000,8 @@ pub(crate) mod tests {
             .unwrap();
 
         let txid2 = st
-            .create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal)
-            .unwrap();
+            .create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal)
+            .unwrap()[0];
 
         let (h, _) = st.generate_next_block_including(txid2);
         st.scan_cached_blocks(h, 1);
@@ -1066,7 +1066,7 @@ pub(crate) mod tests {
             )?;
 
             // Executing the proposal should succeed
-            let txid = st.create_proposed_transaction(&usk, ovk_policy, &proposal)?;
+            let txid = st.create_proposed_transactions(&usk, ovk_policy, &proposal)?[0];
 
             // Fetch the transaction from the database
             let raw_tx: Vec<_> = st
@@ -1170,8 +1170,8 @@ pub(crate) mod tests {
 
         // Executing the proposal should succeed
         assert_matches!(
-            st.create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal),
-            Ok(_)
+            st.create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal),
+            Ok(txids) if txids.len() == 1
         );
     }
 
@@ -1232,8 +1232,8 @@ pub(crate) mod tests {
 
         // Executing the proposal should succeed
         assert_matches!(
-            st.create_proposed_transaction::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal),
-            Ok(_)
+            st.create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal),
+            Ok(txids) if txids.len() == 1
         );
     }
 
@@ -1310,7 +1310,7 @@ pub(crate) mod tests {
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
             )
-            .unwrap();
+            .unwrap()[0];
 
         let amount_left = (value - (amount_sent + fee_rule.fixed_fee()).unwrap()).unwrap();
         let pending_change = (amount_left - amount_legacy_change).unwrap();
@@ -1441,7 +1441,7 @@ pub(crate) mod tests {
                 OvkPolicy::Sender,
                 NonZeroU32::new(1).unwrap(),
             )
-            .unwrap();
+            .unwrap()[0];
 
         let (h, _) = st.generate_next_block_including(txid);
         st.scan_cached_blocks(h, 1);

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -521,8 +521,13 @@ pub(crate) mod tests {
 
     #[cfg(feature = "transparent-inputs")]
     use {
-        zcash_client_backend::wallet::WalletTransparentOutput,
-        zcash_primitives::transaction::components::{OutPoint, TxOut},
+        zcash_client_backend::{
+            fees::TransactionBalance, proposal::Step, wallet::WalletTransparentOutput, PoolType,
+        },
+        zcash_primitives::{
+            legacy::keys::IncomingViewingKey,
+            transaction::components::{OutPoint, TxOut},
+        },
     };
 
     pub(crate) fn test_prover() -> impl SpendProver + OutputProver {
@@ -530,7 +535,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn send_proposed_transfer() {
+    fn send_single_step_proposed_transfer() {
         let mut st = TestBuilder::new()
             .with_block_cache()
             .with_test_account(AccountBirthday::from_sapling_activation)
@@ -674,6 +679,158 @@ pub(crate) mod tests {
             st.wallet()
                 .get_memo(NoteId::new(sent_tx_id, ShieldedProtocol::Sapling, 12345)),
             Ok(None)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn send_multi_step_proposed_transfer() {
+        use nonempty::NonEmpty;
+        use zcash_client_backend::proposal::{Proposal, StepOutput, StepOutputIndex};
+
+        let mut st = TestBuilder::new()
+            .with_block_cache()
+            .with_test_account(AccountBirthday::from_sapling_activation)
+            .build();
+
+        let (account, usk, _) = st.test_account().unwrap();
+        let dfvk = st.test_account_sapling().unwrap();
+
+        // Add funds to the wallet in a single note
+        let value = NonNegativeAmount::const_from_u64(65000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        // Spendable balance matches total balance
+        assert_eq!(st.get_total_balance(account), value);
+        assert_eq!(st.get_spendable_balance(account, 1), value);
+
+        assert_eq!(
+            block_max_scanned(&st.wallet().conn, &st.wallet().params)
+                .unwrap()
+                .unwrap()
+                .block_height(),
+            h
+        );
+
+        // Generate a single-step proposal. Then, instead of executing that proposal,
+        // we will use its only step as the first step in a multi-step proposal that
+        // spends the first step's output.
+
+        // The first step will deshield to the wallet's default transparent address
+        let to0 = Address::Transparent(usk.default_transparent_address().0);
+        let request0 = zip321::TransactionRequest::new(vec![Payment {
+            recipient_address: to0,
+            amount: NonNegativeAmount::const_from_u64(50000),
+            memo: None,
+            label: None,
+            message: None,
+            other_params: vec![],
+        }])
+        .unwrap();
+
+        let fee_rule = StandardFeeRule::Zip317;
+        let input_selector = GreedyInputSelector::new(
+            standard::SingleOutputChangeStrategy::new(fee_rule, None),
+            DustOutputPolicy::default(),
+        );
+        let proposal0 = st
+            .propose_transfer(
+                account,
+                &input_selector,
+                request0,
+                NonZeroU32::new(1).unwrap(),
+            )
+            .unwrap();
+
+        let min_target_height = proposal0.min_target_height();
+        let step0 = &proposal0.steps().head;
+
+        assert!(step0.balance().proposed_change().is_empty());
+        assert_eq!(
+            step0.balance().fee_required(),
+            NonNegativeAmount::const_from_u64(15000)
+        );
+
+        // We'll use an internal transparent address that hasn't been added to the wallet
+        // to simulate an external transparent recipient.
+        let to1 = Address::Transparent(
+            usk.transparent()
+                .to_account_pubkey()
+                .derive_internal_ivk()
+                .unwrap()
+                .default_address()
+                .0,
+        );
+        let request1 = zip321::TransactionRequest::new(vec![Payment {
+            recipient_address: to1,
+            amount: NonNegativeAmount::const_from_u64(40000),
+            memo: None,
+            label: None,
+            message: None,
+            other_params: vec![],
+        }])
+        .unwrap();
+
+        let step1 = Step::from_parts(
+            &[step0.clone()],
+            request1,
+            [(0, PoolType::Transparent)].into_iter().collect(),
+            vec![],
+            None,
+            vec![StepOutput::new(0, StepOutputIndex::Payment(0))],
+            TransactionBalance::new(vec![], NonNegativeAmount::const_from_u64(10000)).unwrap(),
+            false,
+        )
+        .unwrap();
+
+        let proposal = Proposal::multi_step(
+            fee_rule,
+            min_target_height,
+            NonEmpty::from_vec(vec![step0.clone(), step1]).unwrap(),
+        )
+        .unwrap();
+
+        let create_proposed_result =
+            st.create_proposed_transactions::<Infallible, _>(&usk, OvkPolicy::Sender, &proposal);
+        assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
+        let txids = create_proposed_result.unwrap();
+
+        // Verify that the stored sent outputs match what we're expecting
+        let mut stmt_sent = st
+            .wallet()
+            .conn
+            .prepare(
+                "SELECT value
+                FROM sent_notes
+                JOIN transactions ON transactions.id_tx = sent_notes.tx
+                WHERE transactions.txid = ?",
+            )
+            .unwrap();
+
+        let confirmed_sent = txids
+            .iter()
+            .map(|sent_txid| {
+                // check that there's a sent output with the correct value corresponding to
+                stmt_sent
+                    .query(rusqlite::params![sent_txid.as_ref()])
+                    .unwrap()
+                    .mapped(|row| {
+                        let value: u32 = row.get(0)?;
+                        Ok((sent_txid, value))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            confirmed_sent.get(0).and_then(|v| v.get(0)),
+            Some(&(&txids[0], 50000))
+        );
+        assert_eq!(
+            confirmed_sent.get(1).and_then(|v| v.get(0)),
+            Some(&(&txids[1], 40000))
         );
     }
 

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -8,7 +8,7 @@ use zcash_primitives::{
 use crate::address::UnifiedAddress;
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::legacy::NonHardenedChildIndex;
+use zcash_primitives::legacy::keys::NonHardenedChildIndex;
 
 #[cfg(feature = "transparent-inputs")]
 use {
@@ -815,7 +815,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     #[test]
     fn pk_to_taddr() {
-        use zcash_primitives::legacy::NonHardenedChildIndex;
+        use zcash_primitives::legacy::keys::NonHardenedChildIndex;
 
         let taddr =
             legacy::keys::AccountPrivKey::from_seed(&MAIN_NETWORK, &seed(), AccountId::ZERO)

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,7 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
-- `zcash_primitives::legacy::keys::NonHardenedChildIndex`
+- `zcash_primitives::legacy::keys::{NonHardenedChildIndex, TransparentKeyScope}`
+- `zcash_primitives::legacy::keys::AccountPrivKey::derive_secret_key`
 - Dependency on `bellman 0.14`.
 - `zcash_primitives::consensus::sapling_zip212_enforcement`
 - `zcash_primitives::transaction`:
@@ -127,7 +128,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend` changes related to `local-consensus` feature:
   - added tests that verify `zip321` supports Payment URIs with `Local(P)`
   network parameters.
-- `zcash_primitives::legacy::keys::derive_external_secret_key` parameter type changed from `u32` to `NonHardenedChildIndex`.
+- `zcash_primitives::legacy::keys::{derive_external_secret_key, derive_internal_secret_key}` 
+  arguments changed from `u32` to `NonHardenedChildIndex`.
 
 ### Removed
 - `zcash_primitives::constants`:

--- a/zcash_primitives/src/legacy.rs
+++ b/zcash_primitives/src/legacy.rs
@@ -6,11 +6,6 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::ops::Shl;
 
-#[cfg(feature = "transparent-inputs")]
-use hdwallet::KeyIndex;
-
-use subtle::{Choice, ConstantTimeEq};
-
 use zcash_encoding::Vector;
 
 #[cfg(feature = "transparent-inputs")]
@@ -407,63 +402,6 @@ impl TransparentAddress {
     }
 }
 
-/// A child index for a derived transparent address.
-///
-/// Only NON-hardened derivation is supported.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NonHardenedChildIndex(u32);
-
-impl ConstantTimeEq for NonHardenedChildIndex {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
-    }
-}
-
-impl NonHardenedChildIndex {
-    pub const ZERO: NonHardenedChildIndex = NonHardenedChildIndex(0);
-
-    /// Parses the given ZIP 32 child index.
-    ///
-    /// Returns `None` if the hardened bit is set.
-    pub fn from_index(i: u32) -> Option<Self> {
-        if i < (1 << 31) {
-            Some(NonHardenedChildIndex(i))
-        } else {
-            None
-        }
-    }
-
-    /// Returns the index as a 32-bit integer.
-    pub fn index(&self) -> u32 {
-        self.0
-    }
-
-    pub fn next(&self) -> Option<Self> {
-        // overflow cannot happen because self.0 is 31 bits, and the next index is at most 32 bits
-        // which in that case would lead from_index to return None.
-        Self::from_index(self.0 + 1)
-    }
-}
-
-#[cfg(feature = "transparent-inputs")]
-impl TryFrom<KeyIndex> for NonHardenedChildIndex {
-    type Error = ();
-
-    fn try_from(value: KeyIndex) -> Result<Self, Self::Error> {
-        match value {
-            KeyIndex::Normal(i) => NonHardenedChildIndex::from_index(i).ok_or(()),
-            KeyIndex::Hardened(_) => Err(()),
-        }
-    }
-}
-
-#[cfg(feature = "transparent-inputs")]
-impl From<NonHardenedChildIndex> for KeyIndex {
-    fn from(value: NonHardenedChildIndex) -> Self {
-        Self::Normal(value.index())
-    }
-}
-
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use proptest::prelude::{any, prop_compose};
@@ -479,9 +417,7 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-    use super::{NonHardenedChildIndex, OpCode, Script, TransparentAddress};
-    use hdwallet::KeyIndex;
-    use subtle::ConstantTimeEq;
+    use super::{OpCode, Script, TransparentAddress};
 
     #[test]
     fn script_opcode() {
@@ -547,56 +483,5 @@ mod tests {
             ]
         );
         assert_eq!(addr.script().address(), Some(addr));
-    }
-
-    #[test]
-    fn nonhardened_indexes_accepted() {
-        assert_eq!(0, NonHardenedChildIndex::from_index(0).unwrap().index());
-        assert_eq!(
-            0x7fffffff,
-            NonHardenedChildIndex::from_index(0x7fffffff)
-                .unwrap()
-                .index()
-        );
-    }
-
-    #[test]
-    fn hardened_indexes_rejected() {
-        assert!(NonHardenedChildIndex::from_index(0x80000000).is_none());
-        assert!(NonHardenedChildIndex::from_index(0xffffffff).is_none());
-    }
-
-    #[test]
-    fn nonhardened_index_next() {
-        assert_eq!(1, NonHardenedChildIndex::ZERO.next().unwrap().index());
-        assert!(NonHardenedChildIndex::from_index(0x7fffffff)
-            .unwrap()
-            .next()
-            .is_none());
-    }
-
-    #[test]
-    fn nonhardened_index_ct_eq() {
-        assert!(check(
-            NonHardenedChildIndex::ZERO,
-            NonHardenedChildIndex::ZERO
-        ));
-        assert!(!check(
-            NonHardenedChildIndex::ZERO,
-            NonHardenedChildIndex::ZERO.next().unwrap()
-        ));
-
-        fn check<T: ConstantTimeEq>(v1: T, v2: T) -> bool {
-            v1.ct_eq(&v2).into()
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "transparent-inputs")]
-    fn nonhardened_index_tryfrom_keyindex() {
-        let nh: NonHardenedChildIndex = KeyIndex::Normal(0).try_into().unwrap();
-        assert_eq!(nh.index(), 0);
-
-        assert!(NonHardenedChildIndex::try_from(KeyIndex::Hardened(0)).is_err());
     }
 }

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -950,7 +950,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     fn binding_sig_absent_if_no_shielded_spend_or_output() {
         use crate::consensus::NetworkUpgrade;
-        use crate::legacy::NonHardenedChildIndex;
+        use crate::legacy::keys::NonHardenedChildIndex;
         use crate::transaction::builder::{self, TransparentBuilder};
 
         let sapling_activation_height = TEST_NETWORK


### PR DESCRIPTION
Best reviewed commit-by-commit and with whitespace changes hidden.

* Add the chosen output pool for each payment to the proposal data.
* Move proposal-related types to their own module
* Make proposals able to represent multiple linked transactions, for ZIP 320