### PR TITLE
zcash_client_sqlite: Use account birthday subtree sizes for progress

### DIFF
--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1015,9 +1015,6 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                     })?;
                 }
 
-                // Update now-expired transactions that didn't get mined.
-                wallet::update_expired_notes(wdb.conn.0, last_scanned_height)?;
-
                 wallet::scanning::scan_complete(
                     wdb.conn.0,
                     &wdb.params,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -235,7 +235,7 @@ impl<Cache> TestBuilder<Cache> {
 
         let mut cached_blocks = BTreeMap::new();
 
-        if let Some(initial_state) = self.initial_chain_state {
+        if let Some(initial_state) = &self.initial_chain_state {
             db_data
                 .put_sapling_subtree_roots(0, &initial_state.prior_sapling_roots)
                 .unwrap();
@@ -302,7 +302,9 @@ impl<Cache> TestBuilder<Cache> {
         TestState {
             cache: self.cache,
             cached_blocks,
-            latest_block_height: None,
+            latest_block_height: self
+                .initial_chain_state
+                .map(|s| s.chain_state.block_height()),
             _data_file: data_file,
             db_data,
             test_account,
@@ -776,6 +778,11 @@ impl<Cache> TestState<Cache> {
     /// Exposes a mutable reference to the test's [`WalletDb`].
     pub(crate) fn wallet_mut(&mut self) -> &mut WalletDb<Connection, LocalNetwork> {
         &mut self.db_data
+    }
+
+    /// Exposes the test framework's source of randomness.
+    pub(crate) fn rng_mut(&mut self) -> &mut ChaChaRng {
+        &mut self.rng
     }
 
     /// Exposes the network in use.

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -474,6 +474,7 @@ where
             value,
             prior_cached_block.sapling_end_size,
             prior_cached_block.orchard_end_size,
+            false,
         );
 
         (height, res, nf)
@@ -529,6 +530,7 @@ where
         value: NonNegativeAmount,
         initial_sapling_tree_size: u32,
         initial_orchard_tree_size: u32,
+        allow_broken_hash_chain: bool,
     ) -> (Cache::InsertResult, Fvk::Nullifier) {
         let mut prior_cached_block = self
             .latest_cached_block_below_height(height)
@@ -542,7 +544,9 @@ where
         // we need to generate a new prior cached block that the block to be generated can
         // successfully chain from, with the provided tree sizes.
         if prior_cached_block.chain_state.block_height() == height - 1 {
-            assert_eq!(prev_hash, prior_cached_block.chain_state.block_hash());
+            if !allow_broken_hash_chain {
+                assert_eq!(prev_hash, prior_cached_block.chain_state.block_hash());
+            }
         } else {
             let final_sapling_tree =
                 (prior_cached_block.sapling_end_size..initial_sapling_tree_size).fold(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -2,16 +2,19 @@
 //!
 //! Generalised for sharing across the Sapling and Orchard implementations.
 
-use std::{convert::Infallible, num::NonZeroU32};
+use std::{
+    convert::Infallible,
+    num::{NonZeroU32, NonZeroU8},
+};
 
-use incrementalmerkletree::Level;
+use incrementalmerkletree::{frontier::Frontier, Level};
 use rand_core::RngCore;
 use rusqlite::params;
 use secrecy::Secret;
 use shardtree::error::ShardTreeError;
 use zcash_primitives::{
     block::BlockHash,
-    consensus::BranchId,
+    consensus::{BranchId, NetworkUpgrade, Parameters},
     legacy::TransparentAddress,
     memo::{Memo, MemoBytes},
     transaction::{
@@ -28,7 +31,7 @@ use zcash_client_backend::{
     address::Address,
     data_api::{
         self,
-        chain::{self, CommitmentTreeRoot, ScanSummary},
+        chain::{self, ChainState, CommitmentTreeRoot, ScanSummary},
         error::Error,
         wallet::input_selection::{GreedyInputSelector, GreedyInputSelectorError},
         AccountBirthday, DecryptedTransaction, Ratio, WalletRead, WalletSummary, WalletWrite,
@@ -46,11 +49,8 @@ use zcash_protocol::consensus::BlockHeight;
 use super::TestFvk;
 use crate::{
     error::SqliteClientError,
-    testing::{input_selector, AddressType, BlockCache, TestBuilder, TestState},
-    wallet::{
-        block_max_scanned, commitment_tree, parse_scope,
-        scanning::tests::test_with_nu5_birthday_offset, truncate_to_height,
-    },
+    testing::{input_selector, AddressType, BlockCache, InitialChainState, TestBuilder, TestState},
+    wallet::{block_max_scanned, commitment_tree, parse_scope, truncate_to_height},
     AccountId, NoteId, ReceivedNoteId,
 };
 
@@ -1260,67 +1260,75 @@ pub(crate) fn shield_transparent<T: ShieldedPoolTester>() {
 // FIXME: This requires fixes to the test framework.
 #[allow(dead_code)]
 pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
-    // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
-    let (mut st, dfvk, birthday, _) = test_with_nu5_birthday_offset::<T>(76, BlockHash([0; 32]));
-
     // Set up the following situation:
     //
     //        |<------ 500 ------->|<--- 10 --->|<--- 10 --->|
     // last_shard_start   wallet_birthday  received_tx  anchor_height
     //
-    // Set up some shard root history before the wallet birthday.
-    let prev_shard_start = birthday.height() - 500;
-    T::put_subtree_roots(
-        &mut st,
-        0,
-        &[CommitmentTreeRoot::from_parts(
-            prev_shard_start,
-            // fake a hash, the value doesn't matter
-            T::empty_tree_leaf(),
-        )],
-    )
-    .unwrap();
+    // We set the Sapling and Orchard frontiers at the birthday block initial state to 1234
+    // notes beyond the end of the first shard.
+    let frontier_tree_size: u32 = (0x1 << 16) + 1234;
+    let mut st = TestBuilder::new()
+        .with_block_cache()
+        .with_initial_chain_state(|rng, network| {
+            let birthday_height = network.activation_height(NetworkUpgrade::Nu5).unwrap() + 1000;
 
-    let received_tx_height = birthday.height() + 10;
+            // Construct a fake chain state for the end of the block with the given
+            // birthday_offset from the Nu5 birthday.
+            let (prior_sapling_roots, sapling_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    frontier_tree_size.into(),
+                    NonZeroU8::new(16).unwrap(),
+                );
+            // There will only be one prior root
+            let prior_sapling_roots = prior_sapling_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
 
-    let initial_sapling_tree_size = birthday
-        .sapling_frontier()
-        .value()
-        .map(|f| u64::from(f.position() + 1))
-        .unwrap_or(0)
-        .try_into()
-        .unwrap();
-    #[cfg(feature = "orchard")]
-    let initial_orchard_tree_size = birthday
-        .orchard_frontier()
-        .value()
-        .map(|f| u64::from(f.position() + 1))
-        .unwrap_or(0)
-        .try_into()
-        .unwrap();
-    #[cfg(not(feature = "orchard"))]
-    let initial_orchard_tree_size = 0;
+            #[cfg(feature = "orchard")]
+            let (prior_orchard_roots, orchard_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    frontier_tree_size.into(),
+                    NonZeroU8::new(16).unwrap(),
+                );
+            // There will only be one prior root
+            #[cfg(feature = "orchard")]
+            let prior_orchard_roots = prior_orchard_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
+
+            InitialChainState {
+                chain_state: ChainState::new(
+                    birthday_height - 1,
+                    BlockHash([5; 32]),
+                    sapling_initial_tree,
+                    #[cfg(feature = "orchard")]
+                    orchard_initial_tree,
+                ),
+                prior_sapling_roots,
+                #[cfg(feature = "orchard")]
+                prior_orchard_roots,
+            }
+        })
+        .with_account_having_current_birthday()
+        .build();
 
     // Generate 9 blocks that have no value for us, starting at the birthday height.
-    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
     let not_our_value = NonNegativeAmount::const_from_u64(10000);
-    st.generate_block_at(
-        birthday.height(),
-        BlockHash([0; 32]),
-        &not_our_key,
-        AddressType::DefaultExternal,
-        not_our_value,
-        initial_sapling_tree_size,
-        initial_orchard_tree_size,
-        false,
-    );
+    let not_our_key = T::random_fvk(st.rng_mut());
+    let (initial_height, _, _) =
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
     for _ in 1..9 {
         st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
     }
 
     // Now, generate a block that belongs to our wallet
-    st.generate_next_block(
-        &dfvk,
+    let (received_tx_height, _, _) = st.generate_next_block(
+        &T::test_account_fvk(&st),
         AddressType::DefaultExternal,
         NonNegativeAmount::const_from_u64(500000),
     );
@@ -1332,7 +1340,7 @@ pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
 
     // Scan a block range that includes our received note, but skips some blocks we need to
     // make it spendable.
-    st.scan_cached_blocks(birthday.height() + 5, 20);
+    st.scan_cached_blocks(initial_height + 5, 20);
 
     // Verify that the received note is not considered spendable
     let account = st.test_account().unwrap();
@@ -1349,7 +1357,7 @@ pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
     assert_eq!(spendable.len(), 0);
 
     // Scan the blocks we skipped
-    st.scan_cached_blocks(birthday.height(), 5);
+    st.scan_cached_blocks(initial_height, 5);
 
     // Verify that the received note is now considered spendable
     let spendable = T::select_spendable_notes(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -1312,6 +1312,7 @@ pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {
         not_our_value,
         initial_sapling_tree_size,
         initial_orchard_tree_size,
+        false,
     );
     for _ in 1..9 {
         st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
@@ -1392,6 +1393,7 @@ pub(crate) fn checkpoint_gaps<T: ShieldedPoolTester>() {
         not_our_value,
         st.latest_cached_block().unwrap().sapling_end_size,
         st.latest_cached_block().unwrap().orchard_end_size,
+        false,
     );
 
     // Scan the block
@@ -1888,6 +1890,7 @@ pub(crate) fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>() {
         NonNegativeAmount::const_from_u64(8),
         2,
         2,
+        true,
     );
     st.generate_next_block(
         &dfvk,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -730,7 +730,7 @@ pub(crate) fn spend_fails_on_locked_notes<T: ShieldedPoolTester>() {
             value,
         );
     }
-    st.scan_cached_blocks(h1 + 1, 41);
+    st.scan_cached_blocks(h1 + 1, 40);
 
     // Second proposal still fails
     assert_matches!(
@@ -1927,20 +1927,20 @@ pub(crate) fn data_db_truncation<T: ShieldedPoolTester>() {
     // Scan the cache
     st.scan_cached_blocks(h, 2);
 
-    // Account balance should reflect both received notes
+    // Spendable balance should reflect both received notes
     assert_eq!(
-        st.get_total_balance(account.account_id()),
+        st.get_spendable_balance(account.account_id(), 1),
         (value + value2).unwrap()
     );
 
-    // "Rewind" to height of last scanned block
+    // "Rewind" to height of last scanned block (this is a no-op)
     st.wallet_mut()
         .transactionally(|wdb| truncate_to_height(wdb.conn.0, &wdb.params, h + 1))
         .unwrap();
 
-    // Account balance should be unaltered
+    // Spendable balance should be unaltered
     assert_eq!(
-        st.get_total_balance(account.account_id()),
+        st.get_spendable_balance(account.account_id(), 1),
         (value + value2).unwrap()
     );
 
@@ -1949,15 +1949,20 @@ pub(crate) fn data_db_truncation<T: ShieldedPoolTester>() {
         .transactionally(|wdb| truncate_to_height(wdb.conn.0, &wdb.params, h))
         .unwrap();
 
-    // Account balance should only contain the first received note
-    assert_eq!(st.get_total_balance(account.account_id()), value);
+    // Spendable balance should only contain the first received note;
+    // the rest should be pending.
+    assert_eq!(st.get_spendable_balance(account.account_id(), 1), value);
+    assert_eq!(
+        st.get_pending_shielded_balance(account.account_id(), 1),
+        value2
+    );
 
     // Scan the cache again
     st.scan_cached_blocks(h, 2);
 
     // Account balance should again reflect both received notes
     assert_eq!(
-        st.get_total_balance(account.account_id()),
+        st.get_spendable_balance(account.account_id(), 1),
         (value + value2).unwrap()
     );
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3103,6 +3103,7 @@ mod tests {
             not_our_value,
             0,
             0,
+            false,
         );
         let (mid_height, _, _) =
             st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -374,19 +374,27 @@ pub(crate) fn add_account<P: consensus::Parameters>(
     #[cfg(not(feature = "transparent-inputs"))]
     let transparent_item: Option<Vec<u8>> = None;
 
+    let birthday_sapling_tree_size = Some(birthday.sapling_frontier().tree_size());
+    #[cfg(feature = "orchard")]
+    let birthday_orchard_tree_size = Some(birthday.orchard_frontier().tree_size());
+    #[cfg(not(feature = "orchard"))]
+    let birthday_orchard_tree_size: Option<u64> = None;
+
     let account_id: AccountId = conn.query_row(
         r#"
         INSERT INTO accounts (
             account_kind, hd_seed_fingerprint, hd_account_index,
             ufvk, uivk,
             orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
-            birthday_height, recover_until_height
+            birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
+            recover_until_height
         )
         VALUES (
             :account_kind, :hd_seed_fingerprint, :hd_account_index,
             :ufvk, :uivk,
             :orchard_fvk_item_cache, :sapling_fvk_item_cache, :p2pkh_fvk_item_cache,
-            :birthday_height, :recover_until_height
+            :birthday_height, :birthday_sapling_tree_size, :birthday_orchard_tree_size,
+            :recover_until_height
         )
         RETURNING id;
         "#,
@@ -400,6 +408,8 @@ pub(crate) fn add_account<P: consensus::Parameters>(
             ":sapling_fvk_item_cache": sapling_item,
             ":p2pkh_fvk_item_cache": transparent_item,
             ":birthday_height": u32::from(birthday.height()),
+            ":birthday_sapling_tree_size": birthday_sapling_tree_size,
+            ":birthday_orchard_tree_size": birthday_orchard_tree_size,
             ":recover_until_height": birthday.recover_until().map(u32::from)
         ],
         |row| Ok(AccountId(row.get(0)?)),
@@ -884,22 +894,39 @@ impl ScanProgress for SubtreeScanProgress {
             )
             .map_err(SqliteClientError::from)
         } else {
-            let start_height = birthday_height;
-            // Compute the starting number of notes directly from the blocks table
-            let start_size = conn.query_row(
-                "SELECT MAX(sapling_commitment_tree_size)
-                 FROM blocks
-                 WHERE height <= :start_height",
-                named_params![":start_height": u32::from(start_height)],
-                |row| row.get::<_, Option<u64>>(0),
-            )?;
+            // Get the starting note commitment tree size from the wallet birthday, or failing that
+            // from the blocks table.
+            let start_size = conn
+                .query_row(
+                    "SELECT birthday_sapling_tree_size
+                     FROM accounts
+                     WHERE birthday_height = :birthday_height",
+                    named_params![":birthday_height": u32::from(birthday_height)],
+                    |row| row.get::<_, Option<u64>>(0),
+                )
+                .optional()?
+                .flatten()
+                .map(Ok)
+                .or_else(|| {
+                    conn.query_row(
+                        "SELECT MAX(sapling_commitment_tree_size - sapling_output_count)
+                         FROM blocks
+                         WHERE height <= :start_height",
+                        named_params![":start_height": u32::from(birthday_height)],
+                        |row| row.get::<_, Option<u64>>(0),
+                    )
+                    .optional()
+                    .map(|opt| opt.flatten())
+                    .transpose()
+                })
+                .transpose()?;
 
             // Compute the total blocks scanned so far above the starting height
             let scanned_count = conn.query_row(
                 "SELECT SUM(sapling_output_count)
                  FROM blocks
                  WHERE height > :start_height",
-                named_params![":start_height": u32::from(start_height)],
+                named_params![":start_height": u32::from(birthday_height)],
                 |row| row.get::<_, Option<u64>>(0),
             )?;
 
@@ -915,22 +942,22 @@ impl ScanProgress for SubtreeScanProgress {
                      FROM sapling_tree_shards
                      WHERE subtree_end_height > :start_height
                      OR subtree_end_height IS NULL",
-                    named_params![":start_height": u32::from(start_height)],
+                    named_params![":start_height": u32::from(birthday_height)],
                     |row| {
                         let min_tree_size = row
                             .get::<_, Option<u64>>(0)?
-                            .map(|min| min << SAPLING_SHARD_HEIGHT);
-                        let max_idx = row.get::<_, Option<u64>>(1)?;
-                        Ok(start_size
-                            .or(min_tree_size)
-                            .zip(max_idx)
-                            .map(|(min_tree_size, max)| {
-                                let max_tree_size = (max + 1) << SAPLING_SHARD_HEIGHT;
+                            .map(|min_idx| min_idx << SAPLING_SHARD_HEIGHT);
+                        let max_tree_size = row
+                            .get::<_, Option<u64>>(1)?
+                            .map(|max_idx| (max_idx + 1) << SAPLING_SHARD_HEIGHT);
+                        Ok(start_size.or(min_tree_size).zip(max_tree_size).map(
+                            |(min_tree_size, max_tree_size)| {
                                 Ratio::new(
                                     scanned_count.unwrap_or(0),
                                     max_tree_size - min_tree_size,
                                 )
-                            }))
+                            },
+                        ))
                     },
                 )
                 .optional()?
@@ -961,22 +988,38 @@ impl ScanProgress for SubtreeScanProgress {
             )
             .map_err(SqliteClientError::from)
         } else {
-            let start_height = birthday_height;
             // Compute the starting number of notes directly from the blocks table
-            let start_size = conn.query_row(
-                "SELECT MAX(orchard_commitment_tree_size)
-                 FROM blocks
-                 WHERE height <= :start_height",
-                named_params![":start_height": u32::from(start_height)],
-                |row| row.get::<_, Option<u64>>(0),
-            )?;
+            let start_size = conn
+                .query_row(
+                    "SELECT birthday_orchard_tree_size
+                     FROM accounts
+                     WHERE birthday_height = :birthday_height",
+                    named_params![":birthday_height": u32::from(birthday_height)],
+                    |row| row.get::<_, Option<u64>>(0),
+                )
+                .optional()?
+                .flatten()
+                .map(Ok)
+                .or_else(|| {
+                    conn.query_row(
+                        "SELECT MAX(orchard_commitment_tree_size - orchard_action_count)
+                         FROM blocks
+                         WHERE height <= :start_height",
+                        named_params![":start_height": u32::from(birthday_height)],
+                        |row| row.get::<_, Option<u64>>(0),
+                    )
+                    .optional()
+                    .map(|opt| opt.flatten())
+                    .transpose()
+                })
+                .transpose()?;
 
             // Compute the total blocks scanned so far above the starting height
             let scanned_count = conn.query_row(
                 "SELECT SUM(orchard_action_count)
                  FROM blocks
                  WHERE height > :start_height",
-                named_params![":start_height": u32::from(start_height)],
+                named_params![":start_height": u32::from(birthday_height)],
                 |row| row.get::<_, Option<u64>>(0),
             )?;
 
@@ -992,22 +1035,22 @@ impl ScanProgress for SubtreeScanProgress {
                      FROM orchard_tree_shards
                      WHERE subtree_end_height > :start_height
                      OR subtree_end_height IS NULL",
-                    named_params![":start_height": u32::from(start_height)],
+                    named_params![":start_height": u32::from(birthday_height)],
                     |row| {
                         let min_tree_size = row
                             .get::<_, Option<u64>>(0)?
-                            .map(|min| min << ORCHARD_SHARD_HEIGHT);
-                        let max_idx = row.get::<_, Option<u64>>(1)?;
-                        Ok(start_size
-                            .or(min_tree_size)
-                            .zip(max_idx)
-                            .map(|(min_tree_size, max)| {
-                                let max_tree_size = (max + 1) << ORCHARD_SHARD_HEIGHT;
+                            .map(|min_idx| min_idx << ORCHARD_SHARD_HEIGHT);
+                        let max_tree_size = row
+                            .get::<_, Option<u64>>(1)?
+                            .map(|max_idx| (max_idx + 1) << ORCHARD_SHARD_HEIGHT);
+                        Ok(start_size.or(min_tree_size).zip(max_tree_size).map(
+                            |(min_tree_size, max_tree_size)| {
                                 Ratio::new(
                                     scanned_count.unwrap_or(0),
                                     max_tree_size - min_tree_size,
                                 )
-                            }))
+                            },
+                        ))
                     },
                 )
                 .optional()?

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -370,8 +370,23 @@ mod tests {
                 sapling_fvk_item_cache BLOB,
                 p2pkh_fvk_item_cache BLOB,
                 birthday_height INTEGER NOT NULL,
+                birthday_sapling_tree_size INTEGER,
+                birthday_orchard_tree_size INTEGER,
                 recover_until_height INTEGER,
-                CHECK ( (account_kind = 0 AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL) OR (account_kind = 1 AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL) )
+                CHECK (
+                  (
+                    account_kind = 0
+                    AND hd_seed_fingerprint IS NOT NULL
+                    AND hd_account_index IS NOT NULL
+                    AND ufvk IS NOT NULL
+                  )
+                  OR
+                  (
+                    account_kind = 1
+                    AND hd_seed_fingerprint IS NULL
+                    AND hd_account_index IS NULL
+                  )
+                )
             )"#,
             r#"CREATE TABLE "addresses" (
                 account_id INTEGER NOT NULL,

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -402,6 +402,17 @@ mod tests {
                     ON UPDATE RESTRICT,
                 CONSTRAINT nf_uniq UNIQUE (spend_pool, nf)
             )",
+            "CREATE TABLE orchard_received_note_spends (
+                orchard_received_note_id INTEGER NOT NULL,
+                transaction_id INTEGER NOT NULL,
+                FOREIGN KEY (orchard_received_note_id)
+                    REFERENCES orchard_received_notes(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (transaction_id)
+                    -- We do not delete transactions, so this does not cascade
+                    REFERENCES transactions(id_tx),
+                UNIQUE (orchard_received_note_id, transaction_id)
+            )",
             "CREATE TABLE orchard_received_notes (
                 id INTEGER PRIMARY KEY,
                 tx INTEGER NOT NULL,
@@ -414,12 +425,10 @@ mod tests {
                 nf BLOB UNIQUE,
                 is_change INTEGER NOT NULL,
                 memo BLOB,
-                spent INTEGER,
                 commitment_tree_position INTEGER,
                 recipient_key_scope INTEGER,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account_id) REFERENCES accounts(id),
-                FOREIGN KEY (spent) REFERENCES transactions(id_tx),
                 CONSTRAINT tx_output UNIQUE (tx, action_index)
             )",
             "CREATE TABLE orchard_tree_cap (
@@ -447,6 +456,17 @@ mod tests {
                 contains_marked INTEGER,
                 CONSTRAINT root_unique UNIQUE (root_hash)
             )",
+            "CREATE TABLE sapling_received_note_spends (
+                sapling_received_note_id INTEGER NOT NULL,
+                transaction_id INTEGER NOT NULL,
+                FOREIGN KEY (sapling_received_note_id)
+                    REFERENCES sapling_received_notes(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (transaction_id)
+                    -- We do not delete transactions, so this does not cascade
+                    REFERENCES transactions(id_tx),
+                UNIQUE (sapling_received_note_id, transaction_id)
+            )",
             r#"CREATE TABLE "sapling_received_notes" (
                 id INTEGER PRIMARY KEY,
                 tx INTEGER NOT NULL,
@@ -458,12 +478,10 @@ mod tests {
                 nf BLOB UNIQUE,
                 is_change INTEGER NOT NULL,
                 memo BLOB,
-                spent INTEGER,
                 commitment_tree_position INTEGER,
                 recipient_key_scope INTEGER,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account_id) REFERENCES accounts(id),
-                FOREIGN KEY (spent) REFERENCES transactions(id_tx),
                 CONSTRAINT tx_output UNIQUE (tx, output_index)
             )"#,
             "CREATE TABLE sapling_tree_cap (
@@ -535,6 +553,17 @@ mod tests {
                 fee INTEGER,
                 FOREIGN KEY (block) REFERENCES blocks(height)
             )",
+            "CREATE TABLE transparent_received_output_spends (
+                transparent_received_output_id INTEGER NOT NULL,
+                transaction_id INTEGER NOT NULL,
+                FOREIGN KEY (transparent_received_output_id)
+                    REFERENCES utxos(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (transaction_id)
+                    -- We do not delete transactions, so this does not cascade
+                    REFERENCES transactions(id_tx),
+                UNIQUE (transparent_received_output_id, transaction_id)
+            )",
             "CREATE TABLE tx_locator_map (
                 block_height INTEGER NOT NULL,
                 tx_index INTEGER NOT NULL,
@@ -550,9 +579,7 @@ mod tests {
                 script BLOB NOT NULL,
                 value_zat INTEGER NOT NULL,
                 height INTEGER NOT NULL,
-                spent_in_tx INTEGER,
                 FOREIGN KEY (received_by_account_id) REFERENCES accounts(id),
-                FOREIGN KEY (spent_in_tx) REFERENCES transactions(id_tx),
                 CONSTRAINT tx_outpoint UNIQUE (prevout_txid, prevout_idx)
             )"#,
         ];
@@ -584,17 +611,11 @@ mod tests {
             r#"CREATE INDEX orchard_received_notes_account ON orchard_received_notes (
                 account_id ASC
             )"#,
-            r#"CREATE INDEX orchard_received_notes_spent ON orchard_received_notes (
-                spent ASC
-            )"#,
             r#"CREATE INDEX orchard_received_notes_tx ON orchard_received_notes (
                 tx ASC
             )"#,
             r#"CREATE INDEX "sapling_received_notes_account" ON "sapling_received_notes" (
                 "account_id" ASC
-            )"#,
-            r#"CREATE INDEX "sapling_received_notes_spent" ON "sapling_received_notes" (
-                "spent" ASC
             )"#,
             r#"CREATE INDEX "sapling_received_notes_tx" ON "sapling_received_notes" (
                 "tx" ASC
@@ -603,7 +624,6 @@ mod tests {
             r#"CREATE INDEX sent_notes_to_account ON "sent_notes" (to_account_id)"#,
             r#"CREATE INDEX sent_notes_tx ON "sent_notes" (tx)"#,
             r#"CREATE INDEX utxos_received_by_account ON "utxos" (received_by_account_id)"#,
-            r#"CREATE INDEX utxos_spent_in_tx ON "utxos" (spent_in_tx)"#,
         ];
         let mut indices_query = st
             .wallet()
@@ -686,6 +706,19 @@ mod tests {
                 subtree_start_height,
                 subtree_end_height,
                 contains_marked".to_owned(),
+            // v_received_note_spends
+            "CREATE VIEW v_received_note_spends AS
+            SELECT
+                2 AS pool,
+                sapling_received_note_id AS received_note_id,
+                transaction_id
+            FROM sapling_received_note_spends
+            UNION
+            SELECT
+                3 AS pool,
+                orchard_received_note_id AS received_note_id,
+                transaction_id
+            FROM orchard_received_note_spends".to_owned(),
             // v_received_notes
             "CREATE VIEW v_received_notes AS
                 SELECT
@@ -697,7 +730,6 @@ mod tests {
                     sapling_received_notes.value,
                     is_change,
                     sapling_received_notes.memo,
-                    spent,
                     sent_notes.id AS sent_note_id
                 FROM sapling_received_notes
                 LEFT JOIN sent_notes
@@ -713,7 +745,6 @@ mod tests {
                     orchard_received_notes.value,
                     is_change,
                     orchard_received_notes.memo,
-                    spent,
                     sent_notes.id AS sent_note_id
                 FROM orchard_received_notes
                 LEFT JOIN sent_notes
@@ -834,8 +865,11 @@ mod tests {
                            0                            AS received_count,
                            0                            AS memo_present
                     FROM v_received_notes
+                    JOIN v_received_note_spends rns
+                         ON rns.pool = v_received_notes.pool
+                         AND rns.received_note_id = v_received_notes.id_within_pool_table
                     JOIN transactions
-                         ON transactions.id_tx = v_received_notes.spent
+                         ON transactions.id_tx = rns.transaction_id
                     UNION
                     -- Transparent TXOs spent in this transaction
                     SELECT utxos.received_by_account_id AS account_id,
@@ -848,8 +882,10 @@ mod tests {
                            0                            AS received_count,
                            0                            AS memo_present
                     FROM utxos
+                    JOIN transparent_received_output_spends tros
+                         ON tros.transparent_received_output_id = utxos.id
                     JOIN transactions
-                         ON transactions.id_tx = utxos.spent_in_tx
+                         ON transactions.id_tx = tros.transaction_id
                 ),
                 -- Obtain a count of the notes that the wallet created in each transaction,
                 -- not counting change notes.

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -56,10 +56,10 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //       v_sapling_shard_unscanned_ranges    \           |       v_tx_outputs_use_legacy_false
     //                        |                   \          |                     |
     //                wallet_summaries             \         |      v_transactions_shielding_balance
-    //                                              \        |                     |
-    //                                               \       |       v_transactions_note_uniqueness
-    //                                                \      |        /
-    //                                                full_account_ids
+    //                        \                     \        |                     |
+    //                         \                     \       |       v_transactions_note_uniqueness
+    //                          \                     \      |        /
+    //                           -------------------- full_account_ids
     //                                                       |
     //                                             orchard_received_notes
     vec![

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -10,7 +10,9 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus;
 use zip32::fingerprint::SeedFingerprint;
 
-use super::{add_account_birthdays, receiving_key_scopes, v_transactions_note_uniqueness, wallet_summaries};
+use super::{
+    add_account_birthdays, receiving_key_scopes, v_transactions_note_uniqueness, wallet_summaries,
+};
 
 /// The migration that switched from presumed seed-derived account IDs to supporting
 /// HD accounts and all sorts of imported keys.

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, rc::Rc};
 
 use crate::wallet::{account_kind_code, init::WalletMigrationError};
-use rusqlite::{named_params, Transaction};
+use rusqlite::{named_params, OptionalExtension, Transaction};
 use schemer_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
@@ -10,7 +10,7 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus;
 use zip32::fingerprint::SeedFingerprint;
 
-use super::{add_account_birthdays, receiving_key_scopes, v_transactions_note_uniqueness};
+use super::{add_account_birthdays, receiving_key_scopes, v_transactions_note_uniqueness, wallet_summaries};
 
 /// The migration that switched from presumed seed-derived account IDs to supporting
 /// HD accounts and all sorts of imported keys.
@@ -31,6 +31,7 @@ impl<P: consensus::Parameters> schemer::Migration for Migration<P> {
             receiving_key_scopes::MIGRATION_ID,
             add_account_birthdays::MIGRATION_ID,
             v_transactions_note_uniqueness::MIGRATION_ID,
+            wallet_summaries::MIGRATION_ID,
         ]
         .into_iter()
         .collect()
@@ -50,8 +51,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
             account_index: zip32::AccountId::ZERO,
         });
         let account_kind_imported = account_kind_code(AccountSource::Imported);
-        transaction.execute_batch(
-            &format!(r#"
+        transaction.execute_batch(&format!(
+            r#"
             PRAGMA foreign_keys = OFF;
             PRAGMA legacy_alter_table = ON;
 
@@ -66,18 +67,29 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 sapling_fvk_item_cache BLOB,
                 p2pkh_fvk_item_cache BLOB,
                 birthday_height INTEGER NOT NULL,
+                birthday_sapling_tree_size INTEGER,
+                birthday_orchard_tree_size INTEGER,
                 recover_until_height INTEGER,
                 CHECK (
-                    (account_kind = {account_kind_derived} AND hd_seed_fingerprint IS NOT NULL AND hd_account_index IS NOT NULL AND ufvk IS NOT NULL)
-                    OR
-                    (account_kind = {account_kind_imported} AND hd_seed_fingerprint IS NULL AND hd_account_index IS NULL)
+                  (
+                    account_kind = {account_kind_derived}
+                    AND hd_seed_fingerprint IS NOT NULL
+                    AND hd_account_index IS NOT NULL
+                    AND ufvk IS NOT NULL
+                  )
+                  OR
+                  (
+                    account_kind = {account_kind_imported}
+                    AND hd_seed_fingerprint IS NULL
+                    AND hd_account_index IS NULL
+                  )
                 )
             );
             CREATE UNIQUE INDEX hd_account ON accounts_new (hd_seed_fingerprint, hd_account_index);
             CREATE UNIQUE INDEX accounts_uivk ON accounts_new (uivk);
             CREATE UNIQUE INDEX accounts_ufvk ON accounts_new (ufvk);
-            "#),
-        )?;
+            "#
+        ))?;
 
         // We require the seed *if* there are existing accounts in the table.
         if transaction.query_row("SELECT COUNT(*) FROM accounts", [], |row| {
@@ -158,19 +170,40 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                     #[cfg(not(feature = "transparent-inputs"))]
                     let transparent_item: Option<Vec<u8>> = None;
 
+                    // Get the tree sizes for the birthday height from the blocks table, if
+                    // available.
+                    let (birthday_sapling_tree_size, birthday_orchard_tree_size) = transaction
+                        .query_row(
+                            "SELECT sapling_commitment_tree_size - sapling_output_count,
+                                    orchard_commitment_tree_size - orchard_action_count
+                             FROM blocks
+                             WHERE height = :birthday_height",
+                            named_params![":birthday_height": birthday_height],
+                            |row| {
+                                Ok(row
+                                    .get::<_, Option<u32>>(0)?
+                                    .zip(row.get::<_, Option<u32>>(1)?))
+                            },
+                        )
+                        .optional()?
+                        .flatten()
+                        .map_or((None, None), |(s, o)| (Some(s), Some(o)));
+
                     transaction.execute(
                         r#"
                         INSERT INTO accounts_new (
                             id, account_kind, hd_seed_fingerprint, hd_account_index,
                             ufvk, uivk,
                             orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
-                            birthday_height, recover_until_height
+                            birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
+                            recover_until_height
                         )
                         VALUES (
                             :account_id, :account_kind, :seed_id, :account_index,
                             :ufvk, :uivk,
                             :orchard_fvk_item_cache, :sapling_fvk_item_cache, :p2pkh_fvk_item_cache,
-                            :birthday_height, :recover_until_height
+                            :birthday_height, :birthday_sapling_tree_size, :birthday_orchard_tree_size,
+                            :recover_until_height
                         );
                         "#,
                         named_params![
@@ -184,6 +217,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                             ":sapling_fvk_item_cache": ufvk_parsed.sapling().map(|k| k.to_bytes()),
                             ":p2pkh_fvk_item_cache": transparent_item,
                             ":birthday_height": birthday_height,
+                            ":birthday_sapling_tree_size": birthday_sapling_tree_size,
+                            ":birthday_orchard_tree_size": birthday_orchard_tree_size,
                             ":recover_until_height": recover_until_height,
                         ],
                     )?;

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
@@ -45,12 +45,10 @@ impl RusqliteMigration for Migration {
                 nf BLOB UNIQUE,
                 is_change INTEGER NOT NULL,
                 memo BLOB,
-                spent INTEGER,
                 commitment_tree_position INTEGER,
                 recipient_key_scope INTEGER,
                 FOREIGN KEY (tx) REFERENCES transactions(id_tx),
                 FOREIGN KEY (account_id) REFERENCES accounts(id),
-                FOREIGN KEY (spent) REFERENCES transactions(id_tx),
                 CONSTRAINT tx_output UNIQUE (tx, action_index)
             );
             CREATE INDEX orchard_received_notes_account ON orchard_received_notes (
@@ -59,8 +57,17 @@ impl RusqliteMigration for Migration {
             CREATE INDEX orchard_received_notes_tx ON orchard_received_notes (
                 tx ASC
             );
-            CREATE INDEX orchard_received_notes_spent ON orchard_received_notes (
-                spent ASC
+
+            CREATE TABLE orchard_received_note_spends (
+                orchard_received_note_id INTEGER NOT NULL,
+                transaction_id INTEGER NOT NULL,
+                FOREIGN KEY (orchard_received_note_id)
+                    REFERENCES orchard_received_notes(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (transaction_id)
+                    -- We do not delete transactions, so this does not cascade
+                    REFERENCES transactions(id_tx),
+                UNIQUE (orchard_received_note_id, transaction_id)
             );",
         )?;
 
@@ -78,7 +85,6 @@ impl RusqliteMigration for Migration {
                         sapling_received_notes.value,
                         is_change,
                         sapling_received_notes.memo,
-                        spent,
                         sent_notes.id AS sent_note_id
                     FROM sapling_received_notes
                     LEFT JOIN sent_notes
@@ -94,12 +100,30 @@ impl RusqliteMigration for Migration {
                         orchard_received_notes.value,
                         is_change,
                         orchard_received_notes.memo,
-                        spent,
                         sent_notes.id AS sent_note_id
                     FROM orchard_received_notes
                     LEFT JOIN sent_notes
                     ON (sent_notes.tx, sent_notes.output_pool, sent_notes.output_index) =
                        (orchard_received_notes.tx, {orchard_pool_code}, orchard_received_notes.action_index);"
+            )
+        })?;
+
+        transaction.execute_batch({
+            let sapling_pool_code = pool_code(PoolType::Shielded(ShieldedProtocol::Sapling));
+            let orchard_pool_code = pool_code(PoolType::Shielded(ShieldedProtocol::Orchard));
+            &format!(
+                "CREATE VIEW v_received_note_spends AS
+                SELECT
+                    {sapling_pool_code} AS pool,
+                    sapling_received_note_id AS received_note_id,
+                    transaction_id
+                FROM sapling_received_note_spends
+                UNION
+                SELECT
+                    {orchard_pool_code} AS pool,
+                    orchard_received_note_id AS received_note_id,
+                    transaction_id
+                FROM orchard_received_note_spends;"
             )
         })?;
 
@@ -157,8 +181,11 @@ impl RusqliteMigration for Migration {
                            0                            AS received_count,
                            0                            AS memo_present
                     FROM v_received_notes
+                    JOIN v_received_note_spends rns
+                         ON rns.pool = v_received_notes.pool
+                         AND rns.received_note_id = v_received_notes.id_within_pool_table
                     JOIN transactions
-                         ON transactions.id_tx = v_received_notes.spent
+                         ON transactions.id_tx = rns.transaction_id
                     UNION
                     -- Transparent TXOs spent in this transaction
                     SELECT utxos.received_by_account_id AS account_id,
@@ -171,8 +198,10 @@ impl RusqliteMigration for Migration {
                            0                            AS received_count,
                            0                            AS memo_present
                     FROM utxos
+                    JOIN transparent_received_output_spends tros
+                         ON tros.transparent_received_output_id = utxos.id
                     JOIN transactions
-                         ON transactions.id_tx = utxos.spent_in_tx
+                         ON transactions.id_tx = tros.transaction_id
                 ),
                 -- Obtain a count of the notes that the wallet created in each transaction,
                 -- not counting change notes.
@@ -223,9 +252,14 @@ impl RusqliteMigration for Migration {
                 LEFT JOIN sent_note_counts
                      ON sent_note_counts.account_id = notes.account_id
                      AND sent_note_counts.txid = notes.txid
-                GROUP BY notes.account_id, notes.txid;
+                GROUP BY notes.account_id, notes.txid;"
+            )
+        })?;
 
-                DROP VIEW v_tx_outputs;
+        transaction.execute_batch({
+            let transparent_pool_code = pool_code(PoolType::Transparent);
+            &format!(
+                "DROP VIEW v_tx_outputs;
                 CREATE VIEW v_tx_outputs AS
                 SELECT transactions.txid              AS txid,
                        v_received_notes.pool          AS output_pool,
@@ -267,7 +301,8 @@ impl RusqliteMigration for Migration {
                     ON transactions.id_tx = sent_notes.tx
                 LEFT JOIN v_received_notes
                     ON sent_notes.id = v_received_notes.sent_note_id
-                WHERE COALESCE(v_received_notes.is_change, 0) = 0;")
+                WHERE COALESCE(v_received_notes.is_change, 0) = 0;"
+            )
         })?;
 
         Ok(())

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -699,6 +699,7 @@ pub(crate) mod tests {
             value,
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            false,
         );
 
         for _ in 1..=10 {
@@ -1107,6 +1108,7 @@ pub(crate) mod tests {
             NonNegativeAmount::const_from_u64(10000),
             frontier_tree_size + 10,
             frontier_tree_size + 10,
+            false,
         );
         st.scan_cached_blocks(max_scanned, 1);
 
@@ -1293,6 +1295,7 @@ pub(crate) mod tests {
             NonNegativeAmount::const_from_u64(10000),
             frontier_tree_size + 10,
             frontier_tree_size + 10,
+            false,
         );
         st.scan_cached_blocks(max_scanned, 1);
 

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -594,7 +594,6 @@ pub(crate) mod tests {
         consensus::{BlockHeight, NetworkUpgrade, Parameters},
         transaction::components::amount::NonNegativeAmount,
     };
-    use zcash_protocol::ShieldedProtocol;
 
     use crate::{
         error::SqliteClientError,
@@ -610,10 +609,7 @@ pub(crate) mod tests {
     };
 
     #[cfg(feature = "orchard")]
-    use {
-        crate::wallet::orchard::tests::OrchardPoolTester, orchard::tree::MerkleHashOrchard,
-        zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT,
-    };
+    use {crate::wallet::orchard::tests::OrchardPoolTester, orchard::tree::MerkleHashOrchard};
 
     #[test]
     fn sapling_scan_complete() {
@@ -1188,9 +1184,7 @@ pub(crate) mod tests {
         assert_eq!(actual, expected);
     }
 
-    // FIXME: This requires fixes to the test framework.
     #[test]
-    #[cfg(feature = "orchard")]
     fn sapling_update_chain_tip_stable_max_scanned() {
         update_chain_tip_stable_max_scanned::<SaplingPoolTester>();
     }
@@ -1201,14 +1195,8 @@ pub(crate) mod tests {
         update_chain_tip_stable_max_scanned::<OrchardPoolTester>();
     }
 
-    // FIXME: This requires fixes to the test framework.
-    #[allow(dead_code)]
     fn update_chain_tip_stable_max_scanned<T: ShieldedPoolTester>() {
         use ScanPriority::*;
-
-        // Use a non-zero birthday offset because Sapling and NU5 are activated at the same height.
-        let (mut st, dfvk, birthday, sap_active) =
-            test_with_nu5_birthday_offset::<T>(76, BlockHash([0; 32]));
 
         // Set up the following situation:
         //
@@ -1216,21 +1204,65 @@ pub(crate) mod tests {
         //        |<--- 500 --->|<- 20 ->|<-- 50 -->|<- 20 ->|
         // wallet_birthday  max_scanned     last_shard_start
         //
-        let max_scanned = birthday.height() + 500;
-        let prior_tip = max_scanned + 20;
+        let birthday_offset = 76;
+        let birthday_prior_block_hash = BlockHash([0; 32]);
+        // We set the Sapling and Orchard frontiers at the birthday block initial state to 1234
+        // notes beyond the end of the first shard.
+        let frontier_tree_size: u32 = (0x1 << 16) + 1234;
+        let mut st = TestBuilder::new()
+            .with_block_cache()
+            .with_initial_chain_state(|rng, network| {
+                let birthday_height =
+                    network.activation_height(NetworkUpgrade::Nu5).unwrap() + birthday_offset;
 
-        // Set up some shard root history before the wallet birthday.
-        let second_to_last_shard_start = birthday.height() - 1000;
-        T::put_subtree_roots(
-            &mut st,
-            0,
-            &[CommitmentTreeRoot::from_parts(
-                second_to_last_shard_start,
-                // fake a hash, the value doesn't matter
-                T::empty_tree_leaf(),
-            )],
-        )
-        .unwrap();
+                // Construct a fake chain state for the end of the block with the given
+                // birthday_offset from the Nu5 birthday.
+                let (prior_sapling_roots, sapling_initial_tree) =
+                    Frontier::random_with_prior_subtree_roots(
+                        rng,
+                        frontier_tree_size.into(),
+                        NonZeroU8::new(16).unwrap(),
+                    );
+                // There will only be one prior root
+                let prior_sapling_roots = prior_sapling_roots
+                    .into_iter()
+                    .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 10, root))
+                    .collect::<Vec<_>>();
+
+                #[cfg(feature = "orchard")]
+                let (prior_orchard_roots, orchard_initial_tree) =
+                    Frontier::random_with_prior_subtree_roots(
+                        rng,
+                        frontier_tree_size.into(),
+                        NonZeroU8::new(16).unwrap(),
+                    );
+                // There will only be one prior root
+                #[cfg(feature = "orchard")]
+                let prior_orchard_roots = prior_orchard_roots
+                    .into_iter()
+                    .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 10, root))
+                    .collect::<Vec<_>>();
+
+                InitialChainState {
+                    chain_state: ChainState::new(
+                        birthday_height - 1,
+                        birthday_prior_block_hash,
+                        sapling_initial_tree,
+                        #[cfg(feature = "orchard")]
+                        orchard_initial_tree,
+                    ),
+                    prior_sapling_roots,
+                    #[cfg(feature = "orchard")]
+                    prior_orchard_roots,
+                }
+            })
+            .with_account_having_current_birthday()
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let dfvk = T::test_account_fvk(&st);
+        let birthday = account.birthday();
+        let sap_active = st.sapling_activation_height();
 
         // We have scan ranges and a subtree, but have scanned no blocks.
         let summary = st.get_wallet_summary(1);
@@ -1238,67 +1270,55 @@ pub(crate) mod tests {
 
         // Set up prior chain state. This simulates us having imported a wallet
         // with a birthday 520 blocks below the chain tip.
+        let max_scanned = birthday.height() + 500;
+        let prior_tip = max_scanned + 20;
         st.wallet_mut().update_chain_tip(prior_tip).unwrap();
 
         // Verify that the suggested scan ranges match what is expected.
         let expected = vec![
             scan_range(birthday.height().into()..(prior_tip + 1).into(), ChainTip),
-            scan_range(sap_active..birthday.height().into(), Ignored),
+            scan_range(sap_active.into()..birthday.height().into(), Ignored),
         ];
 
         let actual = suggest_scan_ranges(&st.wallet().conn, Ignored).unwrap();
         assert_eq!(actual, expected);
 
-        // Now, scan the max scanned block.
-        let initial_sapling_tree_size = birthday
-            .sapling_frontier()
-            .value()
-            .map(|f| u64::from(f.position() + 1))
-            .unwrap_or(0)
-            .try_into()
-            .unwrap();
-        #[cfg(feature = "orchard")]
-        let initial_orchard_tree_size = birthday
-            .orchard_frontier()
-            .value()
-            .map(|f| u64::from(f.position() + 1))
-            .unwrap_or(0)
-            .try_into()
-            .unwrap();
-        #[cfg(not(feature = "orchard"))]
-        let initial_orchard_tree_size = 0;
+        // Simulate that in the blocks between the wallet birthday and the max_scanned height,
+        // there are 10 Sapling notes and 10 Orchard notes created on the chain.
         st.generate_block_at(
             max_scanned,
-            BlockHash([0u8; 32]),
+            BlockHash([1; 32]),
             &dfvk,
             AddressType::DefaultExternal,
             NonNegativeAmount::const_from_u64(10000),
-            initial_sapling_tree_size,
-            initial_orchard_tree_size,
+            frontier_tree_size + 10,
+            frontier_tree_size + 10,
         );
         st.scan_cached_blocks(max_scanned, 1);
 
         // We have scanned a block, so we now have a starting tree position, 500 blocks above the
         // wallet birthday but before the end of the shard.
         let summary = st.get_wallet_summary(1);
-        assert_eq!(summary.as_ref().map(|s| T::next_subtree_index(s)), Some(0),);
+        assert_eq!(summary.as_ref().map(|s| T::next_subtree_index(s)), Some(0));
 
         // Progress denominator depends on which pools are enabled (which changes the
-        // initial tree states in `test_with_nu5_birthday_offset`).
-        let expected_denom = 1 << SAPLING_SHARD_HEIGHT;
+        // initial tree states). Here we compute the denominator based upon the fact that
+        // the trees are the same size at present.
+        let expected_denom = (1 << SAPLING_SHARD_HEIGHT) * 2 - frontier_tree_size;
         #[cfg(feature = "orchard")]
-        let expected_denom = expected_denom + (1 << ORCHARD_SHARD_HEIGHT);
+        let expected_denom = expected_denom * 2;
         assert_eq!(
             summary.and_then(|s| s.scan_progress()),
-            Some(Ratio::new(1, expected_denom))
+            Some(Ratio::new(1, u64::from(expected_denom)))
         );
 
         // Now simulate shutting down, and then restarting 70 blocks later, after a shard
-        // has been completed.
+        // has been completed in one pool. This shard will have index 2, as our birthday
+        // was in shard 1.
         let last_shard_start = prior_tip + 50;
         T::put_subtree_roots(
             &mut st,
-            0,
+            2,
             &[CommitmentTreeRoot::from_parts(
                 last_shard_start,
                 // fake a hash, the value doesn't matter
@@ -1306,6 +1326,36 @@ pub(crate) mod tests {
             )],
         )
         .unwrap();
+
+        {
+            let mut shard_stmt = st
+                .wallet_mut()
+                .conn
+                .prepare("SELECT shard_index, subtree_end_height FROM sapling_tree_shards")
+                .unwrap();
+            (shard_stmt
+                .query_and_then::<_, rusqlite::Error, _, _>([], |row| {
+                    Ok((row.get::<_, u32>(0)?, row.get::<_, Option<u32>>(1)?))
+                })
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>())
+            .unwrap();
+        }
+
+        {
+            let mut shard_stmt = st
+                .wallet_mut()
+                .conn
+                .prepare("SELECT shard_index, subtree_end_height FROM orchard_tree_shards")
+                .unwrap();
+            (shard_stmt
+                .query_and_then::<_, rusqlite::Error, _, _>([], |row| {
+                    Ok((row.get::<_, u32>(0)?, row.get::<_, Option<u32>>(1)?))
+                })
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>())
+            .unwrap();
+        }
 
         let new_tip = last_shard_start + 20;
         st.wallet_mut().update_chain_tip(new_tip).unwrap();
@@ -1320,26 +1370,20 @@ pub(crate) mod tests {
             // The max scanned block itself is left as-is.
             scan_range(max_scanned.into()..(max_scanned + 1).into(), Scanned),
             // The range below the second-to-last shard is ignored.
-            scan_range(sap_active..birthday.height().into(), Ignored),
+            scan_range(sap_active.into()..birthday.height().into(), Ignored),
         ];
 
         let actual = suggest_scan_ranges(&st.wallet().conn, Ignored).unwrap();
         assert_eq!(actual, expected);
 
-        // We've crossed a subtree boundary, and so still only have one scanned note but have two
-        // shards worth of notes to scan.
-        let expected_denom = expected_denom
-            + match T::SHIELDED_PROTOCOL {
-                ShieldedProtocol::Sapling => 1 << SAPLING_SHARD_HEIGHT,
-                #[cfg(feature = "orchard")]
-                ShieldedProtocol::Orchard => 1 << ORCHARD_SHARD_HEIGHT,
-                #[cfg(not(feature = "orchard"))]
-                ShieldedProtocol::Orchard => unreachable!(),
-            };
+        // We've crossed a subtree boundary, but only in one pool. We still only have one scanned
+        // note but in the pool where we crossed the subtree boundary we have two shards worth of
+        // notes to scan.
+        let expected_denom = expected_denom + (1 << 16);
         let summary = st.get_wallet_summary(1);
         assert_eq!(
             summary.and_then(|s| s.scan_progress()),
-            Some(Ratio::new(1, expected_denom))
+            Some(Ratio::new(1, u64::from(expected_denom)))
         );
     }
 


### PR DESCRIPTION
This fixes the remainder of the tests that were broken by the Orchard migration.

Fixes #1265
