### PR TITLE
fix: Fix cargo-vet store format errors

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -721,13 +721,13 @@ delta = "0.21.8 -> 0.21.12"
 notes = """
 A comment in get_sni_extension asks whether the behaviour of parsing an IPv4 or IPv6 address
 in a host_name field of a server_name extension, but then ignoring the extension (because
-'Literal IPv4 and IPv6 addresses are not permitted in \"HostName\"'), as the server, is
+'Literal IPv4 and IPv6 addresses are not permitted in "HostName"'), as the server, is
 compliant with RFC 6066. As an original author of RFC 3546 which has very similar wording,
 I can speak to the intent: yes this is fine. The client is clearly nonconformant in this
 case, but the server isn't.
 
-RFC 3546 said \"If the server understood the client hello extension but does not recognize
-the server name, it SHOULD send an \"unrecognized_name\" alert (which MAY be fatal).\"
+RFC 3546 said "If the server understood the client hello extension but does not recognize
+the server name, it SHOULD send an "unrecognized_name" alert (which MAY be fatal)."
 This wording was preserved in RFC 5746, and then updated in RFC 6066 to:
 
    If the server understood the ClientHello extension but
@@ -745,9 +745,9 @@ This wording was preserved in RFC 5746, and then updated in RFC 6066 to:
 
 To me it's clear that it is reasonable to consider an IP address as a name that the
 server does not recognize. And so the server SHOULD *either* send a fatal unrecognized_name
-alert, *or* continue the handshake and let the client application decide when it \"performs
-the server endpoint identification\". There's no conformance requirement for the server to
-take any notice of a host_name that is \"not permitted\". (It would have been clearer to
+alert, *or* continue the handshake and let the client application decide when it "performs
+the server endpoint identification". There's no conformance requirement for the server to
+take any notice of a host_name that is "not permitted". (It would have been clearer to
 express this by specifying the allowed client and server behaviour separately, i.e. saying
 that the client MUST NOT send an IP address in host_name, and then explicitly specifying
 the server behaviour if it does so anyway. That's how I would write it now. But honestly

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -809,7 +809,7 @@ delta = "0.3.27 -> 0.3.31"
 who = "Pat Hickey <pat@moreproductive.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.27 -> 0.3.31"
-notes = "New waker_ref module contains \"FIXME: panics on Arc::clone / refcount changes could wreak havoc...\" comment, but this corner case feels low risk."
+notes = 'New waker_ref module contains "FIXME: panics on Arc::clone / refcount changes could wreak havoc..." comment, but this corner case feels low risk.'
 
 [[audits.bytecode-alliance.audits.hashbrown]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1593,8 +1593,8 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.35"
 notes = """
-Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
-(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -1656,7 +1656,7 @@ and there were no hits except for:
 * Using `unsafe` in a string:
 
     ```
-    src/constfn.rs:            \"unsafe\" => Qualifiers::Unsafe,
+    src/constfn.rs:            "unsafe" => Qualifiers::Unsafe,
     ```
 
 * Using `std::fs` in `build/build.rs` to write `${OUT_DIR}/version.expr`
@@ -1798,7 +1798,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.0.197"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -1811,7 +1811,7 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.202 -> 1.0.203"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
+notes = 'Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits'
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde_derive]]
@@ -3538,7 +3538,7 @@ Uses `unsafe` blocks to interact with `windows-sys` crate.
 - The slice constructed from the `PWSTR` correctly goes out of scope before
   `guard` is dropped.
 - A code comment says that `path_ptr` is valid for `len` bytes, but `PCWSTR` is
-  a `*const u16` and `lstrlenW` returns its length \"in characters\" (which the
+  a `*const u16` and `lstrlenW` returns its length "in characters" (which the
   Windows documentation confirms means the number of `WCHAR` values). This is
   likely a typo; the code checks that `len * size_of::<u16>() <= isize::MAX`.
 """


### PR DESCRIPTION
CI was failing, because cargo-vet failed due to format errors in the audit log. This PR fixes the format errors.

Resolves https://github.com/zcash/librustzcash/issues/2105