### PR TITLE
Drop orchard unstable flag from VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-    "rust-analyzer.cargo.extraEnv": {
-        "RUSTFLAGS": "--cfg zcash_unstable=\"orchard\""
-    },
     "rust-analyzer.cargo.features": "all"
 }


### PR DESCRIPTION
This setting is no longer required, and its presence greatly increases build and test times while using VS Code extensions for rust because inconsistent settings are used, defeating the rust build cache.