### PR TITLE
zcash_protocol: Remove impl {Add, Sub} for BlockHeight

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Removed
+- `impl {Add, Sub} for BlockHeight` - these operations were unused, and block
+  heights are a vector space, not a monoid.
+
 ## [0.2.0] - 2024-08-19
 ### Added
 - `zcash_protocol::PoolType::{TRANSPARENT, SAPLING, ORCHARD}`

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -107,14 +107,6 @@ impl Add<u32> for BlockHeight {
     }
 }
 
-impl Add for BlockHeight {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self {
-        self + other.0
-    }
-}
-
 impl Sub<u32> for BlockHeight {
     type Output = Self;
 
@@ -124,14 +116,6 @@ impl Sub<u32> for BlockHeight {
         }
 
         BlockHeight(self.0 - other)
-    }
-}
-
-impl Sub for BlockHeight {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self {
-        self - other.0
     }
 }
 


### PR DESCRIPTION
These operations are unused, and it does not make sense to add block heights (or to subtract two block heights returning a block height).