### PR TITLE
fix: make `diversifier_index` optional to prevent crashes

### DIFF
--- a/zcash_client_backend/examples/diversify-address.rs
+++ b/zcash_client_backend/examples/diversify-address.rs
@@ -40,7 +40,7 @@ struct MyOptions {
         help = "The index of the diversified address to generate (default 0). Some indices don't have a corresponding address.",
         parse(try_from_str = "parse_diversifier_index")
     )]
-    diversifier_index: DiversifierIndex,
+    diversifier_index: Option<DiversifierIndex>,
 }
 
 fn main() {
@@ -53,6 +53,8 @@ fn main() {
         return;
     };
 
+    let diversifier_index = opts.diversifier_index.unwrap_or_else(|| DiversifierIndex::new());
+    
     let (diversifier_index, address) = extfvk.find_address(opts.diversifier_index).unwrap();
     println!(
         "# Diversifier index: {}",


### PR DESCRIPTION
`diversifier_index` was a required field, which caused the program to crash if it wasn't provided in the command line arguments. this update makes it optional and defaults to `DiversifierIndex::new()` when not specified.  
