### PR TITLE
CI: Use a variable to allow configuration of larger runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
         include:
           - target: Linux
-            os: ubuntu-latest-8cores
+            os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
 
           - state: transparent
             transparent-pool: true
@@ -103,7 +103,7 @@ jobs:
           - target: macOS
             os: macOS-latest
           - target: Windows
-            os: windows-latest-8cores
+            os: ${{ vars.WINDOWS_LARGE_RUNNER || 'windows-latest' }}
 
           - state: transparent
             transparent-pool: true
@@ -173,7 +173,7 @@ jobs:
 
         include:
           - target: Linux
-            os: ubuntu-latest-8cores
+            os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
 
           - state: transparent
             transparent-pool: true


### PR DESCRIPTION
By using a variable to provide the larger runner configurations, we make it possible to both run CI jobs on forks, and ensure that we can fall back to the slower default runners if larger runners are not available.