### PR TITLE
zcash_client_sqlite: Add methods for fixing broken note commitment trees.

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,6 +39,8 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `zcash_client_sqlite::WalletDb::from_connection`
+- `zcash_client_sqlite::WalletDb::check_witnesses`
+- `zcash_client_sqlite::WalletDb::queue_rescans`
 
 ### Changed
 - MSRV is now 1.81.0.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -457,12 +457,10 @@ impl<C: BorrowMut<Connection>, P, CL> WalletDb<C, P, CL> {
     }
 
     /// Attempts to construct a witness for each note belonging to the wallet that is believed by
-    /// the wallet to currently be spendable, and returns a vector of .
+    /// the wallet to currently be spendable, and returns a vector of the ranges that must be
+    /// rescanned in order to correct missing witness data.
     ///
     /// This method is intended for repairing wallets that broke due to bugs in `shardtree`.
-    ///
-    /// Returns a vector of the ranges that must be rescanned in order to correct missing witness
-    /// data.
     pub fn check_witnesses(&mut self) -> Result<Vec<Range<BlockHeight>>, SqliteClientError> {
         self.transactionally(|wdb| wallet::commitment_tree::check_witnesses(wdb.conn.0))
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -4040,9 +4040,12 @@ pub(crate) fn get_block_range(
     ))?;
 
     stmt.query_row(
+        // BETWEEN is inclusive on both ends. However, we are comparing commitment tree sizes
+        // to commitment tree positions, so we must add one to the start, and we do not subtract
+        // one from the end.
         named_params! {
             ":min_tree_size": u64::from(commitment_tree_address.position_range_start()) + 1,
-            ":max_tree_size": u64::from(commitment_tree_address.position_range_start()) + 1,
+            ":max_tree_size": u64::from(commitment_tree_address.position_range_end()),
         },
         |row| {
             let min_height = row

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -69,7 +69,7 @@ use std::{
     convert::TryFrom,
     io::{self, Cursor},
     num::NonZeroU32,
-    ops::RangeInclusive,
+    ops::{Range, RangeInclusive},
     time::SystemTime,
 };
 
@@ -4022,6 +4022,40 @@ pub(crate) fn prune_nullifier_map(
     stmt_delete_locators.execute(named_params![":block_height": u32::from(block_height)])?;
 
     Ok(())
+}
+
+pub(crate) fn get_block_range(
+    conn: &rusqlite::Connection,
+    protocol: ShieldedProtocol,
+    commitment_tree_address: incrementalmerkletree::Address,
+) -> Result<Option<Range<BlockHeight>>, SqliteClientError> {
+    let prefix = match protocol {
+        ShieldedProtocol::Sapling => "sapling",
+        ShieldedProtocol::Orchard => "orchard",
+    };
+    let mut stmt = conn.prepare_cached(&format!(
+        "SELECT MIN(height), MAX(height)
+         FROM blocks
+         WHERE {prefix}_commitment_tree_size BETWEEN :min_tree_size AND :max_tree_size"
+    ))?;
+
+    stmt.query_row(
+        named_params! {
+            ":min_tree_size": u64::from(commitment_tree_address.position_range_start()) + 1,
+            ":max_tree_size": u64::from(commitment_tree_address.position_range_start()) + 1,
+        },
+        |row| {
+            let min_height = row
+                .get::<_, Option<u32>>(0)?
+                .map(|h| BlockHeight::from_u32(h.saturating_sub(1)));
+            let max_height = row
+                .get::<_, Option<u32>>(1)?
+                .map(|h| BlockHeight::from_u32(h.saturating_add(1)));
+
+            Ok(min_height.zip(max_height).map(|(min, max)| min..max))
+        },
+    )
+    .map_err(SqliteClientError::from)
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -1,5 +1,6 @@
 //! Functions common to Sapling and Orchard support in the wallet.
 
+use incrementalmerkletree::Position;
 use rusqlite::{named_params, types::Value, Connection, Row};
 use std::{num::NonZeroU64, rc::Rc};
 
@@ -234,6 +235,98 @@ where
     notes
         .filter_map(|r| r.transpose())
         .collect::<Result<_, _>>()
+}
+
+#[allow(dead_code)]
+pub(crate) struct UnspentNoteMeta {
+    note_id: ReceivedNoteId,
+    txid: TxId,
+    output_index: u32,
+    commitment_tree_position: Position,
+    value: Zatoshis,
+}
+
+#[allow(dead_code)]
+impl UnspentNoteMeta {
+    pub(crate) fn note_id(&self) -> ReceivedNoteId {
+        self.note_id
+    }
+
+    pub(crate) fn txid(&self) -> TxId {
+        self.txid
+    }
+
+    pub(crate) fn output_index(&self) -> u32 {
+        self.output_index
+    }
+
+    pub(crate) fn commitment_tree_position(&self) -> Position {
+        self.commitment_tree_position
+    }
+
+    pub(crate) fn value(&self) -> Zatoshis {
+        self.value
+    }
+}
+
+pub(crate) fn select_unspent_note_meta(
+    conn: &rusqlite::Connection,
+    protocol: ShieldedProtocol,
+    chain_tip_height: BlockHeight,
+    wallet_birthday: BlockHeight,
+) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
+    let (table_prefix, index_col, _) = per_protocol_names(protocol);
+    let mut stmt = conn.prepare_cached(&format!("
+        SELECT {table_prefix}_received_notes.id AS id, txid, {index_col},
+               commitment_tree_position, value
+        FROM {table_prefix}_received_notes
+        INNER JOIN transactions
+           ON transactions.id_tx = {table_prefix}_received_notes.tx
+        WHERE value > 5000 -- FIXME #1316, allow selection of dust inputs
+        AND recipient_key_scope IS NOT NULL
+        AND nf IS NOT NULL
+        AND commitment_tree_position IS NOT NULL
+        AND {table_prefix}_received_notes.id NOT IN (
+          SELECT {table_prefix}_received_note_id
+          FROM {table_prefix}_received_note_spends
+          JOIN transactions stx ON stx.id_tx = transaction_id
+          WHERE stx.block IS NOT NULL -- the spending tx is mined
+          OR stx.expiry_height IS NULL -- the spending tx will not expire
+          OR stx.expiry_height > :anchor_height -- the spending tx is unexpired
+        )
+        AND NOT EXISTS (
+           SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges unscanned
+           -- select all the unscanned ranges involving the shard containing this note
+           WHERE {table_prefix}_received_notes.commitment_tree_position >= unscanned.start_position
+           AND {table_prefix}_received_notes.commitment_tree_position < unscanned.end_position_exclusive
+           -- exclude unscanned ranges that start above the anchor height (they don't affect spendability)
+           AND unscanned.block_range_start <= :anchor_height
+           -- exclude unscanned ranges that end below the wallet birthday
+           AND unscanned.block_range_end > :wallet_birthday
+        )
+    "))?;
+
+    let res = stmt
+        .query_and_then::<_, SqliteClientError, _, _>(
+            named_params![
+                ":anchor_height": u32::from(chain_tip_height),
+                ":wallet_birthday": u32::from(wallet_birthday),
+            ],
+            |row| {
+                Ok(UnspentNoteMeta {
+                    note_id: row.get("id").map(|id| ReceivedNoteId(protocol, id))?,
+                    txid: row.get("txid").map(TxId::from_bytes)?,
+                    output_index: row.get(index_col)?,
+                    commitment_tree_position: row
+                        .get::<_, u64>("commitment_tree_position")
+                        .map(Position::from)?,
+                    value: Zatoshis::from_nonnegative_i64(row.get("value")?)?,
+                })
+            },
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(res)
 }
 
 pub(crate) fn spendable_notes_meta(

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -276,6 +276,10 @@ pub(crate) fn select_unspent_note_meta(
     wallet_birthday: BlockHeight,
 ) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
     let (table_prefix, index_col, _) = per_protocol_names(protocol);
+    // This query is effectively the same as the internal `eligible` subquery
+    // used in `select_spendable_notes`.
+    //
+    // TODO: Deduplicate this in the future by introducing a view?
     let mut stmt = conn.prepare_cached(&format!("
         SELECT {table_prefix}_received_notes.id AS id, txid, {index_col},
                commitment_tree_position, value

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -24,7 +24,9 @@ use zip32::Scope;
 
 use crate::{error::SqliteClientError, AccountRef, AccountUuid, AddressRef, ReceivedNoteId, TxRef};
 
-use super::{get_account, get_account_ref, memo_repr, upsert_address, KeyScope};
+use super::{
+    common::UnspentNoteMeta, get_account, get_account_ref, memo_repr, upsert_address, KeyScope,
+};
 
 /// This trait provides a generalization over shielded output representations.
 pub(crate) trait ReceivedOrchardOutput {
@@ -270,6 +272,19 @@ pub(crate) fn ensure_address<
     } else {
         Ok(None)
     }
+}
+
+pub(crate) fn select_unspent_note_meta(
+    conn: &Connection,
+    chain_tip_height: BlockHeight,
+    wallet_birthday: BlockHeight,
+) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
+    super::common::select_unspent_note_meta(
+        conn,
+        ShieldedProtocol::Orchard,
+        chain_tip_height,
+        wallet_birthday,
+    )
 }
 
 /// Records the specified shielded output as having been received.

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -23,7 +23,9 @@ use zip32::Scope;
 
 use crate::{error::SqliteClientError, AccountRef, AccountUuid, AddressRef, ReceivedNoteId, TxRef};
 
-use super::{get_account, get_account_ref, memo_repr, upsert_address, KeyScope};
+use super::{
+    common::UnspentNoteMeta, get_account, get_account_ref, memo_repr, upsert_address, KeyScope,
+};
 
 /// This trait provides a generalization over shielded output representations.
 pub(crate) trait ReceivedSaplingOutput {
@@ -237,6 +239,19 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         exclude,
         ShieldedProtocol::Sapling,
         to_spendable_note,
+    )
+}
+
+pub(crate) fn select_unspent_note_meta(
+    conn: &Connection,
+    chain_tip_height: BlockHeight,
+    wallet_birthday: BlockHeight,
+) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
+    super::common::select_unspent_note_meta(
+        conn,
+        ShieldedProtocol::Sapling,
+        chain_tip_height,
+        wallet_birthday,
     )
 }
 


### PR DESCRIPTION
This functionality is needed in order to make it possible for wallets that have corrupted note commitment tree state to recover from that situation.