### PR TITLE
Narrow the permissions granted to CI steps and other CI refactoring

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Enable all pool-specific feature flags'
     required: false
     default: true
+  all-features:
+    description: 'Enable all feature flags'
+    required: false
+    default: false
   test-dependencies:
     description: 'Include test dependencies'
     required: false
@@ -22,7 +26,7 @@ runs:
   steps:
     - id: pools
       shell: bash
-      run: echo "features=orchard transparent-inputs" >> $GITHUB_OUTPUT
+      run: echo "features=orchard transparent-inputs transparent-key-encoding" >> $GITHUB_OUTPUT
       if: inputs.all-pools == 'true'
 
     - id: test
@@ -52,3 +56,9 @@ runs:
         '" >> $GITHUB_OUTPUT
       env:
         EXTRA_FEATURES: ${{ inputs.extra-features }}
+      if: inputs.all-features == 'false'
+
+    - id: prepare-all
+      shell: bash
+      run: echo "flags=--all-features" >> $GITHUB_OUTPUT
+      if: inputs.all-features == 'true'

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
         with:
           command: check licenses
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -35,7 +35,7 @@ jobs:
           mv ./target/doc ./book/book/rustdoc/latest
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
           --timeout 600
           --out xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.3.1
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -525,7 +525,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
       - name: Install protoc
-        uses: supplypike/setup-bin@v4
+        uses: supplypike/setup-bin@1fafb085795af4a3f183502f3a9dffa8f7b83217 # v5.0.0
         with:
           uri: 'https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip'
           name: 'protoc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - Sapling-only
           - Orchard
           - all-pools
+          - all-features
           - NU7
 
         include:
@@ -31,13 +32,15 @@ jobs:
             os: ubuntu-latest-8cores
 
           - state: transparent
-            extra_flags: transparent-inputs
+            extra_flags: transparent-inputs transparent-key-encoding
           - state: Orchard
             extra_flags: orchard
           - state: all-pools
-            extra_flags: orchard transparent-inputs
+            extra_flags: orchard transparent-inputs transparent-key-encoding
+          - state: all-features
+            all-features: true
           - state: NU7
-            extra_flags: orchard transparent-inputs
+            all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
 
     env:
@@ -52,6 +55,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           all-pools: false
+          all-features: ${{ matrix.all-features }}
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -70,27 +74,6 @@ jobs:
       - name: Verify working directory is clean
         run: git diff --exit-code
 
-  test-all-features:
-    name: Test with --all-features
-    runs-on: ubuntu-latest-8cores
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run tests with --all-features enabled
-        run: cargo test --workspace --all-features
-      - name: Verify working directory is clean
-        run: git diff --exit-code
-
   test:
     name: Test ${{ matrix.state }} on ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -105,6 +88,7 @@ jobs:
           - Sapling-only
           - Orchard
           - all-pools
+          - all-features
           - NU7
 
         include:
@@ -114,16 +98,20 @@ jobs:
             os: windows-latest-8cores
 
           - state: transparent
-            extra_flags: transparent-inputs
+            extra_flags: transparent-inputs transparent-key-encoding
           - state: Orchard
             extra_flags: orchard
           - state: all-pools
-            extra_flags: orchard transparent-inputs
+            extra_flags: orchard transparent-inputs transparent-key-encoding
+          - state: all-features
+            all-features: true
           - state: NU7
-            extra_flags: orchard transparent-inputs
+            all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
 
         exclude:
+          - target: macOS
+            state: all-features
           - target: macOS
             state: NU7
 
@@ -139,6 +127,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           all-pools: false
+          all-features: ${{ matrix.all-features }}
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -165,11 +154,11 @@ jobs:
       matrix:
         target:
           - Linux
-        state:
+        state: # all-pools intentionally omitted
           - transparent
           - Sapling-only
           - Orchard
-          - all-pools
+          - all-features
           - NU7
 
         include:
@@ -180,10 +169,10 @@ jobs:
             extra_flags: transparent-inputs
           - state: Orchard
             extra_flags: orchard
-          - state: all-pools
-            extra_flags: orchard transparent-inputs
+          - state: all-features
+            all-features: true
           - state: NU7
-            extra_flags: orchard transparent-inputs
+            all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
 
     env:
@@ -198,6 +187,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           all-pools: false
+          all-features: ${{ matrix.all-features }}
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:
@@ -230,6 +220,7 @@ jobs:
           - Windows
         state:
           - ZFuture
+          - ZFuture-allfeatures
 
         include:
           - target: Linux
@@ -240,6 +231,9 @@ jobs:
             os: windows-latest
 
           - state: ZFuture
+            rustflags: '--cfg zcash_unstable="zfuture"'
+          - state: ZFuture-allfeatures
+            all-features: true
             rustflags: '--cfg zcash_unstable="zfuture"'
 
     env:
@@ -253,6 +247,7 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
+          all-features: ${{ matrix.all-features }}
           extra-features: ${{ matrix.extra_flags || '' }}
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -10,6 +12,9 @@ jobs:
   required-test:
     name: Test ${{ matrix.state }} on ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      statuses: write
     strategy:
       matrix:
         target:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0 + a doc-only README update
         with:
           persist-credentials: false
       - name: Install the latest version of uv


### PR DESCRIPTION
* Narrow the permissions granted to CI steps (fixing a zizmor warning).
* CI refactoring:
  * Make 'all-features' a variable allowing it to be enabled for any job.
  * Make the 'all-features' tests required-to-pass on Linux.
  * Also test with 'all-features' on Windows.
  * Enable the "transparent-key-encoding" feature whenever "transparent-inputs" is enabled.
* Fix documentation links.
* Correctly document the version of `actions/checkout` used by `zizmor.yml`.
* Use SHA references for GitHub actions from sources other than official GitHub namespaces and the Rust toolchains (`todtolnay/rust-toolchain@*`).