### PR TITLE
zcash_client_sqlite: Ensure unsatisfiable tx status requests get deleted.

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+- `TransactionDataRequest::GetStatus` requests for txids that do not
+  correspond to unexpired transactions in the transactions table are now
+  deleted from the status check queue when `set_transaction_status` is
+  called with a status of either `TxidNotRecognized` or `NotInMainChain`.
+
 ## [0.16.3] - 2025-06-12
 
 ### Fixed

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -492,11 +492,15 @@ pub(super) const INDEX_SENT_NOTES_TX: &str = r#"CREATE INDEX sent_notes_tx ON "s
 ///   about transparent inputs to a transaction, this is a reference to that transaction record.
 ///   NULL for transactions where the request for enhancement data is based on discovery due
 ///   to blockchain scanning.
+/// - `request_expiry`: The block height at which this transaction data request will be considered
+///   expired. This is used to ensure that permanently-unsatisfiable transaction data requests
+///   do not stay in the queue forever.
 pub(super) const TABLE_TX_RETRIEVAL_QUEUE: &str = r#"
 CREATE TABLE tx_retrieval_queue (
     txid BLOB NOT NULL UNIQUE,
     query_type INTEGER NOT NULL,
     dependent_transaction_id INTEGER,
+    request_expiry INTEGER,
     FOREIGN KEY (dependent_transaction_id) REFERENCES transactions(id_tx)
 )"#;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -22,6 +22,7 @@ mod spend_key_available;
 mod support_legacy_sqlite;
 mod transparent_gap_limit_handling;
 mod tx_retrieval_queue;
+mod tx_retrieval_queue_expiry;
 mod ufvk_support;
 mod utxos_table;
 mod utxos_to_txos;
@@ -175,6 +176,7 @@ pub(super) fn all_migrations<
         Box::new(ensure_default_transparent_address::Migration {
             params: params.clone(),
         }),
+        Box::new(tx_retrieval_queue_expiry::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -5,9 +5,9 @@ use schemerz_rusqlite::RusqliteMigration;
 use std::collections::HashSet;
 use uuid::Uuid;
 use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
-use zcash_protocol::consensus;
+use zcash_protocol::{consensus, TxId};
 
-use crate::wallet::init::WalletMigrationError;
+use crate::wallet::{init::WalletMigrationError, TxQueryType};
 
 use super::{
     ensure_orchard_ua_receiver, ephemeral_addresses, nullifier_map, orchard_shardtree,
@@ -19,15 +19,12 @@ pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xfec02b61_3988_4b4f_9699_
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::{
-        error::SqliteClientError,
-        wallet::{
-            queue_transparent_input_retrieval, queue_unmined_tx_retrieval,
-            transparent::{queue_transparent_spend_detection, uivk_legacy_transparent_address},
-        },
-        AccountRef, TxRef,
+        error::SqliteClientError, wallet::transparent::uivk_legacy_transparent_address, AccountRef,
+        TxRef,
     },
     rusqlite::OptionalExtension as _,
     std::convert::Infallible,
+    transparent::address::TransparentAddress,
     zcash_client_backend::data_api::DecryptedTransaction,
     zcash_keys::encoding::AddressCodec,
     zcash_protocol::consensus::{BlockHeight, BranchId},
@@ -86,8 +83,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 prevout_txid BLOB NOT NULL,
                 prevout_output_index INTEGER NOT NULL,
                 FOREIGN KEY (spending_transaction_id) REFERENCES transactions(id_tx)
-                -- NOTE: We can't create a unique constraint on just (prevout_txid, prevout_output_index) 
-                -- because the same output may be attempted to be spent in multiple transactions, even 
+                -- NOTE: We can't create a unique constraint on just (prevout_txid, prevout_output_index)
+                -- because the same output may be attempted to be spent in multiple transactions, even
                 -- though only one will ever be mined.
                 CONSTRAINT transparent_spend_map_unique UNIQUE (
                     spending_transaction_id, prevout_txid, prevout_output_index
@@ -215,6 +212,106 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
 
         Ok(())
     }
+}
+
+#[cfg(feature = "transparent-inputs")]
+fn queue_transparent_spend_detection<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction<'_>,
+    params: &P,
+    receiving_address: TransparentAddress,
+    tx_ref: TxRef,
+    output_index: u32,
+) -> Result<(), SqliteClientError> {
+    let mut stmt = conn.prepare_cached(
+        "INSERT INTO transparent_spend_search_queue
+         (address, transaction_id, output_index)
+         VALUES
+         (:address, :transaction_id, :output_index)
+         ON CONFLICT (transaction_id, output_index) DO NOTHING",
+    )?;
+
+    let addr_str = receiving_address.encode(params);
+    stmt.execute(named_params! {
+        ":address": addr_str,
+        ":transaction_id": tx_ref.0,
+        ":output_index": output_index
+    })?;
+
+    Ok(())
+}
+
+#[cfg(feature = "transparent-inputs")]
+fn queue_transparent_input_retrieval<AccountId>(
+    conn: &rusqlite::Transaction<'_>,
+    tx_ref: TxRef,
+    d_tx: &DecryptedTransaction<'_, AccountId>,
+) -> Result<(), SqliteClientError> {
+    if let Some(b) = d_tx.tx().transparent_bundle() {
+        if !b.is_coinbase() {
+            // queue the transparent inputs for enhancement
+            queue_tx_retrieval(
+                conn,
+                b.vin.iter().map(|txin| *txin.prevout.txid()),
+                Some(tx_ref),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "transparent-inputs")]
+fn queue_unmined_tx_retrieval<AccountId>(
+    conn: &rusqlite::Transaction<'_>,
+    d_tx: &DecryptedTransaction<'_, AccountId>,
+) -> Result<(), SqliteClientError> {
+    let detectable_via_scanning = d_tx.tx().sapling_bundle().is_some();
+    #[cfg(feature = "orchard")]
+    let detectable_via_scanning = detectable_via_scanning | d_tx.tx().orchard_bundle().is_some();
+
+    if d_tx.mined_height().is_none() && !detectable_via_scanning {
+        queue_tx_retrieval(conn, std::iter::once(d_tx.tx().txid()), None)?
+    }
+
+    Ok(())
+}
+
+fn queue_tx_retrieval(
+    conn: &rusqlite::Transaction<'_>,
+    txids: impl Iterator<Item = TxId>,
+    dependent_tx_ref: Option<TxRef>,
+) -> Result<(), SqliteClientError> {
+    // Add an entry to the transaction retrieval queue if it would not be redundant.
+    let mut stmt_insert_tx = conn.prepare_cached(
+        "INSERT INTO tx_retrieval_queue (txid, query_type, dependent_transaction_id)
+            SELECT
+            :txid,
+            IIF(
+                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
+                :status_type,
+                :enhancement_type
+            ),
+            :dependent_transaction_id
+        ON CONFLICT (txid) DO UPDATE
+        SET query_type =
+            IIF(
+                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
+                :status_type,
+                :enhancement_type
+            ),
+            dependent_transaction_id = IFNULL(:dependent_transaction_id, dependent_transaction_id)",
+    )?;
+
+    for txid in txids {
+        stmt_insert_tx.execute(named_params! {
+            ":txid": txid.as_ref(),
+            ":status_type": TxQueryType::Status.code(),
+            ":enhancement_type": TxQueryType::Enhancement.code(),
+            ":dependent_transaction_id": dependent_tx_ref.map(|r| r.0),
+        })?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
@@ -1,0 +1,79 @@
+//! Adds expiration to transaction enhancement requests.
+
+use rusqlite::{named_params, Transaction};
+use schemerz_rusqlite::RusqliteMigration;
+use std::collections::HashSet;
+use uuid::Uuid;
+use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+
+use crate::wallet::{chain_tip_height, init::WalletMigrationError};
+
+use super::tx_retrieval_queue;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x9ffe82d4_3bf5_459a_9a21_7affd9e88e95);
+
+const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds expiration to transaction enhancement requests"
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &Transaction) -> Result<(), WalletMigrationError> {
+        let chain_tip = chain_tip_height(conn)?;
+
+        conn.execute_batch(
+            "ALTER TABLE tx_retrieval_queue ADD COLUMN request_expiry INTEGER;
+
+             UPDATE tx_retrieval_queue
+             SET request_expiry = t.expiry_height
+             FROM transactions t
+             WHERE t.txid = tx_retrieval_queue.txid;",
+        )?;
+
+        // Requests may have been added to the queue for transaction IDs that do not correspond to
+        // any mined transaction; this has occurred in the past when the null txid was added to the
+        // queue when trying to traverse the input graph from a coinbase transaction belonging to
+        // the wallet; it also has the potential to occur in some reorg cases involving zero-conf
+        // transactions.
+        conn.execute(
+            "UPDATE tx_retrieval_queue
+             SET request_expiry = :manual_expiry
+             WHERE request_expiry IS NULL",
+            named_params! {
+                ":manual_expiry": chain_tip.map(|h| u32::from(h) + DEFAULT_TX_EXPIRY_DELTA)
+            },
+        )?;
+        Ok(())
+    }
+
+    fn down(&self, _: &Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    use super::MIGRATION_ID;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+}


### PR DESCRIPTION
`TransactionDataRequest::GetStatus` requests for txids that do not correspond to unexpired transactions in the transactions table will now be deleted from the status check queue when `set_transaction_status` is called with a status of either `TxidNotRecognized` or `NotInMainChain`.