### PR TITLE
Report proposal errors earlier and more precisely where possible

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -67,8 +67,25 @@ funds to those addresses. See [ZIP 320](https://zips.z.cash/zip-0320) for detail
   - `WalletWrite` has a new `reserve_next_n_ephemeral_addresses` method when
     the "transparent-inputs" feature is enabled.
   - `WalletWrite` has new methods `import_account_hd` and `import_account_ufvk`.
-  - `error::Error` has new `Address` and (when the "transparent-inputs" feature
-    is enabled) `PaysEphemeralTransparentAddress` variants.
+  - `error::Error` and `proposal::ProposalError`:
+    - `ProposalError` has new variants `SpendsChange`, `EphemeralOutputLeftUnspent`,
+      `PaysTexFromShielded`, `SpendsPaymentFromUnsupportedPool`, and
+      `PaysUnsupportedPoolRecipient` (some of which are conditional on the
+      "transparent-inputs" feature).
+      Of these, `SpendsChange` and `SpendsPaymentFromUnsupportedPool` are
+      currently reported when a `Proposal` or one of its `Step`s is constructed,
+      and the others are reported from `create_proposed_transactions`.
+      This may be changed in future to report these errors earlier; callers
+      should not rely on being able to construct `Proposal`s or `Step`s that
+      would result in these errors if a transaction were created from them.
+    - The `Error::ProposalNotSupported` variant now has an argument of type
+      `ProposalError` giving the more specific error. This will be used to
+      report the errors mentioned above that have "Unsupported" in their
+      names.
+    - The `Error::UnsupportedChangeType` variant has been removed since it
+      cannot occur (see `data_api::fees::TransactionBalance` below).
+    - `Error` has new `Address` and (when the "transparent-inputs" feature
+      is enabled) `PaysEphemeralTransparentAddress` variants.
   - `wallet::input_selection::InputSelectorError` has a new `Address` variant.
   - `DecryptedTransaction::new` takes an additional `mined_height` argument.
 - `zcash_client_backend::data_api::fees`
@@ -83,11 +100,12 @@ funds to those addresses. See [ZIP 320](https://zips.z.cash/zip-0320) for detail
     outputs. Passing `None` will retain the previous
     behaviour (and is necessary when the "transparent-inputs" feature is
     not enabled).
+  - `TransactionBalance::new` now enforces that the change and ephemeral
+    outputs are for supported pools, and will return an error if they are
+    not. This makes `data_api::error::Error::UnsupportedChangeType` impossible,
+    so it has been removed as mentioned above.
 - `zcash_client_backend::input_selection::GreedyInputSelectorError` has a
   new variant `UnsupportedTexAddress`.
-- `zcash_client_backend::proposal::ProposalError` has new variants
-  `SpendsChange`, `EphemeralOutputLeftUnspent`, and `PaysTexFromShielded`.
-  (the last two are conditional on the "transparent-inputs" feature).
 - `zcash_client_backend::proto`:
   - `ProposalDecodingError` has a new variant `InvalidEphemeralRecipient`.
   - `proposal::Proposal::{from_standard_proposal, try_into_standard_proposal}`

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -187,6 +187,9 @@ where
     let (change_pool, sapling_change, orchard_change) =
         single_change_output_policy(&net_flows, fallback_change_pool);
 
+    #[cfg(not(feature = "orchard"))]
+    assert!(change_pool != ShieldedProtocol::Orchard);
+
     // We don't create a fully-transparent transaction if a change memo is used.
     let transparent = net_flows.is_transparent() && change_memo.is_none();
 
@@ -432,6 +435,8 @@ where
             .map(ChangeValue::ephemeral_transparent),
     );
 
+    // Any error here can only be overflow, because we checked that `change_pool`
+    // is supported and only constructed `change` to that pool.
     TransactionBalance::new(change, fee).map_err(|_| overflow())
 }
 


### PR DESCRIPTION
This follow-up to #1257 is not essential, but it improves the error reporting by:
* reporting some errors when a proposal is constructed rather than when it is used to create transactions;
* reporting more precise errors for unsupported operations.

Closes #2111, the tracking issue opened for this pull request.
