### PR TITLE
zcash_client_sqlite: Do not store a transaction record if there is no wallet involvement.

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -2001,6 +2001,17 @@ impl<'a, AccountId> DecryptedTransaction<'a, AccountId> {
     pub fn orchard_outputs(&self) -> &[DecryptedOutput<orchard::note::Note, AccountId>] {
         &self.orchard_outputs
     }
+
+    /// Returns whether the transaction has decrypted outputs
+    pub fn has_decrypted_outputs(&self) -> bool {
+        let has_sapling = !self.sapling_outputs.is_empty();
+        #[cfg(feature = "orchard")]
+        let has_orchard = !self.orchard_outputs.is_empty();
+        #[cfg(not(feature = "orchard"))]
+        let has_orchard = false;
+
+        has_sapling || has_orchard
+    }
 }
 
 /// A transaction that was constructed and sent by the wallet.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -78,7 +78,6 @@ use zcash_primitives::{
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     memo::Memo,
-    value::Zatoshis,
     ShieldedProtocol,
 };
 use zip32::{fingerprint::SeedFingerprint, DiversifierIndex};
@@ -104,6 +103,7 @@ use {
     std::collections::BTreeSet,
     zcash_client_backend::wallet::TransparentAddressMetadata,
     zcash_keys::encoding::AddressCodec,
+    zcash_protocol::value::Zatoshis,
 };
 
 #[cfg(feature = "multicore")]
@@ -1008,6 +1008,8 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
         &self,
         txid: &TxId,
     ) -> Result<Vec<OutputOfSentTx>, <Self as WalletRead>::Error> {
+        use zcash_protocol::value::Zatoshis;
+
         let mut stmt_sent = self.conn.borrow().prepare(
             "SELECT value, to_address,
                     a.cached_transparent_receiver_address, a.transparent_child_index


### PR DESCRIPTION
Prior to this change, `decrypt_and_store_transaction` would erroneously create a record in the `transactions` table, even if the transaction didn't involve the wallet at all.