### PR TITLE
zcash_client_backend: Fix overly-constrained type signature of TestState::create_proposed_transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,10 +278,12 @@ jobs:
           path: crates
       # We use a synthetic crate to ensure no dev-dependencies are enabled, which can
       # be incompatible with some of these targets.
+      - name: Copy Rust toolchain into the root for use in synthetic crate setup
+        run: cp crates/rust-toolchain.toml .
       - name: Create synthetic crate for testing
-        run: cargo init --lib ci-build --edition 2021
-      - name: Copy Rust version into synthetic crate
-        run: cp crates/rust-toolchain.toml ci-build/
+        run: cargo init --lib ci-build
+      - name: Move Rust toolchain file into synthetic crate
+        run: mv rust-toolchain.toml ci-build/
       - name: Copy patch directives into synthetic crate
         run: |
           echo "[patch.crates-io]" >> ./ci-build/Cargo.toml
@@ -315,10 +317,12 @@ jobs:
           path: crates
       # We use a synthetic crate to ensure no dev-dependencies are enabled, which can
       # be incompatible with some of these targets.
+      - name: Copy Rust toolchain into the root for use in synthetic crate setup
+        run: cp crates/rust-toolchain.toml .
       - name: Create synthetic crate for testing
-        run: cargo init --lib ci-build --edition 2021
-      - name: Copy Rust version into synthetic crate
-        run: cp crates/rust-toolchain.toml ci-build/
+        run: cargo init --lib ci-build
+      - name: Move Rust toolchain file into synthetic crate
+        run: mv rust-toolchain.toml ci-build/
       - name: Copy patch directives into synthetic crate
         run: |
           echo "[patch.crates-io]" >> ./ci-build/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "bech32",
  "bip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ static_assertions = "1"
 ambassador = "0.4"
 assert_matches = "1.5"
 criterion = "0.5"
-proptest = "1"
+proptest = ">=1,<1.7" # proptest 1.7 updates to rand 0.9
 rand_chacha = "0.3"
 rand_xorshift = "0.3"
 incrementalmerkletree-testing = "0.3"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The signature of `zcash_client_backend::data_api::testing::TestState::create_proposed_transaction`
+  has been modified to allow transactions to be created from shielding proposals; this API
+  was previously overconstrained. This only affects users of the `test-dependencies` feature.
+
 ## [0.18.0] - 2025-03-19
 
 ### Added

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -7,10 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.18.1] - 2025-07-18
+
 ### Changed
 - The signature of `zcash_client_backend::data_api::testing::TestState::create_proposed_transaction`
-  has been modified to allow transactions to be created from shielding proposals; this API
-  was previously overconstrained. This only affects users of the `test-dependencies` feature.
+  has been modified to allow transactions to be created from shielding
+  proposals; this API was previously overconstrained. This only affects users
+  of the `test-dependencies` feature.
+- Documentation of the `test-dependencies` feature has been updated to indicate
+  that breaking changes to the APIs exposed by this feature flag may appear
+  in any release version of this crate, including patch releases.
 
 ## [0.18.0] - 2025-03-19
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.18.0"
+version = "0.18.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"
@@ -220,6 +220,9 @@ tor = [
 ]
 
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
+##
+## NOTE: Semver-breaking changes to the APIs exposed by this feature may be
+## present in any release version, including patch releases.
 test-dependencies = [
     "dep:ambassador",
     "dep:assert_matches",

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1081,15 +1081,12 @@ where
 
     /// Invokes [`create_proposed_transactions`] with the given arguments.
     #[allow(clippy::type_complexity)]
-    pub fn create_proposed_transactions<InputsErrT, FeeRuleT, ChangeErrT>(
+    pub fn create_proposed_transactions<InputsErrT, FeeRuleT, ChangeErrT, N>(
         &mut self,
         usk: &UnifiedSpendingKey,
         ovk_policy: OvkPolicy,
-        proposal: &Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
-    ) -> Result<
-        NonEmpty<TxId>,
-        super::wallet::CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, DbT::NoteRef>,
-    >
+        proposal: &Proposal<FeeRuleT, N>,
+    ) -> Result<NonEmpty<TxId>, super::wallet::CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
     where
         FeeRuleT: FeeRule,
     {

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -248,7 +248,7 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal,
@@ -406,7 +406,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
     let step = &proposal.steps().head;
     assert_eq!(step.balance().proposed_change().len(), 2);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal,
@@ -621,11 +621,12 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
         );
         assert_eq!(steps[1].balance().proposed_change(), []);
 
-        let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
-            account.usk(),
-            OvkPolicy::Sender,
-            &proposal,
-        );
+        let create_proposed_result = st
+            .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                account.usk(),
+                OvkPolicy::Sender,
+                &proposal,
+            );
         assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
         let txids = create_proposed_result.unwrap();
 
@@ -730,7 +731,7 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal,
@@ -944,7 +945,7 @@ pub fn proposal_fails_if_not_all_ephemeral_outputs_consumed<T: ShieldedPoolTeste
     // This is somewhat redundant with `send_multi_step_proposed_transfer`,
     // but tests the case with no change memo and ensures we haven't messed
     // up the test setup.
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal,
@@ -960,7 +961,7 @@ pub fn proposal_fails_if_not_all_ephemeral_outputs_consumed<T: ShieldedPoolTeste
     )
     .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &frobbed_proposal,
@@ -1187,7 +1188,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
 
     // Executing the proposal should succeed
     let txid = st
-        .create_proposed_transactions::<Infallible, _, Infallible>(
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
             account.usk(),
             OvkPolicy::Sender,
             &proposal,
@@ -1249,7 +1250,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
 
     // Executing the proposal should succeed
     assert_matches!(
-        st.create_proposed_transactions::<Infallible, _, Infallible>(account.usk(), OvkPolicy::Sender, &proposal,),
+        st.create_proposed_transactions::<Infallible, _, Infallible, _>(account.usk(), OvkPolicy::Sender, &proposal,),
         Ok(txids) if txids.len() == 1
     );
 
@@ -1331,7 +1332,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
         .unwrap();
 
     let txid2 = st
-        .create_proposed_transactions::<Infallible, _, Infallible>(
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
             account.usk(),
             OvkPolicy::Sender,
             &proposal,
@@ -1483,7 +1484,7 @@ pub fn spend_succeeds_to_t_addr_zero_change<T: ShieldedPoolTester>(
 
     // Executing the proposal should succeed
     assert_matches!(
-        st.create_proposed_transactions::<Infallible, _, Infallible>(account.usk(), OvkPolicy::Sender, &proposal),
+        st.create_proposed_transactions::<Infallible, _, Infallible, _>(account.usk(), OvkPolicy::Sender, &proposal),
         Ok(txids) if txids.len() == 1
     );
 }
@@ -1543,7 +1544,7 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
 
     // Executing the proposal should succeed
     assert_matches!(
-        st.create_proposed_transactions::<Infallible, _, Infallible>(account.usk(), OvkPolicy::Sender, &proposal),
+        st.create_proposed_transactions::<Infallible, _, Infallible, _>(account.usk(), OvkPolicy::Sender, &proposal),
         Ok(txids) if txids.len() == 1
     );
 }
@@ -2098,7 +2099,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     );
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal0,
@@ -2189,7 +2190,7 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
     );
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal0,
@@ -2276,7 +2277,7 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     assert_eq!(change_output.output_pool(), PoolType::SAPLING);
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
         account.usk(),
         OvkPolicy::Sender,
         &proposal0,

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1795,11 +1795,12 @@ pub(crate) mod tests {
             )
             .unwrap();
 
-        let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
-            account.usk(),
-            OvkPolicy::Sender,
-            &proposal,
-        );
+        let create_proposed_result = st
+            .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                account.usk(),
+                OvkPolicy::Sender,
+                &proposal,
+            );
         assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
     }
 

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -6,6 +6,18 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.8.2] - 2025-07-18
+
+### Added
+- `zcash_keys::keys::{UnifiedFullViewingKey, UnifiedIncomingViewingKey}::default_transparent_address`
+  have been added under the `test-dependencies` feature.
+
+## [0.4.1, 0.5.1, 0.6.1, 0.7.1, 0.8.1] - 2025-05-07
+
+### Added
+- `zcash_keys::Address::to_transparent_address`
+- `zcash_keys::Address::to_sapling_address`
+
 ## [0.8.0] - 2025-03-19
 
 ### Added

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_keys"
 description = "Zcash key and address management"
-version = "0.8.0"
+version = "0.8.2"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -436,6 +436,18 @@ impl Address {
             Address::Tex(addr_bytes) => Some(TransparentAddress::PublicKeyHash(*addr_bytes)),
         }
     }
+
+    /// Returns the Sapling address corresponding to this address, if it is a ZIP 32-encoded
+    /// Sapling address, or a Unified address with a Sapling receiver.
+    #[cfg(feature = "sapling")]
+    pub fn to_sapling_address(&self) -> Option<PaymentAddress> {
+        match self {
+            Address::Sapling(addr) => Some(*addr),
+            Address::Transparent(_) => None,
+            Address::Unified(ua) => ua.sapling().copied(),
+            Address::Tex(_) => None,
+        }
+    }
 }
 
 #[cfg(all(

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -457,6 +457,10 @@ impl UnifiedSpendingKey {
         }
     }
 
+    /// Returns the unified address corresponding to the smallest valid diversifier index,
+    /// along with that diversifier index.
+    ///
+    /// See [`UnifiedFullViewingKey::default_address`] for additional details.
     #[cfg(any(test, feature = "test-dependencies"))]
     pub fn default_address(
         &self,
@@ -467,6 +471,11 @@ impl UnifiedSpendingKey {
             .unwrap()
     }
 
+    /// Returns the default external transparent address using the transparent account pubkey.
+    ///
+    /// See [`ExternalIvk::default_address`] for more information.
+    ///
+    /// [`ExternalIvk::default_address`]: transparent::keys::ExternalIvk::default_address
     #[cfg(all(
         feature = "transparent-inputs",
         any(test, feature = "test-dependencies")
@@ -975,8 +984,6 @@ impl UnifiedFullViewingKey {
     }
 
     /// Attempts to derive the Unified Address for the given diversifier index and receiver types.
-    /// If `request` is None, the address should be derived to contain a receiver for each item in
-    /// this UFVK.
     ///
     /// Returns `None` if the specified index does not produce a valid diversifier.
     pub fn address(
@@ -989,8 +996,7 @@ impl UnifiedFullViewingKey {
 
     /// Searches the diversifier space starting at diversifier index `j` for one which will produce
     /// a valid diversifier, and return the Unified Address constructed using that diversifier
-    /// along with the index at which the valid diversifier was found. If `request` is None, the
-    /// address should be derived to contain a receiver for each item in this UFVK.
+    /// along with the index at which the valid diversifier was found.
     ///
     /// Returns an `Err(AddressGenerationError)` if no valid diversifier exists or if the features
     /// required to satisfy the unified address request are not properly enabled.
@@ -1004,8 +1010,7 @@ impl UnifiedFullViewingKey {
     }
 
     /// Find the Unified Address corresponding to the smallest valid diversifier index, along with
-    /// that index. If `request` is None, the address should be derived to contain a receiver for
-    /// each item in this UFVK.
+    /// that index.
     ///
     /// Returns an `Err(AddressGenerationError)` if no valid diversifier exists or if the features
     /// required to satisfy the unified address request are not properly enabled.
@@ -1014,6 +1019,25 @@ impl UnifiedFullViewingKey {
         request: UnifiedAddressRequest,
     ) -> Result<(UnifiedAddress, DiversifierIndex), AddressGenerationError> {
         self.find_address(DiversifierIndex::new(), request)
+    }
+
+    /// Returns the default external transparent address using the transparent account pubkey.
+    ///
+    /// See [`ExternalIvk::default_address`] for more information.
+    ///
+    /// [`ExternalIvk::default_address`]: transparent::keys::ExternalIvk::default_address
+    #[cfg(all(
+        feature = "transparent-inputs",
+        any(test, feature = "test-dependencies")
+    ))]
+    pub fn default_transparent_address(
+        &self,
+    ) -> Option<(TransparentAddress, NonHardenedChildIndex)> {
+        self.transparent().map(|k| {
+            k.derive_external_ivk()
+                .expect("ability to derive the external IVK was checked at construction")
+                .default_address()
+        })
     }
 }
 
@@ -1228,8 +1252,6 @@ impl UnifiedIncomingViewingKey {
     }
 
     /// Attempts to derive the Unified Address for the given diversifier index and receiver types.
-    /// If `request` is None, the address will be derived to contain a receiver for each item in
-    /// this UFVK.
     ///
     /// Returns an error if the this key does not produce a valid receiver for a required receiver
     /// type at the given diversifier index.
@@ -1381,8 +1403,7 @@ impl UnifiedIncomingViewingKey {
     }
 
     /// Find the Unified Address corresponding to the smallest valid diversifier index, along with
-    /// that index. If `request` is None, the address will be derived to contain a receiver for
-    /// each data item in this UFVK.
+    /// that index.
     ///
     /// Returns an error if the this key does not produce a valid receiver for a required receiver
     /// type at any diversifier index.
@@ -1457,6 +1478,21 @@ impl UnifiedIncomingViewingKey {
         }
 
         ReceiverRequirements::new(orchard, sapling, p2pkh)
+    }
+
+    /// Returns the default external transparent address using the transparent account pubkey.
+    ///
+    /// See [`ExternalIvk::default_address`] for more information.
+    ///
+    /// [`ExternalIvk::default_address`]: transparent::keys::ExternalIvk::default_address
+    #[cfg(all(
+        feature = "transparent-inputs",
+        any(test, feature = "test-dependencies")
+    ))]
+    pub fn default_transparent_address(
+        &self,
+    ) -> Option<(TransparentAddress, NonHardenedChildIndex)> {
+        self.transparent.as_ref().map(|k| k.default_address())
     }
 }
 


### PR DESCRIPTION
The existing type signature of this method made it impossible to use it with a proposal created by `zcash_client_backend::data_api::wallet::propose_shielding`.

This is technically a semver-breaking change, but as it only affects test code under the `test-dependencies` feature flag, it's worth it to include this in a patch release.

Once it has an approving review, this PR will merge as part of #1862