### PR TITLE
chore(deps): bump bip0039 to v0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,13 +424,16 @@ dependencies = [
 
 [[package]]
 name = "bip0039"
-version = "0.12.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
+checksum = "c2758a6b386455c1586e91cc1c1ecb910cf4fb7d9d391256820e9c96efba0872"
 dependencies = [
+ "anyhow",
  "hmac 0.12.1",
  "pbkdf2",
- "rand 0.8.5",
+ "phf",
+ "phf_codegen",
+ "rand 0.9.2",
  "sha2 0.10.8",
  "unicode-normalization",
  "zeroize",
@@ -3212,6 +3215,16 @@ dependencies = [
  "phf_macros",
  "phf_shared",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -7469,9 +7482,9 @@ checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ trait-variant = "0.1"
 
 # ZIP 32
 aes = "0.8"
-bip0039 = { version = "0.12" }
+bip0039 = "0.13.4"
 fpe = { version = "0.6", default-features = false, features = ["alloc"] }
 zip32 = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
changelog: https://github.com/koushiro/rust-bips/releases?q=bip0039-v0.13&expanded=true