### PR TITLE
Backport changes from `zcash_protocol-0.5.x` to `zcash_client_sqlite-0.16.x` branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "core2",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "core2",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,4 +210,4 @@ opt-level = 3
 debug = true
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture", "nu7"))'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ zcash_address = { version = "0.7", path = "components/zcash_address", default-fe
 zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.8", path = "zcash_keys" }
-zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.5.3", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.3", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.5.2] - 2025-05-30
 ### Added
 - `zcash_protocol::constants::`
   - `V3_TX_VERSION`

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.3] - 2025-06-12
 ### Added
   - `zcash_protocol::txid::TxId::is_null`
 

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,10 +7,18 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::constants::`
+  - `OVERWINTER_TX_VERSION`
+  - `OVERWINTER_VERSION_GROUP_ID`
+  - `SAPLING_TX_VERSION`
+  - `SAPLING_VERSION_GROUP_ID`
+  - `V5_TX_VERSION`
+  - `V5_VERSION_GROUP_ID`
+
 ## [0.5.1] - 2025-03-19
 ### Added
 - `impl<P: zcash_protocol::consensus::Parameters> zcash::consensus::Parameters for &P`
-
 
 ## [0.5.0] - 2025-02-21
 ### Added

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - `zcash_protocol::txid::TxId::is_null`
 
 ## [0.5.2] - 2025-05-30
 ### Added

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -9,10 +9,10 @@ and this library adheres to Rust's notion of
 
 ### Added
 - `zcash_protocol::constants::`
-  - `OVERWINTER_TX_VERSION`
-  - `OVERWINTER_VERSION_GROUP_ID`
-  - `SAPLING_TX_VERSION`
-  - `SAPLING_VERSION_GROUP_ID`
+  - `V3_TX_VERSION`
+  - `V3_VERSION_GROUP_ID`
+  - `V4_TX_VERSION`
+  - `V4_VERSION_GROUP_ID`
   - `V5_TX_VERSION`
   - `V5_VERSION_GROUP_ID`
 

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.5.2"
+version = "0.5.3"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -138,7 +138,7 @@ pub trait NetworkConstants: Clone {
     ///
     /// Defined in [ZIP 32].
     ///
-    /// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
+    /// [ZIP 32]: https://github.com/zcash/zips/blob/main/zips/zip-0032.rst
     fn hrp_sapling_extended_spending_key(&self) -> &'static str;
 
     /// Returns the human-readable prefix for Bech32-encoded Sapling extended full
@@ -154,7 +154,7 @@ pub trait NetworkConstants: Clone {
     ///
     /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
     ///
-    /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
+    /// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf
     fn hrp_sapling_payment_address(&self) -> &'static str;
 
     /// Returns the human-readable prefix for Base58Check-encoded Sprout

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -408,6 +408,8 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Canopy => Some(BlockHeight(1_046_400)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_687_104)),
             NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
+            #[cfg(zcash_unstable = "nu7")]
+            NetworkUpgrade::Nu7 => None,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
@@ -438,6 +440,8 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Canopy => Some(BlockHeight(1_028_500)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1_842_420)),
             NetworkUpgrade::Nu6 => Some(BlockHeight(2_976_000)),
+            #[cfg(zcash_unstable = "nu7")]
+            NetworkUpgrade::Nu7 => None,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
@@ -506,6 +510,11 @@ pub enum NetworkUpgrade {
     ///
     /// [Nu6]: https://z.cash/upgrade/nu6/
     Nu6,
+    /// The [Nu7 (proposed)] network upgrade.
+    ///
+    /// [Nu7 (proposed)]: https://z.cash/upgrade/nu7/
+    #[cfg(zcash_unstable = "nu7")]
+    Nu7,
     /// The ZFUTURE network upgrade.
     ///
     /// This upgrade is expected never to activate on mainnet;
@@ -528,6 +537,8 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Canopy => write!(f, "Canopy"),
             NetworkUpgrade::Nu5 => write!(f, "Nu5"),
             NetworkUpgrade::Nu6 => write!(f, "Nu6"),
+            #[cfg(zcash_unstable = "nu7")]
+            NetworkUpgrade::Nu7 => write!(f, "Nu7"),
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => write!(f, "ZFUTURE"),
         }
@@ -544,6 +555,8 @@ impl NetworkUpgrade {
             NetworkUpgrade::Canopy => BranchId::Canopy,
             NetworkUpgrade::Nu5 => BranchId::Nu5,
             NetworkUpgrade::Nu6 => BranchId::Nu6,
+            #[cfg(zcash_unstable = "nu7")]
+            NetworkUpgrade::Nu7 => BranchId::Nu7,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => BranchId::ZFuture,
         }
@@ -562,6 +575,8 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Canopy,
     NetworkUpgrade::Nu5,
     NetworkUpgrade::Nu6,
+    #[cfg(zcash_unstable = "nu7")]
+    NetworkUpgrade::Nu7,
 ];
 
 /// The "grace period" defined in [ZIP 212].
@@ -600,6 +615,9 @@ pub enum BranchId {
     Nu5,
     /// The consensus rules deployed by [`NetworkUpgrade::Nu6`].
     Nu6,
+    /// The consensus rules to be deployed by [`NetworkUpgrade::Nu7`].
+    #[cfg(zcash_unstable = "nu7")]
+    Nu7,
     /// Candidates for future consensus rules; this branch will never
     /// activate on mainnet.
     #[cfg(zcash_unstable = "zfuture")]
@@ -622,6 +640,8 @@ impl TryFrom<u32> for BranchId {
             0xe9ff_75a6 => Ok(BranchId::Canopy),
             0xc2d6_d0b4 => Ok(BranchId::Nu5),
             0xc8e7_1055 => Ok(BranchId::Nu6),
+            #[cfg(zcash_unstable = "nu7")]
+            0xffff_ffff => Ok(BranchId::Nu7),
             #[cfg(zcash_unstable = "zfuture")]
             0xffff_ffff => Ok(BranchId::ZFuture),
             _ => Err("Unknown consensus branch ID"),
@@ -640,6 +660,8 @@ impl From<BranchId> for u32 {
             BranchId::Canopy => 0xe9ff_75a6,
             BranchId::Nu5 => 0xc2d6_d0b4,
             BranchId::Nu6 => 0xc8e7_1055,
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => 0xffff_ffff,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => 0xffff_ffff,
         }
@@ -709,12 +731,18 @@ impl BranchId {
                 .activation_height(NetworkUpgrade::Nu5)
                 .map(|lower| (lower, params.activation_height(NetworkUpgrade::Nu6))),
             BranchId::Nu6 => params.activation_height(NetworkUpgrade::Nu6).map(|lower| {
+                #[cfg(zcash_unstable = "nu7")]
+                let upper = params.activation_height(NetworkUpgrade::Nu7);
                 #[cfg(zcash_unstable = "zfuture")]
                 let upper = params.activation_height(NetworkUpgrade::ZFuture);
-                #[cfg(not(zcash_unstable = "zfuture"))]
+                #[cfg(not(any(zcash_unstable = "nu7", zcash_unstable = "zfuture")))]
                 let upper = None;
                 (lower, upper)
             }),
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => params
+                .activation_height(NetworkUpgrade::Nu7)
+                .map(|lower| (lower, None)),
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => params
                 .activation_height(NetworkUpgrade::ZFuture)
@@ -744,6 +772,8 @@ pub mod testing {
             BranchId::Canopy,
             BranchId::Nu5,
             BranchId::Nu6,
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture,
         ])

--- a/components/zcash_protocol/src/constants.rs
+++ b/components/zcash_protocol/src/constants.rs
@@ -3,3 +3,29 @@
 pub mod mainnet;
 pub mod regtest;
 pub mod testnet;
+
+/// The transaction version introduced by the Overwinter network upgrade.
+pub const OVERWINTER_TX_VERSION: u32 = 3;
+/// The version group id for Zcash Overwinter transactions.
+pub const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C48270;
+
+/// The transaction version introduced by the Sapling network upgrade.
+pub const SAPLING_TX_VERSION: u32 = 4;
+/// The version group id for Zcash Sapling transactions.
+pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F2085;
+
+/// The transaction version introduced by the NU5 network upgrade.
+pub const V5_TX_VERSION: u32 = 5;
+/// The version group id for Zcash Nu5 transactions.
+pub const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
+
+/// These versions are used exclusively for in-development transaction
+/// serialization, and will never be active under the consensus rules.
+/// When new consensus transaction versions are added, all call sites
+/// using these constants should be inspected, and use of these constants
+/// should be removed as appropriate in favor of the new consensus
+/// transaction version and group.
+#[cfg(zcash_unstable = "zfuture")]
+pub const ZFUTURE_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
+#[cfg(zcash_unstable = "zfuture")]
+pub const ZFUTURE_TX_VERSION: u32 = 0x0000FFFF;

--- a/components/zcash_protocol/src/constants.rs
+++ b/components/zcash_protocol/src/constants.rs
@@ -4,35 +4,56 @@ pub mod mainnet;
 pub mod regtest;
 pub mod testnet;
 
-/// The transaction version introduced by the Overwinter network upgrade.
-pub const OVERWINTER_TX_VERSION: u32 = 3;
-/// The version group id for Zcash Overwinter transactions.
-pub const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C48270;
+// The `V<n>_TX_VERSION` constants, although trivial, serve to clarify that a
+// transaction version is meant in APIs that use a bare `u32`. Consider using
+// `zcash_primitives::transaction::TxVersion` instead.
 
-/// The transaction version introduced by the Sapling network upgrade.
-pub const SAPLING_TX_VERSION: u32 = 4;
-/// The version group id for Zcash Sapling transactions.
-pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F2085;
+/// Transaction version 3, which was introduced by the Overwinter network upgrade
+/// and allowed until Sapling activation. It is specified in
+/// [§ 7.1 Transaction Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#txnencoding).
+///
+/// This constant is called `OVERWINTER_TX_VERSION` in the zcashd source.
+pub const V3_TX_VERSION: u32 = 3;
+/// The version group ID for Zcash v3 transactions.
+///
+/// This constant is called `OVERWINTER_VERSION_GROUP_ID` in the zcashd source.
+pub const V3_VERSION_GROUP_ID: u32 = 0x03C48270;
 
-/// The transaction version introduced by the NU5 network upgrade.
+/// Transaction version 4, which was introduced by the Sapling network upgrade.
+/// It is specified in [§ 7.1 Transaction Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#txnencoding).
+///
+/// This constant is called `SAPLING_TX_VERSION` in the zcashd source.
+pub const V4_TX_VERSION: u32 = 4;
+/// The version group ID for Zcash v4 transactions.
+///
+/// This constant is called `SAPLING_VERSION_GROUP_ID` in the zcashd source.
+pub const V4_VERSION_GROUP_ID: u32 = 0x892F2085;
+
+/// Transaction version 5, which was introduced by the NU5 network upgrade.
+/// It is specified in [§ 7.1 Transaction Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#txnencoding)
+/// and [ZIP 225](https://zips.z.cash/zip-0225).
 pub const V5_TX_VERSION: u32 = 5;
-/// The version group id for Zcash Nu5 transactions.
+/// The version group ID for Zcash v5 transactions.
 pub const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
 
-/// The transaction version introduced by ZIP 230.
+/// Transaction version 6, specified in [ZIP 230](https://zips.z.cash/zip-0230).
 #[cfg(zcash_unstable = "nu7")]
 pub const V6_TX_VERSION: u32 = 6;
-/// The version group id for Zcash ZIP 230 transactions.
+/// The version group ID for Zcash v6 transactions.
 #[cfg(zcash_unstable = "nu7")]
 pub const V6_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
 
-/// These versions are used exclusively for in-development transaction
+/// This version is used exclusively for in-development transaction
 /// serialization, and will never be active under the consensus rules.
 /// When new consensus transaction versions are added, all call sites
-/// using these constants should be inspected, and use of these constants
-/// should be removed as appropriate in favor of the new consensus
-/// transaction version and group.
-#[cfg(zcash_unstable = "zfuture")]
-pub const ZFUTURE_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
+/// using this constant should be inspected, and uses should be
+/// removed as appropriate in favor of the new transaction version.
 #[cfg(zcash_unstable = "zfuture")]
 pub const ZFUTURE_TX_VERSION: u32 = 0x0000FFFF;
+/// This version group ID is used exclusively for in-development transaction
+/// serialization, and will never be active under the consensus rules.
+/// When new consensus version group IDs are added, all call sites
+/// using this constant should be inspected, and uses should be
+/// removed as appropriate in favor of the new version group ID.
+#[cfg(zcash_unstable = "zfuture")]
+pub const ZFUTURE_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;

--- a/components/zcash_protocol/src/constants.rs
+++ b/components/zcash_protocol/src/constants.rs
@@ -19,6 +19,13 @@ pub const V5_TX_VERSION: u32 = 5;
 /// The version group id for Zcash Nu5 transactions.
 pub const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
 
+/// The transaction version introduced by ZIP 230.
+#[cfg(zcash_unstable = "nu7")]
+pub const V6_TX_VERSION: u32 = 6;
+/// The version group id for Zcash ZIP 230 transactions.
+#[cfg(zcash_unstable = "nu7")]
+pub const V6_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
+
 /// These versions are used exclusively for in-development transaction
 /// serialization, and will never be active under the consensus rules.
 /// When new consensus transaction versions are added, all call sites

--- a/components/zcash_protocol/src/constants/mainnet.rs
+++ b/components/zcash_protocol/src/constants/mainnet.rs
@@ -10,7 +10,7 @@ pub const COIN_TYPE: u32 = 133;
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedSpendingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedSpendingKey.html
-/// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
+/// [ZIP 32]: https://github.com/zcash/zips/blob/main/zips/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-main";
 
 /// The HRP for a Bech32-encoded mainnet [`ExtendedFullViewingKey`].
@@ -18,7 +18,7 @@ pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-main";
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedFullViewingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedFullViewingKey.html
-/// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
+/// [ZIP 32]: https://github.com/zcash/zips/blob/main/zips/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviews";
 
 /// The HRP for a Bech32-encoded mainnet Sapling [`PaymentAddress`].
@@ -26,7 +26,7 @@ pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviews";
 /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
 ///
 /// [`PaymentAddress`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/struct.PaymentAddress.html
-/// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
+/// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf
 pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "zs";
 
 /// The prefix for a Base58Check-encoded mainnet Sprout address.

--- a/components/zcash_protocol/src/constants/testnet.rs
+++ b/components/zcash_protocol/src/constants/testnet.rs
@@ -10,7 +10,7 @@ pub const COIN_TYPE: u32 = 1;
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedSpendingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedSpendingKey.html
-/// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
+/// [ZIP 32]: https://github.com/zcash/zips/blob/main/zips/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-test";
 
 /// The HRP for a Bech32-encoded testnet Sapling [`ExtendedFullViewingKey`].
@@ -18,7 +18,7 @@ pub const HRP_SAPLING_EXTENDED_SPENDING_KEY: &str = "secret-extended-key-test";
 /// Defined in [ZIP 32].
 ///
 /// [`ExtendedFullViewingKey`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/zip32/struct.ExtendedFullViewingKey.html
-/// [ZIP 32]: https://github.com/zcash/zips/blob/master/zip-0032.rst
+/// [ZIP 32]: https://github.com/zcash/zips/blob/main/zips/zip-0032.rst
 pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewtestsapling";
 
 /// The HRP for a Bech32-encoded testnet Sapling [`PaymentAddress`].
@@ -26,7 +26,7 @@ pub const HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY: &str = "zxviewtestsapling";
 /// Defined in section 5.6.4 of the [Zcash Protocol Specification].
 ///
 /// [`PaymentAddress`]: https://docs.rs/sapling-crypto/latest/sapling_crypto/struct.PaymentAddress.html
-/// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
+/// [Zcash Protocol Specification]: https://github.com/zcash/zips/blob/main/rendered/protocol/protocol.pdf
 pub const HRP_SAPLING_PAYMENT_ADDRESS: &str = "ztestsapling";
 
 /// The prefix for a Base58Check-encoded testnet Sprout address.

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -40,6 +40,8 @@ pub struct LocalNetwork {
     pub canopy: Option<BlockHeight>,
     pub nu5: Option<BlockHeight>,
     pub nu6: Option<BlockHeight>,
+    #[cfg(zcash_unstable = "nu7")]
+    pub nu7: Option<BlockHeight>,
     #[cfg(zcash_unstable = "zfuture")]
     pub z_future: Option<BlockHeight>,
 }
@@ -59,6 +61,8 @@ impl Parameters for LocalNetwork {
             NetworkUpgrade::Canopy => self.canopy,
             NetworkUpgrade::Nu5 => self.nu5,
             NetworkUpgrade::Nu6 => self.nu6,
+            #[cfg(zcash_unstable = "nu7")]
+            NetworkUpgrade::Nu7 => self.nu7,
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => self.z_future,
         }
@@ -82,6 +86,8 @@ mod tests {
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
+        #[cfg(zcash_unstable = "nu7")]
+        let expected_nu7 = BlockHeight::from_u32(8);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(8);
 
@@ -93,6 +99,8 @@ mod tests {
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
             nu6: Some(expected_nu6),
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),
         };
@@ -104,8 +112,10 @@ mod tests {
         assert!(regtest.is_nu_active(NetworkUpgrade::Canopy, expected_canopy));
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu5, expected_nu5));
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu6, expected_nu6));
+        #[cfg(zcash_unstable = "nu7")]
+        assert!(!regtest.is_nu_active(NetworkUpgrade::Nu7, expected_nu6));
         #[cfg(zcash_unstable = "zfuture")]
-        assert!(!regtest.is_nu_active(NetworkUpgrade::ZFuture, expected_nu5));
+        assert!(!regtest.is_nu_active(NetworkUpgrade::ZFuture, expected_nu6));
     }
 
     #[test]
@@ -117,6 +127,8 @@ mod tests {
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
+        #[cfg(zcash_unstable = "nu7")]
+        let expected_nu7 = BlockHeight::from_u32(8);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(8);
 
@@ -128,6 +140,8 @@ mod tests {
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
             nu6: Some(expected_nu6),
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),
         };
@@ -156,6 +170,11 @@ mod tests {
             regtest.activation_height(NetworkUpgrade::Nu5),
             Some(expected_nu5)
         );
+        #[cfg(zcash_unstable = "nu7")]
+        assert_eq!(
+            regtest.activation_height(NetworkUpgrade::Nu7),
+            Some(expected_nu7)
+        );
         #[cfg(zcash_unstable = "zfuture")]
         assert_eq!(
             regtest.activation_height(NetworkUpgrade::ZFuture),
@@ -172,6 +191,8 @@ mod tests {
         let expected_canopy = BlockHeight::from_u32(5);
         let expected_nu5 = BlockHeight::from_u32(6);
         let expected_nu6 = BlockHeight::from_u32(7);
+        #[cfg(zcash_unstable = "nu7")]
+        let expected_nu7 = BlockHeight::from_u32(8);
         #[cfg(zcash_unstable = "zfuture")]
         let expected_z_future = BlockHeight::from_u32(8);
 
@@ -183,6 +204,8 @@ mod tests {
             canopy: Some(expected_canopy),
             nu5: Some(expected_nu5),
             nu6: Some(expected_nu6),
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]
             z_future: Some(expected_z_future),
         };

--- a/components/zcash_protocol/src/txid.rs
+++ b/components/zcash_protocol/src/txid.rs
@@ -48,18 +48,27 @@ impl From<TxId> for [u8; 32] {
 }
 
 impl TxId {
+    /// Wraps the given byte array as a TxId value
     pub const fn from_bytes(bytes: [u8; 32]) -> Self {
         TxId(bytes)
     }
 
+    /// Reads a 32-byte txid directly from the provided reader.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut hash = [0u8; 32];
         reader.read_exact(&mut hash)?;
         Ok(TxId::from_bytes(hash))
     }
 
+    /// Writes the 32-byte payload directly to the provided writer.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.0)?;
         Ok(())
+    }
+
+    /// Returns true when the txid consists of all zeros; this only occurs for coinbase
+    /// transactions.
+    pub fn is_null(&self) -> bool {
+        self.0 == [0u8; 32]
     }
 }

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 zcash_note_encryption = { workspace = true, optional = true }
 zcash_primitives = { workspace = true, optional = true }
-zcash_protocol = { workspace = true, optional = true }
+zcash_protocol = { workspace = true, default-features = false }
 
 blake2b_simd = { workspace = true, optional = true }
 rand_core = { workspace = true, optional = true }
@@ -73,7 +73,6 @@ orchard = [
     "dep:nonempty",
     "dep:orchard",
     "dep:pasta_curves",
-    "dep:zcash_protocol",
 ]
 
 ## Enables functionality that requires Sapling protocol types.
@@ -84,14 +83,13 @@ sapling = [
     "dep:redjubjub",
     "dep:sapling",
     "dep:zcash_note_encryption",
-    "dep:zcash_protocol",
 ]
 
 ## Enables functionality that requires Zcash transparent protocol types.
-transparent = ["dep:secp256k1", "dep:transparent", "dep:zcash_protocol"]
+transparent = ["dep:secp256k1", "dep:transparent"]
 
 ## Enables building a PCZT from the output of `zcash_primitives`'s `Builder::build_for_pczt`.
-zcp-builder = ["dep:zcash_primitives", "dep:zcash_protocol"]
+zcp-builder = ["dep:zcash_primitives"]
 
 #! ### PCZT roles behind feature flags
 #!

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -39,11 +39,6 @@ pub mod transparent;
 const MAGIC_BYTES: &[u8] = b"PCZT";
 const PCZT_VERSION_1: u32 = 1;
 
-#[cfg(feature = "zcp-builder")]
-const SAPLING_TX_VERSION: u32 = 4;
-const V5_TX_VERSION: u32 = 5;
-const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
-
 /// A partially-created Zcash transaction.
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Pczt {

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -9,8 +9,10 @@ use crate::{
         FLAG_SHIELDED_MODIFIABLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
         FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
     },
-    Pczt, V5_TX_VERSION, V5_VERSION_GROUP_ID,
+    Pczt,
 };
+
+use zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID};
 
 /// Initial flags allowing any modification.
 const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
@@ -108,9 +110,9 @@ impl Creator {
         parts: zcash_primitives::transaction::builder::PcztParts<P>,
     ) -> Option<Pczt> {
         use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_SINGLE};
-        use zcash_protocol::consensus::NetworkConstants;
+        use zcash_protocol::{consensus::NetworkConstants, constants::SAPLING_TX_VERSION};
 
-        use crate::{common::FLAG_HAS_SIGHASH_SINGLE, SAPLING_TX_VERSION};
+        use crate::common::FLAG_HAS_SIGHASH_SINGLE;
 
         let tx_version = match parts.version {
             zcash_primitives::transaction::TxVersion::Sprout(_)

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -110,7 +110,7 @@ impl Creator {
         parts: zcash_primitives::transaction::builder::PcztParts<P>,
     ) -> Option<Pczt> {
         use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_SINGLE};
-        use zcash_protocol::{consensus::NetworkConstants, constants::SAPLING_TX_VERSION};
+        use zcash_protocol::{consensus::NetworkConstants, constants::V4_TX_VERSION};
 
         use crate::common::FLAG_HAS_SIGHASH_SINGLE;
 
@@ -119,11 +119,11 @@ impl Creator {
 
         let tx_version = match parts.version {
             zcash_primitives::transaction::TxVersion::Sprout(_)
-            | zcash_primitives::transaction::TxVersion::Overwinter => None,
-            zcash_primitives::transaction::TxVersion::Sapling => Some(SAPLING_TX_VERSION),
-            zcash_primitives::transaction::TxVersion::Zip225 => Some(V5_TX_VERSION),
+            | zcash_primitives::transaction::TxVersion::V3 => None,
+            zcash_primitives::transaction::TxVersion::V4 => Some(V4_TX_VERSION),
+            zcash_primitives::transaction::TxVersion::V5 => Some(V5_TX_VERSION),
             #[cfg(zcash_unstable = "nu7")]
-            zcash_primitives::transaction::TxVersion::Zip230 => Some(V6_TX_VERSION),
+            zcash_primitives::transaction::TxVersion::V6 => Some(V6_TX_VERSION),
             #[cfg(zcash_unstable = "zfuture")]
             zcash_primitives::transaction::TxVersion::ZFuture => None,
         }?;

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -114,11 +114,16 @@ impl Creator {
 
         use crate::common::FLAG_HAS_SIGHASH_SINGLE;
 
+        #[cfg(zcash_unstable = "nu7")]
+        use zcash_protocol::constants::V6_TX_VERSION;
+
         let tx_version = match parts.version {
             zcash_primitives::transaction::TxVersion::Sprout(_)
             | zcash_primitives::transaction::TxVersion::Overwinter => None,
             zcash_primitives::transaction::TxVersion::Sapling => Some(SAPLING_TX_VERSION),
             zcash_primitives::transaction::TxVersion::Zip225 => Some(V5_TX_VERSION),
+            #[cfg(zcash_unstable = "nu7")]
+            zcash_primitives::transaction::TxVersion::Zip230 => Some(V6_TX_VERSION),
             #[cfg(zcash_unstable = "zfuture")]
             zcash_primitives::transaction::TxVersion::ZFuture => None,
         }?;

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -13,8 +13,9 @@ use crate::{
         FLAG_SHIELDED_MODIFIABLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
         FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
     },
-    Pczt, V5_TX_VERSION, V5_VERSION_GROUP_ID,
+    Pczt,
 };
+use zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID};
 
 use super::signer::pczt_to_tx_data;
 

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -260,7 +260,7 @@ pub(crate) fn pczt_to_tx_data(
     orchard: &orchard::pczt::Bundle,
 ) -> Result<TransactionData<EffectsOnly>, Error> {
     let version = match (global.tx_version, global.version_group_id) {
-        (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::Zip225),
+        (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::V5),
         (version, version_group_id) => Err(Error::Global(GlobalError::UnsupportedTxVersion {
             version,
             version_group_id,

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -81,7 +81,7 @@ impl<'a> TransactionExtractor<'a> {
         } = self;
 
         let version = match (pczt.global.tx_version, pczt.global.version_group_id) {
-            (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::Zip225),
+            (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::V5),
             (version, version_group_id) => Err(Error::Global(GlobalError::UnsupportedTxVersion {
                 version,
                 version_group_id,

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -10,9 +10,12 @@ use zcash_primitives::transaction::{
     txid::TxIdDigester,
     Authorization, Transaction, TransactionData, TxVersion,
 };
-use zcash_protocol::consensus::BranchId;
+use zcash_protocol::{
+    consensus::BranchId,
+    constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID},
+};
 
-use crate::{common::determine_lock_time, Pczt, V5_TX_VERSION, V5_VERSION_GROUP_ID};
+use crate::{common::determine_lock_time, Pczt};
 
 mod orchard;
 pub use self::orchard::OrchardError;

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1396,6 +1396,8 @@ impl TestBuilder<(), ()> {
         canopy: Some(BlockHeight::from_u32(100_000)),
         nu5: Some(BlockHeight::from_u32(100_000)),
         nu6: None,
+        #[cfg(zcash_unstable = "nu7")]
+        nu7: None,
         #[cfg(zcash_unstable = "zfuture")]
         z_future: None,
     };

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -901,7 +901,7 @@ mod tests {
             )?;
 
             let tx = TransactionData::from_parts(
-                TxVersion::Sapling,
+                TxVersion::V4,
                 BranchId::Canopy,
                 0,
                 BlockHeight::from(0),

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -413,7 +413,7 @@ mod tests {
 
         // create a UTXO to spend
         let tx = TransactionData::from_parts(
-            TxVersion::Sapling,
+            TxVersion::V4,
             BranchId::Canopy,
             0,
             BlockHeight::from(3),

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -380,7 +380,7 @@ mod tests {
                 .unwrap();
         };
         add_tx_to_wallet(TransactionData::from_parts(
-            TxVersion::Zip225,
+            TxVersion::V5,
             BranchId::Nu5,
             0,
             12345678.into(),

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Variants of `zcash_primitives::transaction::TxVersion` have changed. They
+  now represent explicit transaction versions, in order to avoid accidental
+  confusion with the names of the network upgrades that they were introduced
+  in.
+
 ## [0.22.0] - 2025-02-21
 
 ### Changed

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -45,6 +45,9 @@ use zcash_protocol::constants::{
     SAPLING_VERSION_GROUP_ID, V5_TX_VERSION, V5_VERSION_GROUP_ID,
 };
 
+#[cfg(zcash_unstable = "nu7")]
+use zcash_protocol::constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID};
+
 #[cfg(zcash_unstable = "zfuture")]
 use zcash_protocol::constants::{ZFUTURE_TX_VERSION, ZFUTURE_VERSION_GROUP_ID};
 
@@ -63,6 +66,8 @@ pub enum TxVersion {
     Overwinter,
     Sapling,
     Zip225,
+    #[cfg(zcash_unstable = "nu7")]
+    Zip230,
     #[cfg(zcash_unstable = "zfuture")]
     ZFuture,
 }
@@ -78,6 +83,8 @@ impl TxVersion {
                 (OVERWINTER_TX_VERSION, OVERWINTER_VERSION_GROUP_ID) => Ok(TxVersion::Overwinter),
                 (SAPLING_TX_VERSION, SAPLING_VERSION_GROUP_ID) => Ok(TxVersion::Sapling),
                 (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::Zip225),
+                #[cfg(zcash_unstable = "nu7")]
+                (V6_TX_VERSION, V6_VERSION_GROUP_ID) => Ok(TxVersion::Zip230),
                 #[cfg(zcash_unstable = "zfuture")]
                 (ZFUTURE_TX_VERSION, ZFUTURE_VERSION_GROUP_ID) => Ok(TxVersion::ZFuture),
                 _ => Err(io::Error::new(
@@ -108,6 +115,8 @@ impl TxVersion {
                 TxVersion::Overwinter => OVERWINTER_TX_VERSION,
                 TxVersion::Sapling => SAPLING_TX_VERSION,
                 TxVersion::Zip225 => V5_TX_VERSION,
+                #[cfg(zcash_unstable = "nu7")]
+                TxVersion::Zip230 => V6_TX_VERSION,
                 #[cfg(zcash_unstable = "zfuture")]
                 TxVersion::ZFuture => ZFUTURE_TX_VERSION,
             }
@@ -119,6 +128,8 @@ impl TxVersion {
             TxVersion::Overwinter => OVERWINTER_VERSION_GROUP_ID,
             TxVersion::Sapling => SAPLING_VERSION_GROUP_ID,
             TxVersion::Zip225 => V5_VERSION_GROUP_ID,
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => V6_VERSION_GROUP_ID,
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => ZFUTURE_VERSION_GROUP_ID,
         }
@@ -138,8 +149,10 @@ impl TxVersion {
             TxVersion::Sprout(v) => *v >= 2u32,
             TxVersion::Overwinter | TxVersion::Sapling => true,
             TxVersion::Zip225 => false,
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => false,
             #[cfg(zcash_unstable = "zfuture")]
-            TxVersion::ZFuture => true,
+            TxVersion::ZFuture => false,
         }
     }
 
@@ -153,6 +166,8 @@ impl TxVersion {
             TxVersion::Sprout(_) | TxVersion::Overwinter => false,
             TxVersion::Sapling => true,
             TxVersion::Zip225 => true,
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => true,
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => true,
         }
@@ -163,6 +178,8 @@ impl TxVersion {
         match self {
             TxVersion::Sprout(_) | TxVersion::Overwinter | TxVersion::Sapling => false,
             TxVersion::Zip225 => true,
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => true,
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => true,
         }
@@ -183,6 +200,8 @@ impl TxVersion {
             }
             BranchId::Nu5 => TxVersion::Zip225,
             BranchId::Nu6 => TxVersion::Zip225,
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => TxVersion::Zip230,
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => TxVersion::ZFuture,
         }
@@ -538,6 +557,8 @@ impl Transaction {
                 Self::from_data_v4(data)
             }
             TxVersion::Zip225 => Ok(Self::from_data_v5(data)),
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => todo!(),
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => Ok(Self::from_data_v5(data)),
         }
@@ -581,6 +602,8 @@ impl Transaction {
                 Self::read_v4(reader, version, consensus_branch_id)
             }
             TxVersion::Zip225 => Self::read_v5(reader.into_base_reader(), version),
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => todo!(),
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => Self::read_v5(reader.into_base_reader(), version),
         }
@@ -764,6 +787,8 @@ impl Transaction {
                 self.write_v4(writer)
             }
             TxVersion::Zip225 => self.write_v5(writer),
+            #[cfg(zcash_unstable = "nu7")]
+            TxVersion::Zip230 => todo!(),
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => self.write_v5(writer),
         }
@@ -983,6 +1008,8 @@ pub mod testing {
             }
             BranchId::Nu5 => Just(TxVersion::Zip225).boxed(),
             BranchId::Nu6 => Just(TxVersion::Zip225).boxed(),
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => Just(TxVersion::Zip230).boxed(),
             #[cfg(zcash_unstable = "zfuture")]
             BranchId::ZFuture => Just(TxVersion::ZFuture).boxed(),
         }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -40,24 +40,13 @@ use ::sapling::builder as sapling_builder;
 #[cfg(zcash_unstable = "zfuture")]
 use self::components::tze::{self, TzeIn, TzeOut};
 
-const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C48270;
-const OVERWINTER_TX_VERSION: u32 = 3;
-const SAPLING_VERSION_GROUP_ID: u32 = 0x892F2085;
-const SAPLING_TX_VERSION: u32 = 4;
+use zcash_protocol::constants::{
+    OVERWINTER_TX_VERSION, OVERWINTER_VERSION_GROUP_ID, SAPLING_TX_VERSION,
+    SAPLING_VERSION_GROUP_ID, V5_TX_VERSION, V5_VERSION_GROUP_ID,
+};
 
-const V5_TX_VERSION: u32 = 5;
-const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
-
-/// These versions are used exclusively for in-development transaction
-/// serialization, and will never be active under the consensus rules.
-/// When new consensus transaction versions are added, all call sites
-/// using these constants should be inspected, and use of these constants
-/// should be removed as appropriate in favor of the new consensus
-/// transaction version and group.
 #[cfg(zcash_unstable = "zfuture")]
-const ZFUTURE_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
-#[cfg(zcash_unstable = "zfuture")]
-const ZFUTURE_TX_VERSION: u32 = 0x0000FFFF;
+use zcash_protocol::constants::{ZFUTURE_TX_VERSION, ZFUTURE_VERSION_GROUP_ID};
 
 pub use zcash_protocol::TxId;
 

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -73,6 +73,8 @@ pub fn signature_hash<
 
         TxVersion::Zip225 => v5_signature_hash(tx, signable_input, txid_parts),
 
+        #[cfg(zcash_unstable = "nu7")]
+        TxVersion::Zip230 => todo!(),
         #[cfg(zcash_unstable = "zfuture")]
         TxVersion::ZFuture => v5_signature_hash(tx, signable_input, txid_parts),
     })

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -67,14 +67,14 @@ pub fn signature_hash<
     txid_parts: &TxDigests<Blake2bHash>,
 ) -> SignatureHash {
     SignatureHash(match tx.version {
-        TxVersion::Sprout(_) | TxVersion::Overwinter | TxVersion::Sapling => {
+        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => {
             v4_signature_hash(tx, signable_input)
         }
 
-        TxVersion::Zip225 => v5_signature_hash(tx, signable_input, txid_parts),
+        TxVersion::V5 => v5_signature_hash(tx, signable_input, txid_parts),
 
         #[cfg(zcash_unstable = "nu7")]
-        TxVersion::Zip230 => todo!(),
+        TxVersion::V6 => todo!(),
         #[cfg(zcash_unstable = "zfuture")]
         TxVersion::ZFuture => v5_signature_hash(tx, signable_input, txid_parts),
     })


### PR DESCRIPTION
The `zcash_protocol-0.5.x` branch was produced based on a state of the `main` branch that contains SemVer breaking changes relative to the crates used on the `zcash_client_sqlite-0.16.x` branch. This backport makes it possible to make further SemVer point-release compatible changes to `zcash_protocol-0.5.x` and use those changes in `zcash_client_sqlite-0.16.x`. Any such changes should be made first on the `zcash-protocol-0.5.x` branch, and then backported in the same fashion (using `git cherry-pick -x`) as the commits being backported by this PR. 