### PR TITLE
Implement tracking of ZIP 48 transparent multisig accounts

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -31,6 +31,11 @@ workspace.
   - `Note::receiver`
   - `impl From<sapling_crypto::Note> for Note`
   - `impl From<orchard::Note> for Note`
+- Coin tracking for ZIP 48 multisig accounts (no spend ability)
+  - Create `zip-48` feature
+  - `zcash_client_backend::data_api::AccountSource::Zip48`
+  - `zcash_client_backend::data_api::WalletWrite::import_account_zip48_multisig()`
+  - ZIP 48 tests in `zcash_client_backend::data_api::testing::transparent`
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now takes

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -35,6 +35,8 @@ workspace.
   - Create `zip-48` feature
   - `zcash_client_backend::data_api::AccountSource::Zip48`
   - `zcash_client_backend::data_api::WalletWrite::import_account_zip48_multisig()`
+  - `zcash_client_backend::data_api::WalletWrite::get_next_zip48_multisig_address()`
+  - `zcash_client_backend::data_api::WalletWrite::get_zip48_multisig_address_for_index()`
   - ZIP 48 tests in `zcash_client_backend::data_api::testing::transparent`
 
 ### Changed

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -187,11 +187,24 @@ transparent-inputs = [
     "zcash_primitives/transparent-inputs",
 ]
 
-# Enables operations that permit arbitrary transparent pubkeys to be associated
-# with an account in the wallet. Applications that rely on this feature must
-# maintain spending keys corresponding to all imported pubkeys for any account
-# from which it permits spending.
+## Enables operations that permit arbitrary transparent pubkeys to be associated
+## with an account in the wallet.
+##
+## Applications that enable this feature **MUST** also enable the
+## `transparent-inputs` feature of the crate they are using that implements the
+## `zcash_client_backend` traits.
+##
+## Applications that rely on this feature must maintain spending keys
+## corresponding to all imported pubkeys for any account from which it permits
+## spending.
 transparent-key-import = ["transparent-inputs"]
+
+## Enables tracking of ZIP 48 transparent multisig wallets.
+##
+## Applications that enable this feature **MUST** also enable the
+## `transparent-inputs` feature of the crate they are using that implements the
+## `zcash_client_backend` traits.
+zip-48 = ["transparent-inputs"]
 
 ## Enables receiving and spending Orchard funds.
 orchard = ["dep:orchard", "dep:pasta_curves", "zcash_keys/orchard"]

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -489,6 +489,10 @@ pub enum AccountSource {
         purpose: AccountPurpose,
         key_source: Option<String>,
     },
+
+    /// A ZIP 48 transparent multisig account.
+    #[cfg(feature = "zip-48")]
+    Zip48,
 }
 
 impl AccountSource {
@@ -500,6 +504,8 @@ impl AccountSource {
                 purpose: AccountPurpose::Spending { derivation },
                 ..
             } => derivation.as_ref(),
+            #[cfg(feature = "zip-48")]
+            AccountSource::Zip48 => None,
             _ => None,
         }
     }
@@ -509,6 +515,8 @@ impl AccountSource {
         match self {
             AccountSource::Derived { key_source, .. } => key_source.as_ref().map(|s| s.as_str()),
             AccountSource::Imported { key_source, .. } => key_source.as_ref().map(|s| s.as_str()),
+            #[cfg(feature = "zip-48")]
+            AccountSource::Zip48 => None,
         }
     }
 }
@@ -549,6 +557,8 @@ pub trait Account {
                 derivation: Some(derivation.clone()),
             },
             AccountSource::Imported { purpose, .. } => purpose.clone(),
+            #[cfg(feature = "zip-48")]
+            AccountSource::Zip48 => AccountPurpose::ViewOnly,
         }
     }
 
@@ -2744,6 +2754,10 @@ impl AccountBirthday {
 /// - [`WalletWrite::create_account`]
 /// - [`WalletWrite::import_account_hd`]
 /// - [`WalletWrite::import_account_ufvk`]
+#[cfg_attr(
+    feature = "zip-48",
+    doc = "/// - [`WalletWrite::import_account_zip48_multisig`]"
+)]
 ///
 /// All of these methods take an [`AccountBirthday`]. The birthday height is defined as
 /// the minimum block height that will be scanned for funds belonging to the wallet. If
@@ -2949,6 +2963,29 @@ pub trait WalletWrite: WalletRead {
         purpose: AccountPurpose,
         key_source: Option<&str>,
     ) -> Result<Self::Account, Self::Error>;
+
+    /// Imports a ZIP 48 transparent multisig wallet for tracking.
+    ///
+    /// This creates a new account of kind `account_kind = 2` (ZIP 48 multisig) with the
+    /// provided full viewing key. The account can track received funds and derive addresses.
+    ///
+    /// # Parameters
+    /// - `name`: A human-readable name for the account.
+    /// - `fvk`: The ZIP 48 full viewing key containing threshold and participant public keys.
+    /// - `birthday`: The account birthday, used for determining scan start height.
+    ///
+    /// Returns details about the imported account.
+    #[cfg(feature = "zip-48")]
+    fn import_account_zip48_multisig(
+        &mut self,
+        _name: &str,
+        _fvk: &transparent::zip48::FullViewingKey,
+        _birthday: &AccountBirthday,
+    ) -> Result<Self::Account, Self::Error> {
+        unimplemented!(
+            "WalletWrite::import_account_zip48_multisig must be overridden for wallets to use the `zip-48` feature"
+        )
+    }
 
     /// Deletes the specified account, and all transactions that exclusively involve it, from the
     /// wallet database.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3069,6 +3069,56 @@ pub trait WalletWrite: WalletRead {
         request: UnifiedAddressRequest,
     ) -> Result<Option<UnifiedAddress>, Self::Error>;
 
+    /// Generates, persists, and marks as exposed the next available address for a ZIP 48
+    /// multisig account.
+    ///
+    /// The address and its redeem script are derived from the account's full viewing key
+    /// at the next available index for the specified scope. The redeem script is stored
+    /// alongside the address for later use in transaction construction.
+    ///
+    /// # Parameters
+    /// - `account`: The identifier for the ZIP 48 multisig account.
+    /// - `scope`: The derivation scope (`External` for receiving, `Internal` for change).
+    ///
+    /// Returns `Ok(None)` if the account identifier does not correspond to a known
+    /// ZIP 48 multisig account.
+    #[cfg(feature = "zip-48")]
+    fn get_next_zip48_multisig_address(
+        &mut self,
+        _account: Self::AccountId,
+        _scope: zip32::Scope,
+    ) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        unimplemented!(
+            "WalletWrite::get_next_zip48_multisig_address must be overridden for wallets to use the `zip-48` feature"
+        )
+    }
+
+    /// Generates, persists, and marks as exposed an address at a specific index for a ZIP 48
+    /// multisig account.
+    ///
+    /// This method allows generating addresses at specific indices, which may be useful for
+    /// wallet recovery or coordinating with external systems.
+    ///
+    /// # Parameters
+    /// - `account`: The identifier for the ZIP 48 multisig account.
+    /// - `scope`: The derivation scope (`External` for receiving, `Internal` for change).
+    /// - `address_index`: The specific index at which to derive the address.
+    ///
+    /// # Warning
+    /// If the chosen index is outside the wallet's gap limit, funds sent to this address
+    /// may not be discovered on recovery from the viewing key alone.
+    #[cfg(feature = "zip-48")]
+    fn get_zip48_multisig_address_for_index(
+        &mut self,
+        _account: Self::AccountId,
+        _scope: zip32::Scope,
+        _address_index: NonHardenedChildIndex,
+    ) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        unimplemented!(
+            "WalletWrite::get_zip48_multisig_address_for_index must be overridden for wallets to use the `zip-48` feature"
+        )
+    }
+
     /// Updates the wallet's view of the blockchain.
     ///
     /// This method is used to provide the wallet with information about the state of the

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -32,7 +32,7 @@ use crate::{
 #[cfg(feature = "zip-48")]
 use {
     crate::data_api::{AccountBirthday, AccountSource, chain::ChainState},
-    ::transparent::keys::NonHardenedChildIndex,
+    ::transparent::keys::{NonHardenedChildIndex, TransparentKeyScope},
     ::transparent::zip48::{AccountPrivKey, FullViewingKey},
     zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters},
     zip32::AccountId,
@@ -92,11 +92,17 @@ fn check_balance<DSF>(
     );
 }
 
-/// Creates a ZIP 48 test account and returns its ID, transparent address, and birthday height.
+/// Creates a ZIP 48 test account and returns its ID, transparent address, birthday height,
+/// and the full viewing key.
 #[cfg(feature = "zip-48")]
 fn create_zip48_test_account<Cache, DSF: DataStoreFactory>(
     st: &mut TestState<Cache, DSF::DataStore, LocalNetwork>,
-) -> (DSF::AccountId, TransparentAddress, BlockHeight)
+) -> (
+    DSF::AccountId,
+    TransparentAddress,
+    BlockHeight,
+    FullViewingKey,
+)
 where
     <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
@@ -134,7 +140,7 @@ where
     let (taddr, _redeem) = fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
     let birthday_height = birthday.height();
 
-    (account_id, taddr, birthday_height)
+    (account_id, taddr, birthday_height, fvk)
 }
 
 pub fn put_received_transparent_utxo<DSF>(dsf: DSF, account_type: TransparentAccountType)
@@ -168,7 +174,7 @@ where
         TransparentAccountType::Zip48 => {
             let mut st = TestBuilder::new().with_data_store_factory(dsf).build();
 
-            let (account_id, taddr, birthday) = create_zip48_test_account::<_, DSF>(&mut st);
+            let (account_id, taddr, birthday, _fvk) = create_zip48_test_account::<_, DSF>(&mut st);
             (st, account_id, taddr, birthday)
         }
     };
@@ -432,7 +438,7 @@ pub fn transparent_balance_spendability<DSF>(
                 .with_block_cache(cache)
                 .build();
 
-            let (account_id, taddr, _birthday) = create_zip48_test_account::<_, DSF>(&mut st);
+            let (account_id, taddr, _birthday, _fvk) = create_zip48_test_account::<_, DSF>(&mut st);
             (st, account_id, taddr)
         }
     };
@@ -706,4 +712,140 @@ where
         ),
         Ok(h) if h.get(&expected_taddr).map(|(_, b)| b.spendable_value()) == Some(value)
     );
+}
+
+/// Tests that `get_next_zip48_multisig_address` sequentially derives addresses and that
+/// calling it with a non-ZIP-48 account returns `Ok(None)`.
+#[cfg(feature = "zip-48")]
+pub fn get_next_zip48_multisig_address<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug + PartialEq,
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    // --- ZIP 48 account ---
+    let (zip48_account_id, _taddr, _birthday, fvk) = create_zip48_test_account::<_, DSF>(&mut st);
+
+    // First call should derive index 0 (External).
+    let (addr0, meta0) = st
+        .wallet_mut()
+        .get_next_zip48_multisig_address(zip48_account_id, zip32::Scope::External)
+        .unwrap()
+        .expect("ZIP 48 account should return an address");
+
+    let (expected_addr0, _) =
+        fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+    assert_eq!(addr0, expected_addr0);
+    assert_eq!(meta0.scope(), Some(TransparentKeyScope::EXTERNAL));
+    assert_eq!(meta0.address_index(), Some(NonHardenedChildIndex::ZERO));
+
+    // Second call should derive index 1 (External).
+    let (addr1, meta1) = st
+        .wallet_mut()
+        .get_next_zip48_multisig_address(zip48_account_id, zip32::Scope::External)
+        .unwrap()
+        .expect("ZIP 48 account should return an address");
+
+    let index_one = NonHardenedChildIndex::from_index(1).unwrap();
+    let (expected_addr1, _) = fvk.derive_address(zip32::Scope::External, index_one);
+    assert_eq!(addr1, expected_addr1);
+    assert_eq!(meta1.address_index(), Some(index_one));
+
+    // Internal scope should also work, starting at index 0.
+    let (int_addr0, int_meta0) = st
+        .wallet_mut()
+        .get_next_zip48_multisig_address(zip48_account_id, zip32::Scope::Internal)
+        .unwrap()
+        .expect("ZIP 48 account should return an internal address");
+
+    let (expected_int_addr0, _) =
+        fvk.derive_address(zip32::Scope::Internal, NonHardenedChildIndex::ZERO);
+    assert_eq!(int_addr0, expected_int_addr0);
+    assert_eq!(int_meta0.scope(), Some(TransparentKeyScope::INTERNAL));
+    assert_eq!(int_meta0.address_index(), Some(NonHardenedChildIndex::ZERO));
+
+    // --- Non-ZIP-48 (Derived) account should return Ok(None) ---
+    let derived_account_id = st.test_account().unwrap().id();
+    let result = st
+        .wallet_mut()
+        .get_next_zip48_multisig_address(derived_account_id, zip32::Scope::External)
+        .unwrap();
+    assert!(result.is_none(), "Derived account should return None");
+}
+
+/// Tests that `get_zip48_multisig_address_for_index` derives the correct address at
+/// arbitrary indices and that calling it with a non-ZIP-48 account returns `Ok(None)`.
+#[cfg(feature = "zip-48")]
+pub fn get_zip48_multisig_address_for_index<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug + PartialEq,
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    // --- ZIP 48 account ---
+    let (zip48_account_id, _taddr, _birthday, fvk) = create_zip48_test_account::<_, DSF>(&mut st);
+
+    // Derive at index 5.
+    let index_5 = NonHardenedChildIndex::from_index(5).unwrap();
+    let (addr5, meta5) = st
+        .wallet_mut()
+        .get_zip48_multisig_address_for_index(zip48_account_id, zip32::Scope::External, index_5)
+        .unwrap()
+        .expect("ZIP 48 account should return an address");
+
+    let (expected_addr5, _) = fvk.derive_address(zip32::Scope::External, index_5);
+    assert_eq!(addr5, expected_addr5);
+    assert_eq!(meta5.scope(), Some(TransparentKeyScope::EXTERNAL));
+    assert_eq!(meta5.address_index(), Some(index_5));
+
+    // Derive at index 0.
+    let (addr0, meta0) = st
+        .wallet_mut()
+        .get_zip48_multisig_address_for_index(
+            zip48_account_id,
+            zip32::Scope::External,
+            NonHardenedChildIndex::ZERO,
+        )
+        .unwrap()
+        .expect("ZIP 48 account should return an address");
+
+    let (expected_addr0, _) =
+        fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+    assert_eq!(addr0, expected_addr0);
+    assert_eq!(meta0.address_index(), Some(NonHardenedChildIndex::ZERO));
+
+    // Internal scope at index 3.
+    let index_3 = NonHardenedChildIndex::from_index(3).unwrap();
+    let (int_addr3, int_meta3) = st
+        .wallet_mut()
+        .get_zip48_multisig_address_for_index(zip48_account_id, zip32::Scope::Internal, index_3)
+        .unwrap()
+        .expect("ZIP 48 account should return an internal address");
+
+    let (expected_int_addr3, _) = fvk.derive_address(zip32::Scope::Internal, index_3);
+    assert_eq!(int_addr3, expected_int_addr3);
+    assert_eq!(int_meta3.scope(), Some(TransparentKeyScope::INTERNAL));
+    assert_eq!(int_meta3.address_index(), Some(index_3));
+
+    // --- Non-ZIP-48 (Derived) account should return Ok(None) ---
+    let derived_account_id = st.test_account().unwrap().id();
+    let result = st
+        .wallet_mut()
+        .get_zip48_multisig_address_for_index(
+            derived_account_id,
+            zip32::Scope::External,
+            NonHardenedChildIndex::ZERO,
+        )
+        .unwrap();
+    assert!(result.is_none(), "Derived account should return None");
 }

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -729,7 +729,12 @@ where
         .build();
 
     // --- ZIP 48 account ---
-    let (zip48_account_id, _taddr, _birthday, fvk) = create_zip48_test_account::<_, DSF>(&mut st);
+    let (zip48_account_id, _taddr, birthday_height, fvk) =
+        create_zip48_test_account::<_, DSF>(&mut st);
+
+    // Set the chain tip so that address exposure heights can be recorded.
+    let height = birthday_height + 12345;
+    st.wallet_mut().update_chain_tip(height).unwrap();
 
     // First call should derive index 0 (External).
     let (addr0, meta0) = st
@@ -793,7 +798,12 @@ where
         .build();
 
     // --- ZIP 48 account ---
-    let (zip48_account_id, _taddr, _birthday, fvk) = create_zip48_test_account::<_, DSF>(&mut st);
+    let (zip48_account_id, _taddr, birthday_height, fvk) =
+        create_zip48_test_account::<_, DSF>(&mut st);
+
+    // Set the chain tip so that address exposure heights can be recorded.
+    let height = birthday_height + 12345;
+    st.wallet_mut().update_chain_tip(height).unwrap();
 
     // Derive at index 5.
     let index_5 = NonHardenedChildIndex::from_index(5).unwrap();

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -14,7 +14,6 @@ use zcash_keys::{
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::{local_consensus::LocalNetwork, value::Zatoshis};
 
-use super::TestAccount;
 use crate::{
     data_api::{
         Account as _, Balance, InputSource as _, WalletRead as _, WalletTest as _, WalletWrite,
@@ -30,11 +29,28 @@ use crate::{
     wallet::WalletTransparentOutput,
 };
 
-/// Checks whether the transparent balance of the given test `account` is as `expected`
+#[cfg(feature = "zip-48")]
+use {
+    crate::data_api::{AccountBirthday, AccountSource, chain::ChainState},
+    ::transparent::keys::NonHardenedChildIndex,
+    ::transparent::zip48::{AccountPrivKey, FullViewingKey},
+    zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters},
+    zip32::AccountId,
+};
+
+/// Which kind of account to test against.
+#[derive(Clone, Copy, Debug)]
+pub enum TransparentAccountType {
+    Derived,
+    #[cfg(feature = "zip-48")]
+    Zip48,
+}
+
+/// Checks whether the transparent balance of the given account is as `expected`
 /// considering the `confirmations_policy`.
 fn check_balance<DSF>(
     st: &TestState<impl TestCache, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
-    account: &TestAccount<<DSF as DataStoreFactory>::Account>,
+    account_id: &<DSF as DataStoreFactory>::AccountId,
     taddr: &TransparentAddress,
     confirmations_policy: ConfirmationsPolicy,
     expected: &Balance,
@@ -47,7 +63,7 @@ fn check_balance<DSF>(
         .get_wallet_summary(confirmations_policy)
         .unwrap()
         .unwrap();
-    let balance = summary.account_balances().get(&account.id()).unwrap();
+    let balance = summary.account_balances().get(account_id).unwrap();
 
     #[allow(deprecated)]
     let old_unshielded_value = balance.unshielded();
@@ -58,7 +74,7 @@ fn check_balance<DSF>(
     let target_height = TargetHeight::from(st.wallet().chain_height().unwrap().unwrap() + 1);
     assert_eq!(
         st.wallet()
-            .get_transparent_balances(account.id(), target_height, confirmations_policy)
+            .get_transparent_balances(*account_id, target_height, confirmations_policy)
             .unwrap()
             .get(taddr)
             .cloned()
@@ -76,24 +92,86 @@ fn check_balance<DSF>(
     );
 }
 
-pub fn put_received_transparent_utxo<DSF>(dsf: DSF)
+/// Creates a ZIP 48 test account and returns its ID, transparent address, and birthday height.
+#[cfg(feature = "zip-48")]
+fn create_zip48_test_account<Cache, DSF: DataStoreFactory>(
+    st: &mut TestState<Cache, DSF::DataStore, LocalNetwork>,
+) -> (DSF::AccountId, TransparentAddress, BlockHeight)
+where
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let birthday = AccountBirthday::from_parts(
+        ChainState::empty(
+            st.network()
+                .activation_height(NetworkUpgrade::Sapling)
+                .unwrap()
+                - 1,
+            BlockHash([0; 32]),
+        ),
+        None,
+    );
+
+    // Create a 2-of-3 FVK from three deterministic seeds.
+    let account_id_zip32 = AccountId::ZERO;
+    let seeds: [&[u8; 32]; 3] = [&[1; 32], &[2; 32], &[3; 32]];
+    let pubkeys: Vec<_> = seeds
+        .iter()
+        .map(|seed| {
+            AccountPrivKey::from_seed(st.network(), *seed, account_id_zip32)
+                .unwrap()
+                .to_account_pubkey()
+        })
+        .collect();
+
+    let fvk = FullViewingKey::standard(2, pubkeys).unwrap();
+
+    let account = st
+        .wallet_mut()
+        .import_account_zip48_multisig("zip48-test", &fvk, &birthday)
+        .unwrap();
+
+    let account_id = account.id();
+    let (taddr, _redeem) = fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+    let birthday_height = birthday.height();
+
+    (account_id, taddr, birthday_height)
+}
+
+pub fn put_received_transparent_utxo<DSF>(dsf: DSF, account_type: TransparentAccountType)
 where
     DSF: DataStoreFactory,
     <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug + PartialEq,
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
-    let mut st = TestBuilder::new()
-        .with_data_store_factory(dsf)
-        .with_account_from_sapling_activation(BlockHash([0; 32]))
-        .build();
+    let (mut st, account_id, taddr, birthday) = match account_type {
+        TransparentAccountType::Derived => {
+            let st = TestBuilder::new()
+                .with_data_store_factory(dsf)
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
 
-    let birthday = st.test_account().unwrap().birthday().height();
-    let account_id = st.test_account().unwrap().id();
-    let uaddr = st
-        .wallet()
-        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
-        .unwrap()
-        .unwrap();
-    let taddr = uaddr.transparent().unwrap();
+            let birthday = st.test_account().unwrap().birthday().height();
+            let account_id = st.test_account().unwrap().id();
+            let uaddr = st
+                .wallet()
+                .get_last_generated_address_matching(
+                    account_id,
+                    UnifiedAddressRequest::AllAvailableKeys,
+                )
+                .unwrap()
+                .unwrap();
+            let taddr = *uaddr.transparent().unwrap();
+
+            (st, account_id, taddr, birthday)
+        }
+        #[cfg(feature = "zip-48")]
+        TransparentAccountType::Zip48 => {
+            let mut st = TestBuilder::new().with_data_store_factory(dsf).build();
+
+            let (account_id, taddr, birthday) = create_zip48_test_account::<_, DSF>(&mut st);
+            (st, account_id, taddr, birthday)
+        }
+    };
 
     let height_1 = birthday + 12345;
     st.wallet_mut().update_chain_tip(height_1).unwrap();
@@ -123,7 +201,7 @@ where
     // Confirm that we see the output unspent as of `height_1`.
     assert_matches!(
         st.wallet().get_spendable_transparent_outputs(
-            taddr,
+            &taddr,
             target_height,
             ConfirmationsPolicy::MIN
         ).as_deref(),
@@ -147,7 +225,7 @@ where
     // Confirm that we no longer see any unspent outputs as of `height_1`.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, target_height, ConfirmationsPolicy::MIN)
+            .get_spendable_transparent_outputs(&taddr, target_height, ConfirmationsPolicy::MIN)
             .as_deref(),
         Ok(&[])
     );
@@ -162,7 +240,7 @@ where
     // If we include `height_2` then the output is returned.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN)
+            .get_spendable_transparent_outputs(&taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN)
             .as_deref(),
         Ok([ret]) if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_2))
     );
@@ -173,7 +251,7 @@ where
             TargetHeight::from(height_2 + 1),
             ConfirmationsPolicy::MIN
         ),
-        Ok(h) if h.get(taddr).map(|(_, b)| b.spendable_value()) == Some(value)
+        Ok(h) if h.get(&taddr).map(|(_, b)| b.spendable_value()) == Some(value)
     );
 }
 
@@ -208,7 +286,7 @@ where
     // The wallet starts out with zero balance.
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &Balance::ZERO,
@@ -233,7 +311,7 @@ where
 
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &zero_or_one_conf_value,
@@ -263,7 +341,7 @@ where
     // transaction can be mined.
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &Balance::ZERO,
@@ -276,7 +354,7 @@ where
     // The wallet should still have zero transparent balance.
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &Balance::ZERO,
@@ -291,7 +369,7 @@ where
     // The wallet should still have zero transparent balance.
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &Balance::ZERO,
@@ -308,7 +386,7 @@ where
 
     check_balance::<DSF>(
         &st,
-        &account,
+        &account.id(),
         taddr,
         ConfirmationsPolicy::MIN,
         &zero_or_one_conf_value,
@@ -318,23 +396,46 @@ where
 /// This test attempts to verify that transparent funds spendability is
 /// accounted for properly given the different minimum confirmations values
 /// that can be set when querying for balances.
-pub fn transparent_balance_spendability<DSF>(dsf: DSF, cache: impl TestCache)
-where
+pub fn transparent_balance_spendability<DSF>(
+    dsf: DSF,
+    cache: impl TestCache,
+    account_type: TransparentAccountType,
+) where
     DSF: DataStoreFactory,
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
-    let mut st = TestBuilder::new()
-        .with_data_store_factory(dsf)
-        .with_block_cache(cache)
-        .with_account_from_sapling_activation(BlockHash([0; 32]))
-        .build();
+    let (mut st, account_id, taddr) = match account_type {
+        TransparentAccountType::Derived => {
+            let st = TestBuilder::new()
+                .with_data_store_factory(dsf)
+                .with_block_cache(cache)
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
 
-    let account = st.test_account().cloned().unwrap();
-    let uaddr = st
-        .wallet()
-        .get_last_generated_address_matching(account.id(), UnifiedAddressRequest::AllAvailableKeys)
-        .unwrap()
-        .unwrap();
-    let taddr = uaddr.transparent().unwrap();
+            let account = st.test_account().cloned().unwrap();
+            let uaddr = st
+                .wallet()
+                .get_last_generated_address_matching(
+                    account.id(),
+                    UnifiedAddressRequest::AllAvailableKeys,
+                )
+                .unwrap()
+                .unwrap();
+            let taddr = *uaddr.transparent().unwrap();
+
+            (st, account.id(), taddr)
+        }
+        #[cfg(feature = "zip-48")]
+        TransparentAccountType::Zip48 => {
+            let mut st = TestBuilder::new()
+                .with_data_store_factory(dsf)
+                .with_block_cache(cache)
+                .build();
+
+            let (account_id, taddr, _birthday) = create_zip48_test_account::<_, DSF>(&mut st);
+            (st, account_id, taddr)
+        }
+    };
 
     // Initialize the wallet with chain data that has no shielded notes for us.
     let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
@@ -349,8 +450,8 @@ where
     // The wallet starts out with zero balance.
     check_balance::<DSF>(
         &st as &TestState<_, DSF::DataStore, _>,
-        &account,
-        taddr,
+        &account_id,
+        &taddr,
         ConfirmationsPolicy::MIN,
         &Balance::ZERO,
     );
@@ -374,8 +475,8 @@ where
 
     check_balance::<DSF>(
         &st,
-        &account,
-        taddr,
+        &account_id,
+        &taddr,
         ConfirmationsPolicy::MIN,
         &zero_or_one_conf_value,
     );
@@ -390,8 +491,8 @@ where
 
     check_balance::<DSF>(
         &st,
-        &account,
-        taddr,
+        &account_id,
+        &taddr,
         ConfirmationsPolicy::new_symmetrical_unchecked(2, false),
         &not_confirmed_yet_value,
     );
@@ -409,14 +510,14 @@ where
 
     check_balance::<DSF>(
         &st,
-        &account,
-        taddr,
+        &account_id,
+        &taddr,
         ConfirmationsPolicy::new_symmetrical_unchecked(2, true),
         &zero_or_one_conf_value,
     );
 }
 
-pub fn gap_limits<DSF>(ds_factory: DSF, cache: impl TestCache, gap_limits: GapLimits)
+pub fn zip32_gap_limits<DSF>(ds_factory: DSF, cache: impl TestCache, gap_limits: GapLimits)
 where
     DSF: DataStoreFactory,
     <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
@@ -533,4 +634,76 @@ where
     // sent to any of the set of {addresses in the gap limit range | address prior to the gap}.
     let query_height = st.wallet().utxo_query_height(account_uuid).unwrap();
     assert_eq!(query_height, h0);
+}
+
+/// Tests that a ZIP 48 multisig account can be imported and its properties are correct.
+#[cfg(feature = "zip-48")]
+pub fn import_account_zip48_multisig<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug + PartialEq,
+    <DSF as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new().with_data_store_factory(dsf).build();
+
+    let birthday = AccountBirthday::from_parts(
+        ChainState::empty(
+            st.network()
+                .activation_height(NetworkUpgrade::Sapling)
+                .unwrap()
+                - 1,
+            BlockHash([0; 32]),
+        ),
+        None,
+    );
+
+    // Create a 2-of-3 FVK from three deterministic seeds.
+    let account_id_zip32 = AccountId::ZERO;
+    let seeds: [&[u8; 32]; 3] = [&[1; 32], &[2; 32], &[3; 32]];
+    let pubkeys: Vec<_> = seeds
+        .iter()
+        .map(|seed| {
+            AccountPrivKey::from_seed(st.network(), *seed, account_id_zip32)
+                .unwrap()
+                .to_account_pubkey()
+        })
+        .collect();
+
+    let fvk = FullViewingKey::standard(2, pubkeys).unwrap();
+
+    // Import succeeds.
+    let account = st
+        .wallet_mut()
+        .import_account_zip48_multisig("zip48-test", &fvk, &birthday)
+        .unwrap();
+
+    let account_id = account.id();
+
+    // Account source is Zip48.
+    assert_matches!(account.source(), AccountSource::Zip48);
+
+    // Derive the first external address from the FVK and verify it's a P2SH address.
+    let (expected_taddr, _redeem) =
+        fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+
+    // Can receive UTXOs at the P2SH address.
+    let height = birthday.height() + 12345;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+
+    let value = Zatoshis::const_from_u64(50000);
+    let outpoint = OutPoint::fake();
+    let txout = TxOut::new(value, expected_taddr.script().into());
+    let utxo = WalletTransparentOutput::from_parts(outpoint, txout, Some(height)).unwrap();
+    let res = st.wallet_mut().put_received_transparent_utxo(&utxo);
+    assert_matches!(res, Ok(_));
+
+    // Balance tracking works after UTXO receipt.
+    assert_matches!(
+        st.wallet().get_transparent_balances(
+            account_id,
+            TargetHeight::from(height + 1),
+            ConfirmationsPolicy::MIN
+        ),
+        Ok(h) if h.get(&expected_taddr).map(|(_, b)| b.spendable_value()) == Some(value)
+    );
 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1338,6 +1338,10 @@ where
                         .expect("spending key derivation should not fail"),
                     #[cfg(feature = "transparent-key-import")]
                     TransparentAddressSource::Standalone(pubkey) => *pubkey,
+                    #[cfg(feature = "zip-48")]
+                    TransparentAddressSource::Zip48 { .. } => {
+                        return Err(Error::ProposalNotSupported);
+                    }
                 };
 
                 utxos_spent.push(outpoint.clone());
@@ -1706,6 +1710,10 @@ where
                 .standalone_transparent_keys
                 .get(&_address)
                 .ok_or(Error::AddressNotRecognized(_address))?,
+            #[cfg(feature = "zip-48")]
+            TransparentAddressSource::Zip48 { .. } => {
+                return Err(Error::ProposalNotSupported);
+            }
         });
     }
     let sapling_extsks = &[
@@ -2078,6 +2086,8 @@ where
                                 } => Some((index, *scope, *address_index)),
                                 #[cfg(feature = "transparent-key-import")]
                                 TransparentAddressSource::Standalone(_) => None,
+                                #[cfg(feature = "zip-48")]
+                                TransparentAddressSource::Zip48 { .. } => None,
                             })
                     })
                     .collect::<Vec<_>>();

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -17,6 +17,8 @@ use zcash_protocol::{
     consensus::{BlockHeight, TxIndex},
     value::{BalanceError, Zatoshis},
 };
+#[cfg(feature = "zip-48")]
+use zcash_script::script;
 use zip32::Scope;
 
 use crate::fees::sapling as sapling_fees;
@@ -778,6 +780,30 @@ impl TransparentAddressMetadata {
         }
     }
 
+    /// Returns a [`TransparentAddressMetadata`] for a ZIP 48 transparent multisig address derived
+    /// from a [`::transparent::zip48::FullViewingKey`].
+    ///
+    /// The `scope`, `address_index`, and `redeem_script` should be the values used when
+    /// calling [`::transparent::zip48::FullViewingKey::derive_address`].
+    #[cfg(feature = "zip-48")]
+    pub fn zip48_multisig(
+        scope: TransparentKeyScope,
+        address_index: NonHardenedChildIndex,
+        redeem_script: script::Redeem,
+        exposure: Exposure,
+        next_check_time: Option<SystemTime>,
+    ) -> Self {
+        Self {
+            source: TransparentAddressSource::Zip48 {
+                scope,
+                address_index,
+                redeem_script,
+            },
+            exposure,
+            next_check_time,
+        }
+    }
+
     /// Returns the source metadata for the address.
     pub fn source(&self) -> &TransparentAddressSource {
         &self.source
@@ -825,6 +851,13 @@ impl TransparentAddressMetadata {
     pub fn address_index(&self) -> Option<NonHardenedChildIndex> {
         self.source.address_index()
     }
+
+    /// Returns the redeem script for the address, if this is a P2SH address.
+    /// Returns `None` for non-P2SH addresses.
+    #[cfg(feature = "zip-48")]
+    pub fn redeem_script(&self) -> Option<&script::Redeem> {
+        self.source.redeem_script()
+    }
 }
 
 /// Source information for a transparent address.
@@ -842,6 +875,14 @@ pub enum TransparentAddressSource {
     /// This variant provides the public key directly.
     #[cfg(feature = "transparent-key-import")]
     Standalone(secp256k1::PublicKey),
+    /// ZIP 48 transparent multisig derivation information for the address below account
+    /// pubkey level, i.e. the `change` and `index` elements of the path.
+    #[cfg(feature = "zip-48")]
+    Zip48 {
+        scope: TransparentKeyScope,
+        address_index: NonHardenedChildIndex,
+        redeem_script: script::Redeem,
+    },
 }
 
 #[cfg(feature = "transparent-inputs")]
@@ -853,6 +894,8 @@ impl TransparentAddressSource {
             TransparentAddressSource::Derived { scope, .. } => Some(*scope),
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::Standalone(_) => None,
+            #[cfg(feature = "zip-48")]
+            TransparentAddressSource::Zip48 { scope, .. } => Some(*scope),
         }
     }
 
@@ -863,6 +906,21 @@ impl TransparentAddressSource {
             TransparentAddressSource::Derived { address_index, .. } => Some(*address_index),
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::Standalone(_) => None,
+            #[cfg(feature = "zip-48")]
+            TransparentAddressSource::Zip48 { address_index, .. } => Some(*address_index),
+        }
+    }
+
+    /// Returns the redeem script for the address, if this is a P2SH address.
+    /// Returns `None` for non-P2SH addresses.
+    #[cfg(feature = "zip-48")]
+    pub fn redeem_script(&self) -> Option<&script::Redeem> {
+        match self {
+            TransparentAddressSource::Derived { .. } => None,
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::Standalone(_) => None,
+            #[cfg(feature = "zip-48")]
+            TransparentAddressSource::Zip48 { redeem_script, .. } => Some(redeem_script),
         }
     }
 }

--- a/zcash_client_memory/Cargo.toml
+++ b/zcash_client_memory/Cargo.toml
@@ -125,6 +125,9 @@ zcashd-compat = ["zcash_keys/zcashd-compat", "zcash_client_backend/zcashd-compat
 ## Enables the prospective ZIP 233 (Network Sustainability Mechanism) feature.
 zip-233 = ["zcash_primitives/zip-233"]
 
+## Enables support for ZIP 48 transparent P2SH multisig accounts.
+zip-48 = ["transparent-inputs", "zcash_client_backend/zip-48"]
+
 [build-dependencies]
 prost-build.workspace = true
 which.workspace = true

--- a/zcash_client_memory/src/testing/transparent.rs
+++ b/zcash_client_memory/src/testing/transparent.rs
@@ -5,6 +5,7 @@ use crate::testing::{MemBlockCache, TestMemDbFactory};
 fn put_received_transparent_utxo() {
     zcash_client_backend::data_api::testing::transparent::put_received_transparent_utxo(
         TestMemDbFactory::new(),
+        zcash_client_backend::data_api::testing::transparent::TransparentAccountType::Derived,
     );
 }
 

--- a/zcash_client_memory/src/types/account.rs
+++ b/zcash_client_memory/src/types/account.rs
@@ -587,6 +587,8 @@ mod serialization {
                 kind: match acc.kind {
                     AccountSource::Derived { .. } => 0,
                     AccountSource::Imported { .. } => 1,
+                    #[cfg(feature = "zip-48")]
+                    AccountSource::Zip48 => 2,
                 },
                 seed_fingerprint: match acc.kind {
                     AccountSource::Derived { ref derivation, .. } => {
@@ -598,6 +600,8 @@ mod serialization {
                             .map(|d| d.seed_fingerprint().to_bytes().to_vec()),
                         AccountPurpose::ViewOnly => None,
                     },
+                    #[cfg(feature = "zip-48")]
+                    AccountSource::Zip48 => None,
                 },
                 account_index: match acc.kind {
                     AccountSource::Derived { ref derivation, .. } => {
@@ -609,6 +613,8 @@ mod serialization {
                         }
                         AccountPurpose::ViewOnly => None,
                     },
+                    #[cfg(feature = "zip-48")]
+                    AccountSource::Zip48 => None,
                 },
                 purpose: match acc.kind {
                     AccountSource::Derived { .. } => None,
@@ -616,10 +622,14 @@ mod serialization {
                         AccountPurpose::Spending { .. } => Some(0),
                         AccountPurpose::ViewOnly => Some(1),
                     },
+                    #[cfg(feature = "zip-48")]
+                    AccountSource::Zip48 => Some(1),
                 },
                 key_source: match acc.kind {
                     AccountSource::Derived { ref key_source, .. } => key_source,
                     AccountSource::Imported { ref key_source, .. } => key_source,
+                    #[cfg(feature = "zip-48")]
+                    AccountSource::Zip48 => &None,
                 }
                 .clone(),
                 viewing_key: acc.viewing_key.encode(&EncodingParams),

--- a/zcash_client_memory/src/wallet_read.rs
+++ b/zcash_client_memory/src/wallet_read.rs
@@ -81,6 +81,8 @@ impl<P: consensus::Parameters> WalletRead for MemoryWalletDb<P> {
                     }
                 }
                 AccountSource::Imported { purpose: _, .. } => None,
+                #[cfg(feature = "zip-48")]
+                AccountSource::Zip48 => None,
             }))
     }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -25,11 +25,12 @@ workspace.
 - `impl zcash_keys::keys::transparent::gap_limits::AddressStore for WalletDb`
   (behind the `transparent-inputs` feature flag)
 - `zcash_client_sqlite::AccountRef` is now public.
-- Add `zip-48` feature gates to prevent build errors
+- `impl zcash_client_backend::data_api::WalletWrite::import_account_zip48_multisig()`
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`.
 - `zcash_client_sqlite::error::SqliteClientError` has added variant `GapAddresses`.
+- Allow UIVK to be NULL iff have ZIP 48 FVK in `zcash_client_sqlite::wallet::db::TABLE_ACCOUNTS`
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -26,6 +26,8 @@ workspace.
   (behind the `transparent-inputs` feature flag)
 - `zcash_client_sqlite::AccountRef` is now public.
 - `impl zcash_client_backend::data_api::WalletWrite::import_account_zip48_multisig()`
+- `impl zcash_client_backend::data_api::WalletWrite::get_next_zip48_multisig_address()`
+- `impl zcash_client_backend::data_api::WalletWrite::get_zip48_multisig_address_for_index()`
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -25,6 +25,7 @@ workspace.
 - `impl zcash_keys::keys::transparent::gap_limits::AddressStore for WalletDb`
   (behind the `transparent-inputs` feature flag)
 - `zcash_client_sqlite::AccountRef` is now public.
+- Add `zip-48` feature gates to prevent build errors
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -157,6 +157,12 @@ zcashd-compat = [
 ## Enables `serde` derives for certain types.
 serde = ["dep:serde", "uuid/serde"]
 
+## Enables support for ZIP 48 transparent multisig accounts.
+zip-48 = [
+  "transparent-inputs",
+  "zcash_client_backend/zip-48"
+]
+
 #! ### Experimental features
 
 ## Exposes unstable APIs. Their behaviour may change at any time.

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -31,6 +31,9 @@ use {
     },
 };
 
+#[cfg(feature = "zip-48")]
+use transparent::zip48;
+
 /// The primary error type for the SQLite wallet backend.
 #[derive(Debug)]
 pub enum SqliteClientError {
@@ -175,6 +178,14 @@ pub enum SqliteClientError {
     /// imported to a different account.
     #[cfg(feature = "transparent-key-import")]
     PubkeyImportConflict(Uuid),
+
+    /// The requested operation is not supported for ZIP 48 multisig accounts.
+    #[cfg(feature = "zip-48")]
+    Zip48UnsupportedOperation,
+
+    /// An error occurred parsing or deriving a ZIP 48 full viewing key.
+    #[cfg(feature = "zip-48")]
+    Zip48Fvk(zip48::FullViewingKeyError),
 }
 
 impl error::Error for SqliteClientError {
@@ -340,6 +351,12 @@ impl fmt::Display for SqliteClientError {
                     "The given transparent pubkey is already managed by account {uuid}"
                 )
             }
+            #[cfg(feature = "zip-48")]
+            SqliteClientError::Zip48UnsupportedOperation => {
+                write!(f, "Operation not supported for ZIP 48 multisig accounts.")
+            }
+            #[cfg(feature = "zip-48")]
+            SqliteClientError::Zip48Fvk(e) => write!(f, "ZIP 48 FVK error: {e:?}"),
         }
     }
 }
@@ -409,6 +426,13 @@ impl From<AddressGenerationError> for SqliteClientError {
 impl From<SchedulingError> for SqliteClientError {
     fn from(value: SchedulingError) -> Self {
         SqliteClientError::Scheduling(value)
+    }
+}
+
+#[cfg(feature = "zip-48")]
+impl From<::transparent::zip48::FullViewingKeyError> for SqliteClientError {
+    fn from(e: ::transparent::zip48::FullViewingKeyError) -> Self {
+        SqliteClientError::Zip48Fvk(e)
     }
 }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1299,6 +1299,26 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         })
     }
 
+    #[cfg(feature = "zip-48")]
+    fn import_account_zip48_multisig(
+        &mut self,
+        name: &str,
+        fvk: &transparent::zip48::FullViewingKey,
+        birthday: &AccountBirthday,
+    ) -> Result<Self::Account, Self::Error> {
+        self.transactionally(|wdb| {
+            wallet::add_account(
+                wdb.conn.0,
+                &wdb.params,
+                name,
+                &AccountSource::Zip48,
+                wallet::ViewingKey::Zip48Full(Box::new(fvk.clone())),
+                birthday,
+                &wdb.gap_limits,
+            )
+        })
+    }
+
     fn delete_account(&mut self, account_uuid: Self::AccountId) -> Result<(), Self::Error> {
         self.transactionally(|wdb| wallet::delete_account(wdb.conn.0, account_uuid))
     }
@@ -1340,6 +1360,11 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
     ) -> Result<Option<UnifiedAddress>, Self::Error> {
         if let Some(account) = self.get_account(account)? {
             use zcash_keys::keys::AddressGenerationError::*;
+
+            #[cfg(feature = "zip-48")]
+            if matches!(account.source(), AccountSource::Zip48) {
+                return Err(SqliteClientError::Zip48UnsupportedOperation);
+            }
 
             match account.uivk().address(diversifier_index, request) {
                 Ok(address) => {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1391,6 +1391,41 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         }
     }
 
+    #[cfg(feature = "zip-48")]
+    fn get_next_zip48_multisig_address(
+        &mut self,
+        account: Self::AccountId,
+        scope: zip32::Scope,
+    ) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        self.transactionally(|wdb| {
+            wallet::get_next_available_zip48_multisig_address(
+                wdb.conn.0,
+                &wdb.params,
+                &wdb.gap_limits,
+                account,
+                scope,
+            )
+        })
+    }
+
+    #[cfg(feature = "zip-48")]
+    fn get_zip48_multisig_address_for_index(
+        &mut self,
+        account: Self::AccountId,
+        scope: zip32::Scope,
+        address_index: NonHardenedChildIndex,
+    ) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        self.transactionally(|wdb| {
+            wallet::get_zip48_multisig_address_for_index(
+                wdb.conn.0,
+                &wdb.params,
+                account,
+                scope,
+                address_index,
+            )
+        })
+    }
+
     fn update_chain_tip(&mut self, tip_height: BlockHeight) -> Result<(), Self::Error> {
         self.transactionally(|wdb| {
             wallet::scanning::update_chain_tip(wdb.conn.0, &wdb.params, tip_height)?;

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -86,7 +86,11 @@ use uuid::Uuid;
 
 use zcash_address::ZcashAddress;
 
-use ::transparent::zip48;
+#[cfg(feature = "zip-48")]
+use {
+    ::transparent::{address::TransparentAddress, zip48},
+    zcash_client_backend::wallet::TransparentAddressMetadata,
+};
 
 use zcash_client_backend::{
     DecryptedOutput,
@@ -4601,6 +4605,147 @@ pub mod testing {
 
         Ok(results)
     }
+}
+
+/// Derives and persists the next available address for a ZIP 48 transparent multisig account.
+///
+/// If there are pre-generated unexposed addresses, returns the first unexposed one.
+/// Otherwise, derives a new address at the next index.
+#[cfg(feature = "zip-48")]
+pub(crate) fn get_next_available_zip48_multisig_address<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction<'_>,
+    params: &P,
+    gap_limits: &GapLimits,
+    account_uuid: AccountUuid,
+    scope: zip32::Scope,
+) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, SqliteClientError> {
+    use ::transparent::keys::TransparentKeyScope;
+    use zcash_client_backend::wallet::{Exposure, GapMetadata};
+    use zcash_keys::keys::ReceiverRequirement::*;
+    use zcash_keys::keys::UnifiedAddressRequest;
+
+    let account =
+        get_account(conn, params, account_uuid)?.ok_or(SqliteClientError::AccountUnknown)?;
+
+    // Get the ZIP 48 FVK
+    let fvk_bytes = transparent::get_zip48_fvk(conn, account.id)?;
+    let fvk_bytes = match fvk_bytes {
+        Some(bytes) => bytes,
+        None => return Ok(None),
+    };
+
+    let fvk = zip48::FullViewingKey::parse_multipath_descriptor(&fvk_bytes, params)?;
+
+    let t_scope = TransparentKeyScope::from(scope);
+
+    // Ensure that we have pre-generated as many addresses as we can within the gap.
+    transparent::generate_gap_addresses(
+        conn,
+        params,
+        gap_limits,
+        account.id,
+        t_scope,
+        UnifiedAddressRequest::unsafe_custom(Allow, Allow, Require),
+        true,
+    )?;
+
+    // First, try to find an unexposed pre-generated address
+    let address_index = if let Some(unexposed_index) =
+        transparent::get_first_unexposed_zip48_multisig_address_index(conn, account.id, t_scope)?
+    {
+        unexposed_index
+    } else {
+        // No unexposed addresses, derive a new one
+        transparent::get_next_zip48_multisig_address_index(conn, account.id, t_scope)?
+    };
+
+    let chain_tip = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
+
+    // Derive the address and redeem script
+    let (address, redeem_script) = fvk.derive_address(scope, address_index);
+
+    // Insert/update the address in the database (this marks it as exposed at chain_tip)
+    transparent::insert_zip48_multisig_address(
+        conn,
+        params,
+        account.id,
+        t_scope,
+        address_index,
+        &address,
+        &redeem_script,
+        Some(chain_tip),
+    )?;
+
+    Ok(Some((
+        address,
+        TransparentAddressMetadata::zip48_multisig(
+            t_scope,
+            address_index,
+            redeem_script,
+            Exposure::Exposed {
+                at_height: chain_tip,
+                gap_metadata: GapMetadata::DerivationUnknown,
+            },
+            None,
+        ),
+    )))
+}
+
+/// Derives and persists an address at a specific index for a ZIP 48 transparent multisig account.
+#[cfg(feature = "zip-48")]
+pub(crate) fn get_zip48_multisig_address_for_index<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction<'_>,
+    params: &P,
+    account_uuid: AccountUuid,
+    scope: zip32::Scope,
+    address_index: ::transparent::keys::NonHardenedChildIndex,
+) -> Result<Option<(TransparentAddress, TransparentAddressMetadata)>, SqliteClientError> {
+    use ::transparent::keys::TransparentKeyScope;
+    use zcash_client_backend::wallet::{Exposure, GapMetadata};
+
+    let account =
+        get_account(conn, params, account_uuid)?.ok_or(SqliteClientError::AccountUnknown)?;
+
+    // Get the ZIP 48 FVK
+    let fvk_bytes = transparent::get_zip48_fvk(conn, account.id)?;
+    let fvk_bytes = match fvk_bytes {
+        Some(bytes) => bytes,
+        None => return Ok(None), // Not a multisig account
+    };
+
+    let fvk = zip48::FullViewingKey::parse_multipath_descriptor(&fvk_bytes, params)?;
+
+    let chain_tip = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
+
+    // Derive the address and redeem script
+    let (address, redeem_script) = fvk.derive_address(scope, address_index);
+
+    // Insert the address into the database (marks it as exposed at chain_tip)
+    let t_scope = TransparentKeyScope::from(scope);
+    transparent::insert_zip48_multisig_address(
+        conn,
+        params,
+        account.id,
+        t_scope,
+        address_index,
+        &address,
+        &redeem_script,
+        Some(chain_tip),
+    )?;
+
+    Ok(Some((
+        address,
+        TransparentAddressMetadata::zip48_multisig(
+            t_scope,
+            address_index,
+            redeem_script,
+            Exposure::Exposed {
+                at_height: chain_tip,
+                gap_metadata: GapMetadata::DerivationUnknown,
+            },
+            None,
+        ),
+    )))
 }
 
 #[cfg(test)]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -85,6 +85,9 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use zcash_address::ZcashAddress;
+
+use ::transparent::zip48;
+
 use zcash_client_backend::{
     DecryptedOutput,
     data_api::{
@@ -219,8 +222,14 @@ fn parse_account_source(
             },
             key_source,
         }),
+        #[cfg(feature = "zip-48")]
+        (2, None) => Ok(AccountSource::Zip48),
         (0, None) => Err(SqliteClientError::CorruptedData(
             "Wallet DB account_kind constraint violated".to_string(),
+        )),
+        #[cfg(feature = "zip-48")]
+        (2, Some(_)) => Err(SqliteClientError::CorruptedData(
+            "ZIP 48 multisig accounts should not have HD derivation info".to_string(),
         )),
         (_, _) => Err(SqliteClientError::CorruptedData(
             "Unrecognized account_kind".to_string(),
@@ -242,6 +251,13 @@ pub(crate) enum ViewingKey {
     /// Accounts that have this kind of viewing key cannot be used in wallet contexts,
     /// because they are unable to maintain an accurate balance.
     Incoming(Box<UnifiedIncomingViewingKey>),
+
+    /// A ZIP 48 transparent multisig full viewing key.
+    ///
+    /// These accounts only support transparent P2SH multisig addresses and do not have
+    /// unified viewing keys.
+    #[cfg(feature = "zip-48")]
+    Zip48Full(Box<zip48::FullViewingKey>),
 }
 
 /// An account stored in a `zcash_client_sqlite` database.
@@ -306,6 +322,8 @@ impl ViewingKey {
         match self {
             ViewingKey::Full(ufvk) => Some(ufvk),
             ViewingKey::Incoming(_) => None,
+            #[cfg(feature = "zip-48")]
+            ViewingKey::Zip48Full(_) => None,
         }
     }
 
@@ -313,6 +331,19 @@ impl ViewingKey {
         match self {
             ViewingKey::Full(ufvk) => ufvk.as_ref().to_unified_incoming_viewing_key(),
             ViewingKey::Incoming(uivk) => uivk.as_ref().clone(),
+            #[cfg(feature = "zip-48")]
+            ViewingKey::Zip48Full(_) => {
+                unreachable!("ZIP 48 multisig accounts do not have a unified incoming viewing key")
+            }
+        }
+    }
+
+    /// Returns the serialized ZIP 48 full viewing key bytes if this is a multisig account.
+    #[cfg(feature = "zip-48")]
+    fn zip48_fvk_bytes<P: consensus::Parameters>(&self, params: &P) -> Option<Vec<u8>> {
+        match self {
+            ViewingKey::Zip48Full(fvk) => Some(fvk.multipath_descriptor(params).into_bytes()),
+            _ => None,
         }
     }
 }
@@ -409,6 +440,23 @@ pub(crate) fn add_account<P: consensus::Parameters>(
             return Err(SqliteClientError::AccountCollision(existing_account.id()));
         }
     }
+
+    // Check whether a ZIP 48 multisig account with the same FVK already exists.
+    #[cfg(feature = "zip-48")]
+    if let Some(fvk_bytes) = viewing_key.zip48_fvk_bytes(params) {
+        if let Some(existing_uuid) = conn
+            .query_row(
+                "SELECT uuid FROM accounts WHERE zip48_fvk = :zip48_fvk",
+                named_params![":zip48_fvk": fvk_bytes],
+                |row| Ok(AccountUuid(row.get(0)?)),
+            )
+            .optional()
+            .map_err(SqliteClientError::from)?
+        {
+            return Err(SqliteClientError::AccountCollision(existing_uuid));
+        }
+    }
+
     // TODO(#1490): check for IVK collisions.
 
     let account_uuid = AccountUuid(Uuid::new_v4());
@@ -461,6 +509,20 @@ pub(crate) fn add_account<P: consensus::Parameters>(
     let zcashd_legacy_address_index: i64 = LEGACY_ADDRESS_INDEX_NULL;
 
     let ufvk_encoded = viewing_key.ufvk().map(|ufvk| ufvk.encode(params));
+
+    // For ZIP 48 multisig accounts, uivk is NULL (they have no unified IVK).
+    #[cfg(feature = "zip-48")]
+    let (uivk_encoded, zip48_fvk_bytes): (Option<String>, Option<Vec<u8>>) =
+        if let Some(fvk_bytes) = viewing_key.zip48_fvk_bytes(params) {
+            (None, Some(fvk_bytes))
+        } else {
+            (Some(viewing_key.uivk().encode(params)), None)
+        };
+    #[cfg(not(feature = "zip-48"))]
+    let uivk_encoded: Option<String> = Some(viewing_key.uivk().encode(params));
+    #[cfg(not(feature = "zip-48"))]
+    let zip48_fvk_bytes: Option<Vec<u8>> = None;
+
     let account_id = conn
         .query_row(
             r#"
@@ -474,7 +536,8 @@ pub(crate) fn add_account<P: consensus::Parameters>(
                 orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
                 birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
                 recover_until_height,
-                has_spend_key
+                has_spend_key,
+                zip48_fvk
             )
             VALUES (
                 :account_name,
@@ -486,7 +549,8 @@ pub(crate) fn add_account<P: consensus::Parameters>(
                 :orchard_fvk_item_cache, :sapling_fvk_item_cache, :p2pkh_fvk_item_cache,
                 :birthday_height, :birthday_sapling_tree_size, :birthday_orchard_tree_size,
                 :recover_until_height,
-                :has_spend_key
+                :has_spend_key,
+                :zip48_fvk
             )
             RETURNING id
             "#,
@@ -499,7 +563,7 @@ pub(crate) fn add_account<P: consensus::Parameters>(
                 ":zcashd_legacy_address_index": zcashd_legacy_address_index,
                 ":key_source": key_source,
                 ":ufvk": ufvk_encoded,
-                ":uivk": viewing_key.uivk().encode(params),
+                ":uivk": uivk_encoded,
                 ":orchard_fvk_item_cache": orchard_item,
                 ":sapling_fvk_item_cache": sapling_item,
                 ":p2pkh_fvk_item_cache": transparent_item,
@@ -508,6 +572,7 @@ pub(crate) fn add_account<P: consensus::Parameters>(
                 ":birthday_orchard_tree_size": birthday_orchard_tree_size,
                 ":recover_until_height": birthday.recover_until().map(u32::from),
                 ":has_spend_key": spending_key_available as i64,
+                ":zip48_fvk": zip48_fvk_bytes,
             ],
             |row| row.get(0).map(AccountRef),
         )
@@ -634,52 +699,76 @@ pub(crate) fn add_account<P: consensus::Parameters>(
         )?;
     }
 
-    // Always derive the default Unified Address for the account. If the account's viewing
-    // key has fewer components than the wallet supports (most likely due to this being an
-    // imported viewing key), derive an address containing the common subset of receivers.
-    let (address, d_idx) = account.default_address(UnifiedAddressRequest::AllAvailableKeys)?;
-    upsert_address(
-        conn,
-        params,
-        account_id,
-        d_idx,
-        &address,
-        Some(birthday.height()),
-        false,
-    )?;
+    // ZIP 48 multisig accounts use their own address derivation mechanism and don't have
+    // unified addresses, so we skip the standard address generation for them.
+    #[cfg(feature = "zip-48")]
+    let is_zip48_multisig = matches!(account.viewing_key, ViewingKey::Zip48Full(_));
+    #[cfg(not(feature = "zip-48"))]
+    let is_zip48_multisig = false;
 
-    // Pre-generate external transparent addresses prior to the index of the default address.
-    #[cfg(feature = "transparent-inputs")]
-    if let Ok(default_addr_idx) = NonHardenedChildIndex::try_from(d_idx) {
-        transparent::generate_address_range(
+    if !is_zip48_multisig {
+        // Always derive the default Unified Address for the account. If the account's viewing
+        // key has fewer components than the wallet supports (most likely due to this being an
+        // imported viewing key), derive an address containing the common subset of receivers.
+        let (address, d_idx) = account.default_address(UnifiedAddressRequest::AllAvailableKeys)?;
+        upsert_address(
             conn,
             params,
             account_id,
-            TransparentKeyScope::EXTERNAL,
-            UnifiedAddressRequest::ALLOW_ALL,
-            NonHardenedChildIndex::const_from_index(0)..default_addr_idx,
-            false,
-        )?
-    }
-
-    // Pre-generate transparent addresses up to the gap limits for the external, internal,
-    // and ephemeral key scopes.
-    #[cfg(feature = "transparent-inputs")]
-    for key_scope in [
-        TransparentKeyScope::EXTERNAL,
-        TransparentKeyScope::INTERNAL,
-        TransparentKeyScope::EPHEMERAL,
-    ] {
-        use ReceiverRequirement::*;
-        transparent::generate_gap_addresses(
-            conn,
-            params,
-            gap_limits,
-            account_id,
-            key_scope,
-            UnifiedAddressRequest::unsafe_custom(Allow, Allow, Require),
+            d_idx,
+            &address,
+            Some(birthday.height()),
             false,
         )?;
+
+        // Pre-generate external transparent addresses prior to the index of the default address.
+        #[cfg(feature = "transparent-inputs")]
+        if let Ok(default_addr_idx) = NonHardenedChildIndex::try_from(d_idx) {
+            transparent::generate_address_range(
+                conn,
+                params,
+                account_id,
+                TransparentKeyScope::EXTERNAL,
+                UnifiedAddressRequest::ALLOW_ALL,
+                NonHardenedChildIndex::const_from_index(0)..default_addr_idx,
+                false,
+            )?
+        }
+
+        // Pre-generate transparent addresses up to the gap limits for the external, internal,
+        // and ephemeral key scopes.
+        #[cfg(feature = "transparent-inputs")]
+        for key_scope in [
+            TransparentKeyScope::EXTERNAL,
+            TransparentKeyScope::INTERNAL,
+            TransparentKeyScope::EPHEMERAL,
+        ] {
+            use ReceiverRequirement::*;
+            transparent::generate_gap_addresses(
+                conn,
+                params,
+                gap_limits,
+                account_id,
+                key_scope,
+                UnifiedAddressRequest::unsafe_custom(Allow, Allow, Require),
+                false,
+            )?;
+        }
+    } else {
+        // For ZIP 48 multisig accounts, pre-generate transparent addresses up to the gap limit
+        // for EXTERNAL and INTERNAL scopes (EPHEMERAL is not applicable to ZIP 48)
+        #[cfg(feature = "zip-48")]
+        for key_scope in [TransparentKeyScope::EXTERNAL, TransparentKeyScope::INTERNAL] {
+            transparent::generate_gap_addresses(
+                conn,
+                params,
+                gap_limits,
+                account_id,
+                key_scope,
+                UnifiedAddressRequest::ALLOW_ALL,
+                false,
+            )?;
+        }
     }
 
     Ok(account)
@@ -846,6 +935,11 @@ pub(crate) fn get_next_available_address<P: consensus::Parameters, C: Clock>(
             return Ok(None);
         }
     };
+
+    #[cfg(feature = "zip-48")]
+    if matches!(account.viewing_key, ViewingKey::Zip48Full(_)) {
+        return Err(SqliteClientError::Zip48UnsupportedOperation);
+    }
 
     // This will also ensure that the provided request can be satisfied by the account's UIVK
     let requirements = account.uivk().receiver_requirements(request)?;
@@ -1031,6 +1125,11 @@ pub(crate) fn get_last_generated_address_matching<P: consensus::Parameters>(
 ) -> Result<Option<(UnifiedAddress, DiversifierIndex)>, SqliteClientError> {
     let account: Account =
         get_account(conn, params, account_uuid)?.ok_or(SqliteClientError::AccountUnknown)?;
+
+    #[cfg(feature = "zip-48")]
+    if matches!(account.viewing_key, ViewingKey::Zip48Full(_)) {
+        return Err(SqliteClientError::Zip48UnsupportedOperation);
+    }
 
     let requirements = account
         .uivk()
@@ -1298,6 +1397,18 @@ fn parse_account_row<P: consensus::Parameters>(
     let account_id = AccountRef(row.get("id")?);
     let account_name = row.get("name")?;
     let account_uuid = AccountUuid(row.get("uuid")?);
+
+    let ufvk_str: Option<String> = row.get("ufvk")?;
+    #[cfg(feature = "zip-48")]
+    let zip48_fvk_bytes: Option<Vec<u8>> = row.get("zip48_fvk")?;
+
+    // Parse the ZIP 48 FVK early so we can extract derivation info for parse_account_source.
+    #[cfg(feature = "zip-48")]
+    let zip48_fvk = zip48_fvk_bytes
+        .as_deref()
+        .map(|bytes| zip48::FullViewingKey::parse_multipath_descriptor(bytes, params))
+        .transpose()?;
+
     let kind = parse_account_source(
         row.get("account_kind")?,
         row.get("hd_seed_fingerprint")?,
@@ -1308,7 +1419,6 @@ fn parse_account_row<P: consensus::Parameters>(
         row.get("key_source")?,
     )?;
 
-    let ufvk_str: Option<String> = row.get("ufvk")?;
     let viewing_key = if let Some(ufvk_str) = ufvk_str {
         ViewingKey::Full(Box::new(
             UnifiedFullViewingKey::decode(params, &ufvk_str).map_err(|e| {
@@ -1319,15 +1429,30 @@ fn parse_account_row<P: consensus::Parameters>(
             })?,
         ))
     } else {
-        let uivk_str: String = row.get("uivk")?;
-        ViewingKey::Incoming(Box::new(
-            UnifiedIncomingViewingKey::decode(params, &uivk_str).map_err(|e| {
-                SqliteClientError::CorruptedData(format!(
-                    "Could not decode unified incoming viewing key for account {}: {}",
-                    account_uuid.0, e
-                ))
-            })?,
-        ))
+        let decode_uivk = || -> Result<ViewingKey, SqliteClientError> {
+            let uivk_str: Option<String> = row.get("uivk")?;
+            let uivk_str = uivk_str.ok_or_else(|| {
+                SqliteClientError::CorruptedData("Missing uivk for non-ZIP48 account".into())
+            })?;
+            Ok(ViewingKey::Incoming(Box::new(
+                UnifiedIncomingViewingKey::decode(params, &uivk_str).map_err(|e| {
+                    SqliteClientError::CorruptedData(format!(
+                        "Could not decode unified incoming viewing key for account {}: {}",
+                        account_uuid.0, e
+                    ))
+                })?,
+            )))
+        };
+
+        #[cfg(feature = "zip-48")]
+        if let Some(fvk) = zip48_fvk {
+            ViewingKey::Zip48Full(Box::new(fvk))
+        } else {
+            decode_uivk()?
+        }
+
+        #[cfg(not(feature = "zip-48"))]
+        decode_uivk()?
     };
 
     let birthday = BlockHeight::from(row.get::<_, u32>("birthday_height")?);
@@ -1351,7 +1476,7 @@ pub(crate) fn get_account<P: Parameters>(
         r#"
         SELECT id, name, uuid, account_kind,
                hd_seed_fingerprint, hd_account_index, zcashd_legacy_address_index, key_source,
-               ufvk, uivk, has_spend_key, birthday_height
+               ufvk, uivk, has_spend_key, birthday_height, zip48_fvk
         FROM accounts
         WHERE uuid = :account_uuid
         "#,
@@ -1375,7 +1500,7 @@ pub(crate) fn get_account_internal<P: Parameters>(
         r#"
         SELECT id, name, uuid, account_kind,
                hd_seed_fingerprint, hd_account_index, zcashd_legacy_address_index, key_source,
-               ufvk, uivk, has_spend_key, birthday_height
+               ufvk, uivk, has_spend_key, birthday_height, zip48_fvk
         FROM accounts
         WHERE id = :account_id
         "#,
@@ -1411,7 +1536,7 @@ pub(crate) fn get_account_for_ufvk<P: consensus::Parameters>(
     let mut stmt = conn.prepare(
         "SELECT id, name, uuid, account_kind,
                 hd_seed_fingerprint, hd_account_index, zcashd_legacy_address_index, key_source,
-                ufvk, uivk, has_spend_key, birthday_height
+                ufvk, uivk, has_spend_key, birthday_height, zip48_fvk
          FROM accounts
          WHERE orchard_fvk_item_cache = :orchard_fvk_item_cache
             OR sapling_fvk_item_cache = :sapling_fvk_item_cache

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -4671,8 +4671,7 @@ pub(crate) fn get_next_available_zip48_multisig_address<P: consensus::Parameters
         account.id,
         t_scope,
         address_index,
-        &address,
-        &redeem_script,
+        (&address, &redeem_script),
         Some(chain_tip),
     )?;
 
@@ -4728,8 +4727,7 @@ pub(crate) fn get_zip48_multisig_address_for_index<P: consensus::Parameters>(
         account.id,
         t_scope,
         address_index,
-        &address,
-        &redeem_script,
+        (&address, &redeem_script),
         Some(chain_tip),
     )?;
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -426,6 +426,8 @@ pub(crate) fn add_account<P: consensus::Parameters>(
             purpose: AccountPurpose::ViewOnly,
             key_source,
         } => (None, false, key_source),
+        #[cfg(feature = "zip-48")]
+        AccountSource::Zip48 => (None, false, &None),
     };
 
     #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -35,9 +35,10 @@ use crate::wallet::scanning::priority_code;
 ///   stable for the lifetime of the wallet database, but is not expected or required to be
 ///   stable across wallet restores and it should not be stored in external backup formats.
 /// - `account_kind`: 0 for accounts derived from a mnemonic seed, 1 for imported accounts
-///   for which derivation path information may not be available. This column may be removed in the
-///   future; the distinction between whether an account is derived or imported is better
-///   represented by the presence or absence of HD seed fingerprint and HD account index data.
+///   for which derivation path information may not be available, 2 for ZIP 48 transparent multisig
+///   accounts. This column may be removed in the future; the distinction between whether an account
+///   is derived or imported is better represented by the presence or absence of HD seed fingerprint
+///   and HD account index data.
 /// - `hd_seed_fingerprint`: If this account contains funds in keys obtained via HD derivation,
 ///   the ZIP 32 fingerprint of the root HD seed. If this column is non-null, `hd_account_index`
 ///   must also be non-null.
@@ -66,6 +67,9 @@ use crate::wallet::scanning::priority_code;
 ///   period (to keep the scan progress percentage accurate to what actually needs scanning).
 /// - `has_spend_key`: A boolean flag (0 or 1) indicating whether the application that embeds
 ///   this wallet database has access to spending key(s) for the account.
+/// - `zip48_fvk`: For ZIP 48 transparent multisig accounts (account_kind = 2), the full viewing
+///   key serialized as a BIP 389 multipath descriptor template. This contains the threshold and
+///   all information needed for address derivation. Must be null for non-multisig accounts.
 /// - `zcash_legacy_address_index`: This column is only potentially populated for wallets imported
 ///   from a `zcashd` `wallet.dat` file, for "standalone" Sapling addresses (each of which
 ///   corresponds to an independent account) derived after the introduction of mnemonic seed
@@ -85,7 +89,7 @@ CREATE TABLE "accounts" (
     hd_seed_fingerprint BLOB,
     hd_account_index INTEGER,
     ufvk TEXT,
-    uivk TEXT NOT NULL,
+    uivk TEXT,
     orchard_fvk_item_cache BLOB,
     sapling_fvk_item_cache BLOB,
     p2pkh_fvk_item_cache BLOB,
@@ -95,17 +99,34 @@ CREATE TABLE "accounts" (
     recover_until_height INTEGER,
     has_spend_key INTEGER NOT NULL DEFAULT 1,
     zcashd_legacy_address_index INTEGER NOT NULL DEFAULT -1,
+    zip48_fvk BLOB,
     CHECK (
       (
         account_kind = 0
         AND hd_seed_fingerprint IS NOT NULL
         AND hd_account_index IS NOT NULL
         AND ufvk IS NOT NULL
+        AND uivk IS NOT NULL
+        AND zip48_fvk IS NULL
       )
       OR
       (
         account_kind = 1
         AND (hd_seed_fingerprint IS NULL) = (hd_account_index IS NULL)
+        AND uivk IS NOT NULL
+        AND zip48_fvk IS NULL
+      )
+      OR
+      (
+        account_kind = 2
+        AND zip48_fvk IS NOT NULL
+        AND uivk IS NULL
+        AND hd_seed_fingerprint IS NULL
+        AND hd_account_index IS NULL
+        AND ufvk IS NULL
+        AND orchard_fvk_item_cache IS NULL
+        AND sapling_fvk_item_cache IS NULL
+        AND p2pkh_fvk_item_cache IS NULL
       )
     )
 )"#;
@@ -167,6 +188,9 @@ pub(super) const INDEX_HD_ACCOUNT: &str = r#"CREATE UNIQUE INDEX hd_account ON a
 //    obtained via derivation from an HD seed associated with the account. In cases that
 //    `cached_transparent_receiver_address` is non-null, either this column or
 //    `transparent_child_index` must also be non-null.
+/// - `redeem_script`: For P2SH addresses, the redeem script required to spend funds at this address.
+///   The redeem script encodes the spending conditions and is required when constructing
+///   transactions. This is null for non-P2SH addresses.
 ///
 /// [`ReceiverFlags`]: crate::wallet::encoding::ReceiverFlags
 pub(super) const TABLE_ADDRESSES: &str = r#"
@@ -183,6 +207,7 @@ CREATE TABLE "addresses" (
     receiver_flags INTEGER NOT NULL,
     transparent_receiver_next_check_time INTEGER,
     imported_transparent_receiver_pubkey BLOB,
+    redeem_script BLOB,
     UNIQUE (account_id, key_scope, diversifier_index_be),
     UNIQUE (imported_transparent_receiver_pubkey),
     CONSTRAINT ck_addr_transparent_index_consistency CHECK (

--- a/zcash_client_sqlite/src/wallet/encoding.rs
+++ b/zcash_client_sqlite/src/wallet/encoding.rs
@@ -57,6 +57,8 @@ pub(crate) fn account_kind_code(value: &AccountSource) -> u32 {
     match value {
         AccountSource::Derived { .. } => 0,
         AccountSource::Imported { .. } => 1,
+        #[cfg(feature = "zip-48")]
+        AccountSource::Zip48 { .. } => 2,
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/encoding.rs
+++ b/zcash_client_sqlite/src/wallet/encoding.rs
@@ -58,7 +58,7 @@ pub(crate) fn account_kind_code(value: &AccountSource) -> u32 {
         AccountSource::Derived { .. } => 0,
         AccountSource::Imported { .. } => 1,
         #[cfg(feature = "zip-48")]
-        AccountSource::Zip48 { .. } => 2,
+        AccountSource::Zip48 => 2,
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -253,6 +253,12 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         SqliteClientError::PubkeyImportConflict(_) => {
             unreachable!("we do not import pubkeys in migrations")
         }
+        #[cfg(feature = "zip-48")]
+        SqliteClientError::Zip48UnsupportedOperation => {
+            unreachable!("we do not use ZIP 48 multisig specific methods in migrations")
+        }
+        #[cfg(feature = "zip-48")]
+        SqliteClientError::Zip48Fvk(e) => WalletMigrationError::CorruptedData(format!("{e:?}")),
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -52,6 +52,7 @@ mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
+mod zip48_multisig;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -133,6 +134,8 @@ pub(super) fn all_migrations<
     //                       `------------------- account_delete_cascade ---------------------------------'
     //                                                      |
     //                                           v_tx_outputs_key_scopes
+    //                                                      |
+    //                                               zip48_multisig
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -219,6 +222,7 @@ pub(super) fn all_migrations<
         Box::new(add_transaction_trust_marker::Migration),
         Box::new(account_delete_cascade::Migration),
         Box::new(v_tx_outputs_key_scopes::Migration),
+        Box::new(zip48_multisig::Migration),
     ]
 }
 
@@ -359,7 +363,7 @@ pub const V_0_18_5: &[Uuid] = &[
 pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 /// Leaf migrations as of the current repository state.
-pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[v_tx_outputs_key_scopes::MIGRATION_ID];
+pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[zip48_multisig::MIGRATION_ID];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
     conn: &rusqlite::Connection,

--- a/zcash_client_sqlite/src/wallet/init/migrations/zip48_multisig.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/zip48_multisig.rs
@@ -1,0 +1,160 @@
+//! This migration adds support for tracking ZIP 48 transparent P2SH multisig wallets.
+//!
+//! Schema changes:
+//! - Adds `zip48_fvk BLOB` column to `accounts` table for storing the ZIP 48 full viewing key
+//! - Adds `redeem_script BLOB` column to `addresses` table for P2SH addresses
+//! - Updates the `accounts` CHECK constraint to allow `account_kind = 2` (ZIP 48 multisig)
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::v_tx_outputs_key_scopes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x99f5cdee_3b82_45cc_bd56_c79779ca02a3);
+
+const DEPENDENCIES: &[Uuid] = &[v_tx_outputs_key_scopes::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds support for tracking ZIP 48 transparent P2SH multisig wallets."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // Add zip48_fvk column to accounts table and update CHECK constraint
+        // to allow account_kind = 2 for ZIP 48 multisig accounts.
+        //
+        // We need to recreate the table because SQLite doesn't support
+        // ALTER TABLE ... DROP CONSTRAINT.
+        transaction.execute_batch(
+            r#"
+            CREATE TABLE accounts_new (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                uuid BLOB NOT NULL,
+                account_kind INTEGER NOT NULL DEFAULT 0,
+                key_source TEXT,
+                hd_seed_fingerprint BLOB,
+                hd_account_index INTEGER,
+                ufvk TEXT,
+                uivk TEXT,
+                orchard_fvk_item_cache BLOB,
+                sapling_fvk_item_cache BLOB,
+                p2pkh_fvk_item_cache BLOB,
+                birthday_height INTEGER NOT NULL,
+                birthday_sapling_tree_size INTEGER,
+                birthday_orchard_tree_size INTEGER,
+                recover_until_height INTEGER,
+                has_spend_key INTEGER NOT NULL DEFAULT 1,
+                zcashd_legacy_address_index INTEGER NOT NULL DEFAULT -1,
+                zip48_fvk BLOB,
+                CHECK (
+                  (
+                    account_kind = 0
+                    AND hd_seed_fingerprint IS NOT NULL
+                    AND hd_account_index IS NOT NULL
+                    AND ufvk IS NOT NULL
+                    AND uivk IS NOT NULL
+                    AND zip48_fvk IS NULL
+                  )
+                  OR
+                  (
+                    account_kind = 1
+                    AND (hd_seed_fingerprint IS NULL) = (hd_account_index IS NULL)
+                    AND uivk IS NOT NULL
+                    AND zip48_fvk IS NULL
+                  )
+                  OR
+                  (
+                    account_kind = 2
+                    AND zip48_fvk IS NOT NULL
+                    AND uivk IS NULL
+                    AND hd_seed_fingerprint IS NULL
+                    AND hd_account_index IS NULL
+                    AND ufvk IS NULL
+                    AND orchard_fvk_item_cache IS NULL
+                    AND sapling_fvk_item_cache IS NULL
+                    AND p2pkh_fvk_item_cache IS NULL
+                  )
+                )
+            );
+            "#,
+        )?;
+
+        // Copy existing data to the new table
+        transaction.execute_batch(
+            r#"
+            INSERT INTO accounts_new (
+                id, name, uuid, account_kind, key_source,
+                hd_seed_fingerprint, hd_account_index,
+                ufvk, uivk,
+                orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
+                birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
+                recover_until_height, has_spend_key, zcashd_legacy_address_index
+            )
+            SELECT
+                id, name, uuid, account_kind, key_source,
+                hd_seed_fingerprint, hd_account_index,
+                ufvk, uivk,
+                orchard_fvk_item_cache, sapling_fvk_item_cache, p2pkh_fvk_item_cache,
+                birthday_height, birthday_sapling_tree_size, birthday_orchard_tree_size,
+                recover_until_height, has_spend_key, zcashd_legacy_address_index
+            FROM accounts;
+
+            PRAGMA legacy_alter_table = ON;
+
+            DROP TABLE accounts;
+            ALTER TABLE accounts_new RENAME TO accounts;
+
+            PRAGMA legacy_alter_table = OFF;
+
+            -- Recreate the existing indices
+            CREATE UNIQUE INDEX accounts_uuid ON accounts (uuid);
+            CREATE UNIQUE INDEX accounts_ufvk ON accounts (ufvk);
+            CREATE UNIQUE INDEX accounts_uivk ON accounts (uivk);
+            CREATE UNIQUE INDEX hd_account ON accounts (hd_seed_fingerprint, hd_account_index, zcashd_legacy_address_index);
+            "#,
+        )?;
+
+        // Add redeem_script column to addresses table for P2SH multisig addresses.
+        // This stores the script needed to spend funds at the address.
+        transaction.execute_batch(
+            r#"
+            ALTER TABLE addresses ADD COLUMN redeem_script BLOB;
+            "#,
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -69,6 +69,13 @@ use crate::{
 
 pub(crate) mod ephemeral;
 
+#[cfg(feature = "zip-48")]
+pub(crate) mod zip48_multisig;
+
+// Re-export ZIP 48 multisig functions for use in other modules
+#[cfg(feature = "zip-48")]
+pub(crate) use zip48_multisig::generate_zip48_multisig_address_range;
+
 pub(crate) fn detect_spending_accounts<'a>(
     conn: &Connection,
     spent: impl Iterator<Item = &'a OutPoint>,
@@ -161,7 +168,8 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
             transparent_child_index,
             imported_transparent_receiver_pubkey,
             exposed_at_height,
-            transparent_receiver_next_check_time
+            transparent_receiver_next_check_time,
+            redeem_script
          FROM addresses
          WHERE account_id = :account_id
          AND cached_transparent_receiver_address IS NOT NULL
@@ -243,50 +251,97 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
             .map(decode_epoch_seconds)
             .transpose()?;
 
+        #[cfg(feature = "zip-48")]
+        let redeem_script_bytes: Option<Vec<u8>> = row.get("redeem_script")?;
+
         if let Some(taddr) = taddr {
-            let metadata = match key_scope {
-                #[cfg(feature = "transparent-key-import")]
-                KeyScope::Foreign => {
-                    let pubkey_bytes = row
-                        .get::<_, Option<Vec<u8>>>(3)?
-                        .ok_or_else(|| {
-                            SqliteClientError::CorruptedData(
-                            "Pubkey bytes must be present for all imported transparent addresses."
+            let non_multisig_metadata =
+                || -> Result<TransparentAddressMetadata, SqliteClientError> {
+                    match key_scope {
+                        #[cfg(feature = "transparent-key-import")]
+                        KeyScope::Foreign => {
+                            let pubkey_bytes = row
+                                .get::<_, Option<Vec<u8>>>(3)?
+                                .ok_or_else(|| {
+                                    SqliteClientError::CorruptedData(
+                                    "Pubkey bytes must be present for all imported transparent addresses."
+                                        .to_owned(),
+                                )
+                                })
+                                .and_then(|b| {
+                                    <[u8; 33]>::try_from(&b[..]).map_err(|_| {
+                                        SqliteClientError::CorruptedData(format!(
+                                            "Invalid public key byte length; must be 33 bytes, got {}.",
+                                            b.len()
+                                        ))
+                                    })
+                                })?;
+                            let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| {
+                                SqliteClientError::CorruptedData(format!(
+                                    "Invalid public key: {}",
+                                    e
+                                ))
+                            })?;
+                            Ok(TransparentAddressMetadata::standalone(
+                                pubkey,
+                                exposure,
+                                next_check_time,
+                            ))
+                        }
+                        derived => {
+                            let (scope, address_index) = derived
+                                .as_transparent()
+                                .zip(address_index_opt)
+                                .ok_or_else(|| {
+                                    SqliteClientError::CorruptedData(
+                                        "Derived addresses must have derivation metadata present."
+                                            .to_owned(),
+                                    )
+                                })?;
+
+                            Ok(TransparentAddressMetadata::derived(
+                                scope,
+                                address_index,
+                                exposure,
+                                next_check_time,
+                            ))
+                        }
+                    }
+                };
+
+            // Check for ZIP 48 multisig address first (has redeem_script)
+            #[cfg(feature = "zip-48")]
+            let metadata = if let Some(ref rs_bytes) = redeem_script_bytes {
+                use zcash_script::script::{self, Code};
+
+                let (scope, address_index) = key_scope
+                    .as_transparent()
+                    .zip(address_index_opt)
+                    .ok_or_else(|| {
+                        SqliteClientError::CorruptedData(
+                            "ZIP 48 multisig addresses must have derivation metadata present."
                                 .to_owned(),
                         )
-                        })
-                        .and_then(|b| {
-                            <[u8; 33]>::try_from(&b[..]).map_err(|_| {
-                                SqliteClientError::CorruptedData(format!(
-                                    "Invalid public key byte length; must be 33 bytes, got {}.",
-                                    b.len()
-                                ))
-                            })
-                        })?;
-                    let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| {
-                        SqliteClientError::CorruptedData(format!("Invalid public key: {}", e))
                     })?;
-                    TransparentAddressMetadata::standalone(pubkey, exposure, next_check_time)
-                }
-                derived => {
-                    let (scope, address_index) = derived
-                        .as_transparent()
-                        .zip(address_index_opt)
-                        .ok_or_else(|| {
-                            SqliteClientError::CorruptedData(
-                                "Derived addresses must have derivation metadata present."
-                                    .to_owned(),
-                            )
-                        })?;
 
-                    TransparentAddressMetadata::derived(
-                        scope,
-                        address_index,
-                        exposure,
-                        next_check_time,
-                    )
-                }
+                let redeem_script =
+                    script::Redeem::parse(&Code(rs_bytes.clone())).map_err(|e| {
+                        SqliteClientError::CorruptedData(format!("Invalid redeem script: {:?}", e))
+                    })?;
+
+                TransparentAddressMetadata::zip48_multisig(
+                    scope,
+                    address_index,
+                    redeem_script,
+                    exposure,
+                    next_check_time,
+                )
+            } else {
+                non_multisig_metadata()?
             };
+
+            #[cfg(not(feature = "zip-48"))]
+            let metadata = non_multisig_metadata()?;
 
             ret.insert(taddr, metadata);
         }
@@ -602,13 +657,30 @@ pub(crate) fn generate_address_range<P: consensus::Parameters>(
     range_to_store: Range<NonHardenedChildIndex>,
     require_key: bool,
 ) -> Result<(), SqliteClientError> {
+    #[cfg(feature = "zip-48")]
+    use super::ViewingKey;
+
     let account = get_account_internal(conn, params, account_id)?
         .ok_or_else(|| SqliteClientError::AccountUnknown)?;
+
+    // Check if this is a ZIP 48 multisig account and use ZIP 48-specific address generation
+    #[cfg(feature = "zip-48")]
+    if let ViewingKey::Zip48Full(fvk) = &account.viewing_key {
+        return generate_zip48_multisig_address_range(
+            conn,
+            params,
+            account_id,
+            fvk,
+            key_scope,
+            range_to_store,
+        );
+    }
+
     generate_address_range_internal(
         conn,
         params,
         account_id,
-        &account.uivk(),
+        &account.viewing_key.uivk(),
         account.ufvk(),
         key_scope,
         request,
@@ -2199,6 +2271,33 @@ mod tests {
             TestDbFactory::default(),
             BlockCache::new(),
             GapLimits::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip-48")]
+    fn put_received_transparent_utxo_zip48() {
+        zcash_client_backend::data_api::testing::transparent::put_received_transparent_utxo(
+            TestDbFactory::default(),
+            zcash_client_backend::data_api::testing::transparent::TransparentAccountType::Zip48,
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip-48")]
+    fn transparent_balance_spendability_zip48() {
+        zcash_client_backend::data_api::testing::transparent::transparent_balance_spendability(
+            TestDbFactory::default(),
+            BlockCache::new(),
+            zcash_client_backend::data_api::testing::transparent::TransparentAccountType::Zip48,
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip-48")]
+    fn import_account_zip48_multisig() {
+        zcash_client_backend::data_api::testing::transparent::import_account_zip48_multisig(
+            TestDbFactory::default(),
         );
     }
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -74,7 +74,10 @@ pub(crate) mod zip48_multisig;
 
 // Re-export ZIP 48 multisig functions for use in other modules
 #[cfg(feature = "zip-48")]
-pub(crate) use zip48_multisig::generate_zip48_multisig_address_range;
+pub(crate) use zip48_multisig::{
+    generate_zip48_multisig_address_range, get_first_unexposed_zip48_multisig_address_index,
+    get_next_zip48_multisig_address_index, get_zip48_fvk, insert_zip48_multisig_address,
+};
 
 pub(crate) fn detect_spending_accounts<'a>(
     conn: &Connection,
@@ -2297,6 +2300,22 @@ mod tests {
     #[cfg(feature = "zip-48")]
     fn import_account_zip48_multisig() {
         zcash_client_backend::data_api::testing::transparent::import_account_zip48_multisig(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip-48")]
+    fn get_next_zip48_multisig_address() {
+        zcash_client_backend::data_api::testing::transparent::get_next_zip48_multisig_address(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip-48")]
+    fn get_zip48_multisig_address_for_index() {
+        zcash_client_backend::data_api::testing::transparent::get_zip48_multisig_address_for_index(
             TestDbFactory::default(),
         );
     }

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2172,6 +2172,7 @@ mod tests {
     fn put_received_transparent_utxo() {
         zcash_client_backend::data_api::testing::transparent::put_received_transparent_utxo(
             TestDbFactory::default(),
+            zcash_client_backend::data_api::testing::transparent::TransparentAccountType::Derived,
         );
     }
 
@@ -2188,12 +2189,13 @@ mod tests {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_spendability(
             TestDbFactory::default(),
             BlockCache::new(),
+            zcash_client_backend::data_api::testing::transparent::TransparentAccountType::Derived,
         );
     }
 
     #[test]
     fn gap_limits() {
-        zcash_client_backend::data_api::testing::transparent::gap_limits(
+        zcash_client_backend::data_api::testing::transparent::zip32_gap_limits(
             TestDbFactory::default(),
             BlockCache::new(),
             GapLimits::default(),

--- a/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
@@ -1,0 +1,377 @@
+//! Functions for wallet support of ZIP 48 transparent multisig addresses.
+//!
+//! ZIP 48 defines a standard for deriving P2SH multisig addresses from a set of
+//! participant public keys. This module handles the database operations for
+//! storing and retrieving these addresses.
+
+use std::ops::Range;
+
+use rusqlite::named_params;
+use transparent::{
+    address::TransparentAddress,
+    keys::{NonHardenedChildIndex, NonHardenedChildRange, TransparentKeyScope},
+};
+use zcash_keys::encoding::TransparentCodecError;
+use zcash_protocol::consensus::{self, BlockHeight};
+use zcash_script::script;
+
+use crate::{
+    AccountRef,
+    error::SqliteClientError,
+    wallet::{
+        KeyScope,
+        encoding::{ReceiverFlags, encode_diversifier_index_be},
+        transparent::AddressRef,
+    },
+};
+
+/// Generates a range of ZIP 48 multisig addresses for the given account and stores them
+/// in the wallet database.
+///
+/// This function is the ZIP 48 multisig equivalent of [`super::generate_address_range_internal`],
+/// using the ZIP 48 full viewing key to derive P2SH multisig addresses instead of unified
+/// addresses.
+pub(crate) fn generate_zip48_multisig_address_range<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_id: AccountRef,
+    fvk: &::transparent::zip48::FullViewingKey,
+    key_scope: TransparentKeyScope,
+    range_to_store: Range<NonHardenedChildIndex>,
+) -> Result<(), SqliteClientError> {
+    let scope = match key_scope {
+        TransparentKeyScope::EXTERNAL => zip32::Scope::External,
+        TransparentKeyScope::INTERNAL => zip32::Scope::Internal,
+        _ => return Err(SqliteClientError::Zip48UnsupportedOperation),
+    };
+
+    for address_index in NonHardenedChildRange::from(range_to_store) {
+        let (address, redeem_script) = fvk.derive_address(scope, address_index);
+
+        insert_zip48_multisig_address(
+            conn,
+            params,
+            account_id,
+            key_scope,
+            address_index,
+            &address,
+            &redeem_script,
+            None,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Inserts a new multisig address into the addresses table, or updates the `exposed_at_height`
+/// of an existing address if it has not yet been exposed.
+///
+/// When `exposed_at_height` is `None`, the address is inserted without marking it as exposed
+/// (used for gap-filling). When `Some(height)`, the address is marked as exposed at that height.
+/// On conflict, `COALESCE(existing, new)` preserves an already-set exposure height.
+pub(crate) fn insert_zip48_multisig_address<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction<'_>,
+    params: &P,
+    account_id: AccountRef,
+    scope: TransparentKeyScope,
+    address_index: NonHardenedChildIndex,
+    address: &TransparentAddress,
+    redeem_script: &script::Redeem,
+    exposed_at_height: Option<BlockHeight>,
+) -> Result<AddressRef, SqliteClientError> {
+    use zcash_keys::encoding::AddressCodec;
+    use zcash_script::script::Evaluable;
+
+    if !matches!(address, TransparentAddress::ScriptHash(_)) {
+        return Err(SqliteClientError::TransparentAddress(
+            TransparentCodecError::UnsupportedAddressType("address must be P2SH".into()),
+        ));
+    }
+
+    let addr_str = address.encode(params);
+    let key_scope = KeyScope::try_from(scope)?;
+    let diversifier_index = zip32::DiversifierIndex::from(address_index);
+
+    let address_id = conn.query_row(
+            "INSERT INTO addresses (
+                account_id,
+                key_scope,
+                diversifier_index_be,
+                address,
+                transparent_child_index,
+                cached_transparent_receiver_address,
+                exposed_at_height,
+                receiver_flags,
+                redeem_script
+            )
+            VALUES (
+                :account_id,
+                :key_scope,
+                :diversifier_index_be,
+                :address,
+                :transparent_child_index,
+                :cached_transparent_receiver_address,
+                :exposed_at_height,
+                :receiver_flags,
+                :redeem_script
+            )
+            ON CONFLICT (account_id, key_scope, diversifier_index_be)
+            DO UPDATE SET exposed_at_height = COALESCE(addresses.exposed_at_height, :exposed_at_height)
+            RETURNING id",
+            named_params![
+                ":account_id": account_id.0,
+                ":key_scope": key_scope.encode(),
+                ":diversifier_index_be": encode_diversifier_index_be(diversifier_index),
+                ":address": &addr_str,
+                ":transparent_child_index": address_index.index(),
+                ":cached_transparent_receiver_address": &addr_str,
+                ":exposed_at_height": exposed_at_height.map(u32::from),
+                ":receiver_flags": ReceiverFlags::P2SH.bits(),
+                ":redeem_script": redeem_script.to_bytes(),
+            ],
+            |row| row.get(0).map(AddressRef),
+        )?;
+
+    Ok(address_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use transparent::keys::{NonHardenedChildIndex, TransparentKeyScope};
+    use transparent::zip48::AccountPrivKey;
+    use zcash_client_backend::data_api::{
+        Account as _, AccountBirthday, WalletWrite, chain::ChainState, testing::TestBuilder,
+    };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+    use crate::{testing::db::TestDbFactory, wallet::get_account_ref};
+
+    /// Runs a test with a fully initialized ZIP 48 test environment.
+    fn with_zip48_test_env(
+        f: impl FnOnce(
+            &mut zcash_client_backend::data_api::testing::TestState<
+                (),
+                crate::testing::db::TestDb,
+                zcash_protocol::local_consensus::LocalNetwork,
+            >,
+            AccountRef,
+            &::transparent::zip48::FullViewingKey,
+            zcash_protocol::local_consensus::LocalNetwork,
+        ),
+    ) {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(
+                st.network()
+                    .activation_height(NetworkUpgrade::Sapling)
+                    .unwrap()
+                    - 1,
+                BlockHash([0; 32]),
+            ),
+            None,
+        );
+
+        // Create a 2-of-3 FVK from three deterministic seeds.
+        let account_id_zip32 = zip32::AccountId::ZERO;
+        let seeds: [&[u8; 32]; 3] = [&[1; 32], &[2; 32], &[3; 32]];
+        let pubkeys: Vec<_> = seeds
+            .iter()
+            .map(|seed| {
+                AccountPrivKey::from_seed(st.network(), *seed, account_id_zip32)
+                    .unwrap()
+                    .to_account_pubkey()
+            })
+            .collect();
+        let fvk = ::transparent::zip48::FullViewingKey::standard(2, pubkeys).unwrap();
+
+        let account = st
+            .wallet_mut()
+            .import_account_zip48_multisig("zip48-test", &fvk, &birthday)
+            .unwrap();
+
+        let params = *st.network();
+        let account_ref = get_account_ref(st.wallet().conn(), account.id()).unwrap();
+
+        f(&mut st, account_ref, &fvk, params);
+    }
+
+    // The default gap limits pre-generate 10 external and 5 internal addresses on import.
+    const GAP_EXTERNAL: u32 = 10;
+
+    #[test]
+    fn insert_rejects_non_p2sh_address() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            // Create a P2PKH address (not P2SH).
+            let p2pkh_address = TransparentAddress::PublicKeyHash([0u8; 20]);
+            let (_address, redeem_script) =
+                fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+
+            let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+            let result = insert_zip48_multisig_address(
+                &tx,
+                &params,
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+                NonHardenedChildIndex::ZERO,
+                &p2pkh_address,
+                &redeem_script,
+                None,
+            );
+            assert_matches!(result, Err(SqliteClientError::TransparentAddress(_)));
+        });
+    }
+
+    #[test]
+    fn insert_round_trip() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            use rusqlite::named_params;
+            use zcash_keys::encoding::AddressCodec;
+            use zcash_script::script::Evaluable;
+
+            let index = NonHardenedChildIndex::from_index(GAP_EXTERNAL).unwrap();
+            let (address, redeem_script) = fvk.derive_address(zip32::Scope::External, index);
+            let exposed_height = Some(BlockHeight::from_u32(200));
+
+            let address_ref = {
+                let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+                let r = insert_zip48_multisig_address(
+                    &tx,
+                    &params,
+                    account_ref,
+                    TransparentKeyScope::EXTERNAL,
+                    index,
+                    &address,
+                    &redeem_script,
+                    exposed_height,
+                )
+                .unwrap();
+                tx.commit().unwrap();
+                r
+            };
+
+            let row = st
+                .wallet()
+                .conn()
+                .query_row(
+                    "SELECT address, redeem_script, transparent_child_index,
+                            key_scope, exposed_at_height
+                     FROM addresses WHERE id = :id",
+                    named_params![":id": address_ref.0],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, u32>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, Option<u32>>(4)?,
+                        ))
+                    },
+                )
+                .unwrap();
+
+            assert_eq!(row.0, address.encode(&params));
+            assert_eq!(row.1, redeem_script.to_bytes());
+            assert_eq!(row.2, index.index());
+            assert_eq!(
+                row.3,
+                KeyScope::try_from(TransparentKeyScope::EXTERNAL)
+                    .unwrap()
+                    .encode()
+            );
+            assert_eq!(row.4, Some(200u32));
+        });
+    }
+
+    #[test]
+    fn generate_range_rejects_ephemeral_scope() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            let range_start = NonHardenedChildIndex::ZERO;
+            let range_end = NonHardenedChildIndex::from_index(5).unwrap();
+            let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+            let result = generate_zip48_multisig_address_range(
+                &tx,
+                &params,
+                account_ref,
+                fvk,
+                TransparentKeyScope::EPHEMERAL,
+                range_start..range_end,
+            );
+            assert_matches!(result, Err(SqliteClientError::Zip48UnsupportedOperation));
+        });
+    }
+
+    #[test]
+    fn generate_range_round_trip() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            use rusqlite::named_params;
+            use zcash_keys::encoding::AddressCodec;
+            use zcash_script::script::Evaluable;
+
+            let range_start = NonHardenedChildIndex::from_index(GAP_EXTERNAL).unwrap();
+            let range_end = NonHardenedChildIndex::from_index(GAP_EXTERNAL + 3).unwrap();
+            {
+                let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+                generate_zip48_multisig_address_range(
+                    &tx,
+                    &params,
+                    account_ref,
+                    fvk,
+                    TransparentKeyScope::EXTERNAL,
+                    range_start..range_end,
+                )
+                .unwrap();
+                tx.commit().unwrap();
+            }
+
+            let key_scope = KeyScope::try_from(TransparentKeyScope::EXTERNAL).unwrap();
+            for i in GAP_EXTERNAL..GAP_EXTERNAL + 3 {
+                let index = NonHardenedChildIndex::from_index(i).unwrap();
+                let (address, redeem_script) = fvk.derive_address(zip32::Scope::External, index);
+
+                let row = st
+                    .wallet()
+                    .conn()
+                    .query_row(
+                        "SELECT address, redeem_script, exposed_at_height
+                         FROM addresses
+                         WHERE account_id = :account_id
+                           AND key_scope = :key_scope
+                           AND transparent_child_index = :index",
+                        named_params![
+                            ":account_id": account_ref.0,
+                            ":key_scope": key_scope.encode(),
+                            ":index": i,
+                        ],
+                        |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, Vec<u8>>(1)?,
+                                row.get::<_, Option<u32>>(2)?,
+                            ))
+                        },
+                    )
+                    .unwrap();
+
+                assert_eq!(
+                    row.0,
+                    address.encode(&params),
+                    "address mismatch at index {i}"
+                );
+                assert_eq!(
+                    row.1,
+                    redeem_script.to_bytes(),
+                    "redeem_script mismatch at index {i}"
+                );
+                assert_eq!(row.2, None, "expected unexposed at index {i}");
+            }
+        });
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Range;
 
-use rusqlite::named_params;
+use rusqlite::{Connection, OptionalExtension, named_params};
 use transparent::{
     address::TransparentAddress,
     keys::{NonHardenedChildIndex, NonHardenedChildRange, TransparentKeyScope},
@@ -61,6 +61,21 @@ pub(crate) fn generate_zip48_multisig_address_range<P: consensus::Parameters>(
     }
 
     Ok(())
+}
+
+/// Retrieves the ZIP 48 FVK from an account if it is a multisig account.
+pub(crate) fn get_zip48_fvk(
+    conn: &Connection,
+    account_id: AccountRef,
+) -> Result<Option<Vec<u8>>, SqliteClientError> {
+    conn.query_row(
+        "SELECT zip48_fvk FROM accounts WHERE id = :id AND account_kind = 2",
+        named_params![":id": account_id.0],
+        |row| row.get::<_, Option<Vec<u8>>>(0),
+    )
+    .optional()
+    .map_err(SqliteClientError::from)
+    .map(|opt| opt.flatten())
 }
 
 /// Inserts a new multisig address into the addresses table, or updates the `exposed_at_height`
@@ -135,6 +150,81 @@ pub(crate) fn insert_zip48_multisig_address<P: consensus::Parameters>(
     Ok(address_id)
 }
 
+/// Gets the next available address index for a multisig account.
+///
+/// This returns MAX(transparent_child_index) + 1 for existing multisig addresses.
+pub(crate) fn get_next_zip48_multisig_address_index(
+    conn: &Connection,
+    account_id: AccountRef,
+    scope: TransparentKeyScope,
+) -> Result<NonHardenedChildIndex, SqliteClientError> {
+    let key_scope = KeyScope::try_from(scope)?;
+
+    let max_index: Option<u32> = conn
+        .query_row(
+            "SELECT MAX(transparent_child_index)
+                 FROM addresses
+                 WHERE account_id = :account_id
+                 AND key_scope = :key_scope
+                 AND redeem_script IS NOT NULL",
+            named_params![
+                ":account_id": account_id.0,
+                ":key_scope": key_scope.encode()
+            ],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+
+    let next_index = max_index.map_or(0, |i| i.saturating_add(1));
+
+    NonHardenedChildIndex::from_index(next_index).ok_or_else(|| {
+        SqliteClientError::CorruptedData(
+            "Next address index exceeds maximum non-hardened index".to_owned(),
+        )
+    })
+}
+
+/// Finds the first unexposed ZIP 48 multisig address for the given account and scope.
+///
+/// Returns the address index if an unexposed address exists, or None if all addresses
+/// have been exposed.
+pub(crate) fn get_first_unexposed_zip48_multisig_address_index(
+    conn: &Connection,
+    account_id: AccountRef,
+    scope: TransparentKeyScope,
+) -> Result<Option<NonHardenedChildIndex>, SqliteClientError> {
+    let key_scope = KeyScope::try_from(scope)?;
+
+    let index: Option<u32> = conn
+        .query_row(
+            "SELECT MIN(transparent_child_index)
+                 FROM addresses
+                 WHERE account_id = :account_id
+                 AND key_scope = :key_scope
+                 AND redeem_script IS NOT NULL
+                 AND exposed_at_height IS NULL",
+            named_params![
+                ":account_id": account_id.0,
+                ":key_scope": key_scope.encode()
+            ],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+
+    match index {
+        Some(i) => NonHardenedChildIndex::from_index(i)
+            .map(Some)
+            .ok_or_else(|| {
+                SqliteClientError::CorruptedData(
+                    "Address index exceeds maximum non-hardened index".to_owned(),
+                )
+            }),
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,6 +295,116 @@ mod tests {
 
     // The default gap limits pre-generate 10 external and 5 internal addresses on import.
     const GAP_EXTERNAL: u32 = 10;
+    const GAP_INTERNAL: u32 = 5;
+
+    #[test]
+    fn next_index_after_import() {
+        with_zip48_test_env(|st, account_ref, _fvk, _params| {
+            // After import, gap fill has already generated GAP_EXTERNAL addresses (0..9).
+            let next = get_next_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(
+                next,
+                NonHardenedChildIndex::from_index(GAP_EXTERNAL).unwrap()
+            );
+
+            let next_internal = get_next_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::INTERNAL,
+            )
+            .unwrap();
+            assert_eq!(
+                next_internal,
+                NonHardenedChildIndex::from_index(GAP_INTERNAL).unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn next_index_after_additional_insert() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            // Generate addresses beyond the gap fill range (10..15).
+            let range_start = NonHardenedChildIndex::from_index(GAP_EXTERNAL).unwrap();
+            let range_end = NonHardenedChildIndex::from_index(GAP_EXTERNAL + 5).unwrap();
+            {
+                let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+                generate_zip48_multisig_address_range(
+                    &tx,
+                    &params,
+                    account_ref,
+                    fvk,
+                    TransparentKeyScope::EXTERNAL,
+                    range_start..range_end,
+                )
+                .unwrap();
+                tx.commit().unwrap();
+            }
+
+            let next = get_next_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(
+                next,
+                NonHardenedChildIndex::from_index(GAP_EXTERNAL + 5).unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn first_unexposed_returns_unexposed_index() {
+        with_zip48_test_env(|st, account_ref, _fvk, _params| {
+            // The gap-fill addresses created during import are all unexposed.
+            let result = get_first_unexposed_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(result, Some(NonHardenedChildIndex::ZERO));
+        });
+    }
+
+    #[test]
+    fn first_unexposed_none_when_all_exposed() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            // Mark all gap-fill addresses as exposed by re-inserting with exposed_at_height.
+            for i in 0..GAP_EXTERNAL {
+                let index = NonHardenedChildIndex::from_index(i).unwrap();
+                let (address, redeem_script) = fvk.derive_address(zip32::Scope::External, index);
+                {
+                    let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+                    insert_zip48_multisig_address(
+                        &tx,
+                        &params,
+                        account_ref,
+                        TransparentKeyScope::EXTERNAL,
+                        index,
+                        &address,
+                        &redeem_script,
+                        Some(BlockHeight::from_u32(100)),
+                    )
+                    .unwrap();
+                    tx.commit().unwrap();
+                }
+            }
+
+            let result = get_first_unexposed_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(result, None);
+        });
+    }
 
     #[test]
     fn insert_rejects_non_p2sh_address() {
@@ -372,6 +572,61 @@ mod tests {
                 );
                 assert_eq!(row.2, None, "expected unexposed at index {i}");
             }
+        });
+    }
+
+    #[test]
+    fn generate_range_inserts_correct_count() {
+        with_zip48_test_env(|st, account_ref, fvk, params| {
+            // Generate 5 more external addresses beyond the gap fill (10..15).
+            let range_start = NonHardenedChildIndex::from_index(GAP_EXTERNAL).unwrap();
+            let range_end = NonHardenedChildIndex::from_index(GAP_EXTERNAL + 5).unwrap();
+            {
+                let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+                generate_zip48_multisig_address_range(
+                    &tx,
+                    &params,
+                    account_ref,
+                    fvk,
+                    TransparentKeyScope::EXTERNAL,
+                    range_start..range_end,
+                )
+                .unwrap();
+                tx.commit().unwrap();
+            }
+
+            // The next index should be GAP_EXTERNAL + 5.
+            let next = get_next_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(
+                next,
+                NonHardenedChildIndex::from_index(GAP_EXTERNAL + 5).unwrap()
+            );
+
+            // Gap-fill addresses are still unexposed, first one at index 0.
+            let first_unexposed = get_first_unexposed_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::EXTERNAL,
+            )
+            .unwrap();
+            assert_eq!(first_unexposed, Some(NonHardenedChildIndex::ZERO));
+
+            // Internal scope should still have only the gap fill addresses.
+            let next_internal = get_next_zip48_multisig_address_index(
+                st.wallet().conn(),
+                account_ref,
+                TransparentKeyScope::INTERNAL,
+            )
+            .unwrap();
+            assert_eq!(
+                next_internal,
+                NonHardenedChildIndex::from_index(GAP_INTERNAL).unwrap()
+            );
         });
     }
 }

--- a/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/zip48_multisig.rs
@@ -54,8 +54,7 @@ pub(crate) fn generate_zip48_multisig_address_range<P: consensus::Parameters>(
             account_id,
             key_scope,
             address_index,
-            &address,
-            &redeem_script,
+            (&address, &redeem_script),
             None,
         )?;
     }
@@ -90,12 +89,13 @@ pub(crate) fn insert_zip48_multisig_address<P: consensus::Parameters>(
     account_id: AccountRef,
     scope: TransparentKeyScope,
     address_index: NonHardenedChildIndex,
-    address: &TransparentAddress,
-    redeem_script: &script::Redeem,
+    derived: (&TransparentAddress, &script::Redeem),
     exposed_at_height: Option<BlockHeight>,
 ) -> Result<AddressRef, SqliteClientError> {
     use zcash_keys::encoding::AddressCodec;
     use zcash_script::script::Evaluable;
+
+    let (address, redeem_script) = derived;
 
     if !matches!(address, TransparentAddress::ScriptHash(_)) {
         return Err(SqliteClientError::TransparentAddress(
@@ -387,8 +387,7 @@ mod tests {
                         account_ref,
                         TransparentKeyScope::EXTERNAL,
                         index,
-                        &address,
-                        &redeem_script,
+                        (&address, &redeem_script),
                         Some(BlockHeight::from_u32(100)),
                     )
                     .unwrap();
@@ -421,8 +420,7 @@ mod tests {
                 account_ref,
                 TransparentKeyScope::EXTERNAL,
                 NonHardenedChildIndex::ZERO,
-                &p2pkh_address,
-                &redeem_script,
+                (&p2pkh_address, &redeem_script),
                 None,
             );
             assert_matches!(result, Err(SqliteClientError::TransparentAddress(_)));
@@ -448,8 +446,7 @@ mod tests {
                     account_ref,
                     TransparentKeyScope::EXTERNAL,
                     index,
-                    &address,
-                    &redeem_script,
+                    (&address, &redeem_script),
                     exposed_height,
                 )
                 .unwrap();

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -21,6 +21,8 @@ workspace.
 - `zcash_transparent::builder::TransparentInputInfo::{from_parts, spend_info}`
 - `zcash_transparent::builder::Builder::add_p2pkh_input`
 - `impl Hash for zcash_transparent::keys::TransparentKeyScope`
+- `impl PartialOrd for zcash_transparent::zip48::AccountPubkey`
+- `impl Ord for zcash_transparent::zip48::AccountPubkey`
 
 ### Changed
 - MSRV is now 1.85.1.
@@ -33,6 +35,7 @@ workspace.
   instead of its constituent parts. Use `Builder::add_p2pkh_input` if you need the
   previous API.
 - Made `zcash_transparent::zip48::coin_type_and_account()` public
+- Sort BIP 388 `key_info` to ensure canonical encoding of ZIP 48 multipath descriptors
 
 ## [0.6.3] - 2025-12-17
 

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -32,6 +32,7 @@ workspace.
 - `zcash_transparent::builder::Builder::add_input` now takes a `TransparentInputInfo`
   instead of its constituent parts. Use `Builder::add_p2pkh_input` if you need the
   previous API.
+- Made `zcash_transparent::zip48::coin_type_and_account()` public
 
 ## [0.6.3] - 2025-12-17
 

--- a/zcash_transparent/src/zip48.rs
+++ b/zcash_transparent/src/zip48.rs
@@ -211,6 +211,7 @@ impl AccountPubKey {
 /// P2SH multisig account.
 ///
 /// [ZIP 48]: https://zips.z.cash/zip-0048
+#[derive(Clone, Debug)]
 pub struct FullViewingKey {
     threshold: u8,
     key_info: NonEmpty<AccountPubKey>,
@@ -255,6 +256,46 @@ impl FullViewingKey {
                 key_info,
             })
         }
+    }
+
+    /// Parses a ZIP 48 full viewing key from its serialized BIP 389 multipath descriptor format.
+    pub fn parse_multipath_descriptor<P: zcash_protocol::consensus::Parameters>(
+        bytes: &[u8],
+        params: &P,
+    ) -> Result<Self, FullViewingKeyError> {
+        let s = std::str::from_utf8(bytes).map_err(|_| FullViewingKeyError::InvalidDescriptor)?;
+
+        // Expected format: sh(sortedmulti(<threshold>,<key_info>/<0;1>/*,...))
+        let inner = s
+            .strip_prefix("sh(sortedmulti(")
+            .ok_or(FullViewingKeyError::InvalidDescriptor)?
+            .strip_suffix("))")
+            .ok_or(FullViewingKeyError::InvalidDescriptor)?;
+
+        // Split by comma to get threshold and key expressions
+        // Key expressions contain '/' but not ',', so simple split is safe
+        let mut parts = inner.split(',');
+
+        // Parse threshold
+        let threshold: u8 = parts
+            .next()
+            .ok_or(FullViewingKeyError::InvalidDescriptor)?
+            .parse()
+            .map_err(|_| FullViewingKeyError::InvalidDescriptor)?;
+
+        // Parse key expressions, stripping the /<0;1>/* suffix
+        let key_info: Vec<AccountPubKey> = parts
+            .map(|key_expr| {
+                let key_info_expr = key_expr
+                    .strip_suffix("/<0;1>/*")
+                    .ok_or(FullViewingKeyError::InvalidDescriptor)?;
+                AccountPubKey::parse_key_info_expression(key_info_expr, params)
+                    .ok_or(FullViewingKeyError::InvalidDescriptor)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Use standard constructor to validate
+        FullViewingKey::standard(threshold, key_info)
     }
 
     /// Returns the ZIP 48 coin type and account ID for this full viewing key.
@@ -358,6 +399,8 @@ pub enum FullViewingKeyError {
     InvalidThreshold,
     /// The pubkeys were not all derived following ZIP 48.
     IncompatiblePubKeys,
+    /// The provided descriptor is invalid.
+    InvalidDescriptor,
 }
 
 #[cfg(test)]
@@ -415,6 +458,35 @@ mod tests {
                 addr,
             );
         }
+    }
+
+    #[test]
+    fn multipath_descriptor_round_trip() {
+        let params = MainNetwork;
+        let seeds = [[1; 32], [2; 32], [3; 32]];
+
+        let key_info = seeds
+            .iter()
+            .map(|seed| {
+                AccountPrivKey::from_seed(&params, seed, AccountId::ZERO)
+                    .unwrap()
+                    .to_account_pubkey()
+            })
+            .collect();
+
+        let fvk = FullViewingKey::standard(2, key_info).unwrap();
+        let descriptor = fvk.multipath_descriptor(&params);
+        let parsed =
+            FullViewingKey::parse_multipath_descriptor(descriptor.as_bytes(), &params).unwrap();
+        assert_eq!(parsed.multipath_descriptor(&params), descriptor);
+
+        // Verify derived addresses also match
+        let (addr1, redeem1) =
+            fvk.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+        let (addr2, redeem2) =
+            parsed.derive_address(zip32::Scope::External, NonHardenedChildIndex::ZERO);
+        assert_eq!(addr1, addr2);
+        assert_eq!(redeem1, redeem2);
     }
 
     #[test]

--- a/zcash_transparent/src/zip48.rs
+++ b/zcash_transparent/src/zip48.rs
@@ -258,7 +258,7 @@ impl FullViewingKey {
     }
 
     /// Returns the ZIP 48 coin type and account ID for this full viewing key.
-    fn coin_type_and_account(&self) -> (u32, AccountId) {
+    pub fn coin_type_and_account(&self) -> (u32, AccountId) {
         // By construction of `Self`, all keys in `key_info` have the same derivation
         // information, so we only need to look at the first.
         self.key_info.first().coin_type_and_account()

--- a/zcash_transparent/src/zip48.rs
+++ b/zcash_transparent/src/zip48.rs
@@ -115,6 +115,18 @@ pub struct AccountPubKey {
     key: ExtendedPublicKey<PublicKey>,
 }
 
+impl PartialOrd for AccountPubKey {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AccountPubKey {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
 impl AccountPubKey {
     /// Attempts to parse a [BIP 388 `KEY_INFO` expression] as a ZIP 48 public key.
     ///
@@ -249,8 +261,10 @@ impl FullViewingKey {
                 }
             }
 
-            // TODO: Decide whether `key_info` should be sorted (or checked to be sorted)
-            // to ensure a canonical multipath descriptor.
+            // Enforce canonical ordering to ensure a deterministic multipath descriptor,
+            // as required for collision detection.
+            let mut key_info = key_info;
+            key_info.sort();
             Ok(Self {
                 threshold,
                 key_info,
@@ -440,7 +454,7 @@ mod tests {
         );
         assert_eq!(
             fvk.multipath_descriptor(&params),
-            "sh(sortedmulti(2,[4ba43603/48'/133'/0'/133000']xpub6E96VHgq8MKkYGuNLDjxLxH3LH93NGJX5xSufVjnh7zM8bKehGr3iekJLyc8WJiMemYWuXLPKwygt3j9nfJCapPkYRfCc5YFvzb3aMLsQdV/<0;1>/*,[8dfc9b34/48'/133'/0'/133000']xpub6EuQaJQHwbf2mbyHoYcyjcj9ByB8EeKp4zSKTT9EdxfaQJDgou3SR3oYtP7AYoHQtEUsnsjgdZD8n7c7G4Pv4iXMt98sCvdWNXs1bvhEu29/<0;1>/*,[56c4fac3/48'/133'/0'/133000']xpub6EVJBC6rV3qaNwfK3ChbjpEHnqhymSLmvqB1rKu7sRPH7szS9f4jDAiPyAF7PbnRH512uHhT4te6EJppbCWURtDKbiygGWphd5ej21oNqAx/<0;1>/*))",
+            "sh(sortedmulti(2,[56c4fac3/48'/133'/0'/133000']xpub6EVJBC6rV3qaNwfK3ChbjpEHnqhymSLmvqB1rKu7sRPH7szS9f4jDAiPyAF7PbnRH512uHhT4te6EJppbCWURtDKbiygGWphd5ej21oNqAx/<0;1>/*,[8dfc9b34/48'/133'/0'/133000']xpub6EuQaJQHwbf2mbyHoYcyjcj9ByB8EeKp4zSKTT9EdxfaQJDgou3SR3oYtP7AYoHQtEUsnsjgdZD8n7c7G4Pv4iXMt98sCvdWNXs1bvhEu29/<0;1>/*,[4ba43603/48'/133'/0'/133000']xpub6E96VHgq8MKkYGuNLDjxLxH3LH93NGJX5xSufVjnh7zM8bKehGr3iekJLyc8WJiMemYWuXLPKwygt3j9nfJCapPkYRfCc5YFvzb3aMLsQdV/<0;1>/*))",
         );
         for (i, addr) in [
             (0, "t3gDnw36YBC6SSmccqJYCsq6xtzGXamGxKd"),
@@ -541,12 +555,18 @@ mod tests {
                 tv.wallet_descriptor_template,
             );
 
-            for (key, expected) in fvk.key_info.iter().zip(tv.key_information_vector) {
-                assert_eq!(
-                    AccountPubKey::parse_key_info_expression(expected, &params).as_ref(),
-                    Some(key),
+            // The test vectors list keys in seed order, but FullViewingKey sorts
+            // them canonically (by compressed public key). Verify each key parses
+            // correctly, round-trips, and is present in the FVK.
+            assert_eq!(fvk.key_info.len(), tv.key_information_vector.len());
+            for expected in tv.key_information_vector {
+                let key = AccountPubKey::parse_key_info_expression(expected, &params)
+                    .expect("valid key_info expression");
+                assert_eq!(&key.key_info_expression(&params), *expected);
+                assert!(
+                    fvk.key_info.iter().any(|k| k == &key),
+                    "key from test vector not found in FVK: {expected}",
                 );
-                assert_eq!(&key.key_info_expression(&params), expected);
             }
 
             for (i, seed) in seeds.iter().enumerate() {


### PR DESCRIPTION
This PR implements support for balance tracking of ZIP 48 transparent multisig accounts. This is a first step towards general P2SH account tracking.

I wanted to get feedback on this, before deciding how to approach general P2SH account support.

resolves https://github.com/zcash/librustzcash/issues/2197
resolves COR-1068