### PR TITLE
zcash_client_memory: Fix bad macro interaction with `todo!()` macro.

### DIFF
--- a/zcash_client_memory/src/types/transparent.rs
+++ b/zcash_client_memory/src/types/transparent.rs
@@ -188,7 +188,7 @@ mod serialization {
                 transaction_id: TxId::from_bytes(output.transaction_id.clone().try_into()?),
                 account_id: output.account_id.into(),
                 address: TransparentAddress::decode(&EncodingParams, &output.address)?,
-                key_scope: todo!(),
+                key_scope: TransparentKeyScope::custom(u32::MAX).expect("FIXME"),
                 txout: read_optional!(output, txout)?.try_into()?,
                 max_observed_unspent_height: output.max_observed_unspent_height.map(|h| h.into()),
             })


### PR DESCRIPTION
Clippy beta fails on the interaction between the `todo!()` macro being used to initialize a struct field and a subsequent `read_optional!(...)` macro call. Instead, construct an invalid value so that the line always panics with `FIXME`, which is effectively equivalent to `todo!()` but opaque to the compiler.