### PR TITLE
zcash_client_sqlite: Assign UUIDs to each account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
         run: |
           {
             echo 'UUIDS<<EOF'
-            git grep -h "Uuid::from_u128" zcash_client_sqlite/ |
+            git grep -h "const MIGRATION_ID: Uuid = Uuid::from_u128" zcash_client_sqlite/ |
               sed -e "s,.*Uuid::from_u128(0x,," -e "s,_,-,g" -e "s,);,,"
             echo EOF
           } >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,6 +3506,7 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -5504,6 +5505,9 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,19 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- `zcash_client_backend::data_api::WalletRead`:
+  - The `create_account`, `import_account_hd`, and `import_account_ufvk`
+    methods now each take additional `account_name` and `key_source` arguments.
+    These allow the wallet backend to store additional metadata that is useful
+    to applications managing these accounts.
+- `zcash_client_backend::data_api::AccountSource`:
+  - Both the `Derived` and `Importants` now have an additional `key_source`
+    property that is used to convey application-specific key source metadata.
+  - The `Copy` impl for this type has been removed.
+- `zcash_client_backend::data_api::Account` has an additional `name` method
+  that returns the human-readable name of the account, if any.
+
 ## [0.15.0] - 2024-11-14
 
 ### Added

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -796,7 +796,8 @@ where
     <Cache::BlockSource as BlockSource>::Error: fmt::Debug,
     ParamsT: consensus::Parameters + Send + 'static,
     DbT: InputSource + WalletTest + WalletWrite + WalletCommitmentTrees,
-    <DbT as WalletRead>::AccountId: ConditionallySelectable + Default + Send + 'static,
+    <DbT as WalletRead>::AccountId:
+        std::fmt::Debug + ConditionallySelectable + Default + Send + 'static,
 {
     /// Invokes [`scan_cached_blocks`] with the given arguments, expecting success.
     pub fn scan_cached_blocks(&mut self, from_height: BlockHeight, limit: usize) -> ScanSummary {
@@ -855,7 +856,7 @@ where
 impl<Cache, DbT, ParamsT, AccountIdT, ErrT> TestState<Cache, DbT, ParamsT>
 where
     ParamsT: consensus::Parameters + Send + 'static,
-    AccountIdT: std::cmp::Eq + std::hash::Hash,
+    AccountIdT: std::fmt::Debug + std::cmp::Eq + std::hash::Hash,
     ErrT: std::fmt::Debug,
     DbT: InputSource<AccountId = AccountIdT, Error = ErrT>
         + WalletTest
@@ -1286,7 +1287,7 @@ pub struct InitialChainState {
 /// Trait representing the ability to construct a new data store for use in a test.
 pub trait DataStoreFactory {
     type Error: core::fmt::Debug;
-    type AccountId: ConditionallySelectable + Default + Hash + Eq + Send + 'static;
+    type AccountId: std::fmt::Debug + ConditionallySelectable + Default + Hash + Eq + Send + 'static;
     type Account: Account<AccountId = Self::AccountId> + Clone;
     type DsError: core::fmt::Debug;
     type DataStore: InputSource<AccountId = Self::AccountId, Error = Self::DsError>

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -374,7 +374,11 @@ impl<A: Account> Account for TestAccount<A> {
         self.account.id()
     }
 
-    fn source(&self) -> AccountSource {
+    fn name(&self) -> Option<&str> {
+        self.account.name()
+    }
+
+    fn source(&self) -> &AccountSource {
         self.account.source()
     }
 
@@ -1594,10 +1598,12 @@ impl<Cache, DsFactory: DataStoreFactory> TestBuilder<Cache, DsFactory> {
             let seed = Secret::new(vec![0u8; 32]);
             let (account, usk) = match self.account_index {
                 Some(index) => wallet_data
-                    .import_account_hd(&seed, index, &birthday)
+                    .import_account_hd("", &seed, index, &birthday, None)
                     .unwrap(),
                 None => {
-                    let result = wallet_data.create_account(&seed, &birthday).unwrap();
+                    let result = wallet_data
+                        .create_account("", &seed, &birthday, None)
+                        .unwrap();
                     (
                         wallet_data.get_account(result.0).unwrap().unwrap(),
                         result.1,
@@ -2596,8 +2602,10 @@ impl WalletWrite for MockWalletDb {
 
     fn create_account(
         &mut self,
+        _account_name: &str,
         seed: &SecretVec<u8>,
         _birthday: &AccountBirthday,
+        _key_source: Option<&str>,
     ) -> Result<(Self::AccountId, UnifiedSpendingKey), Self::Error> {
         let account = zip32::AccountId::ZERO;
         UnifiedSpendingKey::from_seed(&self.network, seed.expose_secret(), account)
@@ -2607,18 +2615,22 @@ impl WalletWrite for MockWalletDb {
 
     fn import_account_hd(
         &mut self,
+        _account_name: &str,
         _seed: &SecretVec<u8>,
         _account_index: zip32::AccountId,
         _birthday: &AccountBirthday,
+        _key_source: Option<&str>,
     ) -> Result<(Self::Account, UnifiedSpendingKey), Self::Error> {
         todo!()
     }
 
     fn import_account_ufvk(
         &mut self,
+        _account_name: &str,
         _unified_key: &UnifiedFullViewingKey,
         _birthday: &AccountBirthday,
         _purpose: AccountPurpose,
+        _key_source: Option<&str>,
     ) -> Result<Self::Account, Self::Error> {
         todo!()
     }

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1559,10 +1559,16 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     // Add two accounts to the wallet.
     let seed = Secret::new([0u8; 32].to_vec());
     let birthday = AccountBirthday::from_sapling_activation(st.network(), BlockHash([0; 32]));
-    let (account1, usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account1, usk) = st
+        .wallet_mut()
+        .create_account("account1", &seed, &birthday, None)
+        .unwrap();
     let dfvk = T::sk_to_fvk(T::usk_to_sk(&usk));
 
-    let (account2, usk2) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account2, usk2) = st
+        .wallet_mut()
+        .create_account("account2", &seed, &birthday, None)
+        .unwrap();
     let dfvk2 = T::sk_to_fvk(T::usk_to_sk(&usk2));
 
     // Add funds to the wallet in a single note
@@ -1623,13 +1629,19 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     st.reset();
 
     // Account creation and DFVK derivation should be deterministic.
-    let (account1, restored_usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account1, restored_usk) = st
+        .wallet_mut()
+        .create_account("account1_restored", &seed, &birthday, None)
+        .unwrap();
     assert!(T::fvks_equal(
         &T::sk_to_fvk(T::usk_to_sk(&restored_usk)),
         &dfvk,
     ));
 
-    let (account2, restored_usk2) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account2, restored_usk2) = st
+        .wallet_mut()
+        .create_account("account2_restored", &seed, &birthday, None)
+        .unwrap();
     assert!(T::fvks_equal(
         &T::sk_to_fvk(T::usk_to_sk(&restored_usk2)),
         &dfvk2,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1559,7 +1559,7 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     // Add two accounts to the wallet.
     let seed = Secret::new([0u8; 32].to_vec());
     let birthday = AccountBirthday::from_sapling_activation(st.network(), BlockHash([0; 32]));
-    let (account_id, usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account1, usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
     let dfvk = T::sk_to_fvk(T::usk_to_sk(&usk));
 
     let (account2, usk2) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
@@ -1571,8 +1571,8 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     st.scan_cached_blocks(h, 1);
 
     // Spendable balance matches total balance
-    assert_eq!(st.get_total_balance(account_id), value);
-    assert_eq!(st.get_spendable_balance(account_id, 1), value);
+    assert_eq!(st.get_total_balance(account1), value);
+    assert_eq!(st.get_spendable_balance(account1, 1), value);
     assert_eq!(st.get_total_balance(account2), NonNegativeAmount::ZERO);
 
     let amount_sent = NonNegativeAmount::from_u64(20000).unwrap();
@@ -1610,26 +1610,26 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     let pending_change = (amount_left - amount_legacy_change).unwrap();
 
     // The "legacy change" is not counted by get_pending_change().
-    assert_eq!(st.get_pending_change(account_id, 1), pending_change);
+    assert_eq!(st.get_pending_change(account1, 1), pending_change);
     // We spent the only note so we only have pending change.
-    assert_eq!(st.get_total_balance(account_id), pending_change);
+    assert_eq!(st.get_total_balance(account1), pending_change);
 
     let (h, _) = st.generate_next_block_including(txid);
     st.scan_cached_blocks(h, 1);
 
     assert_eq!(st.get_total_balance(account2), amount_sent,);
-    assert_eq!(st.get_total_balance(account_id), amount_left);
+    assert_eq!(st.get_total_balance(account1), amount_left);
 
     st.reset();
 
     // Account creation and DFVK derivation should be deterministic.
-    let (_, restored_usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account1, restored_usk) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
     assert!(T::fvks_equal(
         &T::sk_to_fvk(T::usk_to_sk(&restored_usk)),
         &dfvk,
     ));
 
-    let (_, restored_usk2) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
+    let (account2, restored_usk2) = st.wallet_mut().create_account(&seed, &birthday).unwrap();
     assert!(T::fvks_equal(
         &T::sk_to_fvk(T::usk_to_sk(&restored_usk2)),
         &dfvk2,
@@ -1637,8 +1637,8 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
 
     st.scan_cached_blocks(st.sapling_activation_height(), 2);
 
-    assert_eq!(st.get_total_balance(account2), amount_sent,);
-    assert_eq!(st.get_total_balance(account_id), amount_left);
+    assert_eq!(st.get_total_balance(account2), amount_sent);
+    assert_eq!(st.get_total_balance(account1), amount_left);
 }
 
 #[allow(dead_code)]

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -9,8 +9,6 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `zcash_client_sqlite::AccountUuid`
-- `zcash_client_sqlite::Account::uuid`
-- `zcash_client_sqlite::WalletDb::get_account_for_uuid`
 
 ### Changed
 - The `v_transactions` view has been modified:
@@ -18,10 +16,18 @@ and this library adheres to Rust's notion of
 - The `v_tx_outputs` view has been modified:
   - The `from_account_id` column has been replaced with `from_account_uuid`.
   - The `to_account_id` column has been replaced with `to_account_uuid`.
+- The `WalletRead` and `InputSource` impls for `WalletDb` now set the `AccountId`
+  associated type to `AccountUuid`.
+- Variants of `SqliteClientError` have changed:
+  - The `AccountCollision` and `ReachedGapLimit` now carry `AccountUuid` values
+    instead of `AccountId`s.
+  - `SqliteClientError::AccountIdDiscontinuity` has been removed as it is now
+    unused.
+  - `SqliteClientError::AccountIdOutOfRange` has been renamed to
+    `Zip32AccountIndexOutOfRange`.
 
 ### Removed
-- `zcash_client_sqlite::AccountId::{from_u32, as_u32}` (use `AccountUuid` and
-  its methods instead).
+- `zcash_client_sqlite::AccountId` (use `AccountUuid` instead).
 
 ## [0.13.0] - 2024-11-14
 
@@ -31,7 +37,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.77.0.
-- Migrated to `zcash_primitives 0.20`, `zcash_keys 0.5`, 
+- Migrated to `zcash_primitives 0.20`, `zcash_keys 0.5`,
   `zcash_client_backend 0.15`.
 - Migrated from `schemer` to our fork `schemerz`.
 - Migrated to `rusqlite 0.32`.
@@ -51,7 +57,7 @@ and this library adheres to Rust's notion of
   summary information is now only returned in the case that some note
   commitment tree size information can be determined, either from subtree root
   download or from downloaded block data. NOTE: The recovery progress ratio may
-  be present as `0:0` in the case that the recovery range contains no notes; 
+  be present as `0:0` in the case that the recovery range contains no notes;
   this was not adequately documented in the previous release.
 
 ## [0.12.0] - 2024-10-04

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,13 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `v_transactions` view has been modified:
+  - The `account_id` column has been replaced with `account_uuid`.
+- The `v_tx_outputs` view has been modified:
+  - The `from_account_id` column has been replaced with `from_account_uuid`.
+  - The `to_account_id` column has been replaced with `to_account_uuid`.
+
 ## [0.13.0] - 2024-11-14
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,12 +7,21 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_sqlite::AccountUuid`
+- `zcash_client_sqlite::Account::uuid`
+- `zcash_client_sqlite::WalletDb::get_account_for_uuid`
+
 ### Changed
 - The `v_transactions` view has been modified:
   - The `account_id` column has been replaced with `account_uuid`.
 - The `v_tx_outputs` view has been modified:
   - The `from_account_id` column has been replaced with `from_account_uuid`.
   - The `to_account_id` column has been replaced with `to_account_uuid`.
+
+### Removed
+- `zcash_client_sqlite::AccountId::{from_u32, as_u32}` (use `AccountUuid` and
+  its methods instead).
 
 ## [0.13.0] - 2024-11-14
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -66,11 +66,11 @@ incrementalmerkletree.workspace = true
 shardtree = { workspace = true, features = ["legacy-api"] }
 
 # - SQLite databases
-rusqlite = { workspace = true, features = ["time", "array"] }
+rusqlite = { workspace = true, features = ["time", "array", "uuid"] }
 schemerz.workspace = true
 schemerz-rusqlite.workspace = true
 time.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 regex = "1.4"
 
 # Dependencies used internally:

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -121,7 +121,7 @@ pub enum SqliteClientError {
     NoteFilterInvalid(NoteFilter),
 
     /// The proposal cannot be constructed until transactions with previously reserved
-    /// ephemeral address outputs have been mined. The parameters are the account id and
+    /// ephemeral address outputs have been mined. The parameters are the account UUID and
     /// the index that could not safely be reserved.
     #[cfg(feature = "transparent-inputs")]
     ReachedGapLimit(AccountUuid, u32),
@@ -174,10 +174,10 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::AddressGeneration(e) => write!(f, "{}", e),
             SqliteClientError::AccountUnknown => write!(f, "The account with the given ID does not belong to this wallet."),
             SqliteClientError::UnknownZip32Derivation => write!(f, "ZIP-32 derivation information is not known for this account."),
-            SqliteClientError::KeyDerivationError(acct_id) => write!(f, "Key derivation failed for account {}", u32::from(*acct_id)),
+            SqliteClientError::KeyDerivationError(zip32_index) => write!(f, "Key derivation failed for ZIP 32 account index {}", u32::from(*zip32_index)),
             SqliteClientError::BadAccountData(e) => write!(f, "Failed to add account: {}", e),
             SqliteClientError::Zip32AccountIndexOutOfRange => write!(f, "ZIP 32 account identifiers must be less than 0x7FFFFFFF."),
-            SqliteClientError::AccountCollision(id) => write!(f, "An account corresponding to the data provided already exists in the wallet with internal identifier {}.", id.0),
+            SqliteClientError::AccountCollision(account_uuid) => write!(f, "An account corresponding to the data provided already exists in the wallet with UUID {account_uuid:?}."),
             #[cfg(feature = "transparent-inputs")]
             SqliteClientError::AddressNotRecognized(_) => write!(f, "The address associated with a received txo is not identifiable as belonging to the wallet."),
             SqliteClientError::CommitmentTree(err) => write!(f, "An error occurred accessing or updating note commitment tree data: {}.", err),

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -35,7 +35,7 @@ use zcash_protocol::{consensus::BlockHeight, local_consensus::LocalNetwork, memo
 use crate::{
     error::SqliteClientError,
     wallet::init::{init_wallet_db, init_wallet_db_internal},
-    AccountId, WalletDb,
+    AccountUuid, WalletDb,
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -163,7 +163,7 @@ impl TestDbFactory {
 
 impl DataStoreFactory for TestDbFactory {
     type Error = ();
-    type AccountId = AccountId;
+    type AccountId = AccountUuid;
     type Account = crate::wallet::Account;
     type DsError = SqliteClientError;
     type DataStore = TestDb;

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3061,9 +3061,9 @@ pub(crate) fn select_receiving_address<P: consensus::Parameters>(
         receiver => {
             let mut stmt = conn.prepare_cached(
                 "SELECT address
-                    FROM addresses
-                    JOIN accounts ON accounts.id = addresses.account_id
-                    WHERE accounts.uuid = :account_uuid",
+                 FROM addresses
+                 JOIN accounts ON accounts.id = addresses.account_id
+                 WHERE accounts.uuid = :account_uuid",
             )?;
 
             let mut result = stmt.query(named_params! { ":account_uuid": account.0 })?;

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -24,8 +24,10 @@ use crate::wallet::scanning::priority_code;
 pub(super) const TABLE_ACCOUNTS: &str = r#"
 CREATE TABLE "accounts" (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
     uuid BLOB NOT NULL,
     account_kind INTEGER NOT NULL DEFAULT 0,
+    key_source TEXT,
     hd_seed_fingerprint BLOB,
     hd_account_index INTEGER,
     ufvk TEXT,

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -24,6 +24,7 @@ use crate::wallet::scanning::priority_code;
 pub(super) const TABLE_ACCOUNTS: &str = r#"
 CREATE TABLE "accounts" (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    uuid BLOB NOT NULL,
     account_kind INTEGER NOT NULL DEFAULT 0,
     hd_seed_fingerprint BLOB,
     hd_account_index INTEGER,
@@ -52,12 +53,14 @@ CREATE TABLE "accounts" (
         )
     )
 )"#;
+pub(super) const INDEX_ACCOUNTS_UUID: &str =
+    r#"CREATE UNIQUE INDEX accounts_uuid ON accounts (uuid)"#;
 pub(super) const INDEX_ACCOUNTS_UFVK: &str =
-    r#"CREATE UNIQUE INDEX accounts_ufvk ON "accounts" (ufvk)"#;
+    r#"CREATE UNIQUE INDEX accounts_ufvk ON accounts (ufvk)"#;
 pub(super) const INDEX_ACCOUNTS_UIVK: &str =
-    r#"CREATE UNIQUE INDEX accounts_uivk ON "accounts" (uivk)"#;
+    r#"CREATE UNIQUE INDEX accounts_uivk ON accounts (uivk)"#;
 pub(super) const INDEX_HD_ACCOUNT: &str =
-    r#"CREATE UNIQUE INDEX hd_account ON "accounts" (hd_seed_fingerprint, hd_account_index)"#;
+    r#"CREATE UNIQUE INDEX hd_account ON accounts (hd_seed_fingerprint, hd_account_index)"#;
 
 /// Stores diversified Unified Addresses that have been generated from accounts in the
 /// wallet.
@@ -825,7 +828,7 @@ sent_note_counts AS (
 blocks_max_height AS (
     SELECT MAX(blocks.height) AS max_height FROM blocks
 )
-SELECT notes.account_id             AS account_id,
+SELECT accounts.uuid                AS account_uuid,
        notes.mined_height           AS mined_height,
        notes.txid                   AS txid,
        transactions.tx_index        AS tx_index,
@@ -855,6 +858,7 @@ SELECT notes.account_id             AS account_id,
             AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
        ) AS is_shielding
 FROM notes
+JOIN accounts ON accounts.id = notes.account_id
 LEFT JOIN transactions
      ON notes.txid = transactions.txid
 JOIN blocks_max_height
@@ -883,8 +887,8 @@ CREATE VIEW v_tx_outputs AS
 SELECT transactions.txid            AS txid,
        ro.pool                      AS output_pool,
        ro.output_index              AS output_index,
-       sent_notes.from_account_id   AS from_account_id,
-       ro.account_id                AS to_account_id,
+       from_account.uuid            AS from_account_uuid,
+       to_account.uuid              AS to_account_uuid,
        NULL                         AS to_address,
        ro.value                     AS value,
        ro.is_change                 AS is_change,
@@ -894,13 +898,16 @@ JOIN transactions
     ON transactions.id_tx = ro.transaction_id
 -- join to the sent_notes table to obtain `from_account_id`
 LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
+-- join on the accounts table to obtain account UUIDs
+JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
+JOIN accounts to_account ON accounts.id = ro.account_id
 UNION
 -- select all outputs sent from the wallet to external recipients
 SELECT transactions.txid            AS txid,
        sent_notes.output_pool       AS output_pool,
        sent_notes.output_index      AS output_index,
-       sent_notes.from_account_id   AS from_account_id,
-       NULL                         AS to_account_id,
+       from_account.uuid            AS from_account_uuid,
+       NULL                         AS to_account_uuid,
        sent_notes.to_address        AS to_address,
        sent_notes.value             AS value,
        0                            AS is_change,
@@ -909,6 +916,8 @@ FROM sent_notes
 JOIN transactions
     ON transactions.id_tx = sent_notes.tx
 LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
+-- join on the accounts table to obtain account UUIDs
+JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
 -- exclude any sent notes for which a row exists in the v_received_outputs view
 WHERE ro.account_id IS NULL";
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -203,8 +203,7 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         | SqliteClientError::NonSequentialBlocks
         | SqliteClientError::RequestedRewindInvalid { .. }
         | SqliteClientError::KeyDerivationError(_)
-        | SqliteClientError::AccountIdDiscontinuity
-        | SqliteClientError::AccountIdOutOfRange
+        | SqliteClientError::Zip32AccountIndexOutOfRange
         | SqliteClientError::AccountCollision(_)
         | SqliteClientError::CacheMiss(_) => {
             unreachable!("we only call WalletRead methods; mutations can't occur")

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -1079,7 +1079,7 @@ mod tests {
 
         let birthday = AccountBirthday::from_sapling_activation(&network, BlockHash([0; 32]));
         let (account_id, _usk) = db_data
-            .create_account(&Secret::new(seed.to_vec()), &birthday)
+            .create_account("", &Secret::new(seed.to_vec()), &birthday, None)
             .unwrap();
         assert_matches!(
             db_data.get_account(account_id),

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -529,6 +529,7 @@ mod tests {
         let expected_indices = vec![
             db::INDEX_ACCOUNTS_UFVK,
             db::INDEX_ACCOUNTS_UIVK,
+            db::INDEX_ACCOUNTS_UUID,
             db::INDEX_HD_ACCOUNT,
             db::INDEX_ADDRESSES_ACCOUNTS,
             db::INDEX_NF_MAP_LOCATOR_IDX,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -141,7 +141,7 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
         }),
         Box::new(spend_key_available::Migration),
         Box::new(tx_retrieval_queue::Migration {
-            params: params.clone(),
+            _params: params.clone(),
         }),
         Box::new(support_legacy_sqlite::Migration),
         Box::new(fix_broken_commitment_trees::Migration {

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -1,4 +1,5 @@
 mod add_account_birthdays;
+mod add_account_uuids;
 mod add_transaction_views;
 mod add_utxo_account;
 mod addresses_table;
@@ -81,10 +82,10 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //              ------------------------------ tx_retrieval_queue ----------------------------
     //                                                     |
     //                                            support_legacy_sqlite
-    //                                                     |
-    //                                         fix_broken_commitment_trees
-    //                                                     |
-    //                                          fix_bad_change_flagging
+    //                                               /           \
+    //                         fix_broken_commitment_trees      add_account_uuids
+    //                                     |
+    //                          fix_bad_change_flagging
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -147,6 +148,7 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
             params: params.clone(),
         }),
         Box::new(fix_bad_change_flagging::Migration),
+        Box::new(add_account_uuids::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -157,7 +157,8 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
 /// included.
 #[allow(dead_code)]
 const PUBLIC_MIGRATION_STATES: &[&[Uuid]] = &[
-    V_0_4_0, V_0_6_0, V_0_8_0, V_0_9_0, V_0_10_0, V_0_10_3, V_0_11_0, V_0_11_1,
+    V_0_4_0, V_0_6_0, V_0_8_0, V_0_9_0, V_0_10_0, V_0_10_3, V_0_11_0, V_0_11_1, V_0_11_2, V_0_12_0,
+    V_0_13_0,
 ];
 
 /// Leaf migrations in the 0.4.0 release.
@@ -207,6 +208,15 @@ const V_0_11_0: &[Uuid] = &[
 
 /// Leaf migrations in the 0.11.1 release.
 const V_0_11_1: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
+
+/// Leaf migrations in the 0.11.2 release.
+const V_0_11_2: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
+
+/// Leaf migrations in the 0.12.0 release.
+const V_0_12_0: &[Uuid] = &[fix_broken_commitment_trees::MIGRATION_ID];
+
+/// Leaf migrations in the 0.13.0 release.
+const V_0_13_0: &[Uuid] = &[fix_bad_change_flagging::MIGRATION_ID];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
     conn: &rusqlite::Connection,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -1,0 +1,325 @@
+//! This migration adds a UUID to each account record.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_client_backend::data_api::{AccountPurpose, AccountSource};
+use zip32::fingerprint::SeedFingerprint;
+
+use crate::wallet::{account_kind_code, init::WalletMigrationError};
+
+use super::support_legacy_sqlite;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xcccc623f_3243_43c7_b884_ceef25149e04);
+
+const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds a UUID for each account."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        let account_kind_derived = account_kind_code(AccountSource::Derived {
+            seed_fingerprint: SeedFingerprint::from_bytes([0; 32]),
+            account_index: zip32::AccountId::ZERO,
+        });
+        let account_kind_imported = account_kind_code(AccountSource::Imported {
+            // the purpose here is irrelevant; we just use it to get the correct code
+            // for the account kind
+            purpose: AccountPurpose::ViewOnly,
+        });
+        transaction.execute_batch(&format!(
+            r#"
+            CREATE TABLE accounts_new (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                uuid BLOB NOT NULL,
+                account_kind INTEGER NOT NULL DEFAULT {account_kind_derived},
+                hd_seed_fingerprint BLOB,
+                hd_account_index INTEGER,
+                ufvk TEXT,
+                uivk TEXT NOT NULL,
+                orchard_fvk_item_cache BLOB,
+                sapling_fvk_item_cache BLOB,
+                p2pkh_fvk_item_cache BLOB,
+                birthday_height INTEGER NOT NULL,
+                birthday_sapling_tree_size INTEGER,
+                birthday_orchard_tree_size INTEGER,
+                recover_until_height INTEGER,
+                has_spend_key INTEGER NOT NULL DEFAULT 1,
+                CHECK (
+                  (
+                    account_kind = {account_kind_derived}
+                    AND hd_seed_fingerprint IS NOT NULL
+                    AND hd_account_index IS NOT NULL
+                    AND ufvk IS NOT NULL
+                  )
+                  OR
+                  (
+                    account_kind = {account_kind_imported}
+                    AND hd_seed_fingerprint IS NULL
+                    AND hd_account_index IS NULL
+                  )
+                )
+            );
+            "#
+        ))?;
+
+        let mut q = transaction.prepare("SELECT * FROM accounts")?;
+        let mut rows = q.query([])?;
+        while let Some(row) = rows.next()? {
+            let preserve = |idx: &str| row.get::<_, rusqlite::types::Value>(idx);
+            transaction.execute(
+                r#"
+                INSERT INTO accounts_new (
+                    id, uuid,
+                    account_kind, hd_seed_fingerprint, hd_account_index,
+                    ufvk, uivk,
+                    orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
+                    birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
+                    recover_until_height,
+                    has_spend_key
+                )
+                VALUES (
+                    :account_id, :uuid,
+                    :account_kind, :hd_seed_fingerprint, :hd_account_index,
+                    :ufvk, :uivk,
+                    :orchard_fvk_item_cache, :sapling_fvk_item_cache, :p2pkh_fvk_item_cache,
+                    :birthday_height, :birthday_sapling_tree_size, :birthday_orchard_tree_size,
+                    :recover_until_height,
+                    :has_spend_key
+                );
+                "#,
+                named_params! {
+                    ":account_id": preserve("id")?,
+                    ":uuid": Uuid::new_v4(),
+                    ":account_kind": preserve("account_kind")?,
+                    ":hd_seed_fingerprint": preserve("hd_seed_fingerprint")?,
+                    ":hd_account_index": preserve("hd_account_index")?,
+                    ":ufvk": preserve("ufvk")?,
+                    ":uivk": preserve("uivk")?,
+                    ":orchard_fvk_item_cache": preserve("orchard_fvk_item_cache")?,
+                    ":sapling_fvk_item_cache": preserve("sapling_fvk_item_cache")?,
+                    ":p2pkh_fvk_item_cache": preserve("p2pkh_fvk_item_cache")?,
+                    ":birthday_height": preserve("birthday_height")?,
+                    ":birthday_sapling_tree_size": preserve("birthday_sapling_tree_size")?,
+                    ":birthday_orchard_tree_size": preserve("birthday_orchard_tree_size")?,
+                    ":recover_until_height": preserve("recover_until_height")?,
+                    ":has_spend_key": preserve("has_spend_key")?,
+                },
+            )?;
+        }
+
+        transaction.execute_batch(
+            "PRAGMA legacy_alter_table = ON;
+            DROP TABLE accounts;
+            ALTER TABLE accounts_new RENAME TO accounts;
+            PRAGMA legacy_alter_table = OFF;
+
+            -- Add the new index.
+            CREATE UNIQUE INDEX accounts_uuid ON accounts (uuid);
+
+            -- Recreate the existing indices now that the original ones have been deleted.
+            CREATE UNIQUE INDEX hd_account ON accounts (hd_seed_fingerprint, hd_account_index);
+            CREATE UNIQUE INDEX accounts_uivk ON accounts (uivk);
+            CREATE UNIQUE INDEX accounts_ufvk ON accounts (ufvk);
+
+            -- Replace accounts.id with accounts.uuid in v_transactions.
+            DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       transactions.mined_height  AS mined_height,
+                       transactions.txid          AS txid,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN transactions
+                     ON transactions.id_tx = ro.transaction_id
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       transactions.mined_height  AS mined_height,
+                       transactions.txid          AS txid,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+                JOIN transactions
+                     ON transactions.id_tx = ros.transaction_id
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       transactions.txid              AS txid,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                JOIN transactions
+                     ON transactions.id_tx = sent_notes.tx
+                LEFT JOIN v_received_outputs ro
+                     ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, txid
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   notes.mined_height           AS mined_height,
+                   notes.txid                   AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        blocks.height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            LEFT JOIN transactions
+                 ON notes.txid = transactions.txid
+            JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = notes.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.txid = notes.txid
+            GROUP BY notes.account_id, notes.txid;
+
+            -- Replace accounts.id with accounts.uuid in v_tx_outputs.
+            DROP VIEW v_tx_outputs;
+            CREATE VIEW v_tx_outputs AS
+            -- select all outputs received by the wallet
+            SELECT transactions.txid            AS txid,
+                   ro.pool                      AS output_pool,
+                   ro.output_index              AS output_index,
+                   from_account.uuid            AS from_account_uuid,
+                   to_account.uuid              AS to_account_uuid,
+                   NULL                         AS to_address,
+                   ro.value                     AS value,
+                   ro.is_change                 AS is_change,
+                   ro.memo                      AS memo
+            FROM v_received_outputs ro
+            JOIN transactions
+                ON transactions.id_tx = ro.transaction_id
+            -- join to the sent_notes table to obtain `from_account_id`
+            LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
+            -- join on the accounts table to obtain account UUIDs
+            JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
+            JOIN accounts to_account ON accounts.id = ro.account_id
+            UNION
+            -- select all outputs sent from the wallet to external recipients
+            SELECT transactions.txid            AS txid,
+                   sent_notes.output_pool       AS output_pool,
+                   sent_notes.output_index      AS output_index,
+                   from_account.uuid            AS from_account_uuid,
+                   NULL                         AS to_account_uuid,
+                   sent_notes.to_address        AS to_address,
+                   sent_notes.value             AS value,
+                   0                            AS is_change,
+                   sent_notes.memo              AS memo
+            FROM sent_notes
+            JOIN transactions
+                ON transactions.id_tx = sent_notes.tx
+            LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
+            -- join on the accounts table to obtain account UUIDs
+            JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
+            -- exclude any sent notes for which a row exists in the v_received_outputs view
+            WHERE ro.account_id IS NULL",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -36,21 +36,25 @@ impl RusqliteMigration for Migration {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
-        let account_kind_derived = account_kind_code(AccountSource::Derived {
+        let account_kind_derived = account_kind_code(&AccountSource::Derived {
             seed_fingerprint: SeedFingerprint::from_bytes([0; 32]),
             account_index: zip32::AccountId::ZERO,
+            key_source: None,
         });
-        let account_kind_imported = account_kind_code(AccountSource::Imported {
+        let account_kind_imported = account_kind_code(&AccountSource::Imported {
             // the purpose here is irrelevant; we just use it to get the correct code
             // for the account kind
             purpose: AccountPurpose::ViewOnly,
+            key_source: None,
         });
         transaction.execute_batch(&format!(
             r#"
             CREATE TABLE accounts_new (
                 id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
                 uuid BLOB NOT NULL,
                 account_kind INTEGER NOT NULL DEFAULT {account_kind_derived},
+                key_source TEXT,
                 hd_seed_fingerprint BLOB,
                 hd_account_index INTEGER,
                 ufvk TEXT,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -227,9 +227,10 @@ mod tests {
         // Simulate creating an account prior to this migration.
         let account0_index = Zip32AccountId::ZERO;
         let account0_seed_fp = [0u8; 32];
-        let account0_kind = account_kind_code(AccountSource::Derived {
+        let account0_kind = account_kind_code(&AccountSource::Derived {
             seed_fingerprint: SeedFingerprint::from_seed(&account0_seed_fp).unwrap(),
             account_index: account0_index,
+            key_source: None,
         });
         assert_eq!(u32::from(account0_index), 0);
         let account0_id = AccountRef(0);

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
@@ -103,7 +103,14 @@ mod tests {
 
     #[cfg(feature = "transparent-inputs")]
     fn shield_transparent<T: ShieldedPoolTester>() {
-        let ds_factory = TestDbFactory::new(super::DEPENDENCIES.to_vec());
+        let ds_factory = TestDbFactory::new(
+            super::DEPENDENCIES
+                .iter()
+                .copied()
+                // Pull in the account UUID migration so `TestBuilder::build` works.
+                .chain(Some(super::super::add_account_uuids::MIGRATION_ID))
+                .collect(),
+        );
         let cache = BlockCache::new();
         let mut st = TestBuilder::new()
             .with_data_store_factory(ds_factory)

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -52,14 +52,16 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &Transaction) -> Result<(), WalletMigrationError> {
-        let account_kind_derived = account_kind_code(AccountSource::Derived {
+        let account_kind_derived = account_kind_code(&AccountSource::Derived {
             seed_fingerprint: SeedFingerprint::from_bytes([0; 32]),
             account_index: zip32::AccountId::ZERO,
+            key_source: None,
         });
-        let account_kind_imported = account_kind_code(AccountSource::Imported {
+        let account_kind_imported = account_kind_code(&AccountSource::Imported {
             // the purpose here is irrelevant; we just use it to get the correct code
             // for the account kind
             purpose: AccountPurpose::ViewOnly,
+            key_source: None,
         });
         transaction.execute_batch(&format!(
             r#"

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -413,7 +413,7 @@ mod tests {
         (ufvk0, height, res)
     }
 
-    fn put_received_note_before_migration<T: ReceivedSaplingOutput>(
+    fn put_received_note_before_migration<T: ReceivedSaplingOutput<AccountId = AccountId>>(
         conn: &Connection,
         output: &T,
         tx_ref: i64,

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -324,7 +324,7 @@ mod tests {
             memo_repr, parse_scope,
             sapling::ReceivedSaplingOutput,
         },
-        AccountId, TxRef, WalletDb,
+        AccountRef, TxRef, WalletDb,
     };
 
     // These must be different.
@@ -413,7 +413,7 @@ mod tests {
         (ufvk0, height, res)
     }
 
-    fn put_received_note_before_migration<T: ReceivedSaplingOutput<AccountId = AccountId>>(
+    fn put_received_note_before_migration<T: ReceivedSaplingOutput<AccountId = AccountRef>>(
         conn: &Connection,
         output: &T,
         tx_ref: i64,
@@ -529,7 +529,7 @@ mod tests {
 
         let (ufvk0, height, res) = prepare_wallet_state(&mut db_data);
         let tx = res.transaction();
-        let account_id = AccountId(0);
+        let account_id = AccountRef(0);
 
         // We can't use `decrypt_and_store_transaction` because we haven't migrated yet.
         // Replicate its relevant innards here.
@@ -544,7 +544,7 @@ mod tests {
             .transactionally::<_, _, rusqlite::Error>(|wdb| {
                 let tx_ref = put_tx_data(wdb.conn.0, d_tx.tx(), None, None).unwrap();
 
-                let mut spending_account_id: Option<AccountId> = None;
+                let mut spending_account_id: Option<AccountRef> = None;
 
                 // Orchard outputs were not supported as of the wallet states that could require this
                 // migration.
@@ -644,7 +644,7 @@ mod tests {
             ..Default::default()
         };
         block.vtx.push(compact_tx);
-        let scanning_keys = ScanningKeys::from_account_ufvks([(AccountId(0), ufvk0)]);
+        let scanning_keys = ScanningKeys::from_account_ufvks([(AccountRef(0), ufvk0)]);
 
         let scanned_block = scan_block(
             &params,
@@ -875,7 +875,7 @@ mod tests {
     /// updates to the database schema require incompatible changes to `put_tx_meta`.
     pub(crate) fn put_tx_meta(
         conn: &rusqlite::Connection,
-        tx: &WalletTx<AccountId>,
+        tx: &WalletTx<AccountRef>,
         height: BlockHeight,
     ) -> Result<i64, SqliteClientError> {
         // It isn't there, so insert our transaction into the database.

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -4,11 +4,10 @@ use rusqlite::{named_params, Transaction};
 use schemerz_rusqlite::RusqliteMigration;
 use std::collections::HashSet;
 use uuid::Uuid;
-use zcash_client_backend::data_api::DecryptedTransaction;
 use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
-use zcash_protocol::consensus::{self, BlockHeight, BranchId};
+use zcash_protocol::consensus;
 
-use crate::wallet::{self, init::WalletMigrationError};
+use crate::wallet::init::WalletMigrationError;
 
 use super::{
     ensure_orchard_ua_receiver, ephemeral_addresses, nullifier_map, orchard_shardtree,
@@ -16,6 +15,23 @@ use super::{
 };
 
 pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xfec02b61_3988_4b4f_9699_98977fac9e7f);
+
+#[cfg(feature = "transparent-inputs")]
+use {
+    crate::{
+        error::SqliteClientError,
+        wallet::{
+            queue_transparent_input_retrieval, queue_unmined_tx_retrieval,
+            transparent::{queue_transparent_spend_detection, uivk_legacy_transparent_address},
+        },
+        AccountId, TxRef,
+    },
+    rusqlite::OptionalExtension as _,
+    std::convert::Infallible,
+    zcash_client_backend::data_api::DecryptedTransaction,
+    zcash_keys::encoding::AddressCodec,
+    zcash_protocol::consensus::{BlockHeight, BranchId},
+};
 
 const DEPENDENCIES: &[Uuid] = &[
     orchard_shardtree::MIGRATION_ID,
@@ -26,7 +42,7 @@ const DEPENDENCIES: &[Uuid] = &[
 ];
 
 pub(super) struct Migration<P> {
-    pub(super) params: P,
+    pub(super) _params: P,
 }
 
 impl<P> schemerz::Migration<Uuid> for Migration<P> {
@@ -46,8 +62,8 @@ impl<P> schemerz::Migration<Uuid> for Migration<P> {
 impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
-    fn up(&self, transaction: &Transaction) -> Result<(), WalletMigrationError> {
-        transaction.execute_batch(
+    fn up(&self, conn: &Transaction) -> Result<(), WalletMigrationError> {
+        conn.execute_batch(
             "CREATE TABLE tx_retrieval_queue (
                 txid BLOB NOT NULL UNIQUE,
                 query_type INTEGER NOT NULL,
@@ -82,7 +98,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         // Add estimated target height information for each transaction we know to
         // have been created by the wallet; transactions that were discovered via
         // chain scanning will have their `created` field set to `NULL`.
-        transaction.execute(
+        conn.execute(
             "UPDATE transactions
              SET target_height = expiry_height - :default_expiry_delta
              WHERE expiry_height > :default_expiry_delta
@@ -90,48 +106,107 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
             named_params![":default_expiry_delta": DEFAULT_TX_EXPIRY_DELTA],
         )?;
 
-        // Call `decrypt_and_store_transaction` for each transaction known to the wallet to
-        // populate the enhancement queues with any transparent history information that we don't
+        // Populate the enhancement queues with any transparent history information that we don't
         // already have.
-        let mut stmt_transactions =
-            transaction.prepare("SELECT raw, mined_height FROM transactions")?;
-        let mut rows = stmt_transactions.query([])?;
-        while let Some(row) = rows.next()? {
-            let tx_data = row.get::<_, Option<Vec<u8>>>(0)?;
-            let mined_height = row.get::<_, Option<u32>>(1)?.map(BlockHeight::from);
+        #[cfg(feature = "transparent-inputs")]
+        {
+            let mut stmt_transactions =
+                conn.prepare("SELECT id_tx, raw, mined_height FROM transactions")?;
+            let mut rows = stmt_transactions.query([])?;
+            while let Some(row) = rows.next()? {
+                let tx_ref = row.get(0).map(TxRef)?;
+                let tx_data = row.get::<_, Option<Vec<u8>>>(1)?;
+                let mined_height = row.get::<_, Option<u32>>(2)?.map(BlockHeight::from);
 
-            if let Some(tx_data) = tx_data {
-                let tx = zcash_primitives::transaction::Transaction::read(
-                    &tx_data[..],
-                    // We assume unmined transactions are created with the current consensus branch ID.
-                    mined_height
-                        .map_or(BranchId::Sapling, |h| BranchId::for_height(&self.params, h)),
-                )
-                .map_err(|_| {
-                    WalletMigrationError::CorruptedData(
-                        "Could not read serialized transaction data.".to_owned(),
+                if let Some(tx_data) = tx_data {
+                    let tx = zcash_primitives::transaction::Transaction::read(
+                        &tx_data[..],
+                        // We assume unmined transactions are created with the current consensus branch ID.
+                        mined_height.map_or(BranchId::Sapling, |h| {
+                            BranchId::for_height(&self._params, h)
+                        }),
                     )
-                })?;
+                    .map_err(|_| {
+                        WalletMigrationError::CorruptedData(
+                            "Could not read serialized transaction data.".to_owned(),
+                        )
+                    })?;
 
-                wallet::store_decrypted_tx(
-                    transaction,
-                    &self.params,
-                    DecryptedTransaction::new(
+                    for (txout, output_index) in tx
+                        .transparent_bundle()
+                        .iter()
+                        .flat_map(|b| b.vout.iter())
+                        .zip(0u32..)
+                    {
+                        if let Some(address) = txout.recipient_address() {
+                            let find_address_account = || {
+                                conn.query_row(
+                                    "SELECT account_id FROM addresses
+                                     WHERE cached_transparent_receiver_address = :address
+                                     UNION
+                                     SELECT account_id from ephemeral_addresses
+                                     WHERE address = :address",
+                                    named_params![":address": address.encode(&self._params)],
+                                    |row| row.get(0).map(AccountId),
+                                )
+                                .optional()
+                            };
+                            let find_legacy_address_account =
+                                || -> Result<Option<AccountId>, SqliteClientError> {
+                                    let mut stmt = conn.prepare("SELECT id, uivk FROM accounts")?;
+                                    let mut rows = stmt.query([])?;
+                                    while let Some(row) = rows.next()? {
+                                        let account_id = row.get(0).map(AccountId)?;
+                                        let uivk_str = row.get::<_, String>(1)?;
+
+                                        if let Some((legacy_taddr, _)) =
+                                            uivk_legacy_transparent_address(
+                                                &self._params,
+                                                &uivk_str,
+                                            )?
+                                        {
+                                            if legacy_taddr == address {
+                                                return Ok(Some(account_id));
+                                            }
+                                        }
+                                    }
+
+                                    Ok(None)
+                                };
+
+                            if find_address_account()?.is_some()
+                                || find_legacy_address_account()?.is_some()
+                            {
+                                queue_transparent_spend_detection(
+                                    conn,
+                                    &self._params,
+                                    address,
+                                    tx_ref,
+                                    output_index,
+                                )?
+                            }
+                        }
+                    }
+
+                    let d_tx = DecryptedTransaction::<'_, Infallible>::new(
                         mined_height,
                         &tx,
                         vec![],
                         #[cfg(feature = "orchard")]
                         vec![],
-                    ),
-                )?;
+                    );
+
+                    queue_transparent_input_retrieval(conn, tx_ref, &d_tx)?;
+                    queue_unmined_tx_retrieval(conn, &d_tx)?;
+                }
             }
         }
 
         Ok(())
     }
 
-    fn down(&self, transaction: &Transaction) -> Result<(), WalletMigrationError> {
-        transaction.execute_batch(
+    fn down(&self, conn: &Transaction) -> Result<(), WalletMigrationError> {
+        conn.execute_batch(
             "DROP TABLE transparent_spend_map;
              DROP TABLE transparent_spend_search_queue;
              ALTER TABLE transactions DROP COLUMN target_height;

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -24,7 +24,7 @@ use {
             queue_transparent_input_retrieval, queue_unmined_tx_retrieval,
             transparent::{queue_transparent_spend_detection, uivk_legacy_transparent_address},
         },
-        AccountId, TxRef,
+        AccountRef, TxRef,
     },
     rusqlite::OptionalExtension as _,
     std::convert::Infallible,
@@ -147,16 +147,16 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                                      SELECT account_id from ephemeral_addresses
                                      WHERE address = :address",
                                     named_params![":address": address.encode(&self._params)],
-                                    |row| row.get(0).map(AccountId),
+                                    |row| row.get(0).map(AccountRef),
                                 )
                                 .optional()
                             };
                             let find_legacy_address_account =
-                                || -> Result<Option<AccountId>, SqliteClientError> {
+                                || -> Result<Option<AccountRef>, SqliteClientError> {
                                     let mut stmt = conn.prepare("SELECT id, uivk FROM accounts")?;
                                     let mut rows = stmt.query([])?;
                                     while let Some(row) = rows.next()? {
-                                        let account_id = row.get(0).map(AccountId)?;
+                                        let account_id = row.get(0).map(AccountRef)?;
                                         let uivk_str = row.get::<_, String>(1)?;
 
                                         if let Some((legacy_taddr, _)) =

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -23,7 +23,7 @@ use zip32::Scope;
 
 use crate::{error::SqliteClientError, AccountUuid, ReceivedNoteId, TxRef};
 
-use super::{get_account_id, memo_repr, parse_scope, scope_code};
+use super::{get_account_ref, memo_repr, parse_scope, scope_code};
 
 /// This trait provides a generalization over shielded output representations.
 pub(crate) trait ReceivedOrchardOutput {
@@ -236,7 +236,7 @@ pub(crate) fn put_received_note<T: ReceivedOrchardOutput<AccountId = AccountUuid
     tx_ref: TxRef,
     spent_in: Option<TxRef>,
 ) -> Result<(), SqliteClientError> {
-    let account_id = get_account_id(conn, output.account_id())?;
+    let account_id = get_account_ref(conn, output.account_id())?;
     let mut stmt_upsert_received_note = conn.prepare_cached(
         "INSERT INTO orchard_received_notes
         (

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -20,14 +20,16 @@ use zcash_protocol::{
 };
 use zip32::Scope;
 
-use crate::{error::SqliteClientError, AccountId, ReceivedNoteId, TxRef};
+use crate::{error::SqliteClientError, AccountUuid, ReceivedNoteId, TxRef};
 
-use super::{memo_repr, parse_scope, scope_code};
+use super::{get_account_id, memo_repr, parse_scope, scope_code};
 
 /// This trait provides a generalization over shielded output representations.
 pub(crate) trait ReceivedSaplingOutput {
+    type AccountId;
+
     fn index(&self) -> usize;
-    fn account_id(&self) -> AccountId;
+    fn account_id(&self) -> Self::AccountId;
     fn note(&self) -> &sapling::Note;
     fn memo(&self) -> Option<&MemoBytes>;
     fn is_change(&self) -> bool;
@@ -36,11 +38,13 @@ pub(crate) trait ReceivedSaplingOutput {
     fn recipient_key_scope(&self) -> Option<Scope>;
 }
 
-impl ReceivedSaplingOutput for WalletSaplingOutput<AccountId> {
+impl<AccountId: Copy> ReceivedSaplingOutput for WalletSaplingOutput<AccountId> {
+    type AccountId = AccountId;
+
     fn index(&self) -> usize {
         self.index()
     }
-    fn account_id(&self) -> AccountId {
+    fn account_id(&self) -> Self::AccountId {
         *WalletSaplingOutput::account_id(self)
     }
     fn note(&self) -> &sapling::Note {
@@ -63,11 +67,13 @@ impl ReceivedSaplingOutput for WalletSaplingOutput<AccountId> {
     }
 }
 
-impl ReceivedSaplingOutput for DecryptedOutput<sapling::Note, AccountId> {
+impl<AccountId: Copy> ReceivedSaplingOutput for DecryptedOutput<sapling::Note, AccountId> {
+    type AccountId = AccountId;
+
     fn index(&self) -> usize {
         self.index()
     }
-    fn account_id(&self) -> AccountId {
+    fn account_id(&self) -> Self::AccountId {
         *self.account()
     }
     fn note(&self) -> &sapling::Note {
@@ -212,7 +218,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
 pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
-    account: AccountId,
+    account: AccountUuid,
     target_value: NonNegativeAmount,
     anchor_height: BlockHeight,
     exclude: &[ReceivedNoteId],
@@ -238,12 +244,13 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
 pub(crate) fn get_sapling_nullifiers(
     conn: &Connection,
     query: NullifierQuery,
-) -> Result<Vec<(AccountId, Nullifier)>, SqliteClientError> {
+) -> Result<Vec<(AccountUuid, Nullifier)>, SqliteClientError> {
     // Get the nullifiers for the notes we are tracking
     let mut stmt_fetch_nullifiers = match query {
         NullifierQuery::Unspent => conn.prepare(
-            "SELECT rn.account_id, rn.nf
+            "SELECT a.uuid, rn.nf
              FROM sapling_received_notes rn
+             JOIN accounts a ON a.id = rn.account_id
              JOIN transactions tx ON tx.id_tx = rn.tx
              WHERE rn.nf IS NOT NULL
              AND tx.block IS NOT NULL
@@ -256,14 +263,15 @@ pub(crate) fn get_sapling_nullifiers(
              )",
         ),
         NullifierQuery::All => conn.prepare(
-            "SELECT rn.account_id, rn.nf
+            "SELECT a.uuid, rn.nf
              FROM sapling_received_notes rn
+             JOIN accounts a ON a.id = rn.account_id
              WHERE nf IS NOT NULL",
         ),
     }?;
 
     let nullifiers = stmt_fetch_nullifiers.query_and_then([], |row| {
-        let account = AccountId(row.get(0)?);
+        let account = AccountUuid(row.get(0)?);
         let nf_bytes: Vec<u8> = row.get(1)?;
         Ok::<_, rusqlite::Error>((account, sapling::Nullifier::from_slice(&nf_bytes).unwrap()))
     })?;
@@ -275,10 +283,11 @@ pub(crate) fn get_sapling_nullifiers(
 pub(crate) fn detect_spending_accounts<'a>(
     conn: &Connection,
     nfs: impl Iterator<Item = &'a Nullifier>,
-) -> Result<HashSet<AccountId>, rusqlite::Error> {
+) -> Result<HashSet<AccountUuid>, rusqlite::Error> {
     let mut account_q = conn.prepare_cached(
-        "SELECT rn.account_id
+        "SELECT accounts.uuid
         FROM sapling_received_notes rn
+        JOIN accounts ON accounts.id = rn.account_id
         WHERE rn.nf IN rarray(:nf_ptr)",
     )?;
 
@@ -286,7 +295,7 @@ pub(crate) fn detect_spending_accounts<'a>(
     let nf_ptr = Rc::new(nf_values);
     let res = account_q
         .query_and_then(named_params![":nf_ptr": &nf_ptr], |row| {
-            row.get::<_, u32>(0).map(AccountId)
+            row.get(0).map(AccountUuid)
         })?
         .collect::<Result<HashSet<_>, _>>()?;
 
@@ -324,12 +333,13 @@ pub(crate) fn mark_sapling_note_spent(
 /// This implementation relies on the facts that:
 /// - A transaction will not contain more than 2^63 shielded outputs.
 /// - A note value will never exceed 2^63 zatoshis.
-pub(crate) fn put_received_note<T: ReceivedSaplingOutput>(
+pub(crate) fn put_received_note<T: ReceivedSaplingOutput<AccountId = AccountUuid>>(
     conn: &Transaction,
     output: &T,
     tx_ref: TxRef,
     spent_in: Option<TxRef>,
 ) -> Result<(), SqliteClientError> {
+    let account_id = get_account_id(conn, output.account_id())?;
     let mut stmt_upsert_received_note = conn.prepare_cached(
         "INSERT INTO sapling_received_notes
         (tx, output_index, account_id, diversifier, value, rcm, memo, nf,
@@ -368,7 +378,7 @@ pub(crate) fn put_received_note<T: ReceivedSaplingOutput>(
     let sql_args = named_params![
         ":tx": tx_ref.0,
         ":output_index": i64::try_from(output.index()).expect("output indices are representable as i64"),
-        ":account_id": output.account_id().0,
+        ":account_id": account_id.0,
         ":diversifier": &diversifier.0.as_ref(),
         ":value": output.note().value().inner(),
         ":rcm": &rcm.as_ref(),

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -22,7 +22,7 @@ use zip32::Scope;
 
 use crate::{error::SqliteClientError, AccountUuid, ReceivedNoteId, TxRef};
 
-use super::{get_account_id, memo_repr, parse_scope, scope_code};
+use super::{get_account_ref, memo_repr, parse_scope, scope_code};
 
 /// This trait provides a generalization over shielded output representations.
 pub(crate) trait ReceivedSaplingOutput {
@@ -339,7 +339,7 @@ pub(crate) fn put_received_note<T: ReceivedSaplingOutput<AccountId = AccountUuid
     tx_ref: TxRef,
     spent_in: Option<TxRef>,
 ) -> Result<(), SqliteClientError> {
-    let account_id = get_account_id(conn, output.account_id())?;
+    let account_id = get_account_ref(conn, output.account_id())?;
     let mut stmt_upsert_received_note = conn.prepare_cached(
         "INSERT INTO sapling_received_notes
         (tx, output_index, account_id, diversifier, value, rcm, memo, nf,

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -912,11 +912,13 @@ pub(crate) mod tests {
         let wallet_birthday = sap_active + 500;
         st.wallet_mut()
             .create_account(
+                "",
                 &SecretVec::new(vec![0; 32]),
                 &AccountBirthday::from_parts(
                     ChainState::empty(wallet_birthday - 1, BlockHash([0; 32])),
                     None,
                 ),
+                None,
             )
             .unwrap();
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -22,7 +22,7 @@ use zcash_primitives::{
 };
 use zcash_protocol::consensus::{self, BlockHeight};
 
-use super::{chain_tip_height, get_account_id, get_account_ids};
+use super::{chain_tip_height, get_account_ids};
 use crate::AccountUuid;
 use crate::{error::SqliteClientError, TxRef, UtxoId};
 
@@ -696,7 +696,7 @@ pub(crate) fn put_transparent_output<P: consensus::Parameters>(
     known_unspent: bool,
 ) -> Result<UtxoId, SqliteClientError> {
     let output_height = output_height.map(u32::from);
-    let receiving_account_id = get_account_id(conn, receiving_account_uuid)?;
+    let receiving_account_id = super::get_account_ref(conn, receiving_account_uuid)?;
 
     // Check whether we have an entry in the blocks table for the output height;
     // if not, the transaction will be updated with its mined height when the

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -7,7 +7,7 @@ use zcash_client_backend::data_api::TransactionDataRequest;
 use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
 use zip32::{DiversifierIndex, Scope};
 
-use zcash_address::unified::{Encoding, Ivk, Uivk};
+use zcash_address::unified::{Ivk, Uivk};
 use zcash_client_backend::{
     data_api::AccountBalance,
     wallet::{TransparentAddressMetadata, WalletTransparentOutput},
@@ -22,18 +22,20 @@ use zcash_primitives::{
 };
 use zcash_protocol::consensus::{self, BlockHeight};
 
-use super::{chain_tip_height, get_account_ids};
-use crate::{error::SqliteClientError, AccountId, TxRef, UtxoId};
+use super::{chain_tip_height, get_account_id, get_account_ids};
+use crate::AccountUuid;
+use crate::{error::SqliteClientError, TxRef, UtxoId};
 
 pub(crate) mod ephemeral;
 
 pub(crate) fn detect_spending_accounts<'a>(
     conn: &Connection,
     spent: impl Iterator<Item = &'a OutPoint>,
-) -> Result<HashSet<AccountId>, rusqlite::Error> {
+) -> Result<HashSet<AccountUuid>, rusqlite::Error> {
     let mut account_q = conn.prepare_cached(
-        "SELECT account_id
+        "SELECT accounts.uuid
         FROM transparent_received_outputs o
+        JOIN accounts ON accounts.id = o.account_id
         JOIN transactions t ON t.id_tx = o.transaction_id
         WHERE t.txid = :prevout_txid
         AND o.output_index = :prevout_idx",
@@ -46,7 +48,7 @@ pub(crate) fn detect_spending_accounts<'a>(
                 ":prevout_txid": prevout.hash(),
                 ":prevout_idx": prevout.n()
             ],
-            |row| row.get::<_, u32>(0).map(AccountId),
+            |row| row.get(0).map(AccountUuid),
         )? {
             acc.insert(account?);
         }
@@ -80,15 +82,18 @@ fn address_index_from_diversifier_index_be(
 pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
-    account: AccountId,
+    account_uuid: AccountUuid,
 ) -> Result<HashMap<TransparentAddress, Option<TransparentAddressMetadata>>, SqliteClientError> {
     let mut ret: HashMap<TransparentAddress, Option<TransparentAddressMetadata>> = HashMap::new();
 
     // Get all UAs derived
     let mut ua_query = conn.prepare(
-        "SELECT address, diversifier_index_be FROM addresses WHERE account_id = :account",
+        "SELECT address, diversifier_index_be 
+         FROM addresses 
+         JOIN accounts ON accounts.id = addresses.account_id
+         WHERE accounts.uuid = :account_uuid",
     )?;
-    let mut rows = ua_query.query(named_params![":account": account.0])?;
+    let mut rows = ua_query.query(named_params![":account_uuid": account_uuid.0])?;
 
     while let Some(row) = rows.next()? {
         let ua_str: String = row.get(0)?;
@@ -113,7 +118,9 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
         }
     }
 
-    if let Some((taddr, address_index)) = get_legacy_transparent_address(params, conn, account)? {
+    if let Some((taddr, address_index)) =
+        get_legacy_transparent_address(params, conn, account_uuid)?
+    {
         let metadata = TransparentAddressMetadata::new(Scope::External.into(), address_index);
         ret.insert(taddr, Some(metadata));
     }
@@ -121,46 +128,56 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
     Ok(ret)
 }
 
+pub(crate) fn uivk_legacy_transparent_address<P: consensus::Parameters>(
+    params: &P,
+    uivk_str: &str,
+) -> Result<Option<(TransparentAddress, NonHardenedChildIndex)>, SqliteClientError> {
+    use zcash_address::unified::{Container as _, Encoding as _};
+    use zcash_primitives::legacy::keys::ExternalIvk;
+
+    let (network, uivk) = Uivk::decode(uivk_str)
+        .map_err(|e| SqliteClientError::CorruptedData(format!("Unable to parse UIVK: {e}")))?;
+
+    if params.network_type() != network {
+        let network_name = |n| match n {
+            consensus::NetworkType::Main => "mainnet",
+            consensus::NetworkType::Test => "testnet",
+            consensus::NetworkType::Regtest => "regtest",
+        };
+        return Err(SqliteClientError::CorruptedData(format!(
+            "Network type mismatch: account UIVK is for {} but a {} address was requested.",
+            network_name(network),
+            network_name(params.network_type())
+        )));
+    }
+
+    // Derive the default transparent address (if it wasn't already part of a derived UA).
+    for item in uivk.items() {
+        if let Ivk::P2pkh(tivk_bytes) = item {
+            let tivk = ExternalIvk::deserialize(&tivk_bytes)?;
+            return Ok(Some(tivk.default_address()));
+        }
+    }
+
+    Ok(None)
+}
+
 pub(crate) fn get_legacy_transparent_address<P: consensus::Parameters>(
     params: &P,
     conn: &rusqlite::Connection,
-    account_id: AccountId,
+    account_uuid: AccountUuid,
 ) -> Result<Option<(TransparentAddress, NonHardenedChildIndex)>, SqliteClientError> {
-    use zcash_address::unified::Container;
-    use zcash_primitives::legacy::keys::ExternalIvk;
-
     // Get the UIVK for the account.
     let uivk_str: Option<String> = conn
         .query_row(
-            "SELECT uivk FROM accounts WHERE id = :account",
-            [account_id.0],
+            "SELECT uivk FROM accounts WHERE uuid = :account_uuid",
+            named_params![":account_uuid": account_uuid.0],
             |row| row.get(0),
         )
         .optional()?;
 
     if let Some(uivk_str) = uivk_str {
-        let (network, uivk) = Uivk::decode(&uivk_str)
-            .map_err(|e| SqliteClientError::CorruptedData(format!("Unable to parse UIVK: {e}")))?;
-        if params.network_type() != network {
-            let network_name = |n| match n {
-                consensus::NetworkType::Main => "mainnet",
-                consensus::NetworkType::Test => "testnet",
-                consensus::NetworkType::Regtest => "regtest",
-            };
-            return Err(SqliteClientError::CorruptedData(format!(
-                "Network type mismatch: account UIVK is for {} but a {} address was requested.",
-                network_name(network),
-                network_name(params.network_type())
-            )));
-        }
-
-        // Derive the default transparent address (if it wasn't already part of a derived UA).
-        for item in uivk.items() {
-            if let Ivk::P2pkh(tivk_bytes) = item {
-                let tivk = ExternalIvk::deserialize(&tivk_bytes)?;
-                return Ok(Some(tivk.default_address()));
-            }
-        }
+        return uivk_legacy_transparent_address(params, &uivk_str);
     }
 
     Ok(None)
@@ -334,7 +351,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
 pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
-    account: AccountId,
+    account_uuid: AccountUuid,
     summary_height: BlockHeight,
 ) -> Result<HashMap<TransparentAddress, NonNegativeAmount>, SqliteClientError> {
     let chain_tip_height = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
@@ -342,9 +359,9 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     let mut stmt_address_balances = conn.prepare(
         "SELECT u.address, SUM(u.value_zat)
          FROM transparent_received_outputs u
-         JOIN transactions t
-         ON t.id_tx = u.transaction_id
-         WHERE u.account_id = :account_id
+         JOIN accounts ON accounts.id = u.account_id
+         JOIN transactions t ON t.id_tx = u.transaction_id
+         WHERE accounts.uuid = :account_uuid
          -- the transaction that created the output is mined or is definitely unexpired
          AND (
             t.mined_height <= :summary_height -- tx is mined
@@ -370,7 +387,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
 
     let mut res = HashMap::new();
     let mut rows = stmt_address_balances.query(named_params![
-        ":account_id": account.0,
+        ":account_uuid": account_uuid.0,
         ":summary_height": u32::from(summary_height),
         ":chain_tip_height": u32::from(chain_tip_height),
         ":spend_expiry_height": u32::from(std::cmp::min(summary_height, chain_tip_height + 1)),
@@ -390,13 +407,13 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
 pub(crate) fn add_transparent_account_balances(
     conn: &rusqlite::Connection,
     mempool_height: BlockHeight,
-    account_balances: &mut HashMap<AccountId, AccountBalance>,
+    account_balances: &mut HashMap<AccountUuid, AccountBalance>,
 ) -> Result<(), SqliteClientError> {
     let mut stmt_account_balances = conn.prepare(
-        "SELECT u.account_id, SUM(u.value_zat)
+        "SELECT a.uuid, SUM(u.value_zat)
          FROM transparent_received_outputs u
-         JOIN transactions t
-         ON t.id_tx = u.transaction_id
+         JOIN accounts a ON a.id = u.account_id
+         JOIN transactions t ON t.id_tx = u.transaction_id
          -- the transaction that created the output is mined or is definitely unexpired
          WHERE (
             t.mined_height < :mempool_height -- tx is mined
@@ -413,13 +430,13 @@ pub(crate) fn add_transparent_account_balances(
            OR tx.expiry_height = 0 -- the spending tx will not expire
            OR tx.expiry_height >= :mempool_height -- the spending tx is unexpired
          )
-         GROUP BY u.account_id",
+         GROUP BY a.uuid",
     )?;
     let mut rows = stmt_account_balances
         .query(named_params![":mempool_height": u32::from(mempool_height),])?;
 
     while let Some(row) = rows.next()? {
-        let account = AccountId(row.get(0)?);
+        let account = AccountUuid(row.get(0)?);
         let raw_value = row.get(1)?;
         let value = NonNegativeAmount::from_nonnegative_i64(raw_value).map_err(|_| {
             SqliteClientError::CorruptedData(format!("Negative UTXO value {:?}", raw_value))
@@ -501,7 +518,9 @@ pub(crate) fn put_received_transparent_utxo<P: consensus::Parameters>(
     output: &WalletTransparentOutput,
 ) -> Result<UtxoId, SqliteClientError> {
     let address = output.recipient_address();
-    if let Some(receiving_account) = find_account_for_transparent_address(conn, params, address)? {
+    if let Some(receiving_account) =
+        find_account_uuid_for_transparent_address(conn, params, address)?
+    {
         put_transparent_output(
             conn,
             params,
@@ -565,7 +584,7 @@ pub(crate) fn transaction_data_requests<P: consensus::Parameters>(
 pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
-    account_id: AccountId,
+    account_uuid: AccountUuid,
     address: &TransparentAddress,
 ) -> Result<Option<TransparentAddressMetadata>, SqliteClientError> {
     let address_str = address.encode(params);
@@ -573,8 +592,10 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
     if let Some(di_vec) = conn
         .query_row(
             "SELECT diversifier_index_be FROM addresses
-             WHERE account_id = :account_id AND cached_transparent_receiver_address = :address",
-            named_params![":account_id": account_id.0, ":address": &address_str],
+             JOIN accounts ON addresses.account_id = accounts.id
+             WHERE accounts.uuid = :account_uuid 
+             AND cached_transparent_receiver_address = :address",
+            named_params![":account_uuid": account_uuid.0, ":address": &address_str],
             |row| row.get::<_, Vec<u8>>(0),
         )
         .optional()?
@@ -585,7 +606,7 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
     }
 
     if let Some((legacy_taddr, address_index)) =
-        get_legacy_transparent_address(params, conn, account_id)?
+        get_legacy_transparent_address(params, conn, account_uuid)?
     {
         if &legacy_taddr == address {
             let metadata = TransparentAddressMetadata::new(Scope::External.into(), address_index);
@@ -595,7 +616,7 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
 
     // Search known ephemeral addresses.
     if let Some(address_index) =
-        ephemeral::find_index_for_ephemeral_address_str(conn, account_id, &address_str)?
+        ephemeral::find_index_for_ephemeral_address_str(conn, account_uuid, &address_str)?
     {
         return Ok(Some(ephemeral::metadata(address_index)));
     }
@@ -613,18 +634,21 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
 ///
 /// Returns `Ok(None)` if the transparent output's recipient address is not in any of the
 /// above locations. This means the wallet considers the output "not interesting".
-pub(crate) fn find_account_for_transparent_address<P: consensus::Parameters>(
+pub(crate) fn find_account_uuid_for_transparent_address<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
     address: &TransparentAddress,
-) -> Result<Option<AccountId>, SqliteClientError> {
+) -> Result<Option<AccountUuid>, SqliteClientError> {
     let address_str = address.encode(params);
 
     if let Some(account_id) = conn
         .query_row(
-            "SELECT account_id FROM addresses WHERE cached_transparent_receiver_address = :address",
+            "SELECT accounts.uuid 
+             FROM addresses 
+             JOIN accounts ON accounts.id = addresses.account_id
+             WHERE cached_transparent_receiver_address = :address",
             named_params![":address": &address_str],
-            |row| Ok(AccountId(row.get(0)?)),
+            |row| Ok(AccountUuid(row.get(0)?)),
         )
         .optional()?
     {
@@ -668,10 +692,11 @@ pub(crate) fn put_transparent_output<P: consensus::Parameters>(
     txout: &TxOut,
     output_height: Option<BlockHeight>,
     address: &TransparentAddress,
-    receiving_account: AccountId,
+    receiving_account_uuid: AccountUuid,
     known_unspent: bool,
 ) -> Result<UtxoId, SqliteClientError> {
     let output_height = output_height.map(u32::from);
+    let receiving_account_id = get_account_id(conn, receiving_account_uuid)?;
 
     // Check whether we have an entry in the blocks table for the output height;
     // if not, the transaction will be updated with its mined height when the
@@ -759,7 +784,7 @@ pub(crate) fn put_transparent_output<P: consensus::Parameters>(
     let sql_args = named_params![
         ":transaction_id": id_tx,
         ":output_index": &outpoint.n(),
-        ":account_id": receiving_account.0,
+        ":account_id": receiving_account_id.0,
         ":address": &address.encode(params),
         ":script": &txout.script_pubkey.0,
         ":value_zat": &i64::from(Amount::from(txout.value)),

--- a/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
@@ -16,6 +16,8 @@ use zcash_primitives::{
 };
 use zcash_protocol::consensus;
 
+use crate::wallet::{self, get_account_id};
+use crate::AccountUuid;
 use crate::{error::SqliteClientError, AccountId, TxRef};
 
 // Returns `TransparentAddressMetadata` in the ephemeral scope for the
@@ -155,12 +157,15 @@ pub(crate) fn get_known_ephemeral_addresses<P: consensus::Parameters>(
     let index_range = index_range.unwrap_or(0..(1 << 31));
 
     let mut stmt = conn.prepare(
-        "SELECT address, address_index FROM ephemeral_addresses
-         WHERE account_id = :account AND address_index >= :start AND address_index < :end
+        "SELECT address, address_index 
+         FROM ephemeral_addresses ea
+         WHERE ea.account_id = :account_id
+         AND address_index >= :start 
+         AND address_index < :end
          ORDER BY address_index",
     )?;
     let mut rows = stmt.query(named_params![
-        ":account": account_id.0,
+        ":account_id": account_id.0,
         ":start": index_range.start,
         ":end": min(1 << 31, index_range.end),
     ])?;
@@ -182,12 +187,15 @@ pub(crate) fn get_known_ephemeral_addresses<P: consensus::Parameters>(
 pub(crate) fn find_account_for_ephemeral_address_str(
     conn: &rusqlite::Connection,
     address_str: &str,
-) -> Result<Option<AccountId>, SqliteClientError> {
+) -> Result<Option<AccountUuid>, SqliteClientError> {
     Ok(conn
         .query_row(
-            "SELECT account_id FROM ephemeral_addresses WHERE address = :address",
+            "SELECT accounts.uuid 
+             FROM ephemeral_addresses ea
+             JOIN accounts ON accounts.id = ea.account_id
+             WHERE address = :address",
             named_params![":address": &address_str],
-            |row| Ok(AccountId(row.get(0)?)),
+            |row| Ok(AccountUuid(row.get(0)?)),
         )
         .optional()?)
 }
@@ -195,9 +203,10 @@ pub(crate) fn find_account_for_ephemeral_address_str(
 /// If this is a known ephemeral address in the given account, return its index.
 pub(crate) fn find_index_for_ephemeral_address_str(
     conn: &rusqlite::Connection,
-    account_id: AccountId,
+    account_uuid: AccountUuid,
     address_str: &str,
 ) -> Result<Option<NonHardenedChildIndex>, SqliteClientError> {
+    let account_id = get_account_id(conn, account_uuid)?;
     Ok(conn
         .query_row(
             "SELECT address_index FROM ephemeral_addresses
@@ -246,8 +255,9 @@ pub(crate) fn reserve_next_n_ephemeral_addresses<P: consensus::Parameters>(
         return Err(AddressGenerationError::DiversifierSpaceExhausted.into());
     }
     if allocation.end > first_unsafe {
+        let account_uuid = wallet::get_account_uuid(conn, account_id)?;
         return Err(SqliteClientError::ReachedGapLimit(
-            account_id,
+            account_uuid,
             max(first_unreserved, first_unsafe),
         ));
     }


### PR DESCRIPTION
This provides equivalent uniqueness to the `accounts` table primary key, but avoids collisions across wallet recreation events (to defend against downstream crate users who don't flush any persisted account IDs at those events).

Closes #1629.