### PR TITLE
Make the `{fixed,standard,zip317}::SingleOutputChangeStrategy` doc comments more accurate concerning the choice of output pool

### DIFF
--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -19,8 +19,10 @@ use super::{
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
-/// A change strategy that proposes change as a single output to the most current supported
-/// shielded pool and delegates fee calculation to the provided fee rule.
+/// A change strategy that proposes change as a single output. The output pool is chosen
+/// as the most current pool that avoids unnecessary pool-crossing (with a specified
+/// fallback when the transaction has no shielded inputs). Fee calculation is delegated
+/// to the provided fee rule.
 pub struct SingleOutputChangeStrategy {
     fee_rule: FixedFeeRule,
     change_memo: Option<MemoBytes>,

--- a/zcash_client_backend/src/fees/standard.rs
+++ b/zcash_client_backend/src/fees/standard.rs
@@ -24,8 +24,10 @@ use super::{
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
-/// A change strategy that proposes change as a single output to the most current supported
-/// shielded pool and delegates fee calculation to the provided fee rule.
+/// A change strategy that proposes change as a single output. The output pool is chosen
+/// as the most current pool that avoids unnecessary pool-crossing (with a specified
+/// fallback when the transaction has no shielded inputs). Fee calculation is delegated
+/// to the provided fee rule.
 pub struct SingleOutputChangeStrategy {
     fee_rule: StandardFeeRule,
     change_memo: Option<MemoBytes>,

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -23,8 +23,10 @@ use super::{
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
-/// A change strategy that proposes change as a single output to the most current supported
-/// shielded pool and delegates fee calculation to the provided fee rule.
+/// A change strategy that proposes change as a single output. The output pool is chosen
+/// as the most current pool that avoids unnecessary pool-crossing (with a specified
+/// fallback when the transaction has no shielded inputs). Fee calculation is delegated
+/// to the provided fee rule.
 pub struct SingleOutputChangeStrategy {
     fee_rule: Zip317FeeRule,
     change_memo: Option<MemoBytes>,


### PR DESCRIPTION
Thanks to @AArnott for pointing out the inaccuracy.