### PR TITLE
zcash_client_sqlite: Fix accounts joins in add_account_uuids migration

### DIFF
--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -859,7 +859,7 @@ SELECT accounts.uuid                AS account_uuid,
             AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
        ) AS is_shielding
 FROM notes
-JOIN accounts ON accounts.id = notes.account_id
+LEFT JOIN accounts ON accounts.id = notes.account_id
 LEFT JOIN transactions
      ON notes.txid = transactions.txid
 JOIN blocks_max_height
@@ -900,8 +900,8 @@ JOIN transactions
 -- join to the sent_notes table to obtain `from_account_id`
 LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
 -- join on the accounts table to obtain account UUIDs
-JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
-JOIN accounts to_account ON to_account.id = ro.account_id
+LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+LEFT JOIN accounts to_account ON to_account.id = ro.account_id
 UNION
 -- select all outputs sent from the wallet to external recipients
 SELECT transactions.txid            AS txid,
@@ -918,7 +918,7 @@ JOIN transactions
     ON transactions.id_tx = sent_notes.tx
 LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
 -- join on the accounts table to obtain account UUIDs
-JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
 -- exclude any sent notes for which a row exists in the v_received_outputs view
 WHERE ro.account_id IS NULL";
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -260,7 +260,7 @@ impl RusqliteMigration for Migration {
                         AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
                    ) AS is_shielding
             FROM notes
-            JOIN accounts ON accounts.id = notes.account_id
+            LEFT JOIN accounts ON accounts.id = notes.account_id
             LEFT JOIN transactions
                  ON notes.txid = transactions.txid
             JOIN blocks_max_height
@@ -289,8 +289,8 @@ impl RusqliteMigration for Migration {
             -- join to the sent_notes table to obtain `from_account_id`
             LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
             -- join on the accounts table to obtain account UUIDs
-            JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
-            JOIN accounts to_account ON to_account.id = ro.account_id
+            LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+            LEFT JOIN accounts to_account ON to_account.id = ro.account_id
             UNION
             -- select all outputs sent from the wallet to external recipients
             SELECT transactions.txid            AS txid,
@@ -307,7 +307,7 @@ impl RusqliteMigration for Migration {
                 ON transactions.id_tx = sent_notes.tx
             LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
             -- join on the accounts table to obtain account UUIDs
-            JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+            LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
             -- exclude any sent notes for which a row exists in the v_received_outputs view
             WHERE ro.account_id IS NULL",
         )?;


### PR DESCRIPTION
Some views had account ID fields that were potentially NULL. As part of migrating to account UUIDs, we now join on the accounts table to access the UUID. We need to use a `LEFT JOIN` specifically to ensure that we propagate a NULL account ID into a NULL account UUID, instead of dropping the row.