### PR TITLE
`zcash_client_backend 0.11.1`, `zcash_client_sqlite 0.9.1` with doc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "assert_matches",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_matches",
  "bs58",

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -53,6 +53,11 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::fees`:
   - Arguments to `ChangeStrategy::compute_balance` have changed.
 
+## [0.11.1] - 2024-03-09
+
+### Fixed
+- Documentation now correctly builds with all feature flags.
+
 ## [0.11.0] - 2024-03-01
 
 ### Added

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -21,7 +21,16 @@ exclude = ["*.proto"]
 development = ["zcash_proofs"]
 
 [package.metadata.docs.rs]
-all-features = true
+# Manually specify features while `orchard` is not in the public API.
+#all-features = true
+features = [
+    "lightwalletd-tonic",
+    "transparent-inputs",
+    "test-dependencies",
+    "unstable",
+    "unstable-serialization",
+    "unstable-spanning-tree",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -7,15 +7,11 @@
 //! shielded internal address belonging to their wallet.
 //!
 //! The important high-level operations provided by this module are [`propose_transfer`],
-//! [`propose_shielding`], and [`create_proposed_transactions`].
+//! and [`create_proposed_transactions`].
 //!
 //! [`propose_transfer`] takes a [`TransactionRequest`] object, selects inputs notes and
 //! computes the fees required to satisfy that request, and returns a [`Proposal`] object that
 //! describes the transaction to be made.
-//!
-//! [`propose_shielding`] takes a set of transparent source addresses, and constructs a
-//! [`Proposal`] to send those funds to a wallet-internal shielded address, as described in
-//! [ZIP 316](https://zips.z.cash/zip-0316).
 //!
 //! [`create_proposed_transactions`] constructs one or more Zcash [`Transaction`]s based upon a
 //! provided [`Proposal`], stores them to the wallet database, and returns the [`TxId`] for each
@@ -24,9 +20,18 @@
 //! the responsibility of the caller to retrieve and serialize the transactions and submit them for
 //! inclusion into the Zcash blockchain.
 //!
+#![cfg_attr(
+    feature = "transparent-inputs",
+    doc = "
+Another important high-level operation provided by this module is [`propose_shielding`], which
+takes a set of transparent source addresses, and constructs a [`Proposal`] to send those funds
+to a wallet-internal shielded address, as described in [ZIP 316](https://zips.z.cash/zip-0316).
+
+[`propose_shielding`]: crate::data_api::wallet::propose_shielding
+"
+)]
 //! [`TransactionRequest`]: crate::zip321::TransactionRequest
 //! [`propose_transfer`]: crate::data_api::wallet::propose_transfer
-//! [`propose_shielding`]: crate::data_api::wallet::propose_shielding
 
 use nonempty::NonEmpty;
 use rand_core::OsRng;

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,11 @@ and this library adheres to Rust's notion of
 - A new `orchard` feature flag has been added to make it possible to
   build client code without `orchard` dependendencies.
 
+## [0.9.1] - 2024-03-09
+
+### Fixed
+- Documentation now correctly builds with all feature flags.
+
 ## [0.9.0] - 2024-03-01
 
 ### Changed

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -15,7 +15,14 @@ rust-version.workspace = true
 categories.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
+# Manually specify features while `orchard` is not in the public API.
+#all-features = true
+features = [
+    "multicore",
+    "test-dependencies",
+    "transparent-inputs",
+    "unstable",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"


### PR DESCRIPTION
These releases should enable documentation to be built for the `zcash_client_backend 0.11` and `zcash_client_sqlite 0.9` versions, which had significant changes.

Backports #1228 onto `zcash_client_backend 0.11.0`.