### PR TITLE
Tkey custom selection

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -52,7 +52,7 @@ use crate::{
     fees::{self, DustOutputPolicy},
     keys::UnifiedSpendingKey,
     proposal::{self, Proposal, ProposalError},
-    wallet::{Note, OvkPolicy, Recipient},
+    wallet::{Note, OvkPolicy, Recipient, TransparentAddressMetadata},
     zip321::{self, Payment},
     PoolType, ShieldedProtocol,
 };
@@ -619,6 +619,7 @@ where
             proposal.min_target_height(),
             &step_results,
             step,
+            None,
         )?;
         step_results.push((step, step_result));
     }
@@ -645,6 +646,9 @@ fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, N>(
     min_target_height: BlockHeight,
     prior_step_results: &[(&proposal::Step<N>, BuildResult)],
     proposal_step: &proposal::Step<N>,
+    usk_to_tkey: Option<
+        fn(&UnifiedSpendingKey, &TransparentAddressMetadata) -> hdwallet::secp256k1::SecretKey,
+    >,
 ) -> Result<
     BuildResult,
     Error<
@@ -823,10 +827,16 @@ where
                 .clone()
                 .ok_or_else(|| Error::NoSpendingKey(addr.encode(params)))?;
 
-            let secret_key = usk
-                .transparent()
-                .derive_secret_key(address_metadata.scope(), address_metadata.address_index())
-                .unwrap();
+            let secret_key = usk_to_tkey
+                .map(|f| f(usk, &address_metadata))
+                .unwrap_or_else(|| {
+                    usk.transparent()
+                        .derive_secret_key(
+                            address_metadata.scope(),
+                            address_metadata.address_index(),
+                        )
+                        .unwrap()
+                });
 
             utxos_spent.push(outpoint.clone());
             builder.add_transparent_input(secret_key, outpoint, utxo)?;


### PR DESCRIPTION
Zingolib uses a UnifiedSpendingKey where the transparent component is the account's externally-scoped key, instead of the account key...so the default usk-to-sk function doesn't get the child transparent key get we need.