### PR TITLE
zcash_client_backend: Add `WalletWrite::mark_tx_trusted`

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -2840,6 +2840,11 @@ pub trait WalletWrite: WalletRead {
         received_tx: DecryptedTransaction<Self::AccountId>,
     ) -> Result<(), Self::Error>;
 
+    /// Marks the given transaction as being trusted, such that its outputs will be available for
+    /// spending with [`ConfirmationsPolicy::trusted`] confirmations even if the output is not
+    /// wallet-internal.
+    fn mark_tx_trusted(&mut self, txid: TxId) -> Result<(), Self::Error>;
+
     /// Saves information about transactions constructed by the wallet to the persistent
     /// wallet store.
     ///

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2859,6 +2859,10 @@ impl WalletWrite for MockWalletDb {
         Ok(())
     }
 
+    fn mark_tx_trusted(&mut self, _txid: TxId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn store_transactions_to_be_sent(
         &mut self,
         _transactions: &[SentTransaction<Self::AccountId>],

--- a/zcash_client_memory/src/wallet_write.rs
+++ b/zcash_client_memory/src/wallet_write.rs
@@ -935,6 +935,10 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
         Ok(())
     }
 
+    fn mark_tx_trusted(&mut self, _txid: TxId) -> Result<(), Self::Error> {
+        todo!()
+    }
+
     /// Truncates the database to the given height.
     ///
     /// If the requested height is greater than or equal to the height of the last scanned

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -896,7 +896,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
     }
 
     fn get_tx_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
-        wallet::get_tx_height(self.conn.borrow(), txid).map_err(SqliteClientError::from)
+        wallet::get_tx_height(self.conn.borrow(), txid)
     }
 
     fn get_unified_full_viewing_keys(
@@ -1911,6 +1911,10 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R>
                 &wdb.gap_limits,
             )
         })
+    }
+
+    fn mark_tx_trusted(&mut self, txid: TxId) -> Result<(), Self::Error> {
+        self.transactionally(|wdb| wallet::mark_tx_trusted(wdb.conn.0, txid))
     }
 
     fn store_transactions_to_be_sent(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3939,6 +3939,23 @@ pub(crate) fn store_decrypted_tx<P: consensus::Parameters>(
     Ok(())
 }
 
+pub(crate) fn mark_tx_trusted(
+    conn: &rusqlite::Transaction,
+    txid: TxId,
+) -> Result<(), SqliteClientError> {
+    conn.execute(
+        "UPDATE transactions
+         SET trust_status = :trust_status
+         WHERE txid = :txid",
+        named_params! {
+           ":txid": &txid.as_ref()[..],
+           ":trust_status": true
+        },
+    )?;
+
+    Ok(())
+}
+
 /// Inserts information about a mined transaction that was observed to
 /// contain a note related to this wallet into the database.
 pub(crate) fn put_tx_meta(

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -288,7 +288,9 @@ where
              accounts.ufvk as ufvk, rn.recipient_key_scope,
              t.block AS mined_height,
              scan_state.max_priority,
-             MAX(tt.mined_height) AS max_shielding_input_height
+             IFNULL(t.trust_status, 0) AS trust_status,
+             MAX(tt.mined_height) AS max_shielding_input_height,
+             MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
          FROM {table_prefix}_received_notes rn
          INNER JOIN accounts ON accounts.id = rn.account_id
          INNER JOIN transactions t ON t.id_tx = rn.tx
@@ -350,6 +352,8 @@ where
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
+            let tx_trust_status = row.get::<_, bool>("trust_status")?;
+            let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
             let shard_scan_priority = max_priority_raw
                 .map(|code| {
                     parse_priority_code(code).ok_or_else(|| {
@@ -360,7 +364,12 @@ where
                 })
                 .transpose()?;
 
-            Ok((result_note, shard_scan_priority))
+            Ok((
+                result_note,
+                shard_scan_priority,
+                tx_trust_status,
+                tx_shielding_inputs_trusted,
+            ))
         },
     )?;
 
@@ -370,7 +379,7 @@ where
 
     row_results
         .map(|t| match t? {
-            (Some(note), max_shard_priority) => {
+            (Some(note), max_shard_priority, trusted, tx_shielding_inputs_trusted) => {
                 let shard_scanned = max_shard_priority
                     .iter()
                     .any(|p| *p <= ScanPriority::Scanned);
@@ -385,13 +394,20 @@ where
                     (Some(received_height), Scope::Internal) => {
                         // The note has the required number of confirmations for a trusted note.
                         received_height <= trusted_height &&
-                        // And, if the note was the output of a shielding transaction, its inputs
-                        // have at least `untrusted` confirmations
-                        note.max_shielding_input_height().iter().all(|h| h <= &untrusted_height)
+                        // if the note was the output of a shielding transaction
+                        note.max_shielding_input_height().iter().all(|h| {
+                            // its inputs have at least `untrusted` confirmations
+                            h <= &untrusted_height ||
+                            // or its inputs are trusted and have at least `trusted` confirmations
+                            (h <= &trusted_height && tx_shielding_inputs_trusted)
+                        })
                     }
                     (Some(received_height), Scope::External) => {
                         // The note has the required number of confirmations for an untrusted note.
-                        received_height <= untrusted_height
+                        received_height <= untrusted_height ||
+                        // or it is the output of an explicitly trusted tx and has at least
+                        // `trusted` confirmations
+                        (received_height <= trusted_height && trusted)
                     }
                 };
 
@@ -467,7 +483,9 @@ where
                  SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,
-                 MAX(tt.mined_height) AS max_shielding_input_height
+                 IFNULL(t.trust_status, 0) AS trust_status,
+                 MAX(tt.mined_height) AS max_shielding_input_height,
+                 MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
              FROM {table_prefix}_received_notes rn
              INNER JOIN accounts ON accounts.id = rn.account_id
              INNER JOIN transactions t ON t.id_tx = rn.tx
@@ -508,13 +526,15 @@ where
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, max_shielding_input_height
+                mined_height, trust_status,
+                max_shielding_input_height, min_shielding_input_trust
          FROM eligible WHERE so_far < :target_value
          UNION
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, max_shielding_input_height
+                mined_height, trust_status,
+                max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
     ))?;
 
@@ -540,7 +560,13 @@ where
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE)
         ],
-        |r| to_spendable_note(params, r),
+        |row| {
+            let tx_trust_status = row.get::<_, bool>("trust_status")?;
+            let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+            let note = to_spendable_note(params, row)?;
+
+            Ok(note.map(|n| (n, tx_trust_status, tx_shielding_inputs_trusted)))
+        },
     )?;
 
     let trusted_height = target_height.saturating_sub(u32::from(confirmations_policy.trusted()));
@@ -551,7 +577,7 @@ where
         .filter_map(|result_maybe_note| {
             let result_note = result_maybe_note.transpose()?;
             result_note
-                .map(|note| {
+                .map(|(note, trusted, tx_shielding_inputs_trusted)| {
                     let received_height = note
                         .mined_height()
                         .expect("mined height checked to be non-null");
@@ -562,9 +588,20 @@ where
                             received_height <= trusted_height &&
                             // And, if the note was the output of a shielding transaction, its
                             // transparent inputs have at least `untrusted` confirmations.
-                            note.max_shielding_input_height().iter().all(|h| h <= &untrusted_height)
+                            note.max_shielding_input_height().iter().all(|h| {
+                                // its inputs have at least `untrusted` confirmations
+                                h <= &untrusted_height ||
+                                // or its inputs are trusted and have at least `trusted` confirmations
+                                (h <= &trusted_height && tx_shielding_inputs_trusted)
+                            })
                         }
-                        Scope::External => received_height <= untrusted_height,
+                        Scope::External => {
+                            // The note has the required number of confirmations for an untrusted note.
+                            received_height <= untrusted_height ||
+                            // or it is the output of an explicitly trusted tx and has at least
+                            // `trusted` confirmations
+                            (received_height <= trusted_height && trusted)
+                        }
                     };
 
                     has_confirmations.then_some(note)

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -278,6 +278,7 @@ CREATE TABLE "transactions" (
     raw BLOB,
     fee INTEGER,
     target_height INTEGER,
+    trust_status INTEGER,
     FOREIGN KEY (block) REFERENCES blocks(height),
     CONSTRAINT height_consistency CHECK (block IS NULL OR mined_height = block)
 )"#;

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -9,6 +9,7 @@
 
 mod add_account_birthdays;
 mod add_account_uuids;
+mod add_transaction_trust_marker;
 mod add_transaction_views;
 mod add_utxo_account;
 mod addresses_table;
@@ -120,6 +121,8 @@ pub(super) fn all_migrations<
     //                     support_zcashd_wallet_import          fix_v_transactions_expired_unmined
     //                                                                           |
     //                                                                v_tx_outputs_return_addrs
+    //                                                                           |
+    //                                                              add_transaction_trust_marker
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),
@@ -198,6 +201,7 @@ pub(super) fn all_migrations<
         Box::new(support_zcashd_wallet_import::Migration),
         Box::new(fix_v_transactions_expired_unmined::Migration),
         Box::new(v_tx_outputs_return_addrs::Migration),
+        Box::new(add_transaction_trust_marker::Migration),
     ]
 }
 
@@ -323,6 +327,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     tx_retrieval_queue_expiry::MIGRATION_ID,
     support_zcashd_wallet_import::MIGRATION_ID,
     v_tx_outputs_return_addrs::MIGRATION_ID,
+    add_transaction_trust_marker::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
@@ -1,0 +1,51 @@
+//! Adds support for marking transactions as explicitly trusted for the purpose of satisfying the
+//! ZIP 315 confirmations policy
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::{migrations::fix_v_transactions_expired_unmined, WalletMigrationError};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x4e68277f_6269_467e_9437_f3853cc4a41f);
+
+const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds support for marking transactions as explicitly trusted."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        transaction.execute_batch("ALTER TABLE transactions ADD COLUMN trust_status INTEGER;")?;
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}


### PR DESCRIPTION
This adds the capability to mark a transaction as explicitly "trusted", meaning that its outputs will be treated in the same fashion as wallet-internal outputs for purposes of spendability.