### PR TITLE
Remove deprecations from zcash_primitives

### DIFF
--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -6,7 +6,7 @@
 //! ```
 //! # #[cfg(feature = "test-dependencies")]
 //! # {
-//! use zcash_primitives::{
+//! use zcash_protocol::{
 //!     consensus::{BlockHeight, Network, Parameters},
 //! };
 //!
@@ -244,7 +244,7 @@ pub trait BlockSource {
 ///        scanning::{ScanPriority, ScanRange},
 ///    };
 ///    use zcash_client_backend::proto::compact_formats::CompactBlock;
-///    use zcash_primitives::consensus::BlockHeight;
+///    use zcash_protocol::consensus::BlockHeight;
 ///
 ///    struct ExampleBlockCache {
 ///        cached_blocks: Arc<Mutex<Vec<CompactBlock>>>,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1544,8 +1544,8 @@ impl<Cache, DsFactory> TestBuilder<Cache, DsFactory> {
     /// use std::num::NonZeroU8;
     ///
     /// use incrementalmerkletree::frontier::Frontier;
-    /// use zcash_primitives::{block::BlockHash, consensus::Parameters};
-    /// use zcash_protocol::consensus::NetworkUpgrade;
+    /// use zcash_primitives::block::BlockHash;
+    /// use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
     /// use zcash_client_backend::data_api::{
     ///     chain::{ChainState, CommitmentTreeRoot},
     ///     testing::{InitialChainState, TestBuilder},

--- a/zcash_client_memory/src/error.rs
+++ b/zcash_client_memory/src/error.rs
@@ -1,12 +1,13 @@
 use std::{array::TryFromSliceError, convert::Infallible};
 
 use shardtree::error::ShardTreeError;
+use transparent::address::TransparentAddress;
 use zcash_address::ConversionError;
 use zcash_keys::{
     encoding::TransparentCodecError,
     keys::{AddressGenerationError, DerivationError},
 };
-use zcash_primitives::{legacy::TransparentAddress, transaction::TxId};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::{consensus::BlockHeight, memo};
 
 use crate::AccountId;

--- a/zcash_client_memory/src/input_source.rs
+++ b/zcash_client_memory/src/input_source.rs
@@ -19,9 +19,8 @@ use zcash_protocol::ShieldedProtocol::Orchard;
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    ::transparent::bundle::OutPoint,
+    ::transparent::{address::TransparentAddress, bundle::OutPoint},
     zcash_client_backend::{data_api::TransactionStatus, wallet::WalletTransparentOutput},
-    zcash_primitives::legacy::TransparentAddress,
     zcash_protocol::consensus::BlockHeight,
 };
 

--- a/zcash_client_memory/src/testing/mod.rs
+++ b/zcash_client_memory/src/testing/mod.rs
@@ -79,7 +79,7 @@ impl TestCache for MemBlockCache {
 
 impl<P> Reset for MemoryWalletDb<P>
 where
-    P: zcash_primitives::consensus::Parameters + Clone + Debug + PartialEq,
+    P: zcash_protocol::consensus::Parameters + Clone + Debug + PartialEq,
 {
     type Handle = ();
 
@@ -91,7 +91,7 @@ where
 
 impl<P> WalletTest for MemoryWalletDb<P>
 where
-    P: zcash_primitives::consensus::Parameters + Clone + Debug + PartialEq,
+    P: zcash_protocol::consensus::Parameters + Clone + Debug + PartialEq,
 {
     #[allow(clippy::type_complexity)]
     fn get_sent_outputs(&self, txid: &TxId) -> Result<Vec<OutputOfSentTx>, Error> {

--- a/zcash_client_memory/src/types/account.rs
+++ b/zcash_client_memory/src/types/account.rs
@@ -4,6 +4,11 @@ use std::{
 };
 
 use subtle::ConditionallySelectable;
+use transparent::address::TransparentAddress;
+#[cfg(feature = "transparent-inputs")]
+use transparent::keys::{
+    AccountPubKey, EphemeralIvk, IncomingViewingKey, NonHardenedChildIndex, TransparentKeyScope,
+};
 use zcash_address::ZcashAddress;
 #[cfg(feature = "transparent-inputs")]
 use zcash_client_backend::wallet::TransparentAddressMetadata;
@@ -17,11 +22,7 @@ use zcash_keys::{
     address::Receiver,
     keys::{AddressGenerationError, UnifiedIncomingViewingKey},
 };
-#[cfg(feature = "transparent-inputs")]
-use zcash_primitives::legacy::keys::{
-    AccountPubKey, EphemeralIvk, IncomingViewingKey, NonHardenedChildIndex, TransparentKeyScope,
-};
-use zcash_primitives::{legacy::TransparentAddress, transaction::TxId};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::NetworkType;
 use zip32::DiversifierIndex;
 
@@ -247,10 +248,10 @@ impl PartialEq for Account {
             && self.kind == other.kind
             && self
                 .viewing_key
-                .encode(&zcash_primitives::consensus::MainNetwork)
+                .encode(&zcash_protocol::consensus::MainNetwork)
                 == other
                     .viewing_key
-                    .encode(&zcash_primitives::consensus::MainNetwork)
+                    .encode(&zcash_protocol::consensus::MainNetwork)
             && self.birthday == other.birthday
             && self.addresses == other.addresses
             && self.ephemeral_addresses == other.ephemeral_addresses
@@ -540,8 +541,8 @@ mod serialization {
     use zcash_client_backend::data_api::Zip32Derivation;
     use zcash_keys::encoding::AddressCodec;
     use zcash_primitives::block::BlockHash;
-    use zcash_primitives::consensus::Network::MainNetwork as EncodingParams;
     use zcash_primitives::merkle_tree::{read_frontier_v1, write_frontier_v1};
+    use zcash_protocol::consensus::Network::MainNetwork as EncodingParams;
     use zip32::fingerprint::SeedFingerprint;
 
     use super::*;

--- a/zcash_client_memory/src/types/block.rs
+++ b/zcash_client_memory/src/types/block.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use zcash_client_backend::wallet::NoteId;
-use zcash_primitives::{block::BlockHash, consensus::BlockHeight, transaction::TxId};
-use zcash_protocol::memo::MemoBytes;
+use zcash_primitives::{block::BlockHash, transaction::TxId};
+use zcash_protocol::{consensus::BlockHeight, memo::MemoBytes};
 
 /// Internal wallet representation of a Block.
 #[derive(Clone, Debug, PartialEq)]

--- a/zcash_client_memory/src/types/data_requests.rs
+++ b/zcash_client_memory/src/types/data_requests.rs
@@ -31,7 +31,7 @@ mod serialization {
     #[cfg(feature = "transparent-inputs")]
     use {
         ::transparent::address::TransparentAddress, zcash_keys::encoding::AddressCodec as _,
-        zcash_primitives::consensus::Network::MainNetwork as EncodingParams,
+        zcash_protocol::consensus::Network::MainNetwork as EncodingParams,
     };
 
     impl From<TransactionDataRequest> for proto::TransactionDataRequest {

--- a/zcash_client_memory/src/types/notes/sent.rs
+++ b/zcash_client_memory/src/types/notes/sent.rs
@@ -170,10 +170,8 @@ mod serialization {
 
     #[cfg(feature = "transparent-inputs")]
     use {
-        zcash_keys::encoding::AddressCodec as _,
-        zcash_primitives::{
-            consensus::Network::MainNetwork as EncodingParams, legacy::TransparentAddress,
-        },
+        transparent::address::TransparentAddress, zcash_keys::encoding::AddressCodec as _,
+        zcash_protocol::consensus::Network::MainNetwork as EncodingParams,
     };
 
     impl From<SentNote> for proto::SentNote {

--- a/zcash_client_memory/src/types/nullifier.rs
+++ b/zcash_client_memory/src/types/nullifier.rs
@@ -1,7 +1,6 @@
 use std::{collections::BTreeMap, ops::Deref};
 
-use zcash_primitives::consensus::BlockHeight;
-use zcash_protocol::PoolType;
+use zcash_protocol::{consensus::BlockHeight, PoolType};
 
 /// Maps a nullifier to the block height and transaction index (NOT txid!) where it was spent.
 #[derive(Debug, Clone, PartialEq)]

--- a/zcash_client_memory/src/types/scanning.rs
+++ b/zcash_client_memory/src/types/scanning.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut, Range};
 use zcash_client_backend::data_api::scanning::{
     spanning_tree::SpanningTree, ScanPriority, ScanRange,
 };
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 
 use crate::error::Error;
 

--- a/zcash_client_memory/src/types/transaction.rs
+++ b/zcash_client_memory/src/types/transaction.rs
@@ -7,11 +7,8 @@ use zcash_client_backend::{
     data_api::{wallet::TargetHeight, TransactionStatus},
     wallet::WalletTx,
 };
-use zcash_primitives::{
-    consensus::BlockHeight,
-    transaction::{Transaction, TxId},
-};
-use zcash_protocol::value::Zatoshis;
+use zcash_primitives::transaction::{Transaction, TxId};
+use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
 
 use crate::error::Error;
 use crate::AccountId;

--- a/zcash_client_memory/src/types/transparent.rs
+++ b/zcash_client_memory/src/types/transparent.rs
@@ -3,9 +3,12 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use ::transparent::bundle::{OutPoint, TxOut};
+use ::transparent::{
+    address::TransparentAddress,
+    bundle::{OutPoint, TxOut},
+};
 use zcash_client_backend::wallet::WalletTransparentOutput;
-use zcash_primitives::legacy::TransparentAddress;
+
 use zcash_protocol::{consensus::BlockHeight, TxId};
 
 use super::AccountId;
@@ -154,8 +157,7 @@ mod serialization {
     use crate::{proto::memwallet as proto, read_optional};
     use transparent::address::Script;
     use zcash_keys::encoding::AddressCodec;
-    use zcash_primitives::consensus::Network::MainNetwork as EncodingParams;
-    use zcash_protocol::value::Zatoshis;
+    use zcash_protocol::{consensus::Network::MainNetwork as EncodingParams, value::Zatoshis};
 
     impl From<ReceivedTransparentOutput> for proto::ReceivedTransparentOutput {
         fn from(output: ReceivedTransparentOutput) -> Self {

--- a/zcash_client_memory/src/wallet_commitment_trees.rs
+++ b/zcash_client_memory/src/wallet_commitment_trees.rs
@@ -7,8 +7,7 @@ use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 use zcash_client_backend::data_api::{
     chain::CommitmentTreeRoot, WalletCommitmentTrees, SAPLING_SHARD_HEIGHT,
 };
-use zcash_primitives::consensus::BlockHeight;
-use zcash_protocol::consensus;
+use zcash_protocol::consensus::{self, BlockHeight};
 
 use crate::MemoryWalletDb;
 

--- a/zcash_client_memory/src/wallet_read.rs
+++ b/zcash_client_memory/src/wallet_read.rs
@@ -22,11 +22,10 @@ use zcash_client_backend::{
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedIncomingViewingKey};
 use zcash_primitives::{
     block::BlockHash,
-    consensus::BlockHeight,
     transaction::{Transaction, TransactionData, TxId},
 };
 use zcash_protocol::{
-    consensus::{self, BranchId},
+    consensus::{self, BlockHeight, BranchId},
     memo::Memo,
     PoolType,
 };
@@ -35,8 +34,8 @@ use zip32::fingerprint::SeedFingerprint;
 #[cfg(feature = "transparent-inputs")]
 use {
     core::ops::Range,
+    transparent::{address::TransparentAddress, keys::NonHardenedChildIndex},
     zcash_client_backend::wallet::TransparentAddressMetadata,
-    zcash_primitives::legacy::{keys::NonHardenedChildIndex, TransparentAddress},
     zip32::Scope,
 };
 
@@ -676,10 +675,8 @@ impl<P: consensus::Parameters> WalletRead for MemoryWalletDb<P> {
             .filter_map(|(diversifier_index, ua)| {
                 ua.transparent().map(|ta| {
                     let metadata =
-                        zcash_primitives::legacy::keys::NonHardenedChildIndex::from_index(
-                            (*diversifier_index).try_into().unwrap(),
-                        )
-                        .map(|i| TransparentAddressMetadata::new(Scope::External.into(), i));
+                        NonHardenedChildIndex::from_index((*diversifier_index).try_into().unwrap())
+                            .map(|i| TransparentAddressMetadata::new(Scope::External.into(), i));
                     (*ta, metadata)
                 })
             })

--- a/zcash_client_memory/src/wallet_write.rs
+++ b/zcash_client_memory/src/wallet_write.rs
@@ -47,11 +47,10 @@ use {
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    ::transparent::bundle::TxOut,
+    ::transparent::{address::TransparentAddress, bundle::TxOut},
     zcash_client_backend::{
         data_api::TransactionsInvolvingAddress, wallet::TransparentAddressMetadata,
     },
-    zcash_primitives::legacy::TransparentAddress,
 };
 
 impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
@@ -1196,7 +1195,7 @@ Instead derive the ufvk in the calling code and import it using `import_account_
         use zcash_keys::keys::AddressGenerationError;
         // TODO: We need to implement first_unsafe_index to make sure we dont violate gap invarient
 
-        use zcash_primitives::legacy::keys::NonHardenedChildIndex;
+        use transparent::keys::NonHardenedChildIndex;
         let first_unsafe = self.first_unsafe_index(account_id)?;
         if let Some(account) = self.accounts.get_mut(account_id) {
             let first_unreserved = account.first_unreserved_index()?;

--- a/zcash_extensions/src/consensus/transparent.rs
+++ b/zcash_extensions/src/consensus/transparent.rs
@@ -1,11 +1,11 @@
 //! Consensus logic for Transparent Zcash Extensions.
 
 use std::convert::TryFrom;
-use zcash_primitives::consensus::{BlockHeight, BranchId};
 use zcash_primitives::extensions::transparent::{
     AuthData, Error, Extension, Precondition, Witness,
 };
 use zcash_primitives::transaction::{components::tze::TzeOut, Transaction};
+use zcash_protocol::consensus::{BlockHeight, BranchId};
 
 use crate::transparent::demo;
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed deprecated modules:
+    - `zcash_primitives::consensus`
+    - `zcash_primitives::constants`
+    - `zcash_primitives::memo`
+    - `zcash_primitives::zip32`
+    - `zcash_primitives::legacy`
+
 ## [0.26.0] - 2025-10-02
 
 ### Added

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -30,29 +30,3 @@ pub(crate) mod encoding;
 pub mod extensions;
 pub mod merkle_tree;
 pub mod transaction;
-
-#[deprecated(note = "This module is deprecated; use `::zcash_protocol::consensus` instead.")]
-pub mod consensus {
-    pub use zcash_protocol::consensus::*;
-}
-#[deprecated(note = "This module is deprecated; use `::zcash_protocol::constants` instead.")]
-pub mod constants {
-    pub use zcash_protocol::constants::*;
-}
-#[deprecated(note = "This module is deprecated; use `::zcash_protocol::memo` instead.")]
-pub mod memo {
-    pub use zcash_protocol::memo::*;
-}
-#[deprecated(note = "This module is deprecated; use the `zip32` crate instead.")]
-pub mod zip32 {
-    pub use zip32::*;
-}
-#[deprecated(note = "This module is deprecated; use the `zcash_transparent` crate instead.")]
-pub mod legacy {
-    pub use transparent::address::*;
-    #[cfg(feature = "transparent-inputs")]
-    #[deprecated(note = "This module is deprecated; use `::zcash_transparent::keys` instead.")]
-    pub mod keys {
-        pub use transparent::keys::*;
-    }
-}

--- a/zcash_primitives/src/transaction/components/tze.rs
+++ b/zcash_primitives/src/transaction/components/tze.rs
@@ -241,9 +241,9 @@ impl TzeOut {
 pub mod testing {
     use proptest::collection::vec;
     use proptest::prelude::*;
+    use zcash_protocol::consensus::BranchId;
 
     use crate::{
-        consensus::BranchId,
         extensions::transparent::{AuthData, Precondition, Witness},
         transaction::components::amount::testing::arb_nonnegative_amount,
         transaction::testing::arb_txid,


### PR DESCRIPTION
This removes deprecated modules from `zcash_primitives` and fixes all callsites.