### PR TITLE
Tell rust-analyzer to compile using stable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "rust-analyzer.cargo.features": "all"
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.server.extraEnv": { "RUSTUP_TOOLCHAIN": "stable" }
 }


### PR DESCRIPTION
This is necessary because the Rust version from `rust-toolchain.toml` is too old for the current proc-macros protocol (specifically, the `--keep-going` flag was not stable in Rust 1.70, as can be verified by `cargo +1.70.0 check --keep-going`).

This works around https://github.com/rust-lang/rust-analyzer/issues/17662 , and very likely future problems, because the rust-analyzer devs are quite aggressive in depending on recent versions: "by policy we don't make any attempts at supporting more than the last couple of stable releases" according to https://github.com/rust-lang/rust-analyzer/issues/17662#issuecomment-2242265513 . The toolchain we select in `rust-toolchain.toml` often lags behind that intentionally, because we want to verify that we build with our MSRV.