### PR TITLE
`zcash_extensions 0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_extensions"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -225,8 +225,8 @@ user-id = 1244
 user-login = "ebfull"
 
 [[publisher.zcash_extensions]]
-version = "0.0.0"
-when = "2020-04-24"
+version = "0.1.0"
+when = "2024-07-15"
 user-id = 6289
 user-login = "str4d"
 

--- a/zcash_extensions/CHANGELOG.md
+++ b/zcash_extensions/CHANGELOG.md
@@ -6,5 +6,7 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2024-07-15
 Initial release.
 MSRV is 1.70.0.

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_extensions"
 description = "Zcash Extension implementations & consensus node integration layer."
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Jack Grigg <jack@z.cash>", "Kris Nuttycombe <kris@z.cash>"]
 homepage = "https://github.com/zcash/librustzcash"
 repository.workspace = true


### PR DESCRIPTION
We are forced to publish this in order to secure the `zcash_extensions` crate name. crates.io changed their Usage Policy in November 2023 to prohibit name-squatting; my account was temporarily locked, and this crate deleted, because it only had a `0.0.0` reservation release with no code.