### PR TITLE
devtools: Add block hash lookups

### DIFF
--- a/devtools/src/bin/inspect/block.rs
+++ b/devtools/src/bin/inspect/block.rs
@@ -7,6 +7,7 @@ use std::convert::{TryFrom, TryInto};
 use std::io::{self, Read};
 
 use sha2::{Digest, Sha256};
+use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_encoding::Vector;
 use zcash_primitives::{
     block::BlockHeader,
@@ -280,6 +281,13 @@ fn inspect_header_inner(header: &BlockHeader, params: Option<Network>) {
     } else {
         eprintln!("🔎 To check contextual rules, add \"network\" to context (either \"main\" or \"test\")");
     }
+}
+
+/// Used when a block hash is resolved via lightwalletd.
+pub(crate) fn inspect_block_hash(block: &CompactBlock, network: &'static str) {
+    eprintln!("Zcash block hash");
+    eprintln!(" - Network: {}", network);
+    eprintln!(" - Height: {}", block.height());
 }
 
 pub(crate) fn inspect(block: &Block, context: Option<Context>) {

--- a/devtools/src/bin/inspect/lookup.rs
+++ b/devtools/src/bin/inspect/lookup.rs
@@ -1,6 +1,7 @@
 use tonic::transport::{Channel, ClientTlsConfig};
-use zcash_client_backend::proto::service::{
-    compact_tx_streamer_client::CompactTxStreamerClient, TxFilter,
+use zcash_client_backend::proto::{
+    compact_formats::CompactBlock,
+    service::{compact_tx_streamer_client::CompactTxStreamerClient, BlockId, TxFilter},
 };
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::{BlockHeight, BranchId, Network};
@@ -56,6 +57,18 @@ impl Lightwalletd {
             inner: connect(&TESTNET).await?,
             parameters: Network::TestNetwork,
         })
+    }
+
+    pub(crate) async fn lookup_block_hash(&mut self, candidate: [u8; 32]) -> Option<CompactBlock> {
+        let request = BlockId {
+            hash: candidate.into(),
+            ..Default::default()
+        };
+        self.inner
+            .get_block(request)
+            .await
+            .ok()
+            .map(|b| b.into_inner())
     }
 
     pub(crate) async fn lookup_txid(


### PR DESCRIPTION
Curently doesn't work because `lightwalletd` does not have support for looking up blocks by hash.