### PR TITLE
Releases supporting `zcash_client_backend 0.19.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "bip32",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6464,7 +6464,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "bech32",
  "bip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "assert_matches",
  "bip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "core2",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6690,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6554,7 +6554,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "assert_matches",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ block-buffer = { version = "=0.11.0-rc.3" } # later RCs require edition2024
 crypto-common = { version = "=0.2.0-rc.1" } # later RCs require edition2024
 ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.29", default-features = false, features = ["alloc"] }
-transparent = { package = "zcash_transparent", version = "0.2", path = "zcash_transparent", default-features = false }
+transparent = { package = "zcash_transparent", version = "0.3", path = "zcash_transparent", default-features = false }
 
 # Boilerplate & missing stdlib
 getset = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ zip321 = { version = "0.4", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.23", path = "zcash_primitives", default-features = false }
-zcash_proofs = { version = "0.22", path = "zcash_proofs", default-features = false }
+zcash_proofs = { version = "0.23", path = "zcash_proofs", default-features = false }
 
 pczt = { version = "0.2", path = "pczt" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ categories = ["cryptography::cryptocurrencies"]
 [workspace.dependencies]
 # Intra-workspace dependencies
 equihash = { version = "0.2", path = "components/equihash", default-features = false }
-zcash_address = { version = "0.7", path = "components/zcash_address", default-features = false }
+zcash_address = { version = "0.8", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.8", path = "zcash_keys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.23", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.23", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.2", path = "pczt" }
+pczt = { version = "0.3", path = "pczt" }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", defaul
 zip321 = { version = "0.4", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
-zcash_primitives = { version = "0.22", path = "zcash_primitives", default-features = false }
+zcash_primitives = { version = "0.23", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.22", path = "zcash_proofs", default-features = false }
 
 pczt = { version = "0.2", path = "pczt" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.8", path = "zcash_keys" }
 zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", default-features = false }
-zip321 = { version = "0.3", path = "components/zip321" }
+zip321 = { version = "0.4", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.22", path = "zcash_primitives", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.2", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.8", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.19", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.9", path = "zcash_keys" }
 zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ equihash = { version = "0.2", path = "components/equihash", default-features = f
 zcash_address = { version = "0.8", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
-zcash_keys = { version = "0.8", path = "zcash_keys" }
+zcash_keys = { version = "0.9", path = "zcash_keys" }
 zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.4", path = "components/zip321" }
 

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-05-30
 ### Changed
 - The following methods with generic parameter `T` now require `T: TryFromAddress`
   instead of `T: TryFromRawAddress`:

--- a/components/zcash_address/Cargo.toml
+++ b/components/zcash_address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_address"
 description = "Zcash address parsing and serialization"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.5.2] - 2025-05-30
 ### Added
 - `zcash_protocol::constants::`
   - `V3_TX_VERSION`

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `zcash_address 0.8`
+
 ## [0.3.0] - 2025-02-21
 ### Changed
 - MSRV is now 1.81.0.

--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-05-30
 ### Changed
 - Migrated to `zcash_address 0.8`
 

--- a/components/zip321/Cargo.toml
+++ b/components/zip321/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zip321"
 description = "Parsing functions and data types for Zcash ZIP 321 Payment Request URIs"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Kris Nuttycombe <kris@electriccoin.co>"
 ]

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `zcash_transparent 0.3`
+
 ## [0.2.1] - 2025-03-04
 
 Documentation improvements and rendering fix; no code changes.

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- Migrated to `zcash_transparent 0.3`
+- Migrated to `zcash_transparent 0.3`, `zcash_primitives 0.23`
 
 ## [0.2.1] - 2025-03-04
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-05-30
+
 ### Changed
 - Migrated to `zcash_transparent 0.3`, `zcash_primitives 0.23`, `zcash_proofs 0.23`
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- Migrated to `zcash_transparent 0.3`, `zcash_primitives 0.23`
+- Migrated to `zcash_transparent 0.3`, `zcash_primitives 0.23`, `zcash_proofs 0.23`
 
 ## [0.2.1] - 2025-03-04
 

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1170,7 +1170,7 @@ end = "2025-08-26"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-03-25"
-end = "2025-04-22"
+end = "2026-06-02"
 
 [[trusted.zcash_client_sqlite]]
 criteria = "safe-to-deploy"
@@ -1182,7 +1182,7 @@ end = "2025-10-22"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-03-25"
-end = "2025-04-22"
+end = "2026-06-02"
 
 [[trusted.zcash_encoding]]
 criteria = "safe-to-deploy"
@@ -1272,7 +1272,7 @@ end = "2025-12-13"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-27"
-end = "2025-04-22"
+end = "2026-06-02"
 
 [[trusted.zcash_spec]]
 criteria = "safe-to-deploy"
@@ -1314,4 +1314,4 @@ end = "2026-02-21"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-15"
-end = "2025-04-22"
+end = "2026-06-02"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -85,11 +85,11 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.pczt]]
-version = "0.2.1"
-when = "2025-03-05"
-user-id = 6289
-user-login = "str4d"
-user-name = "Jack Grigg"
+version = "0.3.0"
+when = "2025-06-02"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
 
 [[publisher.sapling-crypto]]
 version = "0.5.0"
@@ -281,22 +281,22 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.zcash_address]]
-version = "0.7.1"
-when = "2025-05-07"
+version = "0.8.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.18.0"
-when = "2025-03-21"
+version = "0.19.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.16.2"
-when = "2025-04-03"
+version = "0.17.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -323,29 +323,29 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.zcash_keys]]
-version = "0.8.1"
-when = "2025-05-10"
+version = "0.9.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_primitives]]
-version = "0.22.0"
-when = "2025-02-21"
+version = "0.23.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_proofs]]
-version = "0.22.0"
-when = "2025-02-21"
+version = "0.23.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.5.1"
-when = "2025-03-21"
+version = "0.5.2"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -358,8 +358,8 @@ user-login = "daira"
 user-name = "Daira-Emma Hopwood"
 
 [[publisher.zcash_transparent]]
-version = "0.2.3"
-when = "2025-04-04"
+version = "0.3.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -372,8 +372,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zip321]]
-version = "0.3.0"
-when = "2025-02-21"
+version = "0.4.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -27,7 +27,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`,
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,7 +26,7 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
-- Migrated to `zcash_address 0.8`, `zip321 0.4`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,7 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.19.0] - 2025-05-30
+
 ### Added
+- `zcash_client_backend::data_api`:
+  - `TargetValue`: An intent of representing spendable value to reach a certain 
+    targeted amount.
 - `zcash_client_backend::proto::service`:
   - `LightdInfo.donation_address` field.
   - Helper methods for parsing `LightdInfo` fields:
@@ -26,15 +31,13 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
-- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`
+- Migrated to `arti-client 0.28`, `dynosaur 0.2`, `tonic 0.13`, `zcash_address 0.8`, 
+  `zip321 0.4`, `zcash_transparent 0.3`, `zcash_primitives 0.23`, 
+  `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`
 - `zcash_client_backend::data_api`:
-  - `TargetValue`: An intent of representing spendable value to reach a certain 
-    targeted amount.
   - `select_spendable_notes`: parameter `target_value` now is a `TargetValue`. 
     Existing calls to this function that used `Zatoshis` now use 
     `TargetValue::AtLeast(Zatoshis)`
-- Migrated to `arti-client 0.28`, `dynosaur 0.2`, `tonic 0.13`.
 - `zcash_client_backend::tor`:
   - `Client::{connect_to_lightwalletd, get_latest_zec_to_usd_rate}` now ensure
     that the inner Tor client is ready for traffic, and re-bootstrap it if

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,6 +26,7 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
+- Migrated to `zcash_address 0.8`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -27,7 +27,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`,
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,7 +26,8 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
-- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
+  `zcash_primitives 0.23`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -27,7 +27,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,7 +26,7 @@ and this library adheres to Rust's notion of
   - `DormantMode`
 
 ### Changed
-- Migrated to `zcash_address 0.8`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`
 - `zcash_client_backend::data_api`:
   - `TargetValue`: An intent of representing spendable value to reach a certain 
     targeted amount.

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.18.0"
+version = "0.19.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,7 +12,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_sqlite::wallet::init::migrations`
 
 ### Changed
-- Migrated to `zcash_address 0.8`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,7 +13,8 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`,
+  `zcash_client_backend 0.19`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`, `pczt 0.3`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`, `zcash_proofs 0.23`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`, `zcash_keys 0.9`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,7 +12,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_sqlite::wallet::init::migrations`
 
 ### Changed
-- Migrated to `zcash_address 0.8`, `zip321 0.4`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,6 +12,7 @@ and this library adheres to Rust's notion of
 - `zcash_client_sqlite::wallet::init::migrations`
 
 ### Changed
+- Migrated to `zcash_address 0.8`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Changed
 - Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
-  `zcash_primitives 0.23`
+  `zcash_primitives 0.23`, `zcash_proofs 0.23`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.17.0] - 2025-05-30
+
 ### Added
 - `zcash_client_sqlite::wallet::init::WalletMigrator`
 - `zcash_client_sqlite::wallet::init::migrations`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,7 +12,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_sqlite::wallet::init::migrations`
 
 ### Changed
-- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`
+- Migrated to `zcash_address 0.8`, `zip321 0.4`, `zcash_transparent 0.3`,
+  `zcash_primitives 0.23`
 - `zcash_client_sqlite::wallet::init::WalletMigrationError::`
   - Variants `WalletMigrationError::CommitmentTree` and 
     `WalletMigrationError::Other` now `Box` their contents.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.16.2"
+version = "0.17.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.9.0] - 2025-05-30
+
 ### Added
 - `zcash_keys::keys::UnifiedAddressRequest::{SHIELDED, ORCHARD}`
 - `zcash_keys::keys::ReceiverRequirements::{SHIELDED, ORCHARD}`

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -11,7 +11,7 @@ and this library adheres to Rust's notion of
 - `zcash_keys::keys::ReceiverRequirements::{SHIELDED, ORCHARD}`
 
 ### Changed
-- Migrated to `zcash_address 0.8`.
+- Migrated to `zcash_address 0.8`, `zcash_transparent 0.3`.
 
 ## [0.4.1, 0.5.1, 0.6.1, 0.7.1, 0.8.1] - 2025-05-09
 

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_keys"
 description = "Zcash key and address management"
-version = "0.8.1"
+version = "0.9.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
+- Migrated to `zcash_address 0.8`
 - Variants of `zcash_primitives::transaction::TxVersion` have changed. They
   now represent explicit transaction versions, in order to avoid accidental
   confusion with the names of the network upgrades that they were introduced

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- Migrated to `zcash_address 0.8`
+- Migrated to `zcash_address 0.8`, `zcash_transparent 0.3`
 - Variants of `zcash_primitives::transaction::TxVersion` have changed. They
   now represent explicit transaction versions, in order to avoid accidental
   confusion with the names of the network upgrades that they were introduced

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.23.0] - 2025-05-30
+
 ### Changed
 - Migrated to `zcash_address 0.8`, `zcash_transparent 0.3`
 - Variants of `zcash_primitives::transaction::TxVersion` have changed. They

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `zcash_primitives 0.23`.
+
 ## [0.22.0] - 2025-02-21
 
 ### Changed

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.23.0] - 2025-05-30
+
 ### Changed
 - Migrated to `zcash_primitives 0.23`.
 

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_proofs"
 description = "Zcash zk-SNARK circuits and proving APIs"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
 ]

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-05-30
+
 ### Changed
 - Migrated to `zcash_address 0.8`.
 

--- a/zcash_transparent/Cargo.toml
+++ b/zcash_transparent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_transparent"
 description = "Rust implementations of the Zcash transparent protocol"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",


### PR DESCRIPTION
Releases of the following crates are included:
* zcash_protocol 0.5.2
* zcash_address 0.8.0
* zip321 0.4.0
* zcash_transparent 0.3.0
* zcash_primitives 0.23.0
* zcash_proofs 0.23.0
* zcash_keys 0.9.0
* pczt 0.3.0
* zcash_client_backend 0.19.0
* zcash_client_sqlite 0.17.0