### PR TITLE
Introduce a `Backend` type for tests

### DIFF
--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -467,6 +467,15 @@ impl Backend<Connection, LocalNetwork> {
             _ => panic!("Backend is not a WalletDb"),
         }
     }
+
+    #[cfg(feature = "transparent-inputs")]
+    /// Get the connection for this backend.
+    pub fn connection(&self) -> &Connection {
+        match self {
+            Backend::Sqlite(db) => &db.conn,
+            _ => panic!("Backend is not a WalletDb"),
+        }
+    }
 }
 
 impl Backend<Connection, Network> {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -613,9 +613,12 @@ pub(crate) fn send_multi_step_proposed_transfer<T: ShieldedPoolTester>() {
 
     // We call get_wallet_transparent_output with `allow_unspendable = true` to verify
     // storage because the decrypted transaction has not yet been mined.
-    let utxo =
-        get_wallet_transparent_output(&st.db_data.conn, &OutPoint::new(txid.into(), 0), true)
-            .unwrap();
+    let utxo = get_wallet_transparent_output(
+        &st.backend.connection(),
+        &OutPoint::new(txid.into(), 0),
+        true,
+    )
+    .unwrap();
     assert_matches!(utxo, Some(v) if v.value() == utxo_value);
 
     // That should have advanced the start of the gap to index 11.

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -378,7 +378,11 @@ mod tests {
         zip32::AccountId,
     };
 
-    use crate::{testing::TestBuilder, wallet::db, WalletDb, UA_TRANSPARENT};
+    use crate::{
+        testing::{Backend, TestBuilder},
+        wallet::db,
+        WalletDb, UA_TRANSPARENT,
+    };
 
     use super::init_wallet_db;
 
@@ -615,7 +619,10 @@ mod tests {
         }
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = [0xab; 32];
         let account = AccountId::ZERO;
@@ -786,7 +793,10 @@ mod tests {
         }
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = [0xab; 32];
         let account = AccountId::ZERO;
@@ -953,7 +963,10 @@ mod tests {
         }
 
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = [0xab; 32];
         let account = AccountId::ZERO;
@@ -979,7 +992,9 @@ mod tests {
 
         let network = Network::MainNetwork;
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), network).unwrap();
+        let mut db_data = backend.db_mut();
         assert_matches!(init_wallet_db(&mut db_data, None), Ok(_));
 
         // Prior to adding any accounts, every seed phrase is relevant to the wallet.

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -202,13 +202,16 @@ mod tests {
     use uuid::Uuid;
     use zcash_protocol::consensus::Network;
 
-    use crate::{wallet::init::init_wallet_db_internal, WalletDb};
+    use crate::{testing::Backend, wallet::init::init_wallet_db_internal};
 
     /// Tests that we can migrate from a completely empty wallet database to the target
     /// migrations.
     pub(crate) fn test_migrate(migrations: &[Uuid]) {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = [0xab; 32];
         assert_matches!(
@@ -225,7 +228,10 @@ mod tests {
     #[test]
     fn migrate_between_releases_without_data() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = [0xab; 32].to_vec();
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
@@ -80,12 +80,15 @@ mod tests {
     use zcash_protocol::consensus::Network;
 
     use super::{DEPENDENCIES, MIGRATION_ID};
-    use crate::{wallet::init::init_wallet_db_internal, WalletDb};
+    use crate::{testing::Backend, wallet::init::init_wallet_db_internal};
 
     #[test]
     fn migrate() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed_bytes = vec![0xab; 32];
         init_wallet_db_internal(

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -279,8 +279,8 @@ mod tests {
     use zcash_primitives::{consensus::Network, zip32::AccountId};
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db_internal, migrations::addresses_table},
-        WalletDb,
     };
 
     #[cfg(feature = "transparent-inputs")]
@@ -304,7 +304,9 @@ mod tests {
     fn transaction_views() {
         let network = Network::TestNetwork;
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), network).unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(&mut db_data, None, &[addresses_table::MIGRATION_ID], false)
             .unwrap();
         let usk = UnifiedSpendingKey::from_seed(&network, &[0u8; 32][..], AccountId::ZERO).unwrap();
@@ -403,7 +405,9 @@ mod tests {
 
         let network = Network::TestNetwork;
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), network).unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
@@ -97,14 +97,18 @@ mod tests {
     use zcash_primitives::consensus::Network;
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db, init_wallet_db_internal, migrations::addresses_table},
-        WalletDb, UA_ORCHARD, UA_TRANSPARENT,
+        UA_ORCHARD, UA_TRANSPARENT,
     };
 
     #[test]
     fn init_migrate_add_orchard_receiver() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed = vec![0x10; 32];
         let account_id = 0u32;

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -101,6 +101,7 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     use crate::{
         error::SqliteClientError,
+        testing::Backend,
         wallet::{
             self, account_kind_code, init::init_wallet_db_internal, transparent::ephemeral,
             GAP_LIMIT,
@@ -204,7 +205,9 @@ mod tests {
     fn initialize_table() {
         let network = Network::TestNetwork;
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), network).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), network).unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed0 = vec![0x00; 32];
         init_wallet_db_internal(

--- a/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
@@ -232,14 +232,17 @@ mod tests {
     use zcash_primitives::{consensus::Network, zip32::AccountId};
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db_internal, migrations::v_transactions_net},
-        WalletDb,
     };
 
     #[test]
     fn received_notes_nullable_migration() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -317,6 +317,7 @@ mod tests {
 
     use crate::{
         error::SqliteClientError,
+        testing::Backend,
         wallet::{
             init::{
                 init_wallet_db_internal,
@@ -515,7 +516,9 @@ mod tests {
 
         // Create wallet upgraded to just before the current migration.
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), params).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), params).unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,
@@ -614,7 +617,9 @@ mod tests {
 
         // Create wallet upgraded to just before the current migration.
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), params).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), params).unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -157,8 +157,8 @@ mod tests {
     };
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db_internal, migrations::tests::test_migrate},
-        WalletDb,
     };
 
     use super::{DEPENDENCIES, MIGRATION_ID};
@@ -171,7 +171,10 @@ mod tests {
     #[test]
     fn migrate_with_data() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
 
         let seed_bytes = vec![0xab; 32];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -211,14 +211,17 @@ mod tests {
     use zcash_primitives::{consensus::Network, zip32::AccountId};
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db_internal, migrations::add_transaction_views},
-        WalletDb,
     };
 
     #[test]
     fn v_transactions_net() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
@@ -167,6 +167,7 @@ mod tests {
     use zcash_primitives::{consensus::Network, zip32::AccountId};
 
     use crate::{
+        testing::Backend,
         wallet::init::{init_wallet_db_internal, migrations::v_transactions_net},
         WalletDb,
     };
@@ -174,7 +175,10 @@ mod tests {
     #[test]
     fn v_transactions_note_uniqueness_migration() {
         let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(data_file.path(), Network::TestNetwork).unwrap();
+        let mut backend =
+            Backend::new_wallet_db_consensus_network(data_file.path(), Network::TestNetwork)
+                .unwrap();
+        let mut db_data = backend.db_mut();
         init_wallet_db_internal(
             &mut db_data,
             None,


### PR DESCRIPTION
This is a draft of what i have in mind for the refactor part of https://github.com/zcash/librustzcash/issues/1412

An new enum type `Backend` was added to `TestState` replacing the `db_data` with a `backend` field where the inner database type can be retrieved by methods. This should allow tests to use the framework with a `WalletDb` or a `MockWalletDb` backend.

Before making more changes, it will be good to get some feedback to see if i am in a good track or if i should rethink it.