### PR TITLE
Remove zcash_primitives::zip339 module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,12 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "base64ct"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,20 +237,6 @@ dependencies = [
  "rand_core",
  "rayon",
  "subtle",
-]
-
-[[package]]
-name = "bip0039"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef0f0152ec5cf17f49a5866afaa3439816207fd4f0a224c0211ffaf5e278426"
-dependencies = [
- "hmac",
- "pbkdf2",
- "rand",
- "sha2",
- "unicode-normalization",
- "zeroize",
 ]
 
 [[package]]
@@ -635,7 +615,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1008,15 +987,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "home"
@@ -1558,17 +1528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,16 +1540,6 @@ dependencies = [
  "rand",
  "static_assertions",
  "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest",
- "password-hash",
 ]
 
 [[package]]
@@ -2682,15 +2631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,7 +3138,6 @@ version = "0.15.0"
 dependencies = [
  "aes",
  "assert_matches",
- "bip0039",
  "blake2b_simd",
  "byteorder",
  "chacha20poly1305",

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Removed
+- The `zcash_primitives::zip339` module, which reexported parts of the API of
+  the `bip0039` crate, has been removed. Use the `bip0039` crate directly
+  instead.
+
 ## [0.15.0] - 2024-03-25
 
 ### Added

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -63,9 +63,6 @@ hdwallet = { workspace = true, optional = true }
 #   - `SecretKey` and `PublicKey` types exposed
 secp256k1 = { workspace = true, optional = true }
 
-# - ZIP 339
-bip0039 = { version = "0.10", features = ["std", "all-languages"] }
-
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 # - Documentation

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -28,4 +28,3 @@ pub mod transaction;
 pub use zip32;
 #[cfg(zcash_unstable = "zfuture")]
 pub mod extensions;
-pub mod zip339;

--- a/zcash_primitives/src/zip339.rs
+++ b/zcash_primitives/src/zip339.rs
@@ -1,5 +1,0 @@
-//! [ZIP 339] for seed phrase support.
-//!
-//! [ZIP 339]: https://zips.z.cash/zip-0339
-
-pub use bip0039::{Count, Error, Language, Mnemonic};


### PR DESCRIPTION
Supercedes #1377. This helps with Arti support in Zebra. See https://github.com/zcash/librustzcash/pull/1377#issuecomment-2098664351 for discussion.