### PR TITLE
Distinguish seed relevance when no derived accounts are present

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -22,6 +22,7 @@ and this library adheres to Rust's notion of
   - `NoteRetention`
   - `ScannedBlock::orchard`
   - `ScannedBlockCommitments::orchard`
+  - `SeedRelevance`
   - `SentTransaction::new`
   - `SpendableNotes`
   - `ORCHARD_SHARD_HEIGHT`

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -45,6 +45,7 @@ tracing.workspace = true
 
 # - Serialization
 byteorder.workspace = true
+nonempty.workspace = true
 prost.workspace = true
 group.workspace = true
 jubjub.workspace = true
@@ -82,7 +83,6 @@ bls12_381.workspace = true
 incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
 pasta_curves.workspace = true
 shardtree = { workspace = true, features = ["legacy-api", "test-dependencies"] }
-nonempty.workspace = true
 orchard = { workspace = true, features = ["test-dependencies"] }
 proptest.workspace = true
 rand_chacha.workspace = true

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -137,6 +137,7 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         SqliteClientError::Bech32DecodeError(e) => {
             WalletMigrationError::CorruptedData(e.to_string())
         }
+        #[cfg(feature = "transparent-inputs")]
         SqliteClientError::HdwalletError(e) => WalletMigrationError::CorruptedData(e.to_string()),
         SqliteClientError::TransparentAddress(e) => {
             WalletMigrationError::CorruptedData(e.to_string())
@@ -158,8 +159,11 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         | SqliteClientError::KeyDerivationError(_)
         | SqliteClientError::AccountIdDiscontinuity
         | SqliteClientError::AccountIdOutOfRange
-        | SqliteClientError::AddressNotRecognized(_)
         | SqliteClientError::CacheMiss(_) => {
+            unreachable!("we only call WalletRead methods; mutations can't occur")
+        }
+        #[cfg(feature = "transparent-inputs")]
+        SqliteClientError::AddressNotRecognized(_) => {
             unreachable!("we only call WalletRead methods; mutations can't occur")
         }
         SqliteClientError::AccountUnknown => {


### PR DESCRIPTION
During wallet migration in particular, the absence of _any_ accounts is expected, and all seeds should be treated as relevant (because accounts cannot be added before a wallet is initialized).