### PR TITLE
Make `nu6` rust feature stable

### DIFF
--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -354,7 +354,6 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_000)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_046_400)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_687_104)),
-            #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => None,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
@@ -384,8 +383,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
-            #[cfg(zcash_unstable = "nu6")]
-            NetworkUpgrade::Nu6 => None,
+            NetworkUpgrade::Nu6 => Some(BlockHeight(2_942_000)),
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
@@ -452,7 +450,6 @@ pub enum NetworkUpgrade {
     /// The [Nu6] network upgrade.
     ///
     /// [Nu6]: https://z.cash/upgrade/nu6/
-    #[cfg(zcash_unstable = "nu6")]
     Nu6,
     /// The ZFUTURE network upgrade.
     ///
@@ -474,7 +471,6 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Heartwood => write!(f, "Heartwood"),
             NetworkUpgrade::Canopy => write!(f, "Canopy"),
             NetworkUpgrade::Nu5 => write!(f, "Nu5"),
-            #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => write!(f, "Nu6"),
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => write!(f, "ZFUTURE"),
@@ -491,7 +487,6 @@ impl NetworkUpgrade {
             NetworkUpgrade::Heartwood => BranchId::Heartwood,
             NetworkUpgrade::Canopy => BranchId::Canopy,
             NetworkUpgrade::Nu5 => BranchId::Nu5,
-            #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => BranchId::Nu6,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => BranchId::ZFuture,
@@ -510,7 +505,6 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Heartwood,
     NetworkUpgrade::Canopy,
     NetworkUpgrade::Nu5,
-    #[cfg(zcash_unstable = "nu6")]
     NetworkUpgrade::Nu6,
 ];
 
@@ -549,7 +543,6 @@ pub enum BranchId {
     /// The consensus rules deployed by [`NetworkUpgrade::Nu5`].
     Nu5,
     /// The consensus rules deployed by [`NetworkUpgrade::Nu6`].
-    #[cfg(zcash_unstable = "nu6")]
     Nu6,
     /// Candidates for future consensus rules; this branch will never
     /// activate on mainnet.
@@ -571,7 +564,6 @@ impl TryFrom<u32> for BranchId {
             0xf5b9_230b => Ok(BranchId::Heartwood),
             0xe9ff_75a6 => Ok(BranchId::Canopy),
             0xc2d6_d0b4 => Ok(BranchId::Nu5),
-            #[cfg(zcash_unstable = "nu6")]
             0xc8e7_1055 => Ok(BranchId::Nu6),
             #[cfg(zcash_unstable = "zfuture")]
             0xffff_ffff => Ok(BranchId::ZFuture),
@@ -590,7 +582,6 @@ impl From<BranchId> for u32 {
             BranchId::Heartwood => 0xf5b9_230b,
             BranchId::Canopy => 0xe9ff_75a6,
             BranchId::Nu5 => 0xc2d6_d0b4,
-            #[cfg(zcash_unstable = "nu6")]
             BranchId::Nu6 => 0xc8e7_1055,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => 0xffff_ffff,
@@ -657,15 +648,16 @@ impl BranchId {
             BranchId::Canopy => params
                 .activation_height(NetworkUpgrade::Canopy)
                 .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu5))),
-            BranchId::Nu5 => params.activation_height(NetworkUpgrade::Nu5).map(|lower| {
+            BranchId::Nu5 => params
+                .activation_height(NetworkUpgrade::Nu5)
+                .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu6))),
+            BranchId::Nu6 => params.activation_height(NetworkUpgrade::Nu6).map(|lower| {
                 #[cfg(zcash_unstable = "zfuture")]
                 let upper = params.activation_height(NetworkUpgrade::ZFuture);
                 #[cfg(not(zcash_unstable = "zfuture"))]
                 let upper = None;
                 (lower, upper)
             }),
-            #[cfg(zcash_unstable = "nu6")]
-            BranchId::Nu6 => None,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => params
                 .activation_height(NetworkUpgrade::ZFuture)
@@ -694,7 +686,6 @@ pub mod testing {
             BranchId::Heartwood,
             BranchId::Canopy,
             BranchId::Nu5,
-            #[cfg(zcash_unstable = "nu6")]
             BranchId::Nu6,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture,

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -383,7 +383,7 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(903_800)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
-            NetworkUpgrade::Nu6 => Some(BlockHeight(2_942_000)),
+            NetworkUpgrade::Nu6 => None,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -37,7 +37,6 @@ pub struct LocalNetwork {
     pub heartwood: Option<BlockHeight>,
     pub canopy: Option<BlockHeight>,
     pub nu5: Option<BlockHeight>,
-    #[cfg(zcash_unstable = "nu6")]
     pub nu6: Option<BlockHeight>,
     #[cfg(zcash_unstable = "zfuture")]
     pub z_future: Option<BlockHeight>,
@@ -57,7 +56,6 @@ impl Parameters for LocalNetwork {
             NetworkUpgrade::Heartwood => self.heartwood,
             NetworkUpgrade::Canopy => self.canopy,
             NetworkUpgrade::Nu5 => self.nu5,
-            #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => self.nu6,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => self.z_future,
@@ -81,7 +79,6 @@ mod tests {
         let expected_heartwood = BlockHeight::from_u32(4);
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
-        #[cfg(zcash_unstable = "nu6")]
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(7);
@@ -93,7 +90,6 @@ mod tests {
             heartwood: Some(expected_heartwood),
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
-            #[cfg(zcash_unstable = "nu6")]
             nu6: Some(expected_nu6),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),
@@ -105,7 +101,6 @@ mod tests {
         assert!(regtest.is_nu_active(NetworkUpgrade::Heartwood, expected_heartwood));
         assert!(regtest.is_nu_active(NetworkUpgrade::Canopy, expected_canopy));
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu5, expected_nu5));
-        #[cfg(zcash_unstable = "nu6")]
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu6, expected_nu6));
         #[cfg(zcash_unstable = "zfuture")]
         assert!(!regtest.is_nu_active(NetworkUpgrade::ZFuture, expected_nu5));
@@ -119,7 +114,6 @@ mod tests {
         let expected_heartwood = BlockHeight::from_u32(4);
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
-        #[cfg(zcash_unstable = "nu6")]
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(7);
@@ -131,7 +125,6 @@ mod tests {
             heartwood: Some(expected_heartwood),
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
-            #[cfg(zcash_unstable = "nu6")]
             nu6: Some(expected_nu6),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),
@@ -176,7 +169,6 @@ mod tests {
         let expected_heartwood = BlockHeight::from_u32(4);
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
-        #[cfg(zcash_unstable = "nu6")]
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(7);
@@ -188,7 +180,6 @@ mod tests {
             heartwood: Some(expected_heartwood),
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
-            #[cfg(zcash_unstable = "nu6")]
             nu6: Some(expected_nu6),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -83,7 +83,7 @@ mod tests {
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(7);
+        let expected_z_future = BlockHeight::from_u32(8);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),
@@ -118,7 +118,7 @@ mod tests {
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(7);
+        let expected_z_future = BlockHeight::from_u32(8);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),
@@ -173,7 +173,7 @@ mod tests {
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(7);
+        let expected_z_future = BlockHeight::from_u32(8);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -16,6 +16,7 @@ use crate::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
 ///     nuparams=f5b9230b:1 # Heartwood
 ///     nuparams=e9ff75a6:1 # Canopy
 ///     nuparams=c2d6d0b4:1 # NU5
+///     nuparams=c8e71055:1 # NU6
 ///     ```
 ///     would use the following `LocalNetwork` struct
 ///     ```
@@ -26,7 +27,8 @@ use crate::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
 ///         heartwood: Some(BlockHeight::from_u32(1)),
 ///         canopy: Some(BlockHeight::from_u32(1)),
 ///         nu5: Some(BlockHeight::from_u32(1)),
-///         };
+///         nu6: Some(BlockHeight::from_u32(1)),
+///     };
 ///     ```
 ///     
 #[derive(Clone, PartialEq, Eq, Copy, Debug, Hash)]

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -127,7 +127,6 @@ impl TestBuilder<()> {
         heartwood: Some(BlockHeight::from_u32(100_000)),
         canopy: Some(BlockHeight::from_u32(100_000)),
         nu5: Some(BlockHeight::from_u32(100_000)),
-        #[cfg(zcash_unstable = "nu6")]
         nu6: None,
         #[cfg(zcash_unstable = "zfuture")]
         z_future: None,

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -513,7 +513,6 @@ mod tests {
                 NetworkUpgrade::Heartwood => Some(BlockHeight::from_u32(903_800)),
                 NetworkUpgrade::Canopy => Some(BlockHeight::from_u32(1_028_500)),
                 NetworkUpgrade::Nu5 => Some(BlockHeight::from_u32(1_200_000)),
-                #[cfg(zcash_unstable = "nu6")]
                 NetworkUpgrade::Nu6 => Some(BlockHeight::from_u32(1_300_000)),
                 NetworkUpgrade::ZFuture => Some(BlockHeight::from_u32(1_400_000)),
             }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -250,7 +250,6 @@ impl TxVersion {
                 TxVersion::Sapling
             }
             BranchId::Nu5 => TxVersion::Zip225,
-            #[cfg(zcash_unstable = "nu6")]
             BranchId::Nu6 => TxVersion::Zip225,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
@@ -1005,7 +1004,6 @@ pub mod testing {
                 Just(TxVersion::Sapling).boxed()
             }
             BranchId::Nu5 => Just(TxVersion::Zip225).boxed(),
-            #[cfg(zcash_unstable = "nu6")]
             BranchId::Nu6 => Just(TxVersion::Zip225).boxed(),
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => Just(TxVersion::ZFuture).boxed(),


### PR DESCRIPTION
We want to add the [testnet network activation to Zebra](https://github.com/ZcashFoundation/zebra/issues/8689) but we need the same in `zcash_primitives`. We also need to remove the `zcash_unstable = "nu6"` feature.