### PR TITLE
free2z-hosted 'Rust Crates Walkthrough' w/ nuttycom

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ graph TB
 
 ### Crates
 
+[librustzcash: a Rust Crates Walkthrough w/ nuttycom](https://free2z.cash/uploadz/public/ZcashTutorial/librustzcash-a-rust-crates.mp4)
+
 #### Zcash Protocol
 
 * `zcash_protocol`: Constants & common types


### PR DESCRIPTION
Added link to free2z-hosted 'Rust Crates Walkthrough' w/ nuttycom in the README.