### PR TITLE
Fixed cargo doc build failure

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -7,15 +7,11 @@
 //! shielded internal address belonging to their wallet.
 //!
 //! The important high-level operations provided by this module are [`propose_transfer`],
-//! [`propose_shielding`], and [`create_proposed_transactions`].
+//! and [`create_proposed_transactions`].
 //!
 //! [`propose_transfer`] takes a [`TransactionRequest`] object, selects inputs notes and
 //! computes the fees required to satisfy that request, and returns a [`Proposal`] object that
 //! describes the transaction to be made.
-//!
-//! [`propose_shielding`] takes a set of transparent source addresses, and constructs a
-//! [`Proposal`] to send those funds to a wallet-internal shielded address, as described in
-//! [ZIP 316](https://zips.z.cash/zip-0316).
 //!
 //! [`create_proposed_transactions`] constructs one or more Zcash [`Transaction`]s based upon a
 //! provided [`Proposal`], stores them to the wallet database, and returns the [`TxId`] for each
@@ -24,9 +20,18 @@
 //! the responsibility of the caller to retrieve and serialize the transactions and submit them for
 //! inclusion into the Zcash blockchain.
 //!
+#![cfg_attr(
+    feature = "transparent-inputs",
+    doc = "
+Another important high-level operation provided by this module is [`propose_shielding`], which
+takes a set of transparent source addresses, and constructs a [`Proposal`] to send those funds
+to a wallet-internal shielded address, as described in [ZIP 316](https://zips.z.cash/zip-0316).
+
+[`propose_shielding`]: crate::data_api::wallet::propose_shielding
+"
+)]
 //! [`TransactionRequest`]: crate::zip321::TransactionRequest
 //! [`propose_transfer`]: crate::data_api::wallet::propose_transfer
-//! [`propose_shielding`]: crate::data_api::wallet::propose_shielding
 
 use nonempty::NonEmpty;
 use rand_core::OsRng;


### PR DESCRIPTION
This fixes cargo doc build when transparent-inputs feature is not specified