### PR TITLE
zcash_client_backend: Fix zcash/librustzcash#1746

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -42,11 +42,20 @@ and this library adheres to Rust's notion of
   - `TransactionDataRequest::SpendsFromAddress` has been renamed to
     `TransactionDataRequest::TransactionsInvolvingAddress` and has added struct
     fields `request_at`, `tx_status_filter`, and `output_status_filter`.
+- Arguments to `zcash_client_backend::decrypt::decrypt_transaction` have changed.
+  It now takes separate `mined_height` and `chain_tip_height` parameters; this
+  fixes https://github.com/zcash/librustzcash/issues/1746 as described in the
+  `Fixed` section below.
 
 ### Removed
 - `zcash_client_backend::data_api::GAP_LIMIT` gap limits are now configured
   based upon the key scope that they're associated with; there is no longer a
   globally applicable gap limit.
+
+### Fixed
+- This release fixes https://github.com/zcash/librustzcash/issues/1746, which
+  made it possible for `zcash_client_backend::decrypt_and_store_transaction`
+  to incorrectly set a `mined_height` value for a mempool transaction.
 
 ## [0.17.0] - 2025-02-21
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -266,7 +266,7 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
     let ufvks = [(account.id(), account.usk().to_unified_full_viewing_key())]
         .into_iter()
         .collect();
-    let d_tx = decrypt_transaction(st.network(), h + 1, &tx, &ufvks);
+    let d_tx = decrypt_transaction(st.network(), None, Some(h), &tx, &ufvks);
     assert_eq!(T::decrypted_pool_outputs_count(&d_tx), 2);
 
     let mut found_tx_change_memo = false;
@@ -424,7 +424,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
     let ufvks = [(account.id(), account.usk().to_unified_full_viewing_key())]
         .into_iter()
         .collect();
-    let d_tx = decrypt_transaction(st.network(), h + 1, &tx, &ufvks);
+    let d_tx = decrypt_transaction(st.network(), None, Some(h), &tx, &ufvks);
     assert_eq!(T::decrypted_pool_outputs_count(&d_tx), 3);
 
     let mut found_tx_change_memo = false;

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -549,7 +549,8 @@ mod tests {
         // Replicate its relevant innards here.
         let d_tx = decrypt_transaction(
             &params,
-            height,
+            Some(height),
+            None,
             tx,
             &[(account_id, ufvk0)].into_iter().collect(),
         );

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -108,7 +108,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                     ))
                 })?;
 
-            let decrypted_outputs = decrypt_transaction(&self.params, block_height, &tx, &ufvks);
+            let decrypted_outputs =
+                decrypt_transaction(&self.params, Some(block_height), None, &tx, &ufvks);
 
             // Orchard outputs were not supported as of the wallet states that could require this
             // migration.


### PR DESCRIPTION
This fixes https://github.com/zcash/librustzcash/issues/1746, which made it possible for `zcash_client_backend::decrypt_and_store_transaction` to incorrectly set a `mined_height` value for a mempool transaction.