### PR TITLE
zcash_address: Removes `TryFromRawAddress`

### DIFF
--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- A blanket impl of `zcash_address::convert::TryFromAddress` for `(NetworkType, T)`
+  has been added to replace the similar impl that had previously been provided
+  bounded by `TryFromRawAddress`.
+
+### Removed
+- `zcash_address::convert::TryFromRawAddress` has been removed. All of its
+  functions can be served by `TryFromAddress` impls, and its presence adds
+  complexity and some pitfalls to the API.
+
 ## [0.6.3, 0.7.1] - 2025-05-07
 ### Added
 - `zcash_address::Converter`

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,13 +7,14 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
-### Added
-- A blanket impl of `zcash_address::convert::TryFromAddress` for `(NetworkType, T)`
-  has been added to replace the similar impl that had previously been provided
-  bounded by `TryFromRawAddress`.
+### Changed
+- The following methods with generic parameter `T` now require `T: TryFromAddress`
+  instead of `T: TryFromRawAddress`:
+  - `zcash_address::ZcashAddress::convert_if_network`
+  - The blanket `impl zcash_address::TryFromAddress for (NetworkType, T)`
 
 ### Removed
-- `zcash_address::convert::TryFromRawAddress` has been removed. All of its
+- `zcash_address::TryFromRawAddress` has been removed. All of its
   functions can be served by `TryFromAddress` impls, and its presence adds
   complexity and some pitfalls to the API.
 

--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -63,9 +63,10 @@ impl SealedItem for Receiver {
 ///
 /// ```
 /// # use core::convert::Infallible;
+/// # use zcash_protocol::consensus::NetworkType;
 /// use zcash_address::{
 ///     unified::{self, Container, Encoding},
-///     ConversionError, TryFromRawAddress, ZcashAddress,
+///     ConversionError, TryFromAddress, ZcashAddress,
 /// };
 ///
 /// # #[cfg(not(feature = "std"))]
@@ -80,12 +81,15 @@ impl SealedItem for Receiver {
 ///
 /// // Or we can parse via `ZcashAddress` (which you should do):
 /// struct MyUnifiedAddress(unified::Address);
-/// impl TryFromRawAddress for MyUnifiedAddress {
+/// impl TryFromAddress for MyUnifiedAddress {
 ///     // In this example we aren't checking the validity of the
 ///     // inner Unified Address, but your code should do so!
 ///     type Error = Infallible;
 ///
-///     fn try_from_raw_unified(ua: unified::Address) -> Result<Self, ConversionError<Self::Error>> {
+///     fn try_from_unified(
+///         _net: NetworkType,
+///         ua: unified::Address
+///     ) -> Result<Self, ConversionError<Self::Error>> {
 ///         Ok(MyUnifiedAddress(ua))
 ///     }
 /// }

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -62,7 +62,7 @@
 //! use std::ffi::{CStr, c_char, c_void};
 //! use std::ptr;
 //!
-//! use zcash_address::{ConversionError, ZcashAddress};
+//! use zcash_address::{ConversionError, TryFromAddress, ZcashAddress};
 //! use zcash_protocol::consensus::NetworkType;
 //!
 //! // Functions that return a pointer to a heap-allocated address of the given kind in
@@ -78,6 +78,7 @@
 //!     type Error = &'static str;
 //!
 //!     fn try_from_sapling(
+//!         _net: NetworkType,
 //!         data: [u8; 43],
 //!     ) -> Result<Self, ConversionError<Self::Error>> {
 //!         let parsed = unsafe { addr_from_sapling(data[..].as_ptr()) };
@@ -89,6 +90,7 @@
 //!     }
 //!
 //!     fn try_from_transparent_p2pkh(
+//!         _net: NetworkType,
 //!         data: [u8; 20],
 //!     ) -> Result<Self, ConversionError<Self::Error>> {
 //!         let parsed = unsafe { addr_from_transparent_p2pkh(data[..].as_ptr()) };
@@ -145,8 +147,7 @@ mod kind;
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod test_vectors;
 
-use convert::Converter;
-pub use convert::{ConversionError, ToAddress, TryFromAddress, UnsupportedAddress};
+pub use convert::{ConversionError, Converter, ToAddress, TryFromAddress, UnsupportedAddress};
 pub use encoding::ParseError;
 pub use kind::unified;
 use kind::unified::Receiver;
@@ -242,11 +243,10 @@ impl ZcashAddress {
 
     /// Converts this address into another type, if it matches the expected network.
     ///
-    /// `convert_if_network` can convert into any type that implements the
-    /// [`TryFromRawAddress`] trait. This enables `ZcashAddress` to be used as a common
-    /// parsing and serialization interface for Zcash addresses, while delegating
-    /// operations on those addresses (such as constructing transactions) to downstream
-    /// crates.
+    /// `convert_if_network` can convert into any type that implements the [`TryFromAddress`]
+    /// trait. This enables `ZcashAddress` to be used as a common parsing and serialization
+    /// interface for Zcash addresses, while delegating operations on those addresses (such as
+    /// constructing transactions) to downstream crates.
     ///
     /// If you want to get the encoded string for this address, use the [`encode`]
     /// method or the [`Display` implementation] via [`address.to_string()`] instead.

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- Updated to `zcash_address 0.8.0`
+- Migrated to `zcash_address 0.8`.
 
 ## [0.4.1, 0.5.1, 0.6.1, 0.7.1, 0.8.1] - 2025-05-09
 

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Updated to `zcash_address 0.8.0`
+
 ## [0.4.1, 0.5.1, 0.6.1, 0.7.1, 0.8.1] - 2025-05-09
 
 ### Added

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use transparent::address::TransparentAddress;
 use zcash_address::{
     unified::{self, Container, Encoding, Typecode},
-    ConversionError, ToAddress, TryFromRawAddress, ZcashAddress,
+    ConversionError, ToAddress, TryFromAddress, ZcashAddress,
 };
 use zcash_protocol::consensus::{self, NetworkType};
 
@@ -333,16 +333,20 @@ impl From<UnifiedAddress> for Address {
     }
 }
 
-impl TryFromRawAddress for Address {
+impl TryFromAddress for Address {
     type Error = &'static str;
 
     #[cfg(feature = "sapling")]
-    fn try_from_raw_sapling(data: [u8; 43]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_sapling(
+        _net: NetworkType,
+        data: [u8; 43],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         let pa = PaymentAddress::from_bytes(&data).ok_or("Invalid Sapling payment address")?;
         Ok(pa.into())
     }
 
-    fn try_from_raw_unified(
+    fn try_from_unified(
+        _net: NetworkType,
         ua: zcash_address::unified::Address,
     ) -> Result<Self, ConversionError<Self::Error>> {
         UnifiedAddress::try_from(ua)
@@ -350,17 +354,24 @@ impl TryFromRawAddress for Address {
             .map(Address::from)
     }
 
-    fn try_from_raw_transparent_p2pkh(
+    fn try_from_transparent_p2pkh(
+        _net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(TransparentAddress::PublicKeyHash(data).into())
     }
 
-    fn try_from_raw_transparent_p2sh(data: [u8; 20]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_transparent_p2sh(
+        _net: NetworkType,
+        data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(TransparentAddress::ScriptHash(data).into())
     }
 
-    fn try_from_raw_tex(data: [u8; 20]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_tex(
+        _net: NetworkType,
+        data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address::Tex(data))
     }
 }

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- Updated to `zcash_address 0.8.0`
+- Migrated to `zcash_address 0.8`.
 
 ## [0.2.3] - 2025-04-04
 

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Updated to `zcash_address 0.8.0`
+
 ## [0.2.3] - 2025-04-04
 
 ### Added

--- a/zcash_transparent/src/address.rs
+++ b/zcash_transparent/src/address.rs
@@ -5,8 +5,9 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Shl;
 use core2::io::{self, Read, Write};
+use zcash_address::TryFromAddress;
+use zcash_protocol::consensus::NetworkType;
 
-use zcash_address::TryFromRawAddress;
 use zcash_encoding::Vector;
 
 /// Defined script opcodes.
@@ -408,16 +409,18 @@ impl TransparentAddress {
     }
 }
 
-impl TryFromRawAddress for TransparentAddress {
+impl TryFromAddress for TransparentAddress {
     type Error = ();
 
-    fn try_from_raw_transparent_p2pkh(
+    fn try_from_transparent_p2pkh(
+        _net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
         Ok(TransparentAddress::PublicKeyHash(data))
     }
 
-    fn try_from_raw_transparent_p2sh(
+    fn try_from_transparent_p2sh(
+        _net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
         Ok(TransparentAddress::ScriptHash(data))


### PR DESCRIPTION
The functionality of `TryFromRawAddress` impls can be entirely subsumed by `TryFromAddress` impls that simply ignore the `net` argument; the removed type added interface complexity that has presented a stumbling block to users of the API.