### PR TITLE
zcash_client_sqlite: Fix incorrect input selection filtering when sending to transparent.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "assert_matches",
  "base64",

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,13 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.12.1] - 2024-03-27
+
+### Fixed
+- This release fixes a problem in note selection when sending to a transparent
+  recipient, whereby available funds were being incorrectly excluded from 
+  input selection.
+
 ## [0.12.0] - 2024-03-25
 
 ### Added

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -657,6 +657,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn fully_funded_send_to_t() {
+        testing::pool::fully_funded_send_to_t::<OrchardPoolTester, SaplingPoolTester>()
+    }
+
+    #[test]
     fn multi_pool_checkpoint() {
         testing::pool::multi_pool_checkpoint::<OrchardPoolTester, SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -670,6 +670,14 @@ pub(crate) mod tests {
 
     #[test]
     #[cfg(feature = "orchard")]
+    fn fully_funded_send_to_t() {
+        use crate::wallet::orchard::tests::OrchardPoolTester;
+
+        testing::pool::fully_funded_send_to_t::<SaplingPoolTester, OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
     fn multi_pool_checkpoint() {
         use crate::wallet::orchard::tests::OrchardPoolTester;
 


### PR DESCRIPTION
The "avoid pool crossing" conditions in note selection were erroneously not taking into account the need to pay transparent outputs.