### PR TITLE
zcash_client_backend: Make `AccountId` an associated type of `WalletRead`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -56,6 +56,7 @@ and this library adheres to Rust's notion of
     }`
   - `WalletSummary::next_sapling_subtree_index`
   - `wallet`:
+    - `Account`
     - `propose_standard_transfer_to_address`
     - `create_proposed_transactions`
     - `input_selection`:
@@ -96,6 +97,40 @@ and this library adheres to Rust's notion of
   - `parse::Param::name`
 
 ### Changed
+- Several structs and functions now take an `AccountId` type parameter
+  parameter in order to decouple the concept of an account identifier from
+  the ZIP 32 account index. Many APIs that previously referenced
+  `zcash_primitives::zip32::AccountId` now reference the generic type.
+  Impacted types and functions are:
+  - `zcash_client_backend::data_api`:
+    - `WalletRead` now has an associated `AccountId` type.
+    - `WalletRead::{
+        get_account_birthday,
+        get_current_address,
+        get_unified_full_viewing_keys,
+        get_account_for_ufvk,
+        get_wallet_summary,
+        get_sapling_nullifiers,
+        get_transparent_receivers,
+        get_transparent_balances,
+        get_account_ids
+      }` now refer to the `WalletRead::AccountId` associated type.
+    - `WalletWrite::{create_account, get_next_available_address}`
+      now refer to the `WalletRead::AccountId` associated type.
+    - `ScannedBlock` now takes an additional `AccountId` type parameter.
+    - `DecryptedTransaction` is now parameterized by `AccountId`
+    - `SentTransaction` is now parameterized by `AccountId`
+    - `SentTransactionOutput` is now parameterized by `AccountId`
+    - `WalletSummary` is now parameterized by `AccountId`
+  - `zcash_client_backend::decrypt`
+    - `DecryptedOutput` is now parameterized by `AccountId`
+    - `decrypt_transaction` is now parameterized by `AccountId`
+  - `zcash_client_backend::scanning::scan_block` is now parameterized by `AccountId`
+  - `zcash_client_backend::wallet`:
+    - `Recipient` now takes an additional `AccountId` type parameter.
+    - `WalletTx` now takes an additional `AccountId` type parameter.
+    - `WalletSaplingSpend` now takes an additional `AccountId` type parameter.
+    - `WalletSaplingOutput` now takes an additional `AccountId` type parameter.
 - `zcash_client_backend::data_api`:
   - `BlockMetadata::sapling_tree_size` now returns an `Option<u32>` instead of
     a `u32` for future consistency with Orchard.
@@ -111,9 +146,13 @@ and this library adheres to Rust's notion of
   - Fields of `Balance` and `AccountBalance` have been made private and the values
     of these fields have been made available via methods having the same names
     as the previously-public fields.
-  - `WalletSummary::new` now takes an additional `next_sapling_subtree_index`
-    argument.
+  - `WalletSummary::new` now takes an additional `next_sapling_subtree_index` argument.
+  - `WalletSummary::new` now takes a `HashMap` instead of a `BTreeMap` for its
+    `account_balances` argument.
+  - `WalletSummary::account_balances` now returns a `HashMap` instead of a `BTreeMap`.
   - Changes to the `WalletRead` trait:
+    - Added associated type `AccountId`.
+    - Added `get_account` function.
     - `get_checkpoint_depth` has been removed without replacement. This is no
       longer needed given the change to use the stored anchor height for
       transaction proposal execution.
@@ -273,7 +312,7 @@ and this library adheres to Rust's notion of
 ### Removed
 - `zcash_client_backend::wallet`:
   - `ReceivedSaplingNote` (use `zcash_client_backend::ReceivedNote` instead).
-  - `input_selection::{Proposal, ProposalError}` (moved to
+  - `input_selection::{Proposal, ShieldedInputs, ProposalError}` (moved to
     `zcash_client_backend::proposal`).
   - `SentTransactionOutput::sapling_change_to` - the note created by an internal
     transfer is now conveyed in the `recipient` field.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -56,7 +56,6 @@ and this library adheres to Rust's notion of
     }`
   - `WalletSummary::next_sapling_subtree_index`
   - `wallet`:
-    - `Account`
     - `propose_standard_transfer_to_address`
     - `create_proposed_transactions`
     - `input_selection`:

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -280,7 +280,7 @@ where
     ParamsT: consensus::Parameters + Send + 'static,
     BlockSourceT: BlockSource,
     DbT: WalletWrite,
-    <DbT as WalletRead>::AccountId: Clone + ConditionallySelectable + Default + Send + 'static,
+    <DbT as WalletRead>::AccountId: ConditionallySelectable + Default + Send + 'static,
 {
     // Fetch the UnifiedFullViewingKeys we are tracking
     let ufvks = data_db

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1,10 +1,14 @@
-use std::num::NonZeroU32;
-
 use nonempty::NonEmpty;
 use rand_core::OsRng;
 use sapling::{
     note_encryption::{try_sapling_note_decryption, PreparedIncomingViewingKey},
     prover::{OutputProver, SpendProver},
+};
+use std::num::NonZeroU32;
+
+use zcash_keys::{
+    address::UnifiedAddress,
+    keys::{UnifiedAddressRequest, UnifiedFullViewingKey},
 };
 use zcash_primitives::{
     consensus::{self, BlockHeight, NetworkUpgrade},
@@ -15,9 +19,11 @@ use zcash_primitives::{
         fees::{zip317::FeeError as Zip317FeeError, FeeRule, StandardFeeRule},
         Transaction, TxId,
     },
-    zip32::{AccountId, Scope},
+    zip32::Scope,
 };
+use zip32::DiversifierIndex;
 
+use super::InputSource;
 use crate::{
     address::Address,
     data_api::{
@@ -33,13 +39,6 @@ use crate::{
     PoolType, ShieldedProtocol,
 };
 
-pub mod input_selection;
-use input_selection::{
-    GreedyInputSelector, GreedyInputSelectorError, InputSelector, InputSelectorError,
-};
-
-use super::InputSource;
-
 #[cfg(feature = "transparent-inputs")]
 use {
     input_selection::ShieldingSelector,
@@ -48,6 +47,50 @@ use {
     zcash_primitives::legacy::TransparentAddress,
     zcash_primitives::transaction::components::{OutPoint, TxOut},
 };
+
+pub mod input_selection;
+use input_selection::{
+    GreedyInputSelector, GreedyInputSelectorError, InputSelector, InputSelectorError,
+};
+
+/// The inputs for adding an account to a wallet.
+#[derive(Debug, Clone)]
+pub enum Account {
+    /// An account that was derived from a ZIP-32 HD seed and account index.
+    Zip32 {
+        account_id: zip32::AccountId,
+        ufvk: UnifiedFullViewingKey,
+    },
+    /// An account for which the seed and ZIP-32 account ID are not known.
+    ImportedUfvk(UnifiedFullViewingKey),
+}
+
+impl Account {
+    /// Gets the default UA for the account.
+    pub fn default_address(
+        &self,
+        request: UnifiedAddressRequest,
+    ) -> (UnifiedAddress, DiversifierIndex) {
+        match self {
+            Account::Zip32 { ufvk, .. } => ufvk.default_address(request),
+            Account::ImportedUfvk(ufvk) => ufvk.default_address(request),
+        }
+    }
+
+    /// Gets the unified full viewing key for this account, if available.
+    ///
+    /// Accounts initialized with an incoming viewing key will not have a unified full viewing key.
+    pub fn ufvk(&self) -> Option<&UnifiedFullViewingKey> {
+        match self {
+            Account::Zip32 { ufvk, .. } => Some(ufvk),
+            Account::ImportedUfvk(ufvk) => Some(ufvk),
+        }
+    }
+
+    // TODO: When a UnifiedIncomingViewingKey is available, add a function that
+    // will return it. Even if the Account was initialized with a UFVK, we can always
+    // derive a UIVK from that.
+}
 
 /// Scans a [`Transaction`] for any information that can be decrypted by the accounts in
 /// the wallet, and saves it to the wallet.
@@ -59,6 +102,7 @@ pub fn decrypt_and_store_transaction<ParamsT, DbT>(
 where
     ParamsT: consensus::Parameters,
     DbT: WalletWrite,
+    <DbT as WalletRead>::AccountId: Clone,
 {
     // Fetch the UnifiedFullViewingKeys we are tracking
     let ufvks = data.get_unified_full_viewing_keys()?;
@@ -222,7 +266,13 @@ pub fn create_spend_to_address<DbT, ParamsT>(
 >
 where
     ParamsT: consensus::Parameters + Clone,
-    DbT: WalletWrite + WalletCommitmentTrees + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: InputSource,
+    DbT: WalletWrite<
+        Error = <DbT as InputSource>::Error,
+        AccountId = <DbT as InputSource>::AccountId,
+    >,
+    DbT: WalletCommitmentTrees,
+    <DbT as InputSource>::AccountId: Clone,
     <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
 {
     let account = wallet_db
@@ -328,7 +378,13 @@ pub fn spend<DbT, ParamsT, InputsT>(
     >,
 >
 where
-    DbT: WalletWrite + WalletCommitmentTrees + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: InputSource,
+    DbT: WalletWrite<
+        Error = <DbT as InputSource>::Error,
+        AccountId = <DbT as InputSource>::AccountId,
+    >,
+    DbT: WalletCommitmentTrees,
+    <DbT as InputSource>::AccountId: Clone,
     <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
     ParamsT: consensus::Parameters + Clone,
     InputsT: InputSelector<InputSource = DbT>,
@@ -366,7 +422,7 @@ where
 pub fn propose_transfer<DbT, ParamsT, InputsT, CommitmentTreeErrT>(
     wallet_db: &mut DbT,
     params: &ParamsT,
-    spend_from_account: AccountId,
+    spend_from_account: <DbT as InputSource>::AccountId,
     input_selector: &InputsT,
     request: zip321::TransactionRequest,
     min_confirmations: NonZeroU32,
@@ -433,7 +489,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     wallet_db: &mut DbT,
     params: &ParamsT,
     fee_rule: StandardFeeRule,
-    spend_from_account: AccountId,
+    spend_from_account: <DbT as WalletRead>::AccountId,
     min_confirmations: NonZeroU32,
     to: &Address,
     amount: NonNegativeAmount,
@@ -451,7 +507,12 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
 >
 where
     ParamsT: consensus::Parameters + Clone,
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: InputSource,
+    DbT: WalletRead<
+        Error = <DbT as InputSource>::Error,
+        AccountId = <DbT as InputSource>::AccountId,
+    >,
+    <DbT as WalletRead>::AccountId: Clone,
     DbT::NoteRef: Copy + Eq + Ord,
 {
     let request = zip321::TransactionRequest::new(vec![Payment {
@@ -559,6 +620,7 @@ pub fn create_proposed_transactions<DbT, ParamsT, InputsErrT, FeeRuleT, N>(
 >
 where
     DbT: WalletWrite + WalletCommitmentTrees,
+    <DbT as WalletRead>::AccountId: Clone,
     ParamsT: consensus::Parameters + Clone,
     FeeRuleT: FeeRule,
 {
@@ -612,6 +674,7 @@ fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, N>(
 >
 where
     DbT: WalletWrite + WalletCommitmentTrees,
+    <DbT as WalletRead>::AccountId: Clone,
     ParamsT: consensus::Parameters + Clone,
     FeeRuleT: FeeRule,
 {
@@ -1006,7 +1069,7 @@ where
                 )?;
                 sapling_output_meta.push((
                     Recipient::InternalAccount(
-                        account,
+                        account.clone(),
                         PoolType::Shielded(ShieldedProtocol::Sapling),
                     ),
                     change_value.value(),
@@ -1029,7 +1092,7 @@ where
                     )?;
                     orchard_output_meta.push((
                         Recipient::InternalAccount(
-                            account,
+                            account.clone(),
                             PoolType::Shielded(ShieldedProtocol::Orchard),
                         ),
                         change_value.value(),
@@ -1057,7 +1120,7 @@ where
                     .expect("An action should exist in the transaction for each Orchard output.");
 
                 let recipient = recipient
-                    .map_internal_account(|pool| {
+                    .map_internal_note(|pool| {
                         assert!(pool == PoolType::Shielded(ShieldedProtocol::Orchard));
                         build_result
                             .transaction()
@@ -1068,7 +1131,7 @@ where
                                     .map(|(note, _, _)| Note::Orchard(note))
                             })
                     })
-                    .internal_account_transpose_option()
+                    .internal_note_transpose_option()
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK");
 
                 SentTransactionOutput::from_parts(output_index, recipient, value, memo)
@@ -1087,7 +1150,7 @@ where
                     .expect("An output should exist in the transaction for each Sapling payment.");
 
                 let recipient = recipient
-                    .map_internal_account(|pool| {
+                    .map_internal_note(|pool| {
                         assert!(pool == PoolType::Shielded(ShieldedProtocol::Sapling));
                         build_result
                             .transaction()
@@ -1104,7 +1167,7 @@ where
                                 .map(|(note, _, _)| Note::Sapling(note))
                             })
                     })
-                    .internal_account_transpose_option()
+                    .internal_note_transpose_option()
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK");
 
                 SentTransactionOutput::from_parts(output_index, recipient, value, memo)
@@ -1206,6 +1269,7 @@ pub fn shield_transparent_funds<DbT, ParamsT, InputsT>(
 where
     ParamsT: consensus::Parameters,
     DbT: WalletWrite + WalletCommitmentTrees + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as WalletRead>::AccountId: Clone,
     InputsT: ShieldingSelector<InputSource = DbT>,
 {
     let proposal = propose_shielding(

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -314,7 +314,6 @@ impl<DbT, ChangeT: ChangeStrategy> GreedyInputSelector<DbT, ChangeT> {
 impl<DbT, ChangeT> InputSelector for GreedyInputSelector<DbT, ChangeT>
 where
     DbT: InputSource,
-    <DbT as InputSource>::AccountId: Clone,
     ChangeT: ChangeStrategy,
     ChangeT::FeeRule: Clone,
 {

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -17,7 +17,6 @@ use zcash_primitives::{
         },
         fees::FeeRule,
     },
-    zip32::AccountId,
 };
 
 use crate::{
@@ -149,7 +148,7 @@ pub trait InputSelector {
         wallet_db: &Self::InputSource,
         target_height: BlockHeight,
         anchor_height: BlockHeight,
-        account: AccountId,
+        account: <Self::InputSource as InputSource>::AccountId,
         transaction_request: TransactionRequest,
     ) -> Result<
         Proposal<Self::FeeRule, <Self::InputSource as InputSource>::NoteRef>,
@@ -315,6 +314,7 @@ impl<DbT, ChangeT: ChangeStrategy> GreedyInputSelector<DbT, ChangeT> {
 impl<DbT, ChangeT> InputSelector for GreedyInputSelector<DbT, ChangeT>
 where
     DbT: InputSource,
+    <DbT as InputSource>::AccountId: Clone,
     ChangeT: ChangeStrategy,
     ChangeT::FeeRule: Clone,
 {
@@ -329,7 +329,7 @@ where
         wallet_db: &Self::InputSource,
         target_height: BlockHeight,
         anchor_height: BlockHeight,
-        account: AccountId,
+        account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
     ) -> Result<
         Proposal<Self::FeeRule, DbT::NoteRef>,

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -252,7 +252,7 @@ impl fmt::Display for ScanError {
 pub fn scan_block<
     P: consensus::Parameters + Send + 'static,
     K: ScanningKey,
-    A: Clone + Default + Eq + Hash + Send + ConditionallySelectable + 'static,
+    A: Default + Eq + Hash + Send + ConditionallySelectable + 'static,
 >(
     params: &P,
     block: CompactBlock,
@@ -283,7 +283,7 @@ pub(crate) fn add_block_to_runner<P, S, T, A>(
     P: consensus::Parameters + Send + 'static,
     S: Clone + Send + 'static,
     T: Tasks<TaggedBatch<A, S>>,
-    A: Clone + Default + Eq + Send + 'static,
+    A: Copy + Default + Eq + Send + 'static,
 {
     let block_hash = block.hash();
     let block_height = block.height();
@@ -336,7 +336,7 @@ pub(crate) fn scan_block_with_runner<
     P: consensus::Parameters + Send + 'static,
     K: ScanningKey,
     T: Tasks<TaggedBatch<A, K::Scope>> + Sync,
-    A: Send + Clone + Default + Eq + Hash + ConditionallySelectable + 'static,
+    A: Send + Default + Eq + Hash + ConditionallySelectable + 'static,
 >(
     params: &P,
     block: CompactBlock,

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -14,7 +14,7 @@ use zcash_primitives::{
         fees::transparent as transparent_fees,
         TxId,
     },
-    zip32::{AccountId, Scope},
+    zip32::Scope,
 };
 
 use crate::{address::UnifiedAddress, fees::sapling as sapling_fees, PoolType, ShieldedProtocol};
@@ -65,15 +65,15 @@ impl NoteId {
 /// internal account ID and the pool to which funds were sent in the case of a wallet-internal
 /// output.
 #[derive(Debug, Clone)]
-pub enum Recipient<N> {
+pub enum Recipient<AccountId, N> {
     Transparent(TransparentAddress),
     Sapling(sapling::PaymentAddress),
     Unified(UnifiedAddress, PoolType),
     InternalAccount(AccountId, N),
 }
 
-impl<N> Recipient<N> {
-    pub fn map_internal_account<B, F: FnOnce(N) -> B>(self, f: F) -> Recipient<B> {
+impl<AccountId, N> Recipient<AccountId, N> {
+    pub fn map_internal_note<B, F: FnOnce(N) -> B>(self, f: F) -> Recipient<AccountId, B> {
         match self {
             Recipient::Transparent(t) => Recipient::Transparent(t),
             Recipient::Sapling(s) => Recipient::Sapling(s),
@@ -83,8 +83,8 @@ impl<N> Recipient<N> {
     }
 }
 
-impl<N> Recipient<Option<N>> {
-    pub fn internal_account_transpose_option(self) -> Option<Recipient<N>> {
+impl<AccountId, N> Recipient<AccountId, Option<N>> {
+    pub fn internal_note_transpose_option(self) -> Option<Recipient<AccountId, N>> {
         match self {
             Recipient::Transparent(t) => Some(Recipient::Transparent(t)),
             Recipient::Sapling(s) => Some(Recipient::Sapling(s)),
@@ -97,11 +97,11 @@ impl<N> Recipient<Option<N>> {
 /// A subset of a [`Transaction`] relevant to wallets and light clients.
 ///
 /// [`Transaction`]: zcash_primitives::transaction::Transaction
-pub struct WalletTx<N, S> {
+pub struct WalletTx<N, S, A> {
     pub txid: TxId,
     pub index: usize,
-    pub sapling_spends: Vec<WalletSaplingSpend>,
-    pub sapling_outputs: Vec<WalletSaplingOutput<N, S>>,
+    pub sapling_spends: Vec<WalletSaplingSpend<A>>,
+    pub sapling_outputs: Vec<WalletSaplingOutput<N, S, A>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,13 +161,13 @@ impl transparent_fees::InputView for WalletTransparentOutput {
 /// A subset of a [`SpendDescription`] relevant to wallets and light clients.
 ///
 /// [`SpendDescription`]: sapling::bundle::SpendDescription
-pub struct WalletSaplingSpend {
+pub struct WalletSaplingSpend<AccountId> {
     index: usize,
     nf: sapling::Nullifier,
     account: AccountId,
 }
 
-impl WalletSaplingSpend {
+impl<AccountId> WalletSaplingSpend<AccountId> {
     pub fn from_parts(index: usize, nf: sapling::Nullifier, account: AccountId) -> Self {
         Self { index, nf, account }
     }
@@ -178,8 +178,8 @@ impl WalletSaplingSpend {
     pub fn nf(&self) -> &sapling::Nullifier {
         &self.nf
     }
-    pub fn account(&self) -> AccountId {
-        self.account
+    pub fn account(&self) -> &AccountId {
+        &self.account
     }
 }
 
@@ -195,11 +195,11 @@ impl WalletSaplingSpend {
 /// `()` for sent notes.
 ///
 /// [`OutputDescription`]: sapling::bundle::OutputDescription
-pub struct WalletSaplingOutput<N, S> {
+pub struct WalletSaplingOutput<N, S, A> {
     index: usize,
     cmu: sapling::note::ExtractedNoteCommitment,
     ephemeral_key: EphemeralKeyBytes,
-    account: AccountId,
+    account: A,
     note: sapling::Note,
     is_change: bool,
     note_commitment_tree_position: Position,
@@ -207,14 +207,14 @@ pub struct WalletSaplingOutput<N, S> {
     recipient_key_scope: S,
 }
 
-impl<N, S> WalletSaplingOutput<N, S> {
+impl<N, S, A> WalletSaplingOutput<N, S, A> {
     /// Constructs a new `WalletSaplingOutput` value from its constituent parts.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
         index: usize,
         cmu: sapling::note::ExtractedNoteCommitment,
         ephemeral_key: EphemeralKeyBytes,
-        account: AccountId,
+        account: A,
         note: sapling::Note,
         is_change: bool,
         note_commitment_tree_position: Position,
@@ -243,8 +243,8 @@ impl<N, S> WalletSaplingOutput<N, S> {
     pub fn ephemeral_key(&self) -> &EphemeralKeyBytes {
         &self.ephemeral_key
     }
-    pub fn account(&self) -> AccountId {
-        self.account
+    pub fn account(&self) -> &A {
+        &self.account
     }
     pub fn note(&self) -> &sapling::Note {
         &self.note

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -73,7 +73,7 @@ pub enum Recipient<AccountId, N> {
 }
 
 impl<AccountId, N> Recipient<AccountId, N> {
-    pub fn map_internal_note<B, F: FnOnce(N) -> B>(self, f: F) -> Recipient<AccountId, B> {
+    pub fn map_internal_account_note<B, F: FnOnce(N) -> B>(self, f: F) -> Recipient<AccountId, B> {
         match self {
             Recipient::Transparent(t) => Recipient::Transparent(t),
             Recipient::Sapling(s) => Recipient::Sapling(s),
@@ -84,7 +84,7 @@ impl<AccountId, N> Recipient<AccountId, N> {
 }
 
 impl<AccountId, N> Recipient<AccountId, Option<N>> {
-    pub fn internal_note_transpose_option(self) -> Option<Recipient<AccountId, N>> {
+    pub fn internal_account_note_transpose_option(self) -> Option<Recipient<AccountId, N>> {
         match self {
             Recipient::Transparent(t) => Some(Recipient::Transparent(t)),
             Recipient::Sapling(s) => Some(Recipient::Sapling(s)),

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -386,13 +386,6 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
     fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error> {
         wallet::get_account_ids(self.conn.borrow())
     }
-
-    fn get_account(
-        &self,
-        account_id: &Self::AccountId,
-    ) -> Result<Option<data_api::wallet::Account>, Self::Error> {
-        wallet::get_account(self.conn.borrow(), &self.params, *account_id)
-    }
 }
 
 impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P> {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -179,6 +179,7 @@ impl<P: consensus::Parameters + Clone> WalletDb<Connection, P> {
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for WalletDb<C, P> {
     type Error = SqliteClientError;
     type NoteRef = ReceivedNoteId;
+    type AccountId = AccountId;
 
     fn get_spendable_note(
         &self,
@@ -242,6 +243,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
 
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for WalletDb<C, P> {
     type Error = SqliteClientError;
+    type AccountId = AccountId;
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
         wallet::scan_queue_extrema(self.conn.borrow())
@@ -322,7 +324,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
     fn get_wallet_summary(
         &self,
         min_confirmations: u32,
-    ) -> Result<Option<WalletSummary>, Self::Error> {
+    ) -> Result<Option<WalletSummary<Self::AccountId>>, Self::Error> {
         // This will return a runtime error if we call `get_wallet_summary` from two
         // threads at the same time, as transactions cannot nest.
         wallet::get_wallet_summary(
@@ -356,23 +358,6 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         }
     }
 
-    #[cfg(feature = "transparent-inputs")]
-    fn get_transparent_receivers(
-        &self,
-        _account: AccountId,
-    ) -> Result<HashMap<TransparentAddress, Option<TransparentAddressMetadata>>, Self::Error> {
-        wallet::get_transparent_receivers(self.conn.borrow(), &self.params, _account)
-    }
-
-    #[cfg(feature = "transparent-inputs")]
-    fn get_transparent_balances(
-        &self,
-        _account: AccountId,
-        _max_height: BlockHeight,
-    ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
-        wallet::get_transparent_balances(self.conn.borrow(), &self.params, _account, _max_height)
-    }
-
     #[cfg(feature = "orchard")]
     fn get_orchard_nullifiers(
         &self,
@@ -381,8 +366,32 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         todo!()
     }
 
+    #[cfg(feature = "transparent-inputs")]
+    fn get_transparent_receivers(
+        &self,
+        account: AccountId,
+    ) -> Result<HashMap<TransparentAddress, Option<TransparentAddressMetadata>>, Self::Error> {
+        wallet::get_transparent_receivers(self.conn.borrow(), &self.params, account)
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    fn get_transparent_balances(
+        &self,
+        account: AccountId,
+        max_height: BlockHeight,
+    ) -> Result<HashMap<TransparentAddress, Amount>, Self::Error> {
+        wallet::get_transparent_balances(self.conn.borrow(), &self.params, account, max_height)
+    }
+
     fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error> {
         wallet::get_account_ids(self.conn.borrow())
+    }
+
+    fn get_account(
+        &self,
+        account_id: &Self::AccountId,
+    ) -> Result<Option<data_api::wallet::Account>, Self::Error> {
+        wallet::get_account(self.conn.borrow(), &self.params, *account_id)
     }
 }
 
@@ -452,7 +461,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
     #[allow(clippy::type_complexity)]
     fn put_blocks(
         &mut self,
-        blocks: Vec<ScannedBlock<sapling::Nullifier, Scope>>,
+        blocks: Vec<ScannedBlock<sapling::Nullifier, Scope, Self::AccountId>>,
     ) -> Result<(), Self::Error> {
         self.transactionally(|wdb| {
             let start_positions = blocks.first().map(|block| {
@@ -591,7 +600,10 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
         Ok(())
     }
 
-    fn store_decrypted_tx(&mut self, d_tx: DecryptedTransaction) -> Result<(), Self::Error> {
+    fn store_decrypted_tx(
+        &mut self,
+        d_tx: DecryptedTransaction<AccountId>,
+    ) -> Result<(), Self::Error> {
         self.transactionally(|wdb| {
             let tx_ref = wallet::put_tx_data(wdb.conn.0, d_tx.tx, None, None)?;
 
@@ -683,7 +695,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
         })
     }
 
-    fn store_sent_tx(&mut self, sent_tx: &SentTransaction) -> Result<(), Self::Error> {
+    fn store_sent_tx(&mut self, sent_tx: &SentTransaction<AccountId>) -> Result<(), Self::Error> {
         self.transactionally(|wdb| {
             let tx_ref = wallet::put_tx_data(
                 wdb.conn.0,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -731,7 +731,10 @@ impl<Cache> TestState<Cache> {
         })
     }
 
-    pub(crate) fn get_wallet_summary(&self, min_confirmations: u32) -> Option<WalletSummary> {
+    pub(crate) fn get_wallet_summary(
+        &self,
+        min_confirmations: u32,
+    ) -> Option<WalletSummary<AccountId>> {
         get_wallet_summary(
             &self.wallet().conn.unchecked_transaction().unwrap(),
             &self.wallet().params,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -38,12 +38,12 @@ pub(crate) trait ReceivedSaplingOutput {
     fn recipient_key_scope(&self) -> Scope;
 }
 
-impl ReceivedSaplingOutput for WalletSaplingOutput<sapling::Nullifier, Scope> {
+impl ReceivedSaplingOutput for WalletSaplingOutput<sapling::Nullifier, Scope, AccountId> {
     fn index(&self) -> usize {
         self.index()
     }
     fn account(&self) -> AccountId {
-        WalletSaplingOutput::account(self)
+        *WalletSaplingOutput::account(self)
     }
     fn note(&self) -> &sapling::Note {
         WalletSaplingOutput::note(self)
@@ -66,7 +66,7 @@ impl ReceivedSaplingOutput for WalletSaplingOutput<sapling::Nullifier, Scope> {
     }
 }
 
-impl ReceivedSaplingOutput for DecryptedOutput<sapling::Note> {
+impl ReceivedSaplingOutput for DecryptedOutput<sapling::Note, AccountId> {
     fn index(&self) -> usize {
         self.index
     }


### PR DESCRIPTION
This PR was extracted from #1175 in order to make the changes to `zcash_client_backend` usable without the additional generalizations to `zcash_client_sqlite` made by that PR.