### PR TITLE
zcash_client_backend: Allow sharing instances of `ScanningKeys` between threads

### DIFF
--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -591,7 +591,7 @@ where
     ParamsT: consensus::Parameters + Send + 'static,
     BlockSourceT: BlockSource,
     DbT: WalletWrite,
-    <DbT as WalletRead>::AccountId: ConditionallySelectable + Default + Send + 'static,
+    <DbT as WalletRead>::AccountId: ConditionallySelectable + Default + Send + Sync + 'static,
 {
     assert_eq!(from_height, from_state.block_height + 1);
 

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -52,7 +52,7 @@ use std::marker::PhantomData;
 /// [`CompactSaplingOutput`]: crate::proto::compact_formats::CompactSaplingOutput
 /// [`CompactOrchardAction`]: crate::proto::compact_formats::CompactOrchardAction
 /// [`scan_block`]: crate::scanning::scan_block
-pub trait ScanningKeyOps<D: Domain, AccountId, Nf> {
+pub trait ScanningKeyOps<D: Domain, AccountId, Nf>: Send + Sync {
     /// Prepare the key for use in batch trial decryption.
     fn prepare(&self) -> D::IncomingViewingKey;
 
@@ -72,8 +72,8 @@ pub trait ScanningKeyOps<D: Domain, AccountId, Nf> {
     fn nf(&self, note: &D::Note, note_position: Position) -> Option<Nf>;
 }
 
-impl<D: Domain, AccountId, Nf, K: ScanningKeyOps<D, AccountId, Nf>> ScanningKeyOps<D, AccountId, Nf>
-    for &K
+impl<D: Domain, AccountId, Nf, K: ScanningKeyOps<D, AccountId, Nf> + Send + Sync>
+    ScanningKeyOps<D, AccountId, Nf> for &K
 {
     fn prepare(&self) -> D::IncomingViewingKey {
         (*self).prepare()
@@ -120,7 +120,7 @@ pub struct ScanningKey<Ivk, Nk, AccountId> {
     key_scope: Option<Scope>,
 }
 
-impl<AccountId> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
+impl<AccountId: Send + Sync> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
     for ScanningKey<sapling::SaplingIvk, sapling::NullifierDerivingKey, AccountId>
 {
     fn prepare(&self) -> sapling::note_encryption::PreparedIncomingViewingKey {
@@ -140,7 +140,7 @@ impl<AccountId> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
     }
 }
 
-impl<AccountId> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
+impl<AccountId: Send + Sync> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
     for (AccountId, SaplingIvk)
 {
     fn prepare(&self) -> sapling::note_encryption::PreparedIncomingViewingKey {
@@ -161,7 +161,7 @@ impl<AccountId> ScanningKeyOps<SaplingDomain, AccountId, sapling::Nullifier>
 }
 
 #[cfg(feature = "orchard")]
-impl<AccountId> ScanningKeyOps<OrchardDomain, AccountId, orchard::note::Nullifier>
+impl<AccountId: Send + Sync> ScanningKeyOps<OrchardDomain, AccountId, orchard::note::Nullifier>
     for ScanningKey<orchard::keys::IncomingViewingKey, orchard::keys::FullViewingKey, AccountId>
 {
     fn prepare(&self) -> orchard::keys::PreparedIncomingViewingKey {
@@ -241,7 +241,9 @@ impl<AccountId, IvkTag> ScanningKeys<AccountId, IvkTag> {
     }
 }
 
-impl<AccountId: Copy + Eq + Hash + 'static> ScanningKeys<AccountId, (AccountId, Scope)> {
+impl<AccountId: Copy + Eq + Hash + 'static + Send + Sync>
+    ScanningKeys<AccountId, (AccountId, Scope)>
+{
     /// Constructs a [`ScanningKeys`] from an iterator of [`UnifiedFullViewingKey`]s,
     /// along with the account identifiers corresponding to those UFVKs.
     pub fn from_account_ufvks(

--- a/zcash_client_backend/src/sync.rs
+++ b/zcash_client_backend/src/sync.rs
@@ -58,7 +58,7 @@ where
     CaT: BlockCache,
     CaT::Error: std::error::Error + Send + Sync + 'static,
     DbT: WalletWrite + WalletCommitmentTrees,
-    DbT::AccountId: ConditionallySelectable + Default + Send + 'static,
+    DbT::AccountId: ConditionallySelectable + Default + Send + Sync + 'static,
     <DbT as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
     <DbT as WalletCommitmentTrees>::Error: std::error::Error + Send + Sync + 'static,
 {
@@ -87,7 +87,7 @@ where
     CaT: BlockCache,
     CaT::Error: std::error::Error + Send + Sync + 'static,
     DbT: WalletWrite,
-    DbT::AccountId: ConditionallySelectable + Default + Send + 'static,
+    DbT::AccountId: ConditionallySelectable + Default + Send + Sync + 'static,
     DbT::Error: std::error::Error + Send + Sync + 'static,
 {
     // 3) Download chain tip metadata from lightwalletd
@@ -363,7 +363,7 @@ where
     CaT: BlockCache,
     CaT::Error: std::error::Error + Send + Sync + 'static,
     DbT: WalletWrite,
-    DbT::AccountId: ConditionallySelectable + Default + Send + 'static,
+    DbT::AccountId: ConditionallySelectable + Default + Send + Sync + 'static,
     DbT::Error: std::error::Error + Send + Sync + 'static,
 {
     info!("Scanning {}", scan_range);


### PR DESCRIPTION
## Motivation

It would be handy if Zebra could share instances of `ScanningKeys` between threads.

## Solution

- Bound `ScanningKeyOps` by `Send + Sync` so `ScanningKeys` auto-implements `Send` and `Sync` instead of `!Send` and `!Sync`.