### PR TITLE
chore: remove duplicate words

### DIFF
--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -409,7 +409,7 @@ pub trait Encoding: private::SealedContainer {
     }
 }
 
-/// Trait for for Unified containers, that exposes the items within them.
+/// Trait for Unified containers, that exposes the items within them.
 pub trait Container {
     /// The type of item in this unified container.
     type Item: SealedItem;

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1644,7 +1644,7 @@ impl BlockSource for BlockDb {
 ///
 /// This block source is intended to be used with the following data flow:
 /// * When the cache is being filled:
-///   * The caller requests the current maximum height height at which cached data is available
+///   * The caller requests the current maximum height at which cached data is available
 ///     using [`FsBlockDb::get_max_cached_height`]. If no cached data is available, the caller
 ///     can use the wallet's synced-to height for the following operations instead.
 ///   * (recommended for privacy) the caller should round the returned height down to some 100- /

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1134,7 +1134,7 @@ pub(crate) mod tests {
             &[FakeCompactOutput::new(
                 &dfvk,
                 AddressType::DefaultExternal,
-                // 1235 notes into into the second shard
+                // 1235 notes into the second shard
                 NonNegativeAmount::const_from_u64(10000),
             )],
             frontier_tree_size + 10,

--- a/zcash_primitives/src/extensions/transparent.rs
+++ b/zcash_primitives/src/extensions/transparent.rs
@@ -14,7 +14,7 @@ pub struct AuthData(pub Vec<u8>);
 /// Binary parsing capability for TZE preconditions & witnesses.
 ///
 /// Serialization formats interpreted by implementations of this trait become consensus-critical
-/// upon activation of of the extension that uses them.
+/// upon activation of the extension that uses them.
 pub trait FromPayload: Sized {
     type Error;
 
@@ -25,7 +25,7 @@ pub trait FromPayload: Sized {
 /// Binary serialization capability for TZE preconditions & witnesses.
 ///
 /// Serialization formats used by implementations of this trait become consensus-critical upon
-/// activation of of the extension that uses them.
+/// activation of the extension that uses them.
 pub trait ToPayload {
     /// Returns a serialized payload and its corresponding mode.
     fn to_payload(&self) -> (u32, Vec<u8>);

--- a/zcash_primitives/src/legacy/keys.rs
+++ b/zcash_primitives/src/legacy/keys.rs
@@ -112,7 +112,7 @@ impl AccountPrivKey {
     /// `m/44'/<coin_type>'/<account>'`.
     ///
     /// This produces the root of the derivation tree for transparent
-    /// viewing keys and addresses for the for the provided account.
+    /// viewing keys and addresses for the provided account.
     pub fn from_seed<P: consensus::Parameters>(
         params: &P,
         seed: &[u8],

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -39,7 +39,7 @@ impl FeeRule {
         }
     }
 
-    /// Returns the fixed fee amount which which this rule was configured.
+    /// Returns the fixed fee amount which this rule was configured.
     pub fn fixed_fee(&self) -> NonNegativeAmount {
         self.fixed_fee
     }


### PR DESCRIPTION
remove duplicate words in comments to improve readability.