### PR TITLE
feat: COR-716 support for uint256 in eip681

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "pretty_assertions",
+ "primitive-types",
  "proptest",
  "sha3",
  "snafu",

--- a/components/eip681/Cargo.toml
+++ b/components/eip681/Cargo.toml
@@ -17,6 +17,9 @@ categories.workspace = true
 # - Error handling
 snafu = "0.8.6"
 
+# - Large integers
+primitive-types = { version = "0.12", default-features = false }
+
 # - Parsing and Encoding
 base64.workspace = true
 ens-normalize-rs = "0.1.1"

--- a/components/eip681/src/error.rs
+++ b/components/eip681/src/error.rs
@@ -125,6 +125,9 @@ pub enum ValidationError {
     ))]
     Overflow,
 
+    #[snafu(display("Cannot convert negative number to unsigned type"))]
+    NegativeValueForUnsignedType,
+
     #[snafu(display("Could not decode url-encoded string: {source}"))]
     UrlEncoding { source: std::str::Utf8Error },
 

--- a/components/eip681/src/lib.rs
+++ b/components/eip681/src/lib.rs
@@ -29,6 +29,7 @@
 //! See
 //! [ABNF core rules](https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form#Core_rules)
 //! for general information about the `ABNF` format.
+pub use primitive_types::U256;
 
 pub mod error;
 mod parse;


### PR DESCRIPTION
These changes add uint256 support to `Number` with the `as_uint256` method. 

This enables proper support for ERC-20 transaction requests which require `uint256` values that can exceed `i128::MAX`.