### PR TITLE
zcash_history: allow to return `V::NodeData` from `Entry`

### DIFF
--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -9,6 +9,9 @@ and this library adheres to Rust's notion of
 ### Changed
 - MSRV is now 1.81.0.
 
+### Added
+- `zcash_history::Entry::data`
+
 ## [0.4.0] - 2023-03-01
 ### Changed
 - MSRV is now 1.65.0.

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -21,9 +21,9 @@ impl<V: Version> Entry<V> {
         }
     }
 
-    /// Returns the inner data associated with this node.
-    pub fn data(&self) -> V::NodeData {
-        V::node_data(&self.data)
+    /// Returns the data associated with this node.
+    pub fn data(&self) -> &V::NodeData {
+        &self.data
     }
 
     /// Creates a new leaf.

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -21,6 +21,11 @@ impl<V: Version> Entry<V> {
         }
     }
 
+    /// Returns the inner data associated with this node.
+    pub fn data(&self) -> V::NodeData {
+        V::node_data(&self.data)
+    }
+
     /// Creates a new leaf.
     pub fn new_leaf(data: V::NodeData) -> Self {
         Entry {

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -30,6 +30,9 @@ pub trait Version {
     /// The node data for this tree version.
     type NodeData: fmt::Debug;
 
+    /// Returns the node data.
+    fn node_data(data: &Self::NodeData) -> Self::NodeData;
+
     /// Returns the consensus branch ID for the given node data.
     fn consensus_branch_id(data: &Self::NodeData) -> u32;
 
@@ -114,6 +117,10 @@ pub enum V1 {}
 impl Version for V1 {
     type NodeData = NodeData;
 
+    fn node_data(data: &Self::NodeData) -> Self::NodeData {
+        data.clone()
+    }
+
     fn consensus_branch_id(data: &Self::NodeData) -> u32 {
         data.consensus_branch_id
     }
@@ -150,6 +157,10 @@ pub enum V2 {}
 
 impl Version for V2 {
     type NodeData = node_data::V2;
+
+    fn node_data(data: &Self::NodeData) -> Self::NodeData {
+        data.clone()
+    }
 
     fn consensus_branch_id(data: &Self::NodeData) -> u32 {
         data.v1.consensus_branch_id

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -30,9 +30,6 @@ pub trait Version {
     /// The node data for this tree version.
     type NodeData: fmt::Debug;
 
-    /// Returns the node data.
-    fn node_data(data: &Self::NodeData) -> Self::NodeData;
-
     /// Returns the consensus branch ID for the given node data.
     fn consensus_branch_id(data: &Self::NodeData) -> u32;
 
@@ -117,10 +114,6 @@ pub enum V1 {}
 impl Version for V1 {
     type NodeData = NodeData;
 
-    fn node_data(data: &Self::NodeData) -> Self::NodeData {
-        data.clone()
-    }
-
     fn consensus_branch_id(data: &Self::NodeData) -> u32 {
         data.consensus_branch_id
     }
@@ -157,10 +150,6 @@ pub enum V2 {}
 
 impl Version for V2 {
     type NodeData = node_data::V2;
-
-    fn node_data(data: &Self::NodeData) -> Self::NodeData {
-        data.clone()
-    }
 
     fn consensus_branch_id(data: &Self::NodeData) -> u32 {
         data.v1.consensus_branch_id


### PR DESCRIPTION
As discussed on discord, I am working on implementing flyclient prover functionalities into zebrad. Because zebrad's implementation of history trees uses `Entry` as the type for nodes, it would be useful to have access to its inner `NodeData`, to avoid having to operate on the serialized bytes directly. This is needed especially when reading nodes from the database and sending them to clients.