### PR TITLE
fix: proper error types for `UnifiedFullViewingKey::decode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,6 +4243,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "snafu"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6484,6 +6505,7 @@ dependencies = [
  "rand_core",
  "sapling-crypto",
  "secrecy",
+ "snafu",
  "subtle",
  "tracing",
  "zcash_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,9 @@ zip32 = { version = "0.2", default-features = false }
 # Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
 time-core = "=0.1.2"
 
+# Error handling
+snafu = "0.8.6"
+
 [workspace.metadata.release]
 consolidate-commits = false
 pre-release-commit-message = "{{crate_name}} {{version}}"

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1072,7 +1072,7 @@ pub(crate) fn get_unified_full_viewing_keys<P: consensus::Parameters>(
         let ufvk_str: Option<String> = row.get(1)?;
         if let Some(ufvk_str) = ufvk_str {
             let ufvk = UnifiedFullViewingKey::decode(params, &ufvk_str)
-                .map_err(SqliteClientError::CorruptedData);
+                .map_err(|e| SqliteClientError::CorruptedData(e.to_string()));
             Ok(Some((AccountUuid(row.get(0)?), ufvk)))
         } else {
             Ok(None)

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -73,7 +73,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
 
             let ufvk_str: String = row.get(1)?;
             let ufvk = UnifiedFullViewingKey::decode(&self.params, &ufvk_str)
-                .map_err(WalletMigrationError::CorruptedData)?;
+                .map_err(|e| WalletMigrationError::CorruptedData(e.to_string()))?;
 
             // Verify that the address column contains the expected value.
             let address: String = row.get(2)?;

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -160,7 +160,7 @@ fn to_spendable_note<P: consensus::Parameters>(
         .zip(scope_code)
         .map(|(ufvk_str, scope_code)| {
             let ufvk = UnifiedFullViewingKey::decode(params, &ufvk_str)
-                .map_err(SqliteClientError::CorruptedData)?;
+                .map_err(|e| SqliteClientError::CorruptedData(e.to_string()))?;
 
             let spending_key_scope = zip32::Scope::try_from(KeyScope::decode(scope_code)?)
                 .map_err(|_| {

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -67,6 +67,9 @@ byteorder = { workspace = true, optional = true }
 # - Digests
 blake2b_simd = { workspace = true }
 
+# - Error handling
+thiserror.workspace = true
+
 [dev-dependencies]
 hex.workspace = true
 jubjub.workspace = true

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -68,7 +68,7 @@ byteorder = { workspace = true, optional = true }
 blake2b_simd = { workspace = true }
 
 # - Error handling
-thiserror.workspace = true
+snafu.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -79,7 +79,9 @@ orchard = { workspace = true, features = ["circuit"] }
 zcash_address = { workspace = true, features = ["test-dependencies"] }
 
 [features]
-default = ["std"]
+# TODO(schell): remove this
+#default = ["std"]
+default = ["std", "transparent-inputs", "orchard", "sapling"]
 std = ["dep:document-features"]
 
 ## Enables use of transparent key parts and addresses


### PR DESCRIPTION
These changes refactor and add to the `DecodeError` enum to provide some extra variants for improving error handling in `zcash_keys`. Fixes #598.