### PR TITLE
zcash_transparent: Fix its dependencies to work with no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6451,7 +6451,6 @@ dependencies = [
  "bip32",
  "blake2b_simd",
  "bs58",
- "byteorder",
  "core2",
  "document-features",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["cryptography::cryptocurrencies"]
 [workspace.dependencies]
 # Intra-workspace dependencies
 equihash = { version = "0.2", path = "components/equihash" }
-zcash_address = { version = "0.6", path = "components/zcash_address" }
+zcash_address = { version = "0.6", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.15", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.2.1", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.5", path = "zcash_keys" }
@@ -71,8 +71,8 @@ pasta_curves = "0.5"
 
 # - Transparent
 bip32 = { version = "0.5", default-features = false }
-ripemd = "0.1"
-secp256k1 = "0.27"
+ripemd = { version = "0.1", default-features = false }
+secp256k1 = { version = "0.27", default-features = false, features = ["alloc"] }
 transparent = { package = "zcash_transparent", version = "0.0", path = "zcash_transparent", default-features = false }
 
 # Boilerplate
@@ -86,8 +86,8 @@ rand_core = "0.6"
 rust_decimal = { version = "1.35", default-features = false, features = ["serde"] }
 
 # Digests
-blake2b_simd = "1"
-sha2 = "0.10"
+blake2b_simd = { version = "1", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 
 # Documentation
 document-features = "0.2"
@@ -97,7 +97,7 @@ base64 = "0.22"
 bech32 = { version = "0.11", default-features = false, features = ["alloc"] }
 bs58 = { version = "0.5", default-features = false, features = ["alloc", "check"] }
 byteorder = "1"
-hex = "0.4"
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
 percent-encoding = "2.1.0"
 postcard = { version = "1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
@@ -129,7 +129,7 @@ tonic-build = { version = "0.12", default-features = false }
 
 # Secret management
 secrecy = "0.8"
-subtle = "2.2.3"
+subtle = { version = "2.2.3", default-features = false }
 
 # SQLite databases
 # - Warning: One of the downstream consumers requires that SQLite be available through
@@ -167,7 +167,7 @@ trait-variant = "0.1"
 # ZIP 32
 aes = "0.8"
 fpe = "0.6"
-zip32 = "0.1.1"
+zip32 = { version = "0.1.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -42,7 +42,8 @@ proptest.workspace = true
 
 [features]
 default = ["std"]
-std = ["document-features", "dep:memuse"]
+std = ["dep:document-features", "dep:memuse"]
+
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
 test-dependencies = [
     "dep:incrementalmerkletree",

--- a/components/zip321/Cargo.toml
+++ b/components/zip321/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 
 [dependencies]
 zcash_address.workspace = true
-zcash_protocol.workspace = true
+zcash_protocol = { workspace = true, features = ["std"] }
 
 # - Parsing and Encoding
 nom = "7"
@@ -27,7 +27,7 @@ proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 zcash_address = { workspace = true, features = ["test-dependencies"] }
-zcash_protocol = { workspace = true, features = ["test-dependencies"] }
+zcash_protocol = { workspace = true, features = ["std", "test-dependencies"] }
 proptest.workspace = true
 
 [features]

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 equihash.workspace = true
 zcash_address.workspace = true
-zcash_encoding.workspace = true
+zcash_encoding = { workspace = true, features = ["std"] }
 zcash_protocol.workspace = true
 zip32.workspace = true
 

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+The entries below are relative to the `zcash_primitives` crate as of the tag
+`zcash_primitives-0.20.0`.
+
+### Added
+- `zcash_transparent::keys::AccountPubKey::derive_pubkey_at_bip32_path`

--- a/zcash_transparent/Cargo.toml
+++ b/zcash_transparent/Cargo.toml
@@ -18,13 +18,15 @@ zcash_address.workspace = true
 zcash_encoding.workspace = true
 zcash_protocol.workspace = true
 zip32.workspace = true
-core2.workspace = true
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)
 # - Digests (output types exposed)
 blake2b_simd.workspace = true
 sha2.workspace = true
+
+# - Encodings
+core2.workspace = true
 
 # - Secret management
 subtle.workspace = true
@@ -47,17 +49,21 @@ secp256k1 = { workspace = true, optional = true }
 getset.workspace = true
 
 # - Documentation
-document-features.workspace = true
+document-features = { workspace = true, optional = true }
 
 # - Encodings
 bs58.workspace = true
-byteorder.workspace = true
 hex.workspace = true
 
 # - Transparent protocol
 ripemd.workspace = true
 
 [features]
+default = ["std"]
+std = [
+    "dep:document-features",
+]
+
 ## Enables spending transparent notes with the transaction builder.
 transparent-inputs = ["bip32/secp256k1-ffi", "dep:secp256k1"]
 

--- a/zcash_transparent/src/lib.rs
+++ b/zcash_transparent/src/lib.rs
@@ -1,4 +1,8 @@
 //! # Zcash transparent protocol
+//!
+#![cfg_attr(feature = "std", doc = "## Feature flags")]
+#![cfg_attr(feature = "std", doc = document_features::document_features!())]
+//!
 
 #![no_std]
 


### PR DESCRIPTION
Also adds a new method that the Keystone firmware requires.