### PR TITLE
zcash_client_sqlite: Fix errors in progress computation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -346,6 +346,13 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zip321]]
+version = "0.2.0"
+when = "2024-10-04"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.13.0"
 version = "0.12.0"
 audited_as = "0.11.2"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.12.1"
+audited_as = "0.12.0"
+
 [[unpublished.zcash_keys]]
 version = "0.4.0"
 audited_as = "0.3.0"
@@ -266,6 +270,13 @@ user-name = "Kris Nuttycombe"
 [[publisher.zcash_client_sqlite]]
 version = "0.11.2"
 when = "2024-09-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_sqlite]]
+version = "0.12.0"
+when = "2024-10-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -534,10 +534,11 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
     /// Progress is represented in terms of the ratio between notes scanned and the total
     /// number of notes added to the chain in the relevant window. This ratio should only
     /// be used to compute progress percentages, and the numerator and denominator should
-    /// not be treated as authoritative note counts.
+    /// not be treated as authoritative note counts. The denominator of this ratio is
+    /// guaranteed to be nonzero.
     ///
-    /// Returns `None` if the wallet is unable to determine the size of the note
-    /// commitment tree.
+    /// Returns `None` if the wallet has insufficient information to be able to determine
+    /// scan progress.
     pub fn scan_progress(&self) -> Option<Ratio<u64>> {
         self.scan_progress
     }
@@ -554,10 +555,12 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
     /// Progress is represented in terms of the ratio between notes scanned and the total
     /// number of notes added to the chain in the relevant window. This ratio should only
     /// be used to compute progress percentages, and the numerator and denominator should
-    /// not be treated as authoritative note counts.
+    /// not be treated as authoritative note counts. Note that both the numerator and the
+    /// denominator of this ratio may be zero in the case that there is no recovery range
+    /// that need be scanned.
     ///
-    /// Returns `None` if the wallet is unable to determine the size of the note
-    /// commitment tree.
+    /// Returns `None` if the wallet has insufficient information to be able to determine
+    /// progress in scanning between the wallet birthday and the wallet recovery height.
     pub fn recovery_progress(&self) -> Option<Ratio<u64>> {
         self.recovery_progress
     }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1270,6 +1270,7 @@ pub trait WalletTest: InputSource + WalletRead {
 ///
 /// This type is opaque, and exists for use by tests defined in this crate.
 #[cfg(any(test, feature = "test-dependencies"))]
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct OutputOfSentTx {
     value: NonNegativeAmount,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -881,20 +881,17 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
         NonNegativeAmount::ZERO
     );
 
-    // The account is configured without a recover-until height, so is by definition
-    // fully recovered, and we count 1 per pool for both numerator and denominator.
-    let fully_recovered = {
-        let n = 1;
-        #[cfg(feature = "orchard")]
-        let n = n * 2;
-        Some(Ratio::new(n, n))
-    };
+    // If none of the wallet's accounts have a recover-until height, then there
+    // is no recovery phase for the wallet, and therefore the denominator in the
+    // resulting ratio (the number of notes in the recovery range) is zero.
+    let no_recovery = Some(Ratio::new(0, 0));
+
 
     // Wallet is fully scanned
     let summary = st.get_wallet_summary(1);
     assert_eq!(
         summary.as_ref().and_then(|s| s.recovery_progress()),
-        fully_recovered,
+        no_recovery,
     );
     assert_eq!(
         summary.and_then(|s| s.scan_progress()),
@@ -915,7 +912,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     let summary = st.get_wallet_summary(1);
     assert_eq!(
         summary.as_ref().and_then(|s| s.recovery_progress()),
-        fully_recovered
+        no_recovery
     );
     assert_eq!(
         summary.and_then(|s| s.scan_progress()),

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -886,7 +886,6 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     // resulting ratio (the number of notes in the recovery range) is zero.
     let no_recovery = Some(Ratio::new(0, 0));
 
-
     // Wallet is fully scanned
     let summary = st.get_wallet_summary(1);
     assert_eq!(

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.12.1] - 2024-10-10
+
+### Fixed
+- An error in scan progress computation was fixed. As part of this fix, wallet
+  summary information is now only returned in the case that some note
+  commitment tree size information can be determined, either from subtree root
+  download or from downloaded block data. NOTE: The recovery progress ratio may
+  be present as `0:0` in the case that the recovery range contains no notes; 
+  this was not adequately documented in the previous release.
+
 ## [0.12.0] - 2024-10-04
 
 ### Added

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -128,7 +128,7 @@ pub mod error;
 pub mod wallet;
 use wallet::{
     commitment_tree::{self, put_shard_roots},
-    SubtreeScanProgress,
+    SubtreeProgressEstimator,
 };
 
 #[cfg(test)]
@@ -461,7 +461,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> WalletRead for W
             &self.conn.borrow().unchecked_transaction()?,
             &self.params,
             min_confirmations,
-            &SubtreeScanProgress,
+            &SubtreeProgressEstimator,
         )
     }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -852,9 +852,7 @@ fn table_constants(
             ORCHARD_SHARD_HEIGHT,
         )),
         #[cfg(not(feature = "orchard"))]
-        ShieldedProtocol::Orchard => {
-            Err(SqliteClientError::UnsupportedPoolType(PoolType::ORCHARD))
-        }
+        ShieldedProtocol::Orchard => Err(SqliteClientError::UnsupportedPoolType(PoolType::ORCHARD)),
     }
 }
 
@@ -912,7 +910,7 @@ fn estimate_tree_size<P: consensus::Parameters>(
             #[cfg(feature = "orchard")]
             ShieldedProtocol::Orchard => last_scanned.orchard_tree_size(),
             #[cfg(not(feature = "orchard"))]
-            ShieldedProtocol::Orchard => None
+            ShieldedProtocol::Orchard => None,
         }
         .map(|tree_size| (last_scanned.block_height(), u64::from(tree_size)))
     });

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1292,20 +1292,16 @@ pub(crate) mod tests {
         let birthday = account.birthday();
         let sap_active = st.sapling_activation_height();
 
-        // The account is configured without a recover-until height, so is by definition
-        // fully recovered, and we count 1 per pool for both numerator and denominator.
-        let fully_recovered = {
-            let n = 1;
-            #[cfg(feature = "orchard")]
-            let n = n * 2;
-            Some(Ratio::new(n, n))
-        };
+        // If none of the wallet's accounts have a recover-until height, then there
+        // is no recovery phase for the wallet, and therefore the denominator in the
+        // resulting ratio (the number of notes in the recovery range) is zero.
+        let no_recovery = Some(Ratio::new(0, 0));
 
         // We have scan ranges and a subtree, but have scanned no blocks.
         let summary = st.get_wallet_summary(1);
         assert_eq!(
             summary.as_ref().and_then(|s| s.recovery_progress()),
-            fully_recovered,
+            no_recovery,
         );
         assert_eq!(summary.and_then(|s| s.scan_progress()), None);
 
@@ -1347,7 +1343,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             summary.as_ref().and_then(|s| s.recovery_progress()),
-            fully_recovered,
+            no_recovery
         );
 
         // Progress denominator depends on which pools are enabled (which changes the

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1303,7 +1303,10 @@ pub(crate) mod tests {
             summary.as_ref().and_then(|s| s.recovery_progress()),
             no_recovery,
         );
-        assert_eq!(summary.and_then(|s| s.scan_progress()), None);
+        assert_matches!(
+            summary.and_then(|s| s.scan_progress()),
+            Some(progress) if progress.numerator() == &0
+        );
 
         // Set up prior chain state. This simulates us having imported a wallet
         // with a birthday 520 blocks below the chain tip.


### PR DESCRIPTION
This ensures that we use `recover_until_height` as an exclusive end height, and makes sure that we are estimating tree size based upon consistent heights between the recovery and scan ranges.