### PR TITLE
Fix the memory wallet build by hiding orchard fields in `new()` behind a flag

### DIFF
--- a/zcash_client_backend/src/data_api/mem_wallet.rs
+++ b/zcash_client_backend/src/data_api/mem_wallet.rs
@@ -110,8 +110,10 @@ impl MemoryWalletDb {
             blocks: BTreeMap::new(),
             tx_idx: HashMap::new(),
             sapling_spends: BTreeMap::new(),
+            #[cfg(feature = "orchard")]
             orchard_spends: BTreeMap::new(),
             sapling_tree: ShardTree::new(MemoryShardStore::empty(), max_checkpoints),
+            #[cfg(feature = "orchard")]
             orchard_tree: ShardTree::new(MemoryShardStore::empty(), max_checkpoints),
         }
     }


### PR DESCRIPTION
Needed for building the branch locally. 