### PR TITLE
Set the default optimization level to 3 for testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ lto = true
 panic = 'abort'
 codegen-units = 1
 
+[profile.test]
+opt-level = 3
+debug = true
+
 [patch.crates-io]
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "337f59179eda51261e9ddfc6b18e8fb84ea277c9" }
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "337f59179eda51261e9ddfc6b18e8fb84ea277c9" }


### PR DESCRIPTION
Use `--profile=dev` to disable this. (As well as the fact that much of our code essentially requires optimization to run at all reasonably, this ensures that we are testing the code as it is compiled for release builds.)

An advantage of this over using `--release` when running tests is that it builds with full debug information (as far as possible given that some things will be optimized out).