### PR TITLE
zcash_client_sqlite: Run single-shielded-pool tests on Orchard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix.extra_flags != 'NOT_A_PUZZLE' && format(' with --features {0}', matrix.extra_flags) || ''
       }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.extra_flags != 'NOT_A_PUZZLE' }}
     strategy:
       matrix:
         os: [ubuntu-latest-8cores, windows-latest-8cores, macOS-latest]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,6 +3069,7 @@ dependencies = [
  "pasta_curves",
  "proptest",
  "prost",
+ "rand_chacha",
  "rand_core",
  "regex",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,21 +3102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_extensions"
-version = "0.0.0"
-dependencies = [
- "blake2b_simd",
- "ff",
- "jubjub",
- "orchard",
- "rand_core",
- "sapling-crypto",
- "zcash_address",
- "zcash_primitives",
- "zcash_proofs",
-]
-
-[[package]]
 name = "zcash_history"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
     "components/zcash_protocol",
     "zcash_client_backend",
     "zcash_client_sqlite",
-    "zcash_extensions",
+    # Disabled until we replace the `zfutures` feature flag with a compiler flag.
+    # "zcash_extensions",
     "zcash_history",
     "zcash_keys",
     "zcash_primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ lazy_static = "1"
 assert_matches = "1.5"
 criterion = "0.4"
 proptest = "1"
+rand_chacha = "0.3"
 rand_xorshift = "0.3"
 
 # ZIP 32

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -90,11 +90,14 @@ zcash_keys = { workspace = true, features = ["test-dependencies"] }
 zcash_note_encryption.workspace = true
 zcash_proofs = { workspace = true, features = ["bundled-prover"] }
 zcash_primitives = { workspace = true, features = ["test-dependencies"] }
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
 zcash_client_backend = { workspace = true, features = ["test-dependencies", "unstable-serialization", "unstable-spanning-tree"] }
 zcash_address = { workspace = true, features = ["test-dependencies"] }
 
 [features]
 default = ["multicore"]
+unstable-nu6 = ["zcash_primitives/unstable-nu6"]
+zfuture = ["zcash_primitives/zfuture"]
 
 ## Enables multithreading support for creating proofs and building subtrees.
 multicore = ["maybe-rayon/threads", "zcash_primitives/multicore"]

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -83,6 +83,7 @@ pasta_curves.workspace = true
 shardtree = { workspace = true, features = ["legacy-api", "test-dependencies"] }
 nonempty.workspace = true
 proptest.workspace = true
+rand_chacha.workspace = true
 rand_core.workspace = true
 regex = "1.4"
 tempfile = "3.5.0"

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -111,6 +111,8 @@ pub(crate) const PRUNING_DEPTH: u32 = 100;
 pub(crate) const VERIFY_LOOKAHEAD: u32 = 10;
 
 pub(crate) const SAPLING_TABLES_PREFIX: &str = "sapling";
+#[cfg(feature = "orchard")]
+pub(crate) const ORCHARD_TABLES_PREFIX: &str = "orchard";
 
 #[cfg(not(feature = "transparent-inputs"))]
 pub(crate) const UA_TRANSPARENT: bool = false;

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -501,6 +501,14 @@ impl<Cache> TestState<Cache> {
             .and_then(|(_, _, usk, _)| usk.to_unified_full_viewing_key().sapling().cloned())
     }
 
+    /// Exposes the test account's Sapling DFVK, if enabled via [`TestBuilder::with_test_account`].
+    #[cfg(feature = "orchard")]
+    pub(crate) fn test_account_orchard(&self) -> Option<orchard::keys::FullViewingKey> {
+        self.test_account
+            .as_ref()
+            .and_then(|(_, _, usk, _)| usk.to_unified_full_viewing_key().orchard().cloned())
+    }
+
     /// Invokes [`create_spend_to_address`] with the given arguments.
     #[allow(deprecated)]
     #[allow(clippy::type_complexity)]

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -147,7 +147,7 @@ pub(crate) fn send_single_step_proposed_transfer<T: ShieldedPoolTester>() {
         h
     );
 
-    let to_extsk = T::sk(&[]);
+    let to_extsk = T::sk(&[0xf5; 32]);
     let to: Address = T::sk_default_address(&to_extsk);
     let request = zip321::TransactionRequest::new(vec![Payment {
         recipient_address: to,
@@ -522,7 +522,7 @@ pub(crate) fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>() {
     );
 
     // Spend fails because there are insufficient verified notes
-    let extsk2 = T::sk(&[]);
+    let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
     assert_matches!(
         st.propose_standard_transfer::<Infallible>(
@@ -643,7 +643,7 @@ pub(crate) fn spend_fails_on_locked_notes<T: ShieldedPoolTester>() {
     assert_eq!(st.get_spendable_balance(account, 1), value);
 
     // Send some of the funds to another address, but don't mine the tx.
-    let extsk2 = T::sk(&[]);
+    let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
     let min_confirmations = NonZeroU32::new(1).unwrap();
     let proposal = st
@@ -774,7 +774,7 @@ pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     assert_eq!(st.get_total_balance(account), value);
     assert_eq!(st.get_spendable_balance(account, 1), value);
 
-    let extsk2 = T::sk(&[]);
+    let extsk2 = T::sk(&[0xf5; 32]);
     let addr2 = T::sk_default_address(&extsk2);
 
     // TODO: This test was originally written to use the pre-zip-313 fee rule
@@ -1267,7 +1267,7 @@ pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
     let initial_orchard_tree_size = 0;
 
     // Generate 9 blocks that have no value for us, starting at the birthday height.
-    let not_our_key = T::sk_to_fvk(&T::sk(&[]));
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
     let not_our_value = NonNegativeAmount::const_from_u64(10000);
     st.generate_block_at(
         birthday.height(),
@@ -1346,7 +1346,7 @@ pub(crate) fn checkpoint_gaps<T: ShieldedPoolTester>() {
 
     // Create a gap of 10 blocks having no shielded outputs, then add a block that doesn't
     // belong to us so that we can get a checkpoint in the tree.
-    let not_our_key = T::sk_to_fvk(&T::sk(&[]));
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
     let not_our_value = NonNegativeAmount::const_from_u64(10000);
     st.generate_block_at(
         birthday.height() + 10,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -46,7 +46,8 @@ use crate::{
     error::SqliteClientError,
     testing::{input_selector, AddressType, BlockCache, TestBuilder, TestState},
     wallet::{
-        block_max_scanned, commitment_tree, parse_scope, scanning::tests::test_with_canopy_birthday,
+        block_max_scanned, commitment_tree, parse_scope,
+        scanning::tests::test_with_nu5_birthday_offset,
     },
     AccountId, NoteId, ReceivedNoteId,
 };
@@ -1226,7 +1227,8 @@ pub(crate) fn shield_transparent<T: ShieldedPoolTester>() {
 }
 
 pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
-    let (mut st, dfvk, birthday, _) = test_with_canopy_birthday::<T>();
+    // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
+    let (mut st, dfvk, birthday, _) = test_with_nu5_birthday_offset::<T>(76);
 
     // Set up the following situation:
     //

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -127,6 +127,8 @@ use {
 
 pub mod commitment_tree;
 pub mod init;
+#[cfg(feature = "orchard")]
+pub(crate) mod orchard;
 pub(crate) mod sapling;
 pub(crate) mod scanning;
 

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -1111,6 +1111,52 @@ mod tests {
         ShardTree::new(store, m)
     }
 
+    #[cfg(feature = "orchard")]
+    mod orchard {
+        use super::new_tree;
+        use crate::wallet::orchard::tests::OrchardPoolTester;
+
+        #[test]
+        fn append() {
+            super::check_append(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn root_hashes() {
+            super::check_root_hashes(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn witnesses() {
+            super::check_witnesses(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn witness_consistency() {
+            super::check_witness_consistency(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn checkpoint_rewind() {
+            super::check_checkpoint_rewind(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn remove_mark() {
+            super::check_remove_mark(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn rewind_remove_mark() {
+            super::check_rewind_remove_mark(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn put_shard_roots() {
+            super::put_shard_roots::<OrchardPoolTester>()
+        }
+    }
+
     #[test]
     fn sapling_append() {
         check_append(new_tree::<SaplingPoolTester>);

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1,0 +1,238 @@
+#[cfg(test)]
+pub(crate) mod tests {
+    use incrementalmerkletree::{Hashable, Level};
+    use orchard::{
+        keys::{FullViewingKey, SpendingKey},
+        note_encryption::OrchardDomain,
+        tree::MerkleHashOrchard,
+    };
+    use shardtree::error::ShardTreeError;
+    use zcash_client_backend::{
+        data_api::{
+            chain::CommitmentTreeRoot, DecryptedTransaction, WalletCommitmentTrees, WalletSummary,
+        },
+        wallet::{Note, ReceivedNote},
+    };
+    use zcash_keys::{
+        address::{Address, UnifiedAddress},
+        keys::UnifiedSpendingKey,
+    };
+    use zcash_note_encryption::try_output_recovery_with_ovk;
+    use zcash_primitives::transaction::Transaction;
+    use zcash_protocol::{consensus::BlockHeight, memo::MemoBytes, ShieldedProtocol};
+
+    use crate::{
+        error::SqliteClientError,
+        testing::{
+            self,
+            pool::{OutputRecoveryError, ShieldedPoolTester},
+            TestState,
+        },
+        wallet::commitment_tree,
+        ORCHARD_TABLES_PREFIX,
+    };
+
+    pub(crate) struct OrchardPoolTester;
+    impl ShieldedPoolTester for OrchardPoolTester {
+        const SHIELDED_PROTOCOL: ShieldedProtocol = ShieldedProtocol::Orchard;
+        const TABLES_PREFIX: &'static str = ORCHARD_TABLES_PREFIX;
+
+        type Sk = SpendingKey;
+        type Fvk = FullViewingKey;
+        type MerkleTreeHash = MerkleHashOrchard;
+
+        fn test_account_fvk<Cache>(st: &TestState<Cache>) -> Self::Fvk {
+            st.test_account_orchard().unwrap()
+        }
+
+        fn usk_to_sk(usk: &UnifiedSpendingKey) -> &Self::Sk {
+            usk.orchard()
+        }
+
+        fn sk(seed: &[u8]) -> Self::Sk {
+            let mut account = zip32::AccountId::ZERO;
+            loop {
+                if let Ok(sk) = SpendingKey::from_zip32_seed(seed, 1, account) {
+                    break sk;
+                }
+                account = account.next().unwrap();
+            }
+        }
+
+        fn sk_to_fvk(sk: &Self::Sk) -> Self::Fvk {
+            sk.into()
+        }
+
+        fn sk_default_address(sk: &Self::Sk) -> Address {
+            Self::fvk_default_address(&Self::sk_to_fvk(sk))
+        }
+
+        fn fvk_default_address(fvk: &Self::Fvk) -> Address {
+            UnifiedAddress::from_receivers(
+                Some(fvk.address_at(0u32, zip32::Scope::External)),
+                None,
+                None,
+            )
+            .unwrap()
+            .into()
+        }
+
+        fn fvks_equal(a: &Self::Fvk, b: &Self::Fvk) -> bool {
+            a == b
+        }
+
+        fn empty_tree_leaf() -> Self::MerkleTreeHash {
+            MerkleHashOrchard::empty_leaf()
+        }
+
+        fn empty_tree_root(level: Level) -> Self::MerkleTreeHash {
+            MerkleHashOrchard::empty_root(level)
+        }
+
+        fn put_subtree_roots<Cache>(
+            st: &mut TestState<Cache>,
+            start_index: u64,
+            roots: &[CommitmentTreeRoot<Self::MerkleTreeHash>],
+        ) -> Result<(), ShardTreeError<commitment_tree::Error>> {
+            st.wallet_mut()
+                .put_orchard_subtree_roots(start_index, roots)
+        }
+
+        fn next_subtree_index(s: &WalletSummary<crate::AccountId>) -> u64 {
+            todo!()
+        }
+
+        fn select_spendable_notes<Cache>(
+            st: &TestState<Cache>,
+            account: crate::AccountId,
+            target_value: zcash_protocol::value::Zatoshis,
+            anchor_height: BlockHeight,
+            exclude: &[crate::ReceivedNoteId],
+        ) -> Result<Vec<ReceivedNote<crate::ReceivedNoteId, Note>>, SqliteClientError> {
+            todo!()
+        }
+
+        fn decrypted_pool_outputs_count(
+            d_tx: &DecryptedTransaction<'_, crate::AccountId>,
+        ) -> usize {
+            d_tx.orchard_outputs().len()
+        }
+
+        fn with_decrypted_pool_memos(
+            d_tx: &DecryptedTransaction<'_, crate::AccountId>,
+            mut f: impl FnMut(&MemoBytes),
+        ) {
+            for output in d_tx.orchard_outputs() {
+                f(output.memo());
+            }
+        }
+
+        fn try_output_recovery<Cache>(
+            _: &TestState<Cache>,
+            _: BlockHeight,
+            tx: &Transaction,
+            fvk: &Self::Fvk,
+        ) -> Result<Option<(Note, Address, MemoBytes)>, OutputRecoveryError> {
+            for action in tx.orchard_bundle().unwrap().actions() {
+                // Find the output that decrypts with the external OVK
+                let result = try_output_recovery_with_ovk(
+                    &OrchardDomain::for_action(action),
+                    &fvk.to_ovk(zip32::Scope::External),
+                    action,
+                    action.cv_net(),
+                    &action.encrypted_note().out_ciphertext,
+                );
+
+                if result.is_some() {
+                    return Ok(result.map(|(note, addr, memo)| {
+                        (
+                            Note::Orchard(note),
+                            UnifiedAddress::from_receivers(Some(addr), None, None)
+                                .unwrap()
+                                .into(),
+                            MemoBytes::from_bytes(&memo).expect("correct length"),
+                        )
+                    }));
+                }
+            }
+
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn send_single_step_proposed_transfer() {
+        testing::pool::send_single_step_proposed_transfer::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn send_multi_step_proposed_transfer() {
+        testing::pool::send_multi_step_proposed_transfer::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn create_to_address_fails_on_incorrect_usk() {
+        testing::pool::create_to_address_fails_on_incorrect_usk::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn proposal_fails_with_no_blocks() {
+        testing::pool::proposal_fails_with_no_blocks::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn spend_fails_on_unverified_notes() {
+        testing::pool::spend_fails_on_unverified_notes::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn spend_fails_on_locked_notes() {
+        testing::pool::spend_fails_on_locked_notes::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn ovk_policy_prevents_recovery_from_chain() {
+        testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn spend_succeeds_to_t_addr_zero_change() {
+        testing::pool::spend_succeeds_to_t_addr_zero_change::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn change_note_spends_succeed() {
+        testing::pool::change_note_spends_succeed::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn external_address_change_spends_detected_in_restore_from_seed() {
+        testing::pool::external_address_change_spends_detected_in_restore_from_seed::<
+            OrchardPoolTester,
+        >()
+    }
+
+    #[test]
+    fn zip317_spend() {
+        testing::pool::zip317_spend::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn shield_transparent() {
+        testing::pool::shield_transparent::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn birthday_in_anchor_shard() {
+        testing::pool::birthday_in_anchor_shard::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn checkpoint_gaps() {
+        testing::pool::checkpoint_gaps::<OrchardPoolTester>()
+    }
+}

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -708,14 +708,16 @@ pub(crate) mod tests {
         );
     }
 
-    pub(crate) fn test_with_canopy_birthday<T: ShieldedPoolTester>(
+    pub(crate) fn test_with_nu5_birthday_offset<T: ShieldedPoolTester>(
+        offset: u32,
     ) -> (TestState<BlockCache>, T::Fvk, AccountBirthday, u32) {
         let st = TestBuilder::new()
             .with_block_cache()
             .with_test_account(|network| {
-                // We use Canopy activation as an arbitrary birthday height that's greater than Sapling
-                // activation. We set the Canopy Sapling frontier to be 1234 notes into the second shard.
-                let birthday_height = network.activation_height(NetworkUpgrade::Canopy).unwrap();
+                // We set the Sapling frontier at the birthday height to be 1234 notes
+                // into the second shard.
+                let birthday_height =
+                    network.activation_height(NetworkUpgrade::Nu5).unwrap() + offset;
                 let sapling_frontier_position = Position::from((0x1 << 16) + 1234);
                 let sapling_frontier = Frontier::from_parts(
                     sapling_frontier_position,
@@ -754,7 +756,8 @@ pub(crate) mod tests {
     fn create_account_creates_ignored_range<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
-        let (st, _, birthday, sap_active) = test_with_canopy_birthday::<T>();
+        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
+        let (st, _, birthday, sap_active) = test_with_nu5_birthday_offset::<T>(76);
         let birthday_height = birthday.height().into();
 
         let expected = vec![
@@ -823,7 +826,8 @@ pub(crate) mod tests {
     fn update_chain_tip_with_no_subtree_roots<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
-        let (mut st, _, birthday, sap_active) = test_with_canopy_birthday::<T>();
+        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
+        let (mut st, _, birthday, sap_active) = test_with_nu5_birthday_offset::<T>(76);
 
         // Set up the following situation:
         //
@@ -864,7 +868,8 @@ pub(crate) mod tests {
     fn update_chain_tip_when_never_scanned<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
-        let (mut st, _, birthday, sap_active) = test_with_canopy_birthday::<T>();
+        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
+        let (mut st, _, birthday, sap_active) = test_with_nu5_birthday_offset::<T>(76);
 
         // Set up the following situation:
         //
@@ -919,8 +924,9 @@ pub(crate) mod tests {
     fn update_chain_tip_unstable_max_scanned<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
+        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
         // this birthday is 1234 notes into the second shard
-        let (mut st, dfvk, birthday, sap_active) = test_with_canopy_birthday::<T>();
+        let (mut st, dfvk, birthday, sap_active) = test_with_nu5_birthday_offset::<T>(76);
 
         // Set up the following situation:
         //
@@ -1057,7 +1063,8 @@ pub(crate) mod tests {
     fn update_chain_tip_stable_max_scanned<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
-        let (mut st, dfvk, birthday, sap_active) = test_with_canopy_birthday::<T>();
+        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
+        let (mut st, dfvk, birthday, sap_active) = test_with_nu5_birthday_offset::<T>(76);
 
         // Set up the following situation:
         //

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -565,9 +565,18 @@ pub(crate) mod tests {
         VERIFY_LOOKAHEAD,
     };
 
+    #[cfg(feature = "orchard")]
+    use crate::wallet::orchard::tests::OrchardPoolTester;
+
     #[test]
     fn sapling_scan_complete() {
         scan_complete::<SaplingPoolTester>();
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_scan_complete() {
+        scan_complete::<OrchardPoolTester>();
     }
 
     fn scan_complete<T: ShieldedPoolTester>() {
@@ -736,6 +745,12 @@ pub(crate) mod tests {
         create_account_creates_ignored_range::<SaplingPoolTester>();
     }
 
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_create_account_creates_ignored_range() {
+        create_account_creates_ignored_range::<OrchardPoolTester>();
+    }
+
     fn create_account_creates_ignored_range<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
@@ -799,6 +814,12 @@ pub(crate) mod tests {
         update_chain_tip_with_no_subtree_roots::<SaplingPoolTester>();
     }
 
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_update_chain_tip_with_no_subtree_roots() {
+        update_chain_tip_with_no_subtree_roots::<OrchardPoolTester>();
+    }
+
     fn update_chain_tip_with_no_subtree_roots<T: ShieldedPoolTester>() {
         use ScanPriority::*;
 
@@ -832,6 +853,12 @@ pub(crate) mod tests {
     #[test]
     fn sapling_update_chain_tip_when_never_scanned() {
         update_chain_tip_when_never_scanned::<SaplingPoolTester>();
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_update_chain_tip_when_never_scanned() {
+        update_chain_tip_when_never_scanned::<OrchardPoolTester>();
     }
 
     fn update_chain_tip_when_never_scanned<T: ShieldedPoolTester>() {
@@ -881,6 +908,12 @@ pub(crate) mod tests {
     #[test]
     fn sapling_update_chain_tip_unstable_max_scanned() {
         update_chain_tip_unstable_max_scanned::<SaplingPoolTester>();
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_update_chain_tip_unstable_max_scanned() {
+        update_chain_tip_unstable_max_scanned::<OrchardPoolTester>();
     }
 
     fn update_chain_tip_unstable_max_scanned<T: ShieldedPoolTester>() {
@@ -1013,6 +1046,12 @@ pub(crate) mod tests {
     #[test]
     fn sapling_update_chain_tip_stable_max_scanned() {
         update_chain_tip_stable_max_scanned::<SaplingPoolTester>();
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_update_chain_tip_stable_max_scanned() {
+        update_chain_tip_stable_max_scanned::<OrchardPoolTester>();
     }
 
     fn update_chain_tip_stable_max_scanned<T: ShieldedPoolTester>() {


### PR DESCRIPTION
Almost all of these tests currently fail, as expected.

This PR also makes some fixes and improvements to the test harness, that arose from debugging the new Orchard code.