### PR TITLE
zip321: Return Result<Self, PaymentError> from Payment::new

### DIFF
--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -10,8 +10,16 @@ workspace.
 
 ## [0.7.0] - PENDING
 
+### Added
+- `zip321::PaymentError` enum for errors in constructing a `Payment`.
+- `zip321::PaymentError::with_index` method to convert a `PaymentError` into a
+  `Zip321Error` with an associated payment index.
+
 ### Changed
 - MSRV is now 1.85.1.
+- `zip321::Payment::new` now returns `Result<Self, PaymentError>` instead of
+  `Option<Self>`, providing a meaningful error when a memo is sent to a
+  transparent recipient or a zero-valued output is sent to a transparent address.
 - `zip321::Payment::amount` now returns `Option<Zatoshis>` instead of `Zatoshis`.
   Previously, the amount field of the payment would be set to zero if no amount
   parameter was present; however, this behavior is not specified by ZIP 321.
@@ -19,8 +27,7 @@ workspace.
   specified by a payment request, this should be interpreted to mean that the
   sender of the transaction should specify an amount for the payment.
 - `zip321::Payment::new` now takes its `amount` parameter as `Option<Zatoshis>`
-  instead of `Zatoshis`. It now returns `None` if the payment requests that a
-  zero-valued output OR a memo be sent to a transparent-only address.
+  instead of `Zatoshis`.
 - `zip321::Zip321Error` has added variant `Zip321Error::ZeroValuedTransparentOutput`.
   Zero-valued transparent outputs are rejected by the Zcash consensus rules,
   and so payments to transparent addresses with the `amount` parameter explicitly

--- a/components/zip321/src/lib.rs
+++ b/components/zip321/src/lib.rs
@@ -23,6 +23,44 @@ use zcash_protocol::{
     value::Zatoshis,
 };
 
+/// Errors that may be produced in constructing a [`Payment`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaymentError {
+    /// A memo was provided for a recipient address that cannot receive a memo.
+    TransparentMemo,
+    /// A zero-valued output was requested for a transparent recipient address, which is
+    /// disallowed by the Zcash consensus rules.
+    ZeroValuedTransparentOutput,
+}
+
+impl Display for PaymentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PaymentError::TransparentMemo => {
+                write!(f, "Cannot send a memo to a transparent recipient address")
+            }
+            PaymentError::ZeroValuedTransparentOutput => write!(
+                f,
+                "Zero-valued transparent outputs are disallowed by consensus"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PaymentError {}
+
+impl PaymentError {
+    /// Adds a payment index to this error to produce a [`Zip321Error`].
+    pub fn with_index(self, index: usize) -> Zip321Error {
+        match self {
+            PaymentError::TransparentMemo => Zip321Error::TransparentMemo(index),
+            PaymentError::ZeroValuedTransparentOutput => {
+                Zip321Error::ZeroValuedTransparentOutput(index)
+            }
+        }
+    }
+}
+
 /// Errors that may be produced in decoding of payment requests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -157,7 +195,7 @@ impl Payment {
     ///   purpose of this payment within the larger structure of the transaction request.
     /// - `other_params`: A list of other arbitrary key/value pairs associated with this payment.
     ///
-    /// Returns `None` if the payment requests that a memo be sent to a recipient that cannot
+    /// Returns an error if the payment requests that a memo be sent to a recipient that cannot
     /// receive a memo or a zero-valued output be sent to a transparent address.
     pub fn new(
         recipient_address: ZcashAddress,
@@ -166,13 +204,13 @@ impl Payment {
         label: Option<String>,
         message: Option<String>,
         other_params: Vec<(String, String)>,
-    ) -> Option<Self> {
-        if (recipient_address.is_transparent_only() && amount == Some(Zatoshis::ZERO))
-            || (memo.is_some() && !recipient_address.can_receive_memo())
-        {
-            None
+    ) -> Result<Self, PaymentError> {
+        if memo.is_some() && !recipient_address.can_receive_memo() {
+            Err(PaymentError::TransparentMemo)
+        } else if recipient_address.is_transparent_only() && amount == Some(Zatoshis::ZERO) {
+            Err(PaymentError::ZeroValuedTransparentOutput)
         } else {
-            Some(Self {
+            Ok(Self {
                 recipient_address,
                 amount,
                 memo,

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -33,6 +33,9 @@ workspace.
   - `impl From<orchard::Note> for Note`
 
 ### Changed
+- `zcash_client_backend::data_api::error::Error::MemoForbidden` has been replaced
+  by `Error::Payment(zip321::PaymentError)`, which can represent both memo-to-transparent
+  and zero-valued-transparent-output errors.
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now takes
   an additional `proposed_version: Option<TxVersion>` parameter under the `unstable`
   feature flag, allowing callers to request a specific transaction version.

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -72,8 +72,8 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
     /// An error occurred building a new transaction.
     Builder(builder::Error<FeeError>),
 
-    /// It is forbidden to provide a memo when constructing a transparent output.
-    MemoForbidden,
+    /// An error occurred constructing a payment for the transaction.
+    Payment(zip321::PaymentError),
 
     /// Attempted to send change to an unsupported pool.
     ///
@@ -211,10 +211,7 @@ where
             ),
             Error::ScanRequired => write!(f, "Must scan blocks first"),
             Error::Builder(e) => write!(f, "An error occurred building the transaction: {e}"),
-            Error::MemoForbidden => write!(
-                f,
-                "It is not possible to send a memo to a transparent address."
-            ),
+            Error::Payment(e) => write!(f, "An error occurred constructing a payment: {e}"),
             Error::UnsupportedChangeType(t) => write!(
                 f,
                 "Attempted to send change to an unsupported pool type: {t}"

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -787,7 +787,9 @@ pub fn fails_to_send_max_spendable_to_transparent_with_memo<T: ShieldedPoolTeste
             MaxSpendMode::Everything,
             ConfirmationsPolicy::MIN
         ),
-        Err(data_api::error::Error::MemoForbidden)
+        Err(data_api::error::Error::Payment(
+            zip321::PaymentError::TransparentMemo
+        ))
     );
 }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -716,7 +716,7 @@ where
             None,
             vec![],
         )
-        .ok_or(Error::MemoForbidden)?,
+        .map_err(Error::Payment)?,
     ])
     .expect(
         "It should not be possible for this to violate ZIP 321 request construction invariants.",
@@ -774,7 +774,7 @@ where
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
     if memo.is_some() && !recipient.can_receive_memo() {
-        return Err(Error::MemoForbidden);
+        return Err(Error::Payment(zip321::PaymentError::TransparentMemo));
     }
 
     let proposal = propose_send_max(
@@ -1472,7 +1472,7 @@ where
              to: TransparentAddress|
              -> Result<(), CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>> {
                 if payment.memo().is_some() {
-                    return Err(Error::MemoForbidden);
+                    return Err(Error::Payment(zip321::PaymentError::TransparentMemo));
                 }
                 builder.add_transparent_output(&to, payment_amount)?;
                 transparent_output_meta.push((

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -471,7 +471,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             payment.message().cloned(),
                             payment.other_params().to_vec(),
                         )
-                        .expect("cannot fail because memo is None"),
+                        .expect("cannot fail because memo is None and amount is nonzero"),
                     );
                     total_ephemeral = (total_ephemeral + payment_amount)
                         .ok_or(GreedyInputSelectorError::Balance(BalanceError::Overflow))?;
@@ -924,11 +924,7 @@ where
         None,
         vec![],
     )
-    .ok_or_else(|| {
-        InputSelectorError::Proposal(ProposalError::Zip321(zip321::Zip321Error::TransparentMemo(
-            0,
-        )))
-    })?;
+    .map_err(|e| InputSelectorError::Proposal(ProposalError::Zip321(e.with_index(0))))?;
 
     let transaction_request =
         TransactionRequest::new(vec![payment.clone()]).map_err(|payment_error| {


### PR DESCRIPTION
Changes `Payment::new` to return `Result<Self, PaymentError>` instead of `Option<Self>`, giving callers a meaningful error when payment construction fails. The new `PaymentError` enum distinguishes between sending a memo to a transparent recipient and creating a zero-valued transparent output.

Closes #1794.