### PR TITLE
Migrate from `hdwallet` to `bip32`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e141fb0f8be1c7b45887af94c88b182472b57c96b56773250ae00cd6a14a164"
+dependencies = [
+ "bs58",
+ "hmac",
+ "rand_core",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +677,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -998,19 +1015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdwallet"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a03ba7d4c9ea41552cd4351965ff96883e629693ae85005c501bb4b9e1c48a7"
-dependencies = [
- "lazy_static",
- "rand_core",
- "ring 0.16.20",
- "secp256k1",
- "thiserror",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1031,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1961,21 +1974,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -1985,7 +1983,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2039,7 +2037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -2050,8 +2048,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2155,15 +2153,15 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -2655,12 +2653,6 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3061,6 +3053,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bech32",
+ "bip32",
  "bls12_381",
  "bs58",
  "byteorder",
@@ -3069,7 +3062,6 @@ dependencies = [
  "futures-util",
  "group",
  "gumdrop",
- "hdwallet",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -3108,12 +3100,12 @@ name = "zcash_client_sqlite"
 version = "0.10.3"
 dependencies = [
  "assert_matches",
+ "bip32",
  "bls12_381",
  "bs58",
  "byteorder",
  "document-features",
  "group",
- "hdwallet",
  "incrementalmerkletree",
  "jubjub",
  "maybe-rayon",
@@ -3186,13 +3178,13 @@ name = "zcash_keys"
 version = "0.2.0"
 dependencies = [
  "bech32",
+ "bip32",
  "blake2b_simd",
  "bls12_381",
  "bs58",
  "byteorder",
  "document-features",
  "group",
- "hdwallet",
  "hex",
  "jubjub",
  "memuse",
@@ -3230,7 +3222,9 @@ version = "0.15.1"
 dependencies = [
  "aes",
  "assert_matches",
+ "bip32",
  "blake2b_simd",
+ "bs58",
  "byteorder",
  "chacha20poly1305",
  "clap",
@@ -3240,7 +3234,6 @@ dependencies = [
  "ff",
  "fpe",
  "group",
- "hdwallet",
  "hex",
  "incrementalmerkletree",
  "jubjub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ orchard = { version = "0.8.0", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent
-hdwallet = "0.4"
+bip32 = { version = "0.5", default-features = false, features = ["secp256k1-ffi"] }
 ripemd = "0.1"
-secp256k1 = "0.26"
+secp256k1 = "0.27"
 
 # CSPRNG
 rand = "0.8"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -22,6 +22,15 @@ who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.3.0"
 
+[[audits.bip32]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+notes = """
+- Crate has no unsafe code, and sets `#![forbid(unsafe_code)]`.
+- Crate has no powerful imports. Only filesystem acces is via `include_str!`, and is safe.
+"""
+
 [[audits.bytemuck]]
 who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-run"
@@ -248,6 +257,11 @@ delta = "1.0.16 -> 1.0.17"
 who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-run"
 delta = "1.0.17 -> 1.0.18"
+
+[[audits.secp256k1]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = ["safe-to-deploy", "crypto-reviewed"]
+delta = "0.26.0 -> 0.27.0"
 
 [[audits.serde]]
 who = "Daira-Emma Hopwood <daira@jacaranda.org>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -308,10 +308,6 @@ criteria = "safe-to-deploy"
 version = "0.8.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.hdwallet]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.hermit-abi]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -358,7 +354,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
 version = "0.3.65"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.jubjub]]
 version = "0.10.0"
@@ -553,10 +549,6 @@ version = "0.8.37"
 criteria = "safe-to-run"
 
 [[exemptions.ring]]
-version = "0.16.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.ring]]
 version = "0.17.8"
 criteria = "safe-to-deploy"
 
@@ -742,35 +734,31 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
 version = "0.2.92"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-backend]]
 version = "0.2.88"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-macro]]
 version = "0.2.88"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.web-sys]]
 version = "0.3.65"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.which]]
 version = "4.4.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.winapi]]
-version = "0.3.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.wyz]]
 version = "0.5.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1127,6 +1127,17 @@ criteria = "safe-to-deploy"
 version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.winapi]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.3.9"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.winapi-util]]
 who = "danakj@chromium.org"
 criteria = "safe-to-run"
@@ -1197,6 +1208,11 @@ delta = "0.2.12 -> 0.2.14"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.14 -> 0.2.15"
+
+[[audits.isrg.audits.hmac]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.12.1"
 
 [[audits.isrg.audits.num-bigint]]
 who = "David Cook <dcook@divviup.org>"
@@ -1297,11 +1313,6 @@ version = "0.4.1"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.5.0 -> 0.5.1"
-
-[[audits.isrg.audits.untrusted]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-version = "0.7.1"
 
 [[audits.isrg.audits.wasm-bindgen-shared]]
 who = "David Cook <dcook@divviup.org>"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -58,7 +58,7 @@ bech32.workspace = true
 bs58.workspace = true
 
 # - Errors
-hdwallet = { workspace = true, optional = true }
+bip32 = { workspace = true, optional = true }
 
 # - Logging and metrics
 memuse.workspace = true
@@ -133,7 +133,7 @@ lightwalletd-tonic-transport = ["lightwalletd-tonic", "tonic?/transport"]
 
 ## Enables receiving transparent funds and shielding them.
 transparent-inputs = [
-    "dep:hdwallet",
+    "dep:bip32",
     "zcash_keys/transparent-inputs",
     "zcash_primitives/transparent-inputs",
 ]

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,6 +8,9 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 ### Changed
 - MSRV is now 1.70.0.
+- `zcash_client_sqlite::error::SqliteClientError` has changed variants:
+  - Removed `HdwalletError`.
+  - Added `TransparentDerivation`.
 
 ## [0.10.3] - 2024-04-08
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -37,8 +37,8 @@ zip32.workspace = true
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 # - Errors
+bip32 = { workspace = true, optional = true }
 bs58.workspace = true
-hdwallet = { workspace = true, optional = true }
 
 # - Logging and metrics
 tracing.workspace = true
@@ -117,7 +117,7 @@ test-dependencies = [
 
 ## Enables receiving transparent funds and sending to transparent recipients
 transparent-inputs = [
-  "dep:hdwallet", 
+  "dep:bip32",
   "zcash_keys/transparent-inputs",
   "zcash_client_backend/transparent-inputs"
 ]

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -39,7 +39,7 @@ pub enum SqliteClientError {
 
     /// An error produced in legacy transparent address derivation
     #[cfg(feature = "transparent-inputs")]
-    HdwalletError(hdwallet::error::Error),
+    TransparentDerivation(bip32::Error),
 
     /// An error encountered in decoding a transparent address from its
     /// serialized form.
@@ -139,7 +139,7 @@ impl fmt::Display for SqliteClientError {
                 write!(f, "A rewind must be either of less than {} blocks, or at least back to block {} for your wallet; the requested height was {}.", PRUNING_DEPTH, h, r),
             SqliteClientError::DecodingError(e) => write!(f, "{}", e),
             #[cfg(feature = "transparent-inputs")]
-            SqliteClientError::HdwalletError(e) => write!(f, "{:?}", e),
+            SqliteClientError::TransparentDerivation(e) => write!(f, "{:?}", e),
             #[cfg(feature = "transparent-inputs")]
             SqliteClientError::TransparentAddress(e) => write!(f, "{}", e),
             SqliteClientError::TableNotEmpty => write!(f, "Table is not empty"),
@@ -190,9 +190,9 @@ impl From<prost::DecodeError> for SqliteClientError {
 }
 
 #[cfg(feature = "transparent-inputs")]
-impl From<hdwallet::error::Error> for SqliteClientError {
-    fn from(e: hdwallet::error::Error) -> Self {
-        SqliteClientError::HdwalletError(e)
+impl From<bip32::Error> for SqliteClientError {
+    fn from(e: bip32::Error) -> Self {
+        SqliteClientError::TransparentDerivation(e)
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -136,7 +136,9 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         }
         SqliteClientError::DecodingError(e) => WalletMigrationError::CorruptedData(e.to_string()),
         #[cfg(feature = "transparent-inputs")]
-        SqliteClientError::HdwalletError(e) => WalletMigrationError::CorruptedData(e.to_string()),
+        SqliteClientError::TransparentDerivation(e) => {
+            WalletMigrationError::CorruptedData(e.to_string())
+        }
         #[cfg(feature = "transparent-inputs")]
         SqliteClientError::TransparentAddress(e) => {
             WalletMigrationError::CorruptedData(e.to_string())

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -223,7 +223,7 @@ fn get_legacy_transparent_address<P: consensus::Parameters>(
             .map(|tfvk| {
                 tfvk.derive_external_ivk()
                     .map(|tivk| tivk.default_address())
-                    .map_err(SqliteClientError::HdwalletError)
+                    .map_err(SqliteClientError::TransparentDerivation)
             })
             .transpose()
     } else {

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -11,6 +11,9 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.70.0.
+- `zcash_keys::keys`:
+  - The (unstable) encoding of `UnifiedSpendingKey` has changed.
+  - `DerivationError::Transparent` now contains `bip32::Error`.
 
 ## [0.2.0] - 2024-03-25
 

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -36,7 +36,7 @@ bech32.workspace = true
 bs58.workspace = true
 
 # - Transparent protocols
-hdwallet = { workspace = true, optional = true }
+bip32 = { workspace = true, optional = true }
 
 # - Logging and metrics
 memuse.workspace = true
@@ -76,7 +76,7 @@ zcash_primitives = { workspace = true, features = ["test-dependencies"] }
 
 [features]
 ## Enables use of transparent key parts and addresses
-transparent-inputs = ["dep:hdwallet", "zcash_primitives/transparent-inputs"]
+transparent-inputs = ["dep:bip32", "zcash_primitives/transparent-inputs"]
 
 ## Enables use of Orchard key parts and addresses
 orchard = ["dep:orchard"]

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -93,7 +93,7 @@ pub enum DerivationError {
     #[cfg(feature = "orchard")]
     Orchard(orchard::zip32::Error),
     #[cfg(feature = "transparent-inputs")]
-    Transparent(hdwallet::error::Error),
+    Transparent(bip32::Error),
 }
 
 impl Display for DerivationError {
@@ -398,11 +398,11 @@ impl UnifiedSpendingKey {
                     }
                 }
                 Typecode::P2pkh => {
-                    if len != 64 {
+                    if len != 74 {
                         return Err(DecodingError::LengthMismatch(Typecode::P2pkh, len));
                     }
 
-                    let mut key = [0u8; 64];
+                    let mut key = [0u8; 74];
                     source
                         .read_exact(&mut key)
                         .map_err(|_| DecodingError::InsufficientData(Typecode::P2pkh))?;
@@ -604,8 +604,8 @@ impl UnifiedAddressRequest {
 }
 
 #[cfg(feature = "transparent-inputs")]
-impl From<hdwallet::error::Error> for DerivationError {
-    fn from(e: hdwallet::error::Error) -> Self {
+impl From<bip32::Error> for DerivationError {
+    fn from(e: bip32::Error) -> Self {
         DerivationError::Transparent(e)
     }
 }
@@ -1660,8 +1660,10 @@ mod tests {
 
                 let len = len + 2 + 169;
 
+                // Transparent part is an `xprv` transparent extended key deserialized
+                // into bytes from Base58, minus the 4 prefix bytes.
                 #[cfg(feature = "transparent-inputs")]
-                let len = len + 2 + 64;
+                let len = len + 2 + 74;
 
                 len
             };

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -6,13 +6,39 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `zcash_primitives::legacy::keys`:
+  - `impl From<TransparentKeyScope> for bip32::ChildNumber`
+  - `impl From<NonHardenedChildIndex> for bip32::ChildNumber`
+  - `impl TryFrom<bip32::ChildNumber> for NonHardenedChildIndex`
+
 ### Changed
 - MSRV is now 1.70.0.
+- Bumped dependencies to `secp256k1 0.27`.
+- `zcash_primitives::legacy::keys`:
+  - `AccountPrivKey::{from_bytes, to_bytes}` now use the byte encoding from the
+    inside of a `xprv` Base58 string encoding from BIP 32, excluding the prefix
+    bytes (i.e. starting with `depth`).
+  - `AccountPrivKey::from_extended_privkey` now takes
+    `bip32::ExtendedPrivateKey<secp256k1::SecretKey>`.
+  - The following methods now return `Result<_, bip32::Error>`:
+    - `AccountPrivKey::from_seed`
+    - `AccountPrivKey::derive_secret_key`
+    - `AccountPrivKey::derive_external_secret_key`
+    - `AccountPrivKey::derive_internal_secret_key`
+    - `AccountPubKey::derive_external_ivk`
+    - `AccountPubKey::derive_internal_ivk`
+    - `AccountPubKey::deserialize`
+    - `IncomingViewingKey::derive_address`
 
 ### Removed
 - The `zcash_primitives::zip339` module, which reexported parts of the API of
   the `bip0039` crate, has been removed. Use the `bip0039` crate directly
   instead.
+- The `hdwallet` dependency and its effect on `zcash_primitives::legacy::keys`:
+  - `impl From<TransparentKeyScope> for hdwallet::KeyIndex`
+  - `impl From<NonHardenedChildIndex> for hdwallet::KeyIndex`
+  - `impl TryFrom<hdwallet::KeyIndex> for NonHardenedChildIndex`
 
 ## [0.15.1] - 2024-05-23
 

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { workspace = true, optional = true }
 
 # - Transparent inputs
 #   - `Error` type exposed
-hdwallet = { workspace = true, optional = true }
+bip32 = { workspace = true, optional = true }
 #   - `SecretKey` and `PublicKey` types exposed
 secp256k1 = { workspace = true, optional = true }
 
@@ -69,6 +69,7 @@ secp256k1 = { workspace = true, optional = true }
 document-features.workspace = true
 
 # - Encodings
+bs58.workspace = true
 byteorder.workspace = true
 hex.workspace = true
 
@@ -109,7 +110,7 @@ default = ["multicore"]
 multicore = ["orchard/multicore", "sapling/multicore"]
 
 ## Enables spending transparent notes with the transaction builder.
-transparent-inputs = ["dep:hdwallet", "dep:ripemd", "dep:secp256k1"]
+transparent-inputs = ["dep:bip32", "dep:ripemd", "dep:secp256k1"]
 
 ### A temporary feature flag that exposes granular APIs needed by `zcashd`. These APIs
 ### should not be relied upon and will be removed in a future release.


### PR DESCRIPTION
As part of this, we migrate to `secp256k1 0.27`. This version does not bump `secp256k1-sys`, so remains compatible with the `libsecp256k1` revision used in `zcashd`.

The `zcash_primitives::legacy::keys::AccountPrivKey` encoding also changes to preserve the transparent extended key metadata. Previously the type was documented as such, but only encoded the private key and chain code; the new encoding now matches the documentation. As a side effect, the unstable encoding of `zcash_keys::keys::UnifiedSpendingKey` also changes.

Closes zcash/librustzcash#1407.
Closes zcash/librustzcash#1408.