### PR TITLE
zcash_client_backend: Remove lightwalletd workaround

### DIFF
--- a/zcash_client_backend/src/sync.rs
+++ b/zcash_client_backend/src/sync.rs
@@ -252,8 +252,6 @@ where
 {
     let mut request = service::GetSubtreeRootsArg::default();
     request.set_shielded_protocol(service::ShieldedProtocol::Sapling);
-    // Hack to work around a bug in the initial lightwalletd implementation.
-    request.max_entries = 65536;
 
     let sapling_roots: Vec<CommitmentTreeRoot<sapling::Node>> = client
         .get_subtree_roots(request)
@@ -278,8 +276,7 @@ where
     {
         let mut request = service::GetSubtreeRootsArg::default();
         request.set_shielded_protocol(service::ShieldedProtocol::Orchard);
-        // Hack to work around a bug in the initial lightwalletd implementation.
-        request.max_entries = 65536;
+
         let orchard_roots: Vec<CommitmentTreeRoot<MerkleHashOrchard>> = client
             .get_subtree_roots(request)
             .await?


### PR DESCRIPTION
The bug was fixed in zcash/lightwalletd@b805382ac34e91678ed0d06e9c5f84187ac630cc, and the workaround doesn't work with backed by zebrad.