### PR TITLE
zcash_client_backend: Fix `tor::grpc` module feature flag

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,10 @@ and this library adheres to Rust's notion of
   type instead of a type parameter. This change allows for the simplification
   of some type signatures.
 
+### Fixed
+- `zcash_client_backend::tor::grpc` now needs the `lightwalletd-tonic-tls-webpki-roots`
+  feature flag instead of `lightwalletd-tonic`, to fix compilation issues.
+
 ## [0.13.0] - 2024-08-20
 
 `zcash_client_backend` now supports TEX (transparent-source-only) addresses as specified

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -21,17 +21,7 @@ exclude = ["*.proto"]
 development = ["zcash_proofs"]
 
 [package.metadata.docs.rs]
-# Manually specify features while `orchard` is not in the public API.
-#all-features = true
-features = [
-    "lightwalletd-tonic",
-    "transparent-inputs",
-    "test-dependencies",
-    "tor",
-    "unstable",
-    "unstable-serialization",
-    "unstable-spanning-tree",
-]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
@@ -162,6 +152,9 @@ zcash_protocol = { workspace = true, features = ["local-consensus"] }
 ## Enables the `tonic` gRPC client bindings for connecting to a `lightwalletd` server.
 lightwalletd-tonic = ["dep:tonic", "hyper-util?/tokio"]
 
+## Enables the `tls-webpki-roots` feature of `tonic`.
+lightwalletd-tonic-tls-webpki-roots = ["lightwalletd-tonic", "tonic?/tls-webpki-roots"]
+
 ## Enables the `transport` feature of `tonic` producing a fully-featured client and server implementation
 lightwalletd-tonic-transport = ["lightwalletd-tonic", "tonic?/transport"]
 
@@ -228,14 +221,6 @@ unstable-serialization = ["dep:byteorder"]
 
 ## Exposes the [`data_api::scanning::spanning_tree`] module.
 unstable-spanning-tree = []
-
-## Exposes access to the lightwalletd server via TOR
-tor-lightwalletd-tonic = [
-  "tor",
-  "lightwalletd-tonic",
-  "tonic?/tls",
-  "tonic?/tls-webpki-roots"
-]
 
 [lib]
 bench = false

--- a/zcash_client_backend/src/tor.rs
+++ b/zcash_client_backend/src/tor.rs
@@ -6,7 +6,7 @@ use arti_client::{config::TorClientConfigBuilder, TorClient};
 use tor_rtcompat::PreferredRuntime;
 use tracing::debug;
 
-#[cfg(feature = "tor-lightwalletd-tonic")]
+#[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
 mod grpc;
 
 pub mod http;
@@ -76,7 +76,7 @@ impl Client {
 pub enum Error {
     /// The directory passed to [`Client::create`] does not exist.
     MissingTorDirectory,
-    #[cfg(feature = "lightwalletd-tonic")]
+    #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
     /// An error occurred while using gRPC-over-Tor.
     Grpc(self::grpc::GrpcError),
     /// An error occurred while using HTTP-over-Tor.
@@ -91,7 +91,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::MissingTorDirectory => write!(f, "Tor directory is missing"),
-            #[cfg(feature = "lightwalletd-tonic")]
+            #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
             Error::Grpc(e) => write!(f, "gRPC-over-Tor error: {}", e),
             Error::Http(e) => write!(f, "HTTP-over-Tor error: {}", e),
             Error::Io(e) => write!(f, "IO error: {}", e),
@@ -104,7 +104,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::MissingTorDirectory => None,
-            #[cfg(feature = "lightwalletd-tonic")]
+            #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
             Error::Grpc(e) => Some(e),
             Error::Http(e) => Some(e),
             Error::Io(e) => Some(e),
@@ -113,7 +113,7 @@ impl std::error::Error for Error {
     }
 }
 
-#[cfg(feature = "lightwalletd-tonic")]
+#[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
 impl From<self::grpc::GrpcError> for Error {
     fn from(e: self::grpc::GrpcError) -> Self {
         Error::Grpc(e)


### PR DESCRIPTION
We already depend on `rustls` and `webpki-roots` for `tor::http`, but `tonic` has its own feature flag that needs to be enabled for equivalent support in `tor::grpc`. We didn't need that feature flag enabled for the `proto::service::compact_tx_streamer_client` module because those constructors take a `D: TryInto<tonic::transport::Endpoint>`, which abstracts over TLS and leaves it up to the caller. By constrast, in `tor::grpc` we need to construct the `Endpoint` manually from a `Uri` and then configure TLS ourselves.