### PR TITLE
zcash_client_sqlite: Disallow selection of dust notes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           --release
           --workspace
           ${{ steps.prepare.outputs.feature-flags }}
+          --features expensive-tests
           -- --ignored
       - name: Verify working directory is clean
         run: git diff --exit-code

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -127,5 +127,8 @@ transparent-inputs = [
 ## Exposes unstable APIs. Their behaviour may change at any time.
 unstable = ["zcash_client_backend/unstable"]
 
+## A feature used to isolate tests that are expensive to run. Test-only.
+expensive-tests = []
+
 [lib]
 bench = false

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -158,6 +158,7 @@ where
                  INNER JOIN transactions
                     ON transactions.id_tx = {table_prefix}_received_notes.tx
                  WHERE {table_prefix}_received_notes.account_id = :account
+                 AND value >= 5000 -- FIXME #1016, allow selection of a dust inputs
                  AND accounts.ufvk IS NOT NULL
                  AND recipient_key_scope IS NOT NULL
                  AND nf IS NOT NULL

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -596,6 +596,7 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[ignore] // FIXME: #1316 This requires support for dust outputs.
     fn zip317_spend() {
         testing::pool::zip317_spend::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -597,6 +597,7 @@ pub(crate) mod tests {
 
     #[test]
     #[ignore] // FIXME: #1316 This requires support for dust outputs.
+    #[cfg(not(feature = "expensive-tests"))]
     fn zip317_spend() {
         testing::pool::zip317_spend::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -603,6 +603,7 @@ pub(crate) mod tests {
 
     #[test]
     #[ignore] // FIXME: #1316 This requires support for dust outputs.
+    #[cfg(not(feature = "expensive-tests"))]
     fn zip317_spend() {
         testing::pool::zip317_spend::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -602,6 +602,7 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[ignore] // FIXME: #1316 This requires support for dust outputs.
     fn zip317_spend() {
         testing::pool::zip317_spend::<SaplingPoolTester>()
     }
@@ -612,9 +613,7 @@ pub(crate) mod tests {
         testing::pool::shield_transparent::<SaplingPoolTester>()
     }
 
-    // FIXME: This requires fixes to the test framework.
     #[test]
-    #[cfg(feature = "orchard")]
     fn birthday_in_anchor_shard() {
         testing::pool::birthday_in_anchor_shard::<SaplingPoolTester>()
     }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -123,6 +123,9 @@ test-dependencies = [
     "zcash_protocol/test-dependencies",
 ]
 
+## A feature used to isolate tests that are expensive to run. Test-only.
+expensive-tests = []
+
 [lib]
 bench = false
 

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -62,6 +62,7 @@ fn check_roundtrip(tx: Transaction) -> Result<(), TestCaseError> {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_sprout(tx in arb_tx(BranchId::Sprout)) {
         check_roundtrip(tx)?;
     }
@@ -70,6 +71,7 @@ proptest! {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_overwinter(tx in arb_tx(BranchId::Overwinter)) {
         check_roundtrip(tx)?;
     }
@@ -78,6 +80,7 @@ proptest! {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_sapling(tx in arb_tx(BranchId::Sapling)) {
         check_roundtrip(tx)?;
     }
@@ -86,6 +89,7 @@ proptest! {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_blossom(tx in arb_tx(BranchId::Blossom)) {
         check_roundtrip(tx)?;
     }
@@ -94,6 +98,7 @@ proptest! {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_heartwood(tx in arb_tx(BranchId::Heartwood)) {
         check_roundtrip(tx)?;
     }
@@ -119,6 +124,7 @@ proptest! {
 proptest! {
     #[test]
     #[ignore]
+    #[cfg(feature = "expensive-tests")]
     fn tx_serialization_roundtrip_future(tx in arb_tx(BranchId::ZFuture)) {
         check_roundtrip(tx)?;
     }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -67,6 +67,9 @@ local-prover = ["directories"]
 ## Enables multithreading support for creating proofs.
 multicore = ["bellman/multicore", "zcash_primitives/multicore"]
 
+## A feature used to isolate tests that are expensive to run. Test-only.
+expensive-tests = []
+
 [lib]
 bench = false
 

--- a/zcash_proofs/src/circuit/sprout/mod.rs
+++ b/zcash_proofs/src/circuit/sprout/mod.rs
@@ -335,6 +335,7 @@ where
 
 #[test]
 #[ignore]
+#[cfg(feature = "expensive-tests")]
 fn test_sprout_constraints() {
     use bellman::gadgets::test::*;
     use bls12_381::Scalar;


### PR DESCRIPTION
At present, we don't take builder padding rules into account in the determination of whether or not we can include spends of dust notes in grace actions. It's too complex to attempt a complete fix for Zashi 1.0, but we can have a tolerable workaround for launch by just never selecting dust-valued notes.