### PR TITLE
Post #1425 fixes

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1636,7 +1636,7 @@ pub trait WalletWrite: WalletRead {
     /// The ZIP-32 account index may be obtained by calling [`WalletRead::get_account`]
     /// with the returned account identifier.
     ///
-    /// Learn more about account creation and import in the [`WalletWrite`] trait documentation.
+    /// The [`WalletWrite`] trait documentation has more details about account creation and import.
     ///
     /// # Panics
     ///
@@ -1657,11 +1657,11 @@ pub trait WalletWrite: WalletRead {
     /// account index. It is an opaque identifier for a pool of funds or set of outputs controlled
     /// by a single spending authority.
     ///
-    /// Import accounts with indexes that are exactly one greater than the highest existing account
-    /// index to ensure account indexes are contiguous, thereby facilitating automated account
+    /// Import accounts with indices that are exactly one greater than the highest existing account
+    /// index to ensure account indices are contiguous, thereby facilitating automated account
     /// recovery.
     ///
-    /// Learn more about account creation and import in the [`WalletWrite`] trait documentation.
+    /// The [`WalletWrite`] trait documentation has more details about account creation and import.
     ///
     /// # Panics
     ///
@@ -1686,7 +1686,7 @@ pub trait WalletWrite: WalletRead {
     /// `spending_key_available` is `false`, the wallet may choose to optimize for this case, in
     /// which case any attempt to spend funds from the account will result in an error.
     ///
-    /// Learn more about account creation and import in the [`WalletWrite`] trait documentation.
+    /// The [`WalletWrite`] trait documentation has more details about account creation and import.
     ///
     /// # Panics
     ///

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1460,7 +1460,7 @@ impl AccountBirthday {
     /// Constructs a new [`AccountBirthday`] from its constituent parts.
     ///
     /// * `prior_chain_state`: The chain state prior to the birthday height of the account. The
-    ///    birthday height  is defined as the height of the first block to be scanned in wallet
+    ///    birthday height is defined as the height of the first block to be scanned in wallet
     ///    recovery.
     /// * `recover_until`: An optional height at which the wallet should exit "recovery mode". In
     ///    order to avoid confusing shifts in wallet balance and spendability that may temporarily be
@@ -1651,11 +1651,11 @@ pub trait WalletWrite: WalletRead {
 
     /// Tells the wallet to track a specific account index for a given seed.
     ///
-    /// Returns details about the imported account, including the unique account  identifier for
-    /// the newly-created wallet database entry, along with the associated  [`UnifiedSpendingKey`].
-    /// Note that the unique account identifier should *not* be  assumed equivalent to the ZIP 32
-    /// account index. It is an opaque identifier for a  pool of funds or set of outputs controlled
-    /// by a single spending authority.  
+    /// Returns details about the imported account, including the unique account identifier for
+    /// the newly-created wallet database entry, along with the associated [`UnifiedSpendingKey`].
+    /// Note that the unique account identifier should *not* be assumed equivalent to the ZIP 32
+    /// account index. It is an opaque identifier for a pool of funds or set of outputs controlled
+    /// by a single spending authority.
     ///
     /// Import accounts with indexes that are exactly one greater than the highest existing account
     /// index to ensure account indexes are contiguous, thereby facilitating automated account
@@ -1677,10 +1677,10 @@ pub trait WalletWrite: WalletRead {
 
     /// Tells the wallet to track an account using a unified full viewing key.
     ///
-    /// Returns details about the imported account, including the unique account  identifier for
-    /// the newly-created wallet database entry. Unlike the other account  creation APIs
-    /// ([`Self::create_account`] and [`Self::import_account_hd`]), no  spending key is returned
-    /// because the wallet has no information about how the UFVK  was derived.  
+    /// Returns details about the imported account, including the unique account identifier for
+    /// the newly-created wallet database entry. Unlike the other account creation APIs
+    /// ([`Self::create_account`] and [`Self::import_account_hd`]), no spending key is returned
+    /// because the wallet has no information about how the UFVK was derived.
     ///
     /// Certain optimizations are possible for accounts which will never be used to spend funds. If
     /// `spending_key_available` is `false`, the wallet may choose to optimize for this case, in

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1597,8 +1597,7 @@ impl AccountBirthday {
 /// # Account creation
 ///
 /// Any of several functions may be used to create the first or subsequent accounts, including:
-/// - [`WalletWrite::create_account`] takes a seed phrase and creates a new account with the
-///   smallest unused [`ZIP 32`] account index.
+/// - [`WalletWrite::create_account`] takes a seed phrase and creates a new account.
 /// - [`WalletWrite::import_account_hd`] takes a seed phrase and creates an account with a specific
 ///   [`ZIP 32`] account index.
 /// - [`WalletWrite::import_account_ufvk`] creates an account with a specific Unified Full Viewing
@@ -1621,12 +1620,10 @@ pub trait WalletWrite: WalletRead {
     /// Tells the wallet to track the next available account-level spend authority, given the
     /// current set of [ZIP 316] account identifiers known to the wallet database.
     ///
-    /// The "next available account" is defined as the first unused ZIP-32 account index (counting
-    /// from 0) among all accounts that share the given seed. When [`Self::import_account_hd`] is
-    /// used to import an account with a specific index, account indexes *may* become fragmented
-    /// instead of one contiguous range. Where fragmentation occurs, the implementations *may*
-    /// choose to find the first unused account index or add 1 to the highest existing account
-    /// index.
+    /// The "next available account" is defined as the ZIP-32 account index immediately following
+    /// the highest existing account index among all accounts in the wallet that share the given
+    /// seed. Users of the [`WalletWrite`] trait that only call this method are guaranteed to have
+    /// accounts with sequential indices.
     ///
     /// Returns the account identifier for the newly-created wallet database entry, along with the
     /// associated [`UnifiedSpendingKey`]. Note that the unique account identifier should *not* be
@@ -1637,6 +1634,12 @@ pub trait WalletWrite: WalletRead {
     /// with the returned account identifier.
     ///
     /// The [`WalletWrite`] trait documentation has more details about account creation and import.
+    ///
+    /// # Implementation notes
+    ///
+    /// Implementations of this method **MUST NOT** "fill in gaps" by selecting an account index
+    /// that is lower than any existing account index among all accounts in the wallet that share
+    /// the given seed.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Todo:
- [x] Doc comment fixes left over from #1425.
- [x] Revert redefinition of `WalletWrite::create_account`.
- [x] Rewrite `WalletWrite` trait documentation to clarify account creation.