### PR TITLE
zcash_client_backend: Fix `tor::Client::create` argument

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -16,8 +16,9 @@ and this library adheres to Rust's notion of
 - Migrated to `bip32 =0.6.0-pre.1`, `nonempty 0.11`, `incrementalmerkletree 0.8`,
   `shardtree 0.6`.
 - `zcash_client_backend::tor`:
-  - `tor::Client::create` now takes an optional `with_permissions` argument for
-    configuring `fs_mistrust::Mistrust`.
+  - `tor::Client::create` now takes a `with_permissions` argument for configuring
+    `fs_mistrust::Mistrust`. If you don't need to configure it, pass `|_| ()`
+    (the empty closure).
 - `zcash_client_backend::wallet::Recipient` has changed:
   - The `Recipient::External` variant is now a structured variant.
   - The `Recipient::EphemeralTransparent` variant is now only available if

--- a/zcash_client_backend/src/tor.rs
+++ b/zcash_client_backend/src/tor.rs
@@ -24,9 +24,10 @@ impl Client {
     /// Preserving the contents of this directory will speed up subsequent calls to
     /// `Client::create`.
     ///
-    /// If the `with_permissions` closure does not make any changes, the default from
-    /// [`arti_client`] will be used (enable permissions checks unless the
-    /// `ARTI_FS_DISABLE_PERMISSION_CHECKS` env variable is set).
+    /// If the `with_permissions` closure does not make any changes (e.g. is
+    /// passed as `|_| {}`), the default from [`arti_client`] will be used.
+    /// This default will enable permissions checks unless the
+    /// `ARTI_FS_DISABLE_PERMISSION_CHECKS` env variable is set.
     ///
     /// Returns an error if `tor_dir` does not exist, or if bootstrapping fails.
     pub async fn create(

--- a/zcash_client_backend/src/tor.rs
+++ b/zcash_client_backend/src/tor.rs
@@ -24,14 +24,14 @@ impl Client {
     /// Preserving the contents of this directory will speed up subsequent calls to
     /// `Client::create`.
     ///
-    /// If `with_permissions` is `None`, the default from [`arti_client`] will be used
-    /// (enable permissions checks unless the `ARTI_FS_DISABLE_PERMISSION_CHECKS` env
-    /// variable is set).
+    /// If the `with_permissions` closure does not make any changes, the default from
+    /// [`arti_client`] will be used (enable permissions checks unless the
+    /// `ARTI_FS_DISABLE_PERMISSION_CHECKS` env variable is set).
     ///
     /// Returns an error if `tor_dir` does not exist, or if bootstrapping fails.
     pub async fn create(
         tor_dir: &Path,
-        with_permissions: Option<impl FnOnce(&mut fs_mistrust::MistrustBuilder)>,
+        with_permissions: impl FnOnce(&mut fs_mistrust::MistrustBuilder),
     ) -> Result<Self, Error> {
         let runtime = PreferredRuntime::current()?;
 
@@ -44,9 +44,7 @@ impl Client {
             tor_dir.join("arti-cache"),
         );
 
-        if let Some(f) = with_permissions {
-            f(config_builder.storage().permissions());
-        }
+        with_permissions(config_builder.storage().permissions());
 
         let config = config_builder
             .build()


### PR DESCRIPTION
The optional closure was requiring a type annotation when using `None`, which would create a more complex API than just passing an empty closure.