### PR TITLE
zcash_client_sqlite: Add unstable conversions between `AccountId` and `u32`.

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- Exposed `AccountId::from_u32` and `AccountId::as_u32` conversions under the
+  `unstable` feature flag.
+
 ## [0.12.0] - 2024-10-04
 
 ### Added

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -164,6 +164,26 @@ pub(crate) const DEFAULT_UA_REQUEST: UnifiedAddressRequest =
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct AccountId(u32);
 
+impl AccountId {
+    /// Constructs an `AccountId` from a bare `u32` value. The resulting identifier is not
+    /// guaranteed to correspond to any account stored in the database.
+    #[cfg(feature = "unstable")]
+    pub fn from_u32(value: u32) -> Self {
+        AccountId(value)
+    }
+
+    /// Unwraps a raw `accounts` table primary key value from its typesafe wrapper.
+    ///
+    /// Note that account identifiers are not guaranteed to be stable; if a wallet is restored from
+    /// seed, the account identifiers of the restored wallet are not likely to correspond to the
+    /// identifiers for the same accounts in another wallet created or restored from the same seed.
+    /// These unwrapped identifier values should therefore be treated as ephemeral.
+    #[cfg(feature = "unstable")]
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
 impl ConditionallySelectable for AccountId {
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         AccountId(ConditionallySelectable::conditional_select(


### PR DESCRIPTION
This is necessary for third parties using the `zcash_client_sqlite` crate directly to be able to refer to individual account IDs without having to always use FVKs to look them up.