### PR TITLE
pczt: Add `Prover::{requires_sapling_proofs, requires_orchard_proof}`

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -19,6 +19,7 @@ and this library adheres to Rust's notion of
   - `Output::{cmx, ephemeral_key, enc_ciphertext, out_ciphertext}`
 - `pczt::roles`:
   - `low_level_signer` module
+  - `prover::Prover::{requires_sapling_proofs, requires_orchard_proof}`
   - `redactor` module
 - `pczt::sapling`:
   - `Bundle::{value_sum, anchor}`

--- a/pczt/src/roles/prover/mod.rs
+++ b/pczt/src/roles/prover/mod.rs
@@ -20,6 +20,20 @@ impl Prover {
         Self { pczt }
     }
 
+    /// Returns `true` if this PCZT contains Sapling Spends or Outputs that are missing
+    /// proofs.
+    pub fn requires_sapling_proofs(&self) -> bool {
+        let sapling_bundle = self.pczt.sapling();
+
+        sapling_bundle.spends().iter().any(|s| s.zkproof.is_none())
+            || sapling_bundle.outputs().iter().any(|o| o.zkproof.is_none())
+    }
+
+    /// Returns `true` if this PCZT contains Orchard Actions but no Orchard proof.
+    pub fn requires_orchard_proof(&self) -> bool {
+        !self.pczt.orchard().actions().is_empty() && self.pczt.orchard().zkproof.is_none()
+    }
+
     /// Finishes the Prover role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt


### PR DESCRIPTION
Closes zcash/librustzcash#1696.