### PR TITLE
Document the change to `v_tx_outputs` in `zcash_client_sqlite 0.11.0`

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -19,7 +19,6 @@ and this library adheres to Rust's notion of
   the wallet and returns this error if not. SQLite version `3.35` or higher
   is required for use with `zcash_client_sqlite`.
 
-
 ## [0.11.1] - 2024-08-21
 
 ### Fixed
@@ -48,8 +47,6 @@ or not the transaction represents a wallet-internal shielding operation.
   - `zcash_protocol 0.2`
 - `zcash_client_sqlite::error::SqliteClientError` has a new `ReachedGapLimit` and
   `EphemeralAddressReuse` variants when the "transparent-inputs" feature is enabled.
-- The result of the `v_tx_outputs` SQL query could now include transparent outputs
-  with unknown height.
 - `zcash_client_sqlite::error::SqliteClientError` has changed variants:
   - Removed `HdwalletError`.
   - Added `AccountCollision`.
@@ -60,6 +57,15 @@ or not the transaction represents a wallet-internal shielding operation.
   - An `is_shielding` column has been added, which is true for transactions where the
     spends from the wallet are all transparent, and the outputs to the wallet are all
     shielded.
+- The `v_tx_outputs` view has been modified:
+  - The result can now include transparent outputs with unknown height.
+
+### Fixed
+- The `to_address` column of the `v_tx_outputs` view is now `NULL` for
+  transparent outputs received by the wallet. This column is only intended to
+  contain addresses for outputs sent to external recipients. The fix aligns
+  received transparent outputs with received shielded outputs (which have always
+  returned `NULL`).
 
 ## [0.10.3] - 2024-04-08
 


### PR DESCRIPTION
Closes zcash/librustzcash#1525.