### PR TITLE
zcash_client_backend: Return key scope from WalletRead::get_transparent_balances

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -43,6 +43,10 @@ workspace.
   - `WalletRead` has added method `get_ephemeral_transparent_receivers`.
   - The result type of `WalletRead::get_transparent_receivers` has changed. The
     value type of the returned `HashMap` is now non-optional.
+  - The result type of `WalletRead::get_transparent_balances` has changed. The
+    key scope for the address must now be returned along with the balance. The
+    semantics of this method have been changed such that it may now return balance
+    received by ephemeral addresses.
   - The inefficient default impl for `WalletRead::get_transparent_address_metadata`
     has been removed. Implementers of `WalletRead` must provide their own
     implementation.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1812,16 +1812,15 @@ pub trait WalletRead {
     }
 
     /// Returns a mapping from each transparent receiver associated with the specified account
-    /// to the balance of funds given the specified target height and confirmations policy.
-    ///
-    /// Balances of ephemeral transparent addresses will not be included.
+    /// to the key scope for that address and the balance of funds given the specified target
+    /// height and confirmations policy.
     #[cfg(feature = "transparent-inputs")]
     fn get_transparent_balances(
         &self,
         _account: Self::AccountId,
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
-    ) -> Result<HashMap<TransparentAddress, Balance>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, (TransparentKeyScope, Balance)>, Self::Error> {
         unimplemented!("WalletRead::get_transparent_balances must be overridden for wallets to use the `transparent-inputs` feature")
     }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -60,8 +60,6 @@ use super::{
     TransactionStatus, WalletCommitmentTrees, WalletRead, WalletSummary, WalletTest, WalletWrite,
     Zip32Derivation, SAPLING_SHARD_HEIGHT,
 };
-#[cfg(feature = "transparent-inputs")]
-use crate::data_api::Balance;
 use crate::{
     data_api::{wallet::TargetHeight, MaxSpendMode, TargetValue},
     fees::{
@@ -78,8 +76,8 @@ use crate::{
 #[cfg(feature = "transparent-inputs")]
 use {
     super::{wallet::input_selection::ShieldingSelector, TransactionsInvolvingAddress},
-    crate::wallet::TransparentAddressMetadata,
-    ::transparent::address::TransparentAddress,
+    crate::{data_api::Balance, wallet::TransparentAddressMetadata},
+    ::transparent::{address::TransparentAddress, keys::TransparentKeyScope},
     transparent::GapLimits,
 };
 
@@ -2736,7 +2734,7 @@ impl WalletRead for MockWalletDb {
         _account: Self::AccountId,
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
-    ) -> Result<HashMap<TransparentAddress, Balance>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, (TransparentKeyScope, Balance)>, Self::Error> {
         Ok(HashMap::new())
     }
 

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -59,7 +59,7 @@ fn check_balance<DSF>(
             .unwrap()
             .get(taddr)
             .cloned()
-            .map_or(Zatoshis::ZERO, |b| b.spendable_value()),
+            .map_or(Zatoshis::ZERO, |(_, b)| b.spendable_value()),
         expected.total(),
     );
     assert_eq!(
@@ -170,7 +170,7 @@ where
             TargetHeight::from(height_2 + 1),
             ConfirmationsPolicy::MIN
         ),
-        Ok(h) if h.get(taddr).map(|b| b.spendable_value()) == Some(value)
+        Ok(h) if h.get(taddr).map(|(_, b)| b.spendable_value()) == Some(value)
     );
 }
 

--- a/zcash_client_memory/src/types/memory_wallet/mod.rs
+++ b/zcash_client_memory/src/types/memory_wallet/mod.rs
@@ -1038,6 +1038,7 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
     }
 
     #[cfg(feature = "transparent-inputs")]
+    #[allow(unreachable_code, unused_variables)] //FIXME: need address key scope detection
     pub(crate) fn put_transparent_output(
         &mut self,
         output: &WalletTransparentOutput,
@@ -1088,6 +1089,7 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
         };
 
         // insert into transparent_received_outputs table. Update if it exists
+        #[allow(clippy::diverging_sub_expression)] // FIXME
         match self
             .transparent_received_outputs
             .entry(output.outpoint().clone())
@@ -1103,6 +1105,7 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                     txid,
                     *receiving_account,
                     *address,
+                    todo!("look up the key scope for the address"),
                     output.txout().clone(),
                     max_observed_unspent.unwrap_or(BlockHeight::from(0)),
                 ));

--- a/zcash_client_memory/src/types/transparent.rs
+++ b/zcash_client_memory/src/types/transparent.rs
@@ -7,6 +7,7 @@ use ::transparent::{
     address::TransparentAddress,
     bundle::{OutPoint, TxOut},
 };
+use transparent::keys::TransparentKeyScope;
 use zcash_client_backend::wallet::WalletTransparentOutput;
 
 use zcash_protocol::{consensus::BlockHeight, TxId};
@@ -88,6 +89,8 @@ pub struct ReceivedTransparentOutput {
     pub(crate) account_id: AccountId,
     // The address to which this TXO was sent
     pub(crate) address: TransparentAddress,
+    // The key scope at which the address was derived
+    pub(crate) key_scope: TransparentKeyScope,
     // script, value_zat
     pub(crate) txout: TxOut,
     /// The maximum block height at which this TXO was either
@@ -103,6 +106,7 @@ impl ReceivedTransparentOutput {
         transaction_id: TxId,
         account_id: AccountId,
         address: TransparentAddress,
+        key_scope: TransparentKeyScope,
         txout: TxOut,
         max_observed_unspent_height: BlockHeight,
     ) -> Self {
@@ -110,6 +114,7 @@ impl ReceivedTransparentOutput {
             transaction_id,
             account_id,
             address,
+            key_scope,
             txout,
             max_observed_unspent_height: Some(max_observed_unspent_height),
         }
@@ -171,6 +176,10 @@ mod serialization {
         }
     }
 
+    // FIXME: Key scope information needs to be added to both `proto::Address` and
+    // `proto::ReceivedTransparentOutput`, with a data migration that updates stored data with
+    // correct scope information.
+    #[allow(unreachable_code)]
     impl TryFrom<proto::ReceivedTransparentOutput> for ReceivedTransparentOutput {
         type Error = crate::Error;
 
@@ -179,6 +188,7 @@ mod serialization {
                 transaction_id: TxId::from_bytes(output.transaction_id.clone().try_into()?),
                 account_id: output.account_id.into(),
                 address: TransparentAddress::decode(&EncodingParams, &output.address)?,
+                key_scope: todo!(),
                 txout: read_optional!(output, txout)?.try_into()?,
                 max_observed_unspent_height: output.max_observed_unspent_height.map(|h| h.into()),
             })

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -44,7 +44,11 @@ use crate::{
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::TransparentAddressMetadata,
-    ::transparent::{address::TransparentAddress, bundle::OutPoint, keys::NonHardenedChildIndex},
+    ::transparent::{
+        address::TransparentAddress,
+        bundle::OutPoint,
+        keys::{NonHardenedChildIndex, TransparentKeyScope},
+    },
     core::ops::Range,
     testing::transparent::GapLimits,
 };


### PR DESCRIPTION
Wallets need key scope information to inform their behavior whenever they are interacting with light wallet servers or shielding funds. Returning the key scope facilitates this interaction.