### PR TITLE
test(zcash_address): Add unit tests for has_receiver_of_type, contains_receiver, and can_receive_memo

### DIFF
--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -438,4 +438,44 @@ mod tests {
             ]
         )
     }
+
+    #[test]
+    fn address_receiver_queries() {
+        use zcash_protocol::PoolType;
+
+        // A UA with all receiver types
+        let ua = Address(vec![
+            Receiver::Orchard([0; 43]),
+            Receiver::Sapling([1; 43]),
+            Receiver::P2pkh([2; 20]),
+        ]);
+
+        // has_receiver_of_type
+        assert!(ua.has_receiver_of_type(PoolType::ORCHARD));
+        assert!(ua.has_receiver_of_type(PoolType::SAPLING));
+        assert!(ua.has_receiver_of_type(PoolType::TRANSPARENT));
+
+        // can_receive_memo: true only when Sapling or Orchard is present
+        assert!(ua.can_receive_memo());
+
+        // contains_receiver: exact data match required
+        assert!(ua.contains_receiver(&Receiver::Orchard([0; 43])));
+        assert!(!ua.contains_receiver(&Receiver::Orchard([1; 43]))); // same type, different data
+
+        // Transparent-only address cannot receive memos
+        let transparent_only = Address(vec![Receiver::P2pkh([0; 20])]);
+        assert!(!transparent_only.can_receive_memo());
+        assert!(!transparent_only.has_receiver_of_type(PoolType::ORCHARD));
+        assert!(!transparent_only.has_receiver_of_type(PoolType::SAPLING));
+        assert!(transparent_only.has_receiver_of_type(PoolType::TRANSPARENT));
+
+        // Unknown receiver does not count for any pool type
+        let with_unknown = Address(vec![
+            Receiver::Orchard([0; 43]),
+            Receiver::Unknown { typecode: 0xAA, data: vec![0; 32] },
+        ]);
+        assert!(!with_unknown.has_receiver_of_type(PoolType::SAPLING));
+        // Unknown receiver is NOT counted as transparent
+        assert!(!with_unknown.has_receiver_of_type(PoolType::TRANSPARENT));
+    }
 }


### PR DESCRIPTION
## Summary
The three public query methods on `unified::Address`, `has_receiver_of_type`, 
`contains_receiver`, and `can_receive_memo`, had no test coverage. This PR adds 
a focused unit test covering their behaviour across meaningful cases.

## What's tested
- `has_receiver_of_type` returns correct results for Orchard, Sapling, and 
  Transparent pool types
- `can_receive_memo` returns `true` when shielded receivers are present, and 
  `false` for transparent-only addresses
- `contains_receiver` requires exact byte-for-byte equality, not just type match
- A transparent-only address correctly reports no memo capability and no shielded 
  pool support
- An `Unknown` receiver does not contribute to any pool type query — guarding 
  against future regressions where a new receiver type might accidentally be 
  mapped incorrectly

<img width="849" height="103" alt="Screenshot 2026-03-05 at 12 44 49 PM" src="https://github.com/user-attachments/assets/94dd3fa2-a03e-4795-90ef-06cfee2a9700" />

## Why
These methods are part of the public API and are likely called by wallets to make 
decisions about memo sending and receiver selection. A silent regression here 
could cause real user-facing bugs. The `Unknown` receiver case in particular is 
non-obvious from reading the code alone and benefits from being pinned by a test.

## Notes
No behaviour changes. Test-only.