### PR TITLE
Use a single database transaction when storing transactions to be sent

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -69,8 +69,15 @@ funds to those addresses. See [ZIP 320](https://zips.z.cash/zip-0320) for detail
   - `WalletWrite` has new methods `import_account_hd` and `import_account_ufvk`.
   - `error::Error` has new `Address` and (when the "transparent-inputs" feature
     is enabled) `PaysEphemeralTransparentAddress` variants.
+  - The `WalletWrite::store_sent_tx` method has been renamed to
+    `store_transactions_to_be_sent`, and its signature changed to take a slice
+    of `SentTransaction`s. This can be used by the wallet storage backend (e.g.
+    `zcash_client_sqlite`) to improve transactionality of writes for multi-step
+    proposals.
   - `wallet::input_selection::InputSelectorError` has a new `Address` variant.
   - `DecryptedTransaction::new` takes an additional `mined_height` argument.
+  - `SentTransaction` now stores its `outputs` and `utxos_spent` fields as
+    references to slices, with a corresponding change to `SentTransaction::new`.
 - `zcash_client_backend::data_api::fees`
   - When the "transparent-inputs" feature is enabled, `ChangeValue` can also
     represent an ephemeral transparent output in a proposal. Accordingly, the

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1434,8 +1434,16 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
         })
     }
 
-    fn store_sent_tx(&mut self, sent_tx: &SentTransaction<AccountId>) -> Result<(), Self::Error> {
-        self.transactionally(|wdb| wallet::store_transaction_to_be_sent(wdb, sent_tx))
+    fn store_transactions_to_be_sent(
+        &mut self,
+        transactions: &[SentTransaction<AccountId>],
+    ) -> Result<(), Self::Error> {
+        self.transactionally(|wdb| {
+            for sent_tx in transactions {
+                wallet::store_transaction_to_be_sent(wdb, sent_tx)?;
+            }
+            Ok(())
+        })
     }
 
     fn truncate_to_height(&mut self, block_height: BlockHeight) -> Result<(), Self::Error> {


### PR DESCRIPTION
This provides more robust transactionality in case a call to `store_sent_tx` (now renamed to `store_transaction_to_be_sent`) fails for a step of a multi-step proposal after the first.