### PR TITLE
fix(zcash_client_sqlite): ensure Address is in scope for transparent-inputs feature

### DIFF
--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -72,7 +72,7 @@ use zcash_client_backend::{
     wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput, WalletTx},
 };
 use zcash_keys::{
-    address::UnifiedAddress,
+    address::{Address, UnifiedAddress},
     keys::{ReceiverRequirement, UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
 };
 use zcash_primitives::{
@@ -130,7 +130,6 @@ use {
 use {
     rusqlite::named_params,
     zcash_client_backend::data_api::{OutputOfSentTx, WalletTest, testing::TransactionSummary},
-    zcash_keys::address::Address,
 };
 
 #[cfg(any(test, feature = "test-dependencies", feature = "transparent-inputs"))]


### PR DESCRIPTION
This PR fixes a build failure in `zcash_client_sqlite` when the `transparent-inputs` feature is enabled.

The failure was caused by the `Address` type being used in the `WalletWrite::store_address_range` implementation (line 2214) but only being imported within a test-only configuration block.

Fixed by moving the `Address` import to the global imports section of `zcash_client_sqlite/src/lib.rs`.

Fixes #2157