### PR TITLE
zcash_client_sqlite: Fix `add_account_uuids` migration

### DIFF
--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -900,8 +900,8 @@ JOIN transactions
 -- join to the sent_notes table to obtain `from_account_id`
 LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
 -- join on the accounts table to obtain account UUIDs
-JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
-JOIN accounts to_account ON accounts.id = ro.account_id
+JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+JOIN accounts to_account ON to_account.id = ro.account_id
 UNION
 -- select all outputs sent from the wallet to external recipients
 SELECT transactions.txid            AS txid,
@@ -918,7 +918,7 @@ JOIN transactions
     ON transactions.id_tx = sent_notes.tx
 LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
 -- join on the accounts table to obtain account UUIDs
-JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
+JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
 -- exclude any sent notes for which a row exists in the v_received_outputs view
 WHERE ro.account_id IS NULL";
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -289,8 +289,8 @@ impl RusqliteMigration for Migration {
             -- join to the sent_notes table to obtain `from_account_id`
             LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
             -- join on the accounts table to obtain account UUIDs
-            JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
-            JOIN accounts to_account ON accounts.id = ro.account_id
+            JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+            JOIN accounts to_account ON to_account.id = ro.account_id
             UNION
             -- select all outputs sent from the wallet to external recipients
             SELECT transactions.txid            AS txid,
@@ -307,7 +307,7 @@ impl RusqliteMigration for Migration {
                 ON transactions.id_tx = sent_notes.tx
             LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
             -- join on the accounts table to obtain account UUIDs
-            JOIN accounts from_account ON accounts.id = sent_notes.from_account_id
+            JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
             -- exclude any sent notes for which a row exists in the v_received_outputs view
             WHERE ro.account_id IS NULL",
         )?;


### PR DESCRIPTION
`v_tx_outputs` gains new JOINs on `accounts.id` in order to migrate to exposing `accounts.uuid`, but as there are two table joins the tables are given aliases. The aliases were not being used in the JOIN's ON condition, leading to an error when querying the view.