### PR TITLE
fix(memo): return payment error when memo to t-address

### DIFF
--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -11,6 +11,9 @@ workspace.
 ## [Unreleased]
 
 ### Changed
+- `zip::Payment::new` now returns `Err(Zip321Error::TransparentMemo(0))`
+  instead of `None` for payment requests that include a memo. The recipient
+  can't receive memos because we're sending payment to a t-address.
 - MSRV is now 1.85.1.
 
 ## [0.6.0] - 2025-10-02

--- a/components/zip321/src/lib.rs
+++ b/components/zip321/src/lib.rs
@@ -136,7 +136,7 @@ pub struct Payment {
 impl Payment {
     /// Constructs a new [`Payment`] from its constituent parts.
     ///
-    /// Returns `None` if the payment requests that a memo be sent to a recipient that cannot
+    /// Returns `Err` if the payment requests that a memo be sent to a recipient that cannot
     /// receive a memo.
     pub fn new(
         recipient_address: ZcashAddress,
@@ -145,9 +145,9 @@ impl Payment {
         label: Option<String>,
         message: Option<String>,
         other_params: Vec<(String, String)>,
-    ) -> Option<Self> {
+    ) -> Result<Payment, Zip321Error> {
         if memo.is_none() || recipient_address.can_receive_memo() {
-            Some(Self {
+            Ok(Self {
                 recipient_address,
                 amount,
                 memo,
@@ -156,7 +156,7 @@ impl Payment {
                 other_params,
             })
         } else {
-            None
+            Err(Zip321Error::TransparentMemo(0))
         }
     }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -623,7 +623,8 @@ where
             None,
             vec![],
         )
-        .ok_or(Error::MemoForbidden)?,
+        // Assume failure is due to memo
+        .map_err(|_| Error::MemoForbidden)?,
     ])
     .expect(
         "It should not be possible for this to violate ZIP 321 request construction invariants.",


### PR DESCRIPTION
Recipients using a transparent address can't receive memos but the current `Option` doesn't express that to the caller. We explicitly return a `Result` now with a `TransparentMemo(0)` error when that type of failure happens. This issue was originally mentioned in https://github.com/zcash/zcash-devtool/issues/95 as part of the `zcash-devtool` project.