### PR TITLE
docs(`zcash_protocol`): use `doc_cfg` instead of `doc_auto_cfg`

### DIFF
--- a/components/zcash_protocol/src/lib.rs
+++ b/components/zcash_protocol/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, doc(auto_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 // Temporary until we have addressed all Result<T, ()> cases.


### PR DESCRIPTION
Nightly rustdoc removed `doc_auto_cfg` and folded its functionality into the `doc_cfg` work: [RFC 3631](https://github.com/rust-lang/rfcs/blob/master/text/3631-rustdoc-cfgs-handling.md).
This crate still gated on `#![feature(doc_auto_cfg)]`, which causes docs.rs to fail on current nightly.

Here's [the original PR](https://github.com/rust-lang/rust/pull/138907).