### PR TITLE
pczt: Add output field for storing the user-facing address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.10.0"
-source = "git+https://github.com/zcash/orchard.git?rev=3d951b4201a63f3c07cba8b179dd9abde142cf33#3d951b4201a63f3c07cba8b179dd9abde142cf33"
+source = "git+https://github.com/zcash/orchard.git?rev=7a44e3279b5747819022c4d8f4474fa79b2d9746#7a44e3279b5747819022c4d8f4474fa79b2d9746"
 dependencies = [
  "aes",
  "bitvec",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.3.0"
-source = "git+https://github.com/zcash/sapling-crypto.git?rev=231f81911628499a8877be57e66e60c09e55bdea#231f81911628499a8877be57e66e60c09e55bdea"
+source = "git+https://github.com/zcash/sapling-crypto.git?rev=e47d57f5c9c46f05740328f8ef9601f6d697cf34#e47d57f5c9c46f05740328f8ef9601f6d697cf34"
 dependencies = [
  "aes",
  "bellman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,5 +190,5 @@ debug = true
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture"))'] }
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "3d951b4201a63f3c07cba8b179dd9abde142cf33" }
-sapling-crypto = { git = "https://github.com/zcash/sapling-crypto.git", rev = "231f81911628499a8877be57e66e60c09e55bdea" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "7a44e3279b5747819022c4d8f4474fa79b2d9746" }
+sapling-crypto = { git = "https://github.com/zcash/sapling-crypto.git", rev = "e47d57f5c9c46f05740328f8ef9601f6d697cf34" }

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -232,6 +232,14 @@ pub struct Output {
     /// The ZIP 32 derivation path at which the spending key can be found for the output.
     pub(crate) zip32_derivation: Option<Zip32Derivation>,
 
+    /// The user-facing address to which this output is being sent, if any.
+    ///
+    /// - This is set by an Updater.
+    /// - Signers must parse this address (if present) and confirm that it contains
+    ///   `recipient` (either directly, or e.g. as a receiver within a Unified Address).
+    #[getset(get = "pub")]
+    pub(crate) user_address: Option<String>,
+
     /// Proprietary fields related to the note being created.
     #[getset(get = "pub")]
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
@@ -335,6 +343,7 @@ impl Bundle {
                         rseed: output_rseed,
                         ock,
                         zip32_derivation: output_zip32_derivation,
+                        user_address,
                         proprietary: output_proprietary,
                     },
                 rcv,
@@ -367,6 +376,7 @@ impl Bundle {
                 && merge_optional(&mut lhs.output.rseed, output_rseed)
                 && merge_optional(&mut lhs.output.ock, ock)
                 && merge_optional(&mut lhs.output.zip32_derivation, output_zip32_derivation)
+                && merge_optional(&mut lhs.output.user_address, user_address)
                 && merge_map(&mut lhs.output.proprietary, output_proprietary)
                 && merge_optional(&mut lhs.rcv, rcv))
             {
@@ -430,6 +440,7 @@ impl Bundle {
                             )
                         })
                         .transpose()?,
+                    action.output.user_address,
                     action.output.proprietary,
                 )?;
 
@@ -521,6 +532,7 @@ impl Bundle {
                                     .collect(),
                             }
                         }),
+                        user_address: output.user_address().clone(),
                         proprietary: output.proprietary().clone(),
                     },
                     rcv: action.rcv().as_ref().map(|rcv| rcv.to_bytes()),

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -231,6 +231,14 @@ pub struct Output {
     /// The ZIP 32 derivation path at which the spending key can be found for the output.
     pub(crate) zip32_derivation: Option<Zip32Derivation>,
 
+    /// The user-facing address to which this output is being sent, if any.
+    ///
+    /// - This is set by an Updater.
+    /// - Signers must parse this address (if present) and confirm that it contains
+    ///   `recipient` (either directly, or e.g. as a receiver within a Unified Address).
+    #[getset(get = "pub")]
+    pub(crate) user_address: Option<String>,
+
     /// Proprietary fields related to the note being spent.
     #[getset(get = "pub")]
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
@@ -391,6 +399,7 @@ impl Bundle {
                 rcv,
                 ock,
                 zip32_derivation,
+                user_address,
                 proprietary,
             } = rhs;
 
@@ -410,6 +419,7 @@ impl Bundle {
                 && merge_optional(&mut lhs.rcv, rcv)
                 && merge_optional(&mut lhs.ock, ock)
                 && merge_optional(&mut lhs.zip32_derivation, zip32_derivation)
+                && merge_optional(&mut lhs.user_address, user_address)
                 && merge_map(&mut lhs.proprietary, proprietary))
             {
                 return None;
@@ -481,6 +491,7 @@ impl Bundle {
                             )
                         })
                         .transpose()?,
+                    output.user_address,
                     output.proprietary,
                 )
             })
@@ -561,6 +572,7 @@ impl Bundle {
                     seed_fingerprint: *z.seed_fingerprint(),
                     derivation_path: z.derivation_path().iter().map(|i| i.index()).collect(),
                 }),
+                user_address: output.user_address().clone(),
                 proprietary: output.proprietary().clone(),
             })
             .collect();

--- a/pczt/src/transparent.rs
+++ b/pczt/src/transparent.rs
@@ -158,6 +158,14 @@ pub struct Output {
     #[serde_as(as = "BTreeMap<[_; 33], _>")]
     pub(crate) bip32_derivation: BTreeMap<[u8; 33], Zip32Derivation>,
 
+    /// The user-facing address to which this output is being sent, if any.
+    ///
+    /// - This is set by an Updater.
+    /// - Signers must parse this address (if present) and confirm that it contains
+    ///   `recipient` (either directly, or e.g. as a receiver within a Unified Address).
+    #[getset(get = "pub")]
+    pub(crate) user_address: Option<String>,
+
     /// Proprietary fields related to the note being spent.
     #[getset(get = "pub")]
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
@@ -267,6 +275,7 @@ impl Bundle {
                 script_pubkey,
                 redeem_script,
                 bip32_derivation,
+                user_address,
                 proprietary,
             } = rhs;
 
@@ -276,6 +285,7 @@ impl Bundle {
 
             if !(merge_optional(&mut lhs.redeem_script, redeem_script)
                 && merge_map(&mut lhs.bip32_derivation, bip32_derivation)
+                && merge_optional(&mut lhs.user_address, user_address)
                 && merge_map(&mut lhs.proprietary, proprietary))
             {
                 return None;
@@ -346,6 +356,7 @@ impl Bundle {
                             .map(|v| (k, v))
                         })
                         .collect::<Result<_, _>>()?,
+                    output.user_address,
                     output.proprietary,
                 )
             })
@@ -430,6 +441,7 @@ impl Bundle {
                         )
                     })
                     .collect(),
+                user_address: output.user_address().clone(),
                 proprietary: output.proprietary().clone(),
             })
             .collect();

--- a/zcash_primitives/src/transaction/components/transparent/builder.rs
+++ b/zcash_primitives/src/transaction/components/transparent/builder.rs
@@ -275,6 +275,7 @@ impl TransparentBuilder {
                     // script.
                     redeem_script: None,
                     bip32_derivation: BTreeMap::new(),
+                    user_address: None,
                     proprietary: BTreeMap::new(),
                 })
                 .collect();

--- a/zcash_primitives/src/transaction/components/transparent/pczt.rs
+++ b/zcash_primitives/src/transaction/components/transparent/pczt.rs
@@ -210,6 +210,13 @@ pub struct Output {
     ///   In particular, it is not possible to include entries for non-BIP-32 pubkeys.
     pub(crate) bip32_derivation: BTreeMap<[u8; 33], Bip32Derivation>,
 
+    /// The user-facing address to which this output is being sent, if any.
+    ///
+    /// - This is set by an Updater.
+    /// - Signers must parse this address (if present) and confirm that it contains
+    ///   `recipient` (either directly, or e.g. as a receiver within a Unified Address).
+    pub(crate) user_address: Option<String>,
+
     /// Proprietary fields related to the transparent coin being created.
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
 }

--- a/zcash_primitives/src/transaction/components/transparent/pczt/parse.rs
+++ b/zcash_primitives/src/transaction/components/transparent/pczt/parse.rs
@@ -94,6 +94,7 @@ impl Output {
         script_pubkey: Vec<u8>,
         redeem_script: Option<Vec<u8>>,
         bip32_derivation: BTreeMap<[u8; 33], Bip32Derivation>,
+        user_address: Option<String>,
         proprietary: BTreeMap<String, Vec<u8>>,
     ) -> Result<Self, ParseError> {
         let value = Zatoshis::from_u64(value).map_err(|_| ParseError::InvalidValue)?;
@@ -109,6 +110,7 @@ impl Output {
             script_pubkey,
             redeem_script,
             bip32_derivation,
+            user_address,
             proprietary,
         })
     }

--- a/zcash_primitives/src/transaction/components/transparent/pczt/updater.rs
+++ b/zcash_primitives/src/transaction/components/transparent/pczt/updater.rs
@@ -135,6 +135,11 @@ impl<'a> OutputUpdater<'a> {
         self.0.bip32_derivation.insert(pubkey, derivation);
     }
 
+    /// Sets the user-facing address that the new note is being sent to.
+    pub fn set_user_address(&mut self, user_address: String) {
+        self.0.user_address = Some(user_address);
+    }
+
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);


### PR DESCRIPTION
This is necessary in order for Signers to display the address encoding that a user is expecting to confirm.