### PR TITLE
zcash_keys: Enable `no_std` usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,9 +2609,8 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+version = "0.10.0"
+source = "git+https://github.com/nuttycom/nonempty.git?rev=38d37189faecb2a0e3d6adc05aa24e1b93c2483b#38d37189faecb2a0e3d6adc05aa24e1b93c2483b"
 
 [[package]]
 name = "notify"
@@ -2789,8 +2788,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f7152474406422f572de163e0bc63b2126cdbfe17bc849efbbde36fcfe647e"
+source = "git+https://github.com/zcash/orchard.git?rev=e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629#e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,8 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
-source = "git+https://github.com/nuttycom/nonempty.git?rev=38d37189faecb2a0e3d6adc05aa24e1b93c2483b#38d37189faecb2a0e3d6adc05aa24e1b93c2483b"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "notify"
@@ -2788,7 +2789,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.10.1"
-source = "git+https://github.com/zcash/orchard.git?rev=e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629#e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629"
+source = "git+https://github.com/zcash/orchard.git?rev=cd3e0901ccac2c630dd7fd03eb496d5030c1bbfe#cd3e0901ccac2c630dd7fd03eb496d5030c1bbfe"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ transparent = { package = "zcash_transparent", version = "0.1", path = "zcash_tr
 
 # Boilerplate & missing stdlib
 getset = "0.1"
-nonempty = { version = "0.10", default-features = false }
+nonempty = { version = "0.11", default-features = false }
 
 # CSPRNG
 rand = { version = "0.8", default-features = false }
@@ -195,5 +195,4 @@ debug = true
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture"))'] }
 
 [patch.crates-io]
-nonempty = { git = "https://github.com/nuttycom/nonempty.git", rev = "38d37189faecb2a0e3d6adc05aa24e1b93c2483b" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "cd3e0901ccac2c630dd7fd03eb496d5030c1bbfe" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ redjubjub = "0.7"
 sapling = { package = "sapling-crypto", version = "0.4", default-features = false }
 
 # - Orchard
-nonempty = "0.7"
 orchard = { version = "0.10.1", default-features = false }
 pasta_curves = "0.5"
 
@@ -77,6 +76,7 @@ transparent = { package = "zcash_transparent", version = "0.1", path = "zcash_tr
 
 # Boilerplate & missing stdlib
 getset = "0.1"
+nonempty = { version = "0.10", default-features = false }
 
 # CSPRNG
 rand = { version = "0.8", default-features = false }
@@ -193,3 +193,7 @@ debug = true
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture"))'] }
+
+[patch.crates-io]
+nonempty = { git = "https://github.com/nuttycom/nonempty.git", rev = "38d37189faecb2a0e3d6adc05aa24e1b93c2483b" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629" }

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.2.2] - 2024-12-13
 ### Added
 - `no-std` support, via a default-enabled `std` feature flag.

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -7,5 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.1.0] - 2024-12-16
 Initial release supporting the PCZT v1 format.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -254,6 +254,26 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "2.11.2 -> 2.12.0"
 
+[[audits.nonempty]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+version = "0.11.0"
+notes = """
+Additional use of `unsafe` to wrap `NonZeroUsize::new_unchecked`; in both cases
+the argument to this method is `<Vec length or capacity> + 1`; in general this
+is safe with the exception that if an existing `Vec` has length or capacity
+`usize::MAX` this could wrap into zero; it would be better to use the safe
+operation and then `expect` to generate a panic, rather than risk undefined
+behavior.
+
+Additions are:
+- no_std support
+- sorting
+- `nonzero` module (just wrappers
+- `serde` support
+- `nonempty macro` (trivial, verified safe)
+"""
+
 [[audits.num-bigint]]
 who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -765,10 +765,6 @@ criteria = "safe-to-deploy"
 version = "0.8.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.nonempty]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.notify]]
 version = "6.1.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -77,13 +77,6 @@ user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
 
-[[publisher.orchard]]
-version = "0.10.1"
-when = "2024-12-17"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.pczt]]
 version = "0.1.0"
 when = "2024-12-17"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.16.0] - 2024-12-16
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.14.0] - 2024-12-16
 
 ### Added

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -10,6 +10,9 @@ and this library adheres to Rust's notion of
 - `no-std` compatibility (`alloc` is required). A default-enabled `std` feature
   flag has been added gating the `std::error::Error` usage.
 
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.6.0] - 2024-12-16
 
 ### Changed

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `no-std` compatibility (`alloc` is required). A default-enabled `std` feature
+  flag has been added gating the `std::error::Error` usage.
+
 ## [0.6.0] - 2024-12-16
 
 ### Changed

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -59,7 +59,7 @@ proptest = { workspace = true, optional = true }
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 # - Documentation
-document-features.workspace = true
+document-features = { workspace = true, optional = true }
 
 # - Encodings
 byteorder = { workspace = true, optional = true }
@@ -76,6 +76,9 @@ orchard = { workspace = true, features = ["circuit"] }
 zcash_address = { workspace = true, features = ["test-dependencies"] }
 
 [features]
+default = ["std"]
+std = ["dep:document-features"]
+
 ## Enables use of transparent key parts and addresses
 transparent-inputs = [
   "dep:bip32", 

--- a/zcash_keys/src/encoding.rs
+++ b/zcash_keys/src/encoding.rs
@@ -76,7 +76,7 @@ impl fmt::Display for Bech32DecodeError {
     }
 }
 
-#[cfg(feature = "sapling")]
+#[cfg(all(feature = "sapling", feature = "std"))]
 impl std::error::Error for Bech32DecodeError {}
 
 #[cfg(feature = "sapling")]
@@ -135,6 +135,7 @@ impl fmt::Display for TransparentCodecError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for TransparentCodecError {}
 
 impl<P: consensus::Parameters> AddressCodec<P> for TransparentAddress {

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -113,6 +113,7 @@ impl Display for DerivationError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DerivationError {}
 
 /// A version identifier for the encoding of unified spending keys.
@@ -180,6 +181,7 @@ impl core::fmt::Display for DecodingError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DecodingError {}
 
 #[cfg(feature = "unstable")]
@@ -547,6 +549,7 @@ impl fmt::Display for AddressGenerationError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for AddressGenerationError {}
 
 /// Specification for how a unified address should be generated from a unified viewing key.
@@ -1308,7 +1311,6 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-
     use proptest::prelude::proptest;
 
     use zcash_protocol::consensus::MAIN_NETWORK;

--- a/zcash_keys/src/lib.rs
+++ b/zcash_keys/src/lib.rs
@@ -4,7 +4,8 @@
 //! and viewing keys and addresses.
 //!
 //! ## Feature flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "std", doc = "## Feature flags")]
+#![cfg_attr(feature = "std", doc = document_features::document_features!())]
 //!
 
 #![no_std]
@@ -18,6 +19,7 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "std")]
 extern crate std;
 
 pub mod address;

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `nonempty 0.11`
+
 ## [0.21.0] - 2024-12-16
 
 ### Added


### PR DESCRIPTION
This cannot be merged until we have `nonempty` and `orchard` releases that support `no_std`