### PR TITLE
Fix typos in primitives, keys, and PCZT documentation

### DIFF
--- a/pczt/src/transparent.rs
+++ b/pczt/src/transparent.rs
@@ -50,7 +50,7 @@ pub struct Input {
     #[getset(get = "pub")]
     pub(crate) sequence: Option<u32>,
 
-    /// The minimum Unix timstamp that this input requires to be set as the transaction's
+    /// The minimum Unix timestamp that this input requires to be set as the transaction's
     /// lock time.
     ///
     /// - This is set by the Constructor.

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -249,7 +249,7 @@ The entries below are relative to the `zcash_client_backend` crate as of
   - `AddressGenerationError`
   - `UnifiedAddressRequest`
 - A new `orchard` feature flag has been added to make it possible to
-  build client code without `orchard` dependendencies.
+  build client code without `orchard` dependencies.
 - `zcash_keys::address::Address::to_zcash_address`
 
 ### Changed

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -1062,7 +1062,7 @@ and `zcash_encoding`.
 - `zcash_primitives::transaction::components::tze::TzeOutPoint` constructor
   now taxes a TxId rather than a raw byte array.
 - `zcash_primitives::transaction::components::Amount` addition, subtraction,
-  and summation now return `Option` rather than panicing on overflow.
+  and summation now return `Option` rather than panicking on overflow.
 - `zcash_primitives::transaction::builder`:
   - `Error` has been modified to wrap the error types produced by its child
     builders.

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -933,7 +933,7 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'_, 
         };
 
         // The unwrap() here is safe because the txid hashing
-        // of freeze() should be infalliable.
+        // of freeze() should be infallible.
         Ok(BuildResult {
             transaction: authorized_tx.freeze().unwrap(),
             sapling_meta,

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -308,7 +308,7 @@ fn zip_0244() {
         let (txdata, txid_parts) = to_test_txdata(&tv);
 
         if let Some(index) = tv.transparent_input {
-            // nIn is a u32, but to actually use it we need a usize.
+            // n_in is a u32, but to actually use it we need a usize.
             let index = index as usize;
             let bundle = txdata.transparent_bundle().unwrap();
             let value = bundle.authorization.input_amounts[index];

--- a/zcash_transparent/src/pczt.rs
+++ b/zcash_transparent/src/pczt.rs
@@ -90,7 +90,7 @@ pub struct Input {
     ///   (`0xffffffff`).
     pub(crate) sequence: Option<u32>,
 
-    /// The minimum Unix timstamp that this input requires to be set as the transaction's
+    /// The minimum Unix timestamp that this input requires to be set as the transaction's
     /// lock time.
     ///
     /// - This is set by the Constructor.


### PR DESCRIPTION
- correct “panicing” → “panicking” in zcash_primitives changelog
- fix “infalliable” comment and “nIn” reference in transaction code/tests
- update zcash_keys changelog to use “dependencies”
- spell “timestamp” correctly in PCZT transparent input docs

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-11-30T16:02:18Z
Repository: librustzcash
Branch: main
Signing: GPG (989AF9F0)
Performance: 6 files, +6/-6 lines