### PR TITLE
zcash_client_sqlite: Fix migration error caused by missing transparent addresses prior to the index of the default address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "ambassador",
  "assert_matches",
@@ -6456,7 +6456,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bip32",
  "blake2b_simd",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -977,10 +977,6 @@ criteria = "safe-to-run"
 version = "0.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.reddsa]]
 version = "0.5.1"
 criteria = "safe-to-deploy"
@@ -1519,10 +1515,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-core]]
-version = "0.52.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,14 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_client_sqlite]]
-version = "0.16.2"
-audited_as = "0.16.1"
-
-[[unpublished.zcash_transparent]]
-version = "0.2.2"
-audited_as = "0.2.1"
-
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -303,11 +295,11 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.16.1"
-when = "2025-03-27"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
+version = "0.16.2"
+when = "2025-04-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_encoding]]
 version = "0.3.0"
@@ -366,8 +358,8 @@ user-login = "daira"
 user-name = "Daira-Emma Hopwood"
 
 [[publisher.zcash_transparent]]
-version = "0.2.1"
-when = "2025-03-21"
+version = "0.2.2"
+when = "2025-04-03"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,25 +1,13 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_client_backend]]
-version = "0.18.0"
-audited_as = "0.17.0"
-
 [[unpublished.zcash_client_sqlite]]
-version = "0.16.0"
-audited_as = "0.15.0"
-
-[[unpublished.zcash_keys]]
-version = "0.8.0"
-audited_as = "0.7.0"
-
-[[unpublished.zcash_protocol]]
-version = "0.5.1"
-audited_as = "0.5.0"
+version = "0.16.2"
+audited_as = "0.16.1"
 
 [[unpublished.zcash_transparent]]
-version = "0.2.1"
-audited_as = "0.2.0"
+version = "0.2.2"
+audited_as = "0.2.1"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -308,18 +296,18 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.17.0"
-when = "2025-02-21"
+version = "0.18.0"
+when = "2025-03-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.15.0"
-when = "2025-02-21"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
+version = "0.16.1"
+when = "2025-03-27"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
 
 [[publisher.zcash_encoding]]
 version = "0.3.0"
@@ -343,8 +331,8 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.zcash_keys]]
-version = "0.7.0"
-when = "2025-02-21"
+version = "0.8.0"
+when = "2025-03-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -364,8 +352,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.5.0"
-when = "2025-02-21"
+version = "0.5.1"
+when = "2025-03-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -378,8 +366,8 @@ user-login = "daira"
 user-name = "Daira-Emma Hopwood"
 
 [[publisher.zcash_transparent]]
-version = "0.2.0"
-when = "2025-02-21"
+version = "0.2.1"
+when = "2025-03-21"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -1365,6 +1353,15 @@ criteria = "safe-to-deploy"
 delta = "1.0.35 -> 1.0.36"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.rand]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.8.5"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.ring]]
 who = "Laura Peskin <pesk@google.com>"
 criteria = "safe-to-deploy"
@@ -1631,6 +1628,13 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "1.0.2"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.windows-core]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.52.0"
+notes = "Implements Windows system APIs"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.isrg.audits.aes]]
 who = "Tim Geoghegan <timg@divviup.org>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.16.2] - 2025-04-02
+
 ### Fixed
 - This release fixes a migration error that could cause some wallets
   to crash on startup due to an attempt to associate a received transparent

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+- This release fixes a migration error that could cause some wallets
+  to crash on startup due to an attempt to associate a received transparent
+  output with an address that does not exist in the wallet's `addresses`
+  table.
+
 ## [0.16.1] - 2025-03-26
 
 ### Fixed

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.16.1"
+version = "0.16.2"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -611,7 +611,7 @@ pub(crate) fn add_account<P: consensus::Parameters>(
         false,
     )?;
 
-    // Pre-generate transparent addresses prior to the index of the default address.
+    // Pre-generate external transparent addresses prior to the index of the default address.
     #[cfg(feature = "transparent-inputs")]
     if let Ok(default_addr_idx) = NonHardenedChildIndex::try_from(d_idx) {
         transparent::generate_address_range(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -611,6 +611,20 @@ pub(crate) fn add_account<P: consensus::Parameters>(
         false,
     )?;
 
+    // Pre-generate transparent addresses prior to the index of the default address.
+    #[cfg(feature = "transparent-inputs")]
+    if let Ok(default_addr_idx) = NonHardenedChildIndex::try_from(d_idx) {
+        transparent::generate_address_range(
+            conn,
+            params,
+            account_id,
+            KeyScope::EXTERNAL,
+            UnifiedAddressRequest::ALLOW_ALL,
+            NonHardenedChildIndex::const_from_index(0)..default_addr_idx,
+            false,
+        )?
+    }
+
     // Pre-generate transparent addresses up to the gap limits for the external, internal,
     // and ephemeral key scopes.
     #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -173,7 +173,7 @@ pub(super) fn all_migrations<
             _rng: rng.clone(),
         }),
         Box::new(ensure_default_transparent_address::Migration {
-            params: params.clone(),
+            _params: params.clone(),
         }),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -186,7 +186,7 @@ pub(super) fn all_migrations<
 #[allow(dead_code)]
 const PUBLIC_MIGRATION_STATES: &[&[Uuid]] = &[
     V_0_4_0, V_0_6_0, V_0_8_0, V_0_9_0, V_0_10_0, V_0_10_3, V_0_11_0, V_0_11_1, V_0_11_2, V_0_12_0,
-    V_0_13_0, V_0_14_0, V_0_15_0,
+    V_0_13_0, V_0_14_0, V_0_15_0, V_0_16_0, V_0_16_2,
 ];
 
 /// Leaf migrations in the 0.4.0 release.
@@ -257,6 +257,10 @@ const V_0_15_0: &[Uuid] = &[
     fix_bad_change_flagging::MIGRATION_ID,
     v_transactions_additional_totals::MIGRATION_ID,
 ];
+
+const V_0_16_0: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
+
+const V_0_16_2: &[Uuid] = &[ensure_default_transparent_address::MIGRATION_ID];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
     conn: &rusqlite::Connection,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -3,6 +3,7 @@ mod add_account_uuids;
 mod add_transaction_views;
 mod add_utxo_account;
 mod addresses_table;
+mod ensure_default_transparent_address;
 mod ensure_orchard_ua_receiver;
 mod ephemeral_addresses;
 mod fix_bad_change_flagging;
@@ -99,6 +100,8 @@ pub(super) fn all_migrations<
     //                          fix_bad_change_flagging     v_transactions_additional_totals
     //                                                                     |
     //                                                       transparent_gap_limit_handling
+    //                                                                     |
+    //                                                     ensure_default_transparent_address
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),
@@ -168,6 +171,9 @@ pub(super) fn all_migrations<
             params: params.clone(),
             _clock: clock.clone(),
             _rng: rng.clone(),
+        }),
+        Box::new(ensure_default_transparent_address::Migration {
+            params: params.clone(),
         }),
     ]
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
@@ -1,0 +1,50 @@
+//! Ensures that an external transparent address exists in the `addresses` table for each
+//! non-hardened child index starting at index 0 and ending at the index corresponding to default
+//! address for the account.
+
+use std::collections::HashSet;
+use uuid::Uuid;
+
+use rusqlite::Transaction;
+use schemerz_rusqlite::RusqliteMigration;
+use zcash_protocol::consensus;
+
+use super::transparent_gap_limit_handling;
+use crate::wallet::init::WalletMigrationError;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x702cf97b_8395_4edc_b584_5c9f87f0ef35);
+
+const DEPENDENCIES: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
+
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
+
+impl<P> schemerz::Migration<Uuid> for Migration<P> {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Add support for general transparent gap limit handling, unifying the `addresses` and `ephemeral_addresses` tables."
+    }
+}
+
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &Transaction) -> Result<(), WalletMigrationError> {
+        #[cfg(feature = "transparent-inputs")]
+        transparent_gap_limit_handling::insert_initial_transparent_addrs(conn, &self.params)?;
+
+        Ok(())
+    }
+
+    fn down(&self, _: &Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
@@ -30,7 +30,7 @@ impl<P> schemerz::Migration<Uuid> for Migration<P> {
     }
 
     fn description(&self) -> &'static str {
-        "Add support for general transparent gap limit handling, unifying the `addresses` and `ephemeral_addresses` tables."
+        "Ensures the existence of transparent addresses in the range 0..<default_address_idx>"
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
@@ -17,7 +17,7 @@ pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x702cf97b_8395_4edc_b584_
 const DEPENDENCIES: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
-    pub(super) params: P,
+    pub(super) _params: P,
 }
 
 impl<P> schemerz::Migration<Uuid> for Migration<P> {
@@ -37,9 +37,9 @@ impl<P> schemerz::Migration<Uuid> for Migration<P> {
 impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
-    fn up(&self, conn: &Transaction) -> Result<(), WalletMigrationError> {
+    fn up(&self, _conn: &Transaction) -> Result<(), WalletMigrationError> {
         #[cfg(feature = "transparent-inputs")]
-        transparent_gap_limit_handling::insert_initial_transparent_addrs(conn, &self.params)?;
+        transparent_gap_limit_handling::insert_initial_transparent_addrs(_conn, &self._params)?;
 
         Ok(())
     }

--- a/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
@@ -101,9 +101,9 @@ pub(super) fn insert_initial_transparent_addrs<P: consensus::Parameters>(
             .transpose()?
             .and_then(|di| NonHardenedChildIndex::try_from(di).ok());
 
-        // Ensure that there is an address for each possible external address index prior
-        // to the default UA for the account. We guarantee addresses up to the gap limit,
-        // but not beyond.
+        // Ensure that there is an address for each possible external address index prior to the
+        // default UA for the account. If the default address has a diversifier index greater than
+        // the gap limit, we generate transparent addresses up to that index but not beyond.
         let start = NonHardenedChildIndex::const_from_index(0);
         let end = std::cmp::min(
             min_transparent_idx
@@ -338,7 +338,7 @@ impl<P: consensus::Parameters, C: Clock, R: RngCore> RusqliteMigration for Migra
                                 .ok()
                                 .and_then(NonHardenedChildIndex::from_index)
                                 .ok_or(WalletMigrationError::CorruptedData(
-                                    "ephermeral address indices must be in the range of `u31`"
+                                    "ephemeral address indices must be in the range of `u31`"
                                         .to_owned(),
                                 ))?
                                 .index(),

--- a/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
@@ -26,7 +26,7 @@ use {
     crate::{
         wallet::{
             encoding::{decode_diversifier_index_be, encode_diversifier_index_be, epoch_seconds},
-            transparent::{generate_gap_addresses, next_check_time},
+            transparent::{generate_address_range, generate_gap_addresses, next_check_time},
         },
         GapLimits,
     },
@@ -58,6 +58,77 @@ impl<P, C, R> schemerz::Migration<Uuid> for Migration<P, C, R> {
     fn description(&self) -> &'static str {
         "Add support for general transparent gap limit handling, unifying the `addresses` and `ephemeral_addresses` tables."
     }
+}
+
+// For each account, ensure that all diversifier indexes prior to that for the default
+// address have corresponding cached transparent addresses.
+#[cfg(feature = "transparent-inputs")]
+pub(super) fn insert_initial_transparent_addrs<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+) -> Result<(), WalletMigrationError> {
+    let mut min_addr_diversifiers = conn.prepare(
+        r#"
+        SELECT accounts.id AS account_id,
+               MIN(addresses.transparent_child_index) AS transparent_child_index,
+               MIN(addresses.diversifier_index_be) AS diversifier_index_be
+        FROM accounts
+        LEFT OUTER JOIN addresses
+            ON accounts.id = addresses.account_id
+            AND addresses.key_scope = :key_scope_external
+        GROUP BY accounts.id
+        "#,
+    )?;
+
+    let mut min_addr_rows = min_addr_diversifiers.query(named_params![
+        ":key_scope_external": KeyScope::EXTERNAL.encode()
+    ])?;
+    while let Some(row) = min_addr_rows.next()? {
+        let account_id = AccountRef(row.get::<_, u32>("account_id")?);
+
+        let min_transparent_idx = row
+            .get::<_, Option<u32>>("transparent_child_index")?
+            .map(|i| {
+                NonHardenedChildIndex::from_index(i).ok_or(WalletMigrationError::CorruptedData(
+                    format!("{} is not a valid transparent child index.", i),
+                ))
+            })
+            .transpose()?;
+
+        let min_diversifier_idx = row
+            .get::<_, Option<Vec<u8>>>("diversifier_index_be")?
+            .map(|b| decode_diversifier_index_be(&b[..]))
+            .transpose()?
+            .and_then(|di| NonHardenedChildIndex::try_from(di).ok());
+
+        // Ensure that there is an address for each possible external address index prior
+        // to the default UA for the account. We guarantee addresses up to the gap limit,
+        // but not beyond.
+        let start = NonHardenedChildIndex::const_from_index(0);
+        let end = std::cmp::min(
+            min_transparent_idx
+                .or(min_diversifier_idx)
+                // guarantee that we have an entry at index 0; this address will have previously
+                // been provided explicitly as one of the wallet's addresses in response to a call
+                // to `get_transparent_receivers, even if we have no other addresses generated
+                // (which shouldn't ordinarily be the case anyway)
+                .unwrap_or(NonHardenedChildIndex::const_from_index(1)),
+            NonHardenedChildIndex::from_index(GapLimits::default().external())
+                .expect("default external gap limit fits in non-hardened child index space."),
+        );
+
+        generate_address_range(
+            conn,
+            params,
+            account_id,
+            KeyScope::EXTERNAL,
+            UnifiedAddressRequest::ALLOW_ALL,
+            start..end,
+            false,
+        )?;
+    }
+
+    Ok(())
 }
 
 impl<P: consensus::Parameters, C: Clock, R: RngCore> RusqliteMigration for Migration<P, C, R> {
@@ -351,6 +422,9 @@ impl<P: consensus::Parameters, C: Clock, R: RngCore> RusqliteMigration for Migra
             PRAGMA legacy_alter_table = OFF;
             "#,
         )?;
+
+        #[cfg(feature = "transparent-inputs")]
+        insert_initial_transparent_addrs(conn, &self.params)?;
 
         // Add foreign key references from the *_received_{notes|outputs} tables to the addresses
         // table to make it possible to identify which address was involved. These foreign key

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1,4 +1,5 @@
 //! Functions for transparent input support in the wallet.
+use core::ops::Range;
 use std::collections::{HashMap, HashSet};
 use std::num::TryFromIntError;
 use std::ops::DerefMut;
@@ -17,6 +18,7 @@ use ::transparent::{
     bundle::{OutPoint, TxOut},
     keys::{IncomingViewingKey, NonHardenedChildIndex},
 };
+use transparent::keys::NonHardenedChildRange;
 use zcash_address::unified::{Ivk, Typecode, Uivk};
 use zcash_client_backend::{
     data_api::{
@@ -25,6 +27,7 @@ use zcash_client_backend::{
     },
     wallet::{TransparentAddressMetadata, WalletTransparentOutput},
 };
+use zcash_keys::keys::UnifiedIncomingViewingKey;
 use zcash_keys::{
     address::Address,
     encoding::AddressCodec,
@@ -36,7 +39,7 @@ use zcash_protocol::{
     value::{ZatBalance, Zatoshis},
     TxId,
 };
-use zip32::Scope;
+use zip32::{DiversifierIndex, Scope};
 
 use super::encoding::{decode_epoch_seconds, ReceiverFlags};
 use super::{
@@ -401,6 +404,133 @@ pub(crate) fn reserve_next_n_addresses<P: consensus::Parameters>(
     Ok(addresses_to_reserve)
 }
 
+pub(crate) fn generate_external_address(
+    uivk: &UnifiedIncomingViewingKey,
+    ua_request: UnifiedAddressRequest,
+    index: NonHardenedChildIndex,
+) -> Result<(Address, TransparentAddress), AddressGenerationError> {
+    let ua = uivk.address(index.into(), ua_request);
+    let transparent_address = uivk
+        .transparent()
+        .as_ref()
+        .ok_or(AddressGenerationError::KeyNotAvailable(Typecode::P2pkh))?
+        .derive_address(index)
+        .map_err(|_| {
+            AddressGenerationError::InvalidTransparentChildIndex(DiversifierIndex::from(index))
+        })?;
+    Ok((
+        ua.map_or_else(
+            |e| {
+                if matches!(e, AddressGenerationError::ShieldedReceiverRequired) {
+                    // fall back to the transparent-only address
+                    Ok(Address::from(transparent_address))
+                } else {
+                    // other address generation errors are allowed to propagate
+                    Err(e)
+                }
+            },
+            |addr| Ok(Address::from(addr)),
+        )?,
+        transparent_address,
+    ))
+}
+
+/// Generates addresses to fill the specified non-hardened child index range.
+///
+/// The provided [`UnifiedAddressRequest`] is used to pre-generate unified addresses that correspond
+/// to each transparent address index in question; such unified addresses need not internally
+/// contain a transparent receiver, and may be overwritten when these addresses are exposed via the
+/// [`WalletWrite::get_next_available_address`] or [`WalletWrite::get_address_for_index`] methods.
+/// If no request is provided, each address so generated will contain a receiver for each possible
+/// pool: i.e., a recevier for each data item in the account's UFVK or UIVK where the transparent
+/// child index is valid.
+///
+/// [`WalletWrite::get_next_available_address`]: zcash_client_backend::data_api::WalletWrite::get_next_available_address
+/// [`WalletWrite::get_address_for_index`]: zcash_client_backend::data_api::WalletWrite::get_address_for_index
+pub(crate) fn generate_address_range<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_id: AccountRef,
+    key_scope: KeyScope,
+    request: UnifiedAddressRequest,
+    range_to_store: Range<NonHardenedChildIndex>,
+    require_key: bool,
+) -> Result<(), SqliteClientError> {
+    let account = get_account_internal(conn, params, account_id)?
+        .ok_or_else(|| SqliteClientError::AccountUnknown)?;
+
+    if !account.uivk().has_transparent() {
+        if require_key {
+            return Err(SqliteClientError::AddressGeneration(
+                AddressGenerationError::KeyNotAvailable(Typecode::P2pkh),
+            ));
+        } else {
+            return Ok(());
+        }
+    }
+
+    let gen_addrs = |key_scope: KeyScope, index: NonHardenedChildIndex| {
+        Ok::<_, SqliteClientError>(match key_scope {
+            KeyScope::Zip32(zip32::Scope::External) => {
+                generate_external_address(&account.uivk(), request, index)?
+            }
+            KeyScope::Zip32(zip32::Scope::Internal) => {
+                let internal_address = account
+                    .ufvk()
+                    .and_then(|k| k.transparent())
+                    .expect("presence of transparent key was checked above.")
+                    .derive_internal_ivk()?
+                    .derive_address(index)?;
+                (Address::from(internal_address), internal_address)
+            }
+            KeyScope::Ephemeral => {
+                let ephemeral_address = account
+                    .ufvk()
+                    .and_then(|k| k.transparent())
+                    .expect("presence of transparent key was checked above.")
+                    .derive_ephemeral_ivk()?
+                    .derive_ephemeral_address(index)?;
+                (Address::from(ephemeral_address), ephemeral_address)
+            }
+        })
+    };
+
+    // exposed_at_height is initially NULL
+    let mut stmt_insert_address = conn.prepare_cached(
+        "INSERT INTO addresses (
+            account_id, diversifier_index_be, key_scope, address,
+            transparent_child_index, cached_transparent_receiver_address,
+            receiver_flags
+         )
+         VALUES (
+            :account_id, :diversifier_index_be, :key_scope, :address,
+            :transparent_child_index, :transparent_address,
+            :receiver_flags
+         )
+         ON CONFLICT (account_id, diversifier_index_be, key_scope) DO NOTHING",
+    )?;
+
+    for transparent_child_index in NonHardenedChildRange::from(range_to_store) {
+        let (address, transparent_address) = gen_addrs(key_scope, transparent_child_index)?;
+        let zcash_address = address.to_zcash_address(params);
+        let receiver_flags: ReceiverFlags = zcash_address
+            .clone()
+            .convert::<ReceiverFlags>()
+            .expect("address is valid");
+
+        stmt_insert_address.execute(named_params![
+            ":account_id": account_id.0,
+            ":diversifier_index_be": encode_diversifier_index_be(transparent_child_index.into()),
+            ":key_scope": key_scope.encode(),
+            ":address": zcash_address.encode(),
+            ":transparent_child_index": transparent_child_index.index(),
+            ":transparent_address": transparent_address.encode(params),
+            ":receiver_flags": receiver_flags.bits()
+        ])?;
+    }
+    Ok(())
+}
+
 /// Extend the range of preallocated addresses in an account to ensure that a full `gap_limit` of
 /// transparent addresses is available from the first gap in existing indices of addresses at which
 /// a received transaction has been observed on the chain, for each key scope.
@@ -424,72 +554,6 @@ pub(crate) fn generate_gap_addresses<P: consensus::Parameters>(
     request: UnifiedAddressRequest,
     require_key: bool,
 ) -> Result<(), SqliteClientError> {
-    let account = get_account_internal(conn, params, account_id)?
-        .ok_or_else(|| SqliteClientError::AccountUnknown)?;
-
-    if !account.uivk().has_transparent() {
-        if require_key {
-            return Err(SqliteClientError::AddressGeneration(
-                AddressGenerationError::KeyNotAvailable(Typecode::P2pkh),
-            ));
-        } else {
-            return Ok(());
-        }
-    }
-
-    let gen_addrs = |key_scope: KeyScope, index: NonHardenedChildIndex| {
-        Ok::<_, SqliteClientError>(match key_scope {
-            KeyScope::Zip32(zip32::Scope::External) => {
-                let ua = account.uivk().address(index.into(), request);
-                let transparent_address = account
-                    .uivk()
-                    .transparent()
-                    .as_ref()
-                    .expect("presence of transparent key was checked above.")
-                    .derive_address(index)?;
-                (
-                    ua.map_or_else(
-                        |e| {
-                            if matches!(e, AddressGenerationError::ShieldedReceiverRequired) {
-                                // fall back to the transparent-only address
-                                Ok(Address::from(transparent_address).to_zcash_address(params))
-                            } else {
-                                // other address generation errors are allowed to propagate
-                                Err(e)
-                            }
-                        },
-                        |addr| Ok(Address::from(addr).to_zcash_address(params)),
-                    )?,
-                    transparent_address,
-                )
-            }
-            KeyScope::Zip32(zip32::Scope::Internal) => {
-                let internal_address = account
-                    .ufvk()
-                    .and_then(|k| k.transparent())
-                    .expect("presence of transparent key was checked above.")
-                    .derive_internal_ivk()?
-                    .derive_address(index)?;
-                (
-                    Address::from(internal_address).to_zcash_address(params),
-                    internal_address,
-                )
-            }
-            KeyScope::Ephemeral => {
-                let ephemeral_address = account
-                    .ufvk()
-                    .and_then(|k| k.transparent())
-                    .expect("presence of transparent key was checked above.")
-                    .derive_ephemeral_ivk()?
-                    .derive_ephemeral_address(index)?;
-                (
-                    Address::from(ephemeral_address).to_zcash_address(params),
-                    ephemeral_address,
-                )
-            }
-        })
-    };
-
     let gap_limit = match key_scope {
         KeyScope::Zip32(zip32::Scope::External) => gap_limits.external(),
         KeyScope::Zip32(zip32::Scope::Internal) => gap_limits.internal(),
@@ -497,45 +561,15 @@ pub(crate) fn generate_gap_addresses<P: consensus::Parameters>(
     };
 
     if let Some(gap_start) = find_gap_start(conn, account_id, key_scope, gap_limit)? {
-        let range_to_store = gap_start.index()..gap_start.saturating_add(gap_limit).index();
-        if range_to_store.is_empty() {
-            return Ok(());
-        }
-        // exposed_at_height is initially NULL
-        let mut stmt_insert_address = conn.prepare_cached(
-            "INSERT INTO addresses (
-                account_id, diversifier_index_be, key_scope, address,
-                transparent_child_index, cached_transparent_receiver_address,
-                receiver_flags
-             )
-             VALUES (
-                :account_id, :diversifier_index_be, :key_scope, :address,
-                :transparent_child_index, :transparent_address,
-                :receiver_flags
-             )
-             ON CONFLICT (account_id, diversifier_index_be, key_scope) DO NOTHING",
+        generate_address_range(
+            conn,
+            params,
+            account_id,
+            key_scope,
+            request,
+            gap_start..gap_start.saturating_add(gap_limit),
+            require_key,
         )?;
-
-        for raw_index in range_to_store {
-            let transparent_child_index = NonHardenedChildIndex::from_index(raw_index)
-                .expect("restricted to valid range above");
-            let (zcash_address, transparent_address) =
-                gen_addrs(key_scope, transparent_child_index)?;
-            let receiver_flags: ReceiverFlags = zcash_address
-                .clone()
-                .convert::<ReceiverFlags>()
-                .expect("address is valid");
-
-            stmt_insert_address.execute(named_params![
-                ":account_id": account_id.0,
-                ":diversifier_index_be": encode_diversifier_index_be(transparent_child_index.into()),
-                ":key_scope": key_scope.encode(),
-                ":address": zcash_address.encode(),
-                ":transparent_child_index": raw_index,
-                ":transparent_address": transparent_address.encode(params),
-                ":receiver_flags": receiver_flags.bits()
-            ])?;
-        }
     }
 
     Ok(())

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_transparent::keys::NonHardenedChildRange`
+- `zcash_transparent::keys::NonHardenedChildIter`
+- `zcash_transparent::keys::NonHardenedChildIndex::const_from_index`
+
 ## [0.2.1] - 2025-03-19
 
 ### Added

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-04-02
+
 ### Added
 - `zcash_transparent::keys::NonHardenedChildRange`
 - `zcash_transparent::keys::NonHardenedChildIter`

--- a/zcash_transparent/Cargo.toml
+++ b/zcash_transparent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_transparent"
 description = "Rust implementations of the Zcash transparent protocol"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",


### PR DESCRIPTION
Earlier versions of the `zcash_client_sqlite` wallet did not store the transparent addresses at child indices prior to the diversifier index of the first unified address in the `addresses` table. This caused an error in migration for wallets that had received outputs at the address with child index 0, likely because they imported a seed generated by a wallet that had previously exposed that address.