### PR TITLE
Fix crate documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,7 +2911,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "blake2b_simd",
  "cc",
  "core2",
+ "document-features",
  "hex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "blake2b_simd",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ version = "0.2.0"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
+ "document-features",
  "ff",
  "getset",
  "incrementalmerkletree",

--- a/components/equihash/CHANGELOG.md
+++ b/components/equihash/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-03-04
+
 Documentation improvements and rendering fix; no code changes.
 
 ## [0.2.1] - 2025-02-21

--- a/components/equihash/CHANGELOG.md
+++ b/components/equihash/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+Documentation improvements and rendering fix; no code changes.
+
 ## [0.2.1] - 2025-02-21
 ### Added
 - `equihash::tromp` module behind the experimental `solver` feature flag.

--- a/components/equihash/Cargo.toml
+++ b/components/equihash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "equihash"
 description = "The Equihash Proof-of-Work function"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jack Grigg <jack@z.cash>"]
 homepage = "https://github.com/zcash/librustzcash"
 repository = "https://github.com/zcash/librustzcash"

--- a/components/equihash/Cargo.toml
+++ b/components/equihash/Cargo.toml
@@ -9,16 +9,25 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.56.1"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["std"]
-std = []
+std = ["document-features"]
 
-# Experimental tromp solver support, builds the C++ tromp solver and Rust FFI layer.
+## Experimental tromp solver support, builds the C++ tromp solver and Rust FFI layer.
 solver = ["dep:cc", "std"]
 
 [dependencies]
 core2.workspace = true
 blake2b_simd.workspace = true
+
+# Dependencies used internally:
+# (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
+# - Documentation
+document-features = { workspace = true, optional = true }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/components/equihash/src/lib.rs
+++ b/components/equihash/src/lib.rs
@@ -7,6 +7,9 @@
 //! verify solutions for any valid `(n, k)` parameters, as long as the row indices are no
 //! larger than 32 bits (that is, `ceiling(((n / (k + 1)) + 1) / 8) <= 4`).
 //!
+#![cfg_attr(feature = "std", doc = "## Feature flags")]
+#![cfg_attr(feature = "std", doc = document_features::document_features!())]
+//!
 //! References
 //! ==========
 //! - [Section 7.6.1: Equihash.] Zcash Protocol Specification, version 2020.1.10 or later.
@@ -20,6 +23,8 @@
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -184,8 +184,8 @@ impl ZcashAddress {
     /// [ZIP 316](https://zips.z.cash/zip-0316). The [`Display` implementation] can also
     /// be used to produce this encoding using [`address.to_string()`].
     ///
-    /// [`Display` implementation]: std::fmt::Display
-    /// [`address.to_string()`]: std::string::ToString
+    /// [`Display` implementation]: core::fmt::Display
+    /// [`address.to_string()`]: alloc::string::ToString
     pub fn encode(&self) -> String {
         format!("{}", self)
     }
@@ -194,7 +194,7 @@ impl ZcashAddress {
     ///
     /// This simply calls [`s.parse()`], leveraging the [`FromStr` implementation].
     ///
-    /// [`s.parse()`]: std::primitive::str::parse
+    /// [`s.parse()`]: str::parse
     /// [`FromStr` implementation]: ZcashAddress#impl-FromStr
     ///
     /// # Errors
@@ -229,8 +229,8 @@ impl ZcashAddress {
     /// method or the [`Display` implementation] via [`address.to_string()`] instead.
     ///
     /// [`encode`]: Self::encode
-    /// [`Display` implementation]: std::fmt::Display
-    /// [`address.to_string()`]: std::string::ToString
+    /// [`Display` implementation]: core::fmt::Display
+    /// [`address.to_string()`]: alloc::string::ToString
     pub fn convert<T: TryFromAddress>(self) -> Result<T, ConversionError<T::Error>> {
         match self.kind {
             AddressKind::Sprout(data) => T::try_from_sprout(self.net, data),
@@ -254,8 +254,8 @@ impl ZcashAddress {
     /// method or the [`Display` implementation] via [`address.to_string()`] instead.
     ///
     /// [`encode`]: Self::encode
-    /// [`Display` implementation]: std::fmt::Display
-    /// [`address.to_string()`]: std::string::ToString
+    /// [`Display` implementation]: core::fmt::Display
+    /// [`address.to_string()`]: alloc::string::ToString
     pub fn convert_if_network<T: TryFromRawAddress>(
         self,
         net: NetworkType,

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -138,7 +138,6 @@ pub trait NetworkConstants: Clone {
     ///
     /// Defined in [ZIP 32].
     ///
-    /// [`ExtendedSpendingKey`]: zcash_primitives::zip32::ExtendedSpendingKey
     /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
     fn hrp_sapling_extended_spending_key(&self) -> &'static str;
 
@@ -147,7 +146,6 @@ pub trait NetworkConstants: Clone {
     ///
     /// Defined in [ZIP 32].
     ///
-    /// [`ExtendedFullViewingKey`]: zcash_primitives::zip32::ExtendedFullViewingKey
     /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
     fn hrp_sapling_extended_full_viewing_key(&self) -> &'static str;
 
@@ -156,7 +154,6 @@ pub trait NetworkConstants: Clone {
     ///
     /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
     ///
-    /// [`PaymentAddress`]: zcash_primitives::primitives::PaymentAddress
     /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
     fn hrp_sapling_payment_address(&self) -> &'static str;
 
@@ -172,14 +169,10 @@ pub trait NetworkConstants: Clone {
     /// Returns the human-readable prefix for Base58Check-encoded transparent
     /// pay-to-public-key-hash payment addresses for the network to which this NetworkConstants value
     /// applies.
-    ///
-    /// [`TransparentAddress::PublicKey`]: zcash_primitives::legacy::TransparentAddress::PublicKey
     fn b58_pubkey_address_prefix(&self) -> [u8; 2];
 
     /// Returns the human-readable prefix for Base58Check-encoded transparent pay-to-script-hash
     /// payment addresses for the network to which this NetworkConstants value applies.
-    ///
-    /// [`TransparentAddress::Script`]: zcash_primitives::legacy::TransparentAddress::Script
     fn b58_script_address_prefix(&self) -> [u8; 2];
 
     /// Returns the Bech32-encoded human-readable prefix for TEX addresses, for the

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-03-04
+
 Documentation improvements and rendering fix; no code changes.
 
 ## [0.2.0] - 2025-02-21

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+Documentation improvements and rendering fix; no code changes.
+
 ## [0.2.0] - 2025-02-21
 
 ### Added

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace = true
 license.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 zcash_note_encryption = { workspace = true, optional = true }
 zcash_primitives = { workspace = true, optional = true }
@@ -40,8 +44,13 @@ nonempty = { workspace = true, optional = true }
 orchard = { workspace = true, optional = true }
 pasta_curves = { workspace = true, optional = true }
 
-# - Bolierplate
-getset = "0.1"
+# Dependencies used internally:
+# (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
+# - Boilerplate
+getset.workspace = true
+
+# - Documentation
+document-features = { workspace = true, optional = true }
 
 [dev-dependencies]
 incrementalmerkletree.workspace = true
@@ -55,6 +64,10 @@ zcash_proofs = { workspace = true, features = ["bundled-prover"] }
 zip32.workspace = true
 
 [features]
+default = ["std"]
+std = ["document-features"]
+
+## Enables functionality that requires Orchard protocol types.
 orchard = [
     "dep:ff",
     "dep:nonempty",
@@ -62,6 +75,8 @@ orchard = [
     "dep:pasta_curves",
     "dep:zcash_protocol",
 ]
+
+## Enables functionality that requires Sapling protocol types.
 sapling = [
     "dep:bls12_381",
     "dep:ff",
@@ -71,10 +86,25 @@ sapling = [
     "dep:zcash_note_encryption",
     "dep:zcash_protocol",
 ]
+
+## Enables functionality that requires Zcash transparent protocol types.
 transparent = ["dep:secp256k1", "dep:transparent", "dep:zcash_protocol"]
+
+## Enables building a PCZT from the output of `zcash_primitives`'s `Builder::build_for_pczt`.
 zcp-builder = ["dep:zcash_primitives", "dep:zcash_protocol"]
+
+#! ### PCZT roles behind feature flags
+#!
+#! These roles require awareness of at least one payment protocol's types in order to
+#! function.
+
+## Enables the I/O Finalizer role.
 io-finalizer = ["dep:zcash_primitives", "orchard", "sapling", "transparent"]
+
+## Enables the Prover role.
 prover = ["dep:rand_core", "sapling?/temporary-zcashd"]
+
+## Enables the Signer role.
 signer = [
     "dep:blake2b_simd",
     "dep:rand_core",
@@ -83,7 +113,11 @@ signer = [
     "sapling",
     "transparent",
 ]
+
+## Enables the Spend Finalizer role.
 spend-finalizer = ["transparent"]
+
+## Enables the Transaction Extractor role.
 tx-extractor = [
     "dep:rand_core",
     "dep:zcash_primitives",

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/pczt/README.md
+++ b/pczt/README.md
@@ -1,6 +1,13 @@
 # pczt
 
-TBD
+This library implements the Partially Created Zcash Transaction (PCZT) format.
+This format enables splitting up the logical steps of creating a Zcash transaction
+across distinct entities. The entity roles roughly match those specified in
+[BIP 174: Partially Signed Bitcoin Transaction Format] and [BIP 370: PSBT Version 2],
+with additional Zcash-specific roles.
+
+[BIP 174: Partially Signed Bitcoin Transaction Format]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+[BIP 370: PSBT Version 2]: https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki
 
 ## License
 

--- a/pczt/src/common.rs
+++ b/pczt/src/common.rs
@@ -1,3 +1,5 @@
+//! The common fields of a PCZT.
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -45,8 +45,16 @@
 //!   - Combines partial transparent signatures into `script_sig`s.
 //! - Transaction Extractor (anyone can execute)
 //!   - Creates bindingSig and extracts the final transaction.
+//!
+#![cfg_attr(feature = "std", doc = "## Feature flags")]
+#![cfg_attr(feature = "std", doc = document_features::document_features!())]
+//!
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Catch documentation errors caused by code changes.
+#![deny(rustdoc::broken_intra_doc_links)]
 
 #[macro_use]
 extern crate alloc;

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -1,50 +1,12 @@
 //! The Partially Created Zcash Transaction (PCZT) format.
 //!
-//! Goal is to split up the parts of creating a transaction across distinct entities.
-//! The entity roles roughly match BIP 174: Partially Signed Bitcoin Transaction Format.
-//! - Creator (single entity)
-//!   - Creates the base PCZT with no information about spends or outputs.
-//! - Constructor (anyone can contribute)
-//!   - Adds spends and outputs to the PCZT.
-//!   - Before any input or output may be added, the constructor must check the
-//!     `Global.tx_modifiable` field. Inputs may only be added if the Inputs Modifiable
-//!     flag is True. Outputs may only be added if the Outputs Modifiable flag is True.
-//!   - A single entity is likely to be both a Creator and Constructor.
-//! - IO Finalizer (anyone can execute)
-//!   - Sets the appropriate bits in `Global.tx_modifiable` to 0.
-//!   - Updates the various bsk values using the rcv information from spends and outputs.
-//! - Updater (anyone can contribute)
-//!   - Adds information necessary for subsequent entities to proceed, such as key paths
-//!     for signing spends.
-//! - Redactor (anyone can execute)
-//!   - Removes information that is unnecessary for subsequent entities to proceed.
-//!   - This can be useful e.g. when creating a transaction that has inputs from multiple
-//!     independent Signers; each can receive a PCZT with just the information they need
-//!     to sign, but (e.g.) not the `alpha` values for other Signers.
-//! - Prover (capability holders can contribute)
-//!   - Needs all private information for a single spend or output.
-//!   - In practice, the Updater that adds a given spend or output will either act as
-//!     the Prover themselves, or add the necessary data, offload to the Prover, and
-//!     then receive back the PCZT with private data stripped and proof added.
-//! - Signer (capability holders can contribute)
-//!   - Needs the spend authorization randomizers to create signatures.
-//!   - Needs sufficient information to verify that the proof is over the correct data,
-//!     without needing to verify the proof itself.
-//!   - A Signer should only need to implement:
-//!     - Pedersen commitments using Jubjub / Pallas arithmetic (for note and value
-//!       commitments)
-//!     - BLAKE2b and BLAKE2s (and the various PRFs / CRHs they are used in)
-//!     - Nullifier check (using Jubjub / Pallas arithmetic)
-//!     - KDF plus note decryption (AEAD_CHACHA20_POLY1305)
-//!     - SignatureHash algorithm
-//!     - Signatures (RedJubjub / RedPallas)
-//!     - A source of randomness.
-//! - Combiner (anyone can execute)
-//!   - Combines several PCZTs that represent the same transaction into a single PCZT.
-//! - Spend Finalizer (anyone can execute)
-//!   - Combines partial transparent signatures into `script_sig`s.
-//! - Transaction Extractor (anyone can execute)
-//!   - Creates bindingSig and extracts the final transaction.
+//! This format enables splitting up the logical steps of creating a Zcash transaction
+//! across distinct entities. The entity roles roughly match those specified in
+//! [BIP 174: Partially Signed Bitcoin Transaction Format] and [BIP 370: PSBT Version 2],
+//! with additional Zcash-specific roles.
+//!
+//! [BIP 174: Partially Signed Bitcoin Transaction Format]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+//! [BIP 370: PSBT Version 2]: https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki
 //!
 #![cfg_attr(feature = "std", doc = "## Feature flags")]
 #![cfg_attr(feature = "std", doc = document_features::document_features!())]

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -1,3 +1,5 @@
+//! The Orchard fields of a PCZT.
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -62,6 +64,7 @@ pub struct Bundle {
     pub(crate) bsk: Option<[u8; 32]>,
 }
 
+/// Information about an Orchard action within a transaction.
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Action {
     //
@@ -89,7 +92,7 @@ pub struct Action {
     pub(crate) rcv: Option<[u8; 32]>,
 }
 
-/// Information about a Sapling spend within a transaction.
+/// Information about the spend part of an Orchard action.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Spend {
@@ -178,7 +181,7 @@ pub struct Spend {
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
 }
 
-/// Information about an Orchard output within a transaction.
+/// Information about the output part of an Orchard action.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Output {

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -1,3 +1,13 @@
+//! Implementations of the PCZT roles.
+//!
+//! The roles currently without an implementation are:
+//! - Constructor (anyone can contribute)
+//!   - Adds spends and outputs to the PCZT.
+//!   - Before any input or output may be added, the constructor must check the
+//!     `Global.tx_modifiable` field. Inputs may only be added if the Inputs Modifiable
+//!     flag is True. Outputs may only be added if the Outputs Modifiable flag is True.
+//!   - A single entity is likely to be both a Creator and Constructor.
+
 pub mod creator;
 
 #[cfg(feature = "io-finalizer")]

--- a/pczt/src/roles/combiner/mod.rs
+++ b/pczt/src/roles/combiner/mod.rs
@@ -1,3 +1,7 @@
+//! The Combiner role (anyone can execute).
+//!
+//! - Combines several PCZTs that represent the same transaction into a single PCZT.
+
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -1,3 +1,7 @@
+//! The Creator role (single entity).
+//!
+//!  - Creates the base PCZT with no information about spends or outputs.
+
 use alloc::collections::BTreeMap;
 
 use crate::{

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -1,3 +1,8 @@
+//! The IO Finalizer role (anyone can execute).
+//!
+//! - Sets the appropriate bits in `Global.tx_modifiable` to 0.
+//! - Updates the various bsk values using the rcv information from spends and outputs.
+
 use rand_core::OsRng;
 use zcash_primitives::transaction::{
     sighash::SignableInput, sighash_v5::v5_signature_hash, txid::TxIdDigester,

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -1,3 +1,5 @@
+//! A low-level variant of the Signer role, for dependency-constrained environments.
+
 use crate::Pczt;
 
 pub struct Signer {

--- a/pczt/src/roles/prover/mod.rs
+++ b/pczt/src/roles/prover/mod.rs
@@ -1,3 +1,10 @@
+//! The Prover role (capability holders can contribute).
+//!
+//! - Needs all private information for a single spend or output.
+//! - In practice, the Updater that adds a given spend or output will either act as
+//!   the Prover themselves, or add the necessary data, offload to the Prover, and
+//!   then receive back the PCZT with private data stripped and proof added.
+
 use crate::Pczt;
 
 #[cfg(feature = "orchard")]

--- a/pczt/src/roles/redactor/mod.rs
+++ b/pczt/src/roles/redactor/mod.rs
@@ -1,3 +1,10 @@
+//! The Redactor role (anyone can execute).
+//!
+//! - Removes information that is unnecessary for subsequent entities to proceed.
+//! - This can be useful e.g. when creating a transaction that has inputs from multiple
+//!   independent Signers; each can receive a PCZT with just the information they need
+//!   to sign, but (e.g.) not the `alpha` values for other Signers.
+
 use crate::{common::Global, Pczt};
 
 pub mod orchard;

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -1,3 +1,18 @@
+//! The Signer role (capability holders can contribute).
+//!
+//! - Needs the spend authorization randomizers to create signatures.
+//! - Needs sufficient information to verify that the proof is over the correct data,
+//!   without needing to verify the proof itself.
+//! - A Signer should only need to implement:
+//!   - Pedersen commitments using Jubjub / Pallas arithmetic (for note and value
+//!     commitments)
+//!   - BLAKE2b and BLAKE2s (and the various PRFs / CRHs they are used in)
+//!   - Nullifier check (using Jubjub / Pallas arithmetic)
+//!   - KDF plus note decryption (AEAD_CHACHA20_POLY1305)
+//!   - SignatureHash algorithm
+//!   - Signatures (RedJubjub / RedPallas)
+//!   - A source of randomness.
+
 use blake2b_simd::Hash as Blake2bHash;
 use rand_core::OsRng;
 

--- a/pczt/src/roles/spend_finalizer/mod.rs
+++ b/pczt/src/roles/spend_finalizer/mod.rs
@@ -1,3 +1,7 @@
+//! The Spend Finalizer role (anyone can execute).
+//!
+//! - Combines partial transparent signatures into `script_sig`s.
+
 use crate::Pczt;
 
 pub struct SpendFinalizer {

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -1,3 +1,7 @@
+//! The Transaction Extractor role (anyone can execute).
+//!
+//! - Creates bindingSig and extracts the final transaction.
+
 use core::marker::PhantomData;
 use rand_core::OsRng;
 

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -1,3 +1,8 @@
+//! The Updater role (anyone can contribute).
+//!
+//! - Adds information necessary for subsequent entities to proceed, such as key paths
+//!   for signing spends.
+
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/pczt/src/roles/verifier/mod.rs
+++ b/pczt/src/roles/verifier/mod.rs
@@ -1,3 +1,8 @@
+//! The Verifier role (anyone can inspect).
+//!
+//! This isn't a real role per se; it's instead a way for accessing the parsed
+//! protocol-specific bundles for individual access and verification.
+
 use crate::Pczt;
 
 #[cfg(feature = "orchard")]

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -1,3 +1,5 @@
+//! The Sapling fields of a PCZT.
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/pczt/src/transparent.rs
+++ b/pczt/src/transparent.rs
@@ -1,3 +1,5 @@
+//! The transparent fields of a PCZT.
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -22,6 +24,7 @@ pub struct Bundle {
     pub(crate) outputs: Vec<Output>,
 }
 
+/// Information about a transparent input within a transaction.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Input {
@@ -132,6 +135,7 @@ pub struct Input {
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
 }
 
+/// Information about a transparent output within a transaction.
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Output {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.equihash]]
+version = "0.2.2"
+audited_as = "0.2.1"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.2.2"
 audited_as = "0.2.1"
 
+[[unpublished.pczt]]
+version = "0.2.1"
+audited_as = "0.2.0"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/zcash_keys/src/lib.rs
+++ b/zcash_keys/src/lib.rs
@@ -3,7 +3,6 @@
 //! `zcash_keys` contains Rust structs, traits and functions for creating Zcash spending
 //! and viewing keys and addresses.
 //!
-//! ## Feature flags
 #![cfg_attr(feature = "std", doc = "## Feature flags")]
 #![cfg_attr(feature = "std", doc = document_features::document_features!())]
 //!


### PR DESCRIPTION
This PR includes patch releases of `equihash` and `pczt`, for which their public documentation omits significant parts of their APIs (due to not being built with `--all-features`). The rest of the fixes don't appear to affect the public doc builds, they are just local issues I noticed while fixing the other two.