### PR TITLE
zcash_client_sqlite: Use consistent criteria for detecting what accounts fund a transaction.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -103,6 +103,8 @@ and this library adheres to Rust's notion of
     feature flag.
 - `zcash_client_backend::proto`:
   - `ProposalDecodingError` has a new variant `TransparentMemo`.
+- `zcash_client_backend::wallet::Recipient::InternalAccount` is now a structured
+  variant with an additional `external_address` field.
 - `zcash_client_backend::zip321::render::amount_str` now takes a
   `NonNegativeAmount` rather than a signed `Amount` as its argument.
 - `zcash_client_backend::zip321::parse::parse_amount` now parses a

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1049,10 +1049,11 @@ where
                     memo.clone(),
                 )?;
                 sapling_output_meta.push((
-                    Recipient::InternalAccount(
-                        account,
-                        PoolType::Shielded(ShieldedProtocol::Sapling),
-                    ),
+                    Recipient::InternalAccount {
+                        receiving_account: account,
+                        external_address: None,
+                        note: PoolType::Shielded(ShieldedProtocol::Sapling),
+                    },
                     change_value.value(),
                     Some(memo),
                 ))
@@ -1072,10 +1073,11 @@ where
                         memo.clone(),
                     )?;
                     orchard_output_meta.push((
-                        Recipient::InternalAccount(
-                            account,
-                            PoolType::Shielded(ShieldedProtocol::Orchard),
-                        ),
+                        Recipient::InternalAccount {
+                            receiving_account: account,
+                            external_address: None,
+                            note: PoolType::Shielded(ShieldedProtocol::Orchard),
+                        },
                         change_value.value(),
                         Some(memo),
                     ))

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -166,12 +166,8 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         .flat_map(|bundle| {
             ufvks
                 .iter()
-                .flat_map(move |(account, ufvk)| {
-                    ufvk.orchard()
-                        .into_iter()
-                        .map(|fvk| (account.to_owned(), fvk))
-                })
-                .flat_map(move |(account, fvk)| {
+                .flat_map(|(account, ufvk)| ufvk.orchard().into_iter().map(|fvk| (*account, fvk)))
+                .flat_map(|(account, fvk)| {
                     let ivk_external = orchard::keys::PreparedIncomingViewingKey::new(
                         &fvk.to_ivk(Scope::External),
                     );

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -2,6 +2,7 @@
 //! light client.
 
 use incrementalmerkletree::Position;
+use zcash_keys::address::Address;
 use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_primitives::{
     consensus::BlockHeight,
@@ -70,7 +71,11 @@ pub enum Recipient<AccountId, N> {
     Transparent(TransparentAddress),
     Sapling(sapling::PaymentAddress),
     Unified(UnifiedAddress, PoolType),
-    InternalAccount(AccountId, N),
+    InternalAccount {
+        receiving_account: AccountId,
+        external_address: Option<Address>,
+        note: N,
+    },
 }
 
 impl<AccountId, N> Recipient<AccountId, N> {
@@ -79,7 +84,15 @@ impl<AccountId, N> Recipient<AccountId, N> {
             Recipient::Transparent(t) => Recipient::Transparent(t),
             Recipient::Sapling(s) => Recipient::Sapling(s),
             Recipient::Unified(u, p) => Recipient::Unified(u, p),
-            Recipient::InternalAccount(a, n) => Recipient::InternalAccount(a, f(n)),
+            Recipient::InternalAccount {
+                receiving_account,
+                external_address,
+                note,
+            } => Recipient::InternalAccount {
+                receiving_account,
+                external_address,
+                note: f(note),
+            },
         }
     }
 }
@@ -90,7 +103,15 @@ impl<AccountId, N> Recipient<AccountId, Option<N>> {
             Recipient::Transparent(t) => Some(Recipient::Transparent(t)),
             Recipient::Sapling(s) => Some(Recipient::Sapling(s)),
             Recipient::Unified(u, p) => Some(Recipient::Unified(u, p)),
-            Recipient::InternalAccount(a, n) => n.map(|n0| Recipient::InternalAccount(a, n0)),
+            Recipient::InternalAccount {
+                receiving_account,
+                external_address,
+                note,
+            } => note.map(|n0| Recipient::InternalAccount {
+                receiving_account,
+                external_address,
+                note: n0,
+            }),
         }
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1049,8 +1049,16 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
     ) -> Result<(), Self::Error> {
         self.transactionally(|wdb| {
             let tx_ref = wallet::put_tx_data(wdb.conn.0, d_tx.tx(), None, None)?;
+            let funding_accounts = wallet::get_funding_accounts(wdb.conn.0, d_tx.tx())?;
+            let funding_account = funding_accounts.iter().next().copied();
+            if funding_accounts.len() > 1 {
+                warn!(
+                    "More than one wallet account detected as funding transaction {:?}, selecting {:?}",
+                    d_tx.tx().txid(),
+                    funding_account.unwrap()
+                )
+            }
 
-            let mut spending_account_id: Option<AccountId> = None;
             for output in d_tx.sapling_outputs() {
                 match output.transfer_type() {
                     TransferType::Outgoing | TransferType::WalletInternal => {
@@ -1080,18 +1088,26 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                         }
                     }
                     TransferType::Incoming => {
-                        match spending_account_id {
-                            Some(id) => {
-                                if id != *output.account() {
-                                    panic!("Unable to determine a unique account identifier for z->t spend.");
-                                }
-                            }
-                            None => {
-                                spending_account_id = Some(*output.account());
-                            }
-                        }
-
                         wallet::sapling::put_received_note(wdb.conn.0, output, tx_ref, None)?;
+
+                        if let Some(account_id) = funding_account {
+                            // Even if the recipient address is external, record the send as internal.
+                            let recipient = Recipient::InternalAccount(
+                                *output.account(),
+                                Note::Sapling(output.note().clone()),
+                            );
+
+                            wallet::put_sent_output(
+                                wdb.conn.0,
+                                &wdb.params,
+                                account_id,
+                                tx_ref,
+                                output.index(),
+                                &recipient,
+                                output.note_value(),
+                                Some(output.memo()),
+                            )?;
+                        }
                     }
                 }
             }
@@ -1106,9 +1122,10 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                                 UnifiedAddress::from_receivers(
                                     Some(output.note().recipient()),
                                     None,
-                                    None
-                                ).expect("UA has an Orchard receiver by construction."),
-                                PoolType::Shielded(ShieldedProtocol::Orchard)
+                                    None,
+                                )
+                                .expect("UA has an Orchard receiver by construction."),
+                                PoolType::Shielded(ShieldedProtocol::Orchard),
                             )
                         } else {
                             Recipient::InternalAccount(
@@ -1133,50 +1150,69 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                         }
                     }
                     TransferType::Incoming => {
-                        match spending_account_id {
-                            Some(id) => {
-                                if id != *output.account() {
-                                    panic!("Unable to determine a unique account identifier for z->t spend.");
-                                }
-                            }
-                            None => {
-                                spending_account_id = Some(*output.account());
-                            }
-                        }
-
                         wallet::orchard::put_received_note(wdb.conn.0, output, tx_ref, None)?;
+
+                        if let Some(account_id) = funding_account {
+                            // Even if the recipient address is external, record the send as internal.
+                            let recipient = Recipient::InternalAccount(
+                                *output.account(),
+                                Note::Orchard(*output.note()),
+                            );
+
+                            wallet::put_sent_output(
+                                wdb.conn.0,
+                                &wdb.params,
+                                account_id,
+                                tx_ref,
+                                output.index(),
+                                &recipient,
+                                output.note_value(),
+                                Some(output.memo()),
+                            )?;
+                        }
                     }
                 }
             }
 
             // If any of the utxos spent in the transaction are ours, mark them as spent.
             #[cfg(feature = "transparent-inputs")]
-            for txin in d_tx.tx().transparent_bundle().iter().flat_map(|b| b.vin.iter()) {
+            for txin in d_tx
+                .tx()
+                .transparent_bundle()
+                .iter()
+                .flat_map(|b| b.vin.iter())
+            {
                 wallet::mark_transparent_utxo_spent(wdb.conn.0, tx_ref, &txin.prevout)?;
             }
 
             // If we have some transparent outputs:
-            if d_tx.tx().transparent_bundle().iter().any(|b| !b.vout.is_empty()) {
+            if d_tx
+                .tx()
+                .transparent_bundle()
+                .iter()
+                .any(|b| !b.vout.is_empty())
+            {
                 // If the transaction contains spends from our wallet, we will store z->t
                 // transactions we observe in the same way they would be stored by
                 // create_spend_to_address.
-                let sapling_from_account = wdb.get_sapling_nullifiers(NullifierQuery::All)?.into_iter().find(
-                    |(_, nf)|
-                        d_tx.tx().sapling_bundle().into_iter().flat_map(|b| b.shielded_spends().iter())
-                        .any(|input| nf == input.nullifier())
-                ).map(|(account_id, _)| account_id);
+                let funding_accounts = wallet::get_funding_accounts(wdb.conn.0, d_tx.tx())?;
+                let funding_account = funding_accounts.iter().next().copied();
+                if let Some(account_id) = funding_account {
+                    if funding_accounts.len() > 1 {
+                        warn!(
+                            "More than one wallet account detected as funding transaction {:?}, selecting {:?}",
+                            d_tx.tx().txid(),
+                            account_id
+                        )
+                    }
 
-                #[cfg(feature = "orchard")]
-                let orchard_from_account = wdb.get_orchard_nullifiers(NullifierQuery::All)?.into_iter().find(
-                    |(_, nf)|
-                        d_tx.tx().orchard_bundle().iter().flat_map(|b| b.actions().iter())
-                        .any(|input| nf == input.nullifier())
-                ).map(|(account_id, _)| account_id);
-                #[cfg(not(feature = "orchard"))]
-                let orchard_from_account = None;
-
-                if let Some(account_id) = orchard_from_account.or(sapling_from_account) {
-                    for (output_index, txout) in d_tx.tx().transparent_bundle().iter().flat_map(|b| b.vout.iter()).enumerate() {
+                    for (output_index, txout) in d_tx
+                        .tx()
+                        .transparent_bundle()
+                        .iter()
+                        .flat_map(|b| b.vout.iter())
+                        .enumerate()
+                    {
                         if let Some(address) = txout.recipient_address() {
                             wallet::put_sent_output(
                                 wdb.conn.0,
@@ -1186,7 +1222,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                                 output_index,
                                 &Recipient::Transparent(address),
                                 txout.value,
-                                None
+                                None,
                             )?;
                         }
                     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2605,7 +2605,7 @@ pub(crate) fn put_sent_output<P: consensus::Parameters>(
         ON CONFLICT (tx, output_pool, output_index) DO UPDATE
         SET from_account_id = :from_account_id,
             to_address = :to_address,
-            to_account_id = :to_account_id,
+            to_account_id = IFNULL(to_account_id, :to_account_id),
             value = :value,
             memo = IFNULL(:memo, memo)",
     )?;

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2527,9 +2527,13 @@ fn recipient_params<P: consensus::Parameters>(
             PoolType::Shielded(ShieldedProtocol::Sapling),
         ),
         Recipient::Unified(addr, pool) => (Some(addr.encode(params)), None, *pool),
-        Recipient::InternalAccount(id, note) => (
-            None,
-            Some(id.to_owned()),
+        Recipient::InternalAccount {
+            receiving_account,
+            external_address,
+            note,
+        } => (
+            external_address.as_ref().map(|a| a.encode(params)),
+            Some(*receiving_account),
             PoolType::Shielded(note.protocol()),
         ),
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1888,9 +1888,10 @@ pub(crate) fn get_tx_height(
     conn.query_row(
         "SELECT block FROM transactions WHERE txid = ?",
         [txid.as_ref().to_vec()],
-        |row| row.get(0).map(u32::into),
+        |row| Ok(row.get::<_, Option<u32>>(0)?.map(BlockHeight::from)),
     )
     .optional()
+    .map(|opt| opt.flatten())
 }
 
 /// Returns the block hash for the block at the specified height,

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -344,7 +344,7 @@ pub(crate) fn detect_spending_accounts<'a>(
     let mut account_q = conn.prepare_cached(
         "SELECT rn.account_id
         FROM orchard_received_notes rn
-        WHERE rn.nf IN :nf_ptr",
+        WHERE rn.nf IN rarray(:nf_ptr)",
     )?;
 
     let nf_values: Vec<Value> = nfs.map(|nf| Value::Blob(nf.to_bytes().to_vec())).collect();

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -278,7 +278,7 @@ pub(crate) fn detect_spending_accounts<'a>(
     let mut account_q = conn.prepare_cached(
         "SELECT rn.account_id
         FROM sapling_received_notes rn
-        WHERE rn.nf IN :nf_ptr",
+        WHERE rn.nf IN rarray(:nf_ptr)",
     )?;
 
     let nf_values: Vec<Value> = nfs.map(|nf| Value::Blob(nf.to_vec())).collect();

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1,0 +1,34 @@
+//! Functions for transparent input support in the wallet.
+use std::collections::HashSet;
+
+use rusqlite::{named_params, Connection};
+use zcash_primitives::transaction::components::OutPoint;
+
+use crate::AccountId;
+
+pub(crate) fn detect_spending_accounts<'a>(
+    conn: &Connection,
+    spent: impl Iterator<Item = &'a OutPoint>,
+) -> Result<HashSet<AccountId>, rusqlite::Error> {
+    let mut account_q = conn.prepare_cached(
+        "SELECT received_by_account_id
+        FROM utxos
+        WHERE prevout_txid = :prevout_txid
+        AND prevout_idx = :prevout_idx",
+    )?;
+
+    let mut acc = HashSet::new();
+    for prevout in spent {
+        for account in account_q.query_and_then(
+            named_params![
+                ":prevout_txid": prevout.hash(),
+                ":prevout_idx": prevout.n()
+            ],
+            |row| row.get::<_, u32>(0).map(AccountId),
+        )? {
+            acc.insert(account?);
+        }
+    }
+
+    Ok(acc)
+}


### PR DESCRIPTION
Fixes #1304, #1282, #1238