### PR TITLE
Account APIs needed for the mobile SDKs

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -54,10 +54,10 @@ and this library adheres to Rust's notion of
   - Arguments to `ScannedBlock::from_parts` have changed.
   - Changes to the `WalletRead` trait:
     - Added `Account` associated type.
-    - Added `get_orchard_nullifiers` method.
-    - `get_account_for_ufvk` now returns an `Self::Account` instead of a bare
-      `AccountId`
+    - `get_account_for_ufvk` now returns `Self::Account` instead of a bare
+      `AccountId`.
     - Added `get_seed_account` method.
+    - Added `get_orchard_nullifiers` method.
   - Changes to the `InputSource` trait:
     - `select_spendable_notes` now takes its `target_value` argument as a
       `NonNegativeAmount`. Also, the values of the returned map are also

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -54,9 +54,9 @@ and this library adheres to Rust's notion of
   - Arguments to `ScannedBlock::from_parts` have changed.
   - Changes to the `WalletRead` trait:
     - Added `Account` associated type.
+    - Added `get_derived_account` method.
     - `get_account_for_ufvk` now returns `Self::Account` instead of a bare
       `AccountId`.
-    - Added `get_seed_account` method.
     - Added `get_orchard_nullifiers` method.
   - Changes to the `InputSource` trait:
     - `select_spendable_notes` now takes its `target_value` argument as a

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -16,6 +16,7 @@ and this library adheres to Rust's notion of
   - `Account`
   - `AccountBalance::with_orchard_balance_mut`
   - `AccountBirthday::orchard_frontier`
+  - `AccountKind`
   - `BlockMetadata::orchard_tree_size`
   - `DecryptedTransaction::{new, tx(), orchard_outputs()}`
   - `ScannedBlock::orchard`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -54,6 +54,7 @@ and this library adheres to Rust's notion of
   - Arguments to `ScannedBlock::from_parts` have changed.
   - Changes to the `WalletRead` trait:
     - Added `Account` associated type.
+    - Added `get_account` method.
     - Added `get_derived_account` method.
     - `get_account_for_ufvk` now returns `Self::Account` instead of a bare
       `AccountId`.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -576,7 +576,7 @@ pub trait WalletRead {
 
     /// Returns the account corresponding to a given [`HdSeedFingerprint`] and
     /// [`zip32::AccountId`], if any.
-    fn get_seed_account(
+    fn get_derived_account(
         &self,
         seed: &HdSeedFingerprint,
         account_id: zip32::AccountId,
@@ -1553,7 +1553,7 @@ pub mod testing {
             Ok(Vec::new())
         }
 
-        fn get_seed_account(
+        fn get_derived_account(
             &self,
             _seed: &HdSeedFingerprint,
             _account_id: zip32::AccountId,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -574,6 +574,12 @@ pub trait WalletRead {
     /// Returns a vector with the IDs of all accounts known to this wallet.
     fn get_account_ids(&self) -> Result<Vec<Self::AccountId>, Self::Error>;
 
+    /// Returns the account corresponding to the given ID, if any.
+    fn get_account(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Result<Option<Self::Account>, Self::Error>;
+
     /// Returns the account corresponding to a given [`HdSeedFingerprint`] and
     /// [`zip32::AccountId`], if any.
     fn get_derived_account(
@@ -1551,6 +1557,13 @@ pub mod testing {
 
         fn get_account_ids(&self) -> Result<Vec<Self::AccountId>, Self::Error> {
             Ok(Vec::new())
+        }
+
+        fn get_account(
+            &self,
+            _account_id: Self::AccountId,
+        ) -> Result<Option<Self::Account>, Self::Error> {
+            Ok(None)
         }
 
         fn get_derived_account(

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,7 +10,8 @@ and this library adheres to Rust's notion of
 ### Added
 - A new `orchard` feature flag has been added to make it possible to
   build client code without `orchard` dependendencies.
-- `zcash_client_sqlite::AccountId` 
+- `zcash_client_sqlite::AccountId`
+- `zcash_client_sqlite::wallet::Account`
 - `impl From<zcash_keys::keys::AddressGenerationError> for SqliteClientError`
 
 ### Changed

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -60,9 +60,9 @@ use zcash_client_backend::{
         self,
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
-        AccountBirthday, BlockMetadata, DecryptedTransaction, InputSource, NullifierQuery,
-        ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
-        WalletWrite, SAPLING_SHARD_HEIGHT,
+        Account, AccountBirthday, AccountKind, BlockMetadata, DecryptedTransaction, InputSource,
+        NullifierQuery, ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead,
+        WalletSummary, WalletWrite, SAPLING_SHARD_HEIGHT,
     },
     keys::{
         AddressGenerationError, UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey,
@@ -100,7 +100,7 @@ pub mod error;
 pub mod wallet;
 use wallet::{
     commitment_tree::{self, put_shard_roots},
-    AccountType, SubtreeScanProgress,
+    SubtreeScanProgress,
 };
 
 #[cfg(test)]
@@ -307,10 +307,10 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         seed: &SecretVec<u8>,
     ) -> Result<bool, Self::Error> {
         if let Some(account) = wallet::get_account(self, account_id)? {
-            if let AccountType::Derived {
+            if let AccountKind::Derived {
                 seed_fingerprint,
                 account_index,
-            } = account.kind
+            } = account.kind()
             {
                 let seed_fingerprint_match = HdSeedFingerprint::from_seed(seed) == seed_fingerprint;
 
@@ -507,7 +507,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
             let account_id = wallet::add_account(
                 wdb.conn.0,
                 &wdb.params,
-                AccountType::Derived {
+                AccountKind::Derived {
                     seed_fingerprint,
                     account_index,
                 },

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -293,6 +293,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         wallet::get_account_ids(self.conn.borrow())
     }
 
+    fn get_account(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Result<Option<Self::Account>, Self::Error> {
+        wallet::get_account(self.conn.borrow(), &self.params, account_id)
+    }
+
     fn get_derived_account(
         &self,
         seed: &HdSeedFingerprint,
@@ -306,7 +313,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         account_id: Self::AccountId,
         seed: &SecretVec<u8>,
     ) -> Result<bool, Self::Error> {
-        if let Some(account) = wallet::get_account(self, account_id)? {
+        if let Some(account) = self.get_account(account_id)? {
             if let AccountKind::Derived {
                 seed_fingerprint,
                 account_index,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -287,7 +287,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for WalletDb<C, P> {
     type Error = SqliteClientError;
     type AccountId = AccountId;
-    type Account = (AccountId, Option<UnifiedFullViewingKey>);
+    type Account = wallet::Account;
 
     fn get_account_ids(&self) -> Result<Vec<AccountId>, Self::Error> {
         wallet::get_account_ids(self.conn.borrow())

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -293,12 +293,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
         wallet::get_account_ids(self.conn.borrow())
     }
 
-    fn get_seed_account(
+    fn get_derived_account(
         &self,
         seed: &HdSeedFingerprint,
         account_id: zip32::AccountId,
     ) -> Result<Option<Self::Account>, Self::Error> {
-        wallet::get_seed_account(self.conn.borrow(), &self.params, seed, account_id)
+        wallet::get_derived_account(self.conn.borrow(), &self.params, seed, account_id)
     }
 
     fn validate_seed(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -767,7 +767,7 @@ pub(crate) fn get_account_for_ufvk<P: consensus::Parameters>(
 
 /// Returns the account id corresponding to a given [`HdSeedFingerprint`]
 /// and [`zip32::AccountId`], if any.
-pub(crate) fn get_seed_account<P: consensus::Parameters>(
+pub(crate) fn get_derived_account<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
     seed: &HdSeedFingerprint,

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -1282,9 +1282,7 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn account_produces_expected_ua_sequence() {
-        use zcash_client_backend::data_api::{AccountBirthday, AccountKind};
-
-        use crate::wallet::get_account;
+        use zcash_client_backend::data_api::{AccountBirthday, AccountKind, WalletRead};
 
         let network = Network::MainNetwork;
         let data_file = NamedTempFile::new().unwrap();
@@ -1300,7 +1298,7 @@ mod tests {
             .create_account(&Secret::new(seed.to_vec()), birthday)
             .unwrap();
         assert_matches!(
-            get_account(&db_data, account_id),
+            db_data.get_account(account_id),
             Ok(Some(account)) if matches!(
                 account.kind,
                 AccountKind::Derived{account_index, ..} if account_index == zip32::AccountId::ZERO,

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -1282,9 +1282,9 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn account_produces_expected_ua_sequence() {
-        use zcash_client_backend::data_api::AccountBirthday;
+        use zcash_client_backend::data_api::{AccountBirthday, AccountKind};
 
-        use crate::wallet::{get_account, AccountType};
+        use crate::wallet::get_account;
 
         let network = Network::MainNetwork;
         let data_file = NamedTempFile::new().unwrap();
@@ -1303,7 +1303,7 @@ mod tests {
             get_account(&db_data, account_id),
             Ok(Some(account)) if matches!(
                 account.kind,
-                AccountType::Derived{account_index, ..} if account_index == zip32::AccountId::ZERO,
+                AccountKind::Derived{account_index, ..} if account_index == zip32::AccountId::ZERO,
             )
         );
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -224,7 +224,7 @@ mod tests {
         let expected_tables = vec![
             r#"CREATE TABLE "accounts" (
                 id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-                account_type INTEGER NOT NULL DEFAULT 0,
+                account_kind INTEGER NOT NULL DEFAULT 0,
                 hd_seed_fingerprint BLOB,
                 hd_account_index INTEGER,
                 ufvk TEXT,
@@ -234,7 +234,7 @@ mod tests {
                 p2pkh_fvk_item_cache BLOB,
                 birthday_height INTEGER NOT NULL,
                 recover_until_height INTEGER,
-                CHECK ( (account_type = 0 AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL) OR (account_type = 1 AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL) )
+                CHECK ( (account_kind = 0 AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL) OR (account_kind = 1 AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL) )
             )"#,
             r#"CREATE TABLE "addresses" (
                 account_id INTEGER NOT NULL,

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -1284,7 +1284,7 @@ mod tests {
     fn account_produces_expected_ua_sequence() {
         use zcash_client_backend::data_api::AccountBirthday;
 
-        use crate::wallet::{get_account, Account};
+        use crate::wallet::{get_account, AccountType};
 
         let network = Network::MainNetwork;
         let data_file = NamedTempFile::new().unwrap();
@@ -1301,7 +1301,10 @@ mod tests {
             .unwrap();
         assert_matches!(
             get_account(&db_data, account_id),
-            Ok(Some(Account::Zip32(hdaccount))) if hdaccount.account_index() == zip32::AccountId::ZERO
+            Ok(Some(account)) if matches!(
+                account.kind,
+                AccountType::Derived{account_index, ..} if account_index == zip32::AccountId::ZERO,
+            )
         );
 
         for tv in &test_vectors::UNIFIED[..3] {

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashSet, rc::Rc};
 
-use crate::wallet::{account_kind_code, init::WalletMigrationError, ufvk_to_uivk, AccountType};
+use crate::wallet::{account_kind_code, init::WalletMigrationError, ufvk_to_uivk};
 use rusqlite::{named_params, Transaction};
 use schemer_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
-use zcash_client_backend::keys::UnifiedSpendingKey;
+use zcash_client_backend::{data_api::AccountKind, keys::UnifiedSpendingKey};
 use zcash_keys::keys::{HdSeedFingerprint, UnifiedFullViewingKey};
 use zcash_primitives::consensus;
 
@@ -44,11 +44,11 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &Transaction) -> Result<(), WalletMigrationError> {
-        let account_type_derived = account_kind_code(AccountType::Derived {
+        let account_type_derived = account_kind_code(AccountKind::Derived {
             seed_fingerprint: HdSeedFingerprint::from_bytes([0; 32]),
             account_index: zip32::AccountId::ZERO,
         });
-        let account_type_imported = account_kind_code(AccountType::Imported);
+        let account_type_imported = account_kind_code(AccountKind::Imported);
         transaction.execute_batch(
             &format!(r#"
             PRAGMA foreign_keys = OFF;

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -44,11 +44,11 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &Transaction) -> Result<(), WalletMigrationError> {
-        let account_type_derived = account_kind_code(AccountKind::Derived {
+        let account_kind_derived = account_kind_code(AccountKind::Derived {
             seed_fingerprint: HdSeedFingerprint::from_bytes([0; 32]),
             account_index: zip32::AccountId::ZERO,
         });
-        let account_type_imported = account_kind_code(AccountKind::Imported);
+        let account_kind_imported = account_kind_code(AccountKind::Imported);
         transaction.execute_batch(
             &format!(r#"
             PRAGMA foreign_keys = OFF;
@@ -56,7 +56,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
 
             CREATE TABLE accounts_new (
                 id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-                account_type INTEGER NOT NULL DEFAULT {account_type_derived},
+                account_kind INTEGER NOT NULL DEFAULT {account_kind_derived},
                 hd_seed_fingerprint BLOB,
                 hd_account_index INTEGER,
                 ufvk TEXT,
@@ -67,9 +67,9 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 birthday_height INTEGER NOT NULL,
                 recover_until_height INTEGER,
                 CHECK (
-                    (account_type = {account_type_derived} AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL)
+                    (account_kind = {account_kind_derived} AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL)
                     OR
-                    (account_type = {account_type_imported} AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL)
+                    (account_kind = {account_kind_imported} AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL)
                 )
             );
             CREATE UNIQUE INDEX hd_account ON accounts_new (hd_seed_fingerprint, hd_account_index);
@@ -130,13 +130,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                     transaction.execute(
                         r#"
                         INSERT INTO accounts_new (
-                            id, account_type, hd_seed_fingerprint, hd_account_index,
+                            id, account_kind, hd_seed_fingerprint, hd_account_index,
                             ufvk, uivk,
                             orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
                             birthday_height, recover_until_height
                         )
                         VALUES (
-                            :account_id, :account_type, :seed_id, :account_index,
+                            :account_id, :account_kind, :seed_id, :account_index,
                             :ufvk, :uivk,
                             :orchard_fvk_item_cache, :sapling_fvk_item_cache, :p2pkh_fvk_item_cache,
                             :birthday_height, :recover_until_height
@@ -144,7 +144,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                         "#,
                         named_params![
                             ":account_id": account_id,
-                            ":account_type": account_type_derived,
+                            ":account_kind": account_kind_derived,
                             ":seed_id": seed_id.as_bytes(),
                             ":account_index": account_index,
                             ":ufvk": ufvk,


### PR DESCRIPTION
This exposes the kind of account (derived or imported, from which the ZIP 32 account index can be obtained), and enables the `WalletRead::Account` type to be looked up via `WalletRead::AccountId` instead of solely via the derivation parameters or UFVK.