### PR TITLE
zcash_client_backend: Add `WalletRead::validate_seed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_proofs",
+ "zip32",
 ]
 
 [[package]]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -20,7 +20,6 @@ and this library adheres to Rust's notion of
   - `ORCHARD_SHARD_HEIGHT`
   - `BlockMetadata::orchard_tree_size`
   - `chain::ScanSummary::{spent_orchard_note_count, received_orchard_note_count}`
-  - `WalletRead::validate_seed`
 - `zcash_client_backend::fees`:
   - `orchard`
   - `ChangeValue::orchard`
@@ -51,6 +50,7 @@ and this library adheres to Rust's notion of
     - `type OrchardShardStore`
     - `fn with_orchard_tree_mut`
     - `fn put_orchard_subtree_roots`
+  - Added method `WalletRead::validate_seed`
 - `zcash_client_backend::fees`:
   - Arguments to `ChangeStrategy::compute_balance` have changed.
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -20,6 +20,7 @@ and this library adheres to Rust's notion of
   - `ORCHARD_SHARD_HEIGHT`
   - `BlockMetadata::orchard_tree_size`
   - `chain::ScanSummary::{spent_orchard_note_count, received_orchard_note_count}`
+  - `WalletRead::validate_seed`
 - `zcash_client_backend::fees`:
   - `orchard`
   - `ChangeValue::orchard`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -492,6 +492,17 @@ pub trait WalletRead {
     /// will be interpreted as belonging to that account.
     type AccountId: Copy + Debug + Eq + Hash;
 
+    /// Verifies that the given seed corresponds to the viewing key for the specified account.
+    ///
+    /// Returns `Ok(true)` if the viewing key for the specified account can be derived from
+    /// the provided seed, `Ok(false)` if the derived seed does not match or the specified
+    /// account is not present in the database, or an error in the case
+    fn validate_seed(
+        &self,
+        account_id: Self::AccountId,
+        seed: &SecretVec<u8>,
+    ) -> Result<bool, Self::Error>;
+
     /// Returns the height of the chain as known to the wallet as of the most recent call to
     /// [`WalletWrite::update_chain_tip`].
     ///
@@ -1317,14 +1328,15 @@ pub mod testing {
         type Error = ();
         type AccountId = u32;
 
-        fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
-            Ok(None)
+        fn validate_seed(
+            &self,
+            _account_id: Self::AccountId,
+            _seed: &SecretVec<u8>,
+        ) -> Result<bool, Self::Error> {
+            Ok(false)
         }
 
-        fn get_target_and_anchor_heights(
-            &self,
-            _min_confirmations: NonZeroU32,
-        ) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
+        fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
             Ok(None)
         }
 
@@ -1345,6 +1357,13 @@ pub mod testing {
 
         fn suggest_scan_ranges(&self) -> Result<Vec<ScanRange>, Self::Error> {
             Ok(vec![])
+        }
+
+        fn get_target_and_anchor_heights(
+            &self,
+            _min_confirmations: NonZeroU32,
+        ) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
+            Ok(None)
         }
 
         fn get_min_unspent_height(&self) -> Result<Option<BlockHeight>, Self::Error> {

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -494,9 +494,13 @@ pub trait WalletRead {
 
     /// Verifies that the given seed corresponds to the viewing key for the specified account.
     ///
-    /// Returns `Ok(true)` if the viewing key for the specified account can be derived from
-    /// the provided seed, `Ok(false)` if the derived seed does not match or the specified
-    /// account is not present in the database, or an error in the case
+    /// Returns:
+    /// - `Ok(true)` if the viewing key for the specified account can be derived from the
+    ///   provided seed.
+    /// - `Ok(false)` if the derived seed does not match, or the specified account is not
+    ///   present in the database.
+    /// - `Err(_)` if a Unified Spending Key cannot be derived from the seed for the
+    ///   specified account.
     fn validate_seed(
         &self,
         account_id: Self::AccountId,

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -24,6 +24,7 @@ zcash_client_backend = { workspace = true, features = ["unstable-serialization",
 zcash_encoding.workspace = true
 zcash_keys = { workspace = true, features = ["orchard", "sapling"] }
 zcash_primitives.workspace = true
+zip32.workspace = true
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_keys::keys::UnifiedAddressRequest::all`
+
 ## [0.1.0] - 2024-03-01
 The entries below are relative to the `zcash_client_backend` crate as of
 `zcash_client_backend 0.10.0`.

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -450,6 +450,9 @@ pub struct UnifiedAddressRequest {
 }
 
 impl UnifiedAddressRequest {
+    /// Construct a new unified address request from its constituent parts.
+    ///
+    /// Returns `None` if the resulting unified address would not include at least one shielded receiver.
     pub fn new(has_orchard: bool, has_sapling: bool, has_p2pkh: bool) -> Option<Self> {
         let has_shielded_receiver = has_orchard || has_sapling;
 
@@ -462,6 +465,24 @@ impl UnifiedAddressRequest {
                 has_p2pkh,
             })
         }
+    }
+
+    /// Constructs a new unified address request that includes a request for a receiver of each
+    /// type that is supported given the active feature flags.
+    pub fn all() -> Option<Self> {
+        let _has_orchard = false;
+        #[cfg(feature = "orchard")]
+        let _has_orchard = true;
+
+        let _has_sapling = false;
+        #[cfg(feature = "sapling")]
+        let _has_sapling = true;
+
+        let _has_p2pkh = false;
+        #[cfg(feature = "transparent-inputs")]
+        let _has_p2pkh = true;
+
+        Self::new(_has_orchard, _has_sapling, _has_p2pkh)
     }
 
     /// Construct a new unified address request from its constituent parts.


### PR DESCRIPTION
This adds a mechanism that allows a caller to verify that a given seed generates the viewing key that is stored in the wallet for a specified account.

Fixes #1189