### PR TITLE
Define `TargetValue` to select spendable notes

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,12 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
+- `zcash_client_backend::data_api`:
+  - `TargetValue`: An intent of representing spendable value to reach a certain 
+    targeted amount.
+  - `select_spendable_notes`: parameter `target_value` now is a `TargetValue`. 
+    Existing calls to this function that used `Zatoshis` now use 
+    `TargetValue::AtLeast(Zatoshis)`
 - Migrated to `arti-client 0.28`, `dynosaur 0.2`, `tonic 0.13`.
 - `zcash_client_backend::tor`:
   - `Client::{connect_to_lightwalletd, get_latest_zec_to_usd_rate}` now ensure

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -139,6 +139,21 @@ pub enum NullifierQuery {
     All,
 }
 
+/// An intent of representing spendable value to reach a certain targeted
+/// amount.  `AtLeast(Zatoshis)` refers to the amount of `Zatoshis` that can cover
+/// at minimum the given zatoshis that is conformed by the sum of spendable notes.
+///
+/// Discussion: why not just use ``Zatoshis``?
+///
+/// the `Zatoshis` value isn't enough to explain intent when seeking to match a
+/// given a given amount. Is the value expressed in `Zatoshis` the ceiling value
+/// or the minimum value of a given spend intent? How would you express that the
+/// value spend intent is "as much as possible" without knowing the value upfront?
+#[derive(Debug, Clone, Copy)]
+pub enum TargetValue {
+    AtLeast(Zatoshis),
+}
+
 /// Balance information for a value within a single pool in an account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Balance {
@@ -1201,7 +1216,7 @@ pub trait InputSource {
     fn select_spendable_notes(
         &self,
         account: Self::AccountId,
-        target_value: Zatoshis,
+        target_value: TargetValue,
         sources: &[ShieldedProtocol],
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -60,6 +60,7 @@ use super::{
     SAPLING_SHARD_HEIGHT,
 };
 use crate::{
+    data_api::TargetValue,
     fees::{
         standard::{self, SingleOutputChangeStrategy},
         ChangeStrategy, DustOutputPolicy, StandardFeeRule,
@@ -2495,7 +2496,7 @@ impl InputSource for MockWalletDb {
     fn select_spendable_notes(
         &self,
         _account: Self::AccountId,
-        _target_value: Zatoshis,
+        _target_value: TargetValue,
         _sources: &[ShieldedProtocol],
         _anchor_height: BlockHeight,
         _exclude: &[Self::NoteRef],

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -17,7 +17,6 @@ use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::Zatoshis,
     ShieldedProtocol,
 };
 
@@ -25,7 +24,8 @@ use crate::{
     data_api::{
         chain::{CommitmentTreeRoot, ScanSummary},
         testing::{pool::ShieldedPoolTester, TestState},
-        DecryptedTransaction, InputSource, WalletCommitmentTrees, WalletSummary, WalletTest,
+        DecryptedTransaction, InputSource, TargetValue, WalletCommitmentTrees, WalletSummary,
+        WalletTest,
     },
     wallet::{Note, ReceivedNote},
 };
@@ -107,7 +107,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
     fn select_spendable_notes<Cache, DbT: InputSource + WalletTest, P>(
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
-        target_value: Zatoshis,
+        target_value: TargetValue,
         anchor_height: BlockHeight,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -43,7 +43,8 @@ use crate::{
             decrypt_and_store_transaction, input_selection::GreedyInputSelector, TransferErrT,
         },
         Account as _, AccountBirthday, BoundedU8, DecryptedTransaction, InputSource, NoteFilter,
-        Ratio, WalletCommitmentTrees, WalletRead, WalletSummary, WalletTest, WalletWrite,
+        Ratio, TargetValue, WalletCommitmentTrees, WalletRead, WalletSummary, WalletTest,
+        WalletWrite,
     },
     decrypt_transaction,
     fees::{
@@ -147,7 +148,7 @@ pub trait ShieldedPoolTester {
     fn select_spendable_notes<Cache, DbT: InputSource + WalletTest, P>(
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
-        target_value: Zatoshis,
+        target_value: TargetValue,
         anchor_height: BlockHeight,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error>;
@@ -1928,7 +1929,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
     let spendable = T::select_spendable_notes(
         &st,
         account_id,
-        Zatoshis::const_from_u64(300000),
+        TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         received_tx_height + 10,
         &[],
     )
@@ -1943,7 +1944,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
     let spendable = T::select_spendable_notes(
         &st,
         account_id,
-        Zatoshis::const_from_u64(300000),
+        TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         received_tx_height + 10,
         &[],
     )
@@ -1997,7 +1998,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     let spendable = T::select_spendable_notes(
         &st,
         account.id(),
-        Zatoshis::const_from_u64(300000),
+        TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         account.birthday().height() + 5,
         &[],
     )

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -11,7 +11,6 @@ use zcash_primitives::transaction::{components::sapling::zip212_enforcement, Tra
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::Zatoshis,
     ShieldedProtocol,
 };
 use zip32::Scope;
@@ -19,7 +18,8 @@ use zip32::Scope;
 use crate::{
     data_api::{
         chain::{CommitmentTreeRoot, ScanSummary},
-        DecryptedTransaction, InputSource, WalletCommitmentTrees, WalletSummary, WalletTest,
+        DecryptedTransaction, InputSource, TargetValue, WalletCommitmentTrees, WalletSummary,
+        WalletTest,
     },
     wallet::{Note, ReceivedNote},
 };
@@ -91,7 +91,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
     fn select_spendable_notes<Cache, DbT: InputSource + WalletTest, P>(
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
-        target_value: Zatoshis,
+        target_value: TargetValue,
         anchor_height: BlockHeight,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -19,7 +19,7 @@ use zcash_protocol::{
 use zip321::TransactionRequest;
 
 use crate::{
-    data_api::{InputSource, SimpleNoteRetention, SpendableNotes},
+    data_api::{InputSource, SimpleNoteRetention, SpendableNotes, TargetValue},
     fees::{sapling, ChangeError, ChangeStrategy},
     proposal::{Proposal, ProposalError, ShieldedInputs},
     wallet::WalletTransparentOutput,
@@ -749,7 +749,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
-                    amount_required,
+                    TargetValue::AtLeast(amount_required),
                     selectable_pools,
                     anchor_height,
                     &exclude,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -59,7 +59,7 @@ use zcash_client_backend::{
         scanning::{ScanPriority, ScanRange},
         Account, AccountBirthday, AccountMeta, AccountPurpose, AccountSource, AddressInfo,
         BlockMetadata, DecryptedTransaction, InputSource, NoteFilter, NullifierQuery, ScannedBlock,
-        SeedRelevance, SentTransaction, SpendableNotes, TransactionDataRequest,
+        SeedRelevance, SentTransaction, SpendableNotes, TargetValue, TransactionDataRequest,
         WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
         SAPLING_SHARD_HEIGHT,
     },
@@ -563,7 +563,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
     fn select_spendable_notes(
         &self,
         account: Self::AccountId,
-        target_value: Zatoshis,
+        target_value: TargetValue,
         sources: &[ShieldedProtocol],
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -12,13 +12,12 @@ use tempfile::NamedTempFile;
 use rusqlite::{self};
 use secrecy::SecretVec;
 use shardtree::{error::ShardTreeError, ShardTree};
-
 use zcash_client_backend::{
     data_api::{
         chain::{ChainState, CommitmentTreeRoot},
         scanning::ScanRange,
         testing::{DataStoreFactory, Reset, TestState},
-        *,
+        TargetValue, *,
     },
     wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput},
 };

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -8,7 +8,7 @@ use orchard::{
 use rusqlite::{named_params, types::Value, Connection, Row};
 
 use zcash_client_backend::{
-    data_api::{Account as _, NullifierQuery},
+    data_api::{Account as _, NullifierQuery, TargetValue},
     wallet::{ReceivedNote, WalletOrchardOutput},
     DecryptedOutput, TransferType,
 };
@@ -17,7 +17,6 @@ use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::Zatoshis,
     ShieldedProtocol,
 };
 use zip32::Scope;
@@ -217,7 +216,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
-    target_value: Zatoshis,
+    target_value: TargetValue,
     anchor_height: BlockHeight,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -8,7 +8,7 @@ use rusqlite::{named_params, types::Value, Connection, Row};
 
 use sapling::{self, Diversifier, Nullifier, Rseed};
 use zcash_client_backend::{
-    data_api::{Account, NullifierQuery},
+    data_api::{Account, NullifierQuery, TargetValue},
     wallet::{ReceivedNote, WalletSaplingOutput},
     DecryptedOutput, TransferType,
 };
@@ -16,7 +16,6 @@ use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::Zatoshis,
     ShieldedProtocol, TxId,
 };
 use zip32::Scope;
@@ -226,7 +225,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
-    target_value: Zatoshis,
+    target_value: TargetValue,
     anchor_height: BlockHeight,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {


### PR DESCRIPTION
Working towards enabling `send_max_funds`.

Said @nuttycom over discord:

> We can also just chat here: right now, the main impediment to the approach suggested above is that https://docs.rs/zcash_client_backend/latest/zcash_client_backend/data_api/trait.InputSource.html#tymethod.select_spendable_notes requires a target value. We'll likely need to change the API of this method to make the target value a bespoke enum with variants `pub enum TargetValue {MaxSpendable, MinValue(Zatoshis)}`. We could alternately add a separate method, but I think that changing to use an enum for the target value is better.

My idea is to start implementing this in the most non-breaking way as possible. 

``` rust
#[derive(Debug, Clone, Copy)]
pub enum TargetValue {
    MaxSpendable,
    MinValue(Zatoshis)
} 
```

The Send Max feature has a lot of parts. This is the smallest change that I could think of and it does break a public interface already :( 