### PR TITLE
chore: remove duplicate words in comment

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -2577,7 +2577,7 @@ pub trait WalletWrite: WalletRead {
     /// purposes.
     ///
     /// There may be restrictions on heights to which it is possible to truncate. Specifically, it
-    /// will only be possible to truncate to heights at which is is possible to create a witness
+    /// will only be possible to truncate to heights at which is possible to create a witness
     /// given the current state of the wallet's note commitment tree.
     fn truncate_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error>;
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -818,7 +818,7 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
     let txid = build_result.transaction().txid();
 
     // Now, store the transaction, pretending it has been mined (we will actually mine the block
-    // next). This will cause the the gap start to move & a new `gap_limits.ephemeral()` of
+    // next). This will cause the gap start to move & a new `gap_limits.ephemeral()` of
     // addresses to be created.
     let target_height = st.latest_cached_block().unwrap().height() + 1;
     st.wallet_mut()


### PR DESCRIPTION
remove duplicate words in comment