### PR TITLE
zcash_client_sqlite: Only consider notes spendable when both seed fingerprint & key scope are available.

### DIFF
--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -276,7 +276,7 @@ mod tests {
                 memo BLOB,
                 spent INTEGER,
                 commitment_tree_position INTEGER,
-                recipient_key_scope INTEGER NOT NULL DEFAULT 0,
+                recipient_key_scope INTEGER,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account_id) REFERENCES accounts(id),
                 FOREIGN KEY (spent) REFERENCES transactions(id_tx),

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -173,7 +173,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 memo BLOB,
                 spent INTEGER,
                 commitment_tree_position INTEGER,
-                recipient_key_scope INTEGER NOT NULL DEFAULT 0,
+                recipient_key_scope INTEGER,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account_id) REFERENCES accounts(id),
                 FOREIGN KEY (spent) REFERENCES transactions(id_tx),


### PR DESCRIPTION
Closes #1203

This PR is best viewed with whitespace changes hidden.