### PR TITLE
Add correct `BlockHeight` subtraction & remove panics.

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `impl Sub<BlockHeight> for BlockHeight` unlike the implementation that was
+  removed in version `0.3.0`, a saturating subtraction for block heights having
+  a return type of `u32` makes sense for `BlockHeight`. Subtracting one block
+  height from another yields the delta between them.
+
+### Changed
+- Adding a delta to a `BlockHeight` now uses saturating addition.
+- Subtracting a delta to a `BlockHeight` now uses saturating subtraction.
+
 ## [0.3.0] - 2024-08-26
 ### Changed
 - Testnet activation height has been set for `consensus::BranchId::Nu6`.

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -103,7 +103,7 @@ impl Add<u32> for BlockHeight {
     type Output = Self;
 
     fn add(self, other: u32) -> Self {
-        BlockHeight(self.0 + other)
+        BlockHeight(self.0.saturating_add(other))
     }
 }
 
@@ -111,11 +111,15 @@ impl Sub<u32> for BlockHeight {
     type Output = Self;
 
     fn sub(self, other: u32) -> Self {
-        if other > self.0 {
-            panic!("Subtraction resulted in negative block height.");
-        }
+        BlockHeight(self.0.saturating_sub(other))
+    }
+}
 
-        BlockHeight(self.0 - other)
+impl Sub<BlockHeight> for BlockHeight {
+    type Output = u32;
+
+    fn sub(self, other: BlockHeight) -> u32 {
+        self.0.saturating_sub(other.0)
     }
 }
 


### PR DESCRIPTION
In contrast to the implementation of `Sub<BlockHeight> for BlockHeight` that was removed in version `0.3.0`, a saturating subtraction for block heights having a return type of `u32` makes sense for `BlockHeight`. Subtracting one block height from another yields the delta between them.

Other block height addition and subtraction operations have been made saturating, removing panics and the possibility of overflow.