### PR TITLE
CI: Add a job that runs when all required status checks pass

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -28,3 +28,15 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check licenses
+
+  required-checks:
+    name: Required status checks have passed
+    needs:
+      - cargo-vet
+      - cargo-deny
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine whether all required-pass steps succeeded
+        run: |
+          echo '${{ toJSON(needs) }}' | jq -e '[ .[] | .result == "success" ] | all'

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,11 +3,11 @@ name: librustzcash documentation
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - id: prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         state:
           - NOT_A_PUZZLE
           - Orchard
-          - NU6
+          - NU7
 
         include:
           - target: Linux
@@ -35,12 +35,12 @@ jobs:
 
           - state: Orchard
             extra_flags: orchard
-          - state: NU6
-            rustflags: '--cfg zcash_unstable="nu6"'
+          - state: NU7
+            rustflags: '--cfg zcash_unstable="nu7"'
 
         exclude:
           - target: macOS
-            state: NU6
+            state: NU7
 
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI checks
+name: CI
 
 on:
   pull_request:
@@ -366,3 +366,23 @@ jobs:
           ) -eq $(
             uuidparse -n -o uuid $U4 | sort | uniq | wc -l
           )
+
+  required-checks:
+    name: Required status checks have passed
+    needs:
+      - test
+      - check-msrv
+      - build-latest
+      - build-nodefault
+      - bitrot
+      - clippy
+      - doc-links
+      - fmt
+      - protobuf
+      - uuid
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine whether all required-pass steps succeeded
+        run: |
+          echo '${{ toJSON(needs) }}' | jq -e '[ .[] | .result == "success" ] | all'


### PR DESCRIPTION
This enables us to add a single "required status check" to the GitHub repo settings, that covers all required matrix job cases.