### PR TITLE
test(zcash_address): Improve doc comments on Receiver enum and Unknown typecode handling

### DIFF
--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -6,6 +6,8 @@ use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 
 /// The set of known Receivers for Unified Addresses.
+///
+/// Defined in [ZIP 316][zip-0316].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Receiver {
     Orchard([u8; 43]),
@@ -24,6 +26,7 @@ impl TryFrom<(u32, &[u8])> for Receiver {
             Typecode::P2sh => addr.try_into().map(Receiver::P2sh),
             Typecode::Sapling => addr.try_into().map(Receiver::Sapling),
             Typecode::Orchard => addr.try_into().map(Receiver::Orchard),
+            // Preserve unknown typecodes for forward compatibility.
             Typecode::Unknown(_) => Ok(Receiver::Unknown {
                 typecode,
                 data: addr.to_vec(),


### PR DESCRIPTION
## Summary
Two small documentation comment improvements in `address.rs`:

1. Added a ZIP 316 reference to the `Receiver` enum doc comment, so readers 
   know where the specification lives without having to hunt for it.

2. Added an inline comment on the `Typecode::Unknown` match arm explaining 
   *why* unknown typecodes are preserved, rather than leaving it implicit.

## Why
The `Receiver` enum is a core public type and the ZIP 316 reference was 
already present on other types in the same file (e.g. the HRP constants) 
but missing here. The `Unknown` arm's forward-compatibility intent is 
non-obvious to someone reading the code for the first time.

## Notes
No behaviour changes. Comments only.