### PR TITLE
zcash_primitives: Refactor `Transaction` to permit omitting protocol-specific bundles

### DIFF
--- a/devtools/src/bin/inspect/transaction.rs
+++ b/devtools/src/bin/inspect/transaction.rs
@@ -19,7 +19,9 @@ use zcash_primitives::{
     legacy::{keys::pubkey_to_address, Script, TransparentAddress},
     memo::{Memo, MemoBytes},
     transaction::{
-        components::{amount::NonNegativeAmount, sapling as sapling_serialization, transparent},
+        components::{
+            amount::NonNegativeAmount, sapling as sapling_serialization, transparent, AllBundles,
+        },
         sighash::{signature_hash, SignableInput, TransparentAuthorizingContext},
         txid::TxIdDigester,
         Authorization, Transaction, TransactionData, TxId, TxVersion,
@@ -207,7 +209,7 @@ pub(crate) fn inspect(
         tx.write(&mut buf).unwrap();
         let tx = Transaction::read(&buf[..], tx.consensus_branch_id()).unwrap();
 
-        let tx: TransactionData<PrecomputedAuth> = tx.into_data().map_authorization(
+        let tx: TransactionData<AllBundles<PrecomputedAuth>> = tx.into_data().map_authorization(
             f_transparent,
             (),
             (),

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -149,7 +149,10 @@ mod tests {
     use tempfile::NamedTempFile;
     use zcash_primitives::{
         legacy::{Script, TransparentAddress},
-        transaction::{components::transparent, Authorized, TransactionData, TxVersion},
+        transaction::{
+            components::{transparent, AllBundles},
+            Authorized, TransactionData, TxVersion,
+        },
     };
     use zcash_protocol::{
         consensus::{BranchId, Network},
@@ -185,7 +188,7 @@ mod tests {
         .unwrap();
 
         // Add transactions to the wallet that exercise the data migration.
-        let add_tx_to_wallet = |tx: TransactionData<Authorized>| {
+        let add_tx_to_wallet = |tx: TransactionData<AllBundles<Authorized>>| {
             let tx = tx.freeze().unwrap();
             let txid = tx.txid();
             let mut raw_tx = vec![];

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -953,7 +953,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     use crate::{
         legacy::keys::{AccountPrivKey, IncomingViewingKey},
-        transaction::{builder::DEFAULT_TX_EXPIRY_DELTA, OutPoint, TxOut},
+        transaction::{builder::DEFAULT_TX_EXPIRY_DELTA, transparent::TxOut, OutPoint},
         zip32::AccountId,
     };
 

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -1,4 +1,9 @@
-//! Structs representing the components within Zcash transactions.
+//! Types representing the components within Zcash transactions.
+
+use std::marker::PhantomData;
+
+use zcash_protocol::value::BalanceError;
+
 pub mod amount {
     pub use zcash_protocol::value::{
         BalanceError, ZatBalance as Amount, Zatoshis as NonNegativeAmount, COIN,
@@ -31,3 +36,136 @@ pub use self::tze::{TzeIn, TzeOut};
 
 // π_A + π_B + π_C
 pub const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;
+
+/// The protocol-agnostic parts of a shielded bundle.
+///
+/// The trait methods can be implemented without any knowledge of protocol-specific
+/// details, only requiring the ability to parse the general bundle structure within a
+/// transaction.
+pub trait ShieldedBundle {
+    fn value_balance(&self) -> Amount;
+}
+
+impl ShieldedBundle for sprout::Bundle {
+    fn value_balance(&self) -> Amount {
+        // We don't support building Sprout bundles in Rust.
+        self.value_balance()
+            .expect("Sprout bundles are all checked by consensus")
+    }
+}
+
+impl<A: ::sapling::bundle::Authorization> ShieldedBundle for ::sapling::Bundle<A, Amount> {
+    fn value_balance(&self) -> Amount {
+        *self.value_balance()
+    }
+}
+
+impl<A: ::orchard::bundle::Authorization> ShieldedBundle for ::orchard::Bundle<A, Amount> {
+    fn value_balance(&self) -> Amount {
+        *self.value_balance()
+    }
+}
+
+/// The transparent part of a transaction.
+pub trait TransparentPart {
+    type Bundle;
+
+    fn value_balance<E, F>(bundle: &Self::Bundle, get_prevout_value: F) -> Result<Amount, E>
+    where
+        E: From<BalanceError>,
+        F: FnMut(&OutPoint) -> Result<Amount, E>;
+}
+
+#[derive(Debug)]
+pub struct Transparent<A: transparent::Authorization> {
+    _auth: PhantomData<A>,
+}
+
+impl<A: transparent::Authorization> TransparentPart for Transparent<A> {
+    type Bundle = transparent::Bundle<A>;
+
+    fn value_balance<E, F>(bundle: &Self::Bundle, get_prevout_value: F) -> Result<Amount, E>
+    where
+        E: From<BalanceError>,
+        F: FnMut(&OutPoint) -> Result<Amount, E>,
+    {
+        bundle.value_balance(get_prevout_value)
+    }
+}
+
+/// The Sprout part of a transaction.
+pub trait SproutPart {
+    type Bundle: ShieldedBundle;
+}
+
+/// Marker type for a transaction that may contain a Sprout part.
+#[derive(Debug)]
+pub struct Sprout;
+
+impl SproutPart for Sprout {
+    type Bundle = sprout::Bundle;
+}
+
+/// The Sapling part of a transaction.
+pub trait SaplingPart {
+    type Bundle: ShieldedBundle;
+}
+
+/// Marker type for a transaction that may contain a Sapling part.
+#[derive(Debug)]
+pub struct Sapling<A> {
+    _auth: PhantomData<A>,
+}
+
+impl<A: ::sapling::bundle::Authorization> SaplingPart for Sapling<A> {
+    type Bundle = ::sapling::Bundle<A, Amount>;
+}
+
+/// The Orchard part of a transaction.
+pub trait OrchardPart {
+    type Bundle: ShieldedBundle;
+}
+
+/// Marker type for a transaction that may contain an Orchard part.
+#[derive(Debug)]
+pub struct Orchard<A> {
+    _auth: PhantomData<A>,
+}
+
+impl<A: ::orchard::bundle::Authorization> OrchardPart for Orchard<A> {
+    type Bundle = ::orchard::bundle::Bundle<A, Amount>;
+}
+
+/// The TZE part of a transaction.
+#[cfg(zcash_unstable = "zfuture")]
+pub trait TzePart {
+    type Bundle;
+}
+
+/// Marker type for a transaction that may contain a TZE part.
+#[cfg(zcash_unstable = "zfuture")]
+#[derive(Debug)]
+pub struct Tze<A: tze::Authorization> {
+    _auth: PhantomData<A>,
+}
+
+#[cfg(zcash_unstable = "zfuture")]
+impl<A: tze::Authorization> TzePart for Tze<A> {
+    type Bundle = tze::Bundle<A>;
+}
+
+/// The Transparent part of an authorized transaction.
+pub trait AuthorizedTransparentPart: TransparentPart {}
+
+/// The Sprout part of an authorized transaction.
+pub trait AuthorizedSproutPart: SproutPart {}
+
+/// The Sapling part of an authorized transaction.
+pub trait AuthorizedSaplingPart: SaplingPart {}
+
+/// The Orchard part of an authorized transaction.
+pub trait AuthorizedOrchardPart: OrchardPart {}
+
+/// The TZE part of an authorized transaction.
+#[cfg(zcash_unstable = "zfuture")]
+pub trait AuthorizedTzePart: TzePart {}

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -34,8 +34,37 @@ pub use crate::sapling::bundle::{OutputDescription, SpendDescription};
 #[cfg(zcash_unstable = "zfuture")]
 pub use self::tze::{TzeIn, TzeOut};
 
+use super::Authorization;
+
 // π_A + π_B + π_C
 pub const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;
+
+/// The protocol-specific bundles of data within a transaction.
+pub trait Bundles {
+    type Transparent: TransparentPart;
+    type Sprout: SproutPart;
+    type Sapling: SaplingPart;
+    type Orchard: OrchardPart;
+
+    #[cfg(zcash_unstable = "zfuture")]
+    type Tze: TzePart;
+}
+
+/// Marker type for a transaction that may contain payments within any Zcash protocol.
+#[derive(Debug)]
+pub struct AllBundles<A: Authorization> {
+    _auth: PhantomData<A>,
+}
+
+impl<A: Authorization> Bundles for AllBundles<A> {
+    type Transparent = Transparent<A::TransparentAuth>;
+    type Sprout = Sprout;
+    type Sapling = Sapling<A::SaplingAuth>;
+    type Orchard = Orchard<A::OrchardAuth>;
+
+    #[cfg(zcash_unstable = "zfuture")]
+    type Tze = Tze<A::TzeAuth>;
+}
 
 /// The protocol-agnostic parts of a shielded bundle.
 ///

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -44,7 +44,15 @@ impl MapAuth<Authorized, Authorized> for () {
     }
 }
 
-impl AuthorizedOrchardPart for Orchard<orchard::bundle::Authorized> {}
+impl AuthorizedOrchardPart for Orchard<orchard::bundle::Authorized> {
+    fn read_v5_bundle<R: Read>(reader: R) -> io::Result<Option<Self::Bundle>> {
+        read_v5_bundle(reader)
+    }
+
+    fn write_v5_bundle<W: Write>(bundle: Option<&Self::Bundle>, writer: W) -> io::Result<()> {
+        write_v5_bundle(bundle, writer)
+    }
+}
 
 /// Reads an [`orchard::Bundle`] from a v5 transaction format.
 pub fn read_v5_bundle<R: Read>(

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -13,7 +13,7 @@ use orchard::{
 };
 use zcash_encoding::{Array, CompactSize, Vector};
 
-use super::Amount;
+use super::{Amount, AuthorizedOrchardPart, Orchard};
 use crate::transaction::Transaction;
 
 pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
@@ -43,6 +43,8 @@ impl MapAuth<Authorized, Authorized> for () {
         a
     }
 }
+
+impl AuthorizedOrchardPart for Orchard<orchard::bundle::Authorized> {}
 
 /// Reads an [`orchard::Bundle`] from a v5 transaction format.
 pub fn read_v5_bundle<R: Read>(

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -21,7 +21,7 @@ use crate::{
     transaction::Transaction,
 };
 
-use super::{Amount, GROTH_PROOF_SIZE};
+use super::{Amount, AuthorizedSaplingPart, Sapling, GROTH_PROOF_SIZE};
 
 /// Returns the enforcement policy for ZIP 212 at the given height.
 pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip212Enforcement {
@@ -83,6 +83,8 @@ impl MapAuth<Authorized, Authorized> for () {
         a
     }
 }
+
+impl AuthorizedSaplingPart for Sapling<sapling::bundle::Authorized> {}
 
 /// Consensus rules (§4.4) & (§4.5):
 /// - Canonical encoding is enforced here.

--- a/zcash_primitives/src/transaction/components/sprout.rs
+++ b/zcash_primitives/src/transaction/components/sprout.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Read, Write};
 
-use super::{amount::Amount, GROTH_PROOF_SIZE};
+use super::{amount::Amount, AuthorizedSproutPart, Sprout, GROTH_PROOF_SIZE};
 
 // π_A + π_A' + π_B + π_B' + π_C + π_C' + π_K + π_H
 const PHGR_PROOF_SIZE: usize = 33 + 33 + 65 + 33 + 33 + 33 + 33 + 33;
@@ -28,6 +28,8 @@ impl Bundle {
             .try_fold(Amount::zero(), |total, js| total + js.net_value())
     }
 }
+
+impl AuthorizedSproutPart for Sprout {}
 
 #[derive(Clone)]
 #[allow(clippy::upper_case_acronyms)]

--- a/zcash_primitives/src/transaction/components/sprout.rs
+++ b/zcash_primitives/src/transaction/components/sprout.rs
@@ -2,6 +2,8 @@
 
 use std::io::{self, Read, Write};
 
+use zcash_encoding::{CompactSize, Vector};
+
 use super::{amount::Amount, AuthorizedSproutPart, Sprout, GROTH_PROOF_SIZE};
 
 // π_A + π_A' + π_B + π_B' + π_C + π_C' + π_K + π_H
@@ -29,7 +31,50 @@ impl Bundle {
     }
 }
 
-impl AuthorizedSproutPart for Sprout {}
+impl AuthorizedSproutPart for Sprout {
+    fn read_v4_bundle<R: io::Read>(
+        mut reader: R,
+        tx_has_sprout: bool,
+        use_groth: bool,
+    ) -> io::Result<Option<Self::Bundle>> {
+        if tx_has_sprout {
+            let joinsplits = Vector::read(&mut reader, |r| JsDescription::read(r, use_groth))?;
+
+            if !joinsplits.is_empty() {
+                let mut bundle = Bundle {
+                    joinsplits,
+                    joinsplit_pubkey: [0; 32],
+                    joinsplit_sig: [0; 64],
+                };
+                reader.read_exact(&mut bundle.joinsplit_pubkey)?;
+                reader.read_exact(&mut bundle.joinsplit_sig)?;
+                Ok(Some(bundle))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write_v4_bundle<W: io::Write>(
+        bundle: Option<&Self::Bundle>,
+        mut writer: W,
+        tx_has_sprout: bool,
+    ) -> io::Result<()> {
+        if tx_has_sprout {
+            if let Some(bundle) = bundle {
+                Vector::write(&mut writer, &bundle.joinsplits, |w, e| e.write(w))?;
+                writer.write_all(&bundle.joinsplit_pubkey)?;
+                writer.write_all(&bundle.joinsplit_sig)?;
+            } else {
+                CompactSize::write(&mut writer, 0)?;
+            }
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 #[allow(clippy::upper_case_acronyms)]

--- a/zcash_primitives/src/transaction/components/transparent.rs
+++ b/zcash_primitives/src/transaction/components/transparent.rs
@@ -10,7 +10,10 @@ use crate::{
     transaction::TxId,
 };
 
-use super::amount::{Amount, BalanceError, NonNegativeAmount};
+use super::{
+    amount::{Amount, BalanceError, NonNegativeAmount},
+    AuthorizedTransparentPart, Transparent,
+};
 
 pub mod builder;
 
@@ -212,6 +215,8 @@ impl TxOut {
         self.script_pubkey.address()
     }
 }
+
+impl AuthorizedTransparentPart for Transparent<Authorized> {}
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use crate::{
     legacy::{Script, TransparentAddress},
     transaction::{
+        self as tx,
         components::{
             amount::{Amount, BalanceError, NonNegativeAmount},
             transparent::{self, Authorization, Authorized, Bundle, TxIn, TxOut},
@@ -16,7 +17,6 @@ use crate::{
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::transaction::{
-        self as tx,
         components::transparent::OutPoint,
         sighash::{signature_hash, SignableInput, SIGHASH_ALL},
         TransactionData, TxDigests,
@@ -239,9 +239,14 @@ impl TransparentAuthorizingContext for Unauthorized {
 }
 
 impl Bundle<Unauthorized> {
-    pub fn apply_signatures(
+    pub fn apply_signatures<
+        Sp: tx::sighash_v4::SproutSigDigester,
+        Sa: tx::sighash_v4::SaplingSigDigester,
+        B: tx::Bundles<Transparent = tx::Transparent<Unauthorized>, Sprout = Sp, Sapling = Sa>
+            + tx::sighash_v5::FutureBundles,
+    >(
         self,
-        #[cfg(feature = "transparent-inputs")] mtx: &TransactionData<tx::Unauthorized>,
+        #[cfg(feature = "transparent-inputs")] mtx: &TransactionData<B>,
         #[cfg(feature = "transparent-inputs")] txid_parts_cache: &TxDigests<Blake2bHash>,
     ) -> Bundle<Authorized> {
         #[cfg(feature = "transparent-inputs")]

--- a/zcash_primitives/src/transaction/components/tze.rs
+++ b/zcash_primitives/src/transaction/components/tze.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read, Write};
 
 use zcash_encoding::{CompactSize, Vector};
 
-use super::amount::Amount;
+use super::{amount::Amount, AuthorizedTzePart, Tze};
 use crate::{extensions::transparent as tze, transaction::TxId};
 
 pub mod builder;
@@ -229,6 +229,8 @@ impl TzeOut {
         })
     }
 }
+
+impl AuthorizedTzePart for Tze<Authorized> {}
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {

--- a/zcash_primitives/src/transaction/components/tze.rs
+++ b/zcash_primitives/src/transaction/components/tze.rs
@@ -230,7 +230,43 @@ impl TzeOut {
     }
 }
 
-impl AuthorizedTzePart for Tze<Authorized> {}
+impl AuthorizedTzePart for Tze<Authorized> {
+    fn read_bundle<R: Read>(mut reader: R, tx_has_tze: bool) -> io::Result<Option<Self::Bundle>> {
+        if tx_has_tze {
+            let vin = Vector::read(&mut reader, TzeIn::read)?;
+            let vout = Vector::read(&mut reader, TzeOut::read)?;
+            Ok(if vin.is_empty() && vout.is_empty() {
+                None
+            } else {
+                Some(Bundle {
+                    vin,
+                    vout,
+                    authorization: Authorized,
+                })
+            })
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write_bundle<W: Write>(
+        bundle: Option<&Self::Bundle>,
+        mut writer: W,
+        tx_has_tze: bool,
+    ) -> io::Result<()> {
+        if tx_has_tze {
+            if let Some(bundle) = bundle {
+                Vector::write(&mut writer, &bundle.vin, |w, e| e.write(w))?;
+                Vector::write(&mut writer, &bundle.vout, |w, e| e.write(w))?;
+            } else {
+                CompactSize::write(&mut writer, 0)?;
+                CompactSize::write(&mut writer, 0)?;
+            }
+        }
+
+        Ok(())
+    }
+}
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {

--- a/zcash_primitives/src/transaction/components/tze/builder.rs
+++ b/zcash_primitives/src/transaction/components/tze/builder.rs
@@ -157,8 +157,8 @@ impl<'a, BuildCtx> TzeBuilder<'a, BuildCtx> {
 impl Bundle<Unauthorized> {
     pub fn into_authorized(
         self,
-        unauthed_tx: &tx::TransactionData<tx::Unauthorized>,
-        signers: Vec<TzeSigner<'_, tx::TransactionData<tx::Unauthorized>>>,
+        unauthed_tx: &tx::TransactionData<tx::AllBundles<tx::Unauthorized>>,
+        signers: Vec<TzeSigner<'_, tx::TransactionData<tx::AllBundles<tx::Unauthorized>>>>,
     ) -> Result<Bundle<Authorized>, Error> {
         // Create TZE input witnesses
         let payloads = signers

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -32,14 +32,18 @@ use self::{
         orchard as orchard_serialization, sapling as sapling_serialization,
         sprout::{self, JsDescription},
         transparent::{self, TxIn, TxOut},
-        OutPoint,
+        AllBundles, Bundles, Orchard, OrchardPart, OutPoint, Sapling, SaplingPart, ShieldedBundle,
+        Sprout, SproutPart, Transparent, TransparentPart,
     },
     txid::{to_txid, BlockTxCommitmentDigester, TxIdDigester},
     util::sha256d::{HashReader, HashWriter},
 };
 
 #[cfg(zcash_unstable = "zfuture")]
-use self::components::tze::{self, TzeIn, TzeOut};
+use self::components::{
+    tze::{self, TzeIn, TzeOut},
+    Tze, TzePart,
+};
 
 const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C48270;
 const OVERWINTER_TX_VERSION: u32 = 3;
@@ -301,13 +305,13 @@ impl Authorization for Unauthorized {
 #[derive(Debug)]
 pub struct Transaction {
     txid: TxId,
-    data: TransactionData<Authorized>,
+    data: TransactionData<AllBundles<Authorized>>,
 }
 
 impl Deref for Transaction {
-    type Target = TransactionData<Authorized>;
+    type Target = TransactionData<AllBundles<Authorized>>;
 
-    fn deref(&self) -> &TransactionData<Authorized> {
+    fn deref(&self) -> &TransactionData<AllBundles<Authorized>> {
         &self.data
     }
 }
@@ -319,21 +323,70 @@ impl PartialEq for Transaction {
 }
 
 /// The information contained in a Zcash transaction.
-#[derive(Debug)]
-pub struct TransactionData<A: Authorization> {
+pub struct TransactionData<B: Bundles> {
     version: TxVersion,
     consensus_branch_id: BranchId,
     lock_time: u32,
     expiry_height: BlockHeight,
-    transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
-    sprout_bundle: Option<sprout::Bundle>,
-    sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
-    orchard_bundle: Option<orchard::bundle::Bundle<A::OrchardAuth, Amount>>,
+    transparent_bundle: Option<<B::Transparent as TransparentPart>::Bundle>,
+    sprout_bundle: Option<<B::Sprout as SproutPart>::Bundle>,
+    sapling_bundle: Option<<B::Sapling as SaplingPart>::Bundle>,
+    orchard_bundle: Option<<B::Orchard as OrchardPart>::Bundle>,
     #[cfg(zcash_unstable = "zfuture")]
-    tze_bundle: Option<tze::Bundle<A::TzeAuth>>,
+    tze_bundle: Option<<B::Tze as TzePart>::Bundle>,
 }
 
-impl<A: Authorization> TransactionData<A> {
+/// Trait marker for bounds that are not yet required by consensus rules.
+#[cfg(not(zcash_unstable = "zfuture"))]
+trait FutureDebug {}
+#[cfg(not(zcash_unstable = "zfuture"))]
+impl<B: Bundles> FutureDebug for B {}
+
+#[cfg(zcash_unstable = "zfuture")]
+trait FutureDebug: Bundles<Tze = Self::FutureTze> {
+    type FutureTze: TzePart<Bundle = Self::FutureTzeBundle> + fmt::Debug;
+    type FutureTzeBundle: fmt::Debug;
+}
+#[cfg(zcash_unstable = "zfuture")]
+impl<B> FutureDebug for B
+where
+    B: Bundles,
+    B::Tze: TzePart + fmt::Debug,
+    <B::Tze as TzePart>::Bundle: fmt::Debug,
+{
+    type FutureTze = B::Tze;
+    type FutureTzeBundle = <B::Tze as TzePart>::Bundle;
+}
+
+impl<B> fmt::Debug for TransactionData<B>
+where
+    B: Bundles + fmt::Debug + FutureDebug,
+    B::Transparent: TransparentPart + fmt::Debug,
+    B::Sprout: SproutPart + fmt::Debug,
+    B::Sapling: SaplingPart + fmt::Debug,
+    B::Orchard: OrchardPart + fmt::Debug,
+    <B::Transparent as TransparentPart>::Bundle: fmt::Debug,
+    <B::Sprout as SproutPart>::Bundle: fmt::Debug,
+    <B::Sapling as SaplingPart>::Bundle: fmt::Debug,
+    <B::Orchard as OrchardPart>::Bundle: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("TransactionData");
+        s.field("version", &self.version)
+            .field("consensus_branch_id", &self.consensus_branch_id)
+            .field("lock_time", &self.lock_time)
+            .field("expiry_height", &self.expiry_height)
+            .field("transparent_bundle", &self.transparent_bundle)
+            .field("sprout_bundle", &self.sprout_bundle)
+            .field("sapling_bundle", &self.sapling_bundle)
+            .field("orchard_bundle", &self.orchard_bundle);
+        #[cfg(zcash_unstable = "zfuture")]
+        s.field("tze_bundle", &self.tze_bundle);
+        s.finish()
+    }
+}
+
+impl<B: Bundles> TransactionData<B> {
     /// Constructs a `TransactionData` from its constituent parts.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
@@ -341,10 +394,10 @@ impl<A: Authorization> TransactionData<A> {
         consensus_branch_id: BranchId,
         lock_time: u32,
         expiry_height: BlockHeight,
-        transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
-        sprout_bundle: Option<sprout::Bundle>,
-        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
-        orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount>>,
+        transparent_bundle: Option<<B::Transparent as TransparentPart>::Bundle>,
+        sprout_bundle: Option<<B::Sprout as SproutPart>::Bundle>,
+        sapling_bundle: Option<<B::Sapling as SaplingPart>::Bundle>,
+        orchard_bundle: Option<<B::Orchard as OrchardPart>::Bundle>,
     ) -> Self {
         TransactionData {
             version,
@@ -369,11 +422,11 @@ impl<A: Authorization> TransactionData<A> {
         consensus_branch_id: BranchId,
         lock_time: u32,
         expiry_height: BlockHeight,
-        transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
-        sprout_bundle: Option<sprout::Bundle>,
-        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, Amount>>,
-        orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount>>,
-        tze_bundle: Option<tze::Bundle<A::TzeAuth>>,
+        transparent_bundle: Option<<B::Transparent as TransparentPart>::Bundle>,
+        sprout_bundle: Option<<B::Sprout as SproutPart>::Bundle>,
+        sapling_bundle: Option<<B::Sapling as SaplingPart>::Bundle>,
+        orchard_bundle: Option<<B::Orchard as OrchardPart>::Bundle>,
+        tze_bundle: Option<<B::Tze as TzePart>::Bundle>,
     ) -> Self {
         TransactionData {
             version,
@@ -405,28 +458,40 @@ impl<A: Authorization> TransactionData<A> {
     pub fn expiry_height(&self) -> BlockHeight {
         self.expiry_height
     }
+}
 
-    pub fn transparent_bundle(&self) -> Option<&transparent::Bundle<A::TransparentAuth>> {
+impl<TA: transparent::Authorization, B: Bundles<Transparent = Transparent<TA>>> TransactionData<B> {
+    pub fn transparent_bundle(&self) -> Option<&transparent::Bundle<TA>> {
         self.transparent_bundle.as_ref()
     }
+}
 
+impl<B: Bundles<Sprout = Sprout>> TransactionData<B> {
     pub fn sprout_bundle(&self) -> Option<&sprout::Bundle> {
         self.sprout_bundle.as_ref()
     }
+}
 
-    pub fn sapling_bundle(&self) -> Option<&sapling::Bundle<A::SaplingAuth, Amount>> {
+impl<SA: sapling::bundle::Authorization, B: Bundles<Sapling = Sapling<SA>>> TransactionData<B> {
+    pub fn sapling_bundle(&self) -> Option<&sapling::Bundle<SA, Amount>> {
         self.sapling_bundle.as_ref()
     }
+}
 
-    pub fn orchard_bundle(&self) -> Option<&orchard::Bundle<A::OrchardAuth, Amount>> {
+impl<OA: orchard::bundle::Authorization, B: Bundles<Orchard = Orchard<OA>>> TransactionData<B> {
+    pub fn orchard_bundle(&self) -> Option<&orchard::Bundle<OA, Amount>> {
         self.orchard_bundle.as_ref()
     }
+}
 
-    #[cfg(zcash_unstable = "zfuture")]
-    pub fn tze_bundle(&self) -> Option<&tze::Bundle<A::TzeAuth>> {
+#[cfg(zcash_unstable = "zfuture")]
+impl<TA: tze::Authorization, B: Bundles<Tze = Tze<TA>>> TransactionData<B> {
+    pub fn tze_bundle(&self) -> Option<&tze::Bundle<TA>> {
         self.tze_bundle.as_ref()
     }
+}
 
+impl<B: Bundles> TransactionData<B> {
     /// Returns the total fees paid by the transaction, given a function that can be used to
     /// retrieve the value of previous transactions' transparent outputs that are being spent in
     /// this transaction.
@@ -436,19 +501,19 @@ impl<A: Authorization> TransactionData<A> {
         F: FnMut(&OutPoint) -> Result<Amount, E>,
     {
         let value_balances = [
-            self.transparent_bundle
-                .as_ref()
-                .map_or_else(|| Ok(Amount::zero()), |b| b.value_balance(get_prevout))?,
-            self.sprout_bundle.as_ref().map_or_else(
+            self.transparent_bundle.as_ref().map_or_else(
                 || Ok(Amount::zero()),
-                |b| b.value_balance().ok_or(BalanceError::Overflow),
+                |b| B::Transparent::value_balance(b, get_prevout),
             )?,
+            self.sprout_bundle
+                .as_ref()
+                .map_or_else(Amount::zero, |b| b.value_balance()),
             self.sapling_bundle
                 .as_ref()
-                .map_or_else(Amount::zero, |b| *b.value_balance()),
+                .map_or_else(Amount::zero, |b| b.value_balance()),
             self.orchard_bundle
                 .as_ref()
-                .map_or_else(Amount::zero, |b| *b.value_balance()),
+                .map_or_else(Amount::zero, |b| b.value_balance()),
         ];
 
         value_balances
@@ -457,7 +522,7 @@ impl<A: Authorization> TransactionData<A> {
             .ok_or_else(|| BalanceError::Overflow.into())
     }
 
-    pub fn digest<D: TransactionDigest<A>>(&self, digester: D) -> D::Digest {
+    pub fn digest<D: TransactionDigest<B>>(&self, digester: D) -> D::Digest {
         digester.combine(
             digester.digest_header(
                 self.version,
@@ -477,43 +542,48 @@ impl<A: Authorization> TransactionData<A> {
     ///
     /// This shouldn't be necessary for most use cases; it is provided for handling the
     /// cross-FFI builder logic in `zcashd`.
-    pub fn map_bundles<B: Authorization>(
+    pub fn map_bundles<BB: Bundles>(
         self,
         f_transparent: impl FnOnce(
-            Option<transparent::Bundle<A::TransparentAuth>>,
-        ) -> Option<transparent::Bundle<B::TransparentAuth>>,
+            Option<<B::Transparent as TransparentPart>::Bundle>,
+        ) -> Option<<BB::Transparent as TransparentPart>::Bundle>,
+        f_sprout: impl FnOnce(
+            Option<<B::Sprout as SproutPart>::Bundle>,
+        ) -> Option<<BB::Sprout as SproutPart>::Bundle>,
         f_sapling: impl FnOnce(
-            Option<sapling::Bundle<A::SaplingAuth, Amount>>,
-        ) -> Option<sapling::Bundle<B::SaplingAuth, Amount>>,
+            Option<<B::Sapling as SaplingPart>::Bundle>,
+        ) -> Option<<BB::Sapling as SaplingPart>::Bundle>,
         f_orchard: impl FnOnce(
-            Option<orchard::bundle::Bundle<A::OrchardAuth, Amount>>,
-        ) -> Option<orchard::bundle::Bundle<B::OrchardAuth, Amount>>,
+            Option<<B::Orchard as OrchardPart>::Bundle>,
+        ) -> Option<<BB::Orchard as OrchardPart>::Bundle>,
         #[cfg(zcash_unstable = "zfuture")] f_tze: impl FnOnce(
-            Option<tze::Bundle<A::TzeAuth>>,
+            Option<<B::Tze as TzePart>::Bundle>,
         )
-            -> Option<tze::Bundle<B::TzeAuth>>,
-    ) -> TransactionData<B> {
+            -> Option<<BB::Tze as TzePart>::Bundle>,
+    ) -> TransactionData<BB> {
         TransactionData {
             version: self.version,
             consensus_branch_id: self.consensus_branch_id,
             lock_time: self.lock_time,
             expiry_height: self.expiry_height,
             transparent_bundle: f_transparent(self.transparent_bundle),
-            sprout_bundle: self.sprout_bundle,
+            sprout_bundle: f_sprout(self.sprout_bundle),
             sapling_bundle: f_sapling(self.sapling_bundle),
             orchard_bundle: f_orchard(self.orchard_bundle),
             #[cfg(zcash_unstable = "zfuture")]
             tze_bundle: f_tze(self.tze_bundle),
         }
     }
+}
 
-    pub fn map_authorization<B: Authorization>(
+impl<A: Authorization> TransactionData<AllBundles<A>> {
+    pub fn map_authorization<AB: Authorization>(
         self,
-        f_transparent: impl transparent::MapAuth<A::TransparentAuth, B::TransparentAuth>,
-        mut f_sapling: impl sapling_serialization::MapAuth<A::SaplingAuth, B::SaplingAuth>,
-        mut f_orchard: impl orchard_serialization::MapAuth<A::OrchardAuth, B::OrchardAuth>,
-        #[cfg(zcash_unstable = "zfuture")] f_tze: impl tze::MapAuth<A::TzeAuth, B::TzeAuth>,
-    ) -> TransactionData<B> {
+        f_transparent: impl transparent::MapAuth<A::TransparentAuth, AB::TransparentAuth>,
+        mut f_sapling: impl sapling_serialization::MapAuth<A::SaplingAuth, AB::SaplingAuth>,
+        mut f_orchard: impl orchard_serialization::MapAuth<A::OrchardAuth, AB::OrchardAuth>,
+        #[cfg(zcash_unstable = "zfuture")] f_tze: impl tze::MapAuth<A::TzeAuth, AB::TzeAuth>,
+    ) -> TransactionData<AllBundles<AB>> {
         TransactionData {
             version: self.version,
             consensus_branch_id: self.consensus_branch_id,
@@ -545,7 +615,7 @@ impl<A: Authorization> TransactionData<A> {
     }
 }
 
-impl<A: Authorization> TransactionData<A> {
+impl<SA: sapling::bundle::Authorization, B: Bundles<Sapling = Sapling<SA>>> TransactionData<B> {
     pub fn sapling_value_balance(&self) -> Amount {
         self.sapling_bundle
             .as_ref()
@@ -553,14 +623,14 @@ impl<A: Authorization> TransactionData<A> {
     }
 }
 
-impl TransactionData<Authorized> {
+impl TransactionData<AllBundles<Authorized>> {
     pub fn freeze(self) -> io::Result<Transaction> {
         Transaction::from_data(self)
     }
 }
 
 impl Transaction {
-    fn from_data(data: TransactionData<Authorized>) -> io::Result<Self> {
+    fn from_data(data: TransactionData<AllBundles<Authorized>>) -> io::Result<Self> {
         match data.version {
             TxVersion::Sprout(_) | TxVersion::Overwinter | TxVersion::Sapling => {
                 Self::from_data_v4(data)
@@ -571,7 +641,7 @@ impl Transaction {
         }
     }
 
-    fn from_data_v4(data: TransactionData<Authorized>) -> io::Result<Self> {
+    fn from_data_v4(data: TransactionData<AllBundles<Authorized>>) -> io::Result<Self> {
         let mut tx = Transaction {
             txid: TxId([0; 32]),
             data,
@@ -582,7 +652,7 @@ impl Transaction {
         Ok(tx)
     }
 
-    fn from_data_v5(data: TransactionData<Authorized>) -> Self {
+    fn from_data_v5(data: TransactionData<AllBundles<Authorized>>) -> Self {
         let txid = to_txid(
             data.version,
             data.consensus_branch_id,
@@ -592,7 +662,7 @@ impl Transaction {
         Transaction { txid, data }
     }
 
-    pub fn into_data(self) -> TransactionData<Authorized> {
+    pub fn into_data(self) -> TransactionData<AllBundles<Authorized>> {
         self.data
     }
 
@@ -923,7 +993,7 @@ pub struct TxDigests<A> {
     pub tze_digests: Option<TzeDigests<A>>,
 }
 
-pub trait TransactionDigest<A: Authorization> {
+pub trait TransactionDigest<B: Bundles> {
     type HeaderDigest;
     type TransparentDigest;
     type SaplingDigest;
@@ -944,21 +1014,21 @@ pub trait TransactionDigest<A: Authorization> {
 
     fn digest_transparent(
         &self,
-        transparent_bundle: Option<&transparent::Bundle<A::TransparentAuth>>,
+        transparent_bundle: Option<&<B::Transparent as TransparentPart>::Bundle>,
     ) -> Self::TransparentDigest;
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, Amount>>,
+        sapling_bundle: Option<&<B::Sapling as SaplingPart>::Bundle>,
     ) -> Self::SaplingDigest;
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, Amount>>,
+        orchard_bundle: Option<&<B::Orchard as OrchardPart>::Bundle>,
     ) -> Self::OrchardDigest;
 
     #[cfg(zcash_unstable = "zfuture")]
-    fn digest_tze(&self, tze_bundle: Option<&tze::Bundle<A::TzeAuth>>) -> Self::TzeDigest;
+    fn digest_tze(&self, tze_bundle: Option<&<B::Tze as TzePart>::Bundle>) -> Self::TzeDigest;
 
     fn combine(
         &self,
@@ -985,6 +1055,7 @@ pub mod testing {
             orchard::testing::{self as orchard},
             sapling::testing::{self as sapling},
             transparent::testing::{self as transparent},
+            AllBundles,
         },
         Authorized, Transaction, TransactionData, TxId, TxVersion,
     };
@@ -1021,7 +1092,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             version in Just(version)
-        ) -> TransactionData<Authorized> {
+        ) -> TransactionData<AllBundles<Authorized>> {
             TransactionData {
                 version,
                 consensus_branch_id,
@@ -1047,7 +1118,7 @@ pub mod testing {
             orchard_bundle in orchard::arb_bundle_for_version(version),
             tze_bundle in tze::arb_bundle(consensus_branch_id),
             version in Just(version)
-        ) -> TransactionData<Authorized> {
+        ) -> TransactionData<AllBundles<Authorized>> {
             TransactionData {
                 version,
                 consensus_branch_id,

--- a/zcash_primitives/src/transaction/sighash_v5.rs
+++ b/zcash_primitives/src/transaction/sighash_v5.rs
@@ -4,7 +4,10 @@ use blake2b_simd::{Hash as Blake2bHash, Params, State};
 use zcash_encoding::Array;
 
 use crate::transaction::{
-    components::transparent::{self, TxOut},
+    components::{
+        transparent::{self, TxOut},
+        Transparent, TransparentPart,
+    },
     sighash::{
         SignableInput, TransparentAuthorizingContext, SIGHASH_ANYONECANPAY, SIGHASH_MASK,
         SIGHASH_NONE, SIGHASH_SINGLE,
@@ -18,7 +21,10 @@ use crate::transaction::{
 
 #[cfg(zcash_unstable = "zfuture")]
 use {
-    crate::transaction::{components::tze, TzeDigests},
+    crate::transaction::{
+        components::{tze, Tze, TzePart},
+        TzeDigests,
+    },
     byteorder::WriteBytesExt,
     zcash_encoding::{CompactSize, Vector},
 };
@@ -32,6 +38,25 @@ const ZCASH_TZE_INPUT_HASH_PERSONALIZATION: &[u8; 16] = b"Zcash__TzeInHash";
 
 fn hasher(personal: &[u8; 16]) -> State {
     Params::new().hash_length(32).personal(personal).to_state()
+}
+
+/// Trait representing the transparent part of a [ZIP 244] transaction digest.
+///
+/// [ZIP 244]: https://zips.z.cash/zip-0244
+pub trait TransparentSigDigester: TransparentPart {
+    fn digest(
+        tx_data: Option<(&Self::Bundle, &TransparentDigests<Blake2bHash>)>,
+        input: &SignableInput<'_>,
+    ) -> Blake2bHash;
+}
+
+impl<A: TransparentAuthorizingContext> TransparentSigDigester for Transparent<A> {
+    fn digest(
+        tx_data: Option<(&Self::Bundle, &TransparentDigests<Blake2bHash>)>,
+        input: &SignableInput<'_>,
+    ) -> Blake2bHash {
+        transparent_sig_digest(tx_data, input)
+    }
 }
 
 /// Implements [ZIP 244 section S.2](https://zips.z.cash/zip-0244#s-2-transparent-sig-digest).
@@ -139,6 +164,24 @@ fn transparent_sig_digest<A: TransparentAuthorizingContext>(
 }
 
 #[cfg(zcash_unstable = "zfuture")]
+pub trait TzeSigDigester: TzePart {
+    fn digest(
+        tx_data: Option<(&Self::Bundle, &TzeDigests<Blake2bHash>)>,
+        input: &SignableInput<'_>,
+    ) -> Option<TzeDigests<Blake2bHash>>;
+}
+
+#[cfg(zcash_unstable = "zfuture")]
+impl<A: tze::Authorization> TzeSigDigester for Tze<A> {
+    fn digest(
+        tx_data: Option<(&Self::Bundle, &TzeDigests<Blake2bHash>)>,
+        input: &SignableInput<'_>,
+    ) -> Option<TzeDigests<Blake2bHash>> {
+        tx_data.map(|(bundle, tze_digests)| tze_input_sigdigests(bundle, input, tze_digests))
+    }
+}
+
+#[cfg(zcash_unstable = "zfuture")]
 fn tze_input_sigdigests<A: tze::Authorization>(
     bundle: &tze::Bundle<A>,
     input: &SignableInput<'_>,
@@ -168,14 +211,15 @@ fn tze_input_sigdigests<A: tze::Authorization>(
 }
 
 /// Implements the [Signature Digest section of ZIP 244](https://zips.z.cash/zip-0244#signature-digest)
-pub fn v5_signature_hash<
-    TA: TransparentAuthorizingContext,
-    A: Authorization<TransparentAuth = TA>,
->(
+pub fn v5_signature_hash<TA, A>(
     tx: &TransactionData<A>,
     signable_input: &SignableInput<'_>,
     txid_parts: &TxDigests<Blake2bHash>,
-) -> Blake2bHash {
+) -> Blake2bHash
+where
+    TA: TransparentAuthorizingContext,
+    A: Authorization<TransparentAuth = TA>,
+{
     // The caller must provide the transparent digests if and only if the transaction has a
     // transparent component.
     assert_eq!(
@@ -187,7 +231,7 @@ pub fn v5_signature_hash<
         tx.version,
         tx.consensus_branch_id,
         txid_parts.header_digest,
-        transparent_sig_digest(
+        Transparent::digest(
             tx.transparent_bundle
                 .as_ref()
                 .zip(txid_parts.transparent_digests.as_ref()),
@@ -196,10 +240,10 @@ pub fn v5_signature_hash<
         txid_parts.sapling_digest,
         txid_parts.orchard_digest,
         #[cfg(zcash_unstable = "zfuture")]
-        tx.tze_bundle
-            .as_ref()
-            .zip(txid_parts.tze_digests.as_ref())
-            .map(|(bundle, tze_digests)| tze_input_sigdigests(bundle, signable_input, tze_digests))
-            .as_ref(),
+        Tze::digest(
+            tx.tze_bundle.as_ref().zip(txid_parts.tze_digests.as_ref()),
+            signable_input,
+        )
+        .as_ref(),
     )
 }

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -18,7 +18,7 @@ use super::{
     testing::arb_tx,
     transparent::{self},
     txid::TxIdDigester,
-    Authorization, Transaction, TransactionData, TxDigests, TxIn,
+    AllBundles, Authorization, Transaction, TransactionData, TxDigests, TxIn,
 };
 
 #[cfg(zcash_unstable = "zfuture")]
@@ -206,11 +206,13 @@ impl Authorization for TestUnauthorized {
     type TzeAuth = tze::Authorized;
 }
 
+type TestUnauthorizedTransactionData = TransactionData<AllBundles<TestUnauthorized>>;
+
 #[test]
 fn zip_0244() {
     fn to_test_txdata(
         tv: &self::data::zip_0244::TestVector,
-    ) -> (TransactionData<TestUnauthorized>, TxDigests<Blake2bHash>) {
+    ) -> (TestUnauthorizedTransactionData, TxDigests<Blake2bHash>) {
         let tx = Transaction::read(&tv.tx[..], BranchId::Nu5).unwrap();
 
         assert_eq!(tx.txid.as_ref(), &tv.txid);

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -16,9 +16,9 @@ use super::{
     sighash_v4::v4_signature_hash,
     sighash_v5::v5_signature_hash,
     testing::arb_tx,
-    transparent::{self},
+    transparent::{self, TxIn},
     txid::TxIdDigester,
-    AllBundles, Authorization, Transaction, TransactionData, TxDigests, TxIn,
+    AllBundles, Authorization, Transaction, TransactionData, TxDigests,
 };
 
 #[cfg(zcash_unstable = "zfuture")]


### PR DESCRIPTION
Draft because there are still some things that need doing:
- [x] I want some feedback on the overall approach to check the direction makes sense.
- [ ] I haven't documented much yet (spent my time getting the refactor structured correctly so the commits make sense).
- [ ] I haven't checked all the various feature flag combinations yet.
- [x] The `Authorization`-ish traits are still tied to the protocol-specific crates. I think I need to introduce intermediate traits with blanket impls.
- [x] Factor out Sprout for completeness (even though we don't depend on anything for Sprout that we don't inherently need for basic Zcash support).
- [x] Factor out `ZFuture`.
- [ ] Needs changelog updates.