### PR TITLE
zcash_keys: Minor API tweaks.

### DIFF
--- a/zcash_keys/src/keys/transparent.rs
+++ b/zcash_keys/src/keys/transparent.rs
@@ -48,6 +48,12 @@ pub struct Key {
 }
 
 impl Key {
+    /// Constructs a new key value from a secret key and a flag indicating whether
+    /// the compressed encoding should be used when performing DER serialization.
+    pub fn new(secret: SecretKey, compressed: bool) -> Self {
+        Self { secret, compressed }
+    }
+
     /// Decodes a base58-encoded secret key.
     ///
     /// This corresponds to <https://github.com/zcash/zcash/blob/1f1f7a385adc048154e7f25a3a0de76f3658ca09/src/key_io.cpp#L282>

--- a/zcash_keys/src/keys/zcashd.rs
+++ b/zcash_keys/src/keys/zcashd.rs
@@ -12,7 +12,7 @@ use zip32::{AccountId, ChildIndex};
 // zcashd produced a mnemonic from the pre-BIP-39 seed by incrementing the first byte of the
 // pre-BIP-39 seed until we found a value that was usable as valid entropy for seed phrase
 // generation.
-pub fn derive_mnemonic(legacy_seed: SecretVec<u8>) -> Option<Mnemonic> {
+pub fn derive_mnemonic(legacy_seed: &SecretVec<u8>) -> Option<Mnemonic> {
     if legacy_seed.expose_secret().len() != 32 {
         return None;
     }


### PR DESCRIPTION
The surface area affected by these tweaks is all in currently-unreleased APIs, so no CHANGELOG entries are necessary.