### PR TITLE
change(zcash_proofs): Expose `LocalTxProver`'s spend and output params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,8 +3876,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+source = "git+https://github.com/zcash/sapling-crypto.git?branch=access-inner-param#a5c746b8bba09b26dc3ec8b94b41d23ceb4c229a"
 dependencies = [
  "aes",
  "bellman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,10 @@ zip32 = { version = "0.2", default-features = false }
 # Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
 time-core = "=0.1.2"
 
+# TODO Remove this patch once the the upstream changes land in a release.
+[patch.crates-io]
+sapling-crypto = { git = "https://github.com/zcash/sapling-crypto.git", branch = "access-inner-param" }
+
 [workspace.metadata.release]
 consolidate-commits = false
 pre-release-commit-message = "{{crate_name}} {{version}}"

--- a/zcash_proofs/src/prover.rs
+++ b/zcash_proofs/src/prover.rs
@@ -21,6 +21,7 @@ use crate::{default_params_folder, SAPLING_OUTPUT_NAME, SAPLING_SPEND_NAME};
 
 /// An implementation of [`SpendProver`] and [`OutputProver`] using Sapling Spend and
 /// Output parameters from locally-accessible paths.
+#[derive(Clone)]
 pub struct LocalTxProver {
     spend_params: SpendParameters,
     output_params: OutputParameters,
@@ -137,6 +138,11 @@ impl LocalTxProver {
             self.spend_params.verifying_key(),
             self.output_params.verifying_key(),
         )
+    }
+
+    /// Exposes the spend and output parameters.
+    pub fn params(self) -> (SpendParameters, OutputParameters) {
+        (self.spend_params, self.output_params)
     }
 }
 


### PR DESCRIPTION
- Required for https://github.com/ZcashFoundation/zebra/pull/9678.
- Based on https://github.com/zcash/sapling-crypto/pull/165.