### PR TITLE
with this change, zcash_keys compiles without sapling enabled

### DIFF
--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -457,6 +457,7 @@ impl fmt::Display for AddressGenerationError {
                     i
                 )
             }
+            #[cfg(feature = "sapling")]
             AddressGenerationError::InvalidSaplingDiversifierIndex(i) => {
                 write!(
                     f,


### PR DESCRIPTION
This came up during an exploration related to _unused_variables and feature gates. Im not just about to create any anti-sapling code.