### PR TITLE
zcash_client_sqlite: Fix handling of PRAGMA directives.

### DIFF
--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -262,7 +262,7 @@ pub fn init_wallet_db<P: consensus::Parameters + 'static>(
     init_wallet_db_internal(wdb, seed, &[], true)
 }
 
-fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
+pub(crate) fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
     wdb: &mut WalletDb<rusqlite::Connection, P>,
     seed: Option<SecretVec<u8>>,
     target_migrations: &[Uuid],
@@ -270,13 +270,13 @@ fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
 ) -> Result<(), MigratorError<WalletMigrationError>> {
     let seed = seed.map(Rc::new);
 
-    // Turn off foreign keys, and ensure that table replacement/modification
-    // does not break views
+    // Turn off foreign key enforcement, to ensure that table replacement does not break foreign
+    // key references in table definitions.
+    //
+    // It is necessary to perform this operation globally using the outer connection because this
+    // pragma has no effect when set or unset within a transaction.
     wdb.conn
-        .execute_batch(
-            "PRAGMA foreign_keys = OFF;
-             PRAGMA legacy_alter_table = TRUE;",
-        )
+        .execute_batch("PRAGMA foreign_keys = OFF;")
         .map_err(|e| MigratorError::Adapter(WalletMigrationError::from(e)))?;
     let adapter = RusqliteAdapter::new(&mut wdb.conn, Some("schemer_migrations".to_string()));
     adapter.init().expect("Migrations table setup succeeds.");
@@ -325,7 +325,7 @@ fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
 #[cfg(test)]
 #[allow(deprecated)]
 mod tests {
-    use rusqlite::{self, named_params, ToSql};
+    use rusqlite::{self, named_params, Connection, ToSql};
     use secrecy::Secret;
 
     use tempfile::NamedTempFile;
@@ -355,6 +355,15 @@ mod tests {
         zcash_client_backend::data_api::WalletWrite,
         zcash_primitives::zip32::DiversifierIndex,
     };
+
+    pub(crate) fn describe_tables(conn: &Connection) -> Result<Vec<String>, rusqlite::Error> {
+        let result = conn
+            .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' ORDER BY tbl_name")?
+            .query_and_then([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(result)
+    }
 
     #[test]
     fn verify_schema() {
@@ -390,20 +399,12 @@ mod tests {
             db::TABLE_UTXOS,
         ];
 
-        let mut tables_query = st
-            .wallet()
-            .conn
-            .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' ORDER BY tbl_name")
-            .unwrap();
-        let mut rows = tables_query.query([]).unwrap();
-        let mut expected_idx = 0;
-        while let Some(row) = rows.next().unwrap() {
-            let sql: String = row.get(0).unwrap();
+        let rows = describe_tables(&st.wallet().conn).unwrap();
+        for (actual, expected) in rows.iter().zip(expected_tables.iter()) {
             assert_eq!(
-                re.replace_all(&sql, " "),
-                re.replace_all(expected_tables[expected_idx], " ").trim(),
+                re.replace_all(actual, " "),
+                re.replace_all(expected, " ").trim(),
             );
-            expected_idx += 1;
         }
 
         let expected_indices = vec![

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -262,7 +262,7 @@ pub fn init_wallet_db<P: consensus::Parameters + 'static>(
     init_wallet_db_internal(wdb, seed, &[], true)
 }
 
-pub(crate) fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
+fn init_wallet_db_internal<P: consensus::Parameters + 'static>(
     wdb: &mut WalletDb<rusqlite::Connection, P>,
     seed: Option<SecretVec<u8>>,
     target_migrations: &[Uuid],
@@ -400,6 +400,7 @@ mod tests {
         ];
 
         let rows = describe_tables(&st.wallet().conn).unwrap();
+        assert_eq!(rows.len(), expected_tables.len());
         for (actual, expected) in rows.iter().zip(expected_tables.iter()) {
             assert_eq!(
                 re.replace_all(actual, " "),

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -126,6 +126,8 @@ mod tests {
 
     use crate::{wallet::init::init_wallet_db_internal, WalletDb};
 
+    /// Tests that we can migrate from a completely empty wallet database to the target
+    /// migrations.
     pub(crate) fn test_migrate(migrations: &[Uuid]) {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -116,3 +116,29 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         }),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use uuid::Uuid;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{wallet::init::init_wallet_db_internal, WalletDb};
+
+    pub(crate) fn test_migrate(migrations: &[Uuid]) {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+
+        let seed = [0xab; 32];
+        assert_matches!(
+            init_wallet_db_internal(
+                &mut db_data,
+                Some(Secret::new(seed.to_vec())),
+                migrations,
+                false
+            ),
+            Ok(_)
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -230,3 +230,13 @@ fn get_legacy_transparent_address<P: consensus::Parameters>(
         Ok(None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -213,3 +213,13 @@ fn insert_address<P: consensus::Parameters>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
@@ -37,19 +37,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &rusqlite::Transaction<'_>) -> Result<(), Self::Error> {
-        let mut get_accounts = transaction.prepare(
-            r#"
-            SELECT id, ufvk, uivk
-            FROM accounts
-            "#,
-        )?;
+        let mut get_accounts = transaction.prepare("SELECT id, ufvk, uivk FROM accounts")?;
 
         let mut update_address = transaction.prepare(
             r#"UPDATE "addresses"
                SET address = :address
                WHERE account_id = :account_id
-               AND diversifier_index_be = :j
-            "#,
+               AND diversifier_index_be = :j"#,
         )?;
 
         let mut accounts = get_accounts.query([])?;

--- a/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
@@ -107,3 +107,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
@@ -71,3 +71,13 @@ impl RusqliteMigration for Migration {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
@@ -312,3 +312,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
@@ -214,3 +214,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -221,3 +221,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
@@ -77,3 +77,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -280,3 +280,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -295,3 +295,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
@@ -52,3 +52,13 @@ impl RusqliteMigration for Migration {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
@@ -96,3 +96,13 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
@@ -153,3 +153,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
@@ -189,3 +189,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
@@ -90,3 +90,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
@@ -87,3 +87,13 @@ impl RusqliteMigration for Migration {
         Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}


### PR DESCRIPTION
The `foreign_keys` pragma has no effect when used within a transaction, so it should only be set at the top level. The `legacy_alter_table` pragma should only be used in cases where its effect is explicitly intended.

Best reviewed hiding whitespace changes.