### PR TITLE
zcash_client_backend: Return scan and restore progress as a single value.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api`:
+  - `Progress`
+  - `WalletSummary::progress`
+
+### Removed
+- `zcash_client_backend::data_api`:
+  - `WalletSummary::scan_progress` and `WalletSummary::recovery_progress` have
+    been removed. Use `WalletSummary::progress` instead.
+
 ## [0.14.0] - 2024-10-04
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -570,8 +570,9 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
     ///
     /// The window over which progress is computed spans from the wallet's birthday to the current
     /// chain tip. It is divided into two segments: a "recovery" segment, between the wallet
-    /// birthday and the recovery height (the height at which recovery from seed was initiated),
-    /// and a "scan" segment, between the recovery height and the current chain tip.
+    /// birthday and the recovery height (currently the height at which recovery from seed was
+    /// initiated, but how this boundary is computed may change in the future), and a "scan"
+    /// segment, between the recovery height and the current chain tip.
     ///
     /// When converting the ratios returned here to percentages, checked division must be used in
     /// order to avoid divide-by-zero errors. A zero denominator in a returned ratio indicates that

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -889,13 +889,10 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     // Wallet is fully scanned
     let summary = st.get_wallet_summary(1);
     assert_eq!(
-        summary.as_ref().and_then(|s| s.recovery_progress()),
+        summary.as_ref().and_then(|s| s.progress().recovery()),
         no_recovery,
     );
-    assert_eq!(
-        summary.and_then(|s| s.scan_progress()),
-        Some(Ratio::new(1, 1))
-    );
+    assert_eq!(summary.map(|s| s.progress().scan()), Some(Ratio::new(1, 1)));
 
     // Add more funds to the wallet in a second note
     let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
@@ -910,13 +907,10 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     // Wallet is still fully scanned
     let summary = st.get_wallet_summary(1);
     assert_eq!(
-        summary.as_ref().and_then(|s| s.recovery_progress()),
+        summary.as_ref().and_then(|s| s.progress().recovery()),
         no_recovery
     );
-    assert_eq!(
-        summary.and_then(|s| s.scan_progress()),
-        Some(Ratio::new(2, 2))
-    );
+    assert_eq!(summary.map(|s| s.progress().scan()), Some(Ratio::new(2, 2)));
 
     // Spend fails because there are insufficient verified notes
     let extsk2 = T::sk(&[0xf5; 32]);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -69,7 +69,7 @@ use rusqlite::{self, named_params, params, OptionalExtension};
 use secrecy::{ExposeSecret, SecretVec};
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
 use zcash_client_backend::data_api::{
-    AccountPurpose, DecryptedTransaction, TransactionDataRequest, TransactionStatus,
+    AccountPurpose, DecryptedTransaction, Progress, TransactionDataRequest, TransactionStatus,
 };
 use zip32::fingerprint::SeedFingerprint;
 
@@ -802,26 +802,6 @@ pub(crate) fn get_derived_account<P: consensus::Parameters>(
     )?;
 
     accounts.next().transpose()
-}
-
-#[derive(Debug)]
-pub(crate) struct Progress {
-    scan: Ratio<u64>,
-    recovery: Option<Ratio<u64>>,
-}
-
-impl Progress {
-    pub(crate) fn new(scan: Ratio<u64>, recovery: Option<Ratio<u64>>) -> Self {
-        Self { scan, recovery }
-    }
-
-    pub(crate) fn scan(&self) -> Ratio<u64> {
-        self.scan
-    }
-
-    pub(crate) fn recovery(&self) -> Option<Ratio<u64>> {
-        self.recovery
-    }
 }
 
 pub(crate) trait ProgressEstimator {
@@ -1598,8 +1578,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         account_balances,
         chain_tip_height,
         fully_scanned_height.unwrap_or(birthday_height - 1),
-        Some(progress.scan),
-        progress.recovery,
+        progress,
         next_sapling_subtree_index,
         #[cfg(feature = "orchard")]
         next_orchard_subtree_index,

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1297,15 +1297,17 @@ pub(crate) mod tests {
         // resulting ratio (the number of notes in the recovery range) is zero.
         let no_recovery = Some(Ratio::new(0, 0));
 
-        // We have scan ranges and a subtree, but have scanned no blocks.
+        // We have scan ranges and a subtree, but have scanned no blocks. Given the number of
+        // blocks scanned in the previous subtree, we estimate the number of notes in the current
+        // subtree
         let summary = st.get_wallet_summary(1);
         assert_eq!(
-            summary.as_ref().and_then(|s| s.recovery_progress()),
+            summary.as_ref().and_then(|s| s.progress().recovery()),
             no_recovery,
         );
         assert_matches!(
-            summary.and_then(|s| s.scan_progress()),
-            Some(progress) if progress.numerator() == &0
+            summary.map(|s| s.progress().scan()),
+            Some(ratio) if *ratio.numerator() == 0
         );
 
         // Set up prior chain state. This simulates us having imported a wallet
@@ -1345,7 +1347,7 @@ pub(crate) mod tests {
         assert_eq!(summary.as_ref().map(|s| T::next_subtree_index(s)), Some(0));
 
         assert_eq!(
-            summary.as_ref().and_then(|s| s.recovery_progress()),
+            summary.as_ref().and_then(|s| s.progress().recovery()),
             no_recovery
         );
 
@@ -1357,7 +1359,7 @@ pub(crate) mod tests {
         let expected_denom = expected_denom * 2;
         let expected_denom = expected_denom + 1;
         assert_eq!(
-            summary.and_then(|s| s.scan_progress()),
+            summary.map(|s| s.progress().scan()),
             Some(Ratio::new(1, u64::from(expected_denom)))
         );
 
@@ -1450,7 +1452,7 @@ pub(crate) mod tests {
                     / (max_scanned - (birthday.height() - 10)));
         let summary = st.get_wallet_summary(1);
         assert_eq!(
-            summary.and_then(|s| s.scan_progress()),
+            summary.map(|s| s.progress().scan()),
             Some(Ratio::new(1, u64::from(expected_denom)))
         );
     }


### PR DESCRIPTION
In zcash_client_backend 0.14, the semantics of the `WalletSummary::scan_progress` method changed silently, which could lead to unwary users getting bad results for scan progress, in particular, an indication that scanning is complete when there is still a substantial amount of recovery still needed.

In addition, the type of the `WalletSummary::scan_progress` and `recovery_progress` methods incorrectly make the state where recovery progress information is available, but scan progress information is not available, representable. 

This PR introduces a breaking API change that is intended to reduce the possibility of incorrect usage, and correctly represent the possible states of scanning and recovery.