### PR TITLE
feat: zip 315 confirmations policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-.aider*

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,5 @@
+[language-server.rust-analyzer.config.cargo]
+features = "all"
+
+[language-server.rust-analyzer.config.server.extraEnv]
+RUSTUP_TOOLCHAIN = "stable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ members = [
     "zcash_transparent",
 ]
 
+resolver = "2"
+
 [workspace.package]
 edition = "2021"
 rust-version = "1.81"

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -129,9 +129,8 @@ impl Sub<BlockHeight> for BlockHeight {
 /// A wrapper type around [`BlockHeight`] that represents the _next_ chain tip.
 ///
 /// Addition and subtraction are provided by proxying to [`BlockHeight`].
-// TODO(schell): determine if we actually need PartialEq, Eq, Hash
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TargetHeight(BlockHeight);
 
 impl From<BlockHeight> for TargetHeight {

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -126,6 +126,60 @@ impl Sub<BlockHeight> for BlockHeight {
     }
 }
 
+/// A wrapper type around [`BlockHeight`] that represents the _next_ chain tip.
+///
+/// Addition and subtraction are provided by proxying to [`BlockHeight`].
+// TODO(schell): determine if we actually need PartialEq, Eq, Hash
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TargetHeight(BlockHeight);
+
+impl From<BlockHeight> for TargetHeight {
+    fn from(value: BlockHeight) -> Self {
+        TargetHeight(value)
+    }
+}
+
+impl From<TargetHeight> for BlockHeight {
+    fn from(value: TargetHeight) -> Self {
+        value.0
+    }
+}
+
+impl From<TargetHeight> for u32 {
+    fn from(value: TargetHeight) -> Self {
+        value.0 .0
+    }
+}
+
+impl From<u32> for TargetHeight {
+    fn from(value: u32) -> Self {
+        BlockHeight::from_u32(value).into()
+    }
+}
+
+impl<I> Add<I> for TargetHeight
+where
+    BlockHeight: Add<I>,
+{
+    type Output = <BlockHeight as Add<I>>::Output;
+
+    fn add(self, rhs: I) -> Self::Output {
+        self.0 + rhs
+    }
+}
+
+impl<I> Sub<I> for TargetHeight
+where
+    BlockHeight: Sub<I>,
+{
+    type Output = <BlockHeight as Sub<I>>::Output;
+
+    fn sub(self, rhs: I) -> Self::Output {
+        self.0 - rhs
+    }
+}
+
 /// Constants associated with a given Zcash network.
 pub trait NetworkConstants: Clone {
     /// The coin type for ZEC, as defined by [SLIP 44].

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -64,7 +64,6 @@ use std::{
     io,
     num::{NonZeroU32, TryFromIntError},
 };
-use wallet::ConfirmationsPolicy;
 
 use incrementalmerkletree::{frontier::Frontier, Retention};
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -76,7 +76,7 @@ use zcash_keys::{
 };
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
 use zcash_protocol::{
-    consensus::BlockHeight,
+    consensus::{BlockHeight, TargetHeight},
     memo::{Memo, MemoBytes},
     value::{BalanceError, Zatoshis},
     ShieldedProtocol, TxId,
@@ -1294,7 +1294,7 @@ pub trait InputSource {
         account: Self::AccountId,
         target_value: TargetValue,
         sources: &[ShieldedProtocol],
-        target_height: BlockHeight,
+        target_height: zcash_protocol::consensus::TargetHeight,
         confirmations_policy: wallet::ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error>;
@@ -1339,7 +1339,7 @@ pub trait InputSource {
     fn get_spendable_transparent_outputs(
         &self,
         _address: &TransparentAddress,
-        _target_height: BlockHeight,
+        _target_height: zcash_protocol::consensus::TargetHeight,
         _min_confirmations: u32,
     ) -> Result<Vec<WalletTransparentOutput>, Self::Error> {
         Ok(vec![])
@@ -1507,7 +1507,7 @@ pub trait WalletRead {
     fn get_target_and_anchor_heights(
         &self,
         min_confirmations: NonZeroU32,
-    ) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error>;
+    ) -> Result<Option<(zcash_protocol::consensus::TargetHeight, BlockHeight)>, Self::Error>;
 
     /// Returns the block height in which the specified transaction was mined, or `Ok(None)` if the
     /// transaction is not in the main chain.
@@ -2098,7 +2098,7 @@ impl<'a, AccountId> DecryptedTransaction<'a, AccountId> {
 pub struct SentTransaction<'a, AccountId> {
     tx: &'a Transaction,
     created: time::OffsetDateTime,
-    target_height: BlockHeight,
+    target_height: TargetHeight,
     account: AccountId,
     outputs: &'a [SentTransactionOutput<AccountId>],
     fee_amount: Zatoshis,
@@ -2121,7 +2121,7 @@ impl<'a, AccountId> SentTransaction<'a, AccountId> {
     pub fn new(
         tx: &'a Transaction,
         created: time::OffsetDateTime,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         account: AccountId,
         outputs: &'a [SentTransactionOutput<AccountId>],
         fee_amount: Zatoshis,
@@ -2166,7 +2166,7 @@ impl<'a, AccountId> SentTransaction<'a, AccountId> {
     }
 
     /// Returns the block height that this transaction was created to target.
-    pub fn target_height(&self) -> BlockHeight {
+    pub fn target_height(&self) -> TargetHeight {
         self.target_height
     }
 }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -64,6 +64,7 @@ use std::{
     io,
     num::{NonZeroU32, TryFromIntError},
 };
+use wallet::ConfirmationsPolicy;
 
 use incrementalmerkletree::{frontier::Frontier, Retention};
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
@@ -1294,7 +1295,8 @@ pub trait InputSource {
         account: Self::AccountId,
         target_value: TargetValue,
         sources: &[ShieldedProtocol],
-        anchor_height: BlockHeight,
+        target_height: BlockHeight,
+        confirmations_policy: wallet::ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error>;
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -922,8 +922,6 @@ where
             from_account.usk(),
             request,
             OvkPolicy::Sender,
-            // TODO(schell): Check this passes tests.
-            // This was previously `NonZeroU32::MIN`, which is 1.
             ConfirmationsPolicy::MIN,
         )
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -35,7 +35,7 @@ use zcash_primitives::{
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    consensus::{self, BlockHeight, Network, NetworkUpgrade, Parameters as _},
+    consensus::{self, BlockHeight, Network, NetworkUpgrade, Parameters as _, TargetHeight},
     local_consensus::LocalNetwork,
     memo::{Memo, MemoBytes},
     value::{ZatBalance, Zatoshis},
@@ -2501,7 +2501,7 @@ impl InputSource for MockWalletDb {
         _account: Self::AccountId,
         _target_value: TargetValue,
         _sources: &[ShieldedProtocol],
-        _anchor_height: BlockHeight,
+        _anchor_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
@@ -2621,7 +2621,7 @@ impl WalletRead for MockWalletDb {
     fn get_target_and_anchor_heights(
         &self,
         _min_confirmations: NonZeroU32,
-    ) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
+    ) -> Result<Option<(TargetHeight, BlockHeight)>, Self::Error> {
         Ok(None)
     }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -51,7 +51,7 @@ use super::{
     wallet::{
         create_proposed_transactions,
         input_selection::{GreedyInputSelector, InputSelector},
-        propose_standard_transfer_to_address, propose_transfer,
+        propose_standard_transfer_to_address, propose_transfer, ConfirmationsPolicy,
     },
     Account, AccountBalance, AccountBirthday, AccountMeta, AccountPurpose, AccountSource,
     AddressInfo, BlockMetadata, DecryptedTransaction, InputSource, NoteFilter, NullifierQuery,
@@ -922,7 +922,9 @@ where
             from_account.usk(),
             request,
             OvkPolicy::Sender,
-            NonZeroU32::MIN,
+            // TODO(schell): Check this passes tests.
+            // This was previously `NonZeroU32::MIN`, which is 1.
+            ConfirmationsPolicy::MIN,
         )
     }
 
@@ -935,7 +937,7 @@ where
         usk: &UnifiedSpendingKey,
         request: zip321::TransactionRequest,
         ovk_policy: OvkPolicy,
-        min_confirmations: NonZeroU32,
+        confirmations_policy: ConfirmationsPolicy,
     ) -> Result<NonEmpty<TxId>, super::wallet::TransferErrT<DbT, InputsT, ChangeT>>
     where
         InputsT: InputSelector<InputSource = DbT>,
@@ -957,7 +959,7 @@ where
             input_selector,
             change_strategy,
             request,
-            min_confirmations,
+            confirmations_policy,
         )?;
 
         create_proposed_transactions(
@@ -979,7 +981,7 @@ where
         input_selector: &InputsT,
         change_strategy: &ChangeT,
         request: zip321::TransactionRequest,
-        min_confirmations: NonZeroU32,
+        confirmations_policy: ConfirmationsPolicy,
     ) -> Result<
         Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
         super::wallet::ProposeTransferErrT<DbT, Infallible, InputsT, ChangeT>,
@@ -996,7 +998,7 @@ where
             input_selector,
             change_strategy,
             request,
-            min_confirmations,
+            confirmations_policy,
         )
     }
 
@@ -1007,7 +1009,7 @@ where
         &mut self,
         spend_from_account: <DbT as InputSource>::AccountId,
         fee_rule: StandardFeeRule,
-        min_confirmations: NonZeroU32,
+        confirmations_policy: ConfirmationsPolicy,
         to: &Address,
         amount: Zatoshis,
         memo: Option<MemoBytes>,
@@ -1028,7 +1030,7 @@ where
             &network,
             fee_rule,
             spend_from_account,
-            min_confirmations,
+            confirmations_policy,
             to,
             amount,
             memo,
@@ -2500,6 +2502,7 @@ impl InputSource for MockWalletDb {
         _target_value: TargetValue,
         _sources: &[ShieldedProtocol],
         _anchor_height: BlockHeight,
+        _confirmations_policy: ConfirmationsPolicy,
         _exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
         Ok(SpendableNotes::empty())

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -15,7 +15,7 @@ use zcash_keys::{
 use zcash_note_encryption::try_output_recovery_with_ovk;
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, TargetHeight},
     memo::MemoBytes,
     ShieldedProtocol,
 };
@@ -109,7 +109,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         min_confirmations: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -24,6 +24,7 @@ use crate::{
     data_api::{
         chain::{CommitmentTreeRoot, ScanSummary},
         testing::{pool::ShieldedPoolTester, TestState},
+        wallet::ConfirmationsPolicy,
         DecryptedTransaction, InputSource, TargetValue, WalletCommitmentTrees, WalletSummary,
         WalletTest,
     },
@@ -108,7 +109,8 @@ impl ShieldedPoolTester for OrchardPoolTester {
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
-        anchor_height: BlockHeight,
+        target_height: BlockHeight,
+        min_confirmations: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
@@ -116,7 +118,8 @@ impl ShieldedPoolTester for OrchardPoolTester {
                 account,
                 target_value,
                 &[ShieldedProtocol::Orchard],
-                anchor_height,
+                target_height,
+                min_confirmations,
                 exclude,
             )
             .map(|n| n.take_orchard())

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -110,7 +110,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
         target_height: TargetHeight,
-        min_confirmations: ConfirmationsPolicy,
+        confirmation_policy: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
@@ -119,7 +119,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
                 target_value,
                 &[ShieldedProtocol::Orchard],
                 target_height,
-                min_confirmations,
+                confirmation_policy,
                 exclude,
             )
             .map(|n| n.take_orchard())

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2078,8 +2078,6 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
         &st,
         account_id,
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
-        // TODO(schell): this height needs to be changed as we're now taking the target_height (chain tip + 1)
-        // instead of anchor height
         (received_tx_height + 10).into(),
         ConfirmationsPolicy::default(),
         &[],
@@ -2096,8 +2094,6 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
         &st,
         account_id,
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
-        // TODO(schell): this height needs to be changed as we're now taking the target_height (chain tip + 1)
-        // instead of anchor height
         (received_tx_height + 10).into(),
         ConfirmationsPolicy::default(),
         &[],
@@ -2154,7 +2150,6 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
         &st,
         account.id(),
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
-        // TODO(schell): revisit this height, we should be passing chain tip + 1
         (account.birthday().height() + 5).into(),
         ConfirmationsPolicy {
             // 5

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -344,96 +344,95 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
     );
 }
 
-/// Tests that inputs from trusted sources (the same wallet) can be spent according to
-/// the `ConfirmationPolicy`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ConfirmationStep {
+    i: u32,
+    confirmation_requirement: u32,
+    number_of_confirmations: u32,
+    pending_balance: Zatoshis,
+    spendable_balance: Zatoshis,
+    total_balance: Zatoshis,
+}
+
+/// Tests that inputs from a source can be spent according to the default
+/// `ConfirmationPolicy`.
 ///
 /// The test:
-/// - Adds funds to the wallet in a single note.
-/// - Checks that the wallet balances are correct.
-/// - Constructs a request to spend part of that balance to an external address in the
-///   same pool.
-/// - Builds the transaction.
-pub fn can_spend_trusted_inputs_by_confirmations_policy<T: ShieldedPoolTester>(
+/// - Adds funds to the wallet in a single note from an certain source.
+/// - Checks that the wallet balances are correct after N confirmations, according to
+///   the policy.
+pub fn zip_315_confirmations_test_steps<T: ShieldedPoolTester>(
     dsf: impl DataStoreFactory,
     cache: impl TestCache,
+    input_is_trusted: bool,
 ) {
     let mut st = TestBuilder::new()
         .with_data_store_factory(dsf)
         .with_block_cache(cache)
         .with_account_from_sapling_activation(BlockHash([0; 32]))
         .build();
-
     let account = st.test_account().cloned().unwrap();
     let dfvk = T::test_account_fvk(&st);
+    let starting_balance = Zatoshis::const_from_u64(60_000);
+    // Add funds to the wallet in a single note, owned by the internal spending key,
+    // this is the first confirmation
+    let address_type = if input_is_trusted {
+        AddressType::Internal
+    } else {
+        AddressType::DefaultExternal
+    };
 
-    // Add funds to the wallet in a single note
-    let value = Zatoshis::const_from_u64(60000);
-    let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+    let (h, _, _) = st.generate_next_block(&dfvk, address_type, starting_balance);
     st.scan_cached_blocks(h, 1);
 
-    // Spendable balance matches total balance
-    assert_eq!(st.get_total_balance(account.id()), value);
-    assert_eq!(st.get_spendable_balance(account.id(), 1), value);
+    // Spendable balance matches total balance at 1 confirmation.
+    assert_eq!(st.get_total_balance(account.id()), starting_balance);
+    assert_eq!(st.get_spendable_balance(account.id(), 1), starting_balance);
 
-    assert_eq!(
-        st.wallet()
-            .block_max_scanned()
-            .unwrap()
-            .unwrap()
-            .block_height(),
-        h
-    );
+    // Generate N confirmations by mining blocks
+    let confirmations_policy = ConfirmationsPolicy::default();
+    let min_confirmations = u32::from(if input_is_trusted {
+        confirmations_policy.trusted
+    } else {
+        confirmations_policy.untrusted
+    });
+    let steps = (1u32..min_confirmations)
+        .map(|i| {
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+            ConfirmationStep {
+                i,
+                confirmation_requirement: min_confirmations,
+                number_of_confirmations: 1 + i,
+                pending_balance: st.get_pending_shielded_balance(account.id(), min_confirmations),
+                spendable_balance: st.get_spendable_balance(account.id(), min_confirmations),
+                total_balance: st.get_total_balance(account.id()),
+            }
+        })
+        .collect::<Vec<_>>();
 
-    let to_extsk = T::sk(&[0xf5; 32]);
-    let to: Address = T::sk_default_address(&to_extsk);
-    let payment_amount = Zatoshis::const_from_u64(10000);
-    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
-        to.to_zcash_address(st.network()),
-        payment_amount,
-    )])
-    .unwrap();
-
-    let fee_rule = StandardFeeRule::Zip317;
-
-    let change_memo = "Test change memo".parse::<Memo>().unwrap();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        fee_rule,
-        Some(change_memo.clone().into()),
+    let to = T::random_address(st.rng_mut());
+    // Now that the funds are spendable, propose a transaction
+    let proposed = st.propose_standard_transfer::<Infallible>(
+        account.id(),
+        StandardFeeRule::Zip317,
+        confirmations_policy,
+        &to,
+        Zatoshis::const_from_u64(10_000),
+        None,
+        None,
         T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
     );
-    let input_selector = GreedyInputSelector::new();
-
-    let proposal = st
-        .propose_transfer(
-            account.id(),
-            &input_selector,
-            &change_strategy,
-            request,
-            ConfirmationsPolicy::MIN,
-        )
-        .unwrap();
-
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
+    assert!(
+        proposed.is_ok(),
+        "Could not spend funds by confirmation policy ({}): {proposed:#?}\n\
+        steps: {steps:#?}",
+        if input_is_trusted {
+            "trusted"
+        } else {
+            "untrusted"
+        }
     );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
-
-    // Ensure that when the transaction is mined, we cannot spend the change, yet.
-    let (h, _) = st.generate_next_block_including(sent_tx_id);
-    st.scan_cached_blocks(h, 1);
-
-    let fee = Zatoshis::from_u64(1000).unwrap();
-    assert_eq!(
-        st.get_total_balance(account.id()),
-        (value - payment_amount - fee).unwrap()
-    );
-    // Spendable balance matches total balance
-    assert_eq!(st.get_spendable_balance(account.id(), 1), value);
 }
 
 pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Eq,
     convert::Infallible,
     hash::Hash,
-    num::{NonZeroU64, NonZeroU8, NonZeroUsize},
+    num::{NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize},
 };
 
 use assert_matches::assert_matches;
@@ -2055,13 +2055,18 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
     // Scan the block
     st.scan_cached_blocks(account.birthday().height() + 10, 1);
 
+    println!("account_birthday_height: {}", account.birthday().height());
     // Verify that our note is considered spendable
     let spendable = T::select_spendable_notes(
         &st,
         account.id(),
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         account.birthday().height() + 5,
-        ConfirmationsPolicy::default(),
+        ConfirmationsPolicy {
+            // 5
+            untrusted: NonZeroU32::MIN.saturating_add(4),
+            ..Default::default()
+        },
         &[],
     )
     .unwrap();
@@ -3309,7 +3314,7 @@ pub fn wallet_recovery_computes_fees<T: ShieldedPoolTester, DsF: DataStoreFactor
                 &input_selector,
                 &change_strategy,
                 request.clone(),
-                NonZeroU32::new(1).unwrap(),
+                ConfirmationsPolicy::MIN,
             )
             .unwrap();
         let result0 = st

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Eq,
     convert::Infallible,
     hash::Hash,
-    num::{NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize},
+    num::{NonZeroU64, NonZeroU8, NonZeroUsize},
 };
 
 use assert_matches::assert_matches;
@@ -40,7 +40,8 @@ use crate::{
             TestBuilder,
         },
         wallet::{
-            decrypt_and_store_transaction, input_selection::GreedyInputSelector, TransferErrT,
+            decrypt_and_store_transaction, input_selection::GreedyInputSelector,
+            ConfirmationsPolicy, TransferErrT,
         },
         Account as _, AccountBirthday, BoundedU8, DecryptedTransaction, InputSource, NoteFilter,
         Ratio, TargetValue, WalletCommitmentTrees, WalletRead, WalletSummary, WalletTest,
@@ -149,7 +150,8 @@ pub trait ShieldedPoolTester {
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
-        anchor_height: BlockHeight,
+        target_height: BlockHeight,
+        confirmations_policy: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error>;
 
@@ -245,7 +247,7 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
             &input_selector,
             &change_strategy,
             request,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -400,7 +402,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
             &input_selector,
             &change_strategy,
             request.clone(),
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -515,7 +517,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
             &input_selector,
             &change_strategy,
             request,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -599,7 +601,7 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
             .propose_standard_transfer::<Infallible>(
                 account_id,
                 StandardFeeRule::Zip317,
-                NonZeroU32::new(1).unwrap(),
+                ConfirmationsPolicy::MIN,
                 &tex_addr,
                 transfer_amount,
                 None,
@@ -723,7 +725,7 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, DSF>(
         .propose_standard_transfer::<Infallible>(
             account_id,
             StandardFeeRule::Zip317,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
             &ephemeral0,
             transfer_amount,
             None,
@@ -934,7 +936,7 @@ pub fn proposal_fails_if_not_all_ephemeral_outputs_consumed<T: ShieldedPoolTeste
         .propose_standard_transfer::<Infallible>(
             account_id,
             StandardFeeRule::Zip317,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
             &tex_addr,
             transfer_amount,
             None,
@@ -1006,7 +1008,7 @@ pub fn create_to_address_fails_on_incorrect_usk<T: ShieldedPoolTester, DSF: Data
             &usk1,
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         ),
         Err(data_api::error::Error::KeyNotRecognized)
     );
@@ -1034,7 +1036,7 @@ where
         st.propose_standard_transfer::<Infallible>(
             account_id,
             StandardFeeRule::Zip317,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
             &to,
             Zatoshis::const_from_u64(1),
             None,
@@ -1110,7 +1112,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
         st.propose_standard_transfer::<Infallible>(
             account_id,
             StandardFeeRule::Zip317,
-            NonZeroU32::new(2).unwrap(),
+            ConfirmationsPolicy::new_symmetrical(2).unwrap(),
             &to,
             Zatoshis::const_from_u64(70000),
             None,
@@ -1140,7 +1142,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
         st.propose_standard_transfer::<Infallible>(
             account_id,
             StandardFeeRule::Zip317,
-            NonZeroU32::new(10).unwrap(),
+            ConfirmationsPolicy::new_symmetrical(10).unwrap(),
             &to,
             Zatoshis::const_from_u64(70000),
             None,
@@ -1173,7 +1175,7 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
 
     // Should now be able to generate a proposal
     let amount_sent = Zatoshis::from_u64(70000).unwrap();
-    let min_confirmations = NonZeroU32::new(10).unwrap();
+    let min_confirmations = ConfirmationsPolicy::new_symmetrical(10).unwrap();
     let proposal = st
         .propose_standard_transfer::<Infallible>(
             account_id,
@@ -1235,7 +1237,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     // Send some of the funds to another address, but don't mine the tx.
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
-    let min_confirmations = NonZeroU32::new(1).unwrap();
+    let min_confirmations = ConfirmationsPolicy::new_symmetrical(1).unwrap();
     let proposal = st
         .propose_standard_transfer::<Infallible>(
             account_id,
@@ -1260,7 +1262,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
         st.propose_standard_transfer::<Infallible>(
             account_id,
             fee_rule,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
             &to,
             Zatoshis::const_from_u64(2000),
             None,
@@ -1290,7 +1292,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
         st.propose_standard_transfer::<Infallible>(
             account_id,
             fee_rule,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
             &to,
             Zatoshis::const_from_u64(2000),
             None,
@@ -1318,7 +1320,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
 
     // Second spend should now succeed
     let amount_sent2 = Zatoshis::const_from_u64(2000);
-    let min_confirmations = NonZeroU32::new(1).unwrap();
+    let min_confirmations = ConfirmationsPolicy::MIN;
     let proposal = st
         .propose_standard_transfer::<Infallible>(
             account_id,
@@ -1391,7 +1393,7 @@ pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, DSF>(
             SingleOutputChangeStrategy<DSF::DataStore>,
         >,
     > {
-        let min_confirmations = NonZeroU32::new(1).unwrap();
+        let min_confirmations = ConfirmationsPolicy::MIN;
         let proposal = st.propose_standard_transfer(
             account_id,
             fee_rule,
@@ -1469,7 +1471,7 @@ pub fn spend_succeeds_to_t_addr_zero_change<T: ShieldedPoolTester>(
 
     // TODO: generate_next_block_from_tx does not currently support transparent outputs.
     let to = TransparentAddress::PublicKeyHash([7; 20]).into();
-    let min_confirmations = NonZeroU32::new(1).unwrap();
+    let min_confirmations = ConfirmationsPolicy::MIN;
     let proposal = st
         .propose_standard_transfer::<Infallible>(
             account_id,
@@ -1529,7 +1531,7 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
 
     // TODO: generate_next_block_from_tx does not currently support transparent outputs.
     let to = TransparentAddress::PublicKeyHash([7; 20]).into();
-    let min_confirmations = NonZeroU32::new(1).unwrap();
+    let min_confirmations = ConfirmationsPolicy::MIN;
     let proposal = st
         .propose_standard_transfer::<Infallible>(
             account_id,
@@ -1614,7 +1616,7 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
             &usk,
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap()[0];
 
@@ -1715,7 +1717,7 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
             account.usk(),
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         ),
         Err(Error::InsufficientFunds { available, required })
             if available == Zatoshis::const_from_u64(51000)
@@ -1737,7 +1739,7 @@ pub fn zip317_spend<T: ShieldedPoolTester, DSF: DataStoreFactory>(
             account.usk(),
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap()[0];
 
@@ -1985,7 +1987,10 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
         &st,
         account_id,
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
+        // TODO(schell): this height needs to be changed as we're now taking the target_height (chain tip + 1)
+        // instead of anchor height
         received_tx_height + 10,
+        ConfirmationsPolicy::default(),
         &[],
     )
     .unwrap();
@@ -2001,6 +2006,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
         account_id,
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         received_tx_height + 10,
+        ConfirmationsPolicy::default(),
         &[],
     )
     .unwrap();
@@ -2055,6 +2061,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
         account.id(),
         TargetValue::AtLeast(Zatoshis::const_from_u64(300000)),
         account.birthday().height() + 5,
+        ConfirmationsPolicy::default(),
         &[],
     )
     .unwrap();
@@ -2079,7 +2086,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, DSF: DataStoreFactory>(
             account.usk(),
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(5).unwrap(),
+            ConfirmationsPolicy::new_symmetrical(5).unwrap(),
         ),
         Ok(_)
     );
@@ -2128,7 +2135,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
             &input_selector,
             &change_strategy,
             p0_to_p1,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -2220,7 +2227,7 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
             &input_selector,
             &change_strategy,
             p0_to_p1,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -2310,7 +2317,7 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
             &input_selector,
             &change_strategy,
             p0_to_p1,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 
@@ -2417,7 +2424,7 @@ pub fn multi_pool_checkpoint<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
             account.usk(),
             p0_transfer,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
     st.generate_next_block_including(*res.first());
@@ -2449,7 +2456,7 @@ pub fn multi_pool_checkpoint<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
             account.usk(),
             both_transfer,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
     st.generate_next_block_including(*res.first());
@@ -2896,7 +2903,7 @@ pub fn scan_cached_blocks_allows_blocks_out_of_order<T: ShieldedPoolTester>(
             account.usk(),
             req,
             OvkPolicy::Sender,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         ),
         Ok(_)
     );
@@ -3200,7 +3207,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, DSF>(
             &input_selector,
             &change_strategy,
             p0_to_p1,
-            NonZeroU32::new(1).unwrap(),
+            ConfirmationsPolicy::MIN,
         )
         .unwrap();
 

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -9,7 +9,7 @@ use shardtree::error::ShardTreeError;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::transaction::{components::sapling::zip212_enforcement, Transaction};
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, TargetHeight},
     memo::MemoBytes,
     ShieldedProtocol,
 };
@@ -93,7 +93,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
         st: &TestState<Cache, DbT, P>,
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
-        anchor_height: BlockHeight,
+        target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
@@ -102,7 +102,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
                 account,
                 target_value,
                 &[ShieldedProtocol::Sapling],
-                anchor_height,
+                target_height,
                 confirmations_policy,
                 exclude,
             )

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -18,6 +18,7 @@ use zip32::Scope;
 use crate::{
     data_api::{
         chain::{CommitmentTreeRoot, ScanSummary},
+        wallet::ConfirmationsPolicy,
         DecryptedTransaction, InputSource, TargetValue, WalletCommitmentTrees, WalletSummary,
         WalletTest,
     },
@@ -93,6 +94,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
         account: <DbT as InputSource>::AccountId,
         target_value: TargetValue,
         anchor_height: BlockHeight,
+        confirmations_policy: ConfirmationsPolicy,
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
@@ -101,6 +103,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
                 target_value,
                 &[ShieldedProtocol::Sapling],
                 anchor_height,
+                confirmations_policy,
                 exclude,
             )
             .map(|n| n.take_sapling())

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -63,7 +63,7 @@ fn check_balance<DSF>(
     );
     assert_eq!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, mempool_height, min_confirmations)
+            .get_spendable_transparent_outputs(taddr, mempool_height.into(), min_confirmations)
             .unwrap()
             .into_iter()
             .map(|utxo| utxo.value())
@@ -78,7 +78,11 @@ fn check_balance<DSF>(
     if min_confirmations == 0 || min_confirmations == 1 {
         assert_eq!(
             st.wallet()
-                .get_spendable_transparent_outputs(taddr, mempool_height, 1 - min_confirmations)
+                .get_spendable_transparent_outputs(
+                    taddr,
+                    mempool_height.into(),
+                    1 - min_confirmations
+                )
                 .unwrap()
                 .into_iter()
                 .map(|utxo| utxo.value())
@@ -134,7 +138,7 @@ where
     assert_matches!(
         st.wallet().get_spendable_transparent_outputs(
             taddr,
-            height_1,
+            height_1.into(),
             0
         ).as_deref(),
         Ok([ret]) if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
@@ -155,7 +159,7 @@ where
     // Confirm that we no longer see any unspent outputs as of `height_1`.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, height_1, 0)
+            .get_spendable_transparent_outputs(taddr, height_1.into(), 0)
             .as_deref(),
         Ok(&[])
     );
@@ -169,7 +173,7 @@ where
     // If we include `height_2` then the output is returned.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, height_2, 0)
+            .get_spendable_transparent_outputs(taddr, height_2.into(), 0)
             .as_deref(),
         Ok([ret]) if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_2))
     );

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -352,6 +352,7 @@ where
     let (target_height, anchor_height) =
         maybe_intial_heights.ok_or_else(|| InputSelectorError::SyncRequired)?;
 
+    // TODO(schell): should this even take the anchor_height?
     let proposal = input_selector.propose_transaction(
         params,
         wallet_db,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -358,7 +358,6 @@ where
         confirmations: {confirmations_policy:?}"
     );
 
-    // TODO(schell): should this even take the anchor_height?
     let proposal = input_selector.propose_transaction(
         params,
         wallet_db,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -294,7 +294,7 @@ impl Default for ConfirmationsPolicy {
             // 3
             trusted: NonZeroU32::MIN.saturating_add(2),
             // 10
-            untrusted: NonZeroU32::MIN.saturating_add(8),
+            untrusted: NonZeroU32::MIN.saturating_add(9),
         }
     }
 }
@@ -351,13 +351,6 @@ where
         .map_err(InputSelectorError::DataSource)?;
     let (target_height, anchor_height) =
         maybe_intial_heights.ok_or_else(|| InputSelectorError::SyncRequired)?;
-
-    println!(
-        "target_height: {target_height:?}\n\
-        anchor_height: {anchor_height:?}\n\
-        confirmations: {confirmations_policy:?}"
-    );
-
     let proposal = input_selector.propose_transaction(
         params,
         wallet_db,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -255,6 +255,44 @@ pub type ExtractErrT<DbT, N> = Error<
     N,
 >;
 
+/// The minimum number of confirmations required for trusted and untrusted
+/// transactions.
+#[derive(Clone, Copy)]
+pub struct ConfirmationsPolicy {
+    pub trusted: NonZeroU32,
+    pub untrusted: NonZeroU32,
+}
+
+impl Default for ConfirmationsPolicy {
+    fn default() -> Self {
+        ConfirmationsPolicy {
+            // 3
+            trusted: NonZeroU32::MIN.saturating_add(2),
+            // 10
+            untrusted: NonZeroU32::MIN.saturating_add(8),
+        }
+    }
+}
+
+impl ConfirmationsPolicy {
+    pub const MIN: Self = ConfirmationsPolicy {
+        trusted: NonZeroU32::MIN,
+        untrusted: NonZeroU32::MIN,
+    };
+
+    /// Create a new `ConfirmationsPolicy` with `trusted` and `untrusted` fields both
+    /// set to `min_confirmations`.
+    ///
+    /// Returns `None` if `min_confirmations` is `0`.
+    pub fn new_symmetrical(min_confirmations: u32) -> Option<Self> {
+        let confirmations = NonZeroU32::new(min_confirmations)?;
+        Some(Self {
+            trusted: confirmations,
+            untrusted: confirmations,
+        })
+    }
+}
+
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that can then be authorized and made ready for submission to the network with
 /// [`create_proposed_transactions`].
@@ -267,7 +305,7 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     input_selector: &InputsT,
     change_strategy: &ChangeT,
     request: zip321::TransactionRequest,
-    min_confirmations: NonZeroU32,
+    min_confirmations: ConfirmationsPolicy,
 ) -> Result<
     Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
     ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
@@ -279,22 +317,27 @@ where
     InputsT: InputSelector<InputSource = DbT>,
     ChangeT: ChangeStrategy<MetaSource = DbT>,
 {
-    let (target_height, anchor_height) = wallet_db
-        .get_target_and_anchor_heights(min_confirmations)
-        .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
-        .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
+    // Using the trusted confirmations results in an anchor_height that will
+    // include the maximum number of notes being selected, and we can filter
+    // later based on the input source (whether it's trusted or not) and the
+    // number of confirmations
+    let maybe_intial_heights = wallet_db
+        .get_target_and_anchor_heights(min_confirmations.trusted)
+        .map_err(InputSelectorError::DataSource)?;
+    let (target_height, anchor_height) =
+        maybe_intial_heights.ok_or_else(|| InputSelectorError::SyncRequired)?;
 
-    input_selector
-        .propose_transaction(
-            params,
-            wallet_db,
-            target_height,
-            anchor_height,
-            spend_from_account,
-            request,
-            change_strategy,
-        )
-        .map_err(Error::from)
+    let proposal = input_selector.propose_transaction(
+        params,
+        wallet_db,
+        target_height,
+        anchor_height,
+        min_confirmations,
+        spend_from_account,
+        request,
+        change_strategy,
+    )?;
+    Ok(proposal)
 }
 
 /// Proposes making a payment to the specified address from the given account.
@@ -329,7 +372,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     params: &ParamsT,
     fee_rule: StandardFeeRule,
     spend_from_account: <DbT as InputSource>::AccountId,
-    min_confirmations: NonZeroU32,
+    min_confirmations: ConfirmationsPolicy,
     to: &Address,
     amount: Zatoshis,
     memo: Option<MemoBytes>,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -182,7 +182,7 @@ pub trait InputSelector {
         wallet_db: &Self::InputSource,
         target_height: TargetHeight,
         anchor_height: BlockHeight,
-        min_confirmations: ConfirmationsPolicy,
+        confirmations_policy: ConfirmationsPolicy,
         account: <Self::InputSource as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
@@ -370,7 +370,7 @@ impl<DbT: WalletRead + InputSource> InputSelector for GreedyInputSelector<DbT> {
         wallet_db: &Self::InputSource,
         target_height: TargetHeight,
         anchor_height: BlockHeight,
-        min_confirmations: ConfirmationsPolicy,
+        confirmations_policy: ConfirmationsPolicy,
         account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
@@ -753,7 +753,7 @@ impl<DbT: WalletRead + InputSource> InputSelector for GreedyInputSelector<DbT> {
                     TargetValue::AtLeast(amount_required),
                     selectable_pools,
                     target_height,
-                    min_confirmations,
+                    confirmations_policy,
                     &exclude,
                 )
                 .map_err(InputSelectorError::DataSource)?;

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -19,7 +19,9 @@ use zcash_protocol::{
 use zip321::TransactionRequest;
 
 use crate::{
-    data_api::{InputSource, SimpleNoteRetention, SpendableNotes, TargetValue, WalletRead},
+    data_api::{
+        InputSource, SimpleNoteRetention, SpendableNotes, TargetHeight, TargetValue, WalletRead,
+    },
     fees::{sapling, ChangeError, ChangeStrategy},
     proposal::{Proposal, ProposalError, ShieldedInputs},
     wallet::WalletTransparentOutput,
@@ -178,7 +180,7 @@ pub trait InputSelector {
         &self,
         params: &ParamsT,
         wallet_db: &Self::InputSource,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         anchor_height: BlockHeight,
         min_confirmations: ConfirmationsPolicy,
         account: <Self::InputSource as InputSource>::AccountId,
@@ -230,7 +232,7 @@ pub trait ShieldingSelector {
         shielding_threshold: Zatoshis,
         source_addrs: &[TransparentAddress],
         to_account: <Self::InputSource as InputSource>::AccountId,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         min_confirmations: u32,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, Infallible>,
@@ -366,8 +368,8 @@ impl<DbT: WalletRead + InputSource> InputSelector for GreedyInputSelector<DbT> {
         &self,
         params: &ParamsT,
         wallet_db: &Self::InputSource,
-        target_height: BlockHeight,
-        untrusted_anchor_height: BlockHeight,
+        target_height: TargetHeight,
+        anchor_height: BlockHeight,
         min_confirmations: ConfirmationsPolicy,
         account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
@@ -630,7 +632,7 @@ impl<DbT: WalletRead + InputSource> InputSelector for GreedyInputSelector<DbT> {
                             #[cfg(feature = "orchard")]
                             orchard: use_orchard,
                         }))
-                        .map(|notes| ShieldedInputs::from_parts(untrusted_anchor_height, notes));
+                        .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
 
                     #[cfg(feature = "transparent-inputs")]
                     if let Some(tr1_balance) = tr1_balance_opt {
@@ -785,7 +787,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         shielding_threshold: Zatoshis,
         source_addrs: &[TransparentAddress],
         to_account: <Self::InputSource as InputSource>::AccountId,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         min_confirmations: u32,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, Infallible>,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -19,11 +19,13 @@ use zcash_protocol::{
 use zip321::TransactionRequest;
 
 use crate::{
-    data_api::{InputSource, SimpleNoteRetention, SpendableNotes, TargetValue},
+    data_api::{InputSource, SimpleNoteRetention, SpendableNotes, TargetValue, WalletRead},
     fees::{sapling, ChangeError, ChangeStrategy},
     proposal::{Proposal, ProposalError, ShieldedInputs},
     wallet::WalletTransparentOutput,
 };
+
+use super::ConfirmationsPolicy;
 
 #[cfg(feature = "transparent-inputs")]
 use {
@@ -178,6 +180,7 @@ pub trait InputSelector {
         wallet_db: &Self::InputSource,
         target_height: BlockHeight,
         anchor_height: BlockHeight,
+        min_confirmations: ConfirmationsPolicy,
         account: <Self::InputSource as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
@@ -354,7 +357,7 @@ impl<DbT> Default for GreedyInputSelector<DbT> {
     }
 }
 
-impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
+impl<DbT: WalletRead + InputSource> InputSelector for GreedyInputSelector<DbT> {
     type Error = GreedyInputSelectorError;
     type InputSource = DbT;
 
@@ -364,7 +367,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         params: &ParamsT,
         wallet_db: &Self::InputSource,
         target_height: BlockHeight,
-        anchor_height: BlockHeight,
+        untrusted_anchor_height: BlockHeight,
+        min_confirmations: ConfirmationsPolicy,
         account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
@@ -374,7 +378,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
     >
     where
         ParamsT: consensus::Parameters,
-        Self::InputSource: InputSource,
+        Self::InputSource: WalletRead + InputSource,
         ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
         let mut transparent_outputs = vec![];
@@ -626,7 +630,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             #[cfg(feature = "orchard")]
                             orchard: use_orchard,
                         }))
-                        .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
+                        .map(|notes| ShieldedInputs::from_parts(untrusted_anchor_height, notes));
 
                     #[cfg(feature = "transparent-inputs")]
                     if let Some(tr1_balance) = tr1_balance_opt {
@@ -746,7 +750,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     account,
                     TargetValue::AtLeast(amount_required),
                     selectable_pools,
-                    anchor_height,
+                    target_height,
+                    min_confirmations,
                     &exclude,
                 )
                 .map_err(InputSelectorError::DataSource)?;

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -10,7 +10,7 @@ use zcash_primitives::transaction::fees::{
     FeeRule,
 };
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     memo::MemoBytes,
     value::Zatoshis,
     PoolType, ShieldedProtocol,
@@ -39,7 +39,7 @@ impl FeeRule for StandardFeeRule {
     fn fee_required<P: consensus::Parameters>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         transparent_input_sizes: impl IntoIterator<Item = InputSize>,
         transparent_output_sizes: impl IntoIterator<Item = usize>,
         sapling_input_count: usize,
@@ -542,7 +542,7 @@ pub trait ChangeStrategy {
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         transparent_inputs: &[impl transparent::InputView],
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling::BundleView<NoteRefT>,

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -5,7 +5,7 @@ use zcash_primitives::transaction::fees::{
     transparent, zip317::MINIMUM_FEE, zip317::P2PKH_STANDARD_OUTPUT_SIZE, FeeRule,
 };
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
     ShieldedProtocol,
@@ -204,7 +204,7 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
 pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clone, F: FeeRule, E>(
     cfg: SinglePoolBalanceConfig<P, F>,
     wallet_meta: Option<&AccountMeta>,
-    target_height: BlockHeight,
+    target_height: TargetHeight,
     transparent_inputs: &[impl transparent::InputView],
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 use zcash_primitives::transaction::fees::{fixed::FeeRule as FixedFeeRule, transparent};
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
     ShieldedProtocol,
@@ -77,7 +77,7 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         transparent_inputs: &[impl transparent::InputView],
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
@@ -151,7 +151,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(
@@ -191,7 +192,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 
 use zcash_primitives::transaction::fees::{transparent, zip317 as prim_zip317, FeeRule};
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus,
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
     ShieldedProtocol,
@@ -119,7 +119,7 @@ where
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: consensus::TargetHeight,
         transparent_inputs: &[impl transparent::InputView],
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
@@ -228,7 +228,7 @@ where
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: consensus::TargetHeight,
         transparent_inputs: &[impl transparent::InputView],
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
@@ -306,7 +306,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(
@@ -351,7 +352,8 @@ mod tests {
                     &Network::TestNetwork,
                     Network::TestNetwork
                         .activation_height(NetworkUpgrade::Nu5)
-                        .unwrap(),
+                        .unwrap()
+                        .into(),
                     &[] as &[TestTransparentInput],
                     &[] as &[TxOut],
                     &(
@@ -401,7 +403,8 @@ mod tests {
                 &Network::TestNetwork,
                 Network::TestNetwork
                     .activation_height(NetworkUpgrade::Nu5)
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                 &[] as &[TestTransparentInput],
                 &[] as &[TxOut],
                 &(
@@ -441,7 +444,8 @@ mod tests {
                 &Network::TestNetwork,
                 Network::TestNetwork
                     .activation_height(NetworkUpgrade::Nu5)
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                 &[] as &[TestTransparentInput],
                 &[] as &[TxOut],
                 &(
@@ -476,7 +480,8 @@ mod tests {
                 &Network::TestNetwork,
                 Network::TestNetwork
                     .activation_height(NetworkUpgrade::Nu5)
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                 &[] as &[TestTransparentInput],
                 &[] as &[TxOut],
                 &(
@@ -516,7 +521,8 @@ mod tests {
                 &Network::TestNetwork,
                 Network::TestNetwork
                     .activation_height(NetworkUpgrade::Nu5)
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                 &[] as &[TestTransparentInput],
                 &[] as &[TxOut],
                 &(
@@ -564,7 +570,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(
@@ -618,7 +625,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[TxOut {
                 value: Zatoshis::const_from_u64(40000),
@@ -664,7 +672,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[TestTransparentInput {
                 outpoint: OutPoint::fake(),
                 coin: TxOut {
@@ -709,7 +718,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[TestTransparentInput {
                 outpoint: OutPoint::fake(),
                 coin: TxOut {
@@ -760,7 +770,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[TestTransparentInput {
                 outpoint: OutPoint::fake(),
                 coin: TxOut {
@@ -816,7 +827,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(
@@ -862,7 +874,8 @@ mod tests {
             &Network::TestNetwork,
             Network::TestNetwork
                 .activation_height(NetworkUpgrade::Nu5)
-                .unwrap(),
+                .unwrap()
+                .into(),
             &[] as &[TestTransparentInput],
             &[] as &[TxOut],
             &(

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -7,7 +7,11 @@ use std::{
 
 use nonempty::NonEmpty;
 use zcash_primitives::transaction::TxId;
-use zcash_protocol::{consensus::BlockHeight, value::Zatoshis, PoolType, ShieldedProtocol};
+use zcash_protocol::{
+    consensus::{BlockHeight, TargetHeight},
+    value::Zatoshis,
+    PoolType, ShieldedProtocol,
+};
 use zip321::TransactionRequest;
 
 use crate::{
@@ -166,7 +170,7 @@ impl<NoteRef> ShieldedInputs<NoteRef> {
 #[derive(Clone, PartialEq, Eq)]
 pub struct Proposal<FeeRuleT, NoteRef> {
     fee_rule: FeeRuleT,
-    min_target_height: BlockHeight,
+    min_target_height: TargetHeight,
     steps: NonEmpty<Step<NoteRef>>,
 }
 
@@ -183,7 +187,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// * `steps`: A vector of steps that make up the proposal.
     pub fn multi_step(
         fee_rule: FeeRuleT,
-        min_target_height: BlockHeight,
+        min_target_height: TargetHeight,
         steps: NonEmpty<Step<NoteRef>>,
     ) -> Result<Self, ProposalError> {
         let mut consumed_chain_inputs: BTreeSet<(PoolType, TxId, u32)> = BTreeSet::new();
@@ -273,7 +277,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
         shielded_inputs: Option<ShieldedInputs<NoteRef>>,
         balance: TransactionBalance,
         fee_rule: FeeRuleT,
-        min_target_height: BlockHeight,
+        min_target_height: TargetHeight,
         is_shielding: bool,
     ) -> Result<Self, ProposalError> {
         Ok(Self {
@@ -301,7 +305,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     ///
     /// The chain must contain at least this many blocks in order for the proposal to
     /// be executed.
-    pub fn min_target_height(&self) -> BlockHeight {
+    pub fn min_target_height(&self) -> TargetHeight {
         self.min_target_height
     }
 

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -876,7 +876,7 @@ impl proposal::Proposal {
 
                 Proposal::multi_step(
                     fee_rule,
-                    self.min_target_height.into(),
+                    BlockHeight::from_u32(self.min_target_height).into(),
                     NonEmpty::from_vec(steps).ok_or(ProposalDecodingError::NoSteps)?,
                 )
                 .map_err(ProposalDecodingError::ProposalInvalid)

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -77,7 +77,7 @@ use zcash_primitives::{
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, TargetHeight},
     memo::Memo,
     ShieldedProtocol,
 };
@@ -575,7 +575,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         account: Self::AccountId,
         target_value: TargetValue,
         sources: &[ShieldedProtocol],
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         min_confirmations: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
@@ -622,7 +622,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
     fn get_spendable_transparent_outputs(
         &self,
         address: &TransparentAddress,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         min_confirmations: u32,
     ) -> Result<Vec<WalletTransparentOutput>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs(
@@ -847,7 +847,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
     fn get_target_and_anchor_heights(
         &self,
         min_confirmations: NonZeroU32,
-    ) -> Result<Option<(BlockHeight, BlockHeight)>, Self::Error> {
+    ) -> Result<Option<(TargetHeight, BlockHeight)>, Self::Error> {
         wallet::get_target_and_anchor_heights(self.conn.borrow(), min_confirmations)
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -576,7 +576,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_value: TargetValue,
         sources: &[ShieldedProtocol],
         target_height: TargetHeight,
-        min_confirmations: ConfirmationsPolicy,
+        confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
         Ok(SpendableNotes::new(
@@ -587,7 +587,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     account,
                     target_value,
                     target_height,
-                    min_confirmations,
+                    confirmations_policy,
                     exclude,
                 )?
             } else {
@@ -601,7 +601,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     account,
                     target_value,
                     target_height,
-                    min_confirmations,
+                    confirmations_policy,
                     exclude,
                 )?
             } else {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -57,6 +57,7 @@ use zcash_client_backend::{
         self,
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
+        wallet::ConfirmationsPolicy,
         Account, AccountBirthday, AccountMeta, AccountPurpose, AccountSource, AddressInfo,
         BlockMetadata, DecryptedTransaction, InputSource, NoteFilter, NullifierQuery, ScannedBlock,
         SeedRelevance, SentTransaction, SpendableNotes, TargetValue, TransactionDataRequest,
@@ -574,7 +575,8 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         account: Self::AccountId,
         target_value: TargetValue,
         sources: &[ShieldedProtocol],
-        anchor_height: BlockHeight,
+        target_height: BlockHeight,
+        min_confirmations: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
         Ok(SpendableNotes::new(
@@ -584,7 +586,8 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     &self.params,
                     account,
                     target_value,
-                    anchor_height,
+                    target_height,
+                    min_confirmations,
                     exclude,
                 )?
             } else {
@@ -597,7 +600,8 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     &self.params,
                     account,
                     target_value,
-                    anchor_height,
+                    target_height,
+                    min_confirmations,
                     exclude,
                 )?
             } else {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -290,3 +290,9 @@ pub(crate) fn wallet_recovery_computes_fees<T: ShieldedPoolTester>() {
         },
     )
 }
+
+pub(crate) fn can_spend_trusted_inputs_by_confirmations_policy<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::can_spend_trusted_inputs_by_confirmations_policy::<
+        T,
+    >(TestDbFactory::default(), BlockCache::new())
+}

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -291,8 +291,12 @@ pub(crate) fn wallet_recovery_computes_fees<T: ShieldedPoolTester>() {
     )
 }
 
-pub(crate) fn can_spend_trusted_inputs_by_confirmations_policy<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::can_spend_trusted_inputs_by_confirmations_policy::<
-        T,
-    >(TestDbFactory::default(), BlockCache::new())
+pub(crate) fn can_spend_inputs_by_confirmations_policy<T: ShieldedPoolTester>() {
+    for is_trusted in [false, true] {
+        zcash_client_backend::data_api::testing::pool::zip_315_confirmations_test_steps::<T>(
+            TestDbFactory::default(),
+            BlockCache::new(),
+            is_trusted,
+        );
+    }
 }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -12,7 +12,7 @@ use zcash_client_backend::{
 };
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, TargetHeight},
     value::{BalanceError, Zatoshis},
     PoolType, ShieldedProtocol,
 };
@@ -156,7 +156,7 @@ pub(crate) fn select_spendable_notes<P: consensus::Parameters, F, Note>(
     params: &P,
     account: AccountUuid,
     target_value: TargetValue,
-    anchor_height: BlockHeight,
+    target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
     protocol: ShieldedProtocol,
@@ -171,7 +171,7 @@ where
             params,
             account,
             zats,
-            anchor_height,
+            target_height,
             confirmations_policy,
             exclude,
             protocol,
@@ -186,7 +186,7 @@ fn select_minimum_spendable_notes<P: consensus::Parameters, F, Note>(
     params: &P,
     account: AccountUuid,
     target_value: Zatoshis,
-    anchor_height: BlockHeight,
+    target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
     protocol: ShieldedProtocol,
@@ -204,13 +204,15 @@ where
         }
     };
 
+    let trusted_anchor_height = target_height - u32::from(confirmations_policy.trusted);
+
     let TableConstants {
         table_prefix,
         output_index_col,
         note_reconstruction_cols,
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
-    if unscanned_tip_exists(conn, anchor_height, table_prefix)? {
+    if unscanned_tip_exists(conn, trusted_anchor_height, table_prefix)? {
         return Ok(vec![]);
     }
 
@@ -229,6 +231,7 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     let mut stmt_select_notes = conn.prepare_cached(
+        // TODO(schell): use received_notes instead of 
         &format!(
             "WITH eligible AS (
                  SELECT
@@ -237,12 +240,6 @@ where
                      diversifier,
                      {table_prefix}_received_notes.value, {note_reconstruction_cols}, commitment_tree_position, 
                      transactions.block AS mined_height, sent_notes.to_account_id AS sent_to_account_id,
-                     -- EXISTS (
-                     --     SELECT 1
-                     --     FROM sent_notes
-                     --     WHERE sent_notes.tx = transactions.id_tx
-                     --     AND to_account_id NOT NULL
-                     -- ) AS is_trusted,
                      SUM(
                          {table_prefix}_received_notes.value
                      ) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
@@ -270,7 +267,8 @@ where
                    JOIN transactions stx ON stx.id_tx = transaction_id
                    WHERE stx.block IS NOT NULL -- the spending tx is mined
                    OR stx.expiry_height IS NULL -- the spending tx will not expire
-                   OR stx.expiry_height > :anchor_height -- the spending tx is unexpired
+                   -- TODO(schell): this should be chain_tip height
+                   OR stx.expiry_height > :target_height -- the spending tx is unexpired
                  )
                  AND NOT EXISTS (
                     SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges unscanned
@@ -310,7 +308,8 @@ where
     let notes = stmt_select_notes.query_and_then(
         named_params![
             ":account_uuid": account.0,
-            ":anchor_height": &u32::from(anchor_height),
+            ":anchor_height": &u32::from(trusted_anchor_height),
+            ":target_height": &u32::from(target_height),
             ":target_value": &u64::from(target_value),
             ":exclude": &excluded_ptr,
             ":wallet_birthday": u32::from(birthday_height)
@@ -330,19 +329,19 @@ where
         .filter_map(|result_maybe_note| {
             let result_note = result_maybe_note.transpose()?;
             result_note.map(|(note, is_trusted, mined_height)| {
-                let number_of_confirmations = u32::from(anchor_height).saturating_sub(mined_height);
+                let number_of_confirmations = target_height - mined_height;
                 let required_confirmations = u32::from(confirmations_policy.untrusted);
                 // If the note is from a trusted source (this wallet), then we don't have to determine the
                 // number of confirmations, as we've already queried above based on the trusted anchor height.
                 // So we only check if it's trusted, or if it meets the untrusted number of confirmations.
                 let is_spendable =
-                    is_trusted || number_of_confirmations >= confirmations_policy.untrusted.into();
+                    is_trusted || u32::from(number_of_confirmations) >= confirmations_policy.untrusted.into();
                 println!(
                     "note: {} is {}\n  \
                     is_trusted: {is_trusted},\n  \
                     confirmations: {number_of_confirmations} >= {required_confirmations} = {is_spendable},\n  \
                     mined_height: {mined_height},\n  \
-                    anchor_height: {anchor_height}",
+                    target_height: {target_height:?}",
                     note.internal_note_id(),
                     if is_spendable {
                         "spendable"

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -231,7 +231,10 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     let mut stmt_select_notes = conn.prepare_cached(
-        // TODO(schell): use received_notes instead of 
+        // TODO(schell): use received_notes instead of sent_notes.
+        // but maybe sent_notes is fine, because sent_notes has the `to_account_id` field
+        // which specifies internal recipients?
+        // @see the db.rs docs
         &format!(
             "WITH eligible AS (
                  SELECT
@@ -267,8 +270,7 @@ where
                    JOIN transactions stx ON stx.id_tx = transaction_id
                    WHERE stx.block IS NOT NULL -- the spending tx is mined
                    OR stx.expiry_height IS NULL -- the spending tx will not expire
-                   -- TODO(schell): this should be chain_tip height
-                   OR stx.expiry_height > :target_height -- the spending tx is unexpired
+                   OR stx.expiry_height >= :target_height -- the spending tx is unexpired
                  )
                  AND NOT EXISTS (
                     SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges unscanned

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -231,29 +231,19 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     let mut stmt_select_notes = conn.prepare_cached(
-        // TODO(schell): use received_notes instead of sent_notes.
-        // but maybe sent_notes is fine, because sent_notes has the `to_account_id` field
-        // which specifies internal recipients?
-        // @see the db.rs docs
         &format!(
             "WITH eligible AS (
                  SELECT
-                     {table_prefix}_received_notes.id AS id, txid,
-                     {table_prefix}_received_notes.{output_index_col},
-                     diversifier,
-                     {table_prefix}_received_notes.value, {note_reconstruction_cols}, commitment_tree_position, 
-                     transactions.block AS mined_height, sent_notes.to_account_id AS sent_to_account_id,
-                     SUM(
-                         {table_prefix}_received_notes.value
-                     ) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
-                     accounts.ufvk as ufvk, recipient_key_scope
+                     {table_prefix}_received_notes.id AS id, txid, {output_index_col},
+                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position, 
+                     SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
+                     accounts.ufvk as ufvk, recipient_key_scope,
+                     transactions.block AS mined_height
                  FROM {table_prefix}_received_notes
                  INNER JOIN accounts
                     ON accounts.id = {table_prefix}_received_notes.account_id
                  INNER JOIN transactions
                     ON transactions.id_tx = {table_prefix}_received_notes.tx
-                 LEFT JOIN sent_notes
-                    ON transactions.id_tx = sent_notes.tx
                  WHERE accounts.uuid = :account_uuid
                  AND {table_prefix}_received_notes.account_id = accounts.id
                  -- FIXME #1316, allow selection of dust inputs
@@ -285,12 +275,12 @@ where
              )
              SELECT id, txid, {output_index_col},
                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                    ufvk, recipient_key_scope, mined_height, sent_to_account_id
+                    ufvk, recipient_key_scope, mined_height 
              FROM eligible WHERE so_far < :target_value
              UNION
              SELECT id, txid, {output_index_col},
                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                    ufvk, recipient_key_scope, mined_height, sent_to_account_id
+                    ufvk, recipient_key_scope, mined_height
              FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         )
     )?;
@@ -318,10 +308,8 @@ where
         ],
         |r| -> Result<_, SqliteClientError> {
             let maybe_note = to_spendable_note(params, r)?;
-            let sent_to_account_id: Option<i64> = r.get("sent_to_account_id")?;
-            // It's enough to know this account id _exists_ as external recipients are null in
-            // the `sent_notes` table
-            let note_is_trusted = sent_to_account_id.is_some();
+            let recipient_key_scope: i64 = r.get("recipient_key_scope")?;
+            let note_is_trusted = recipient_key_scope == 1;
             let mined_height: u32 = r.get("mined_height")?;
             Ok(maybe_note.map(|note| (note, note_is_trusted, mined_height)))
         },
@@ -330,29 +318,18 @@ where
     notes
         .filter_map(|result_maybe_note| {
             let result_note = result_maybe_note.transpose()?;
-            result_note.map(|(note, is_trusted, mined_height)| {
-                let number_of_confirmations = target_height - mined_height;
-                let required_confirmations = u32::from(confirmations_policy.untrusted);
-                // If the note is from a trusted source (this wallet), then we don't have to determine the
-                // number of confirmations, as we've already queried above based on the trusted anchor height.
-                // So we only check if it's trusted, or if it meets the untrusted number of confirmations.
-                let is_spendable =
-                    is_trusted || u32::from(number_of_confirmations) >= confirmations_policy.untrusted.into();
-                println!(
-                    "note: {} is {}\n  \
-                    is_trusted: {is_trusted},\n  \
-                    confirmations: {number_of_confirmations} >= {required_confirmations} = {is_spendable},\n  \
-                    mined_height: {mined_height},\n  \
-                    target_height: {target_height:?}",
-                    note.internal_note_id(),
-                    if is_spendable {
-                        "spendable"
-                    } else {
-                        "not spendable"
-                    }
-                );
-                is_spendable.then_some(note)
-            }).transpose()
+            result_note
+                .map(|(note, is_trusted, mined_height)| {
+                    let number_of_confirmations = target_height - mined_height;
+                    let required_confirmations = u32::from(confirmations_policy.untrusted);
+                    // If the note is from a trusted source (this wallet), then we don't have to determine the
+                    // number of confirmations, as we've already queried above based on the trusted anchor height.
+                    // So we only check if it's trusted, or if it meets the untrusted number of confirmations.
+                    let is_spendable =
+                        is_trusted || u32::from(number_of_confirmations) >= required_confirmations;
+                    is_spendable.then_some(note)
+                })
+                .transpose()
         })
         .collect::<Result<Vec<_>, _>>()
 }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -5,7 +5,9 @@ use rusqlite::{named_params, types::Value, Connection, Row};
 use std::{num::NonZeroU64, rc::Rc};
 
 use zcash_client_backend::{
-    data_api::{NoteFilter, PoolMeta, TargetValue, SAPLING_SHARD_HEIGHT},
+    data_api::{
+        wallet::ConfirmationsPolicy, NoteFilter, PoolMeta, TargetValue, SAPLING_SHARD_HEIGHT,
+    },
     wallet::ReceivedNote,
 };
 use zcash_primitives::transaction::TxId;
@@ -155,6 +157,7 @@ pub(crate) fn select_spendable_notes<P: consensus::Parameters, F, Note>(
     account: AccountUuid,
     target_value: TargetValue,
     anchor_height: BlockHeight,
+    confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
     protocol: ShieldedProtocol,
     to_spendable_note: F,
@@ -169,6 +172,7 @@ where
             account,
             zats,
             anchor_height,
+            confirmations_policy,
             exclude,
             protocol,
             to_spendable_note,
@@ -183,6 +187,7 @@ fn select_minimum_spendable_notes<P: consensus::Parameters, F, Note>(
     account: AccountUuid,
     target_value: Zatoshis,
     anchor_height: BlockHeight,
+    confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
     protocol: ShieldedProtocol,
     to_spendable_note: F,
@@ -224,6 +229,7 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     let mut stmt_select_notes = conn.prepare_cached(
+        // TODO(schell): query should take anchor height of untrusted as well
         &format!(
             "WITH eligible AS (
                  SELECT

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -229,22 +229,35 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     let mut stmt_select_notes = conn.prepare_cached(
-        // TODO(schell): query should take anchor height of untrusted as well
         &format!(
             "WITH eligible AS (
                  SELECT
-                     {table_prefix}_received_notes.id AS id, txid, {output_index_col},
-                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                     SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
+                     {table_prefix}_received_notes.id AS id, txid,
+                     {table_prefix}_received_notes.{output_index_col},
+                     diversifier,
+                     {table_prefix}_received_notes.value, {note_reconstruction_cols}, commitment_tree_position, 
+                     transactions.block AS mined_height, sent_notes.to_account_id AS sent_to_account_id,
+                     -- EXISTS (
+                     --     SELECT 1
+                     --     FROM sent_notes
+                     --     WHERE sent_notes.tx = transactions.id_tx
+                     --     AND to_account_id NOT NULL
+                     -- ) AS is_trusted,
+                     SUM(
+                         {table_prefix}_received_notes.value
+                     ) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                      accounts.ufvk as ufvk, recipient_key_scope
                  FROM {table_prefix}_received_notes
                  INNER JOIN accounts
                     ON accounts.id = {table_prefix}_received_notes.account_id
                  INNER JOIN transactions
                     ON transactions.id_tx = {table_prefix}_received_notes.tx
+                 LEFT JOIN sent_notes
+                    ON transactions.id_tx = sent_notes.tx
                  WHERE accounts.uuid = :account_uuid
                  AND {table_prefix}_received_notes.account_id = accounts.id
-                 AND value > 5000 -- FIXME #1316, allow selection of dust inputs
+                 -- FIXME #1316, allow selection of dust inputs
+                 AND {table_prefix}_received_notes.value > 5000 
                  AND accounts.ufvk IS NOT NULL
                  AND recipient_key_scope IS NOT NULL
                  AND nf IS NOT NULL
@@ -272,12 +285,12 @@ where
              )
              SELECT id, txid, {output_index_col},
                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                    ufvk, recipient_key_scope
+                    ufvk, recipient_key_scope, mined_height, sent_to_account_id
              FROM eligible WHERE so_far < :target_value
              UNION
              SELECT id, txid, {output_index_col},
                     diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                    ufvk, recipient_key_scope
+                    ufvk, recipient_key_scope, mined_height, sent_to_account_id
              FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         )
     )?;
@@ -302,12 +315,45 @@ where
             ":exclude": &excluded_ptr,
             ":wallet_birthday": u32::from(birthday_height)
         ],
-        |r| to_spendable_note(params, r),
+        |r| -> Result<_, SqliteClientError> {
+            let maybe_note = to_spendable_note(params, r)?;
+            let sent_to_account_id: Option<i64> = r.get("sent_to_account_id")?;
+            // It's enough to know this account id _exists_ as external recipients are null in
+            // the `sent_notes` table
+            let note_is_trusted = sent_to_account_id.is_some();
+            let mined_height: u32 = r.get("mined_height")?;
+            Ok(maybe_note.map(|note| (note, note_is_trusted, mined_height)))
+        },
     )?;
 
     notes
-        .filter_map(|r| r.transpose())
-        .collect::<Result<_, _>>()
+        .filter_map(|result_maybe_note| {
+            let result_note = result_maybe_note.transpose()?;
+            result_note.map(|(note, is_trusted, mined_height)| {
+                let number_of_confirmations = u32::from(anchor_height).saturating_sub(mined_height);
+                let required_confirmations = u32::from(confirmations_policy.untrusted);
+                // If the note is from a trusted source (this wallet), then we don't have to determine the
+                // number of confirmations, as we've already queried above based on the trusted anchor height.
+                // So we only check if it's trusted, or if it meets the untrusted number of confirmations.
+                let is_spendable =
+                    is_trusted || number_of_confirmations >= confirmations_policy.untrusted.into();
+                println!(
+                    "note: {} is {}\n  \
+                    is_trusted: {is_trusted},\n  \
+                    confirmations: {number_of_confirmations} >= {required_confirmations} = {is_spendable},\n  \
+                    mined_height: {mined_height},\n  \
+                    anchor_height: {anchor_height}",
+                    note.internal_note_id(),
+                    if is_spendable {
+                        "spendable"
+                    } else {
+                        "not spendable"
+                    }
+                );
+                is_spendable.then_some(note)
+            }).transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()
 }
 
 #[allow(dead_code)]

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -362,7 +362,7 @@ mod tests {
         // Create a shielding transaction that has an external note and an internal note.
         let mut builder = Builder::new(
             db_data.params.clone(),
-            height,
+            height.into(),
             BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: None,

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -214,7 +214,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     params: &P,
     account: AccountUuid,
     target_value: TargetValue,
-    target_height: BlockHeight,
+    target_height: consensus::TargetHeight,
     min_confirmations: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -215,7 +215,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     account: AccountUuid,
     target_value: TargetValue,
     target_height: consensus::TargetHeight,
-    min_confirmations: ConfirmationsPolicy,
+    confirmation_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
@@ -224,7 +224,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         account,
         target_value,
         target_height,
-        min_confirmations,
+        confirmation_policy,
         exclude,
         ShieldedProtocol::Orchard,
         to_spendable_note,

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -8,7 +8,7 @@ use orchard::{
 use rusqlite::{named_params, types::Value, Connection, Row};
 
 use zcash_client_backend::{
-    data_api::{Account as _, NullifierQuery, TargetValue},
+    data_api::{wallet::ConfirmationsPolicy, Account as _, NullifierQuery, TargetValue},
     wallet::{ReceivedNote, WalletOrchardOutput},
     DecryptedOutput, TransferType,
 };
@@ -214,7 +214,8 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     params: &P,
     account: AccountUuid,
     target_value: TargetValue,
-    anchor_height: BlockHeight,
+    target_height: BlockHeight,
+    min_confirmations: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
@@ -222,7 +223,8 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         params,
         account,
         target_value,
-        anchor_height,
+        target_height,
+        min_confirmations,
         exclude,
         ShieldedProtocol::Orchard,
         to_spendable_note,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -8,7 +8,7 @@ use rusqlite::{named_params, types::Value, Connection, Row};
 
 use sapling::{self, Diversifier, Nullifier, Rseed};
 use zcash_client_backend::{
-    data_api::{Account, NullifierQuery, TargetValue},
+    data_api::{wallet::ConfirmationsPolicy, Account, NullifierQuery, TargetValue},
     wallet::{ReceivedNote, WalletSaplingOutput},
     DecryptedOutput, TransferType,
 };
@@ -223,7 +223,8 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     params: &P,
     account: AccountUuid,
     target_value: TargetValue,
-    anchor_height: BlockHeight,
+    target_height: BlockHeight,
+    min_confirmations: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
@@ -231,7 +232,8 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         params,
         account,
         target_value,
-        anchor_height,
+        target_height,
+        min_confirmations,
         exclude,
         ShieldedProtocol::Sapling,
         to_spendable_note,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -636,7 +636,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn zip315_can_spend_trusted_inputs_by_confirmations_policy() {
-        testing::pool::can_spend_trusted_inputs_by_confirmations_policy::<SaplingPoolTester>();
+    fn zip315_can_spend_inputs_by_confirmations_policy() {
+        testing::pool::can_spend_inputs_by_confirmations_policy::<SaplingPoolTester>();
     }
 }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -14,7 +14,7 @@ use zcash_client_backend::{
 };
 use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, TargetHeight},
     memo::MemoBytes,
     ShieldedProtocol, TxId,
 };
@@ -223,7 +223,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     params: &P,
     account: AccountUuid,
     target_value: TargetValue,
-    target_height: BlockHeight,
+    target_height: TargetHeight,
     min_confirmations: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -224,7 +224,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     account: AccountUuid,
     target_value: TargetValue,
     target_height: TargetHeight,
-    min_confirmations: ConfirmationsPolicy,
+    confirmation_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
@@ -233,7 +233,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         account,
         target_value,
         target_height,
-        min_confirmations,
+        confirmation_policy,
         exclude,
         ShieldedProtocol::Sapling,
         to_spendable_note,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -634,4 +634,9 @@ pub(crate) mod tests {
     fn wallet_recovery_compute_fees() {
         testing::pool::wallet_recovery_computes_fees::<SaplingPoolTester>();
     }
+
+    #[test]
+    fn zip315_can_spend_trusted_inputs_by_confirmations_policy() {
+        testing::pool::can_spend_trusted_inputs_by_confirmations_policy::<SaplingPoolTester>();
+    }
 }

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -595,7 +595,7 @@ pub(crate) mod tests {
     use {
         incrementalmerkletree::Level,
         orchard::tree::MerkleHashOrchard,
-        std::{convert::Infallible, num::NonZeroU32},
+        std::convert::Infallible,
         zcash_client_backend::{
             data_api::{
                 testing::orchard::OrchardPoolTester, wallet::input_selection::GreedyInputSelector,

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1717,7 +1717,7 @@ pub(crate) mod tests {
     #[test]
     #[cfg(feature = "orchard")]
     fn orchard_block_spanning_tip_boundary_complete() {
-        use zcash_client_backend::data_api::Account as _;
+        use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, Account as _};
 
         let mut st = prepare_orchard_block_spanning_test(true);
         let account = st.test_account().cloned().unwrap();
@@ -1793,7 +1793,7 @@ pub(crate) mod tests {
                 &input_selector,
                 &change_strategy,
                 request,
-                NonZeroU32::new(10).unwrap(),
+                ConfirmationsPolicy::new_symmetrical(10).unwrap(),
             )
             .unwrap();
 
@@ -1811,7 +1811,7 @@ pub(crate) mod tests {
     #[test]
     #[cfg(feature = "orchard")]
     fn orchard_block_spanning_tip_boundary_incomplete() {
-        use zcash_client_backend::data_api::Account as _;
+        use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, Account as _};
 
         let mut st = prepare_orchard_block_spanning_test(false);
         let account = st.test_account().cloned().unwrap();
@@ -1879,7 +1879,7 @@ pub(crate) mod tests {
             &input_selector,
             &change_strategy,
             request.clone(),
-            NonZeroU32::new(10).unwrap(),
+            ConfirmationsPolicy::new_symmetrical(10).unwrap(),
         );
 
         assert_matches!(proposal, Err(_));
@@ -1893,7 +1893,7 @@ pub(crate) mod tests {
             &input_selector,
             &change_strategy,
             request,
-            NonZeroU32::new(10).unwrap(),
+            ConfirmationsPolicy::new_symmetrical(10).unwrap(),
         );
 
         assert_matches!(proposal, Ok(_));

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -35,7 +35,6 @@ use zcash_keys::{
     keys::{AddressGenerationError, UnifiedAddressRequest},
 };
 use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
-use zcash_protocol::consensus::TargetHeight;
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     value::{ZatBalance, Zatoshis},
@@ -793,7 +792,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
     address: &TransparentAddress,
-    target_height: TargetHeight,
+    target_height: consensus::TargetHeight,
     min_confirmations: u32,
 ) -> Result<Vec<WalletTransparentOutput>, SqliteClientError> {
     let confirmed_height = target_height - min_confirmations;

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -35,6 +35,7 @@ use zcash_keys::{
     keys::{AddressGenerationError, UnifiedAddressRequest},
 };
 use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+use zcash_protocol::consensus::TargetHeight;
 use zcash_protocol::{
     consensus::{self, BlockHeight},
     value::{ZatBalance, Zatoshis},
@@ -792,7 +793,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
     address: &TransparentAddress,
-    target_height: BlockHeight,
+    target_height: TargetHeight,
     min_confirmations: u32,
 ) -> Result<Vec<WalletTransparentOutput>, SqliteClientError> {
     let confirmed_height = target_height - min_confirmations;

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -2,7 +2,7 @@
 
 use crate::transaction::fees::transparent::InputSize;
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     value::Zatoshis,
 };
 
@@ -28,7 +28,7 @@ pub trait FeeRule {
     fn fee_required<P: consensus::Parameters>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         transparent_input_sizes: impl IntoIterator<Item = InputSize>,
         transparent_output_sizes: impl IntoIterator<Item = usize>,
         sapling_input_count: usize,
@@ -50,7 +50,7 @@ pub trait FutureFeeRule: FeeRule {
     fn fee_required_zfuture<P: consensus::Parameters>(
         &self,
         params: &P,
-        target_height: BlockHeight,
+        target_height: TargetHeight,
         transparent_input_sizes: impl IntoIterator<Item = InputSize>,
         transparent_output_sizes: impl IntoIterator<Item = usize>,
         sapling_input_count: usize,

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,7 @@
 use crate::transaction::fees::transparent;
 
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     value::Zatoshis,
 };
 
@@ -33,7 +33,7 @@ impl super::FeeRule for FeeRule {
     fn fee_required<P: consensus::Parameters>(
         &self,
         _params: &P,
-        _target_height: BlockHeight,
+        _target_height: TargetHeight,
         _transparent_input_sizes: impl IntoIterator<Item = transparent::InputSize>,
         _transparent_output_sizes: impl IntoIterator<Item = usize>,
         _sapling_input_count: usize,
@@ -49,7 +49,7 @@ impl super::FutureFeeRule for FeeRule {
     fn fee_required_zfuture<P: consensus::Parameters>(
         &self,
         _params: &P,
-        _target_height: BlockHeight,
+        _target_height: TargetHeight,
         _transparent_input_sizes: impl IntoIterator<Item = transparent::InputSize>,
         _transparent_output_sizes: impl IntoIterator<Item = usize>,
         _sapling_input_count: usize,

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -7,7 +7,7 @@ use core::cmp::max;
 
 use ::transparent::bundle::OutPoint;
 use zcash_protocol::{
-    consensus::{self, BlockHeight},
+    consensus::{self, TargetHeight},
     value::{BalanceError, Zatoshis},
 };
 
@@ -155,7 +155,7 @@ impl super::FeeRule for FeeRule {
     fn fee_required<P: consensus::Parameters>(
         &self,
         _params: &P,
-        _target_height: BlockHeight,
+        _target_height: TargetHeight,
         transparent_input_sizes: impl IntoIterator<Item = transparent::InputSize>,
         transparent_output_sizes: impl IntoIterator<Item = usize>,
         sapling_input_count: usize,


### PR DESCRIPTION
These changes add `ConfirmationsPolicy` which specify a customizable number of confirmations for selecting spendable notes.

[ZIP 315](https://zips.z.cash/zip-0315)

* adds `ConfirmationsPolicy` for selecting spendable notes 
* adds `TargetHeight` as a wrapper for `BlockHeight` 
* fixes an expiry bug in note selection 
 
Related:
* https://github.com/zcash/librustzcash/pull/1864 (closed in favor of this PR)