### PR TITLE
zcash_client_sqlite migration and doc fixes; also CI: fix bugs related to pool feature flag combinations

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Extra feature flags to enable'
     required: false
     default: ''
+  all-pools:
+    description: 'Enable all pool-specific feature flags'
+    required: false
+    default: true
   test-dependencies:
     description: 'Include test dependencies'
     required: false
@@ -16,13 +20,19 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - id: pools
+      shell: bash
+      run: echo "features=orchard transparent-inputs" >> $GITHUB_OUTPUT
+      if: inputs.all-pools == 'true'
+
     - id: test
       shell: bash
       run: echo "feature=test-dependencies" >> $GITHUB_OUTPUT
       if: inputs.test-dependencies == 'true'
 
-    # `steps.test.outputs.feature` cannot expand into attacker-controllable code
-    # because the previous step only enables it to have one of two fixed values.
+    # `steps.pools.outputs.features` and `steps.test.outputs.feature` cannot
+    # expand into attacker-controllable code because the previous steps only
+    # enable them to have one of two fixed values.
     - name: Prepare feature flags # zizmor: ignore[template-injection]
       id: prepare
       shell: bash
@@ -38,6 +48,7 @@ runs:
         unstable-serialization
         unstable-spanning-tree
         ${EXTRA_FEATURES}
+        ${{ steps.pools.outputs.features }}
         ${{ steps.test.outputs.feature }}
         '" >> $GITHUB_OUTPUT
       env:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -43,7 +43,6 @@ runs:
         lightwalletd-tonic
         sync
         temporary-zcashd
-        transparent-inputs
         unstable
         unstable-serialization
         unstable-spanning-tree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,24 @@ jobs:
         target:
           - Linux
         state:
-          - no-Orchard
+          - transparent
+          - Sapling-only
           - Orchard
+          - all-pools
           - NU7
 
         include:
           - target: Linux
             os: ubuntu-latest-8cores
 
+          - state: transparent
+            extra_flags: transparent-inputs
           - state: Orchard
             extra_flags: orchard
+          - state: all-pools
+            extra_flags: orchard transparent-inputs
           - state: NU7
-            extra_flags: orchard
+            extra_flags: orchard transparent-inputs
             rustflags: '--cfg zcash_unstable="nu7"'
 
     env:
@@ -69,8 +75,10 @@ jobs:
           - macOS
           - Windows
         state:
-          - no-Orchard
+          - transparent
+          - Sapling-only
           - Orchard
+          - all-pools
           - NU7
 
         include:
@@ -79,10 +87,14 @@ jobs:
           - target: Windows
             os: windows-latest-8cores
 
+          - state: transparent
+            extra_flags: transparent-inputs
           - state: Orchard
             extra_flags: orchard
+          - state: all-pools
+            extra_flags: orchard transparent-inputs
           - state: NU7
-            extra_flags: orchard
+            extra_flags: orchard transparent-inputs
             rustflags: '--cfg zcash_unstable="nu7"'
 
         exclude:
@@ -128,17 +140,24 @@ jobs:
         target:
           - Linux
         state:
+          - transparent
+          - Sapling-only
           - Orchard
+          - all-pools
           - NU7
 
         include:
           - target: Linux
             os: ubuntu-latest-8cores
 
+          - state: transparent
+            extra_flags: transparent-inputs
           - state: Orchard
             extra_flags: orchard
+          - state: all-pools
+            extra_flags: orchard transparent-inputs
           - state: NU7
-            extra_flags: orchard
+            extra_flags: orchard transparent-inputs
             rustflags: '--cfg zcash_unstable="nu7"'
 
     env:
@@ -208,7 +227,6 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
-          all-pools: false
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
+          all-pools: false
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -99,6 +100,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
+          all-pools: false
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -150,6 +152,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
+          all-pools: false
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -205,6 +208,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
+          all-pools: false
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2420,6 +2420,12 @@ mod tests {
             .wallet()
             .get_last_generated_address_matching(account.id(), shielded_only_request)
             .unwrap();
+        // If transparent support is disabled, then the previous "transparent-including"
+        // addresses were actually shielded-only, so we do have a current address.
+        #[cfg(not(feature = "transparent-inputs"))]
+        assert_eq!(cur_shielded_only, addr2);
+        // If transparent support is enabled, this works as expected.
+        #[cfg(feature = "transparent-inputs")]
         assert!(cur_shielded_only.is_none());
 
         let di_lower = st

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -17,6 +17,7 @@ mod ensure_orchard_ua_receiver;
 mod ephemeral_addresses;
 mod fix_bad_change_flagging;
 mod fix_broken_commitment_trees;
+mod fix_transparent_received_outputs;
 mod full_account_ids;
 mod initial_setup;
 mod nullifier_map;
@@ -107,8 +108,10 @@ pub(super) fn all_migrations<
     //                         fix_broken_commitment_trees         add_account_uuids
     //                             /                                /             \
     //          fix_bad_change_flagging      transparent_gap_limit_handling    v_transactions_additional_totals
-    //                                                     |
-    //                                     ensure_default_transparent_address
+    //                             \                       |                      /
+    //                              \      ensure_default_transparent_address    /
+    //                               \                     |                    /
+    //                                `---- fix_transparent_received_outputs --'
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),
@@ -182,6 +185,7 @@ pub(super) fn all_migrations<
         Box::new(ensure_default_transparent_address::Migration {
             _params: params.clone(),
         }),
+        Box::new(fix_transparent_received_outputs::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -105,12 +105,10 @@ pub(super) fn all_migrations<
     //                                            support_legacy_sqlite
     //                                               /              \
     //                         fix_broken_commitment_trees         add_account_uuids
-    //                                     |                               |
-    //                          fix_bad_change_flagging     v_transactions_additional_totals
-    //                                                                     |
-    //                                                       transparent_gap_limit_handling
-    //                                                                     |
-    //                                                     ensure_default_transparent_address
+    //                             /                                /             \
+    //          fix_bad_change_flagging      transparent_gap_limit_handling    v_transactions_additional_totals
+    //                                                     |
+    //                                     ensure_default_transparent_address
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),
@@ -267,9 +265,19 @@ pub const V_0_15_0: &[Uuid] = &[
     v_transactions_additional_totals::MIGRATION_ID,
 ];
 
-const V_0_16_0: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
+/// Leaf migrations in the 0.16.0 release.
+const V_0_16_0: &[Uuid] = &[
+    fix_bad_change_flagging::MIGRATION_ID,
+    v_transactions_additional_totals::MIGRATION_ID,
+    transparent_gap_limit_handling::MIGRATION_ID,
+];
 
-const V_0_16_2: &[Uuid] = &[ensure_default_transparent_address::MIGRATION_ID];
+/// Leaf migrations in the 0.16.2 release.
+const V_0_16_2: &[Uuid] = &[
+    fix_bad_change_flagging::MIGRATION_ID,
+    v_transactions_additional_totals::MIGRATION_ID,
+    ensure_default_transparent_address::MIGRATION_ID,
+];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
     conn: &rusqlite::Connection,

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
@@ -1,0 +1,87 @@
+//! Fixes the `transparent_received_outputs` table schema to not depend on feature flags.
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::{
+    ensure_default_transparent_address, fix_bad_change_flagging, v_transactions_additional_totals,
+};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xb951587c_34fd_4f02_a313_05ff7adb6268);
+
+const DEPENDENCIES: &[Uuid] = &[
+    fix_bad_change_flagging::MIGRATION_ID,
+    v_transactions_additional_totals::MIGRATION_ID,
+    ensure_default_transparent_address::MIGRATION_ID,
+];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Fixes the `transparent_received_outputs` table schema to not depend on feature flags"
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // This is the same table rewrite done in `transparent_gap_limit_handling`, but
+        // unconditionally. If the wallet ran `transparent_gap_limit_handling` with the
+        // `transparent-inputs` feature flag enabled, this will be a no-op.
+        transaction.execute_batch(
+            r#"
+            PRAGMA legacy_alter_table = ON;
+
+            CREATE TABLE transparent_received_outputs_new (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                output_index INTEGER NOT NULL,
+                account_id INTEGER NOT NULL,
+                address TEXT NOT NULL,
+                script BLOB NOT NULL,
+                value_zat INTEGER NOT NULL,
+                max_observed_unspent_height INTEGER,
+                address_id INTEGER NOT NULL REFERENCES addresses(id),
+                FOREIGN KEY (transaction_id) REFERENCES transactions(id_tx),
+                FOREIGN KEY (account_id) REFERENCES accounts(id),
+                CONSTRAINT transparent_output_unique UNIQUE (transaction_id, output_index)
+            );
+            INSERT INTO transparent_received_outputs_new SELECT * FROM transparent_received_outputs;
+
+            DROP TABLE transparent_received_outputs;
+            ALTER TABLE transparent_received_outputs_new RENAME TO transparent_received_outputs;
+
+            PRAGMA legacy_alter_table = OFF;
+            "#,
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}


### PR DESCRIPTION
Previously, in CI we were:
- Not enabling the `orchard` feature flag for our regular builds and linters.
- Always enabling the `transparent-inputs` feature flag for our tests.

These led to bugs being missed, and deployed to production. We now always build/lint with all pool-specific feature flags enabled, and we test with more flag combinations.

This PR also corrects a problem in zcash_client_sqlite with the `transparent_gap_limit_handling` migration only having been run when the `transparent-inputs` feature flag enabled. It should have been run unconditionally. We also make some other doc and test fixes to zcash_client_sqlite.