### PR TITLE
fix: add --all-features test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,28 @@ jobs:
       - name: Verify working directory is clean
         run: git diff --exit-code
 
+  test-all-features:
+    name: Test with --all-features
+    runs-on: ubuntu-latest-8cores
+    continue-on-error: true
+    steps: 
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run slow tests
+        run: cargo test --workspace --all-features 
+      - name: Verify working directory is clean
+        run: git diff --exit-code
+
   test-slow:
     name: Slow Test ${{ matrix.state }} on ${{ matrix.target }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We recently found that a test failure was sneaking past CI because cargo features configured it out. This adds a workflow job to test with `--all-features`, which should catch this case in the future.