### PR TITLE
zcash_client_backend: Switch from `async-trait` to RPIT for `tor` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dynosaur"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47baef31f408cc1a54eadcb0160ffe2b935b5963bd2b519719f3a101749af524"
+dependencies = [
+ "dynosaur_derive",
+ "trait-variant",
+]
+
+[[package]]
+name = "dynosaur_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320c6861ca45ea23faee2bd86a6c7f20ec4b7a64a2773971cd4f52ae61615463"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5374,6 +5395,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5993,6 +6025,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "document-features",
+ "dynosaur",
  "futures-util",
  "group",
  "gumdrop",
@@ -6029,6 +6062,7 @@ dependencies = [
  "tor-rtcompat",
  "tower",
  "tracing",
+ "trait-variant",
  "webpki-roots 0.25.4",
  "which",
  "zcash_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,11 @@ incrementalmerkletree-testing = "0.2"
 # - `arti-client` depends on `rusqlite`, and a version mismatch there causes a compilation
 #   failure due to incompatible `libsqlite3-sys` versions.
 arti-client = { version = "0.23", default-features = false, features = ["compression", "rustls", "tokio"] }
+dynosaur = "0.1.1"
 tokio = "1"
 tor-rtcompat = "0.23"
 tower = "0.4"
+trait-variant = "0.1"
 
 # ZIP 32
 aes = "0.8"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -414,6 +414,14 @@ criteria = "safe-to-deploy"
 version = "1.0.17"
 criteria = "safe-to-deploy"
 
+[[exemptions.dynosaur]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.dynosaur_derive]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.ecdsa]]
 version = "0.16.9"
 criteria = "safe-to-deploy"
@@ -1404,6 +1412,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tracing-test-macro]]
 version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.trait-variant]]
+version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.typed-index-collections]]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -23,6 +23,10 @@ and this library adheres to Rust's notion of
 - A new feature flag, `non-standard-fees`, has been added. This flag is now
   required in order to make use of any types or methods that enable non-standard
   fee calculation.
+- `zcash_client_backend::tor::http::cryptex`:
+  - `LocalExchange`, a variant of the `Exchange` trait without `Send` bounds.
+  - `DynExchange`
+  - `DynLocalExchange`
 
 ### Changed
 - MSRV is now 1.77.0.
@@ -76,6 +80,9 @@ and this library adheres to Rust's notion of
   `ProposalDecodingError::FeeRuleNotSupported` has been added to replace it.
 - `zcash_client_backend::data_api::fees::fixed` is now available only via the
   use of the `non-standard-fees` feature flag.
+- `zcash_client_backend::tor::http::cryptex`:
+  - The `Exchange` trait is no longer object-safe. Replace any existing uses of
+    `dyn Exchange` with `DynExchange`.
 
 ### Removed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -95,8 +95,10 @@ nom = "7"
 #    `hyper::Error`, `hyper::http::Error`, `serde_json::Error`. We could avoid this with
 #    changes to error handling.
 arti-client = { workspace = true, optional = true }
+dynosaur = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true, features = ["client", "http1"] }
 serde_json = { workspace = true, optional = true }
+trait-variant = { workspace = true, optional = true }
 
 # - Currency conversion
 rust_decimal = { workspace = true, optional = true }
@@ -179,7 +181,7 @@ sync = [
 ## operations.
 tor = [
     "dep:arti-client",
-    "dep:async-trait",
+    "dep:dynosaur",
     "dep:futures-util",
     "dep:http-body-util",
     "dep:hyper",
@@ -191,6 +193,7 @@ tor = [
     "dep:tokio",
     "dep:tokio-rustls",
     "dep:tor-rtcompat",
+    "dep:trait-variant",
     "dep:tower",
     "dep:webpki-roots",
 ]

--- a/zcash_client_backend/src/tor/http/cryptex/binance.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/binance.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -44,7 +43,6 @@ struct BinanceData {
     count: u32,
 }
 
-#[async_trait]
 impl Exchange for Binance {
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
         // API documentation:

--- a/zcash_client_backend/src/tor/http/cryptex/coinbase.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/coinbase.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -31,7 +30,6 @@ struct CoinbaseData {
     conversions_volume: Option<Decimal>,
 }
 
-#[async_trait]
 impl Exchange for Coinbase {
     #[allow(dead_code)]
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {

--- a/zcash_client_backend/src/tor/http/cryptex/gate_io.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/gate_io.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use hyper::StatusCode;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -32,7 +31,6 @@ struct GateIoData {
     low_24h: Decimal,
 }
 
-#[async_trait]
 impl Exchange for GateIo {
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
         // API documentation:

--- a/zcash_client_backend/src/tor/http/cryptex/gemini.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/gemini.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -30,7 +29,6 @@ struct GeminiData {
     ask: Decimal,
 }
 
-#[async_trait]
 impl Exchange for Gemini {
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
         // API documentation:

--- a/zcash_client_backend/src/tor/http/cryptex/ku_coin.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/ku_coin.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -46,7 +45,6 @@ struct KuCoinResponse {
     data: KuCoinData,
 }
 
-#[async_trait]
 impl Exchange for KuCoin {
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
         // API documentation:

--- a/zcash_client_backend/src/tor/http/cryptex/mexc.rs
+++ b/zcash_client_backend/src/tor/http/cryptex/mexc.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -39,7 +38,6 @@ struct MexcData {
     closeTime: u64,
 }
 
-#[async_trait]
 impl Exchange for Mexc {
     async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
         // API documentation:


### PR DESCRIPTION
RPIT (return-position `impl Trait`) was stabilized in Rust 1.75, and the `dynosaur` crate providing dynamic dispatch support was published two weeks ago. Now that our MSRV is 1.77, we can use both of these.