### PR TITLE
Check for colliding component FVKs

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1703,11 +1703,20 @@ impl AccountBirthday {
 /// - If [`WalletWrite::import_account_hd`] is used to import accounts with non-sequential
 ///   ZIP 32 account indices from the same seed, a call to [`WalletWrite::create_account`]
 ///   will use the ZIP 32 account index just after the highest-numbered existing account.
-/// - If an account is imported via [`WalletWrite::import_account_ufvk`], and then a later
-///   call to either [`WalletWrite::create_account`] or [`WalletWrite::import_account_hd`]
-///   would produce the same UFVK, an error will be returned.
-///   - A future change to this trait might introduce a method to "upgrade" an imported
-///     account with derivation information. See [zcash/librustzcash#1284] for details.
+/// - If an account is added to the wallet, and then a later call to one of the methods
+///   would produce the same UFVK, an error will be returned. While any combination of
+///   method calls can cause this, there are two main ways it can occur that users of the
+///   `WalletWrite` trait should watch out for:
+///   - An account is created via [`WalletWrite::create_account`] with an auto-selected
+///     ZIP 32 account index, and that index is later imported explicitly via either
+///     [`WalletWrite::import_account_hd`] or [`WalletWrite::import_account_ufvk`].
+///   - An account is imported via [`WalletWrite::import_account_ufvk`], and the ZIP 32
+///     account index corresponding to that account's UFVK is later imported either
+///     implicitly via [`WalletWrite::create_account`] or explicitly via
+///     [`WalletWrite::import_account_hd`].
+///
+/// A future change to this trait might introduce a method to "upgrade" an imported
+/// account with derivation information. See [zcash/librustzcash#1284] for details.
 ///
 /// Users of the `WalletWrite` trait should generally distinguish in their APIs and wallet
 /// UIs between creating a new account, and importing an account that previously existed.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1704,16 +1704,21 @@ impl AccountBirthday {
 ///   ZIP 32 account indices from the same seed, a call to [`WalletWrite::create_account`]
 ///   will use the ZIP 32 account index just after the highest-numbered existing account.
 /// - If an account is added to the wallet, and then a later call to one of the methods
-///   would produce the same UFVK, an error will be returned. While any combination of
-///   method calls can cause this, there are two main ways it can occur that users of the
-///   `WalletWrite` trait should watch out for:
+///   would produce the same UFVK, an error will be returned.  This can occur in the
+///   following cases:
 ///   - An account is created via [`WalletWrite::create_account`] with an auto-selected
 ///     ZIP 32 account index, and that index is later imported explicitly via either
-///     [`WalletWrite::import_account_hd`] or [`WalletWrite::import_account_ufvk`].
-///   - An account is imported via [`WalletWrite::import_account_ufvk`], and the ZIP 32
-///     account index corresponding to that account's UFVK is later imported either
-///     implicitly via [`WalletWrite::create_account`] or explicitly via
-///     [`WalletWrite::import_account_hd`].
+///     [`WalletWrite::import_account_ufvk`] or [`WalletWrite::import_account_hd`].
+///   - An account is imported via [`WalletWrite::import_account_ufvk`] or
+///     [`WalletWrite::import_account_hd`], and then the ZIP 32 account index
+///     corresponding to that account's UFVK is later imported either implicitly
+///     via [`WalletWrite::create_account`], or explicitly via a call to
+///     [`WalletWrite::import_account_ufvk`] or [`WalletWrite::import_account_hd`].
+///
+/// Note that accounts having UFVKs that are not identical but have shared
+/// components (for example, two accounts having the same Sapling FVK, one
+/// of which also has an Orchard FVK while the other does not) are currently
+/// allowed. This will not be allowed in future.
 ///
 /// A future change to this trait might introduce a method to "upgrade" an imported
 /// account with derivation information. See [zcash/librustzcash#1284] for details.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1704,7 +1704,8 @@ impl AccountBirthday {
 ///   ZIP 32 account indices from the same seed, a call to [`WalletWrite::create_account`]
 ///   will use the ZIP 32 account index just after the highest-numbered existing account.
 /// - If an account is added to the wallet, and then a later call to one of the methods
-///   would produce the same UFVK, an error will be returned.  This can occur in the
+///   would produce a UFVK that collides with that account on any FVK component (i.e.
+///   Sapling, Orchard, or transparent), an error will be returned. This can occur in the
 ///   following cases:
 ///   - An account is created via [`WalletWrite::create_account`] with an auto-selected
 ///     ZIP 32 account index, and that index is later imported explicitly via either
@@ -1715,10 +1716,8 @@ impl AccountBirthday {
 ///     via [`WalletWrite::create_account`], or explicitly via a call to
 ///     [`WalletWrite::import_account_ufvk`] or [`WalletWrite::import_account_hd`].
 ///
-/// Note that accounts having UFVKs that are not identical but have shared
-/// components (for example, two accounts having the same Sapling FVK, one
-/// of which also has an Orchard FVK while the other does not) are currently
-/// allowed. This will not be allowed in future.
+/// Note that an error will be returned on an FVK collision even if the UFVKs do not
+/// match exactly, e.g. if they have different subsets of components.
 ///
 /// A future change to this trait might introduce a method to "upgrade" an imported
 /// account with derivation information. See [zcash/librustzcash#1284] for details.

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -74,6 +74,7 @@ pub enum SqliteClientError {
     AccountUnknown,
 
     /// The account being added collides with an existing account in the wallet with the given ID.
+    /// The collision can be on the seed and ZIP-32 account index, or a shared FVK component.
     AccountCollision(AccountId),
 
     /// The account was imported, and ZIP-32 derivation information is not known for it.


### PR DESCRIPTION
When adding an account, check whether any component of its UFVK (if available) collides with an existing imported or derived FVK.

This does not check for collisions on IVK for `Incoming` accounts (#1490), which is okay because those are not yet exposed in the public API.

Builds on #1479, fixes #1474