### PR TITLE
zcash_client_backend: Fix panic related to insertion of frontiers below subtree roots.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.5.1"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=8b4b1315d64d171bcf701e5de59d0707dc029f9c#8b4b1315d64d171bcf701e5de59d0707dc029f9c"
+source = "git+https://github.com/zcash/incrementalmerkletree?rev=337f59179eda51261e9ddfc6b18e8fb84ea277c9#337f59179eda51261e9ddfc6b18e8fb84ea277c9"
 dependencies = [
  "either",
  "proptest",
@@ -2228,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "shardtree"
 version = "0.3.1"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=8b4b1315d64d171bcf701e5de59d0707dc029f9c#8b4b1315d64d171bcf701e5de59d0707dc029f9c"
+source = "git+https://github.com/zcash/incrementalmerkletree?rev=337f59179eda51261e9ddfc6b18e8fb84ea277c9#337f59179eda51261e9ddfc6b18e8fb84ea277c9"
 dependencies = [
  "assert_matches",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,5 +124,5 @@ panic = 'abort'
 codegen-units = 1
 
 [patch.crates-io]
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "8b4b1315d64d171bcf701e5de59d0707dc029f9c" }
-shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "8b4b1315d64d171bcf701e5de59d0707dc029f9c" }
+incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "337f59179eda51261e9ddfc6b18e8fb84ea277c9" }
+shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "337f59179eda51261e9ddfc6b18e8fb84ea277c9" }

--- a/zcash_client_backend/src/serialization/shardtree.rs
+++ b/zcash_client_backend/src/serialization/shardtree.rs
@@ -13,7 +13,6 @@ const SER_V1: u8 = 1;
 const NIL_TAG: u8 = 0;
 const LEAF_TAG: u8 = 1;
 const PARENT_TAG: u8 = 2;
-const PRUNED_TAG: u8 = 3;
 
 /// Writes a [`PrunableTree`] to the provided [`Write`] instance.
 ///
@@ -42,10 +41,6 @@ pub fn write_shard<H: HashSer, W: Write>(writer: &mut W, tree: &PrunableTree<H>)
             }
             Node::Nil => {
                 writer.write_u8(NIL_TAG)?;
-                Ok(())
-            }
-            Node::Pruned => {
-                writer.write_u8(PRUNED_TAG)?;
                 Ok(())
             }
         }
@@ -79,7 +74,6 @@ fn read_shard_v1<H: HashSer, R: Read>(mut reader: &mut R) -> io::Result<Prunable
             Ok(Tree::leaf((value, flags)))
         }
         NIL_TAG => Ok(Tree::empty()),
-        PRUNED_TAG => Ok(Tree::empty_pruned()),
         other => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("Node tag not recognized: {}", other),


### PR DESCRIPTION
Fixes #1431