### PR TITLE
Deprecate reexports of types that have been moved to other crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "zcash_proofs",
  "zcash_protocol",
  "zcash_transparent",
+ "zip32",
 ]
 
 [[package]]
@@ -6248,6 +6249,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zcash_transparent",
  "zip32",
  "zip321",
 ]
@@ -6297,6 +6299,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zcash_transparent",
  "zip32",
  "zip321",
 ]

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Deprecated
+- `zcash_address::Network` (use `zcash_protocol::consensus::NetworkType` instead).
+
 ## [0.6.2] - 2024-12-13
 ### Fixed
 - Migrated to `f4jumble 0.1.1` to fix `no-std` support.

--- a/components/zcash_address/src/encoding.rs
+++ b/components/zcash_address/src/encoding.rs
@@ -186,7 +186,8 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::*;
-    use crate::{kind::unified, Network};
+    use crate::kind::unified;
+    use zcash_protocol::consensus::NetworkType;
 
     fn encoding(encoded: &str, decoded: ZcashAddress) {
         assert_eq!(decoded.to_string(), encoded);
@@ -197,11 +198,11 @@ mod tests {
     fn sprout() {
         encoding(
             "zc8E5gYid86n4bo2Usdq1cpr7PpfoJGzttwBHEEgGhGkLUg7SPPVFNB2AkRFXZ7usfphup5426dt1buMmY3fkYeRrQGLa8y",
-            ZcashAddress { net: Network::Main, kind: AddressKind::Sprout([0; 64]) },
+            ZcashAddress { net: NetworkType::Main, kind: AddressKind::Sprout([0; 64]) },
         );
         encoding(
             "ztJ1EWLKcGwF2S4NA17pAJVdco8Sdkz4AQPxt1cLTEfNuyNswJJc2BbBqYrsRZsp31xbVZwhF7c7a2L9jsF3p3ZwRWpqqyS",
-            ZcashAddress { net: Network::Test, kind: AddressKind::Sprout([0; 64]) },
+            ZcashAddress { net: NetworkType::Test, kind: AddressKind::Sprout([0; 64]) },
         );
     }
 
@@ -210,21 +211,21 @@ mod tests {
         encoding(
             "zs1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpq6d8g",
             ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::Sapling([0; 43]),
             },
         );
         encoding(
             "ztestsapling1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqfhgwqu",
             ZcashAddress {
-                net: Network::Test,
+                net: NetworkType::Test,
                 kind: AddressKind::Sapling([0; 43]),
             },
         );
         encoding(
             "zregtestsapling1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqknpr3m",
             ZcashAddress {
-                net: Network::Regtest,
+                net: NetworkType::Regtest,
                 kind: AddressKind::Sapling([0; 43]),
             },
         );
@@ -235,21 +236,21 @@ mod tests {
         encoding(
             "u1qpatys4zruk99pg59gcscrt7y6akvl9vrhcfyhm9yxvxz7h87q6n8cgrzzpe9zru68uq39uhmlpp5uefxu0su5uqyqfe5zp3tycn0ecl",
             ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::Unified(unified::Address(vec![unified::address::Receiver::Sapling([0; 43])])),
             },
         );
         encoding(
             "utest10c5kutapazdnf8ztl3pu43nkfsjx89fy3uuff8tsmxm6s86j37pe7uz94z5jhkl49pqe8yz75rlsaygexk6jpaxwx0esjr8wm5ut7d5s",
             ZcashAddress {
-                net: Network::Test,
+                net: NetworkType::Test,
                 kind: AddressKind::Unified(unified::Address(vec![unified::address::Receiver::Sapling([0; 43])])),
             },
         );
         encoding(
             "uregtest15xk7vj4grjkay6mnfl93dhsflc2yeunhxwdh38rul0rq3dfhzzxgm5szjuvtqdha4t4p2q02ks0jgzrhjkrav70z9xlvq0plpcjkd5z3",
             ZcashAddress {
-                net: Network::Regtest,
+                net: NetworkType::Regtest,
                 kind: AddressKind::Unified(unified::Address(vec![unified::address::Receiver::Sapling([0; 43])])),
             },
         );
@@ -266,28 +267,28 @@ mod tests {
         encoding(
             "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs",
             ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::P2pkh([0; 20]),
             },
         );
         encoding(
             "tm9iMLAuYMzJ6jtFLcA7rzUmfreGuKvr7Ma",
             ZcashAddress {
-                net: Network::Test,
+                net: NetworkType::Test,
                 kind: AddressKind::P2pkh([0; 20]),
             },
         );
         encoding(
             "t3JZcvsuaXE6ygokL4XUiZSTrQBUoPYFnXJ",
             ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::P2sh([0; 20]),
             },
         );
         encoding(
             "t26YoyZ1iPgiMEWL4zGUm74eVWfhyDMXzY2",
             ZcashAddress {
-                net: Network::Test,
+                net: NetworkType::Test,
                 kind: AddressKind::P2sh([0; 20]),
             },
         );
@@ -300,7 +301,7 @@ mod tests {
 
         // Transcode P2PKH to TEX
         let p2pkh_zaddr: ZcashAddress = p2pkh_str.parse().unwrap();
-        assert_matches!(p2pkh_zaddr.net, Network::Main);
+        assert_matches!(p2pkh_zaddr.net, NetworkType::Main);
         if let AddressKind::P2pkh(zaddr_data) = p2pkh_zaddr.kind {
             let tex_zaddr = ZcashAddress {
                 net: p2pkh_zaddr.net,
@@ -314,7 +315,7 @@ mod tests {
 
         // Transcode TEX to P2PKH
         let tex_zaddr: ZcashAddress = tex_str.parse().unwrap();
-        assert_matches!(tex_zaddr.net, Network::Main);
+        assert_matches!(tex_zaddr.net, NetworkType::Main);
         if let AddressKind::Tex(zaddr_data) = tex_zaddr.kind {
             let p2pkh_zaddr = ZcashAddress {
                 net: tex_zaddr.net,
@@ -334,7 +335,7 @@ mod tests {
 
         // Transcode P2PKH to TEX
         let p2pkh_zaddr: ZcashAddress = p2pkh_str.parse().unwrap();
-        assert_matches!(p2pkh_zaddr.net, Network::Test);
+        assert_matches!(p2pkh_zaddr.net, NetworkType::Test);
         if let AddressKind::P2pkh(zaddr_data) = p2pkh_zaddr.kind {
             let tex_zaddr = ZcashAddress {
                 net: p2pkh_zaddr.net,
@@ -348,7 +349,7 @@ mod tests {
 
         // Transcode TEX to P2PKH
         let tex_zaddr: ZcashAddress = tex_str.parse().unwrap();
-        assert_matches!(tex_zaddr.net, Network::Test);
+        assert_matches!(tex_zaddr.net, NetworkType::Test);
         if let AddressKind::Tex(zaddr_data) = tex_zaddr.kind {
             let p2pkh_zaddr = ZcashAddress {
                 net: tex_zaddr.net,
@@ -366,14 +367,14 @@ mod tests {
         assert_eq!(
             " t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs".parse(),
             Ok(ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::P2pkh([0; 20])
             }),
         );
         assert_eq!(
             "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs ".parse(),
             Ok(ZcashAddress {
-                net: Network::Main,
+                net: NetworkType::Main,
                 kind: AddressKind::P2pkh([0; 20])
             }),
         );

--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -254,11 +254,11 @@ mod tests {
     use alloc::borrow::ToOwned;
 
     use assert_matches::assert_matches;
+    use zcash_protocol::consensus::NetworkType;
 
     use crate::{
         kind::unified::{private::SealedContainer, Container, Encoding},
         unified::address::testing::arb_unified_address,
-        Network,
     };
 
     use proptest::{prelude::*, sample::select};
@@ -268,7 +268,7 @@ mod tests {
     proptest! {
         #[test]
         fn ua_roundtrip(
-            network in select(vec![Network::Main, Network::Test, Network::Regtest]),
+            network in select(vec![NetworkType::Main, NetworkType::Test, NetworkType::Regtest]),
             ua in arb_unified_address(),
         ) {
             let encoded = ua.encode(&network);

--- a/components/zcash_address/src/kind/unified/fvk.rs
+++ b/components/zcash_address/src/kind/unified/fvk.rs
@@ -155,13 +155,11 @@ mod tests {
     use proptest::{array::uniform1, array::uniform32, prelude::*, sample::select};
 
     use super::{Fvk, ParseError, Typecode, Ufvk};
-    use crate::{
-        kind::unified::{
-            private::{SealedContainer, SealedItem},
-            Container, Encoding,
-        },
-        Network,
+    use crate::kind::unified::{
+        private::{SealedContainer, SealedItem},
+        Container, Encoding,
     };
+    use zcash_protocol::consensus::NetworkType;
 
     prop_compose! {
         fn uniform128()(a in uniform96(), b in uniform32(0u8..)) -> [u8; 128] {
@@ -226,7 +224,7 @@ mod tests {
     proptest! {
         #[test]
         fn ufvk_roundtrip(
-            network in select(vec![Network::Main, Network::Test, Network::Regtest]),
+            network in select(vec![NetworkType::Main, NetworkType::Test, NetworkType::Regtest]),
             ufvk in arb_unified_fvk(),
         ) {
             let encoded = ufvk.encode(&network);

--- a/components/zcash_address/src/kind/unified/ivk.rs
+++ b/components/zcash_address/src/kind/unified/ivk.rs
@@ -164,13 +164,11 @@ mod tests {
     };
 
     use super::{Ivk, ParseError, Typecode, Uivk};
-    use crate::{
-        kind::unified::{
-            private::{SealedContainer, SealedItem},
-            Container, Encoding,
-        },
-        Network,
+    use crate::kind::unified::{
+        private::{SealedContainer, SealedItem},
+        Container, Encoding,
     };
+    use zcash_protocol::consensus::NetworkType;
 
     prop_compose! {
         fn uniform64()(a in uniform32(0u8..), b in uniform32(0u8..)) -> [u8; 64] {
@@ -219,7 +217,7 @@ mod tests {
     proptest! {
         #[test]
         fn uivk_roundtrip(
-            network in select(vec![Network::Main, Network::Test, Network::Regtest]),
+            network in select(vec![NetworkType::Main, NetworkType::Test, NetworkType::Regtest]),
             uivk in arb_unified_ivk(),
         ) {
             let encoded = uivk.encode(&network);
@@ -308,7 +306,7 @@ mod tests {
     fn duplicate_typecode() {
         // Construct and serialize an invalid UIVK.
         let uivk = Uivk(vec![Ivk::Sapling([1; 64]), Ivk::Sapling([2; 64])]);
-        let encoded = uivk.encode(&Network::Main);
+        let encoded = uivk.encode(&NetworkType::Main);
         assert_eq!(
             Uivk::decode(&encoded),
             Err(ParseError::DuplicateTypecode(Typecode::Sapling))

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -63,7 +63,8 @@
 //! use std::ffi::{CStr, c_char, c_void};
 //! use std::ptr;
 //!
-//! use zcash_address::{ConversionError, Network, TryFromRawAddress, ZcashAddress};
+//! use zcash_address::{ConversionError, TryFromRawAddress, ZcashAddress};
+//! use zcash_protocol::consensus::NetworkType;
 //!
 //! // Functions that return a pointer to a heap-allocated address of the given kind in
 //! // the target language. These should be augmented to return any relevant errors.
@@ -112,7 +113,7 @@
 //!         }
 //!     };
 //!
-//!     match addr.convert_if_network::<ParsedAddress>(Network::Main) {
+//!     match addr.convert_if_network::<ParsedAddress>(NetworkType::Main) {
 //!         Ok(parsed) => parsed.0,
 //!         Err(e) => {
 //!             // We didn't implement all of the methods of `TryFromRawAddress`, so if an
@@ -151,13 +152,13 @@ pub use convert::{
 pub use encoding::ParseError;
 pub use kind::unified;
 use kind::unified::Receiver;
-pub use zcash_protocol::consensus::NetworkType as Network;
-use zcash_protocol::PoolType;
+//pub use zcash_protocol::consensus::NetworkType as Network;
+use zcash_protocol::{consensus::NetworkType, PoolType};
 
 /// A Zcash address.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ZcashAddress {
-    net: Network,
+    net: NetworkType,
     kind: AddressKind,
 }
 
@@ -254,13 +255,13 @@ impl ZcashAddress {
     /// [`address.to_string()`]: std::string::ToString
     pub fn convert_if_network<T: TryFromRawAddress>(
         self,
-        net: Network,
+        net: NetworkType,
     ) -> Result<T, ConversionError<T::Error>> {
         let network_matches = self.net == net;
         // The Sprout and transparent address encodings use the same prefix for testnet
         // and regtest, so we need to allow parsing testnet addresses as regtest.
         let regtest_exception =
-            network_matches || (self.net == Network::Test && net == Network::Regtest);
+            network_matches || (self.net == NetworkType::Test && net == NetworkType::Regtest);
 
         match self.kind {
             AddressKind::Sprout(data) if regtest_exception => T::try_from_raw_sprout(data),

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -152,7 +152,10 @@ pub use convert::{
 pub use encoding::ParseError;
 pub use kind::unified;
 use kind::unified::Receiver;
-//pub use zcash_protocol::consensus::NetworkType as Network;
+
+#[deprecated(note = "use ::zcash_protocol::consensus::NetworkType instead")]
+pub type Network = zcash_protocol::consensus::NetworkType;
+
 use zcash_protocol::{consensus::NetworkType, PoolType};
 
 /// A Zcash address.

--- a/components/zcash_address/src/test_vectors.rs
+++ b/components/zcash_address/src/test_vectors.rs
@@ -9,10 +9,11 @@ use {
             self,
             address::{test_vectors::TEST_VECTORS, Receiver},
         },
-        Network, ToAddress, ZcashAddress,
+        ToAddress, ZcashAddress,
     },
     alloc::string::ToString,
     core::iter,
+    zcash_protocol::consensus::NetworkType,
 };
 
 #[test]
@@ -39,7 +40,8 @@ fn unified() {
             }))
             .collect();
 
-        let expected_addr = ZcashAddress::from_unified(Network::Main, unified::Address(receivers));
+        let expected_addr =
+            ZcashAddress::from_unified(NetworkType::Main, unified::Address(receivers));
 
         // Test parsing
         let addr: ZcashAddress = tv.unified_addr.parse().unwrap();

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -24,6 +24,7 @@ zcash_note_encryption.workspace = true
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
 zcash_proofs = { workspace = true, features = ["directories"] }
 zcash_protocol = {workspace = true, features = ["local-consensus"] }
+zip32.workspace = true
 
 # Transparent
 secp256k1.workspace = true

--- a/devtools/src/bin/inspect/address.rs
+++ b/devtools/src/bin/inspect/address.rs
@@ -1,7 +1,8 @@
 use zcash_address::{
     unified::{self, Container, Encoding},
-    ConversionError, Network, ToAddress, ZcashAddress,
+    ConversionError, ToAddress, ZcashAddress,
 };
+use zcash_protocol::consensus::NetworkType;
 
 #[allow(dead_code)]
 enum AddressKind {
@@ -14,14 +15,17 @@ enum AddressKind {
 }
 
 struct Address {
-    net: Network,
+    net: NetworkType,
     kind: AddressKind,
 }
 
 impl zcash_address::TryFromAddress for Address {
     type Error = ();
 
-    fn try_from_sprout(net: Network, data: [u8; 64]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_sprout(
+        net: NetworkType,
+        data: [u8; 64],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
             net,
             kind: AddressKind::Sprout(data),
@@ -29,7 +33,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_sapling(
-        net: Network,
+        net: NetworkType,
         data: [u8; 43],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -39,7 +43,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_unified(
-        net: Network,
+        net: NetworkType,
         data: unified::Address,
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -49,7 +53,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_transparent_p2pkh(
-        net: Network,
+        net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -59,7 +63,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_transparent_p2sh(
-        net: Network,
+        net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -68,7 +72,10 @@ impl zcash_address::TryFromAddress for Address {
         })
     }
 
-    fn try_from_tex(net: Network, data: [u8; 20]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_tex(
+        net: NetworkType,
+        data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
             net,
             kind: AddressKind::Tex(data),
@@ -87,9 +94,9 @@ pub(crate) fn inspect(addr: ZcashAddress) {
             eprintln!(
                 " - Network: {}",
                 match addr.net {
-                    Network::Main => "main",
-                    Network::Test => "testnet",
-                    Network::Regtest => "regtest",
+                    NetworkType::Main => "main",
+                    NetworkType::Test => "testnet",
+                    NetworkType::Regtest => "regtest",
                 }
             );
             eprintln!(

--- a/devtools/src/bin/inspect/block.rs
+++ b/devtools/src/bin/inspect/block.rs
@@ -7,12 +7,10 @@ use std::convert::{TryFrom, TryInto};
 use std::io::{self, Read};
 
 use sha2::{Digest, Sha256};
+
 use zcash_encoding::Vector;
-use zcash_primitives::{
-    block::BlockHeader,
-    consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters},
-    transaction::Transaction,
-};
+use zcash_primitives::{block::BlockHeader, transaction::Transaction};
+use zcash_protocol::consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters};
 
 use crate::{
     transaction::{extract_height_from_coinbase, is_coinbase},

--- a/devtools/src/bin/inspect/keys.rs
+++ b/devtools/src/bin/inspect/keys.rs
@@ -3,18 +3,16 @@ use std::iter;
 
 use bech32::{Bech32, Hrp};
 use secrecy::Zeroize;
+
+use ::transparent::{
+    address::TransparentAddress,
+    keys::{AccountPrivKey, IncomingViewingKey},
+};
 use zcash_address::{
     unified::{self, Encoding},
     ToAddress, ZcashAddress,
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::{
-    legacy::{
-        keys::{AccountPrivKey, IncomingViewingKey},
-        TransparentAddress,
-    },
-    zip32,
-};
 use zcash_protocol::{
     consensus::{Network, NetworkConstants, NetworkType},
     local_consensus::LocalNetwork,

--- a/devtools/src/bin/inspect/main.rs
+++ b/devtools/src/bin/inspect/main.rs
@@ -9,17 +9,20 @@ use gumdrop::{Options, ParsingStyle};
 use lazy_static::lazy_static;
 use secrecy::Zeroize;
 use tokio::runtime::Runtime;
+
 use zcash_address::{
     unified::{self, Encoding},
     ZcashAddress,
 };
-use zcash_primitives::{block::BlockHeader, consensus::BranchId, transaction::Transaction};
+use zcash_primitives::{block::BlockHeader, transaction::Transaction};
 use zcash_proofs::{default_params_folder, load_parameters, ZcashParameters};
-use zcash_protocol::consensus::NetworkType;
+use zcash_protocol::{
+    consensus::{BranchId, NetworkType},
+    constants,
+};
 
 mod context;
 use context::{Context, ZUint256};
-use zcash_protocol::constants;
 
 mod address;
 mod block;

--- a/devtools/src/bin/inspect/transaction.rs
+++ b/devtools/src/bin/inspect/transaction.rs
@@ -3,28 +3,34 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-use ::transparent::sighash::SighashType;
 use bellman::groth16;
 use group::GroupEncoding;
 use orchard::note_encryption::OrchardDomain;
 use sapling::{note_encryption::SaplingDomain, SaplingVerificationContext};
 use secp256k1::{Secp256k1, VerifyOnly};
+
+#[allow(deprecated)]
+use ::transparent::{
+    address::{Script, TransparentAddress},
+    bundle as transparent,
+    keys::pubkey_to_address,
+    sighash::{SighashType, TransparentAuthorizingContext},
+};
 use zcash_address::{
     unified::{self, Encoding},
     ToAddress, ZcashAddress,
 };
 use zcash_note_encryption::try_output_recovery_with_ovk;
-#[allow(deprecated)]
-use zcash_primitives::{
+use zcash_primitives::transaction::{
+    components::sapling as sapling_serialization,
+    sighash::{signature_hash, SignableInput},
+    txid::TxIdDigester,
+    Authorization, Transaction, TransactionData, TxId, TxVersion,
+};
+use zcash_protocol::{
     consensus::BlockHeight,
-    legacy::{keys::pubkey_to_address, Script, TransparentAddress},
     memo::{Memo, MemoBytes},
-    transaction::{
-        components::{amount::NonNegativeAmount, sapling as sapling_serialization, transparent},
-        sighash::{signature_hash, SignableInput, TransparentAuthorizingContext},
-        txid::TxIdDigester,
-        Authorization, Transaction, TransactionData, TxId, TxVersion,
-    },
+    value::Zatoshis,
 };
 
 use crate::{
@@ -109,7 +115,7 @@ impl transparent::Authorization for TransparentAuth {
 }
 
 impl TransparentAuthorizingContext for TransparentAuth {
-    fn input_amounts(&self) -> Vec<NonNegativeAmount> {
+    fn input_amounts(&self) -> Vec<Zatoshis> {
         self.all_prev_outputs
             .iter()
             .map(|prevout| prevout.value)

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -103,7 +103,7 @@ impl Creator {
     pub fn build_from_parts<P: zcash_protocol::consensus::Parameters>(
         parts: zcash_primitives::transaction::builder::PcztParts<P>,
     ) -> Option<Pczt> {
-        use zcash_primitives::transaction::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_SINGLE};
+        use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_SINGLE};
         use zcash_protocol::consensus::NetworkConstants;
 
         use crate::{common::FLAG_HAS_SIGHASH_SINGLE, SAPLING_TX_VERSION};

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -1,10 +1,10 @@
 use blake2b_simd::Hash as Blake2bHash;
 use rand_core::OsRng;
+
+use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE};
 use zcash_primitives::transaction::{
-    sighash::{SignableInput, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE},
-    sighash_v5::v5_signature_hash,
-    txid::TxIdDigester,
-    Authorization, TransactionData, TxDigests, TxVersion,
+    sighash::SignableInput, sighash_v5::v5_signature_hash, txid::TxIdDigester, Authorization,
+    TransactionData, TxDigests, TxVersion,
 };
 use zcash_protocol::consensus::BranchId;
 

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -1,14 +1,12 @@
 use core::marker::PhantomData;
-
 use rand_core::OsRng;
-use zcash_primitives::{
-    consensus::BranchId,
-    transaction::{
-        sighash::{signature_hash, SignableInput},
-        txid::TxIdDigester,
-        Authorization, Transaction, TransactionData, TxVersion,
-    },
+
+use zcash_primitives::transaction::{
+    sighash::{signature_hash, SignableInput},
+    txid::TxIdDigester,
+    Authorization, Transaction, TransactionData, TxVersion,
 };
+use zcash_protocol::consensus::BranchId;
 
 use crate::{Pczt, V5_TX_VERSION, V5_VERSION_GROUP_ID};
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1,5 +1,10 @@
+use rand_core::OsRng;
 use std::sync::OnceLock;
 
+use ::transparent::{
+    bundle as transparent,
+    keys::{AccountPrivKey, IncomingViewingKey},
+};
 use orchard::tree::MerkleHashOrchard;
 use pczt::{
     roles::{
@@ -9,16 +14,11 @@ use pczt::{
     },
     Pczt,
 };
-use rand_core::OsRng;
 use shardtree::{store::memory::MemoryShardStore, ShardTree};
 use zcash_note_encryption::try_note_decryption;
-use zcash_primitives::{
-    legacy::keys::{AccountPrivKey, IncomingViewingKey},
-    transaction::{
-        builder::{BuildConfig, Builder, PcztResult},
-        components::transparent,
-        fees::zip317,
-    },
+use zcash_primitives::transaction::{
+    builder::{BuildConfig, Builder, PcztResult},
+    fees::zip317,
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{consensus::MainNetwork, memo::MemoBytes, value::Zatoshis};

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,14 @@ and this library adheres to Rust's notion of
 ### Changed
 - Migrated to `nonempty 0.11`
 
+### Deprecated
+- `zcash_client_backend::address` (use `zcash_keys::address` instead)
+- `zcash_client_backend::encoding` (use `zcash_keys::encoding` instead)
+- `zcash_client_backend::keys` (use `zcash_keys::keys` instead)
+- `zcash_client_backend::zip321` (use the `zip321` crate instead)
+- `zcash_client_backend::PoolType` (use `zcash_protocol::PoolType` instead)
+- `zcash_client_backend::ShieldedProtocol` (use `zcash_protocol::ShieldedProtocol` instead)
+
 ## [0.16.0] - 2024-12-16
 
 ### Added

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -33,6 +33,7 @@ zcash_primitives.workspace = true
 zcash_protocol.workspace = true
 zip32.workspace = true
 zip321.workspace = true
+transparent.workspace = true
 pczt = { workspace = true, optional = true }
 
 # Dependencies exposed in a public API:

--- a/zcash_client_backend/examples/diversify-address.rs
+++ b/zcash_client_backend/examples/diversify-address.rs
@@ -1,10 +1,8 @@
 use gumdrop::Options;
 use sapling::zip32::ExtendedFullViewingKey;
-use zcash_client_backend::encoding::{decode_extended_full_viewing_key, encode_payment_address};
-use zcash_primitives::{
-    constants::{mainnet, testnet},
-    zip32::DiversifierIndex,
-};
+use zcash_keys::encoding::{decode_extended_full_viewing_key, encode_payment_address};
+use zcash_protocol::constants::{mainnet, testnet};
+use zip32::DiversifierIndex;
 
 fn parse_viewing_key(s: &str) -> Result<(ExtendedFullViewingKey, bool), &'static str> {
     decode_extended_full_viewing_key(mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY, s)

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -55,6 +55,8 @@
 //! [`TransactionRequest`]: crate::zip321::TransactionRequest
 //! [`propose_shielding`]: crate::data_api::wallet::propose_shielding
 
+use nonempty::NonEmpty;
+use secrecy::SecretVec;
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -64,9 +66,25 @@ use std::{
 };
 
 use incrementalmerkletree::{frontier::Frontier, Retention};
-use nonempty::NonEmpty;
-use secrecy::SecretVec;
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
+
+use ::transparent::bundle::OutPoint;
+use zcash_keys::{
+    address::UnifiedAddress,
+    keys::{
+        UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey, UnifiedSpendingKey,
+    },
+};
+use zcash_primitives::{
+    block::BlockHash,
+    transaction::{Transaction, TxId},
+};
+use zcash_protocol::{
+    consensus::BlockHeight,
+    memo::{Memo, MemoBytes},
+    value::{BalanceError, Zatoshis},
+    ShieldedProtocol,
+};
 use zip32::fingerprint::SeedFingerprint;
 
 use self::{
@@ -74,39 +92,22 @@ use self::{
     scanning::ScanRange,
 };
 use crate::{
-    address::UnifiedAddress,
     decrypt::DecryptedOutput,
-    keys::{
-        UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey, UnifiedSpendingKey,
-    },
     proto::service::TreeState,
     wallet::{Note, NoteId, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
-    ShieldedProtocol,
-};
-use zcash_primitives::{
-    block::BlockHash,
-    consensus::BlockHeight,
-    memo::{Memo, MemoBytes},
-    transaction::{
-        components::{
-            amount::{BalanceError, NonNegativeAmount},
-            OutPoint,
-        },
-        Transaction, TxId,
-    },
 };
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    crate::wallet::TransparentAddressMetadata, std::ops::Range,
-    zcash_primitives::legacy::TransparentAddress,
+    crate::wallet::TransparentAddressMetadata, ::transparent::address::TransparentAddress,
+    std::ops::Range,
 };
 
 #[cfg(feature = "test-dependencies")]
 use ambassador::delegatable_trait;
 
 #[cfg(any(test, feature = "test-dependencies"))]
-use {zcash_keys::address::Address, zcash_primitives::consensus::NetworkUpgrade};
+use {zcash_keys::address::Address, zcash_protocol::consensus::NetworkUpgrade};
 
 pub mod chain;
 pub mod error;
@@ -143,23 +144,20 @@ pub enum NullifierQuery {
 /// Balance information for a value within a single pool in an account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Balance {
-    spendable_value: NonNegativeAmount,
-    change_pending_confirmation: NonNegativeAmount,
-    value_pending_spendability: NonNegativeAmount,
+    spendable_value: Zatoshis,
+    change_pending_confirmation: Zatoshis,
+    value_pending_spendability: Zatoshis,
 }
 
 impl Balance {
     /// The [`Balance`] value having zero values for all its fields.
     pub const ZERO: Self = Self {
-        spendable_value: NonNegativeAmount::ZERO,
-        change_pending_confirmation: NonNegativeAmount::ZERO,
-        value_pending_spendability: NonNegativeAmount::ZERO,
+        spendable_value: Zatoshis::ZERO,
+        change_pending_confirmation: Zatoshis::ZERO,
+        value_pending_spendability: Zatoshis::ZERO,
     };
 
-    fn check_total_adding(
-        &self,
-        value: NonNegativeAmount,
-    ) -> Result<NonNegativeAmount, BalanceError> {
+    fn check_total_adding(&self, value: Zatoshis) -> Result<Zatoshis, BalanceError> {
         (self.spendable_value
             + self.change_pending_confirmation
             + self.value_pending_spendability
@@ -170,12 +168,12 @@ impl Balance {
     /// Returns the value in the account that may currently be spent; it is possible to compute
     /// witnesses for all the notes that comprise this value, and all of this value is confirmed to
     /// the required confirmation depth.
-    pub fn spendable_value(&self) -> NonNegativeAmount {
+    pub fn spendable_value(&self) -> Zatoshis {
         self.spendable_value
     }
 
     /// Adds the specified value to the spendable total, checking for overflow.
-    pub fn add_spendable_value(&mut self, value: NonNegativeAmount) -> Result<(), BalanceError> {
+    pub fn add_spendable_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
         self.check_total_adding(value)?;
         self.spendable_value = (self.spendable_value + value).unwrap();
         Ok(())
@@ -183,15 +181,12 @@ impl Balance {
 
     /// Returns the value in the account of shielded change notes that do not yet have sufficient
     /// confirmations to be spendable.
-    pub fn change_pending_confirmation(&self) -> NonNegativeAmount {
+    pub fn change_pending_confirmation(&self) -> Zatoshis {
         self.change_pending_confirmation
     }
 
     /// Adds the specified value to the pending change total, checking for overflow.
-    pub fn add_pending_change_value(
-        &mut self,
-        value: NonNegativeAmount,
-    ) -> Result<(), BalanceError> {
+    pub fn add_pending_change_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
         self.check_total_adding(value)?;
         self.change_pending_confirmation = (self.change_pending_confirmation + value).unwrap();
         Ok(())
@@ -200,22 +195,19 @@ impl Balance {
     /// Returns the value in the account of all remaining received notes that either do not have
     /// sufficient confirmations to be spendable, or for which witnesses cannot yet be constructed
     /// without additional scanning.
-    pub fn value_pending_spendability(&self) -> NonNegativeAmount {
+    pub fn value_pending_spendability(&self) -> Zatoshis {
         self.value_pending_spendability
     }
 
     /// Adds the specified value to the pending spendable total, checking for overflow.
-    pub fn add_pending_spendable_value(
-        &mut self,
-        value: NonNegativeAmount,
-    ) -> Result<(), BalanceError> {
+    pub fn add_pending_spendable_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
         self.check_total_adding(value)?;
         self.value_pending_spendability = (self.value_pending_spendability + value).unwrap();
         Ok(())
     }
 
     /// Returns the total value of funds represented by this [`Balance`].
-    pub fn total(&self) -> NonNegativeAmount {
+    pub fn total(&self) -> Zatoshis {
         (self.spendable_value + self.change_pending_confirmation + self.value_pending_spendability)
             .expect("Balance cannot overflow MAX_MONEY")
     }
@@ -243,7 +235,7 @@ impl AccountBalance {
         unshielded_balance: Balance::ZERO,
     };
 
-    fn check_total(&self) -> Result<NonNegativeAmount, BalanceError> {
+    fn check_total(&self) -> Result<Zatoshis, BalanceError> {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
             + self.unshielded_balance.total())
@@ -288,7 +280,7 @@ impl AccountBalance {
     #[deprecated(
         note = "this function is deprecated. Please use [`AccountBalance::unshielded_balance`] instead."
     )]
-    pub fn unshielded(&self) -> NonNegativeAmount {
+    pub fn unshielded(&self) -> Zatoshis {
         self.unshielded_balance.total()
     }
 
@@ -310,7 +302,7 @@ impl AccountBalance {
     }
 
     /// Returns the total value of funds belonging to the account.
-    pub fn total(&self) -> NonNegativeAmount {
+    pub fn total(&self) -> Zatoshis {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
             + self.unshielded_balance.total())
@@ -319,14 +311,14 @@ impl AccountBalance {
 
     /// Returns the total value of shielded (Sapling and Orchard) funds that may immediately be
     /// spent.
-    pub fn spendable_value(&self) -> NonNegativeAmount {
+    pub fn spendable_value(&self) -> Zatoshis {
         (self.sapling_balance.spendable_value + self.orchard_balance.spendable_value)
             .expect("Account balance cannot overflow MAX_MONEY")
     }
 
     /// Returns the total value of change and/or shielding transaction outputs that are awaiting
     /// sufficient confirmations for spendability.
-    pub fn change_pending_confirmation(&self) -> NonNegativeAmount {
+    pub fn change_pending_confirmation(&self) -> Zatoshis {
         (self.sapling_balance.change_pending_confirmation
             + self.orchard_balance.change_pending_confirmation)
             .expect("Account balance cannot overflow MAX_MONEY")
@@ -334,7 +326,7 @@ impl AccountBalance {
 
     /// Returns the value of shielded funds that are not yet spendable because additional scanning
     /// is required before it will be possible to derive witnesses for the associated notes.
-    pub fn value_pending_spendability(&self) -> NonNegativeAmount {
+    pub fn value_pending_spendability(&self) -> Zatoshis {
         (self.sapling_balance.value_pending_spendability
             + self.orchard_balance.value_pending_spendability)
             .expect("Account balance cannot overflow MAX_MONEY")
@@ -821,26 +813,22 @@ impl<NoteRef> SpendableNotes<NoteRef> {
     }
 
     /// Computes the total value of Sapling notes.
-    pub fn sapling_value(&self) -> Result<NonNegativeAmount, BalanceError> {
-        self.sapling
-            .iter()
-            .try_fold(NonNegativeAmount::ZERO, |acc, n| {
-                (acc + n.note_value()?).ok_or(BalanceError::Overflow)
-            })
+    pub fn sapling_value(&self) -> Result<Zatoshis, BalanceError> {
+        self.sapling.iter().try_fold(Zatoshis::ZERO, |acc, n| {
+            (acc + n.note_value()?).ok_or(BalanceError::Overflow)
+        })
     }
 
     /// Computes the total value of Sapling notes.
     #[cfg(feature = "orchard")]
-    pub fn orchard_value(&self) -> Result<NonNegativeAmount, BalanceError> {
-        self.orchard
-            .iter()
-            .try_fold(NonNegativeAmount::ZERO, |acc, n| {
-                (acc + n.note_value()?).ok_or(BalanceError::Overflow)
-            })
+    pub fn orchard_value(&self) -> Result<Zatoshis, BalanceError> {
+        self.orchard.iter().try_fold(Zatoshis::ZERO, |acc, n| {
+            (acc + n.note_value()?).ok_or(BalanceError::Overflow)
+        })
     }
 
     /// Computes the total value of spendable inputs
-    pub fn total_value(&self) -> Result<NonNegativeAmount, BalanceError> {
+    pub fn total_value(&self) -> Result<Zatoshis, BalanceError> {
         #[cfg(not(feature = "orchard"))]
         return self.sapling_value();
 
@@ -878,12 +866,12 @@ impl<NoteRef> SpendableNotes<NoteRef> {
 #[derive(Debug, Clone)]
 pub struct PoolMeta {
     note_count: usize,
-    value: NonNegativeAmount,
+    value: Zatoshis,
 }
 
 impl PoolMeta {
     /// Constructs a new [`PoolMeta`] value from its constituent parts.
-    pub fn new(note_count: usize, value: NonNegativeAmount) -> Self {
+    pub fn new(note_count: usize, value: Zatoshis) -> Self {
         Self { note_count, value }
     }
 
@@ -895,7 +883,7 @@ impl PoolMeta {
 
     /// Returns the total value of unspent outputs in the account that are accounted for in
     /// [`Self::note_count`].
-    pub fn value(&self) -> NonNegativeAmount {
+    pub fn value(&self) -> Zatoshis {
         self.value
     }
 }
@@ -967,11 +955,11 @@ impl AccountMeta {
         s.zip(o).map(|(s, o)| s + o).or(s).or(o)
     }
 
-    fn sapling_value(&self) -> Option<NonNegativeAmount> {
+    fn sapling_value(&self) -> Option<Zatoshis> {
         self.sapling.as_ref().map(|m| m.value)
     }
 
-    fn orchard_value(&self) -> Option<NonNegativeAmount> {
+    fn orchard_value(&self) -> Option<Zatoshis> {
         self.orchard.as_ref().map(|m| m.value)
     }
 
@@ -980,7 +968,7 @@ impl AccountMeta {
     /// Returns [`None`] if no metadata is available or it was not possible to evaluate the query
     /// described by a [`NoteFilter`] given the available wallet data. If metadata is available
     /// only for a single pool, the metadata for that pool will be returned.
-    pub fn total_value(&self) -> Option<NonNegativeAmount> {
+    pub fn total_value(&self) -> Option<Zatoshis> {
         let s = self.sapling_value();
         let o = self.orchard_value();
         s.zip(o)
@@ -1041,7 +1029,7 @@ impl<const MAX: u8> From<BoundedU8<MAX>> for usize {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NoteFilter {
     /// Selects notes having value greater than or equal to the provided value.
-    ExceedsMinValue(NonNegativeAmount),
+    ExceedsMinValue(Zatoshis),
     /// Selects notes having value greater than or equal to approximately the n'th percentile of
     /// previously sent notes in the account, irrespective of pool. The wrapped value must be in
     /// the range `1..=99`. The value `n` is respected in a best-effort fashion; results are likely
@@ -1123,7 +1111,7 @@ pub trait InputSource {
     fn select_spendable_notes(
         &self,
         account: Self::AccountId,
-        target_value: NonNegativeAmount,
+        target_value: Zatoshis,
         sources: &[ShieldedProtocol],
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],
@@ -1398,7 +1386,7 @@ pub trait WalletRead {
         &self,
         _account: Self::AccountId,
         _max_height: BlockHeight,
-    ) -> Result<HashMap<TransparentAddress, NonNegativeAmount>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, Zatoshis>, Self::Error> {
         Ok(HashMap::new())
     }
 
@@ -1600,7 +1588,7 @@ pub trait WalletTest: InputSource + WalletRead {
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct OutputOfSentTx {
-    value: NonNegativeAmount,
+    value: Zatoshis,
     external_recipient: Option<Address>,
     ephemeral_address: Option<(Address, u32)>,
 }
@@ -1613,7 +1601,7 @@ impl OutputOfSentTx {
     /// address along with the `address_index` it was derived from under the BIP 32 path
     /// `m/44'/<coin_type>'/<account>'/2/<address_index>`.
     pub fn from_parts(
-        value: NonNegativeAmount,
+        value: Zatoshis,
         external_recipient: Option<Address>,
         ephemeral_address: Option<(Address, u32)>,
     ) -> Self {
@@ -1903,7 +1891,7 @@ pub struct SentTransaction<'a, AccountId> {
     target_height: BlockHeight,
     account: AccountId,
     outputs: &'a [SentTransactionOutput<AccountId>],
-    fee_amount: NonNegativeAmount,
+    fee_amount: Zatoshis,
     #[cfg(feature = "transparent-inputs")]
     utxos_spent: &'a [OutPoint],
 }
@@ -1926,7 +1914,7 @@ impl<'a, AccountId> SentTransaction<'a, AccountId> {
         target_height: BlockHeight,
         account: AccountId,
         outputs: &'a [SentTransactionOutput<AccountId>],
-        fee_amount: NonNegativeAmount,
+        fee_amount: Zatoshis,
         #[cfg(feature = "transparent-inputs")] utxos_spent: &'a [OutPoint],
     ) -> Self {
         Self {
@@ -1958,7 +1946,7 @@ impl<'a, AccountId> SentTransaction<'a, AccountId> {
         self.outputs
     }
     /// Returns the fee paid by the transaction.
-    pub fn fee_amount(&self) -> NonNegativeAmount {
+    pub fn fee_amount(&self) -> Zatoshis {
         self.fee_amount
     }
     /// Returns the list of UTXOs spent in the created transaction.
@@ -1979,7 +1967,7 @@ impl<'a, AccountId> SentTransaction<'a, AccountId> {
 pub struct SentTransactionOutput<AccountId> {
     output_index: usize,
     recipient: Recipient<AccountId, Note, OutPoint>,
-    value: NonNegativeAmount,
+    value: Zatoshis,
     memo: Option<MemoBytes>,
 }
 
@@ -1996,7 +1984,7 @@ impl<AccountId> SentTransactionOutput<AccountId> {
     pub fn from_parts(
         output_index: usize,
         recipient: Recipient<AccountId, Note, OutPoint>,
-        value: NonNegativeAmount,
+        value: Zatoshis,
         memo: Option<MemoBytes>,
     ) -> Self {
         Self {
@@ -2022,7 +2010,7 @@ impl<AccountId> SentTransactionOutput<AccountId> {
         &self.recipient
     }
     /// Returns the value of the newly created output.
-    pub fn value(&self) -> NonNegativeAmount {
+    pub fn value(&self) -> Zatoshis {
         self.value
     }
     /// Returns the memo that was attached to the output, if any. This will only be `None`
@@ -2136,7 +2124,7 @@ impl AccountBirthday {
     /// # Panics
     ///
     /// Panics if the activation height for the given network upgrade is not set.
-    pub fn from_activation<P: zcash_primitives::consensus::Parameters>(
+    pub fn from_activation<P: zcash_protocol::consensus::Parameters>(
         params: &P,
         network_upgrade: NetworkUpgrade,
         prior_block_hash: BlockHash,
@@ -2157,7 +2145,7 @@ impl AccountBirthday {
     /// # Panics
     ///
     /// Panics if the Sapling activation height is not set.
-    pub fn from_sapling_activation<P: zcash_primitives::consensus::Parameters>(
+    pub fn from_sapling_activation<P: zcash_protocol::consensus::Parameters>(
         params: &P,
         prior_block_hash: BlockHash,
     ) -> AccountBirthday {

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -155,10 +155,8 @@ use std::ops::Range;
 
 use incrementalmerkletree::frontier::Frontier;
 use subtle::ConditionallySelectable;
-use zcash_primitives::{
-    block::BlockHash,
-    consensus::{self, BlockHeight},
-};
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::consensus::{self, BlockHeight};
 
 use crate::{
     data_api::{NullifierQuery, WalletWrite},
@@ -701,7 +699,7 @@ where
 #[cfg(feature = "test-dependencies")]
 pub mod testing {
     use std::convert::Infallible;
-    use zcash_primitives::consensus::BlockHeight;
+    use zcash_protocol::consensus::BlockHeight;
 
     use crate::proto::compact_formats::CompactBlock;
 

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -5,22 +5,20 @@ use std::fmt::{self, Debug, Display};
 
 use shardtree::error::ShardTreeError;
 use zcash_address::ConversionError;
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
-use zcash_primitives::transaction::{
-    builder,
-    components::{amount::BalanceError, transparent},
+use zcash_keys::address::UnifiedAddress;
+use zcash_primitives::transaction::builder;
+use zcash_protocol::{
+    value::{BalanceError, Zatoshis},
+    PoolType,
 };
 
-use crate::address::UnifiedAddress;
-use crate::data_api::wallet::input_selection::InputSelectorError;
-use crate::fees::ChangeError;
-use crate::proposal::ProposalError;
-use crate::PoolType;
+use crate::{
+    data_api::wallet::input_selection::InputSelectorError, fees::ChangeError,
+    proposal::ProposalError, wallet::NoteId,
+};
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::legacy::TransparentAddress;
-
-use crate::wallet::NoteId;
+use ::transparent::address::TransparentAddress;
 
 /// Errors that can occur as a consequence of wallet operations.
 #[derive(Debug)]
@@ -62,8 +60,8 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
 
     /// Unable to create a new spend because the wallet balance is not sufficient.
     InsufficientFunds {
-        available: NonNegativeAmount,
-        required: NonNegativeAmount,
+        available: Zatoshis,
+        required: Zatoshis,
     },
 
     /// The wallet must first perform a scan of the blockchain before other
@@ -354,7 +352,7 @@ impl<DE, TE, SE, FE, CE, N> From<sapling::builder::Error> for Error<DE, TE, SE, 
 }
 
 impl<DE, TE, SE, FE, CE, N> From<transparent::builder::Error> for Error<DE, TE, SE, FE, CE, N> {
-    fn from(e: transparent::builder::Error) -> Self {
+    fn from(e: ::transparent::builder::Error) -> Self {
         Error::Builder(builder::Error::TransparentBuild(e))
     }
 }

--- a/zcash_client_backend/src/data_api/scanning.rs
+++ b/zcash_client_backend/src/data_api/scanning.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::ops::Range;
 
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 
 #[cfg(feature = "unstable-spanning-tree")]
 pub mod spanning_tree;

--- a/zcash_client_backend/src/data_api/scanning/spanning_tree.rs
+++ b/zcash_client_backend/src/data_api/scanning/spanning_tree.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, Ordering};
 use std::ops::{Not, Range};
 
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 
 use super::{ScanPriority, ScanRange};
 
@@ -397,7 +397,7 @@ impl SpanningTree {
 pub mod testing {
     use std::ops::Range;
 
-    use zcash_primitives::consensus::BlockHeight;
+    use zcash_protocol::consensus::BlockHeight;
 
     use crate::data_api::scanning::{ScanPriority, ScanRange};
 
@@ -413,7 +413,7 @@ pub mod testing {
 mod tests {
     use std::ops::Range;
 
-    use zcash_primitives::consensus::BlockHeight;
+    use zcash_protocol::consensus::BlockHeight;
 
     use super::{join_nonoverlapping, testing::scan_range, Joined, RangeOrdering, SpanningTree};
     use crate::data_api::scanning::{ScanPriority, ScanRange};

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -11,12 +11,11 @@ use rand::{Rng, RngCore};
 use secrecy::Secret;
 use shardtree::error::ShardTreeError;
 
+use ::transparent::address::TransparentAddress;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::{
     block::BlockHash,
-    legacy::TransparentAddress,
     transaction::{
-        components::amount::NonNegativeAmount,
         fees::zip317::{FeeRule as Zip317FeeRule, MARGINAL_FEE, MINIMUM_FEE},
         Transaction,
     },
@@ -66,23 +65,23 @@ use {
         proposal::{Proposal, ProposalError, StepOutput, StepOutputIndex},
         wallet::{TransparentAddressMetadata, WalletTransparentOutput},
     },
+    ::transparent::{
+        bundle::{OutPoint, TxOut},
+        keys::{NonHardenedChildIndex, TransparentKeyScope},
+    },
     nonempty::NonEmpty,
     rand_core::OsRng,
     std::{collections::HashSet, str::FromStr},
-    zcash_primitives::{
-        legacy::keys::{NonHardenedChildIndex, TransparentKeyScope},
-        transaction::{
-            builder::{BuildConfig, Builder},
-            components::{OutPoint, TxOut},
-            fees::zip317,
-        },
+    zcash_primitives::transaction::{
+        builder::{BuildConfig, Builder},
+        fees::zip317,
     },
     zcash_proofs::prover::LocalTxProver,
     zcash_protocol::value::ZatBalance,
 };
 
 #[cfg(feature = "orchard")]
-use crate::PoolType;
+use zcash_protocol::PoolType;
 
 #[cfg(feature = "pczt")]
 use pczt::roles::{prover::Prover, signer::Signer};
@@ -379,7 +378,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
         DustOutputPolicy::default(),
         SplitPolicy::with_min_output_value(
             NonZeroUsize::new(2).unwrap(),
-            NonNegativeAmount::const_from_u64(100_0000),
+            Zatoshis::const_from_u64(100_0000),
         ),
     );
 
@@ -482,7 +481,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
         DustOutputPolicy::default(),
         SplitPolicy::with_min_output_value(
             NonZeroUsize::new(8).unwrap(),
-            NonNegativeAmount::const_from_u64(10_0000),
+            Zatoshis::const_from_u64(10_0000),
         ),
     );
 
@@ -509,7 +508,7 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
     DSF: DataStoreFactory,
     <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
-    use zcash_primitives::transaction::components::transparent::builder::TransparentSigningSet;
+    use ::transparent::builder::TransparentSigningSet;
 
     use crate::data_api::{OutputOfSentTx, GAP_LIMIT};
 
@@ -540,8 +539,8 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
         h
     };
 
-    let value = NonNegativeAmount::const_from_u64(100000);
-    let transfer_amount = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(100000);
+    let transfer_amount = Zatoshis::const_from_u64(50000);
 
     let run_test = |st: &mut TestState<_, DSF::DataStore, _>, expected_index| {
         // Add funds to the wallet.
@@ -929,8 +928,8 @@ pub fn proposal_fails_if_not_all_ephemeral_outputs_consumed<T: ShieldedPoolTeste
         assert_eq!(st.get_spendable_balance(account_id, 1), value);
     };
 
-    let value = NonNegativeAmount::const_from_u64(100000);
-    let transfer_amount = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(100000);
+    let transfer_amount = Zatoshis::const_from_u64(50000);
 
     // Add funds to the wallet.
     add_funds(&mut st, value);
@@ -1006,7 +1005,7 @@ pub fn create_to_address_fails_on_incorrect_usk<T: ShieldedPoolTester, DSF: Data
 
     let req = TransactionRequest::new(vec![Payment::without_memo(
         to.to_zcash_address(st.network()),
-        NonNegativeAmount::const_from_u64(1),
+        Zatoshis::const_from_u64(1),
     )])
     .unwrap();
 
@@ -1048,7 +1047,7 @@ where
             StandardFeeRule::Zip317,
             NonZeroU32::new(1).unwrap(),
             &to,
-            NonNegativeAmount::const_from_u64(1),
+            Zatoshis::const_from_u64(1),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1072,7 +1071,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     let dfvk = T::test_account_fvk(&st);
 
     // Add funds to the wallet in a single note
-    let value = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(50000);
     let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h1, 1);
 
@@ -1082,10 +1081,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
 
     // Value is considered pending at 10 confirmations.
     assert_eq!(st.get_pending_shielded_balance(account_id, 10), value);
-    assert_eq!(
-        st.get_spendable_balance(account_id, 10),
-        NonNegativeAmount::ZERO
-    );
+    assert_eq!(st.get_spendable_balance(account_id, 10), Zatoshis::ZERO);
 
     // If none of the wallet's accounts have a recover-until height, then there
     // is no recovery phase for the wallet, and therefore the denominator in the
@@ -1127,7 +1123,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
             StandardFeeRule::Zip317,
             NonZeroU32::new(2).unwrap(),
             &to,
-            NonNegativeAmount::const_from_u64(70000),
+            Zatoshis::const_from_u64(70000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1136,8 +1132,8 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
             available,
             required
         })
-        if available == NonNegativeAmount::const_from_u64(50000)
-            && required == NonNegativeAmount::const_from_u64(80000)
+        if available == Zatoshis::const_from_u64(50000)
+            && required == Zatoshis::const_from_u64(80000)
     );
 
     // Mine blocks SAPLING_ACTIVATION_HEIGHT + 2 to 9 until just before the second
@@ -1157,7 +1153,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
             StandardFeeRule::Zip317,
             NonZeroU32::new(10).unwrap(),
             &to,
-            NonNegativeAmount::const_from_u64(70000),
+            Zatoshis::const_from_u64(70000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1166,8 +1162,8 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
             available,
             required
         })
-        if available == NonNegativeAmount::const_from_u64(50000)
-            && required == NonNegativeAmount::const_from_u64(80000)
+        if available == Zatoshis::const_from_u64(50000)
+            && required == Zatoshis::const_from_u64(80000)
     );
 
     // Mine block 11 so that the second note becomes verified
@@ -1187,7 +1183,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     );
 
     // Should now be able to generate a proposal
-    let amount_sent = NonNegativeAmount::from_u64(70000).unwrap();
+    let amount_sent = Zatoshis::from_u64(70000).unwrap();
     let min_confirmations = NonZeroU32::new(10).unwrap();
     let proposal = st
         .propose_standard_transfer::<Infallible>(
@@ -1217,9 +1213,8 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     // TODO: send to an account so that we can check its balance.
     assert_eq!(
         st.get_total_balance(account_id),
-        ((value * 11u64).unwrap()
-            - (amount_sent + NonNegativeAmount::from_u64(10000).unwrap()).unwrap())
-        .unwrap()
+        ((value * 11u64).unwrap() - (amount_sent + Zatoshis::from_u64(10000).unwrap()).unwrap())
+            .unwrap()
     );
 }
 
@@ -1240,7 +1235,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     let fee_rule = StandardFeeRule::Zip317;
 
     // Add funds to the wallet in a single note
-    let value = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(50000);
     let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h1, 1);
 
@@ -1258,7 +1253,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
             fee_rule,
             min_confirmations,
             &to,
-            NonNegativeAmount::const_from_u64(15000),
+            Zatoshis::const_from_u64(15000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1278,7 +1273,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
             fee_rule,
             NonZeroU32::new(1).unwrap(),
             &to,
-            NonNegativeAmount::const_from_u64(2000),
+            Zatoshis::const_from_u64(2000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1287,7 +1282,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
             available,
             required
         })
-        if available == NonNegativeAmount::ZERO && required == NonNegativeAmount::const_from_u64(12000)
+        if available == Zatoshis::ZERO && required == Zatoshis::const_from_u64(12000)
     );
 
     // Mine blocks SAPLING_ACTIVATION_HEIGHT + 1 to 41 (that don't send us funds)
@@ -1308,7 +1303,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
             fee_rule,
             NonZeroU32::new(1).unwrap(),
             &to,
-            NonNegativeAmount::const_from_u64(2000),
+            Zatoshis::const_from_u64(2000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1317,7 +1312,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
             available,
             required
         })
-        if available == NonNegativeAmount::ZERO && required == NonNegativeAmount::const_from_u64(12000)
+        if available == Zatoshis::ZERO && required == Zatoshis::const_from_u64(12000)
     );
 
     // Mine block SAPLING_ACTIVATION_HEIGHT + 42 so that the first transaction expires
@@ -1333,7 +1328,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     assert_eq!(st.get_spendable_balance(account_id, 1), value);
 
     // Second spend should now succeed
-    let amount_sent2 = NonNegativeAmount::const_from_u64(2000);
+    let amount_sent2 = Zatoshis::const_from_u64(2000);
     let min_confirmations = NonZeroU32::new(1).unwrap();
     let proposal = st
         .propose_standard_transfer::<Infallible>(
@@ -1362,7 +1357,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     // TODO: send to an account so that we can check its balance.
     assert_eq!(
         st.get_total_balance(account_id),
-        (value - (amount_sent2 + NonNegativeAmount::from_u64(10000).unwrap()).unwrap()).unwrap()
+        (value - (amount_sent2 + Zatoshis::from_u64(10000).unwrap()).unwrap()).unwrap()
     );
 }
 
@@ -1383,7 +1378,7 @@ pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, DSF>(
     let dfvk = T::test_account_fvk(&st);
 
     // Add funds to the wallet in a single note
-    let value = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(50000);
     let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h1, 1);
 
@@ -1413,7 +1408,7 @@ pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, DSF>(
             fee_rule,
             min_confirmations,
             &addr2,
-            NonNegativeAmount::const_from_u64(15000),
+            Zatoshis::const_from_u64(15000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1473,7 +1468,7 @@ pub fn spend_succeeds_to_t_addr_zero_change<T: ShieldedPoolTester>(
     let dfvk = T::test_account_fvk(&st);
 
     // Add funds to the wallet in a single note
-    let value = NonNegativeAmount::const_from_u64(70000);
+    let value = Zatoshis::const_from_u64(70000);
     let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h, 1);
 
@@ -1492,7 +1487,7 @@ pub fn spend_succeeds_to_t_addr_zero_change<T: ShieldedPoolTester>(
             fee_rule,
             min_confirmations,
             &to,
-            NonNegativeAmount::const_from_u64(50000),
+            Zatoshis::const_from_u64(50000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1521,7 +1516,7 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
     let dfvk = T::test_account_fvk(&st);
 
     // Add funds to the wallet in a single note owned by the internal spending key
-    let value = NonNegativeAmount::const_from_u64(70000);
+    let value = Zatoshis::const_from_u64(70000);
     let (h, _, _) = st.generate_next_block(&dfvk, AddressType::Internal, value);
     st.scan_cached_blocks(h, 1);
 
@@ -1531,10 +1526,7 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
 
     // Value is considered pending at 10 confirmations.
     assert_eq!(st.get_pending_shielded_balance(account_id, 10), value);
-    assert_eq!(
-        st.get_spendable_balance(account_id, 10),
-        NonNegativeAmount::ZERO
-    );
+    assert_eq!(st.get_spendable_balance(account_id, 10), Zatoshis::ZERO);
 
     let change_note_scope = st
         .wallet()
@@ -1555,7 +1547,7 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
             fee_rule,
             min_confirmations,
             &to,
-            NonNegativeAmount::const_from_u64(50000),
+            Zatoshis::const_from_u64(50000),
             None,
             None,
             T::SHIELDED_PROTOCOL,
@@ -1597,17 +1589,17 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     let dfvk2 = T::sk_to_fvk(T::usk_to_sk(&usk2));
 
     // Add funds to the wallet in a single note
-    let value = NonNegativeAmount::from_u64(100000).unwrap();
+    let value = Zatoshis::from_u64(100000).unwrap();
     let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h, 1);
 
     // Spendable balance matches total balance
     assert_eq!(st.get_total_balance(account1), value);
     assert_eq!(st.get_spendable_balance(account1, 1), value);
-    assert_eq!(st.get_total_balance(account2), NonNegativeAmount::ZERO);
+    assert_eq!(st.get_total_balance(account2), Zatoshis::ZERO);
 
-    let amount_sent = NonNegativeAmount::from_u64(20000).unwrap();
-    let amount_legacy_change = NonNegativeAmount::from_u64(30000).unwrap();
+    let amount_sent = Zatoshis::from_u64(20000).unwrap();
+    let amount_legacy_change = Zatoshis::from_u64(30000).unwrap();
     let addr = T::fvk_default_address(&dfvk);
     let addr2 = T::fvk_default_address(&dfvk2);
     let req = TransactionRequest::new(vec![
@@ -1697,7 +1689,7 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     let (h1, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::Internal,
-        NonNegativeAmount::const_from_u64(50000),
+        Zatoshis::const_from_u64(50000),
     );
 
     // Add 10 dust notes to the wallet
@@ -1705,14 +1697,14 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
         st.generate_next_block(
             &dfvk,
             AddressType::DefaultExternal,
-            NonNegativeAmount::const_from_u64(1000),
+            Zatoshis::const_from_u64(1000),
         );
     }
 
     st.scan_cached_blocks(h1, 11);
 
     // Spendable balance matches total balance
-    let total = NonNegativeAmount::const_from_u64(60000);
+    let total = Zatoshis::const_from_u64(60000);
     assert_eq!(st.get_total_balance(account_id), total);
     assert_eq!(st.get_spendable_balance(account_id, 1), total);
 
@@ -1723,7 +1715,7 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     // This first request will fail due to insufficient non-dust funds
     let req = TransactionRequest::new(vec![Payment::without_memo(
         T::fvk_default_address(&dfvk).to_zcash_address(st.network()),
-        NonNegativeAmount::const_from_u64(50000),
+        Zatoshis::const_from_u64(50000),
     )])
     .unwrap();
 
@@ -1737,15 +1729,15 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
             NonZeroU32::new(1).unwrap(),
         ),
         Err(Error::InsufficientFunds { available, required })
-            if available == NonNegativeAmount::const_from_u64(51000)
-            && required == NonNegativeAmount::const_from_u64(60000)
+            if available == Zatoshis::const_from_u64(51000)
+            && required == Zatoshis::const_from_u64(60000)
     );
 
     // This request will succeed, spending a single dust input to pay the 10000
     // ZAT fee in addition to the 41000 ZAT output to the recipient
     let req = TransactionRequest::new(vec![Payment::without_memo(
         T::fvk_default_address(&dfvk).to_zcash_address(st.network()),
-        NonNegativeAmount::const_from_u64(41000),
+        Zatoshis::const_from_u64(41000),
     )])
     .unwrap();
 
@@ -1768,7 +1760,7 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     // in the total balance.
     assert_eq!(
         st.get_total_balance(account_id),
-        (total - NonNegativeAmount::const_from_u64(10000)).unwrap()
+        (total - Zatoshis::const_from_u64(10000)).unwrap()
     );
 }
 
@@ -1798,14 +1790,14 @@ where
     let (h, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::Internal,
-        NonNegativeAmount::const_from_u64(50000),
+        Zatoshis::const_from_u64(50000),
     );
     st.scan_cached_blocks(h, 1);
 
     let utxo = WalletTransparentOutput::from_parts(
         OutPoint::fake(),
         TxOut {
-            value: NonNegativeAmount::const_from_u64(100000),
+            value: Zatoshis::const_from_u64(100000),
             script_pubkey: taddr.script(),
         },
         Some(h),
@@ -1823,7 +1815,7 @@ where
         .shield_transparent_funds(
             &input_selector,
             &change_strategy,
-            NonNegativeAmount::from_u64(10000).unwrap(),
+            Zatoshis::from_u64(10000).unwrap(),
             account.usk(),
             &[*taddr],
             account.id(),
@@ -1917,7 +1909,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
         .build();
 
     // Generate 9 blocks that have no value for us, starting at the birthday height.
-    let not_our_value = NonNegativeAmount::const_from_u64(10000);
+    let not_our_value = Zatoshis::const_from_u64(10000);
     let not_our_key = T::random_fvk(st.rng_mut());
     let (initial_height, _, _) =
         st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
@@ -1929,7 +1921,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
     let (received_tx_height, _, _) = st.generate_next_block(
         &T::test_account_fvk(&st),
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(500000),
+        Zatoshis::const_from_u64(500000),
     );
 
     // Generate some more blocks to get above our anchor height
@@ -1947,7 +1939,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
     let spendable = T::select_spendable_notes(
         &st,
         account_id,
-        NonNegativeAmount::const_from_u64(300000),
+        Zatoshis::const_from_u64(300000),
         received_tx_height + 10,
         &[],
     )
@@ -1962,7 +1954,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
     let spendable = T::select_spendable_notes(
         &st,
         account_id,
-        NonNegativeAmount::const_from_u64(300000),
+        Zatoshis::const_from_u64(300000),
         received_tx_height + 10,
         &[],
     )
@@ -1988,14 +1980,14 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(500000),
+        Zatoshis::const_from_u64(500000),
     );
     st.scan_cached_blocks(account.birthday().height(), 1);
 
     // Create a gap of 10 blocks having no shielded outputs, then add a block that doesn't
     // belong to us so that we can get a checkpoint in the tree.
     let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
-    let not_our_value = NonNegativeAmount::const_from_u64(10000);
+    let not_our_value = Zatoshis::const_from_u64(10000);
     st.generate_block_at(
         account.birthday().height() + 10,
         BlockHash([0; 32]),
@@ -2016,7 +2008,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     let spendable = T::select_spendable_notes(
         &st,
         account.id(),
-        NonNegativeAmount::const_from_u64(300000),
+        Zatoshis::const_from_u64(300000),
         account.birthday().height() + 5,
         &[],
     )
@@ -2030,7 +2022,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     let to = T::fvk_default_address(&not_our_key);
     let req = TransactionRequest::new(vec![Payment::without_memo(
         to.to_zcash_address(st.network()),
-        NonNegativeAmount::const_from_u64(10000),
+        Zatoshis::const_from_u64(10000),
     )])
     .unwrap();
 
@@ -2067,7 +2059,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     let p1_fvk = P1::test_account_fvk(&st);
     let p1_to = P1::fvk_default_address(&p1_fvk);
 
-    let note_value = NonNegativeAmount::const_from_u64(350000);
+    let note_value = Zatoshis::const_from_u64(350000);
     st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
     st.scan_cached_blocks(account.birthday().height(), 2);
 
@@ -2075,7 +2067,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     assert_eq!(st.get_total_balance(account.id()), initial_balance);
     assert_eq!(st.get_spendable_balance(account.id(), 1), initial_balance);
 
-    let transfer_amount = NonNegativeAmount::const_from_u64(200000);
+    let transfer_amount = Zatoshis::const_from_u64(200000);
     let p0_to_p1 = TransactionRequest::new(vec![Payment::without_memo(
         p1_to.to_zcash_address(st.network()),
         transfer_amount,
@@ -2100,7 +2092,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     let step0 = &proposal0.steps().head;
 
     // We expect 4 logical actions, two per pool (due to padding).
-    let expected_fee = NonNegativeAmount::const_from_u64(20000);
+    let expected_fee = Zatoshis::const_from_u64(20000);
     assert_eq!(step0.balance().fee_required(), expected_fee);
 
     let expected_change = (note_value - transfer_amount - expected_fee).unwrap();
@@ -2156,7 +2148,7 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
     let p1_fvk = P1::test_account_fvk(&st);
     let p1_to = P1::fvk_default_address(&p1_fvk);
 
-    let note_value = NonNegativeAmount::const_from_u64(350000);
+    let note_value = Zatoshis::const_from_u64(350000);
     st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
     st.generate_next_block(&p1_fvk, AddressType::DefaultExternal, note_value);
     st.scan_cached_blocks(account.birthday().height(), 2);
@@ -2165,7 +2157,7 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
     assert_eq!(st.get_total_balance(account.id()), initial_balance);
     assert_eq!(st.get_spendable_balance(account.id(), 1), initial_balance);
 
-    let transfer_amount = NonNegativeAmount::const_from_u64(200000);
+    let transfer_amount = Zatoshis::const_from_u64(200000);
     let p0_to_p1 = TransactionRequest::new(vec![Payment::without_memo(
         p1_to.to_zcash_address(st.network()),
         transfer_amount,
@@ -2193,7 +2185,7 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
 
     // We expect 2 logical actions, since either pool can pay the full balance required
     // and note selection should choose the fully-private path.
-    let expected_fee = NonNegativeAmount::const_from_u64(10000);
+    let expected_fee = Zatoshis::const_from_u64(10000);
     assert_eq!(step0.balance().fee_required(), expected_fee);
 
     let expected_change = (note_value - transfer_amount - expected_fee).unwrap();
@@ -2246,7 +2238,7 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     let p1_fvk = P1::test_account_fvk(&st);
     let (p1_to, _) = account.usk().default_transparent_address();
 
-    let note_value = NonNegativeAmount::const_from_u64(350000);
+    let note_value = Zatoshis::const_from_u64(350000);
     st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
     st.generate_next_block(&p1_fvk, AddressType::DefaultExternal, note_value);
     st.scan_cached_blocks(account.birthday().height(), 2);
@@ -2255,7 +2247,7 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     assert_eq!(st.get_total_balance(account.id()), initial_balance);
     assert_eq!(st.get_spendable_balance(account.id(), 1), initial_balance);
 
-    let transfer_amount = NonNegativeAmount::const_from_u64(200000);
+    let transfer_amount = Zatoshis::const_from_u64(200000);
     let p0_to_p1 = TransactionRequest::new(vec![Payment::without_memo(
         Address::Transparent(p1_to).to_zcash_address(st.network()),
         transfer_amount,
@@ -2282,7 +2274,7 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     let step0 = &proposal0.steps().head;
 
     // We expect 3 logical actions, one for the transparent output and two for the source pool.
-    let expected_fee = NonNegativeAmount::const_from_u64(15000);
+    let expected_fee = Zatoshis::const_from_u64(15000);
     assert_eq!(step0.balance().fee_required(), expected_fee);
 
     let expected_change = (note_value - transfer_amount - expected_fee).unwrap();
@@ -2335,7 +2327,7 @@ pub fn multi_pool_checkpoint<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
 
     // Add some funds to the wallet; we add two notes to allow successive spends. Also,
     // we will generate a note in the P1 pool to ensure that we have some tree state.
-    let note_value = NonNegativeAmount::const_from_u64(500000);
+    let note_value = Zatoshis::const_from_u64(500000);
     let (start_height, _, _) =
         st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
     st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
@@ -2367,7 +2359,7 @@ pub fn multi_pool_checkpoint<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
         single_output_change_strategy(StandardFeeRule::Zip317, None, P1::SHIELDED_PROTOCOL);
 
     // First, send funds just to P0
-    let transfer_amount = NonNegativeAmount::const_from_u64(200000);
+    let transfer_amount = Zatoshis::const_from_u64(200000);
     let p0_transfer = TransactionRequest::new(vec![Payment::without_memo(
         P0::random_address(st.rng_mut()).to_zcash_address(st.network()),
         transfer_amount,
@@ -2385,7 +2377,7 @@ pub fn multi_pool_checkpoint<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
         .unwrap();
     st.generate_next_block_including(*res.first());
 
-    let expected_fee = NonNegativeAmount::const_from_u64(10000);
+    let expected_fee = Zatoshis::const_from_u64(10000);
     let expected_change = (note_value - transfer_amount - expected_fee).unwrap();
     assert_eq!(
         st.get_total_balance(acct_id),
@@ -2496,7 +2488,7 @@ pub fn multi_pool_checkpoints_with_pruning<P0: ShieldedPoolTester, P1: ShieldedP
     let p0_fvk = P0::random_fvk(st.rng_mut());
     let p1_fvk = P1::random_fvk(st.rng_mut());
 
-    let note_value = NonNegativeAmount::const_from_u64(10000);
+    let note_value = Zatoshis::const_from_u64(10000);
     // Generate 100 P0 blocks, then 100 P1 blocks, then another 100 P0 blocks.
     for _ in 0..10 {
         for _ in 0..10 {
@@ -2533,7 +2525,7 @@ pub fn valid_chain_states<T: ShieldedPoolTester>(
     let (h1, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(5),
+        Zatoshis::const_from_u64(5),
     );
 
     // Scan the cache
@@ -2543,7 +2535,7 @@ pub fn valid_chain_states<T: ShieldedPoolTester>(
     let (h2, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(7),
+        Zatoshis::const_from_u64(7),
     );
 
     // Scanning should detect no inconsistencies
@@ -2568,12 +2560,12 @@ pub fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>(
     let (h, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(5),
+        Zatoshis::const_from_u64(5),
     );
     let (last_contiguous_height, _, _) = st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(7),
+        Zatoshis::const_from_u64(7),
     );
 
     // Scanning the cache should find no inconsistencies
@@ -2587,7 +2579,7 @@ pub fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>(
         &[FakeCompactOutput::new(
             &dfvk,
             AddressType::DefaultExternal,
-            NonNegativeAmount::const_from_u64(8),
+            Zatoshis::const_from_u64(8),
         )],
         2,
         2,
@@ -2596,7 +2588,7 @@ pub fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>(
     st.generate_next_block(
         &dfvk,
         AddressType::DefaultExternal,
-        NonNegativeAmount::const_from_u64(3),
+        Zatoshis::const_from_u64(3),
     );
 
     // Data+cache chain should be invalid at the data/cache boundary
@@ -2628,8 +2620,8 @@ where
     assert_eq!(st.get_wallet_summary(0), None);
 
     // Create fake CompactBlocks sending value to the address
-    let value = NonNegativeAmount::const_from_u64(5);
-    let value2 = NonNegativeAmount::const_from_u64(7);
+    let value = Zatoshis::const_from_u64(5);
+    let value2 = Zatoshis::const_from_u64(7);
     let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
@@ -2822,7 +2814,7 @@ pub fn scan_cached_blocks_allows_blocks_out_of_order<T: ShieldedPoolTester>(
     let account = st.test_account().cloned().unwrap();
     let dfvk = T::test_account_fvk(&st);
 
-    let value = NonNegativeAmount::const_from_u64(50000);
+    let value = Zatoshis::const_from_u64(50000);
     let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     st.scan_cached_blocks(h1, 1);
     assert_eq!(st.get_total_balance(account.id()), value);
@@ -2838,13 +2830,13 @@ pub fn scan_cached_blocks_allows_blocks_out_of_order<T: ShieldedPoolTester>(
     st.scan_cached_blocks(h2, 1);
     assert_eq!(
         st.get_total_balance(account.id()),
-        NonNegativeAmount::const_from_u64(150_000)
+        Zatoshis::const_from_u64(150_000)
     );
 
     // We can spend the received notes
     let req = TransactionRequest::new(vec![Payment::without_memo(
         T::fvk_default_address(&dfvk).to_zcash_address(st.network()),
-        NonNegativeAmount::const_from_u64(110_000),
+        Zatoshis::const_from_u64(110_000),
     )])
     .unwrap();
 
@@ -2885,7 +2877,7 @@ pub fn scan_cached_blocks_finds_received_notes<T: ShieldedPoolTester, DSF>(
     assert_eq!(st.get_wallet_summary(0), None);
 
     // Create a fake CompactBlock sending value to the address
-    let value = NonNegativeAmount::const_from_u64(5);
+    let value = Zatoshis::const_from_u64(5);
     let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
     // Scan the cache
@@ -2898,7 +2890,7 @@ pub fn scan_cached_blocks_finds_received_notes<T: ShieldedPoolTester, DSF>(
     assert_eq!(st.get_total_balance(account.id()), value);
 
     // Create a second fake CompactBlock sending more value to the address
-    let value2 = NonNegativeAmount::const_from_u64(7);
+    let value2 = Zatoshis::const_from_u64(7);
     let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value2);
 
     // Scan the cache again
@@ -2935,7 +2927,7 @@ pub fn scan_cached_blocks_finds_change_notes<T: ShieldedPoolTester, DSF>(
     assert_eq!(st.get_wallet_summary(0), None);
 
     // Create a fake CompactBlock sending value to the address
-    let value = NonNegativeAmount::const_from_u64(5);
+    let value = Zatoshis::const_from_u64(5);
     let (received_height, _, nf) =
         st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
@@ -2948,7 +2940,7 @@ pub fn scan_cached_blocks_finds_change_notes<T: ShieldedPoolTester, DSF>(
     // Create a second fake CompactBlock spending value from the address
     let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
     let to2 = T::fvk_default_address(&not_our_key);
-    let value2 = NonNegativeAmount::const_from_u64(2);
+    let value2 = Zatoshis::const_from_u64(2);
     let (spent_height, _) = st.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
     // Scan the cache again
@@ -2981,14 +2973,14 @@ pub fn scan_cached_blocks_detects_spends_out_of_order<T: ShieldedPoolTester, DSF
     assert_eq!(st.get_wallet_summary(0), None);
 
     // Create a fake CompactBlock sending value to the address
-    let value = NonNegativeAmount::const_from_u64(5);
+    let value = Zatoshis::const_from_u64(5);
     let (received_height, _, nf) =
         st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
 
     // Create a second fake CompactBlock spending value from the address
     let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
     let to2 = T::fvk_default_address(&not_our_key);
-    let value2 = NonNegativeAmount::const_from_u64(2);
+    let value2 = Zatoshis::const_from_u64(2);
     let (spent_height, _) = st.generate_next_block_spending(&dfvk, (nf, value), to2, value2);
 
     // Scan the spending block first.
@@ -3028,11 +3020,11 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, DSF, TC>(
     let dfvk = T::test_account_fvk(&st);
 
     // Create 10 blocks with successively increasing value
-    let value = NonNegativeAmount::const_from_u64(100_0000);
+    let value = Zatoshis::const_from_u64(100_0000);
     let (h0, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
     let mut note_values = vec![value];
     for i in 2..=10 {
-        let value = NonNegativeAmount::const_from_u64(i * 100_0000);
+        let value = Zatoshis::const_from_u64(i * 100_0000);
         st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         note_values.push(value);
     }
@@ -3049,12 +3041,12 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, DSF, TC>(
 
     test_meta(
         &st,
-        NoteFilter::ExceedsMinValue(NonNegativeAmount::const_from_u64(1000_0000)),
+        NoteFilter::ExceedsMinValue(Zatoshis::const_from_u64(1000_0000)),
         Some(1),
     );
     test_meta(
         &st,
-        NoteFilter::ExceedsMinValue(NonNegativeAmount::const_from_u64(500_0000)),
+        NoteFilter::ExceedsMinValue(Zatoshis::const_from_u64(500_0000)),
         Some(6),
     );
     test_meta(
@@ -3140,14 +3132,14 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, DSF>(
     let p1_to = P1::fvk_default_address(&p1_fvk);
 
     // Only mine a block in P0 to ensure the transactions source is there.
-    let note_value = NonNegativeAmount::const_from_u64(350000);
+    let note_value = Zatoshis::const_from_u64(350000);
     st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
     st.scan_cached_blocks(account.birthday().height(), 1);
 
     assert_eq!(st.get_total_balance(account.id()), note_value);
     assert_eq!(st.get_spendable_balance(account.id(), 1), note_value);
 
-    let transfer_amount = NonNegativeAmount::const_from_u64(200000);
+    let transfer_amount = Zatoshis::const_from_u64(200000);
     let p0_to_p1 = TransactionRequest::new(vec![Payment::without_memo(
         p1_to.to_zcash_address(st.network()),
         transfer_amount,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -10,13 +10,14 @@ use crate::{
     wallet::WalletTransparentOutput,
 };
 use assert_matches::assert_matches;
-use sapling::zip32::ExtendedSpendingKey;
-use zcash_primitives::{
-    block::BlockHash,
-    legacy::TransparentAddress,
-    transaction::components::{amount::NonNegativeAmount, OutPoint, TxOut},
+
+use ::transparent::{
+    address::TransparentAddress,
+    bundle::{OutPoint, TxOut},
 };
-use zcash_protocol::local_consensus::LocalNetwork;
+use sapling::zip32::ExtendedSpendingKey;
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::{local_consensus::LocalNetwork, value::Zatoshis};
 
 use super::TestAccount;
 
@@ -54,7 +55,7 @@ fn check_balance<DSF>(
             .unwrap()
             .get(taddr)
             .cloned()
-            .unwrap_or(NonNegativeAmount::ZERO),
+            .unwrap_or(Zatoshis::ZERO),
         expected.total(),
     );
     assert_eq!(
@@ -63,7 +64,7 @@ fn check_balance<DSF>(
             .unwrap()
             .into_iter()
             .map(|utxo| utxo.value())
-            .sum::<Option<NonNegativeAmount>>(),
+            .sum::<Option<Zatoshis>>(),
         Some(expected.spendable_value()),
     );
 
@@ -78,7 +79,7 @@ fn check_balance<DSF>(
                 .unwrap()
                 .into_iter()
                 .map(|utxo| utxo.value())
-                .sum::<Option<NonNegativeAmount>>(),
+                .sum::<Option<Zatoshis>>(),
             Some(expected.spendable_value()),
         );
     }
@@ -113,7 +114,7 @@ where
     assert!(bal_absent.is_empty());
 
     // Create a fake transparent output.
-    let value = NonNegativeAmount::const_from_u64(100000);
+    let value = Zatoshis::const_from_u64(100000);
     let outpoint = OutPoint::fake();
     let txout = TxOut {
         value,
@@ -196,7 +197,7 @@ where
 
     // Initialize the wallet with chain data that has no shielded notes for us.
     let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
-    let not_our_value = NonNegativeAmount::const_from_u64(10000);
+    let not_our_value = Zatoshis::const_from_u64(10000);
     let (start_height, _, _) =
         st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
     for _ in 1..10 {
@@ -208,7 +209,7 @@ where
     check_balance::<DSF>(&st, &account, taddr, 0, &Balance::ZERO);
 
     // Create a fake transparent output.
-    let value = NonNegativeAmount::from_u64(100000).unwrap();
+    let value = Zatoshis::from_u64(100000).unwrap();
     let txout = TxOut {
         value,
         script_pubkey: taddr.script(),
@@ -304,7 +305,7 @@ where
 
     // Initialize the wallet with chain data that has no shielded notes for us.
     let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
-    let not_our_value = NonNegativeAmount::const_from_u64(10000);
+    let not_our_value = Zatoshis::const_from_u64(10000);
     let (start_height, _, _) =
         st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
     for _ in 1..10 {
@@ -322,7 +323,7 @@ where
     );
 
     // Create a fake transparent output.
-    let value = NonNegativeAmount::from_u64(100000).unwrap();
+    let value = Zatoshis::from_u64(100000).unwrap();
     let txout = TxOut {
         value,
         script_pubkey: taddr.script(),

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -41,11 +41,15 @@ use sapling::{
 };
 use shardtree::error::{QueryError, ShardTreeError};
 use std::num::NonZeroU32;
-use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_keys::{
+    address::Address,
+    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
+};
+use zcash_protocol::{PoolType, ShieldedProtocol};
+use zip321::{self, Payment};
 
 use super::InputSource;
 use crate::{
-    address::Address,
     data_api::{
         error::Error, Account, SentTransaction, SentTransactionOutput, WalletCommitmentTrees,
         WalletRead, WalletWrite,
@@ -54,43 +58,40 @@ use crate::{
     fees::{
         standard::SingleOutputChangeStrategy, ChangeStrategy, DustOutputPolicy, StandardFeeRule,
     },
-    keys::UnifiedSpendingKey,
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
     wallet::{Note, OvkPolicy, Recipient},
-    zip321::{self, Payment},
-    PoolType, ShieldedProtocol,
 };
-use zcash_primitives::{
-    legacy::TransparentAddress,
-    transaction::{
-        builder::{BuildConfig, BuildResult, Builder},
-        components::{
-            amount::NonNegativeAmount, sapling::zip212_enforcement,
-            transparent::builder::TransparentSigningSet, OutPoint,
-        },
-        fees::FeeRule,
-        Transaction, TxId,
-    },
+
+use ::transparent::{
+    address::TransparentAddress, builder::TransparentSigningSet, bundle::OutPoint,
+};
+use zcash_primitives::transaction::{
+    builder::{BuildConfig, BuildResult, Builder},
+    components::sapling::zip212_enforcement,
+    fees::FeeRule,
+    Transaction, TxId,
 };
 use zcash_protocol::{
     consensus::{self, BlockHeight, NetworkUpgrade},
     memo::MemoBytes,
+    value::Zatoshis,
 };
 use zip32::Scope;
 
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::{fees::ChangeValue, proposal::StepOutput, wallet::TransparentAddressMetadata},
+    ::transparent::bundle::TxOut,
     core::convert::Infallible,
     input_selection::ShieldingSelector,
     std::collections::HashMap,
     zcash_keys::encoding::AddressCodec,
-    zcash_primitives::transaction::components::TxOut,
 };
 
 #[cfg(feature = "pczt")]
 use {
     crate::data_api::error::PcztError,
+    ::transparent::pczt::Bip32Derivation,
     bip32::ChildNumber,
     orchard::note_encryption::OrchardDomain,
     pczt::roles::{
@@ -101,7 +102,6 @@ use {
     serde::{Deserialize, Serialize},
     zcash_address::ZcashAddress,
     zcash_note_encryption::try_output_recovery_with_pkd_esk,
-    zcash_primitives::transaction::components::transparent::pczt::Bip32Derivation,
     zcash_protocol::{
         consensus::NetworkConstants,
         value::{BalanceError, ZatBalance},
@@ -331,7 +331,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     spend_from_account: <DbT as InputSource>::AccountId,
     min_confirmations: NonZeroU32,
     to: &Address,
-    amount: NonNegativeAmount,
+    amount: Zatoshis,
     memo: Option<MemoBytes>,
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedProtocol,
@@ -395,7 +395,7 @@ pub fn propose_shielding<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     params: &ParamsT,
     input_selector: &InputsT,
     change_strategy: &ChangeT,
-    shielding_threshold: NonNegativeAmount,
+    shielding_threshold: Zatoshis,
     from_addrs: &[TransparentAddress],
     to_account: <DbT as InputSource>::AccountId,
     min_confirmations: u32,
@@ -431,7 +431,7 @@ where
 struct StepResult<AccountId> {
     build_result: BuildResult,
     outputs: Vec<SentTransactionOutput<AccountId>>,
-    fee_amount: NonNegativeAmount,
+    fee_amount: Zatoshis,
     #[cfg(feature = "transparent-inputs")]
     utxos_spent: Vec<OutPoint>,
 }
@@ -546,18 +546,18 @@ struct BuildState<'a, P, AccountId> {
     #[cfg(feature = "orchard")]
     orchard_output_meta: Vec<(
         Recipient<AccountId, PoolType, OutPoint>,
-        NonNegativeAmount,
+        Zatoshis,
         Option<MemoBytes>,
     )>,
     sapling_output_meta: Vec<(
         Recipient<AccountId, PoolType, OutPoint>,
-        NonNegativeAmount,
+        Zatoshis,
         Option<MemoBytes>,
     )>,
     transparent_output_meta: Vec<(
         Recipient<AccountId, Note, ()>,
         TransparentAddress,
-        NonNegativeAmount,
+        Zatoshis,
         StepOutputIndex,
     )>,
     #[cfg(feature = "transparent-inputs")]
@@ -884,20 +884,14 @@ where
     };
 
     #[cfg(feature = "orchard")]
-    let mut orchard_output_meta: Vec<(
-        Recipient<_, PoolType, _>,
-        NonNegativeAmount,
-        Option<MemoBytes>,
-    )> = vec![];
-    let mut sapling_output_meta: Vec<(
-        Recipient<_, PoolType, _>,
-        NonNegativeAmount,
-        Option<MemoBytes>,
-    )> = vec![];
+    let mut orchard_output_meta: Vec<(Recipient<_, PoolType, _>, Zatoshis, Option<MemoBytes>)> =
+        vec![];
+    let mut sapling_output_meta: Vec<(Recipient<_, PoolType, _>, Zatoshis, Option<MemoBytes>)> =
+        vec![];
     let mut transparent_output_meta: Vec<(
         Recipient<_, _, ()>,
         TransparentAddress,
-        NonNegativeAmount,
+        Zatoshis,
         StepOutputIndex,
     )> = vec![];
 
@@ -1823,7 +1817,7 @@ where
             MemoBytes::from_bytes(memo_bytes(&m)).expect("Memo is the correct length.")
         });
 
-        let note_value = NonNegativeAmount::try_from(note_value(&note))?;
+        let note_value = Zatoshis::try_from(note_value(&note))?;
         let recipient = match (pczt_recipient, external_address) {
             (PcztRecipient::External, Some(addr)) => {
                 Ok(Recipient::External(addr, PoolType::Shielded(output_pool)))
@@ -1977,7 +1971,7 @@ where
     outputs.extend(sapling_outputs.into_iter().flatten());
     outputs.extend(transparent_outputs.into_iter().flatten());
 
-    let fee_amount = NonNegativeAmount::try_from(transaction.fee_paid(|outpoint| {
+    let fee_amount = Zatoshis::try_from(transaction.fee_paid(|outpoint| {
         utxos_map
             .get(outpoint)
             .copied()
@@ -2052,7 +2046,7 @@ pub fn shield_transparent_funds<DbT, ParamsT, InputsT, ChangeT>(
     output_prover: &impl OutputProver,
     input_selector: &InputsT,
     change_strategy: &ChangeT,
-    shielding_threshold: NonNegativeAmount,
+    shielding_threshold: Zatoshis,
     usk: &UnifiedSpendingKey,
     from_addrs: &[TransparentAddress],
     to_account: <DbT as InputSource>::AccountId,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -46,7 +46,7 @@ use zcash_keys::{
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
 };
 use zcash_protocol::{PoolType, ShieldedProtocol};
-use zip321::{self, Payment};
+use zip321::Payment;
 
 use super::InputSource;
 use crate::{

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -1,16 +1,19 @@
 use std::collections::HashMap;
 
 use sapling::note_encryption::{PreparedIncomingViewingKey, SaplingDomain};
+use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_note_encryption::{try_note_decryption, try_output_recovery_with_ovk};
 use zcash_primitives::{
+    transaction::components::sapling::zip212_enforcement, transaction::Transaction,
+};
+use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    transaction::components::{amount::NonNegativeAmount, sapling::zip212_enforcement},
-    transaction::Transaction,
-    zip32::Scope,
+    value::Zatoshis,
 };
+use zip32::Scope;
 
-use crate::{data_api::DecryptedTransaction, keys::UnifiedFullViewingKey};
+use crate::data_api::DecryptedTransaction;
 
 #[cfg(feature = "orchard")]
 use orchard::note_encryption::OrchardDomain;
@@ -84,16 +87,16 @@ impl<Note, AccountId> DecryptedOutput<Note, AccountId> {
 }
 
 impl<A> DecryptedOutput<sapling::Note, A> {
-    pub fn note_value(&self) -> NonNegativeAmount {
-        NonNegativeAmount::from_u64(self.note.value().inner())
+    pub fn note_value(&self) -> Zatoshis {
+        Zatoshis::from_u64(self.note.value().inner())
             .expect("Sapling note value is expected to have been validated by consensus.")
     }
 }
 
 #[cfg(feature = "orchard")]
 impl<A> DecryptedOutput<orchard::note::Note, A> {
-    pub fn note_value(&self) -> NonNegativeAmount {
-        NonNegativeAmount::from_u64(self.note.value().inner())
+    pub fn note_value(&self) -> Zatoshis {
+        Zatoshis::from_u64(self.note.value().inner())
             .expect("Orchard note value is expected to have been validated by consensus.")
     }
 }

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -2,9 +2,9 @@
 //! of a transaction.
 
 use std::convert::Infallible;
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
 use orchard::builder::BundleType;
+use zcash_protocol::value::Zatoshis;
 
 /// A trait that provides a minimized view of Orchard bundle configuration
 /// suitable for use in fee and change calculation.
@@ -67,14 +67,14 @@ pub trait InputView<NoteRef> {
     /// An identifier for the input being spent.
     fn note_id(&self) -> &NoteRef;
     /// The value of the input being spent.
-    fn value(&self) -> NonNegativeAmount;
+    fn value(&self) -> Zatoshis;
 }
 
 impl<N> InputView<N> for Infallible {
     fn note_id(&self) -> &N {
         unreachable!()
     }
-    fn value(&self) -> NonNegativeAmount {
+    fn value(&self) -> Zatoshis {
         unreachable!()
     }
 }
@@ -83,11 +83,11 @@ impl<N> InputView<N> for Infallible {
 /// calculation.
 pub trait OutputView {
     /// The value of the output being produced.
-    fn value(&self) -> NonNegativeAmount;
+    fn value(&self) -> Zatoshis;
 }
 
 impl OutputView for Infallible {
-    fn value(&self) -> NonNegativeAmount {
+    fn value(&self) -> Zatoshis {
         unreachable!()
     }
 }

--- a/zcash_client_backend/src/fees/sapling.rs
+++ b/zcash_client_backend/src/fees/sapling.rs
@@ -4,7 +4,7 @@
 use std::convert::Infallible;
 
 use sapling::builder::{BundleType, OutputInfo, SpendInfo};
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
+use zcash_protocol::value::Zatoshis;
 
 /// A trait that provides a minimized view of Sapling bundle configuration
 /// suitable for use in fee and change calculation.
@@ -67,14 +67,14 @@ pub trait InputView<NoteRef> {
     /// An identifier for the input being spent.
     fn note_id(&self) -> &NoteRef;
     /// The value of the input being spent.
-    fn value(&self) -> NonNegativeAmount;
+    fn value(&self) -> Zatoshis;
 }
 
 impl<N> InputView<N> for Infallible {
     fn note_id(&self) -> &N {
         unreachable!()
     }
-    fn value(&self) -> NonNegativeAmount {
+    fn value(&self) -> Zatoshis {
         unreachable!()
     }
 }
@@ -86,8 +86,8 @@ impl InputView<()> for SpendInfo {
         &()
     }
 
-    fn value(&self) -> NonNegativeAmount {
-        NonNegativeAmount::try_from(self.value().inner())
+    fn value(&self) -> Zatoshis {
+        Zatoshis::try_from(self.value().inner())
             .expect("An existing note to be spent must have a valid amount value.")
     }
 }
@@ -96,18 +96,18 @@ impl InputView<()> for SpendInfo {
 /// fee and change calculation.
 pub trait OutputView {
     /// The value of the output being produced.
-    fn value(&self) -> NonNegativeAmount;
+    fn value(&self) -> Zatoshis;
 }
 
 impl OutputView for OutputInfo {
-    fn value(&self) -> NonNegativeAmount {
-        NonNegativeAmount::try_from(self.value().inner())
+    fn value(&self) -> Zatoshis {
+        Zatoshis::try_from(self.value().inner())
             .expect("Output values should be checked at construction.")
     }
 }
 
 impl OutputView for Infallible {
-    fn value(&self) -> NonNegativeAmount {
+    fn value(&self) -> Zatoshis {
         unreachable!()
     }
 }

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -61,18 +61,14 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
-//pub use zcash_keys::address;
 pub mod data_api;
 mod decrypt;
-//pub use zcash_keys::encoding;
 pub mod fees;
-//pub use zcash_keys::keys;
 pub mod proposal;
 pub mod proto;
 pub mod scan;
 pub mod scanning;
 pub mod wallet;
-//pub use zip321;
 
 #[cfg(feature = "sync")]
 pub mod sync;
@@ -84,7 +80,27 @@ pub mod serialization;
 pub mod tor;
 
 pub use decrypt::{decrypt_transaction, DecryptedOutput, TransferType};
-//pub use zcash_protocol::{PoolType, ShieldedProtocol};
+
+#[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
+pub mod address {
+    pub use zcash_keys::address::*;
+}
+#[deprecated(note = "This module is deprecated; use `::zcash_keys::encoding` instead.")]
+pub mod encoding {
+    pub use zcash_keys::encoding::*;
+}
+#[deprecated(note = "This module is deprecated; use `::zcash_keys::keys` instead.")]
+pub mod keys {
+    pub use zcash_keys::keys::*;
+}
+#[deprecated(note = "use ::zcash_protocol::PoolType instead")]
+pub type PoolType = zcash_protocol::PoolType;
+#[deprecated(note = "use ::zcash_protocol::ShieldedProtocol instead")]
+pub type ShieldedProtocol = zcash_protocol::ShieldedProtocol;
+#[deprecated(note = "This module is deprecated; use the `zip321` crate instead.")]
+pub mod zip321 {
+    pub use zip321::*;
+}
 
 #[cfg(test)]
 #[macro_use]

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -61,18 +61,18 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
-pub use zcash_keys::address;
+//pub use zcash_keys::address;
 pub mod data_api;
 mod decrypt;
-pub use zcash_keys::encoding;
+//pub use zcash_keys::encoding;
 pub mod fees;
-pub use zcash_keys::keys;
+//pub use zcash_keys::keys;
 pub mod proposal;
 pub mod proto;
 pub mod scan;
 pub mod scanning;
 pub mod wallet;
-pub use zip321;
+//pub use zip321;
 
 #[cfg(feature = "sync")]
 pub mod sync;
@@ -84,7 +84,7 @@ pub mod serialization;
 pub mod tor;
 
 pub use decrypt::{decrypt_transaction, DecryptedOutput, TransferType};
-pub use zcash_protocol::{PoolType, ShieldedProtocol};
+//pub use zcash_protocol::{PoolType, ShieldedProtocol};
 
 #[cfg(test)]
 #[macro_use]

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -15,9 +15,10 @@ use subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
 use tracing::{debug, trace};
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_note_encryption::{batch, BatchDomain, Domain, ShieldedOutput, COMPACT_NOTE_SIZE};
-use zcash_primitives::{
+use zcash_primitives::transaction::{components::sapling::zip212_enforcement, TxId};
+use zcash_protocol::{
     consensus::{self, BlockHeight, NetworkUpgrade},
-    transaction::{components::sapling::zip212_enforcement, TxId},
+    ShieldedProtocol,
 };
 use zip32::Scope;
 
@@ -26,7 +27,6 @@ use crate::{
     proto::compact_formats::CompactBlock,
     scan::{Batch, BatchRunner, CompactDecryptor, DecryptedOutput, Tasks},
     wallet::{WalletOutput, WalletSpend, WalletTx},
-    ShieldedProtocol,
 };
 
 #[cfg(feature = "orchard")]
@@ -1167,10 +1167,12 @@ pub mod testing {
     };
     use zcash_note_encryption::{Domain, COMPACT_NOTE_SIZE};
     use zcash_primitives::{
-        block::BlockHash,
+        block::BlockHash, transaction::components::sapling::zip212_enforcement,
+    };
+    use zcash_protocol::{
         consensus::{BlockHeight, Network},
         memo::MemoBytes,
-        transaction::components::{amount::NonNegativeAmount, sapling::zip212_enforcement},
+        value::Zatoshis,
     };
 
     use crate::proto::compact_formats::{
@@ -1220,7 +1222,7 @@ pub mod testing {
         prev_hash: BlockHash,
         nf: Nullifier,
         dfvk: &DiversifiableFullViewingKey,
-        value: NonNegativeAmount,
+        value: Zatoshis,
         tx_after: bool,
         initial_tree_sizes: Option<(u32, u32)>,
     ) -> CompactBlock {
@@ -1304,12 +1306,12 @@ mod tests {
     use incrementalmerkletree::{Marking, Position, Retention};
     use sapling::Nullifier;
     use zcash_keys::keys::UnifiedSpendingKey;
-    use zcash_primitives::{
-        block::BlockHash,
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::{
         consensus::{BlockHeight, Network},
-        transaction::components::amount::NonNegativeAmount,
-        zip32::AccountId,
+        value::Zatoshis,
     };
+    use zip32::AccountId;
 
     use crate::{
         data_api::BlockMetadata,
@@ -1334,7 +1336,7 @@ mod tests {
                 BlockHash([0; 32]),
                 Nullifier([0; 32]),
                 &sapling_dfvk,
-                NonNegativeAmount::const_from_u64(5),
+                Zatoshis::const_from_u64(5),
                 false,
                 None,
             );
@@ -1420,7 +1422,7 @@ mod tests {
                 BlockHash([0; 32]),
                 Nullifier([0; 32]),
                 &sapling_dfvk,
-                NonNegativeAmount::const_from_u64(5),
+                Zatoshis::const_from_u64(5),
                 true,
                 Some((0, 0)),
             );
@@ -1500,7 +1502,7 @@ mod tests {
             BlockHash([0; 32]),
             nf,
             ufvk.sapling().unwrap(),
-            NonNegativeAmount::const_from_u64(5),
+            Zatoshis::const_from_u64(5),
             false,
             Some((0, 0)),
         );

--- a/zcash_client_backend/src/sync.rs
+++ b/zcash_client_backend/src/sync.rs
@@ -20,10 +20,10 @@ use tonic::{
     codegen::{Body, Bytes, StdError},
 };
 use tracing::{debug, info};
-use zcash_primitives::{
-    consensus::{BlockHeight, Parameters},
-    merkle_tree::HashSer,
-};
+
+use zcash_keys::encoding::AddressCodec as _;
+use zcash_primitives::merkle_tree::HashSer;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
 
 use crate::{
     data_api::{
@@ -43,10 +43,10 @@ use orchard::tree::MerkleHashOrchard;
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    crate::{encoding::AddressCodec, wallet::WalletTransparentOutput},
-    zcash_primitives::{
-        legacy::Script,
-        transaction::components::transparent::{OutPoint, TxOut},
+    crate::wallet::WalletTransparentOutput,
+    ::transparent::{
+        address::Script,
+        bundle::{OutPoint, TxOut},
     },
     zcash_protocol::{consensus::NetworkUpgrade, value::Zatoshis},
 };

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -33,6 +33,7 @@ zcash_keys = { workspace = true, features = ["sapling"] }
 zcash_primitives.workspace = true
 zcash_protocol.workspace = true
 zip32.workspace = true
+transparent.workspace = true
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -3,7 +3,7 @@
 use prost::Message;
 use rusqlite::params;
 
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 
 use zcash_client_backend::{data_api::chain::error::Error, proto::compact_formats::CompactBlock};
 

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -6,17 +6,16 @@ use std::fmt;
 use shardtree::error::ShardTreeError;
 use zcash_address::ParseError;
 use zcash_client_backend::data_api::NoteFilter;
-use zcash_client_backend::PoolType;
 use zcash_keys::keys::AddressGenerationError;
-use zcash_primitives::zip32;
-use zcash_primitives::{consensus::BlockHeight, transaction::components::amount::BalanceError};
+use zcash_protocol::{consensus::BlockHeight, value::BalanceError, PoolType};
+use zip32;
 
 use crate::{wallet::commitment_tree, AccountUuid};
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    zcash_client_backend::encoding::TransparentCodecError,
-    zcash_primitives::{legacy::TransparentAddress, transaction::TxId},
+    ::transparent::address::TransparentAddress, zcash_keys::encoding::TransparentCodecError,
+    zcash_primitives::transaction::TxId,
 };
 
 /// The primary error type for the SQLite wallet backend.
@@ -53,7 +52,7 @@ pub enum SqliteClientError {
     Io(std::io::Error),
 
     /// A received memo cannot be interpreted as a UTF-8 string.
-    InvalidMemo(zcash_primitives::memo::Error),
+    InvalidMemo(zcash_protocol::memo::Error),
 
     /// An attempt to update block data would overwrite the current hash for a block with a
     /// different hash. This indicates that a required rewind was not performed.
@@ -234,8 +233,8 @@ impl From<TransparentCodecError> for SqliteClientError {
     }
 }
 
-impl From<zcash_primitives::memo::Error> for SqliteClientError {
-    fn from(e: zcash_primitives::memo::Error) -> Self {
+impl From<zcash_protocol::memo::Error> for SqliteClientError {
+    fn from(e: zcash_protocol::memo::Error) -> Self {
         SqliteClientError::InvalidMemo(e)
     }
 }

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -8,7 +8,6 @@ use zcash_address::ParseError;
 use zcash_client_backend::data_api::NoteFilter;
 use zcash_keys::keys::AddressGenerationError;
 use zcash_protocol::{consensus::BlockHeight, value::BalanceError, PoolType};
-use zip32;
 
 use crate::{wallet::commitment_tree, AccountUuid};
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -75,7 +75,7 @@ use zcash_protocol::{
     value::Zatoshis,
     ShieldedProtocol,
 };
-use zip32::{self, fingerprint::SeedFingerprint, DiversifierIndex};
+use zip32::{fingerprint::SeedFingerprint, DiversifierIndex};
 
 use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore};
 
@@ -2257,7 +2257,6 @@ mod tests {
     pub(crate) fn fsblockdb_api() {
         use zcash_client_backend::data_api::testing::AddressType;
         use zcash_protocol::{consensus::NetworkConstants, value::Zatoshis};
-        use zip32;
 
         use crate::testing::FsBlockCache;
 

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -18,19 +18,20 @@ use zcash_client_backend::{
         testing::{DataStoreFactory, Reset, TestState},
         *,
     },
-    keys::UnifiedFullViewingKey,
     wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput},
-    ShieldedProtocol,
 };
 use zcash_keys::{
     address::UnifiedAddress,
-    keys::{UnifiedAddressRequest, UnifiedSpendingKey},
+    keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
 };
 use zcash_primitives::{
     block::BlockHash,
-    transaction::{components::amount::NonNegativeAmount, Transaction, TxId},
+    transaction::{Transaction, TxId},
 };
-use zcash_protocol::{consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo};
+use zcash_protocol::{
+    consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo, value::Zatoshis,
+    ShieldedProtocol,
+};
 
 use crate::{
     error::SqliteClientError,
@@ -41,8 +42,8 @@ use crate::{
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::TransparentAddressMetadata,
+    ::transparent::{address::TransparentAddress, bundle::OutPoint},
     core::ops::Range,
-    zcash_primitives::{legacy::TransparentAddress, transaction::components::OutPoint},
 };
 
 #[derive(Delegate)]

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -8,7 +8,6 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use zcash_client_backend::data_api::chain::CommitmentTreeRoot;
 
 use incrementalmerkletree::{Address, Hashable, Level, Position, Retention};
 use shardtree::{
@@ -17,9 +16,12 @@ use shardtree::{
     LocatedPrunableTree, LocatedTree, PrunableTree, RetentionFlags,
 };
 
-use zcash_primitives::{consensus::BlockHeight, merkle_tree::HashSer};
-
-use zcash_client_backend::serialization::shardtree::{read_shard, write_shard};
+use zcash_client_backend::{
+    data_api::chain::CommitmentTreeRoot,
+    serialization::shardtree::{read_shard, write_shard},
+};
+use zcash_primitives::merkle_tree::HashSer;
+use zcash_protocol::consensus::BlockHeight;
 
 /// Errors that can appear in SQLite-back [`ShardStore`] implementation operations.
 #[derive(Debug)]
@@ -1107,7 +1109,7 @@ mod tests {
         chain::CommitmentTreeRoot,
         testing::{pool::ShieldedPoolTester, sapling::SaplingPoolTester},
     };
-    use zcash_primitives::consensus::{BlockHeight, Network};
+    use zcash_protocol::consensus::{BlockHeight, Network};
 
     use super::SqliteShardStore;
     use crate::{testing::pool::ShieldedPoolPersistence, wallet::init::init_wallet_db, WalletDb};

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -10,11 +10,9 @@ use secrecy::SecretVec;
 use shardtree::error::ShardTreeError;
 use uuid::Uuid;
 
-use zcash_client_backend::{
-    data_api::{SeedRelevance, WalletRead},
-    keys::AddressGenerationError,
-};
-use zcash_primitives::{consensus, transaction::components::amount::BalanceError};
+use zcash_client_backend::data_api::{SeedRelevance, WalletRead};
+use zcash_keys::keys::AddressGenerationError;
+use zcash_protocol::{consensus, value::BalanceError};
 
 use self::migrations::verify_network_compatibility;
 
@@ -279,7 +277,7 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
 /// # use std::error::Error;
 /// # use secrecy::SecretVec;
 /// # use tempfile::NamedTempFile;
-/// use zcash_primitives::consensus::Network;
+/// use zcash_protocol::consensus::Network;
 /// use zcash_client_sqlite::{
 ///     WalletDb,
 ///     wallet::init::{WalletMigrationError, init_wallet_db},
@@ -440,19 +438,16 @@ mod tests {
 
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::{
+    use ::sapling::zip32::ExtendedFullViewingKey;
+    use zcash_client_backend::data_api::testing::TestBuilder;
+    use zcash_keys::{
         address::Address,
-        data_api::testing::TestBuilder,
         encoding::{encode_extended_full_viewing_key, encode_payment_address},
         keys::{sapling, UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
     };
-
-    use ::sapling::zip32::ExtendedFullViewingKey;
-    use zcash_primitives::{
-        consensus::{self, BlockHeight, BranchId, Network, NetworkConstants},
-        transaction::{TransactionData, TxVersion},
-        zip32::AccountId,
-    };
+    use zcash_primitives::transaction::{TransactionData, TxVersion};
+    use zcash_protocol::consensus::{self, BlockHeight, BranchId, Network, NetworkConstants};
+    use zip32::AccountId;
 
     use crate::{testing::db::TestDbFactory, wallet::db, WalletDb, UA_TRANSPARENT};
 
@@ -464,7 +459,7 @@ mod tests {
         crate::wallet::{self, pool_code, PoolType},
         zcash_address::test_vectors,
         zcash_client_backend::data_api::WalletWrite,
-        zcash_primitives::zip32::DiversifierIndex,
+        zip32::DiversifierIndex,
     };
 
     pub(crate) fn describe_tables(conn: &Connection) -> Result<Vec<String>, rusqlite::Error> {

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_primitives::consensus::{self, NetworkUpgrade};
+use zcash_protocol::consensus::{self, NetworkUpgrade};
 
 use crate::wallet::init::WalletMigrationError;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -5,12 +5,10 @@ use rusqlite::{self, types::ToSql, OptionalExtension};
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 
-use zcash_primitives::{
+use zcash_primitives::transaction::Transaction;
+use zcash_protocol::{
     consensus::BranchId,
-    transaction::{
-        components::amount::{Amount, BalanceError},
-        Transaction,
-    },
+    value::{BalanceError, ZatBalance},
 };
 
 use super::{add_utxo_account, sent_notes_to_internal};
@@ -105,7 +103,7 @@ impl RusqliteMigration for Migration {
                     op_amount.map_or_else(
                         || Err(FeeError::UtxoNotFound),
                         |i| {
-                            Amount::from_i64(i).map_err(|_| {
+                            ZatBalance::from_i64(i).map_err(|_| {
                                 FeeError::CorruptedData(format!(
                                     "UTXO amount out of range in outpoint {:?}",
                                     op
@@ -275,8 +273,9 @@ mod tests {
     use rusqlite::{self, params};
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::keys::UnifiedSpendingKey;
-    use zcash_primitives::{consensus::Network, zip32::AccountId};
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+    use zip32::AccountId;
 
     use crate::{
         wallet::init::{init_wallet_db_internal, migrations::addresses_table},
@@ -286,17 +285,16 @@ mod tests {
     #[cfg(feature = "transparent-inputs")]
     use {
         crate::wallet::init::migrations::{ufvk_support, utxos_table},
-        zcash_client_backend::encoding::AddressCodec,
-        zcash_primitives::{
+        ::transparent::{
+            address::Script,
+            bundle::{self as transparent, Authorized, OutPoint, TxIn, TxOut},
+            keys::IncomingViewingKey,
+        },
+        zcash_keys::encoding::AddressCodec,
+        zcash_primitives::transaction::{TransactionData, TxVersion},
+        zcash_protocol::{
             consensus::{BlockHeight, BranchId},
-            legacy::{keys::IncomingViewingKey, Script},
-            transaction::{
-                components::{
-                    transparent::{self, Authorized, OutPoint},
-                    Amount, TxIn, TxOut,
-                },
-                TransactionData, TxVersion,
-            },
+            value::ZatBalance,
         },
     };
 
@@ -394,10 +392,9 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn migrate_from_wm2() {
-        use zcash_client_backend::keys::UnifiedAddressRequest;
-        use zcash_primitives::{
-            legacy::keys::NonHardenedChildIndex, transaction::components::amount::NonNegativeAmount,
-        };
+        use ::transparent::keys::NonHardenedChildIndex;
+        use zcash_keys::keys::UnifiedAddressRequest;
+        use zcash_protocol::value::Zatoshis;
 
         use crate::UA_TRANSPARENT;
 
@@ -425,7 +422,7 @@ mod tests {
                     sequence: 0,
                 }],
                 vout: vec![TxOut {
-                    value: NonNegativeAmount::const_from_u64(1100000000),
+                    value: Zatoshis::const_from_u64(1100000000),
                     script_pubkey: Script(vec![]),
                 }],
                 authorization: Authorized,
@@ -486,10 +483,10 @@ mod tests {
         let fee = db_data
             .conn
             .query_row("SELECT fee FROM transactions WHERE id_tx = 0", [], |row| {
-                Ok(Amount::from_i64(row.get(0)?).unwrap())
+                Ok(ZatBalance::from_i64(row.get(0)?).unwrap())
             })
             .unwrap();
 
-        assert_eq!(fee, Amount::from_i64(300000000).unwrap());
+        assert_eq!(fee, ZatBalance::from_i64(300000000).unwrap());
     }
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -3,7 +3,7 @@
 use schemerz_rusqlite::RusqliteMigration;
 use std::collections::HashSet;
 use uuid::Uuid;
-use zcash_primitives::consensus;
+use zcash_protocol::consensus;
 
 use super::{addresses_table, utxos_table};
 use crate::wallet::init::WalletMigrationError;
@@ -11,16 +11,14 @@ use crate::wallet::init::WalletMigrationError;
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::error::SqliteClientError,
+    ::transparent::{
+        address::TransparentAddress,
+        keys::{IncomingViewingKey, NonHardenedChildIndex},
+    },
     rusqlite::{named_params, OptionalExtension},
     std::collections::HashMap,
-    zcash_client_backend::{
-        encoding::AddressCodec, keys::UnifiedFullViewingKey, wallet::TransparentAddressMetadata,
-    },
-    zcash_keys::address::Address,
-    zcash_primitives::legacy::{
-        keys::{IncomingViewingKey, NonHardenedChildIndex},
-        TransparentAddress,
-    },
+    zcash_client_backend::wallet::TransparentAddressMetadata,
+    zcash_keys::{address::Address, encoding::AddressCodec, keys::UnifiedFullViewingKey},
     zip32::{AccountId, DiversifierIndex, Scope},
 };
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -3,15 +3,15 @@ use std::collections::HashSet;
 use rusqlite::{named_params, Transaction};
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_client_backend::{address::Address, keys::UnifiedFullViewingKey};
+use zcash_keys::{address::Address, keys::UnifiedFullViewingKey};
 use zcash_keys::{address::UnifiedAddress, encoding::AddressCodec, keys::UnifiedAddressRequest};
-use zcash_primitives::consensus;
+use zcash_protocol::consensus;
 use zip32::{AccountId, DiversifierIndex};
 
 use crate::{wallet::init::WalletMigrationError, UA_TRANSPARENT};
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::legacy::keys::IncomingViewingKey;
+use ::transparent::keys::IncomingViewingKey;
 
 use super::ufvk_support;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
@@ -5,10 +5,8 @@ use rusqlite::named_params;
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 
-use zcash_client_backend::keys::{
-    UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey,
-};
-use zcash_primitives::consensus;
+use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey};
+use zcash_protocol::consensus;
 
 use super::orchard_received_notes;
 use crate::{wallet::init::WalletMigrationError, UA_ORCHARD, UA_TRANSPARENT};
@@ -92,9 +90,9 @@ mod tests {
     use secrecy::SecretVec;
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::keys::{UnifiedAddressRequest, UnifiedSpendingKey};
     use zcash_keys::address::Address;
-    use zcash_primitives::consensus::Network;
+    use zcash_keys::keys::{UnifiedAddressRequest, UnifiedSpendingKey};
+    use zcash_protocol::consensus::Network;
 
     use crate::{
         wallet::init::{init_wallet_db, init_wallet_db_internal, migrations::addresses_table},

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -87,21 +87,6 @@ mod tests {
 
     #[cfg(feature = "transparent-inputs")]
     use {
-        rusqlite::{named_params, Connection},
-        secrecy::{ExposeSecret, Secret, SecretVec},
-        tempfile::NamedTempFile,
-        zcash_client_backend::{
-            data_api::{AccountBirthday, AccountSource},
-            wallet::TransparentAddressMetadata,
-        },
-        zcash_keys::keys::UnifiedSpendingKey,
-        zcash_primitives::{block::BlockHash, legacy::keys::NonHardenedChildIndex},
-        zcash_protocol::consensus::Network,
-        zip32::{fingerprint::SeedFingerprint, AccountId as Zip32AccountId},
-    };
-
-    #[cfg(feature = "transparent-inputs")]
-    use {
         crate::{
             error::SqliteClientError,
             wallet::{
@@ -109,7 +94,19 @@ mod tests {
             },
             AccountRef, WalletDb,
         },
+        ::transparent::keys::NonHardenedChildIndex,
+        rusqlite::{named_params, Connection},
+        secrecy::{ExposeSecret, Secret, SecretVec},
+        tempfile::NamedTempFile,
         zcash_client_backend::data_api::GAP_LIMIT,
+        zcash_client_backend::{
+            data_api::{AccountBirthday, AccountSource},
+            wallet::TransparentAddressMetadata,
+        },
+        zcash_keys::keys::UnifiedSpendingKey,
+        zcash_primitives::block::BlockHash,
+        zcash_protocol::consensus::Network,
+        zip32::{fingerprint::SeedFingerprint, AccountId as Zip32AccountId},
     };
 
     /// This is a minimized copy of [`wallet::create_account`] as of the time of the

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
@@ -78,6 +78,7 @@ mod tests {
             testing::{db::TestDbFactory, BlockCache},
             wallet::init::init_wallet_db,
         },
+        ::transparent::bundle::{OutPoint, TxOut},
         zcash_client_backend::{
             data_api::{
                 testing::{
@@ -89,10 +90,7 @@ mod tests {
             fees::{standard, DustOutputPolicy, StandardFeeRule},
             wallet::WalletTransparentOutput,
         },
-        zcash_primitives::{
-            block::BlockHash,
-            transaction::components::{OutPoint, TxOut},
-        },
+        zcash_primitives::block::BlockHash,
         zcash_protocol::value::Zatoshis,
     };
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -1,21 +1,19 @@
 use std::{collections::HashSet, rc::Rc};
 
-use crate::wallet::{account_kind_code, init::WalletMigrationError};
 use rusqlite::{named_params, OptionalExtension, Transaction};
 use schemerz_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
-use zcash_client_backend::{
-    data_api::{AccountPurpose, AccountSource, Zip32Derivation},
-    keys::UnifiedSpendingKey,
-};
-use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::consensus;
+
+use zcash_client_backend::data_api::{AccountPurpose, AccountSource, Zip32Derivation};
+use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
+use zcash_protocol::consensus;
 use zip32::fingerprint::SeedFingerprint;
 
 use super::{
     add_account_birthdays, receiving_key_scopes, v_transactions_note_uniqueness, wallet_summaries,
 };
+use crate::wallet::{account_kind_code, init::WalletMigrationError};
 
 /// The migration that switched from presumed seed-derived account IDs to supporting
 /// HD accounts and all sorts of imported keys.

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
@@ -5,7 +5,8 @@ use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_client_backend::PoolType;
+
+use zcash_protocol::PoolType;
 
 use super::full_account_ids;
 use crate::wallet::{init::WalletMigrationError, pool_code};

--- a/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
@@ -226,8 +226,9 @@ mod tests {
     use rusqlite::{self, params};
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::keys::UnifiedSpendingKey;
-    use zcash_primitives::{consensus::Network, zip32::AccountId};
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+    use zip32::AccountId;
 
     use crate::{
         wallet::init::{init_wallet_db_internal, migrations::v_transactions_net},

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -317,7 +317,7 @@ mod tests {
         memo::MemoBytes,
         value::Zatoshis,
     };
-    use zip32::{self, Scope};
+    use zip32::Scope;
 
     use crate::{
         error::SqliteClientError,

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -7,8 +7,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use rusqlite::named_params;
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_client_backend::{decrypt_transaction, keys::UnifiedFullViewingKey};
-use zcash_primitives::{consensus, transaction::TxId, zip32::AccountId};
+
+use zcash_client_backend::decrypt_transaction;
+use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_protocol::{consensus, TxId};
+use zip32::AccountId;
 
 use crate::{
     error::SqliteClientError,

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -15,10 +15,8 @@ use zcash_client_backend::data_api::{
     scanning::{ScanPriority, ScanRange},
     SAPLING_SHARD_HEIGHT,
 };
-use zcash_primitives::{
-    consensus::{self, BlockHeight, NetworkUpgrade},
-    merkle_tree::{read_commitment_tree, read_incremental_witness},
-};
+use zcash_primitives::merkle_tree::{read_commitment_tree, read_incremental_witness};
+use zcash_protocol::consensus::{self, BlockHeight, NetworkUpgrade};
 
 use crate::{
     wallet::{

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -222,10 +222,12 @@ mod tests {
     use rusqlite::named_params;
     use secrecy::Secret;
     use tempfile::NamedTempFile;
-    use zcash_primitives::{
-        legacy::{Script, TransparentAddress},
-        transaction::{components::transparent, Authorized, TransactionData, TxVersion},
+
+    use ::transparent::{
+        address::{Script, TransparentAddress},
+        bundle::{OutPoint, TxIn, TxOut},
     };
+    use zcash_primitives::transaction::{Authorized, TransactionData, TxVersion};
     use zcash_protocol::{
         consensus::{BranchId, Network},
         value::Zatoshis,
@@ -278,17 +280,17 @@ mod tests {
             BranchId::Nu5,
             0,
             12345678.into(),
-            Some(transparent::Bundle {
-                vin: vec![transparent::TxIn {
-                    prevout: transparent::OutPoint::fake(),
+            Some(transparent::bundle::Bundle {
+                vin: vec![TxIn {
+                    prevout: OutPoint::fake(),
                     script_sig: Script(vec![]),
                     sequence: 0,
                 }],
-                vout: vec![transparent::TxOut {
+                vout: vec![TxOut {
                     value: Zatoshis::const_from_u64(10_000),
                     script_pubkey: TransparentAddress::PublicKeyHash([7; 20]).script(),
                 }],
-                authorization: transparent::Authorized,
+                authorization: transparent::bundle::Authorized,
             }),
             None,
             None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -6,15 +6,18 @@ use schemerz_rusqlite::RusqliteMigration;
 use secrecy::{ExposeSecret, SecretVec};
 use uuid::Uuid;
 
-use zcash_client_backend::{address::Address, keys::UnifiedSpendingKey, PoolType};
-use zcash_keys::keys::UnifiedAddressRequest;
-use zcash_primitives::{consensus, zip32::AccountId};
+use zcash_keys::{
+    address::Address,
+    keys::{UnifiedAddressRequest, UnifiedSpendingKey},
+};
+use zcash_protocol::{consensus, PoolType};
+use zip32::AccountId;
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_primitives::legacy::keys::IncomingViewingKey;
+use ::transparent::keys::IncomingViewingKey;
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_client_backend::encoding::AddressCodec;
+use zcash_keys::encoding::AddressCodec;
 
 use crate::{
     wallet::{

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
@@ -5,8 +5,9 @@ use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
+
 use zcash_client_backend::data_api::{scanning::ScanPriority, SAPLING_SHARD_HEIGHT};
-use zcash_primitives::consensus::{self, NetworkUpgrade};
+use zcash_protocol::consensus::{self, NetworkUpgrade};
 
 use crate::wallet::{init::WalletMigrationError, scanning::priority_code};
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -5,7 +5,8 @@ use std::collections::HashSet;
 use rusqlite::named_params;
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_client_backend::PoolType;
+
+use zcash_protocol::PoolType;
 
 use super::add_transaction_views;
 use crate::wallet::{init::WalletMigrationError, pool_code};
@@ -206,8 +207,9 @@ mod tests {
     use rusqlite::{self, params};
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::keys::UnifiedSpendingKey;
-    use zcash_primitives::{consensus::Network, zip32::AccountId};
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+    use zip32::AccountId;
 
     use crate::{
         wallet::init::{init_wallet_db_internal, migrations::add_transaction_views},

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
@@ -163,8 +163,9 @@ mod tests {
     use rusqlite::{self, params};
     use tempfile::NamedTempFile;
 
-    use zcash_client_backend::keys::UnifiedSpendingKey;
-    use zcash_primitives::{consensus::Network, zip32::AccountId};
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+    use zip32::AccountId;
 
     use crate::{
         wallet::init::{init_wallet_db_internal, migrations::v_transactions_net},

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -10,7 +10,7 @@ use rusqlite::{named_params, types::Value, Connection, Row, Transaction};
 use zcash_client_backend::{
     data_api::NullifierQuery,
     wallet::{ReceivedNote, WalletOrchardOutput},
-    DecryptedOutput, ShieldedProtocol, TransferType,
+    DecryptedOutput, TransferType,
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::TxId;
@@ -18,6 +18,7 @@ use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::Zatoshis,
+    ShieldedProtocol,
 };
 use zip32::Scope;
 

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -10,13 +10,15 @@ use sapling::{self, Diversifier, Nullifier, Rseed};
 use zcash_client_backend::{
     data_api::NullifierQuery,
     wallet::{ReceivedNote, WalletSaplingOutput},
-    DecryptedOutput, ShieldedProtocol, TransferType,
+    DecryptedOutput, TransferType,
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::transaction::{components::amount::NonNegativeAmount, TxId};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
+    value::Zatoshis,
+    ShieldedProtocol,
 };
 use zip32::Scope;
 
@@ -219,7 +221,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
-    target_value: NonNegativeAmount,
+    target_value: Zatoshis,
     anchor_height: BlockHeight,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {

--- a/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
@@ -4,16 +4,14 @@ use std::ops::Range;
 
 use rusqlite::{named_params, OptionalExtension};
 
+use ::transparent::{
+    address::TransparentAddress,
+    keys::{EphemeralIvk, NonHardenedChildIndex, TransparentKeyScope},
+};
 use zcash_client_backend::{data_api::GAP_LIMIT, wallet::TransparentAddressMetadata};
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_keys::{encoding::AddressCodec, keys::AddressGenerationError};
-use zcash_primitives::{
-    legacy::{
-        keys::{EphemeralIvk, NonHardenedChildIndex, TransparentKeyScope},
-        TransparentAddress,
-    },
-    transaction::TxId,
-};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus;
 
 use crate::wallet::{self, get_account_ref};

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,28 @@ and this library adheres to Rust's notion of
 ### Changed
 - Migrated to `nonempty 0.11`
 
+### Deprecated
+- `zcash_primitives::consensus` (use `zcash_protocol::consensus` instead)
+- `zcash_primitives::constants` (use `zcash_protocol::constants` instead)
+- `zcash_primitives::memo` (use `zcash_protocol::memo` instead)
+- `zcash_primitives::zip32` (use the `zip32` crate instead)
+- `zcash_primitives::legacy` (use the `zcash_transparent` crate instead)
+- `zcash_primitives::transaction::components::Amount` (use `zcash_protocol::value::ZatBalance` instead)
+- `zcash_primitives::transaction::components::amount`:
+  - `BalanceError` (use `zcash_protocol::value::BalanceError` instead)
+  - `Amount` (use `zcash_protocol::value::ZatBalance` instead)
+  - `NonNegativeAmount` (use `zcash_protocol::value::Zatoshis` instead)
+  - `COIN` (use `zcash_protocol::value::COIN` instead)
+  - module `testing` (use `zcash_protocol::value::testing` instead)
+    - `arb_positive_amount` (use `zcash_protocol::value::testing::arb_positive_zat_balance` instead.)
+    - `arb_amount` (use `zcash_protocol::value::testing::arb_zat_balance` instead.)
+    - `arb_nonnegative_amount` (use `::zcash_protocol::value::testing::arb_zatoshis` instead.)
+
+### Removed
+- `zcash_primitives::transaction::sighash::TransparentAuthorizingContext` was
+  removed as there is no way to deprecate a previously-reexported trait name.
+  Use `zcash_transparent::sighash::TransparentAuthorizingContext` instead.
+
 ## [0.21.0] - 2024-12-16
 
 ### Added

--- a/zcash_primitives/benches/note_decryption.rs
+++ b/zcash_primitives/benches/note_decryption.rs
@@ -14,9 +14,10 @@ use sapling::{
     Diversifier, SaplingIvk,
 };
 use zcash_note_encryption::batch;
-use zcash_primitives::{
+use zcash_primitives::transaction::components::sapling::zip212_enforcement;
+use zcash_protocol::{
     consensus::{NetworkUpgrade::Canopy, Parameters, TEST_NETWORK},
-    transaction::components::{sapling::zip212_enforcement, Amount},
+    value::ZatBalance,
 };
 
 #[cfg(unix)]
@@ -46,7 +47,7 @@ fn bench_note_decryption(c: &mut Criterion) {
             .add_output(None, pa, NoteValue::from_raw(100), None)
             .unwrap();
         let (bundle, _) = builder
-            .build::<MockSpendProver, MockOutputProver, _, Amount>(&[], &mut rng)
+            .build::<MockSpendProver, MockOutputProver, _, ZatBalance>(&[], &mut rng)
             .unwrap()
             .unwrap();
         bundle.shielded_outputs()[0].clone()

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -18,17 +18,33 @@
 #![allow(clippy::single_component_path_imports)]
 
 pub mod block;
-//pub use zcash_protocol::consensus;
-//pub use zcash_protocol::constants;
-//pub use zcash_protocol::memo;
-pub mod merkle_tree;
-pub mod transaction;
-//pub use zip32;
 #[cfg(zcash_unstable = "zfuture")]
 pub mod extensions;
+pub mod merkle_tree;
+pub mod transaction;
 
-//pub mod legacy {
-//    pub use transparent::address::*;
-//    #[cfg(feature = "transparent-inputs")]
-//    pub use transparent::keys;
-//}
+#[deprecated(note = "This module is deprecated; use `::zcash_protocol::consensus` instead.")]
+pub mod consensus {
+    pub use zcash_protocol::consensus::*;
+}
+#[deprecated(note = "This module is deprecated; use `::zcash_protocol::constants` instead.")]
+pub mod constants {
+    pub use zcash_protocol::constants::*;
+}
+#[deprecated(note = "This module is deprecated; use `::zcash_protocol::memo` instead.")]
+pub mod memo {
+    pub use zcash_protocol::memo::*;
+}
+#[deprecated(note = "This module is deprecated; use the `zip32` crate instead.")]
+pub mod zip32 {
+    pub use zip32::*;
+}
+#[deprecated(note = "This module is deprecated; use the `zcash_transparent` crate instead.")]
+pub mod legacy {
+    pub use transparent::address::*;
+    #[cfg(feature = "transparent-inputs")]
+    #[deprecated(note = "This module is deprecated; use `::zcash_transparent::keys` instead.")]
+    pub mod keys {
+        pub use transparent::keys::*;
+    }
+}

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -18,18 +18,17 @@
 #![allow(clippy::single_component_path_imports)]
 
 pub mod block;
-pub use zcash_protocol::consensus;
-pub use zcash_protocol::constants;
-pub use zcash_protocol::memo;
+//pub use zcash_protocol::consensus;
+//pub use zcash_protocol::constants;
+//pub use zcash_protocol::memo;
 pub mod merkle_tree;
-use sapling;
 pub mod transaction;
-pub use zip32;
+//pub use zip32;
 #[cfg(zcash_unstable = "zfuture")]
 pub mod extensions;
 
-pub mod legacy {
-    pub use transparent::address::*;
-    #[cfg(feature = "transparent-inputs")]
-    pub use transparent::keys;
-}
+//pub mod legacy {
+//    pub use transparent::address::*;
+//    #[cfg(feature = "transparent-inputs")]
+//    pub use transparent::keys;
+//}

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -10,8 +10,6 @@ use orchard::tree::MerkleHashOrchard;
 use std::io::{self, Read, Write};
 use zcash_encoding::{Optional, Vector};
 
-use crate::sapling;
-
 /// A hashable node within a Merkle tree.
 pub trait HashSer {
     /// Parses a node from the given byte source.
@@ -350,7 +348,7 @@ mod tests {
         read_incremental_witness, write_commitment_tree, write_frontier_v1,
         write_incremental_witness, CommitmentTree, HashSer,
     };
-    use crate::sapling::{self, Node};
+    use ::sapling::{self, Node};
 
     proptest! {
         #[test]

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::sync::mpsc::Sender;
 
 use ::sapling::{
-    self,
     builder::SaplingMetadata,
     prover::{OutputProver, SpendProver},
     Note, PaymentAddress,
@@ -994,10 +993,7 @@ mod testing {
     use rand::RngCore;
     use rand_core::CryptoRng;
 
-    use ::sapling::{
-        self,
-        prover::mock::{MockOutputProver, MockSpendProver},
-    };
+    use ::sapling::prover::mock::{MockOutputProver, MockSpendProver};
     use ::transparent::builder::TransparentSigningSet;
     use zcash_protocol::consensus;
 
@@ -1060,7 +1056,7 @@ mod tests {
     use super::{Builder, Error};
     use crate::transaction::builder::BuildConfig;
 
-    use ::sapling::{self, zip32::ExtendedSpendingKey, Node, Rseed};
+    use ::sapling::{zip32::ExtendedSpendingKey, Node, Rseed};
     use ::transparent::{address::TransparentAddress, builder::TransparentSigningSet};
     use zcash_protocol::{
         consensus::{NetworkUpgrade, Parameters, TEST_NETWORK},

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -1,35 +1,35 @@
 //! Structs representing the components within Zcash transactions.
-pub mod amount {
-    pub use zcash_protocol::value::{
-        BalanceError, ZatBalance as Amount, Zatoshis as NonNegativeAmount, COIN,
-    };
-
-    #[cfg(any(test, feature = "test-dependencies"))]
-    pub mod testing {
-        pub use zcash_protocol::value::testing::{
-            arb_positive_zat_balance as arb_positive_amount, arb_zat_balance as arb_amount,
-            arb_zatoshis as arb_nonnegative_amount,
-        };
-    }
-}
+//pub mod amount {
+//    pub use zcash_protocol::value::{
+//        BalanceError, ZatBalance as Amount, Zatoshis as NonNegativeAmount, COIN,
+//    };
+//
+//    #[cfg(any(test, feature = "test-dependencies"))]
+//    pub mod testing {
+//        pub use zcash_protocol::value::testing::{
+//            arb_positive_zat_balance as arb_positive_amount, arb_zat_balance as arb_amount,
+//            arb_zatoshis as arb_nonnegative_amount,
+//        };
+//    }
+//}
 pub mod orchard;
 pub mod sapling;
 pub mod sprout;
 #[cfg(zcash_unstable = "zfuture")]
 pub mod tze;
 
-pub mod transparent {
-    pub use transparent::builder;
-    pub use transparent::bundle::*;
-    pub use transparent::pczt;
-}
+//pub mod transparent {
+//    pub use transparent::builder;
+//    pub use transparent::bundle::*;
+//    pub use transparent::pczt;
+//}
 
 pub use self::{
-    amount::Amount,
+    //    amount::Amount,
     sprout::JsDescription,
-    transparent::{OutPoint, TxIn, TxOut},
+    //    transparent::{OutPoint, TxIn, TxOut},
 };
-pub use crate::sapling::bundle::{OutputDescription, SpendDescription};
+//pub use crate::sapling::bundle::{OutputDescription, SpendDescription};
 
 #[cfg(zcash_unstable = "zfuture")]
 pub use self::tze::{TzeIn, TzeOut};

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -1,35 +1,58 @@
 //! Structs representing the components within Zcash transactions.
-//pub mod amount {
-//    pub use zcash_protocol::value::{
-//        BalanceError, ZatBalance as Amount, Zatoshis as NonNegativeAmount, COIN,
-//    };
-//
-//    #[cfg(any(test, feature = "test-dependencies"))]
-//    pub mod testing {
-//        pub use zcash_protocol::value::testing::{
-//            arb_positive_zat_balance as arb_positive_amount, arb_zat_balance as arb_amount,
-//            arb_zatoshis as arb_nonnegative_amount,
-//        };
-//    }
-//}
 pub mod orchard;
 pub mod sapling;
 pub mod sprout;
 #[cfg(zcash_unstable = "zfuture")]
 pub mod tze;
 
-//pub mod transparent {
-//    pub use transparent::builder;
-//    pub use transparent::bundle::*;
-//    pub use transparent::pczt;
-//}
+pub use self::sprout::JsDescription;
 
-pub use self::{
-    //    amount::Amount,
-    sprout::JsDescription,
-    //    transparent::{OutPoint, TxIn, TxOut},
-};
-//pub use crate::sapling::bundle::{OutputDescription, SpendDescription};
+#[deprecated(note = "This module is deprecated; use `::zcash_protocol::value` instead.")]
+pub mod amount {
+    #[deprecated(note = "Use `::zcash_protocol::value::BalanceError` instead.")]
+    pub type BalanceError = zcash_protocol::value::BalanceError;
+    #[deprecated(note = "Use `::zcash_protocol::value::ZatBalance` instead.")]
+    pub type Amount = zcash_protocol::value::ZatBalance;
+    #[deprecated(note = "Use `::zcash_protocol::value::Zatoshis` instead.")]
+    pub type NonNegativeAmount = zcash_protocol::value::Zatoshis;
+    #[deprecated(note = "Use `::zcash_protocol::value::COIN` instead.")]
+    pub const COIN: u64 = zcash_protocol::value::COIN;
+
+    #[cfg(any(test, feature = "test-dependencies"))]
+    #[deprecated(note = "Use `::zcash_protocol::value::testing` instead.")]
+    pub mod testing {
+        pub use zcash_protocol::value::testing::arb_positive_zat_balance as arb_positive_amount;
+        pub use zcash_protocol::value::testing::arb_zat_balance as arb_amount;
+        pub use zcash_protocol::value::testing::arb_zatoshis as arb_nonnegative_amount;
+    }
+}
+
+#[deprecated(note = "This module is deprecated; use the `zcash_transparent` crate instead.")]
+pub mod transparent {
+    #[deprecated(note = "This module is deprecated; use `::zcash_transparent::builder` instead.")]
+    pub mod builder {
+        pub use ::transparent::builder::*;
+    }
+    pub use ::transparent::bundle::*;
+    #[deprecated(note = "This module is deprecated; use `::zcash_transparent::pczt` instead.")]
+    pub mod pczt {
+        pub use ::transparent::pczt::*;
+    }
+}
+
+#[deprecated(note = "use `::zcash_transparent::bundle::OutPoint` instead.")]
+pub type OutPoint = ::transparent::bundle::OutPoint;
+#[deprecated(note = "use `::zcash_transparent::bundle::TxIn` instead.")]
+pub type TxIn<A> = ::transparent::bundle::TxIn<A>;
+#[deprecated(note = "use `::zcash_transparent::bundle::TxIn` instead.")]
+pub type TxOut = ::transparent::bundle::TxOut;
+#[deprecated(note = "use `::zcash_protocol::value::ZatBalance` instead.")]
+pub type Amount = zcash_protocol::value::ZatBalance;
+
+#[deprecated(note = "Use `::sapling_crypto::bundle::OutputDescription` instead.")]
+pub type OutputDescription<A> = ::sapling::bundle::OutputDescription<A>;
+#[deprecated(note = "Use `::sapling_crypto::bundle::SpendDescription` instead.")]
+pub type SpendDescription<A> = ::sapling::bundle::SpendDescription<A>;
 
 #[cfg(zcash_unstable = "zfuture")]
 pub use self::tze::{TzeIn, TzeOut};

--- a/zcash_primitives/src/transaction/components/sprout.rs
+++ b/zcash_primitives/src/transaction/components/sprout.rs
@@ -2,7 +2,8 @@
 
 use std::io::{self, Read, Write};
 
-use super::{amount::Amount, GROTH_PROOF_SIZE};
+use super::GROTH_PROOF_SIZE;
+use zcash_protocol::value::ZatBalance;
 
 // π_A + π_A' + π_B + π_B' + π_C + π_C' + π_K + π_H
 const PHGR_PROOF_SIZE: usize = 33 + 33 + 65 + 33 + 33 + 33 + 33 + 33;
@@ -22,10 +23,10 @@ impl Bundle {
     /// its value is added to the transparent value pool; when it
     /// is negative, its value is subtracted from the transparent
     /// value pool.
-    pub fn value_balance(&self) -> Option<Amount> {
+    pub fn value_balance(&self) -> Option<ZatBalance> {
         self.joinsplits
             .iter()
-            .try_fold(Amount::zero(), |total, js| total + js.net_value())
+            .try_fold(ZatBalance::zero(), |total, js| total + js.net_value())
     }
 }
 
@@ -47,8 +48,8 @@ impl std::fmt::Debug for SproutProof {
 
 #[derive(Clone)]
 pub struct JsDescription {
-    pub(crate) vpub_old: Amount,
-    pub(crate) vpub_new: Amount,
+    pub(crate) vpub_old: ZatBalance,
+    pub(crate) vpub_new: ZatBalance,
     pub(crate) anchor: [u8; 32],
     pub(crate) nullifiers: [[u8; 32]; ZC_NUM_JS_INPUTS],
     pub(crate) commitments: [[u8; 32]; ZC_NUM_JS_OUTPUTS],
@@ -89,7 +90,7 @@ impl JsDescription {
         let vpub_old = {
             let mut tmp = [0u8; 8];
             reader.read_exact(&mut tmp)?;
-            Amount::from_u64_le_bytes(tmp)
+            ZatBalance::from_u64_le_bytes(tmp)
         }
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "vpub_old out of range"))?;
 
@@ -97,7 +98,7 @@ impl JsDescription {
         let vpub_new = {
             let mut tmp = [0u8; 8];
             reader.read_exact(&mut tmp)?;
-            Amount::from_u64_le_bytes(tmp)
+            ZatBalance::from_u64_le_bytes(tmp)
         }
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "vpub_new out of range"))?;
 
@@ -189,7 +190,7 @@ impl JsDescription {
     /// its value is added to the transparent value pool; when it
     /// is negative, its value is subtracted from the transparent
     /// value pool.
-    pub fn net_value(&self) -> Amount {
+    pub fn net_value(&self) -> ZatBalance {
         (self.vpub_new - self.vpub_old).expect("difference is in range [-MAX_MONEY..=MAX_MONEY]")
     }
 }

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -1,8 +1,9 @@
 //! Abstractions and types related to fee calculations.
 
-use crate::{
+use crate::transaction::fees::transparent::InputSize;
+use zcash_protocol::{
     consensus::{self, BlockHeight},
-    transaction::{components::amount::NonNegativeAmount, fees::transparent::InputSize},
+    value::Zatoshis,
 };
 
 #[cfg(feature = "non-standard-fees")]
@@ -33,7 +34,7 @@ pub trait FeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
-    ) -> Result<NonNegativeAmount, Self::Error>;
+    ) -> Result<Zatoshis, Self::Error>;
 }
 
 /// A trait that represents the ability to compute the fees that must be paid by a transaction
@@ -57,5 +58,5 @@ pub trait FutureFeeRule: FeeRule {
         orchard_action_count: usize,
         tze_inputs: &[impl tze::InputView],
         tze_outputs: &[impl tze::OutputView],
-    ) -> Result<NonNegativeAmount, Self::Error>;
+    ) -> Result<Zatoshis, Self::Error>;
 }

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,8 @@
-use crate::{
+use crate::transaction::fees::transparent;
+
+use zcash_protocol::{
     consensus::{self, BlockHeight},
-    transaction::components::amount::NonNegativeAmount,
-    transaction::fees::transparent,
+    value::Zatoshis,
 };
 
 #[cfg(zcash_unstable = "zfuture")]
@@ -11,17 +12,17 @@ use crate::transaction::fees::tze;
 /// the transaction being constructed.
 #[derive(Clone, Copy, Debug)]
 pub struct FeeRule {
-    fixed_fee: NonNegativeAmount,
+    fixed_fee: Zatoshis,
 }
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
-    pub fn non_standard(fixed_fee: NonNegativeAmount) -> Self {
+    pub fn non_standard(fixed_fee: Zatoshis) -> Self {
         Self { fixed_fee }
     }
 
     /// Returns the fixed fee amount which this rule was configured.
-    pub fn fixed_fee(&self) -> NonNegativeAmount {
+    pub fn fixed_fee(&self) -> Zatoshis {
         self.fixed_fee
     }
 }
@@ -38,7 +39,7 @@ impl super::FeeRule for FeeRule {
         _sapling_input_count: usize,
         _sapling_output_count: usize,
         _orchard_action_count: usize,
-    ) -> Result<NonNegativeAmount, Self::Error> {
+    ) -> Result<Zatoshis, Self::Error> {
         Ok(self.fixed_fee)
     }
 }
@@ -56,7 +57,7 @@ impl super::FutureFeeRule for FeeRule {
         _orchard_action_count: usize,
         _tze_inputs: &[impl tze::InputView],
         _tze_outputs: &[impl tze::OutputView],
-    ) -> Result<NonNegativeAmount, Self::Error> {
+    ) -> Result<Zatoshis, Self::Error> {
         Ok(self.fixed_fee)
     }
 }

--- a/zcash_primitives/src/transaction/fees/transparent.rs
+++ b/zcash_primitives/src/transaction/fees/transparent.rs
@@ -3,16 +3,15 @@
 
 use std::convert::Infallible;
 
-use crate::{
-    legacy::{Script, TransparentAddress},
-    transaction::{
-        components::{amount::NonNegativeAmount, transparent::TxOut, OutPoint},
-        fees::zip317::P2PKH_STANDARD_INPUT_SIZE,
-    },
+use crate::transaction::fees::zip317::P2PKH_STANDARD_INPUT_SIZE;
+use transparent::{
+    address::{Script, TransparentAddress},
+    bundle::{OutPoint, TxOut},
 };
+use zcash_protocol::value::Zatoshis;
 
 #[cfg(feature = "transparent-inputs")]
-use crate::transaction::components::transparent::builder::TransparentInputInfo;
+use transparent::builder::TransparentInputInfo;
 
 /// The size of a transparent input, or the outpoint corresponding to the input
 /// if the size of the script required to spend that input is unknown.
@@ -72,7 +71,7 @@ impl InputView for Infallible {
 /// fee and change computation.
 pub trait OutputView: std::fmt::Debug {
     /// Returns the value of the output being created.
-    fn value(&self) -> NonNegativeAmount;
+    fn value(&self) -> Zatoshis;
 
     /// Returns the script corresponding to the newly created output.
     fn script_pubkey(&self) -> &Script;
@@ -86,7 +85,7 @@ pub trait OutputView: std::fmt::Debug {
 }
 
 impl OutputView for TxOut {
-    fn value(&self) -> NonNegativeAmount {
+    fn value(&self) -> Zatoshis {
         self.value
     }
 

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -4,21 +4,18 @@
 //! [ZIP 317]: https//zips.z.cash/zip-0317
 use core::cmp::max;
 
-use crate::{
+use ::transparent::bundle::OutPoint;
+use zcash_protocol::{
     consensus::{self, BlockHeight},
-    transaction::{
-        components::{
-            amount::{BalanceError, NonNegativeAmount},
-            transparent::OutPoint,
-        },
-        fees::transparent,
-    },
+    value::{BalanceError, Zatoshis},
 };
+
+use crate::transaction::fees::transparent;
 
 /// The standard [ZIP 317] marginal fee.
 ///
 /// [ZIP 317]: https//zips.z.cash/zip-0317
-pub const MARGINAL_FEE: NonNegativeAmount = NonNegativeAmount::const_from_u64(5_000);
+pub const MARGINAL_FEE: Zatoshis = Zatoshis::const_from_u64(5_000);
 
 /// The minimum number of logical actions that must be paid according to [ZIP 317].
 ///
@@ -39,7 +36,7 @@ pub const P2PKH_STANDARD_OUTPUT_SIZE: usize = 34;
 /// `MARGINAL_FEE * GRACE_ACTIONS`.
 ///
 /// [ZIP 317]: https//zips.z.cash/zip-0317
-pub const MINIMUM_FEE: NonNegativeAmount = NonNegativeAmount::const_from_u64(10_000);
+pub const MINIMUM_FEE: Zatoshis = Zatoshis::const_from_u64(10_000);
 
 /// A [`FeeRule`] implementation that implements the [ZIP 317] fee rule.
 ///
@@ -55,7 +52,7 @@ pub const MINIMUM_FEE: NonNegativeAmount = NonNegativeAmount::const_from_u64(10_
 /// [ZIP 317]: https//zips.z.cash/zip-0317
 #[derive(Clone, Debug)]
 pub struct FeeRule {
-    marginal_fee: NonNegativeAmount,
+    marginal_fee: Zatoshis,
     grace_actions: usize,
     p2pkh_standard_input_size: usize,
     p2pkh_standard_output_size: usize,
@@ -88,7 +85,7 @@ impl FeeRule {
     /// zero.
     #[cfg(feature = "non-standard-fees")]
     pub fn non_standard(
-        marginal_fee: NonNegativeAmount,
+        marginal_fee: Zatoshis,
         grace_actions: usize,
         p2pkh_standard_input_size: usize,
         p2pkh_standard_output_size: usize,
@@ -106,7 +103,7 @@ impl FeeRule {
     }
 
     /// Returns the ZIP 317 marginal fee.
-    pub fn marginal_fee(&self) -> NonNegativeAmount {
+    pub fn marginal_fee(&self) -> Zatoshis {
         self.marginal_fee
     }
     /// Returns the ZIP 317 number of grace actions
@@ -164,7 +161,7 @@ impl super::FeeRule for FeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
-    ) -> Result<NonNegativeAmount, Self::Error> {
+    ) -> Result<Zatoshis, Self::Error> {
         let mut t_in_total_size: usize = 0;
         let mut non_p2pkh_outpoints = vec![];
         for sz in transparent_input_sizes.into_iter() {

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-use ::sapling::{self, builder as sapling_builder};
+use ::sapling::builder as sapling_builder;
 use ::transparent::bundle::{self as transparent, OutPoint, TxIn, TxOut};
 use zcash_encoding::{CompactSize, Vector};
 use zcash_protocol::{

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -4,7 +4,7 @@ use super::{
     sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash, Authorization, TransactionData,
     TxDigests, TxVersion,
 };
-use ::sapling::{self, bundle::GrothProofBytes};
+use ::sapling::bundle::GrothProofBytes;
 
 #[cfg(zcash_unstable = "zfuture")]
 use {crate::extensions::transparent::Precondition, zcash_protocol::value::Zatoshis};

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -9,7 +9,19 @@ use ::sapling::{self, bundle::GrothProofBytes};
 #[cfg(zcash_unstable = "zfuture")]
 use {crate::extensions::transparent::Precondition, zcash_protocol::value::Zatoshis};
 
-//pub use transparent::sighash::*;
+#[deprecated(note = "use `::zcash_transparent::sighash::SIGHASH_ALL` instead.")]
+pub const SIGHASH_ALL: u8 = ::transparent::sighash::SIGHASH_ALL;
+#[deprecated(note = "use `::zcash_transparent::sighash::SIGHASH_NONE` instead.")]
+pub const SIGHASH_NONE: u8 = ::transparent::sighash::SIGHASH_NONE;
+#[deprecated(note = "use `::zcash_transparent::sighash::SIGHASH_SINGLE` instead.")]
+pub const SIGHASH_SINGLE: u8 = ::transparent::sighash::SIGHASH_SINGLE;
+#[deprecated(note = "use `::zcash_transparent::sighash::SIGHASH_MASK` instead.")]
+pub const SIGHASH_MASK: u8 = ::transparent::sighash::SIGHASH_MASK;
+#[deprecated(note = "use `::zcash_transparent::sighash::SIGHASH_ANYONECANPAY` instead.")]
+pub const SIGHASH_ANYONECANPAY: u8 = ::transparent::sighash::SIGHASH_ANYONECANPAY;
+
+#[deprecated(note = "use `::zcash_transparent::sighash::SighashType` instead.")]
+pub type SighashType = ::transparent::sighash::SighashType;
 
 pub enum SignableInput<'a> {
     Shielded,

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -4,12 +4,12 @@ use super::{
     sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash, Authorization, TransactionData,
     TxDigests, TxVersion,
 };
-use crate::sapling::{self, bundle::GrothProofBytes};
+use ::sapling::{self, bundle::GrothProofBytes};
 
 #[cfg(zcash_unstable = "zfuture")]
-use {super::components::Amount, crate::extensions::transparent::Precondition};
+use {crate::extensions::transparent::Precondition, zcash_protocol::value::Zatoshis};
 
-pub use transparent::sighash::*;
+//pub use transparent::sighash::*;
 
 pub enum SignableInput<'a> {
     Shielded,
@@ -18,17 +18,17 @@ pub enum SignableInput<'a> {
     Tze {
         index: usize,
         precondition: &'a Precondition,
-        value: Amount,
+        value: Zatoshis,
     },
 }
 
 impl<'a> SignableInput<'a> {
     pub fn hash_type(&self) -> u8 {
         match self {
-            SignableInput::Shielded => SIGHASH_ALL,
+            SignableInput::Shielded => ::transparent::sighash::SIGHASH_ALL,
             SignableInput::Transparent(input) => input.hash_type().encode(),
             #[cfg(zcash_unstable = "zfuture")]
-            SignableInput::Tze { .. } => SIGHASH_ALL,
+            SignableInput::Tze { .. } => ::transparent::sighash::SIGHASH_ALL,
         }
     }
 }
@@ -46,7 +46,7 @@ impl AsRef<[u8; 32]> for SignatureHash {
 /// set of precomputed hashes produced in the construction of the
 /// transaction ID.
 pub fn signature_hash<
-    TA: TransparentAuthorizingContext,
+    TA: ::transparent::sighash::TransparentAuthorizingContext,
     SA: sapling::bundle::Authorization<SpendProof = GrothProofBytes, OutputProof = GrothProofBytes>,
     A: Authorization<SaplingAuth = SA, TransparentAuth = TA>,
 >(

--- a/zcash_primitives/src/transaction/sighash_v4.rs
+++ b/zcash_primitives/src/transaction/sighash_v4.rs
@@ -1,10 +1,7 @@
 use blake2b_simd::{Hash as Blake2bHash, Params as Blake2bParams};
 use ff::PrimeField;
 
-use ::sapling::{
-    self,
-    bundle::{GrothProofBytes, OutputDescription, SpendDescription},
-};
+use ::sapling::bundle::{GrothProofBytes, OutputDescription, SpendDescription};
 use ::transparent::{
     bundle::{self as transparent, TxIn, TxOut},
     sighash::{SIGHASH_ANYONECANPAY, SIGHASH_MASK, SIGHASH_NONE, SIGHASH_SINGLE},

--- a/zcash_primitives/src/transaction/sighash_v4.rs
+++ b/zcash_primitives/src/transaction/sighash_v4.rs
@@ -1,21 +1,19 @@
 use blake2b_simd::{Hash as Blake2bHash, Params as Blake2bParams};
 use ff::PrimeField;
 
-use crate::{
-    consensus::BranchId,
-    sapling::{
-        self,
-        bundle::{GrothProofBytes, OutputDescription, SpendDescription},
-    },
+use ::sapling::{
+    self,
+    bundle::{GrothProofBytes, OutputDescription, SpendDescription},
 };
+use ::transparent::{
+    bundle::{self as transparent, TxIn, TxOut},
+    sighash::{SIGHASH_ANYONECANPAY, SIGHASH_MASK, SIGHASH_NONE, SIGHASH_SINGLE},
+};
+use zcash_protocol::consensus::BranchId;
 
 use super::{
-    components::{
-        sapling as sapling_serialization,
-        sprout::JsDescription,
-        transparent::{self, TxIn, TxOut},
-    },
-    sighash::{SignableInput, SIGHASH_ANYONECANPAY, SIGHASH_MASK, SIGHASH_NONE, SIGHASH_SINGLE},
+    components::{sapling as sapling_serialization, sprout::JsDescription},
+    sighash::SignableInput,
     Authorization, TransactionData,
 };
 

--- a/zcash_primitives/src/transaction/sighash_v5.rs
+++ b/zcash_primitives/src/transaction/sighash_v5.rs
@@ -1,14 +1,17 @@
+use blake2b_simd::{Hash as Blake2bHash, Params, State};
 use std::io::Write;
 
-use blake2b_simd::{Hash as Blake2bHash, Params, State};
+use ::transparent::{
+    bundle::{self as transparent, TxOut},
+    sighash::{
+        TransparentAuthorizingContext, SIGHASH_ANYONECANPAY, SIGHASH_MASK, SIGHASH_NONE,
+        SIGHASH_SINGLE,
+    },
+};
 use zcash_encoding::Array;
 
 use crate::transaction::{
-    components::transparent::{self, TxOut},
-    sighash::{
-        SignableInput, TransparentAuthorizingContext, SIGHASH_ANYONECANPAY, SIGHASH_MASK,
-        SIGHASH_NONE, SIGHASH_SINGLE,
-    },
+    sighash::SignableInput,
     txid::{
         hash_transparent_txid_data, to_hash, transparent_outputs_hash, transparent_prevout_hash,
         transparent_sequence_hash, ZCASH_TRANSPARENT_HASH_PERSONALIZATION,

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -8,7 +8,6 @@ use ::transparent::{address::Script, sighash::TransparentAuthorizingContext};
 use zcash_protocol::{consensus::BranchId, value::Zatoshis};
 
 use super::{
-    sapling,
     sighash::SignableInput,
     sighash_v4::v4_signature_hash,
     sighash_v5::v5_signature_hash,

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -4,13 +4,12 @@ use std::ops::Deref;
 
 use proptest::prelude::*;
 
-use crate::{
-    consensus::BranchId, legacy::Script, transaction::components::amount::NonNegativeAmount,
-};
+use ::transparent::{address::Script, sighash::TransparentAuthorizingContext};
+use zcash_protocol::{consensus::BranchId, value::Zatoshis};
 
 use super::{
     sapling,
-    sighash::{SignableInput, TransparentAuthorizingContext},
+    sighash::SignableInput,
     sighash_v4::v4_signature_hash,
     sighash_v5::v5_signature_hash,
     testing::arb_tx,
@@ -140,7 +139,7 @@ fn zip_0143() {
                     n as usize,
                     &tv.script_code,
                     &tv.script_code,
-                    NonNegativeAmount::from_nonnegative_i64(tv.amount).unwrap(),
+                    Zatoshis::from_nonnegative_i64(tv.amount).unwrap(),
                 ))
             }
             _ => SignableInput::Shielded,
@@ -164,7 +163,7 @@ fn zip_0243() {
                     n as usize,
                     &tv.script_code,
                     &tv.script_code,
-                    NonNegativeAmount::from_nonnegative_i64(tv.amount).unwrap(),
+                    Zatoshis::from_nonnegative_i64(tv.amount).unwrap(),
                 ))
             }
             _ => SignableInput::Shielded,
@@ -179,7 +178,7 @@ fn zip_0243() {
 
 #[derive(Debug)]
 struct TestTransparentAuth {
-    input_amounts: Vec<NonNegativeAmount>,
+    input_amounts: Vec<Zatoshis>,
     input_scriptpubkeys: Vec<Script>,
 }
 
@@ -188,7 +187,7 @@ impl transparent::Authorization for TestTransparentAuth {
 }
 
 impl TransparentAuthorizingContext for TestTransparentAuth {
-    fn input_amounts(&self) -> Vec<NonNegativeAmount> {
+    fn input_amounts(&self) -> Vec<Zatoshis> {
         self.input_amounts.clone()
     }
 
@@ -223,7 +222,7 @@ fn zip_0244() {
         let input_amounts = tv
             .amounts
             .iter()
-            .map(|amount| NonNegativeAmount::from_nonnegative_i64(*amount).unwrap())
+            .map(|amount| Zatoshis::from_nonnegative_i64(*amount).unwrap())
             .collect();
         let input_scriptpubkeys = tv
             .script_pubkeys

--- a/zcash_primitives/src/transaction/tests/data.rs
+++ b/zcash_primitives/src/transaction/tests/data.rs
@@ -140,7 +140,8 @@ pub mod tx_read_write {
 }
 
 pub mod zip_0143 {
-    use crate::{consensus, legacy::Script};
+    use transparent::address::Script;
+    use zcash_protocol::consensus;
 
     pub struct Test0143Vector {
         pub tx: Vec<u8>,
@@ -1953,7 +1954,8 @@ pub mod zip_0143 {
 }
 
 pub mod zip_0243 {
-    use crate::{consensus, legacy::Script};
+    use transparent::address::Script;
+    use zcash_protocol::consensus;
 
     pub struct Test0243Vector {
         pub tx: Vec<u8>,

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -13,10 +13,7 @@ use zcash_protocol::{
     value::ZatBalance,
 };
 
-use ::sapling::{
-    self,
-    bundle::{OutputDescription, SpendDescription},
-};
+use ::sapling::bundle::{OutputDescription, SpendDescription};
 
 use super::{
     Authorization, Authorized, TransactionDigest, TransparentDigests, TxDigests, TxId, TxVersion,

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -5,21 +5,20 @@ use std::io::Write;
 use blake2b_simd::{Hash as Blake2bHash, Params, State};
 use byteorder::{LittleEndian, WriteBytesExt};
 use ff::PrimeField;
-use orchard::bundle::{self as orchard};
 
-use crate::{
+use ::orchard::bundle::{self as orchard};
+use ::transparent::bundle::{self as transparent, TxIn, TxOut};
+use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
-    sapling::{
-        self,
-        bundle::{OutputDescription, SpendDescription},
-    },
+    value::ZatBalance,
+};
+
+use ::sapling::{
+    self,
+    bundle::{OutputDescription, SpendDescription},
 };
 
 use super::{
-    components::{
-        amount::Amount,
-        transparent::{self, TxIn, TxOut},
-    },
     Authorization, Authorized, TransactionDigest, TransparentDigests, TxDigests, TxId, TxVersion,
 };
 
@@ -256,7 +255,7 @@ pub(crate) fn hash_transparent_txid_data(
 
 /// Implements [ZIP 244 section T.3](https://zips.z.cash/zip-0244#t-3-sapling-digest)
 fn hash_sapling_txid_data<A: sapling::bundle::Authorization>(
-    bundle: &sapling::Bundle<A, Amount>,
+    bundle: &sapling::Bundle<A, ZatBalance>,
 ) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_HASH_PERSONALIZATION);
     if !(bundle.shielded_spends().is_empty() && bundle.shielded_outputs().is_empty()) {
@@ -328,14 +327,14 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, Amount>>,
+        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, ZatBalance>>,
     ) -> Self::SaplingDigest {
         sapling_bundle.map(hash_sapling_txid_data)
     }
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, Amount>>,
+        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| b.commitment().0)
     }
@@ -467,7 +466,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
 
     fn digest_sapling(
         &self,
-        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, Amount>>,
+        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, ZatBalance>>,
     ) -> Blake2bHash {
         let mut h = hasher(ZCASH_SAPLING_SIGS_HASH_PERSONALIZATION);
         if let Some(bundle) = sapling_bundle {
@@ -492,7 +491,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, Amount>>,
+        orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::OrchardDigest {
         orchard_bundle.map_or_else(orchard::commitments::hash_bundle_auth_empty, |b| {
             b.authorizing_commitment().0


### PR DESCRIPTION
The first commit of this PR removes the `pub use` reexports of types that have been moved to other crates and replaces the internal usage of these types with the types from their new crates. The second commit reintroduces those `pub use` reexports with `deprecated` pragmas.