### PR TITLE
Fix a mis-merge in the `zcash_transparent` CHANGELOG

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,7 +8,7 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## [Unreleased]
+## [0.27.0] - PENDING
 
 ### Added
 - `zcash_primitives::transaction::builder`:

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -8,17 +8,7 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## [0.6.3] - 2025-12-17
-
-### Added
-- `zcash_transparent::zip48`:
-  - `FullViewingKey::derive_matching_account_priv_key`
-
-### Changed
-- Enabling the `std` feature now enables `zcash_address/std`, `zcash_script/std`,
-  and `secp256k1?/std`. This change is intended to improve the ergonomics for
-  downstream users of this crate, to eliminate the need for users to manually
-  enable the `std` feature of those dependencies.
+## [0.7.0] - PENDING
 
 ### Added
 - `zcash_transparent::pczt`:
@@ -35,6 +25,18 @@ workspace.
     - `InvalidExternalSignature`
     - `MissingPreimage`
     - `UnsupportedPubkey`
+
+## [0.6.3] - 2025-12-17
+
+### Added
+- `zcash_transparent::zip48`:
+  - `FullViewingKey::derive_matching_account_priv_key`
+
+### Changed
+- Enabling the `std` feature now enables `zcash_address/std`, `zcash_script/std`,
+  and `secp256k1?/std`. This change is intended to improve the ergonomics for
+  downstream users of this crate, to eliminate the need for users to manually
+  enable the `std` feature of those dependencies.
 
 ## [0.6.2] - 2025-12-12
 


### PR DESCRIPTION
The replacement of the [Unreleased] tag with the [0.6.3] line on the maintenance branch allowed a no-conflict merge to occur that resulted in CHANGELOG entries being in the wrong order on `main`. I have modified the `Unreleased` line for `zcash_transparent` and `zcash_primitives` to use `-PENDING` release versions to help prevent this sort of error in the future. In general, we should probably not use [Unreleased] for this reason.