### PR TITLE
Only require `alloc` instead of `std` where useful

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6411,7 +6411,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "document-features",
  "incrementalmerkletree",

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `no-std` compatibility (`alloc` is required). A default-enabled `std` feature
+  flag has been added gating the `std::error::Error` and `memuse` usage.
 
 ## [0.4.1] - 2024-11-13
 ### Added

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -6,6 +6,7 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.2] - 2024-12-13
 ### Added
 - `no-std` compatibility (`alloc` is required). A default-enabled `std` feature
   flag has been added gating the `std::error::Error` and `memuse` usage.

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -21,12 +21,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # - Logging and metrics
-memuse.workspace = true
+memuse = { workspace = true, optional = true }
 
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 # - Documentation
-document-features.workspace = true
+document-features = { workspace = true, optional = true }
 
 # - Test dependencies
 proptest = { workspace = true, optional = true }
@@ -37,6 +37,8 @@ incrementalmerkletree-testing = { workspace = true, optional = true }
 proptest.workspace = true
 
 [features]
+default = ["std"]
+std = ["document-features", "dep:memuse"]
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
 test-dependencies = [
     "dep:incrementalmerkletree",

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -1,10 +1,12 @@
 //! Consensus logic and parameters.
 
+use core::cmp::{Ord, Ordering};
+use core::convert::TryFrom;
+use core::fmt;
+use core::ops::{Add, Bound, RangeBounds, Sub};
+
+#[cfg(feature = "std")]
 use memuse::DynamicUsage;
-use std::cmp::{Ord, Ordering};
-use std::convert::TryFrom;
-use std::fmt;
-use std::ops::{Add, Bound, RangeBounds, Sub};
 
 use crate::constants::{mainnet, regtest, testnet};
 
@@ -16,6 +18,7 @@ use crate::constants::{mainnet, regtest, testnet};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BlockHeight(u32);
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(BlockHeight);
 
 /// The height of the genesis block on a network.
@@ -64,7 +67,7 @@ impl From<BlockHeight> for u32 {
 }
 
 impl TryFrom<u64> for BlockHeight {
-    type Error = std::num::TryFromIntError;
+    type Error = core::num::TryFromIntError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         u32::try_from(value).map(BlockHeight)
@@ -78,7 +81,7 @@ impl From<BlockHeight> for u64 {
 }
 
 impl TryFrom<i32> for BlockHeight {
-    type Error = std::num::TryFromIntError;
+    type Error = core::num::TryFromIntError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         u32::try_from(value).map(BlockHeight)
@@ -86,7 +89,7 @@ impl TryFrom<i32> for BlockHeight {
 }
 
 impl TryFrom<i64> for BlockHeight {
-    type Error = std::num::TryFromIntError;
+    type Error = core::num::TryFromIntError;
 
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         u32::try_from(value).map(BlockHeight)
@@ -202,6 +205,7 @@ pub enum NetworkType {
     Regtest,
 }
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(NetworkType);
 
 impl NetworkConstants for NetworkType {
@@ -324,6 +328,7 @@ impl<P: Parameters> NetworkConstants for P {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct MainNetwork;
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(MainNetwork);
 
 /// The production network.
@@ -353,6 +358,7 @@ impl Parameters for MainNetwork {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct TestNetwork;
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(TestNetwork);
 
 /// The test network.
@@ -387,6 +393,7 @@ pub enum Network {
     TestNetwork,
 }
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(Network);
 
 impl Parameters for Network {
@@ -448,6 +455,7 @@ pub enum NetworkUpgrade {
     ZFuture,
 }
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(NetworkUpgrade);
 
 impl fmt::Display for NetworkUpgrade {
@@ -538,6 +546,7 @@ pub enum BranchId {
     ZFuture,
 }
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(BranchId);
 
 impl TryFrom<u32> for BranchId {
@@ -688,7 +697,7 @@ pub mod testing {
             .height_bounds(params)
             .map_or(Strategy::boxed(Just(None)), |(lower, upper)| {
                 Strategy::boxed(
-                    (lower.0..upper.map_or(std::u32::MAX, |u| u.0))
+                    (lower.0..upper.map_or(core::u32::MAX, |u| u.0))
                         .prop_map(|h| Some(BlockHeight(h))),
                 )
             })
@@ -707,7 +716,6 @@ mod tests {
     use super::{
         BlockHeight, BranchId, NetworkUpgrade, Parameters, MAIN_NETWORK, UPGRADES_IN_ORDER,
     };
-    use std::convert::TryFrom;
 
     #[test]
     fn nu_ordering() {

--- a/components/zcash_protocol/src/lib.rs
+++ b/components/zcash_protocol/src/lib.rs
@@ -4,16 +4,23 @@
 //! for the Zcash main and test networks, as well types for representing ZEC amounts and value
 //! balances.
 //!
-//! ## Feature flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "std", doc = "## Feature flags")]
+#![cfg_attr(feature = "std", doc = document_features::document_features!())]
 //!
 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
+
+#[cfg_attr(any(test, feature = "test-dependencies"), macro_use)]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::fmt;
 

--- a/components/zcash_protocol/src/memo.rs
+++ b/components/zcash_protocol/src/memo.rs
@@ -1,10 +1,15 @@
 //! Structs for handling encrypted memos.
 
-use std::cmp::Ordering;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::Deref;
+use core::str;
+
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
-use std::ops::Deref;
-use std::str;
 
 /// Format a byte array as a colon-delimited hex string.
 ///
@@ -30,7 +35,7 @@ where
 /// Errors that may result from attempting to construct an invalid memo.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
-    InvalidUtf8(std::str::Utf8Error),
+    InvalidUtf8(core::str::Utf8Error),
     TooLong(usize),
 }
 
@@ -43,6 +48,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {}
 
 /// The unencrypted memo bytes received alongside a shielded note in a Zcash transaction.
@@ -281,7 +287,8 @@ impl str::FromStr for Memo {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use alloc::boxed::Box;
+    use alloc::str::FromStr;
 
     use super::{Error, Memo, MemoBytes};
 

--- a/components/zcash_protocol/src/value.rs
+++ b/components/zcash_protocol/src/value.rs
@@ -1,9 +1,13 @@
-use std::convert::{Infallible, TryFrom};
-use std::error;
-use std::iter::Sum;
-use std::num::NonZeroU64;
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use core::convert::{Infallible, TryFrom};
+use core::fmt;
+use core::iter::Sum;
+use core::num::NonZeroU64;
+use core::ops::{Add, Div, Mul, Neg, Sub};
 
+#[cfg(feature = "std")]
+use std::error;
+
+#[cfg(feature = "std")]
 use memuse::DynamicUsage;
 
 pub const COIN: u64 = 1_0000_0000;
@@ -21,6 +25,7 @@ pub const MAX_BALANCE: i64 = MAX_MONEY as i64;
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct ZatBalance(i64);
 
+#[cfg(feature = "std")]
 memuse::impl_no_dynamic_usage!(ZatBalance);
 
 impl ZatBalance {
@@ -442,10 +447,11 @@ pub enum BalanceError {
     Underflow,
 }
 
+#[cfg(feature = "std")]
 impl error::Error for BalanceError {}
 
-impl std::fmt::Display for BalanceError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for BalanceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
             BalanceError::Overflow => {
                 write!(

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -935,6 +935,12 @@ end = "2025-04-22"
 
 [[trusted.zcash_protocol]]
 criteria = "safe-to-deploy"
+user-id = 6289 # Jack Grigg (str4d)
+start = "2024-12-13"
+end = "2025-12-13"
+
+[[trusted.zcash_protocol]]
+criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-27"
 end = "2025-04-22"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_protocol]]
+version = "0.4.2"
+audited_as = "0.4.1"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,10 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_protocol]]
-version = "0.4.2"
-audited_as = "0.4.1"
-
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -311,11 +307,11 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.4.1"
-when = "2024-11-14"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
+version = "0.4.2"
+when = "2024-12-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
 
 [[publisher.zcash_spec]]
 version = "0.1.0"


### PR DESCRIPTION
This enables these crates to be used in environments like hardware wallets.