### PR TITLE
Add local network to network enum

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,12 @@ and this library adheres to Rust's notion of
 ### Added
 - `zcash_protocol::memo`:
   - `impl TryFrom<&MemoBytes> for Memo`
+- `zcash_protocol::local_consensus`:
+  - `new`, `all_upgrades_active` and `canopy_active` methods to `LocalNetwork`
+
+### Changed
+- `zcash_protocol::consensus`:
+  - Added `LocalNetwork` variant to `Network` enum behind "local-consensus" feature
 
 ### Removed
 - `unstable-nu6` and `zfuture` feature flags (use `--cfg zcash_unstable=\"nu6\"`

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -8,6 +8,9 @@ use std::ops::{Add, Bound, RangeBounds, Sub};
 
 use crate::constants::{mainnet, regtest, testnet};
 
+#[cfg(feature = "local-consensus")]
+use crate::local_consensus::LocalNetwork;
+
 /// A wrapper type representing blockchain heights.
 ///
 /// Safe conversion from various integer types, as well as addition and subtraction, are
@@ -399,6 +402,9 @@ pub enum Network {
     MainNetwork,
     /// Zcash Testnet.
     TestNetwork,
+    #[cfg(feature = "local-consensus")]
+    /// Zcash local network (regtest)
+    LocalNetwork(LocalNetwork),
 }
 
 memuse::impl_no_dynamic_usage!(Network);
@@ -408,6 +414,8 @@ impl Parameters for Network {
         match self {
             Network::MainNetwork => NetworkType::Main,
             Network::TestNetwork => NetworkType::Test,
+            #[cfg(feature = "local-consensus")]
+            Network::LocalNetwork(ln) => ln.network_type(),
         }
     }
 
@@ -415,6 +423,8 @@ impl Parameters for Network {
         match self {
             Network::MainNetwork => MAIN_NETWORK.activation_height(nu),
             Network::TestNetwork => TEST_NETWORK.activation_height(nu),
+            #[cfg(feature = "local-consensus")]
+            Network::LocalNetwork(ln) => ln.activation_height(nu),
         }
     }
 }

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -43,6 +43,37 @@ pub struct LocalNetwork {
     pub z_future: Option<BlockHeight>,
 }
 
+impl LocalNetwork {
+    pub fn new(
+        overwinter: u64,
+        sapling: u64,
+        blossom: u64,
+        heartwood: u64,
+        canopy: u64,
+        nu5: u64,
+    ) -> Self {
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(overwinter as u32)),
+            sapling: Some(BlockHeight::from_u32(sapling as u32)),
+            blossom: Some(BlockHeight::from_u32(blossom as u32)),
+            heartwood: Some(BlockHeight::from_u32(heartwood as u32)),
+            canopy: Some(BlockHeight::from_u32(canopy as u32)),
+            nu5: Some(BlockHeight::from_u32(nu5 as u32)),
+        }
+    }
+
+    /// Creates a `LocalNetwork` with all network upgrades initially active.
+    pub fn all_upgrades_active() -> Self {
+        Self::new(1, 1, 1, 1, 1, 1)
+    }
+
+    /// Creates a `LocalNetwork` with all network upgrades up to and including canopy
+    /// initally active.
+    pub fn canopy_active(nu5_activation_height: u64) -> Self {
+        Self::new(1, 1, 1, 1, 1, nu5_activation_height)
+    }
+}
+
 /// Parameters implementation for `LocalNetwork`
 impl Parameters for LocalNetwork {
     fn network_type(&self) -> NetworkType {


### PR DESCRIPTION
Adds LocalNetwork variant to Network enum and adds methods for LocalNetwork for defining common network upgrade activation height patterns.

This allows production code of consumers to be tested in a regtest environment by easily switching out network parameters without needing to create their own version of the Network enum with a regtest variant.