### PR TITLE
zcash_client_sqlite: Fix inconsistency in uneconomic value determination.

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -89,6 +89,12 @@ workspace.
 - Type parameters to `zcash_client_backend::data_api::DecryptedTransaction`
   have been modified. It now abstracts over the transaction type, to permit
   use with partial or compact transaction data instead of full transactions.
+- The semantics of `zcash_client_backend::data_api::NoteFilter::ExceedsMinValue`
+  have changed; this filter now selects notes having value strictly greater
+  than the provided minimum value, instead of notes having value greater
+  than or equal to the provided minimum value. This fixes an inconsistency
+  in the various tests related to notes having no economic value in
+  `zcash_client_sqlite`.
 
 ### Removed
 - `zcash_client_backend::data_api::testing::transparent::GapLimits` use

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -250,7 +250,7 @@ impl Balance {
         Ok(())
     }
 
-    /// Returns the value in the account of notes that have value less than the marginal
+    /// Returns the value in the account of notes that have value less than or equal to the marginal
     /// fee, and consequently cannot be spent except as a grace input.
     pub fn uneconomic_value(&self) -> Zatoshis {
         self.uneconomic_value
@@ -1401,7 +1401,7 @@ impl<const MAX: u8> From<BoundedU8<MAX>> for usize {
 /// contexts.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NoteFilter {
-    /// Selects notes having value greater than or equal to the provided value.
+    /// Selects notes having value strictly greater than the provided value.
     ExceedsMinValue(Zatoshis),
     /// Selects notes having value greater than or equal to approximately the n'th percentile of
     /// previously sent notes in the account, irrespective of pool. The wrapped value must be in

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4714,12 +4714,12 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
     test_meta(
         &st,
         NoteFilter::ExceedsMinValue(Zatoshis::const_from_u64(1000_0000)),
-        Some(1),
+        Some(0),
     );
     test_meta(
         &st,
         NoteFilter::ExceedsMinValue(Zatoshis::const_from_u64(500_0000)),
-        Some(6),
+        Some(5),
     );
     test_meta(
         &st,

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -558,11 +558,11 @@ where
 }
 
 /// Returns a `[ChangeStrategy::DustInputs]` error if some of the inputs provided
-/// to the transaction have value less than the marginal fee, and could not be
+/// to the transaction have value less than or equal to the marginal fee, and could not be
 /// determined to have any economic value in the context of this input selection.
 ///
 /// This determination is potentially conservative in the sense that outputs
-/// with value less than the marginal fee might be excluded, even though in
+/// with value less than or equal to the marginal fee might be excluded, even though in
 /// practice they would not cause the fee to increase. Outputs with value
 /// greater than the marginal fee will never be excluded.
 ///

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -34,6 +34,11 @@ workspace.
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.
 - `zcash_client_sqlite::UtxoId` contents are now private.
 
+### Fixed
+- Notes are now consistently treated as having "uneconomic value" if their value is less
+  than **or equal to** the marginal fee. Previously, some call sites only considered
+  note uneconomic if their value was less than the marginal fee.
+
 ## [0.19.3] - 2026-02-19
 ### Fixed
 - Migration no longer crashes in regtest mode.

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -797,7 +797,7 @@ pub(crate) fn unspent_notes_meta(
                  INNER JOIN transactions ON transactions.id_tx = rn.transaction_id
                  WHERE a.uuid = :account_uuid
                  AND a.ufvk IS NOT NULL
-                 AND rn.value >= :min_value
+                 AND rn.value > :min_value
                  AND transactions.mined_height IS NOT NULL
                  AND rn.id NOT IN rarray(:exclude)
                  AND rn.id NOT IN ({})",

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1115,7 +1115,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
          JOIN accounts ON accounts.id = u.account_id
          JOIN addresses ON addresses.id = u.address_id
          WHERE u.address = :address
-         AND u.value_zat >= :min_value
+         AND u.value_zat > :min_value
          AND ({}) -- the transaction is mined or unexpired with minconf 0
          AND u.id NOT IN ({}) -- and the output is unspent
          AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
@@ -1213,7 +1213,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
             })?;
 
         let entry = result.entry(taddr).or_insert((key_scope, Balance::ZERO));
-        if value < zip317::MARGINAL_FEE {
+        if value <= zip317::MARGINAL_FEE {
             entry.1.add_uneconomic_value(value)?;
         } else {
             entry.1.add_spendable_value(value)?;
@@ -1272,7 +1272,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
                 })?;
 
             let entry = result.entry(taddr).or_insert((key_scope, Balance::ZERO));
-            if value < zip317::MARGINAL_FEE {
+            if value <= zip317::MARGINAL_FEE {
                 entry.1.add_uneconomic_value(value)?;
             } else {
                 entry.1.add_spendable_value(value)?;
@@ -1329,10 +1329,10 @@ pub(crate) fn add_transparent_account_balances(
             .entry(account)
             .or_insert(AccountBalance::ZERO)
             .with_unshielded_balance_mut(|bal| {
-                if value >= zip317::MARGINAL_FEE {
-                    bal.add_spendable_value(value)
-                } else {
+                if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
+                } else {
+                    bal.add_spendable_value(value)
                 }
             })?;
     }
@@ -1383,10 +1383,10 @@ pub(crate) fn add_transparent_account_balances(
                 .entry(account)
                 .or_insert(AccountBalance::ZERO)
                 .with_unshielded_balance_mut(|bal| {
-                    if value >= zip317::MARGINAL_FEE {
-                        bal.add_pending_spendable_value(value)
-                    } else {
+                    if value <= zip317::MARGINAL_FEE {
                         bal.add_uneconomic_value(value)
+                    } else {
+                        bal.add_pending_spendable_value(value)
                     }
                 })?;
         }


### PR DESCRIPTION
The only possible use for notes having value exactly equal to the marginal fee is in constructing zero-valued, memo-only transactions within a shielded pool. Transparent outputs with value exactly equal to the marginal fee are entirely uneconomic under ZIP 317 fee rules.

This commit eliminates complexity by treating transparent outputs and shielded outputs consistently; after this change, all outputs must have value greater than the marginal fee in order to be considered to have economic utility.

Fixed #2167