### PR TITLE
Disable `sapling-crypto` default features by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ bitvec = "1"
 blake2s_simd = "1"
 bls12_381 = "0.8"
 jubjub = "0.10"
-sapling = { package = "sapling-crypto", version = "0.1.3" }
+sapling = { package = "sapling-crypto", version = "0.1.3", default-features = false }
 
 # - Orchard
 nonempty = "0.7"

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.15.1] - 2024-05-23
+
 - Fixed `sapling-crypto` dependency to not enable its `multicore` feature flag
   when the default features of `zcash_primitives` are disabled.
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+- Fixed `sapling-crypto` dependency to not enable its `multicore` feature flag
+  when the default features of `zcash_primitives` are disabled.
+
 ## [0.15.0] - 2024-03-25
 
 ### Added

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"


### PR DESCRIPTION
The only default-enabled feature flag in `sapling-crypto` is the `multicore` feature flag, which we re-export in each crate that includes proof creation. We need to disable it as a default feature of our dependency in order to enable it to be correctly disabled when a user of e.g. `zcash_primitives` disables its default features.