### PR TITLE
zcash_client_sqlite: Extend ephemeral transparent address gap limit to 10 addresses.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -72,6 +72,11 @@ workspace.
     consequence of this change, the signature of
     `TransparentAddressMetadata::new` has changed; use
     `TransparentAddressMetadata::derived` instead.
+- `zcash_client_backend::testing`:
+  - `DataStoreFactory::new_data_store` now takes its `GapLimits` argument
+    as an optional value. This avoids the need for the test builder to
+    hardcode a set of gap limits that might inadvertently conflict
+    with defaults provided by a particular backend.
 
 ### Removed
 - `zcash_client_backend::tor::http::cryptex::exchanges::GateIo`

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1412,7 +1412,7 @@ pub trait DataStoreFactory {
     fn new_data_store(
         &self,
         network: LocalNetwork,
-        #[cfg(feature = "transparent-inputs")] gap_limits: GapLimits,
+        #[cfg(feature = "transparent-inputs")] gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error>;
 }
 
@@ -1426,7 +1426,7 @@ pub struct TestBuilder<Cache, DataStoreFactory> {
     account_birthday: Option<AccountBirthday>,
     account_index: Option<zip32::AccountId>,
     #[cfg(feature = "transparent-inputs")]
-    gap_limits: GapLimits,
+    gap_limits: Option<GapLimits>,
 }
 
 impl TestBuilder<(), ()> {
@@ -1460,7 +1460,7 @@ impl TestBuilder<(), ()> {
             account_birthday: None,
             account_index: None,
             #[cfg(feature = "transparent-inputs")]
-            gap_limits: GapLimits::new(10, 5, 5),
+            gap_limits: None,
         }
     }
 }
@@ -1519,7 +1519,7 @@ impl<A, B> TestBuilder<A, B> {
             initial_chain_state: self.initial_chain_state,
             account_birthday: self.account_birthday,
             account_index: self.account_index,
-            gap_limits,
+            gap_limits: Some(gap_limits),
         }
     }
 }

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -450,6 +450,7 @@ where
     let mut st = TestBuilder::new()
         .with_data_store_factory(ds_factory)
         .with_block_cache(cache)
+        .with_gap_limits(gap_limits)
         .with_account_from_sapling_activation(BlockHash([0; 32]))
         .build();
 

--- a/zcash_client_memory/src/testing/mod.rs
+++ b/zcash_client_memory/src/testing/mod.rs
@@ -54,7 +54,7 @@ impl DataStoreFactory for TestMemDbFactory {
     fn new_data_store(
         &self,
         network: LocalNetwork,
-        #[cfg(feature = "transparent-inputs")] _gap_limits: GapLimits,
+        #[cfg(feature = "transparent-inputs")] _gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error> {
         Ok(MemoryWalletDb::new(network, 100))
     }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -20,6 +20,11 @@ workspace.
 - The implementation of `zcash_client_backend::WalletWrite` for `WalletDb` has
   additional type constraints. The `R` type parameter is now constrained to
   types that implement `RngCore`.
+- The default gap limit for ephemeral address generation has been changed from
+  5 addresses to 10. Now that ephemeral addresses are being used for more
+  single-use-address use cases than just transactions sending to TEX addresses,
+  the case that there will be a series of unused addresses (for example, for
+  swap refunds) becomes more common.
 
 ## [0.18.9] - 2025-10-22
 

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -188,13 +188,13 @@ impl DataStoreFactory for TestDbFactory {
     fn new_data_store(
         &self,
         network: LocalNetwork,
-        #[cfg(feature = "transparent-inputs")] gap_limits: GapLimits,
+        #[cfg(feature = "transparent-inputs")] gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error> {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data =
             WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
         #[cfg(feature = "transparent-inputs")]
-        {
+        if let Some(gap_limits) = gap_limits {
             db_data = db_data.with_gap_limits(gap_limits.into());
         }
 
@@ -225,7 +225,7 @@ impl Reset for TestDb {
                 .new_data_store(
                     network,
                     #[cfg(feature = "transparent-inputs")]
-                    gap_limits.into(),
+                    Some(gap_limits.into()),
                 )
                 .unwrap(),
         );


### PR DESCRIPTION
Builds atop #2028