### PR TITLE
zcash_extensions: Fix build errors following value changes to `zcash_protocol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6392,6 +6392,8 @@ dependencies = [
  "zcash_address",
  "zcash_primitives",
  "zcash_proofs",
+ "zcash_protocol",
+ "zcash_transparent",
 ]
 
 [[package]]

--- a/zcash_extensions/Cargo.toml
+++ b/zcash_extensions/Cargo.toml
@@ -16,7 +16,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 blake2b_simd.workspace = true
-zcash_primitives.workspace = true
+zcash_primitives = { workspace = true, features = ["non-standard-fees"] }
+zcash_protocol.workspace = true
 
 [dev-dependencies]
 ff.workspace = true
@@ -24,8 +25,9 @@ jubjub.workspace = true
 rand_core.workspace = true
 sapling.workspace = true
 orchard.workspace = true
+transparent.workspace = true
 zcash_address.workspace = true
-zcash_proofs.workspace = true
+zcash_proofs = { workspace = true, features = ["local-prover", "bundled-prover"] }
 
 [features]
 transparent-inputs = []

--- a/zcash_primitives/src/extensions/transparent.rs
+++ b/zcash_primitives/src/extensions/transparent.rs
@@ -2,10 +2,8 @@
 
 use std::fmt;
 
-use crate::transaction::components::{
-    tze::{self, TzeOut},
-    Amount,
-};
+use crate::transaction::components::tze::{self, TzeOut};
+use zcash_protocol::value::Zatoshis;
 
 /// A typesafe wrapper for witness payloads
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,11 +201,11 @@ pub trait ExtensionTxBuilder<'a> {
         WBuilder: 'a + (FnOnce(&Self::BuildCtx) -> Result<W, Self::BuildError>);
 
     /// Adds a TZE precondition to the transaction which must be satisfied by a future transaction's
-    /// witness in order to spend the specified `amount`.
+    /// witness in order to spend the specified value.
     fn add_tze_output<Precondition: ToPayload>(
         &mut self,
         extension_id: u32,
-        value: Amount,
+        value: Zatoshis,
         guarded_by: &Precondition,
     ) -> Result<(), Self::BuildError>;
 }

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -981,10 +981,11 @@ impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Extensio
     fn add_tze_output<G: ToPayload>(
         &mut self,
         extension_id: u32,
-        value: ZatBalance,
+        value: Zatoshis,
         guarded_by: &G,
     ) -> Result<(), Self::BuildError> {
-        self.tze_builder.add_output(extension_id, value, guarded_by)
+        self.tze_builder.add_output(extension_id, value, guarded_by);
+        Ok(())
     }
 }
 

--- a/zcash_primitives/src/transaction/components/tze.rs
+++ b/zcash_primitives/src/transaction/components/tze.rs
@@ -5,10 +5,9 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::io::{self, Read, Write};
 
-use zcash_encoding::{CompactSize, Vector};
-
-use super::amount::Amount;
 use crate::{extensions::transparent as tze, transaction::TxId};
+use zcash_encoding::{CompactSize, Vector};
+use zcash_protocol::value::Zatoshis;
 
 pub mod builder;
 
@@ -190,7 +189,7 @@ impl TzeIn<<Authorized as Authorization>::Witness> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TzeOut {
-    pub value: Amount,
+    pub value: Zatoshis,
     pub precondition: tze::Precondition,
 }
 
@@ -199,7 +198,7 @@ impl TzeOut {
         let value = {
             let mut tmp = [0; 8];
             reader.read_exact(&mut tmp)?;
-            Amount::from_nonnegative_i64_le_bytes(tmp)
+            Zatoshis::from_nonnegative_i64_le_bytes(tmp)
         }
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "value out of range"))?;
 

--- a/zcash_primitives/src/transaction/components/tze/builder.rs
+++ b/zcash_primitives/src/transaction/components/tze/builder.rs
@@ -6,12 +6,10 @@ use crate::{
     extensions::transparent::{self as tze, ToPayload},
     transaction::{
         self as tx,
-        components::{
-            amount::{Amount, BalanceError},
-            tze::{Authorization, Authorized, Bundle, OutPoint, TzeIn, TzeOut},
-        },
+        components::tze::{Authorization, Authorized, Bundle, OutPoint, TzeIn, TzeOut},
     },
 };
+use zcash_protocol::value::{BalanceError, ZatBalance, Zatoshis};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -100,13 +98,9 @@ impl<'a, BuildCtx> TzeBuilder<'a, BuildCtx> {
     pub fn add_output<G: ToPayload>(
         &mut self,
         extension_id: u32,
-        value: Amount,
+        value: Zatoshis,
         guarded_by: &G,
-    ) -> Result<(), Error> {
-        if value.is_negative() {
-            return Err(Error::InvalidAmount);
-        }
-
+    ) -> () {
         let (mode, payload) = guarded_by.to_payload();
         self.vout.push(TzeOut {
             value,
@@ -116,26 +110,24 @@ impl<'a, BuildCtx> TzeBuilder<'a, BuildCtx> {
                 payload,
             },
         });
-
-        Ok(())
     }
 
-    pub fn value_balance(&self) -> Result<Amount, BalanceError> {
+    pub fn value_balance(&self) -> Result<ZatBalance, BalanceError> {
         let total_in = self
             .vin
             .iter()
             .map(|tzi| tzi.coin.value)
-            .sum::<Option<Amount>>()
+            .sum::<Option<Zatoshis>>()
             .ok_or(BalanceError::Overflow)?;
 
         let total_out = self
             .vout
             .iter()
             .map(|tzo| tzo.value)
-            .sum::<Option<Amount>>()
+            .sum::<Option<Zatoshis>>()
             .ok_or(BalanceError::Overflow)?;
 
-        (total_in - total_out).ok_or(BalanceError::Underflow)
+        (ZatBalance::from(total_in) - ZatBalance::from(total_out)).ok_or(BalanceError::Underflow)
     }
 
     pub fn build(self) -> (Option<Bundle<Unauthorized>>, Vec<TzeSigner<'a, BuildCtx>>) {

--- a/zcash_primitives/src/transaction/fees/tze.rs
+++ b/zcash_primitives/src/transaction/fees/tze.rs
@@ -2,11 +2,9 @@
 
 use crate::{
     extensions::transparent as tze,
-    transaction::components::{
-        amount::Amount,
-        tze::{builder::TzeBuildInput, OutPoint, TzeOut},
-    },
+    transaction::components::tze::{builder::TzeBuildInput, OutPoint, TzeOut},
 };
+use zcash_protocol::value::Zatoshis;
 
 /// This trait provides a minimized view of a TZE input suitable for use in
 /// fee computation.
@@ -30,13 +28,13 @@ impl InputView for TzeBuildInput {
 /// fee computation.
 pub trait OutputView {
     /// The value of the newly created output
-    fn value(&self) -> Amount;
+    fn value(&self) -> Zatoshis;
     /// The precondition that must be satisfied in order to spend this output.
     fn precondition(&self) -> &tze::Precondition;
 }
 
 impl OutputView for TzeOut {
-    fn value(&self) -> Amount {
+    fn value(&self) -> Zatoshis {
         self.value
     }
 


### PR DESCRIPTION
This fixes a few errors that have been introduced over time since `zcash_extensions` is not regularly built, and migrates `zcash_extensions` to eliminate the use of deprecated `zcash_primitives` APIs.