### PR TITLE
CI: Switch book deployment to official GitHub Pages actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,9 +5,16 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,8 +43,11 @@ jobs:
           mkdir -p ./book/book/rustdoc
           mv ./target/doc ./book/book/rustdoc/latest
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/book
+          path: ./book/book
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Replace `peaceiris/actions-gh-pages` with `actions/upload-pages-artifact` and `actions/deploy-pages` for OIDC-based deployment.