### PR TITLE
zcash_client_backend: Fix missing feature flag.

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1976,6 +1976,7 @@ where
                                     scope,
                                     address_index,
                                 } => Some((index, *scope, *address_index)),
+                                #[cfg(feature = "transparent-key-import")]
                                 TransparentAddressMetadata::Standalone(_) => None,
                             })
                     })


### PR DESCRIPTION
Fixes a build failure that occurred when both the `pczt` and `transparent-inputs` features were enabled without `transparent-key-import` being enabled.