### PR TITLE
Release zcash_primitives 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.5.2"
+version = "0.5.4"
 dependencies = [
  "core2",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "assert_matches",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ zcash_address = { version = "0.8", path = "components/zcash_address", default-fe
 zcash_client_backend = { version = "0.18", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.3", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.8", path = "zcash_keys" }
-zcash_protocol = { version = "0.5.1", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.5.4", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.4", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
@@ -152,7 +152,7 @@ static_assertions = "1"
 ambassador = "0.4"
 assert_matches = "1.5"
 criterion = "0.5"
-proptest = "1"
+proptest = ">=1,<1.7" # proptest 1.7 updates to rand 0.9
 rand_chacha = "0.3"
 rand_xorshift = "0.3"
 incrementalmerkletree-testing = "0.3"

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,15 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.5.4] - 2025-07-15
+
+### Added
+- `impl {Add,Sub}<Zatoshis> for {ZatBalance, Option<ZatBalance>}`
+
+## [0.5.3] - 2025-06-12
+### Added
+  - `zcash_protocol::txid::TxId::is_null`
+
 ## [0.5.2] - 2025-05-30
 ### Added
 - `zcash_protocol::constants::`

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.5.2"
+version = "0.5.4"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zcash_protocol/src/txid.rs
+++ b/components/zcash_protocol/src/txid.rs
@@ -48,18 +48,27 @@ impl From<TxId> for [u8; 32] {
 }
 
 impl TxId {
+    /// Wraps the given byte array as a TxId value
     pub const fn from_bytes(bytes: [u8; 32]) -> Self {
         TxId(bytes)
     }
 
+    /// Reads a 32-byte txid directly from the provided reader.
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut hash = [0u8; 32];
         reader.read_exact(&mut hash)?;
         Ok(TxId::from_bytes(hash))
     }
 
+    /// Writes the 32-byte payload directly to the provided writer.
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.0)?;
         Ok(())
+    }
+
+    /// Returns true when the txid consists of all zeros; this only occurs for coinbase
+    /// transactions.
+    pub fn is_null(&self) -> bool {
+        self.0 == [0u8; 32]
     }
 }

--- a/components/zcash_protocol/src/value.rs
+++ b/components/zcash_protocol/src/value.rs
@@ -197,6 +197,38 @@ impl Sub<ZatBalance> for Option<ZatBalance> {
     }
 }
 
+impl Add<Zatoshis> for ZatBalance {
+    type Output = Option<ZatBalance>;
+
+    fn add(self, rhs: Zatoshis) -> Option<ZatBalance> {
+        ZatBalance::from_i64(self.0 + rhs.into_i64()).ok()
+    }
+}
+
+impl Add<Zatoshis> for Option<ZatBalance> {
+    type Output = Self;
+
+    fn add(self, rhs: Zatoshis) -> Option<ZatBalance> {
+        self.and_then(|lhs| lhs + rhs)
+    }
+}
+
+impl Sub<Zatoshis> for ZatBalance {
+    type Output = Option<ZatBalance>;
+
+    fn sub(self, rhs: Zatoshis) -> Option<ZatBalance> {
+        ZatBalance::from_i64(self.0 - rhs.into_i64()).ok()
+    }
+}
+
+impl Sub<Zatoshis> for Option<ZatBalance> {
+    type Output = Self;
+
+    fn sub(self, rhs: Zatoshis) -> Option<ZatBalance> {
+        self.and_then(|lhs| lhs - rhs)
+    }
+}
+
 impl Sum<ZatBalance> for Option<ZatBalance> {
     fn sum<I: Iterator<Item = ZatBalance>>(mut iter: I) -> Self {
         iter.try_fold(ZatBalance::zero(), |acc, a| acc + a)
@@ -260,6 +292,13 @@ impl Zatoshis {
     /// Returns this Zatoshis as a u64.
     pub fn into_u64(self) -> u64 {
         self.0
+    }
+
+    /// Returns this Zatoshis as an i64.
+    pub(crate) fn into_i64(self) -> i64 {
+        // this cast is safe as we know by construction that the value fits into the range of an
+        // i64
+        self.0 as i64
     }
 
     /// Creates a Zatoshis from a u64.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1314,4 +1314,4 @@ end = "2026-02-21"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-15"
-end = "2025-04-22"
+end = "2026-07-16"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1272,7 +1272,7 @@ end = "2025-12-13"
 criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-27"
-end = "2025-04-22"
+end = "2026-06-17"
 
 [[trusted.zcash_spec]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -805,10 +805,6 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.option-ext]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ordered-float]]
 version = "2.10.1"
 criteria = "safe-to-deploy"
@@ -1129,10 +1125,6 @@ criteria = "safe-to-deploy"
 version = "0.8.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde-value]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde_ignored]]
 version = "0.1.10"
 criteria = "safe-to-deploy"
@@ -1243,10 +1235,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.23"
-criteria = "safe-to-deploy"
-
-[[exemptions.tinystr]]
-version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -281,8 +281,8 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.zcash_address]]
-version = "0.7.1"
-when = "2025-05-07"
+version = "0.8.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -330,8 +330,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_primitives]]
-version = "0.22.0"
-when = "2025-02-21"
+version = "0.23.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -358,8 +358,8 @@ user-login = "daira"
 user-name = "Daira-Emma Hopwood"
 
 [[publisher.zcash_transparent]]
-version = "0.2.3"
-when = "2025-04-04"
+version = "0.3.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -372,8 +372,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zip321]]
-version = "0.3.0"
-when = "2025-02-21"
+version = "0.4.0"
+when = "2025-06-02"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -344,8 +344,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.5.1"
-when = "2025-03-21"
+version = "0.5.4"
+when = "2025-07-15"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -2504,6 +2504,12 @@ version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.option-ext]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.percent-encoding]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2578,6 +2584,13 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.27 -> 0.6.28"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde-value]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "Basic implementation of a serde value type. No use of unsafe code."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -2684,6 +2697,37 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.10 -> 0.2.18"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "One of original auther was Zibi Braniecki who worked at Mozilla and maintained by ICU4X developers (Google and Mozilla). I've vetted the one instance of unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.7.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.4 -> 0.7.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.6 -> 0.8.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.tracing-core]]

--- a/zcash_client_backend/src/tor/http/cryptex.rs
+++ b/zcash_client_backend/src/tor/http/cryptex.rs
@@ -63,7 +63,6 @@ pub mod exchanges {
 /// An exchange that can be queried for ZEC data.
 #[trait_variant::make(Exchange: Send)]
 #[dynosaur::dynosaur(DynExchange = dyn Exchange)]
-#[dynosaur::dynosaur(DynLocalExchange = dyn LocalExchange)]
 pub trait LocalExchange {
     /// Queries data about the USD/ZEC pair.
     ///

--- a/zcash_history/src/tree.rs
+++ b/zcash_history/src/tree.rs
@@ -27,7 +27,7 @@ pub struct Tree<V: Version> {
 
 impl<V: Version> Tree<V> {
     /// Resolve link originated from this tree
-    pub fn resolve_link(&self, link: EntryLink) -> Result<IndexedNode<V>, Error> {
+    pub fn resolve_link(&self, link: EntryLink) -> Result<IndexedNode<'_, V>, Error> {
         match link {
             EntryLink::Generated(index) => self.generated.get(index as usize),
             EntryLink::Stored(index) => self.stored.get(&index),
@@ -274,7 +274,7 @@ impl<V: Version> Tree<V> {
     }
 
     /// Reference to the root node.
-    pub fn root_node(&self) -> Result<IndexedNode<V>, Error> {
+    pub fn root_node(&self) -> Result<IndexedNode<'_, V>, Error> {
         self.resolve_link(self.root)
     }
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.23.1] - 2025-07-16
+
+### Changed
+- Migrated to `zcash_protocol 0.5.4` to alleviate a type inference issue
+  observed by downstream users.
+
 ## [0.23.0] - 2025-05-30
 
 ### Changed

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_primitives"
 description = "Rust implementations of the Zcash primitives"
-version = "0.23.0"
+version = "0.23.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -724,8 +724,7 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'_, 
         //
 
         // After fees are accounted for, the value balance of the transaction must be zero.
-        let balance_after_fees =
-            (self.value_balance()? - fee.into()).ok_or(BalanceError::Underflow)?;
+        let balance_after_fees = (self.value_balance()? - fee).ok_or(BalanceError::Underflow)?;
 
         match balance_after_fees.cmp(&ZatBalance::zero()) {
             Ordering::Less => {
@@ -907,8 +906,7 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'_, 
         //
 
         // After fees are accounted for, the value balance of the transaction must be zero.
-        let balance_after_fees =
-            (self.value_balance()? - fee.into()).ok_or(BalanceError::Underflow)?;
+        let balance_after_fees = (self.value_balance()? - fee).ok_or(BalanceError::Underflow)?;
 
         match balance_after_fees.cmp(&ZatBalance::zero()) {
             Ordering::Less => {

--- a/zcash_transparent/src/bundle.rs
+++ b/zcash_transparent/src/bundle.rs
@@ -173,7 +173,7 @@ impl OutPoint {
     fn is_null(&self) -> bool {
         // From `BaseOutPoint::IsNull()` in zcashd:
         //   return (hash.IsNull() && n == (uint32_t) -1);
-        self.hash.as_ref() == &[0; 32] && self.n == u32::MAX
+        self.hash.is_null() && self.n == u32::MAX
     }
 
     /// Returns the output index of this `OutPoint`.


### PR DESCRIPTION
The newly created `Add` impl's in `zcash_protocol 0.5.4` cause build failures of `zcash_primitives 0.23.0` due to an incautious use of `.into()` in the `zcash_primitives` codebase. This release remedies that error.