### PR TITLE
zcash_client_backend: Ensure checkpoint at the end of each block.

### DIFF
--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -372,7 +372,7 @@ impl ChainState {
 /// ## Panics
 ///
 /// This method will panic if `from_height != from_state.block_height() + 1`.
-#[tracing::instrument(skip(params, block_source, data_db))]
+#[tracing::instrument(skip(params, block_source, data_db, from_state))]
 #[allow(clippy::type_complexity)]
 pub fn scan_cached_blocks<ParamsT, DbT, BlockSourceT>(
     params: &ParamsT,


### PR DESCRIPTION
This fixes an error wherein a note commitment in the last note commitment position in a block was not being correctly marked as a checkpoint.

This would occur when a block contained both Sapling and Orchard note commitments, but the final transaction in the block contained only either Sapling or Orchard note commitments, but not both.

Fixes #1302