### PR TITLE
Add `UnifiedIncomingViewingKey` struct

### DIFF
--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -208,7 +208,7 @@ impl Account {
     ) -> Result<(UnifiedAddress, DiversifierIndex), AddressGenerationError> {
         match &self.viewing_key {
             ViewingKey::Full(ufvk) => ufvk.default_address(request),
-            ViewingKey::Incoming(_uivk) => todo!(),
+            ViewingKey::Incoming(uivk) => uivk.default_address(request),
         }
     }
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -235,12 +235,10 @@ impl ViewingKey {
         }
     }
 
-    fn uivk(&self) -> Result<UnifiedIncomingViewingKey, SqliteClientError> {
+    fn uivk(&self) -> UnifiedIncomingViewingKey {
         match self {
-            ViewingKey::Full(ufvk) => Ok(ufvk
-                .to_unified_incoming_viewing_key()
-                .map_err(|e| SqliteClientError::CorruptedData(e.to_string()))?),
-            ViewingKey::Incoming(uivk) => Ok((**uivk).to_owned()),
+            ViewingKey::Full(ufvk) => ufvk.as_ref().to_unified_incoming_viewing_key(),
+            ViewingKey::Incoming(uivk) => uivk.as_ref().clone(),
         }
     }
 }
@@ -349,7 +347,7 @@ pub(crate) fn add_account<P: consensus::Parameters>(
             ":hd_seed_fingerprint": hd_seed_fingerprint.as_ref().map(|fp| fp.as_bytes()),
             ":hd_account_index": hd_account_index.map(u32::from),
             ":ufvk": viewing_key.ufvk().map(|ufvk| ufvk.encode(params)),
-            ":uivk": viewing_key.uivk()?.to_uivk().encode(&params.network_type()),
+            ":uivk": viewing_key.uivk().to_uivk().encode(&params.network_type()),
             ":orchard_fvk_item_cache": orchard_item,
             ":sapling_fvk_item_cache": sapling_item,
             ":p2pkh_fvk_item_cache": transparent_item,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -74,7 +74,7 @@ use std::io::{self, Cursor};
 use std::num::NonZeroU32;
 use std::ops::RangeInclusive;
 use tracing::debug;
-use zcash_address::unified::{Encoding, Ivk, Uivk};
+use zcash_address::unified::{Encoding, Uivk};
 use zcash_keys::keys::{
     AddressGenerationError, HdSeedFingerprint, UnifiedAddressRequest, UnifiedIncomingViewingKey,
 };
@@ -120,6 +120,7 @@ use {
     crate::UtxoId,
     rusqlite::Row,
     std::collections::BTreeSet,
+    zcash_address::unified::Ivk,
     zcash_client_backend::wallet::{TransparentAddressMetadata, WalletTransparentOutput},
     zcash_primitives::{
         legacy::{

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -122,7 +122,6 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
 
                     let uivk = ufvk_parsed
                         .to_unified_incoming_viewing_key()
-                        .map_err(|e| WalletMigrationError::CorruptedData(e.to_string()))?
                         .to_uivk()
                         .encode(&self.params.network_type());
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -5,7 +5,6 @@ use rusqlite::{named_params, Transaction};
 use schemer_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
-use zcash_address::unified::Encoding;
 use zcash_client_backend::{data_api::AccountKind, keys::UnifiedSpendingKey};
 use zcash_keys::keys::{HdSeedFingerprint, UnifiedFullViewingKey};
 use zcash_primitives::consensus;
@@ -122,8 +121,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
 
                     let uivk = ufvk_parsed
                         .to_unified_incoming_viewing_key()
-                        .to_uivk()
-                        .encode(&self.params.network_type());
+                        .encode(&self.params);
 
                     #[cfg(feature = "transparent-inputs")]
                     let transparent_item = ufvk_parsed.transparent().map(|k| k.serialize());

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -11,6 +11,11 @@ and this library adheres to Rust's notion of
 - `zcash_keys::address::Address::has_receiver`
 - `impl Display for zcash_keys::keys::AddressGenerationError`
 - `impl std::error::Error for zcash_keys::keys::AddressGenerationError`
+- `zcash_keys::keys::UnifiedError`
+- `zcash_keys::keys::UnifiedFullViewingKey::from_ufvk`
+- `zcash_keys::keys::UnifiedFullViewingKey::to_ufvk`
+- `zcash_keys::keys::UnifiedFullViewingKey::to_unified_incoming_viewing_key`
+- `zcash_keys::keys::UnifiedIncomingViewingKey`
 
 ### Changed
 - `zcash_keys::keys::AddressGenerationError` has a new variant
@@ -18,6 +23,10 @@ and this library adheres to Rust's notion of
 - `zcash_keys::keys::UnifiedFullViewingKey::{find_address, default_address}` 
   now return `Result<(UnifiedAddress, DiversifierIndex), AddressGenerationError>`
   (instead of `Option<(UnifiedAddress, DiversifierIndex)>` for `find_address`).
+- `zcash_keys::keys::AddressGenerationError`
+  - Dropped `Clone` trait
+  - Added `UnifiedError` variant.
+  - Added `HDWalletError` variant.
 
 ### Fixed
 - `UnifiedFullViewingKey::find_address` can now find an address for a diversifier

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -11,21 +11,20 @@ and this library adheres to Rust's notion of
 - `zcash_keys::address::Address::has_receiver`
 - `impl Display for zcash_keys::keys::AddressGenerationError`
 - `impl std::error::Error for zcash_keys::keys::AddressGenerationError`
+- `zcash_keys::keys::DecodingError`
 - `zcash_keys::keys::UnifiedFullViewingKey::from_ufvk`
 - `zcash_keys::keys::UnifiedFullViewingKey::to_ufvk`
 - `zcash_keys::keys::UnifiedFullViewingKey::to_unified_incoming_viewing_key`
 - `zcash_keys::keys::UnifiedIncomingViewingKey`
 
 ### Changed
-- `zcash_keys::keys::AddressGenerationError` has a new variant
-  `DiversifierSpaceExhausted`.
 - `zcash_keys::keys::UnifiedFullViewingKey::{find_address, default_address}` 
   now return `Result<(UnifiedAddress, DiversifierIndex), AddressGenerationError>`
   (instead of `Option<(UnifiedAddress, DiversifierIndex)>` for `find_address`).
 - `zcash_keys::keys::AddressGenerationError`
   - Dropped `Clone` trait
-- `zcash_keys::keys::DerivationError`
-  - Added `InvalidShieldedKey` variant.
+  - Added `KeyDecoding` variant.
+  - Added `DiversifierSpaceExhausted` variant.
 
 ### Fixed
 - `UnifiedFullViewingKey::find_address` can now find an address for a diversifier

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -18,13 +18,16 @@ and this library adheres to Rust's notion of
 - `zcash_keys::keys::UnifiedIncomingViewingKey`
 
 ### Changed
-- `zcash_keys::keys::UnifiedFullViewingKey::{find_address, default_address}` 
+- `zcash_keys::keys::UnifiedFullViewingKey::{find_address, default_address}`
   now return `Result<(UnifiedAddress, DiversifierIndex), AddressGenerationError>`
   (instead of `Option<(UnifiedAddress, DiversifierIndex)>` for `find_address`).
 - `zcash_keys::keys::AddressGenerationError`
-  - Dropped `Clone` trait
-  - Added `KeyDecoding` variant.
   - Added `DiversifierSpaceExhausted` variant.
+
+### Removed
+- `UnifiedFullViewingKey::new` has been placed behind the `test-dependencies`
+  feature flag. UFVKs should only be produced by derivation from the USK, or
+  parsed from their string representation.
 
 ### Fixed
 - `UnifiedFullViewingKey::find_address` can now find an address for a diversifier
@@ -37,7 +40,7 @@ and this library adheres to Rust's notion of
 - `zcash_keys::keys::UnifiedAddressRequest::all`
 
 ### Fixed
-- A missing application of the `sapling` feature flag was remedied; 
+- A missing application of the `sapling` feature flag was remedied;
   prior to this fix it was not possible to use this crate without the
   `sapling` feature enabled.
 

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -11,7 +11,6 @@ and this library adheres to Rust's notion of
 - `zcash_keys::address::Address::has_receiver`
 - `impl Display for zcash_keys::keys::AddressGenerationError`
 - `impl std::error::Error for zcash_keys::keys::AddressGenerationError`
-- `zcash_keys::keys::UnifiedError`
 - `zcash_keys::keys::UnifiedFullViewingKey::from_ufvk`
 - `zcash_keys::keys::UnifiedFullViewingKey::to_ufvk`
 - `zcash_keys::keys::UnifiedFullViewingKey::to_unified_incoming_viewing_key`
@@ -25,8 +24,8 @@ and this library adheres to Rust's notion of
   (instead of `Option<(UnifiedAddress, DiversifierIndex)>` for `find_address`).
 - `zcash_keys::keys::AddressGenerationError`
   - Dropped `Clone` trait
-  - Added `UnifiedError` variant.
-  - Added `HDWalletError` variant.
+- `zcash_keys::keys::DerivationError`
+  - Added `InvalidShieldedKey` variant.
 
 ### Fixed
 - `UnifiedFullViewingKey::find_address` can now find an address for a diversifier

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -23,6 +23,8 @@ and this library adheres to Rust's notion of
   (instead of `Option<(UnifiedAddress, DiversifierIndex)>` for `find_address`).
 - `zcash_keys::keys::AddressGenerationError`
   - Added `DiversifierSpaceExhausted` variant.
+- At least one of the `orchard`, `sapling`, or `transparent-inputs` features
+  must be enabled for the `keys` module to be accessible.
 
 ### Removed
 - `UnifiedFullViewingKey::new` has been placed behind the `test-dependencies`

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -12,8 +12,6 @@ and this library adheres to Rust's notion of
 - `impl Display for zcash_keys::keys::AddressGenerationError`
 - `impl std::error::Error for zcash_keys::keys::AddressGenerationError`
 - `zcash_keys::keys::DecodingError`
-- `zcash_keys::keys::UnifiedFullViewingKey::from_ufvk`
-- `zcash_keys::keys::UnifiedFullViewingKey::to_ufvk`
 - `zcash_keys::keys::UnifiedFullViewingKey::to_unified_incoming_viewing_key`
 - `zcash_keys::keys::UnifiedIncomingViewingKey`
 

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -342,7 +342,14 @@ impl Address {
     }
 }
 
-#[cfg(any(test, feature = "test-dependencies"))]
+#[cfg(all(
+    any(
+        feature = "orchard",
+        feature = "sapling",
+        feature = "transparent-inputs"
+    ),
+    any(test, feature = "test-dependencies")
+))]
 pub mod testing {
     use proptest::prelude::*;
     use zcash_primitives::consensus::Network;

--- a/zcash_keys/src/lib.rs
+++ b/zcash_keys/src/lib.rs
@@ -16,4 +16,10 @@
 
 pub mod address;
 pub mod encoding;
+
+#[cfg(any(
+    feature = "orchard",
+    feature = "sapling",
+    feature = "transparent-inputs"
+))]
 pub mod keys;


### PR DESCRIPTION
- [x] Remove some fn implementations in the UFVK type and have it instead simply forward to the UIVK type. For example address generation needn't be implemented twice.
- [x] Update zcash_client_sqlite where it left placeholders for using the new UIVK type.
- [x] ~~Consider adding ZIP-316 rev. 1 support to both UFVK and UIVK types.~~
- [x] Add tests