### PR TITLE
Fix documentation in unified address and fvk modules

### DIFF
--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -6,6 +6,8 @@ use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 
 /// The set of known Receivers for Unified Addresses.
+///
+/// Defined in [ZIP 316][zip-0316].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Receiver {
     Orchard([u8; 43]),
@@ -24,6 +26,7 @@ impl TryFrom<(u32, &[u8])> for Receiver {
             Typecode::P2sh => addr.try_into().map(Receiver::P2sh),
             Typecode::Sapling => addr.try_into().map(Receiver::Sapling),
             Typecode::Orchard => addr.try_into().map(Receiver::Orchard),
+            // Preserve unknown typecodes for forward compatibility.
             Typecode::Unknown(_) => Ok(Receiver::Unknown {
                 typecode,
                 data: addr.to_vec(),

--- a/components/zcash_address/src/kind/unified/fvk.rs
+++ b/components/zcash_address/src/kind/unified/fvk.rs
@@ -115,7 +115,7 @@ impl Container for Ufvk {
     /// Returns the FVKs contained within this UFVK, in the order they were
     /// parsed from the string encoding.
     ///
-    /// This API is for advanced usage; in most cases you should use `Ufvk::receivers`.
+    /// This API is for advanced usage; in most cases you should use `Ufvk::items`.
     fn items_as_parsed(&self) -> &[Fvk] {
         &self.0
     }


### PR DESCRIPTION
- Add spec-referenced documentation to the Receiver enum in address.rs
- Clarify the purpose of the Unknown variant for forward compatibility
- Fix incorrect method reference in Ufvk::items_as_parsed doc comment
  (`Ufvk::receivers` → `Ufvk::items`)

No functional changes.