### PR TITLE
Add a `read_transactionally` method for transactional read-only operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,6 +5878,7 @@ dependencies = [
  "pasta_curves",
  "proptest",
  "prost",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -72,6 +72,10 @@ schemer-rusqlite.workspace = true
 time.workspace = true
 uuid.workspace = true
 
+# - Randomness
+rand_core.workspace = true
+rand.workspace = true
+
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 document-features.workspace = true
@@ -86,7 +90,6 @@ shardtree = { workspace = true, features = ["legacy-api", "test-dependencies"] }
 orchard = { workspace = true, features = ["test-dependencies"] }
 proptest.workspace = true
 rand_chacha.workspace = true
-rand_core.workspace = true
 regex = "1.4"
 tempfile = "3.5.0"
 zcash_keys = { workspace = true, features = ["test-dependencies"] }

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1177,13 +1177,16 @@ impl<Cache> TestState<Cache> {
         &self,
         min_confirmations: u32,
     ) -> Option<WalletSummary<AccountId>> {
-        get_wallet_summary(
-            &self.wallet().conn.unchecked_transaction().unwrap(),
-            &self.wallet().params,
-            min_confirmations,
-            &SubtreeScanProgress,
-        )
-        .unwrap()
+        self.wallet()
+            .read_transactionally(|wdb| {
+                get_wallet_summary(
+                    wdb.conn.0,
+                    &wdb.params,
+                    min_confirmations,
+                    &SubtreeScanProgress,
+                )
+            })
+            .unwrap()
     }
 
     /// Returns a vector of transaction summaries


### PR DESCRIPTION
`read_transactionally` does not require a `mut` reference to the wallet db. It works by catching `DatabaseBusy` errors from Sqlite and doing jittered exponential backoff.

fixes #1131