### PR TITLE
zcash_client_sqlite: Fix a problem related to checkpoint pruning.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -53,6 +53,7 @@ and this library adheres to Rust's notion of
   - `ReceivedNote::map_note`
   - `ReceivedNote<_, sapling::Note>::note_value`
   - `ReceivedNote<_, orchard::note::Note>::note_value`
+- `zcash_client_backend::zip321::Payment::without_memo`
 
 ### Changed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/src/zip321.rs
+++ b/zcash_client_backend/src/zip321.rs
@@ -131,6 +131,18 @@ pub struct Payment {
 }
 
 impl Payment {
+    /// Constructs a new [`Payment`] paying the given address the specified amount.
+    pub fn without_memo(recipient_address: Address, amount: NonNegativeAmount) -> Self {
+        Self {
+            recipient_address,
+            amount,
+            memo: None,
+            label: None,
+            message: None,
+            other_params: vec![],
+        }
+    }
+
     /// A utility for use in tests to help check round-trip serialization properties.
     #[cfg(any(test, feature = "test-dependencies"))]
     pub(in crate::zip321) fn normalize(&mut self) {

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -370,7 +370,7 @@ pub(crate) mod tests {
             pool::{OutputRecoveryError, ShieldedPoolTester},
             TestState,
         },
-        wallet::commitment_tree,
+        wallet::{commitment_tree, sapling::tests::SaplingPoolTester},
         ORCHARD_TABLES_PREFIX,
     };
 
@@ -601,15 +601,21 @@ pub(crate) mod tests {
 
     #[test]
     fn pool_crossing_required() {
-        use crate::wallet::sapling::tests::SaplingPoolTester;
-
         testing::pool::pool_crossing_required::<OrchardPoolTester, SaplingPoolTester>()
     }
 
     #[test]
     fn fully_funded_fully_private() {
-        use crate::wallet::sapling::tests::SaplingPoolTester;
-
         testing::pool::fully_funded_fully_private::<OrchardPoolTester, SaplingPoolTester>()
+    }
+
+    #[test]
+    fn multi_pool_checkpoint() {
+        testing::pool::multi_pool_checkpoint::<OrchardPoolTester, SaplingPoolTester>()
+    }
+
+    #[test]
+    fn multi_pool_checkpoints_with_pruning() {
+        testing::pool::multi_pool_checkpoints_with_pruning::<OrchardPoolTester, SaplingPoolTester>()
     }
 }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -622,4 +622,20 @@ pub(crate) mod tests {
 
         testing::pool::fully_funded_fully_private::<SaplingPoolTester, OrchardPoolTester>()
     }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn multi_pool_checkpoint() {
+        use crate::wallet::orchard::tests::OrchardPoolTester;
+
+        testing::pool::multi_pool_checkpoint::<SaplingPoolTester, OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn multi_pool_checkpoints_with_pruning() {
+        use crate::wallet::orchard::tests::OrchardPoolTester;
+
+        testing::pool::multi_pool_checkpoints_with_pruning::<SaplingPoolTester, OrchardPoolTester>()
+    }
 }


### PR DESCRIPTION
This fixes, but does not yet reproduce the bug in #1302, which is likely the same as the bug in #1294.

The error occurs as a consequence of checkpoints that were added for "companion" heights in the other tree being pruned after the nodes that were associated with those checkpoints had been previously pruned. This could occur because updates to the note commitment trees were done in two stages:
* In the initial stage, the tree state is updated for a scanned range, which may trigger pruning of previous checkpoints.
* In the second stage, the "missed" companion checkpoints are re-added to the tree, even if the leaf positions that they were referring to had already been pruned.
* When _those_ checkpoints are later pruned, multiple checkpoints are associated with a single internal node in the note commitment tree whose children have been pruned. This causes the panic observed in #1294.