### PR TITLE
Add OP_RETURN and external signature support to builders

### DIFF
--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -521,6 +521,16 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'_, 
         self.transparent_builder.add_output(to, value)
     }
 
+    /// Adds a transparent OP_RETURN output with the given data payload.
+    pub fn add_transparent_op_return<FE>(
+        &mut self, 
+        data: &[u8]
+    ) -> Result<(), Error<FE>> {
+        self.transparent_builder
+           .add_op_return_output(data)
+           .map_err(Error::TransparentBuild)
+   }
+
     /// Returns the sum of the transparent, Sapling, Orchard, and TZE value balances.
     fn value_balance(&self) -> Result<ZatBalance, BalanceError> {
         let value_balances = [

--- a/zcash_transparent/src/address.rs
+++ b/zcash_transparent/src/address.rs
@@ -14,7 +14,9 @@ use zcash_encoding::Vector;
 /// Most of the opcodes are unused by this crate, but we define them so that the alternate
 /// `Debug` impl for [`Script`] renders correctly for unexpected scripts.
 #[derive(Debug)]
-enum OpCode {
+
+// Maya Protocol integration needs OpCode to be public for add_op_return_output implementation
+pub enum OpCode {
     // push value
     Op0 = 0x00, // False
     PushData1 = 0x4c,

--- a/zcash_transparent/src/builder.rs
+++ b/zcash_transparent/src/builder.rs
@@ -404,4 +404,55 @@ impl Bundle<Unauthorized> {
             authorization: Authorized,
         })
     }
+    
+    pub fn apply_external_signatures(
+        self,
+        #[cfg(feature = "transparent-inputs")] signatures: Vec<secp256k1::ecdsa::Signature>,
+    ) -> Bundle<Authorized> {
+        #[cfg(feature = "transparent-inputs")]
+        let script_sigs = { 
+            // Check that the number of signatures matches the number of inputs
+            assert_eq!(
+                self.authorization.inputs.len(),
+                signatures.len(),
+                "Number of signatures must match number of inputs"
+            );
+
+            // Compute the scriptSigs
+            self
+            .authorization
+            .inputs
+            .iter()
+            .zip(signatures)
+            .map(|(info, signature)| { // For each (input info, signature) pair...
+                // Serialize the provided signature to DER format
+                let mut sig_bytes: Vec<u8> = signature.serialize_der().to_vec();
+                // Append the SIGHASH_ALL byte (0x01)
+                sig_bytes.push(SIGHASH_ALL);
+
+                // Construct the P2PKH scriptSig: <DER sig + SIGHASH byte> <compressed pubkey>
+                // Assumes P2PKH inputs. Needs info.pubkey which comes from TransparentInputInfo.
+                Script::default() << &sig_bytes[..] << &info.pubkey.serialize()[..]
+            })
+        };
+
+        #[cfg(not(feature = "transparent-inputs"))]
+        let script_sigs = std::iter::empty::<Script>();
+
+        // Construct the new authorized Bundle
+        Bundle {
+            vin: self
+                .vin // Take the original vin (which has empty script_sig fields)
+                .iter()
+                .zip(script_sigs) // Pair the old TxIn with the newly computed scriptSig
+                .map(|(txin, sig)| TxIn {
+                    prevout: txin.prevout.clone(),
+                    script_sig: sig, // Assign the computed scriptSig
+                    sequence: txin.sequence,
+                })
+                .collect(),
+            vout: self.vout, // Keep the original vout
+            authorization: Authorized,
+        }
+    }
 }


### PR DESCRIPTION
This PR adds necessary methods to the transaction builders to support workflows where signing happens externally (e.g., TSS,) and where OP_RETURN memos are needed.

**Key Additions:**

1.  **`add_transparent_op_return`:** Allows adding `OP_RETURN` outputs via the `Builder`.
2.  **`apply_external_signatures`:** Enables authorizing a transparent bundle using signatures generated elsewhere.

**Implementation Details:**

*   The `OpCode` enum in `zcash_transparent` is made public to facilitate `OP_RETURN` script construction.
*   An `InvalidOpReturn` error variant is added.
*   The `apply_external_signatures` method constructs standard P2PKH `scriptSig`s using the provided DER signatures and public keys from the input context.

These changes were developed as part of integrating Zcash into MAYAChain.