### PR TITLE
Add Donation Address to gRPC LightdInfo

### DIFF
--- a/zcash_client_backend/proto/service.proto
+++ b/zcash_client_backend/proto/service.proto
@@ -73,6 +73,7 @@ message LightdInfo {
     uint64 estimatedHeight = 12;        // less than tip height if zcashd is syncing
     string zcashdBuild = 13;            // example: "v4.1.1-877212414"
     string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
+    string donationAddress = 15;        // Zcash donation UA address
 }
 
 // TransparentAddressBlockFilter restricts the results to the given address

--- a/zcash_client_backend/src/proto/service.rs
+++ b/zcash_client_backend/src/proto/service.rs
@@ -103,6 +103,9 @@ pub struct LightdInfo {
     /// example: "/MagicBean:4.1.1/"
     #[prost(string, tag = "14")]
     pub zcashd_subversion: ::prost::alloc::string::String,
+    /// Zcash donation UA address
+    #[prost(string, tag = "15")]
+    pub donation_address: ::prost::alloc::string::String,
 }
 /// TransparentAddressBlockFilter restricts the results to the given address
 /// or block range.


### PR DESCRIPTION
In order to encourage more people to run light wallet servers, this change allows operators to specify a donation address for users and grantors to contribute to the server operator's expenses.

Related PRs:
- [Zingolib #1660](https://github.com/zingolabs/zingolib/pull/1660)
- [Zaino #185](https://github.com/zingolabs/zaino/pull/185)
- [Lightwalletd #506](https://github.com/zcash/lightwalletd/pull/506)