### PR TITLE
fix: Fix github-pages build

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,8 @@ jobs:
           persist-credentials: false
       - id: prepare
         uses: ./.github/actions/prepare
+        with:
+          all-features: true
       - uses: dtolnay/rust-toolchain@nightly
         id: toolchain
       - run: rustup override set "${TOOLCHAIN}"


### PR DESCRIPTION
cargo-doc was failing due to doc references to modules behind feature gates. This commit enables all features when building docs for the gitbook.

Resolves https://github.com/zcash/librustzcash/issues/2101