### PR TITLE
zcash_client: add address-to-account lookup with UA conflict detection

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,12 @@ workspace.
 
 ### Added
 - `zcash_client_backend::data_api`:
+  - `FindAccountForAddressError` — error type returned by `WalletRead::find_account_for_address`,
+    with variants `Backend(E)` for storage errors and `UnifiedAddressConflict` when receivers
+    of a Unified Address map to different accounts.
+  - `WalletRead::find_account_for_address` — default method that resolves the wallet account
+    controlling a given address. For Unified Addresses it detects cross-account receiver
+    conflicts and returns `FindAccountForAddressError::UnifiedAddressConflict` in that case.
   - `TransparentKeyOrigin` enum (behind the `transparent-inputs` feature flag).
   - `TransparentBalances` type alias (behind the `transparent-inputs` feature flag).
   - `ll` module

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -160,6 +160,7 @@ rand_chacha.workspace = true
 shardtree = { workspace = true, features = ["test-dependencies"] }
 tempfile = "3.5.0"
 tokio = { version = "1.21.0", features = ["rt-multi-thread"] }
+transparent = { workspace = true, features = ["test-dependencies"] }
 zcash_address = { workspace = true, features = ["test-dependencies"] }
 zcash_keys = { workspace = true, features = ["test-dependencies"] }
 zcash_primitives = { workspace = true, features = ["test-dependencies"] }
@@ -173,7 +174,10 @@ default = ["time/default"]
 lightwalletd-tonic = ["dep:tonic", "dep:tonic-prost", "hyper-util?/tokio"]
 
 ## Enables the `tls-webpki-roots` feature of `tonic`.
-lightwalletd-tonic-tls-webpki-roots = ["lightwalletd-tonic", "tonic?/tls-webpki-roots"]
+lightwalletd-tonic-tls-webpki-roots = [
+    "lightwalletd-tonic",
+    "tonic?/tls-webpki-roots",
+]
 
 ## Enables the `transport` feature of `tonic` producing a fully-featured client and server implementation
 lightwalletd-tonic-transport = ["lightwalletd-tonic", "tonic?/transport"]
@@ -201,24 +205,20 @@ zcashd-compat = ["zcash_keys/zcashd-compat"]
 
 ## Enables creating partially-constructed transactions for use in hardware wallet and multisig scenarios.
 pczt = [
-  "orchard",
-  "transparent-inputs",
-  "pczt/zcp-builder",
-  "pczt/io-finalizer",
-  "pczt/prover",
-  "pczt/signer",
-  "pczt/spend-finalizer",
-  "pczt/tx-extractor",
-  "dep:postcard",
-  "dep:serde",
+    "orchard",
+    "transparent-inputs",
+    "pczt/zcp-builder",
+    "pczt/io-finalizer",
+    "pczt/prover",
+    "pczt/signer",
+    "pczt/spend-finalizer",
+    "pczt/tx-extractor",
+    "dep:postcard",
+    "dep:serde",
 ]
 
 ## Exposes a wallet synchronization function that implements the necessary state machine.
-sync = [
-    "lightwalletd-tonic",
-    "dep:async-trait",
-    "dep:futures-util",
-]
+sync = ["lightwalletd-tonic", "dep:async-trait", "dep:futures-util"]
 
 ## Exposes a Tor client for hiding a wallet's IP address while performing certain wallet
 ## operations.
@@ -253,6 +253,7 @@ test-dependencies = [
     "dep:jubjub",
     "dep:rand",
     "dep:rand_chacha",
+    "transparent/test-dependencies",
     "orchard?/test-dependencies",
     "zcash_keys/test-dependencies",
     "zcash_primitives/test-dependencies",

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -679,6 +679,7 @@ impl AddressSource {
 }
 
 /// Information about an address in the wallet.
+#[derive(Clone)]
 pub struct AddressInfo {
     address: Address,
     source: AddressSource,
@@ -1603,6 +1604,59 @@ pub trait InputSource {
     }
 }
 
+/// Errors that may occur when resolving the account controlling an address.
+#[derive(Debug)]
+pub enum FindAccountForAddressError<E> {
+    /// Error returned by the underlying wallet backend.
+    Backend(E),
+
+    /// A Unified Address whose receivers map to different accounts.
+    UnifiedAddressConflict,
+}
+
+impl<E> From<E> for FindAccountForAddressError<E> {
+    fn from(err: E) -> Self {
+        Self::Backend(err)
+    }
+}
+
+/// Returns `true` if `address` contains any receiver that matches the given `ua`'s
+/// receivers.
+pub fn address_receiver_matches_ua(address: &Address, ua: &UnifiedAddress) -> bool {
+    match address {
+        Address::Transparent(t) => ua.transparent().map(|nt| nt == t).unwrap_or(false),
+        Address::Sapling(s) => ua.sapling().map(|ns| ns == s).unwrap_or(false),
+        Address::Unified(ua2) => {
+            let matches_transparent = ua
+                .transparent()
+                .zip(ua2.transparent())
+                .map(|(a, b)| a == b)
+                .unwrap_or(false);
+            let matches_sapling = ua
+                .sapling()
+                .zip(ua2.sapling())
+                .map(|(a, b)| a == b)
+                .unwrap_or(false);
+            let matches_orchard = {
+                #[cfg(feature = "orchard")]
+                {
+                    ua.orchard()
+                        .zip(ua2.orchard())
+                        .map(|(a, b)| a == b)
+                        .unwrap_or(false)
+                }
+                #[cfg(not(feature = "orchard"))]
+                {
+                    false
+                }
+            };
+            matches_transparent || matches_sapling || matches_orchard
+        }
+        // TEX addresses can never appear as a receiver inside a UnifiedAddress
+        _ => false,
+    }
+}
+
 /// Read-only operations required for light wallet functions.
 ///
 /// This trait defines the read-only portion of the storage interface atop which
@@ -1672,6 +1726,64 @@ pub trait WalletRead {
 
     /// Returns information about every address tracked for this account.
     fn list_addresses(&self, account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error>;
+
+    /// Returns the wallet account that controls the given address, if any.
+    ///
+    /// This method is intended to support efficient "address -> account" lookups.
+    /// Wallet backends are encouraged to override this method with a more efficient
+    /// implementation (e.g. an indexed database lookup). The default implementation
+    /// performs a linear scan over all accounts and their tracked addresses.
+    ///
+    /// # Unified Addresses
+    ///
+    /// For Unified Addresses, each receiver component (transparent, Sapling, Orchard) is
+    /// matched individually against the wallet's tracked addresses. All matched receivers
+    /// must resolve to the **same** account; if any two receivers map to different accounts,
+    /// this is considered an inconsistent wallet state and `Err` is returned rather than
+    /// arbitrarily selecting one account.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(account_id))` if the address (or, for Unified Addresses, all matched
+    ///   receiver components) is controlled by a single account known to this wallet.
+    /// - `Ok(None)` if no receiver of the address is recognized as belonging to any account.
+    /// - `Err(FindAccountForAddressError::BackendError(_))` if the lookup fails due to a
+    ///   backend error.
+    /// - `Err(FindAccountForAddressError::UnifiedAddressConflict)` if the provided address
+    ///   is a Unified Address whose receiver components map to different accounts.
+    fn find_account_for_address(
+        &self,
+        address: &zcash_keys::address::Address,
+    ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
+        let mut baseline_acc_id: Option<Self::AccountId> = None;
+
+        if let Address::Unified(ua) = address {
+            for acc_id in self.get_account_ids()? {
+                for addr_info in self.list_addresses(acc_id)? {
+                    let stored = addr_info.address();
+                    if address_receiver_matches_ua(stored, ua) {
+                        match baseline_acc_id {
+                            None => baseline_acc_id = Some(acc_id),
+                            Some(prev) if prev == acc_id => {}
+                            Some(_) => {
+                                return Err(FindAccountForAddressError::UnifiedAddressConflict);
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            for acc_id in self.get_account_ids()? {
+                for addr_info in self.list_addresses(acc_id)? {
+                    if addr_info.address() == address {
+                        return Ok(Some(acc_id));
+                    }
+                }
+            }
+        }
+
+        Ok(baseline_acc_id)
+    }
 
     /// Returns the most recently generated unified address for the specified account that conforms
     /// to the specified address filter, if the account identifier specified refers to a valid
@@ -3325,4 +3437,402 @@ pub trait WalletCommitmentTrees {
         start_index: u64,
         roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
     ) -> Result<(), ShardTreeError<Self::Error>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "orchard")]
+    use crate::data_api::testing::orchard::OrchardPoolTester;
+    use std::{collections::HashMap, convert::Infallible};
+
+    use crate::data_api::testing::{pool::ShieldedPoolTester, sapling::SaplingPoolTester};
+
+    use transparent::address::TransparentAddress;
+    use zcash_keys::{
+        address::{Address, UnifiedAddress},
+        keys::UnifiedIncomingViewingKey,
+    };
+    use zip32::DiversifierIndex;
+
+    type TestAccountId = u32;
+    type TestAccount = (TestAccountId, UnifiedIncomingViewingKey);
+
+    #[derive(Default)]
+    struct TestWalletDb {
+        account_ids: Vec<TestAccountId>,
+        addresses_by_account: HashMap<TestAccountId, Vec<AddressInfo>>,
+    }
+
+    impl TestWalletDb {
+        fn new(entries: impl IntoIterator<Item = (TestAccountId, Vec<AddressInfo>)>) -> Self {
+            let mut addresses_by_account = HashMap::new();
+            let mut account_ids = vec![];
+
+            for (account_id, addrs) in entries {
+                account_ids.push(account_id);
+                addresses_by_account.insert(account_id, addrs);
+            }
+
+            account_ids.sort_unstable();
+
+            Self {
+                account_ids,
+                addresses_by_account,
+            }
+        }
+    }
+
+    fn derived_source() -> AddressSource {
+        AddressSource::Derived {
+            diversifier_index: DiversifierIndex::default(),
+            #[cfg(feature = "transparent-inputs")]
+            transparent_key_scope: None,
+        }
+    }
+
+    fn address_info_of(address: Address) -> AddressInfo {
+        AddressInfo::from_parts(address, derived_source())
+            .expect("test address metadata must be valid")
+    }
+
+    fn transparent_address_for_tag(tag: u8) -> TransparentAddress {
+        TransparentAddress::PublicKeyHash([tag; 20])
+    }
+
+    fn sapling_address_for_tag(tag: u8) -> sapling::PaymentAddress {
+        match SaplingPoolTester::sk_default_address(&SaplingPoolTester::sk(&[tag; 32])) {
+            Address::Sapling(pa) => pa,
+            other => panic!("expected Sapling address, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "orchard")]
+    fn orchard_address(tag: u8) -> orchard::Address {
+        match OrchardPoolTester::sk_default_address(&OrchardPoolTester::sk(&[tag; 32])) {
+            Address::Unified(ua) => ua
+                .orchard()
+                .copied()
+                .expect("orchard receiver must be present"),
+            other => panic!("expected Orchard UA, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "orchard")]
+    fn unified_account_with(
+        transparent: Option<TransparentAddress>,
+        sapling: Option<sapling::PaymentAddress>,
+        orchard: Option<orchard::Address>,
+    ) -> Address {
+        UnifiedAddress::from_receivers(
+            Some(orchard).flatten(),
+            Some(sapling).flatten(),
+            transparent,
+        )
+        .expect("test UA must be valid")
+        .into()
+    }
+
+    impl WalletRead for TestWalletDb {
+        type Error = Infallible;
+        type AccountId = TestAccountId;
+        type Account = TestAccount;
+
+        fn get_account_ids(&self) -> Result<Vec<Self::AccountId>, Self::Error> {
+            Ok(self.account_ids.clone())
+        }
+
+        fn list_addresses(
+            &self,
+            account: Self::AccountId,
+        ) -> Result<Vec<AddressInfo>, Self::Error> {
+            Ok(self
+                .addresses_by_account
+                .get(&account)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn get_account(
+            &self,
+            _account_id: Self::AccountId,
+        ) -> Result<Option<Self::Account>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_derived_account(
+            &self,
+            _derivation: &Zip32Derivation,
+        ) -> Result<Option<Self::Account>, Self::Error> {
+            Ok(None)
+        }
+
+        fn validate_seed(
+            &self,
+            _account_id: Self::AccountId,
+            _seed: &secrecy::SecretVec<u8>,
+        ) -> Result<bool, Self::Error> {
+            Ok(false)
+        }
+
+        fn seed_relevance_to_derived_accounts(
+            &self,
+            _seed: &secrecy::SecretVec<u8>,
+        ) -> Result<SeedRelevance<Self::AccountId>, Self::Error> {
+            Ok(SeedRelevance::NoAccounts)
+        }
+
+        fn get_account_for_ufvk(
+            &self,
+            _ufvk: &zcash_keys::keys::UnifiedFullViewingKey,
+        ) -> Result<Option<Self::Account>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_last_generated_address_matching(
+            &self,
+            _account: Self::AccountId,
+            _address_filter: zcash_keys::keys::UnifiedAddressRequest,
+        ) -> Result<Option<UnifiedAddress>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_account_birthday(
+            &self,
+            _account: Self::AccountId,
+        ) -> Result<zcash_protocol::consensus::BlockHeight, Self::Error> {
+            unreachable!("not used by these tests")
+        }
+
+        fn get_wallet_birthday(
+            &self,
+        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_wallet_summary(
+            &self,
+            _confirmations_policy: wallet::ConfirmationsPolicy,
+        ) -> Result<Option<WalletSummary<Self::AccountId>>, Self::Error> {
+            Ok(None)
+        }
+
+        fn chain_height(
+            &self,
+        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_block_hash(
+            &self,
+            _block_height: zcash_protocol::consensus::BlockHeight,
+        ) -> Result<Option<zcash_primitives::block::BlockHash>, Self::Error> {
+            Ok(None)
+        }
+
+        fn block_metadata(
+            &self,
+            _height: zcash_protocol::consensus::BlockHeight,
+        ) -> Result<Option<BlockMetadata>, Self::Error> {
+            Ok(None)
+        }
+
+        fn block_fully_scanned(&self) -> Result<Option<BlockMetadata>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_max_height_hash(
+            &self,
+        ) -> Result<
+            Option<(
+                zcash_protocol::consensus::BlockHeight,
+                zcash_primitives::block::BlockHash,
+            )>,
+            Self::Error,
+        > {
+            Ok(None)
+        }
+
+        fn block_max_scanned(&self) -> Result<Option<BlockMetadata>, Self::Error> {
+            Ok(None)
+        }
+
+        fn suggest_scan_ranges(&self) -> Result<Vec<scanning::ScanRange>, Self::Error> {
+            Ok(vec![])
+        }
+
+        fn get_target_and_anchor_heights(
+            &self,
+            _min_confirmations: std::num::NonZeroU32,
+        ) -> Result<
+            Option<(wallet::TargetHeight, zcash_protocol::consensus::BlockHeight)>,
+            Self::Error,
+        > {
+            Ok(None)
+        }
+
+        fn get_tx_height(
+            &self,
+            _txid: zcash_protocol::TxId,
+        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_unified_full_viewing_keys(
+            &self,
+        ) -> Result<HashMap<Self::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, Self::Error>
+        {
+            Ok(HashMap::new())
+        }
+
+        fn get_memo(
+            &self,
+            _note_id: crate::wallet::NoteId,
+        ) -> Result<Option<zcash_protocol::memo::Memo>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_transaction(
+            &self,
+            _txid: zcash_protocol::TxId,
+        ) -> Result<Option<zcash_primitives::transaction::Transaction>, Self::Error> {
+            Ok(None)
+        }
+
+        fn get_sapling_nullifiers(
+            &self,
+            _query: NullifierQuery,
+        ) -> Result<Vec<(Self::AccountId, sapling::Nullifier)>, Self::Error> {
+            Ok(vec![])
+        }
+
+        #[cfg(feature = "orchard")]
+        fn get_orchard_nullifiers(
+            &self,
+            _query: NullifierQuery,
+        ) -> Result<Vec<(Self::AccountId, orchard::note::Nullifier)>, Self::Error> {
+            Ok(vec![])
+        }
+
+        fn transaction_data_requests(&self) -> Result<Vec<TransactionDataRequest>, Self::Error> {
+            Ok(vec![])
+        }
+
+        fn get_received_outputs(
+            &self,
+            _txid: zcash_protocol::TxId,
+            _target_height: wallet::TargetHeight,
+            _confirmations_policy: wallet::ConfirmationsPolicy,
+        ) -> Result<Vec<ReceivedTransactionOutput>, Self::Error> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn find_account_for_transparent_address_returns_matching_account() {
+        let wallet = TestWalletDb::new([
+            (
+                1,
+                vec![address_info_of(Address::Transparent(
+                    transparent_address_for_tag(1),
+                ))],
+            ),
+            (
+                2,
+                vec![address_info_of(Address::Transparent(
+                    transparent_address_for_tag(2),
+                ))],
+            ),
+        ]);
+        let result =
+            wallet.find_account_for_address(&Address::Transparent(transparent_address_for_tag(1)));
+        assert_eq!(result.unwrap(), Some(1));
+    }
+
+    #[test]
+    fn find_account_for_address_returns_none_when_simple_address_is_unknown() {
+        let address = Address::Transparent(transparent_address_for_tag(1));
+        let wallet = TestWalletDb::new([(1, vec![address_info_of(address)])]);
+
+        let other_address = Address::Transparent(transparent_address_for_tag(9));
+        let result = wallet.find_account_for_address(&other_address);
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn find_account_for_unified_address_returns_account_when_receivers_map_to_same_account() {
+        let transparent_address = transparent_address_for_tag(7);
+        let sapling_address = sapling_address_for_tag(11);
+        let orchard_address = orchard_address(13);
+
+        let wallet = TestWalletDb::new([(
+            1,
+            vec![
+                address_info_of(Address::Transparent(transparent_address)),
+                address_info_of(Address::Sapling(sapling_address)),
+                address_info_of(unified_account_with(None, None, Some(orchard_address))),
+            ],
+        )]);
+
+        let ua_with_all_addresses = unified_account_with(
+            Some(transparent_address),
+            Some(sapling_address),
+            Some(orchard_address),
+        );
+
+        let result = wallet.find_account_for_address(&ua_with_all_addresses);
+
+        assert_eq!(result.unwrap(), Some(1));
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn find_account_for_unified_address_returns_none_when_no_receiver_matches() {
+        let wallet = TestWalletDb::new([(
+            1,
+            vec![
+                address_info_of(Address::Transparent(transparent_address_for_tag(1))),
+                address_info_of(Address::Sapling(sapling_address_for_tag(2))),
+                address_info_of(unified_account_with(None, None, Some(orchard_address(3)))),
+            ],
+        )]);
+
+        let ua_with_different_receivers = unified_account_with(
+            Some(transparent_address_for_tag(10)),
+            Some(sapling_address_for_tag(11)),
+            Some(orchard_address(12)),
+        );
+
+        let result = wallet.find_account_for_address(&ua_with_different_receivers);
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn find_account_for_unified_address_errors_when_receivers_map_to_different_accounts() {
+        let transparent_address = transparent_address_for_tag(21);
+        let sapling_address = sapling_address_for_tag(22);
+
+        let wallet = TestWalletDb::new([
+            (
+                1,
+                vec![address_info_of(Address::Transparent(transparent_address))],
+            ),
+            (2, vec![address_info_of(Address::Sapling(sapling_address))]),
+        ]);
+
+        let invalid_unified_address =
+            unified_account_with(Some(transparent_address), Some(sapling_address), None);
+
+        let result = wallet.find_account_for_address(&invalid_unified_address);
+
+        assert!(matches!(
+            result,
+            Err(FindAccountForAddressError::UnifiedAddressConflict)
+        ));
+    }
 }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1725,7 +1725,7 @@ pub trait WalletRead {
     /// - `Ok(Some(account_id))` if the address (or, for Unified Addresses, all matched
     ///   receiver components) is controlled by a single account known to this wallet.
     /// - `Ok(None)` if no receiver of the address is recognized as belonging to any account.
-    /// - `Err(FindAccountForAddressError::BackendError(_))` if the lookup fails due to a
+    /// - `Err(FindAccountForAddressError::Backend(_))` if the lookup fails due to a
     ///   backend error.
     /// - `Err(FindAccountForAddressError::UnifiedAddressConflict)` if the provided address
     ///   is a Unified Address whose receiver components map to different accounts.
@@ -3424,44 +3424,14 @@ mod tests {
 
     #[cfg(feature = "orchard")]
     use crate::data_api::testing::orchard::OrchardPoolTester;
-    use std::{collections::HashMap, convert::Infallible};
 
-    use crate::data_api::testing::{pool::ShieldedPoolTester, sapling::SaplingPoolTester};
+    use crate::data_api::testing::{
+        MockWalletDb, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+    };
 
     use transparent::address::TransparentAddress;
-    use zcash_keys::{
-        address::{Address, UnifiedAddress},
-        keys::UnifiedIncomingViewingKey,
-    };
+    use zcash_keys::address::{Address, UnifiedAddress};
     use zip32::DiversifierIndex;
-
-    type TestAccountId = u32;
-    type TestAccount = (TestAccountId, UnifiedIncomingViewingKey);
-
-    #[derive(Default)]
-    struct TestWalletDb {
-        account_ids: Vec<TestAccountId>,
-        addresses_by_account: HashMap<TestAccountId, Vec<AddressInfo>>,
-    }
-
-    impl TestWalletDb {
-        fn new(entries: impl IntoIterator<Item = (TestAccountId, Vec<AddressInfo>)>) -> Self {
-            let mut addresses_by_account = HashMap::new();
-            let mut account_ids = vec![];
-
-            for (account_id, addrs) in entries {
-                account_ids.push(account_id);
-                addresses_by_account.insert(account_id, addrs);
-            }
-
-            account_ids.sort_unstable();
-
-            Self {
-                account_ids,
-                addresses_by_account,
-            }
-        }
-    }
 
     fn derived_source() -> AddressSource {
         AddressSource::Derived {
@@ -3513,217 +3483,25 @@ mod tests {
         .into()
     }
 
-    impl WalletRead for TestWalletDb {
-        type Error = Infallible;
-        type AccountId = TestAccountId;
-        type Account = TestAccount;
-
-        fn get_account_ids(&self) -> Result<Vec<Self::AccountId>, Self::Error> {
-            Ok(self.account_ids.clone())
-        }
-
-        fn list_addresses(
-            &self,
-            account: Self::AccountId,
-        ) -> Result<Vec<AddressInfo>, Self::Error> {
-            Ok(self
-                .addresses_by_account
-                .get(&account)
-                .cloned()
-                .unwrap_or_default())
-        }
-
-        fn get_account(
-            &self,
-            _account_id: Self::AccountId,
-        ) -> Result<Option<Self::Account>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_derived_account(
-            &self,
-            _derivation: &Zip32Derivation,
-        ) -> Result<Option<Self::Account>, Self::Error> {
-            Ok(None)
-        }
-
-        fn validate_seed(
-            &self,
-            _account_id: Self::AccountId,
-            _seed: &secrecy::SecretVec<u8>,
-        ) -> Result<bool, Self::Error> {
-            Ok(false)
-        }
-
-        fn seed_relevance_to_derived_accounts(
-            &self,
-            _seed: &secrecy::SecretVec<u8>,
-        ) -> Result<SeedRelevance<Self::AccountId>, Self::Error> {
-            Ok(SeedRelevance::NoAccounts)
-        }
-
-        fn get_account_for_ufvk(
-            &self,
-            _ufvk: &zcash_keys::keys::UnifiedFullViewingKey,
-        ) -> Result<Option<Self::Account>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_last_generated_address_matching(
-            &self,
-            _account: Self::AccountId,
-            _address_filter: zcash_keys::keys::UnifiedAddressRequest,
-        ) -> Result<Option<UnifiedAddress>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_account_birthday(
-            &self,
-            _account: Self::AccountId,
-        ) -> Result<zcash_protocol::consensus::BlockHeight, Self::Error> {
-            unreachable!("not used by these tests")
-        }
-
-        fn get_wallet_birthday(
-            &self,
-        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_wallet_summary(
-            &self,
-            _confirmations_policy: wallet::ConfirmationsPolicy,
-        ) -> Result<Option<WalletSummary<Self::AccountId>>, Self::Error> {
-            Ok(None)
-        }
-
-        fn chain_height(
-            &self,
-        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_block_hash(
-            &self,
-            _block_height: zcash_protocol::consensus::BlockHeight,
-        ) -> Result<Option<zcash_primitives::block::BlockHash>, Self::Error> {
-            Ok(None)
-        }
-
-        fn block_metadata(
-            &self,
-            _height: zcash_protocol::consensus::BlockHeight,
-        ) -> Result<Option<BlockMetadata>, Self::Error> {
-            Ok(None)
-        }
-
-        fn block_fully_scanned(&self) -> Result<Option<BlockMetadata>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_max_height_hash(
-            &self,
-        ) -> Result<
-            Option<(
-                zcash_protocol::consensus::BlockHeight,
-                zcash_primitives::block::BlockHash,
-            )>,
-            Self::Error,
-        > {
-            Ok(None)
-        }
-
-        fn block_max_scanned(&self) -> Result<Option<BlockMetadata>, Self::Error> {
-            Ok(None)
-        }
-
-        fn suggest_scan_ranges(&self) -> Result<Vec<scanning::ScanRange>, Self::Error> {
-            Ok(vec![])
-        }
-
-        fn get_target_and_anchor_heights(
-            &self,
-            _min_confirmations: std::num::NonZeroU32,
-        ) -> Result<
-            Option<(wallet::TargetHeight, zcash_protocol::consensus::BlockHeight)>,
-            Self::Error,
-        > {
-            Ok(None)
-        }
-
-        fn get_tx_height(
-            &self,
-            _txid: zcash_protocol::TxId,
-        ) -> Result<Option<zcash_protocol::consensus::BlockHeight>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_unified_full_viewing_keys(
-            &self,
-        ) -> Result<HashMap<Self::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, Self::Error>
-        {
-            Ok(HashMap::new())
-        }
-
-        fn get_memo(
-            &self,
-            _note_id: crate::wallet::NoteId,
-        ) -> Result<Option<zcash_protocol::memo::Memo>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_transaction(
-            &self,
-            _txid: zcash_protocol::TxId,
-        ) -> Result<Option<zcash_primitives::transaction::Transaction>, Self::Error> {
-            Ok(None)
-        }
-
-        fn get_sapling_nullifiers(
-            &self,
-            _query: NullifierQuery,
-        ) -> Result<Vec<(Self::AccountId, sapling::Nullifier)>, Self::Error> {
-            Ok(vec![])
-        }
-
-        #[cfg(feature = "orchard")]
-        fn get_orchard_nullifiers(
-            &self,
-            _query: NullifierQuery,
-        ) -> Result<Vec<(Self::AccountId, orchard::note::Nullifier)>, Self::Error> {
-            Ok(vec![])
-        }
-
-        fn transaction_data_requests(&self) -> Result<Vec<TransactionDataRequest>, Self::Error> {
-            Ok(vec![])
-        }
-
-        fn get_received_outputs(
-            &self,
-            _txid: zcash_protocol::TxId,
-            _target_height: wallet::TargetHeight,
-            _confirmations_policy: wallet::ConfirmationsPolicy,
-        ) -> Result<Vec<ReceivedTransactionOutput>, Self::Error> {
-            Ok(vec![])
-        }
-    }
-
     #[test]
     fn find_account_for_transparent_address_returns_matching_account() {
-        let wallet = TestWalletDb::new([
-            (
-                1,
-                vec![address_info_of(Address::Transparent(
-                    transparent_address_for_tag(1),
-                ))],
-            ),
-            (
-                2,
-                vec![address_info_of(Address::Transparent(
-                    transparent_address_for_tag(2),
-                ))],
-            ),
-        ]);
+        let wallet = MockWalletDb::from_account_addresses(
+            zcash_protocol::consensus::Network::MainNetwork,
+            [
+                (
+                    1,
+                    vec![address_info_of(Address::Transparent(
+                        transparent_address_for_tag(1),
+                    ))],
+                ),
+                (
+                    2,
+                    vec![address_info_of(Address::Transparent(
+                        transparent_address_for_tag(2),
+                    ))],
+                ),
+            ],
+        );
         let result = wallet.find_account_for_address(
             &zcash_protocol::consensus::Network::MainNetwork,
             &Address::Transparent(transparent_address_for_tag(1)),
@@ -3734,7 +3512,10 @@ mod tests {
     #[test]
     fn find_account_for_address_returns_none_when_simple_address_is_unknown() {
         let address = Address::Transparent(transparent_address_for_tag(1));
-        let wallet = TestWalletDb::new([(1, vec![address_info_of(address)])]);
+        let wallet = MockWalletDb::from_account_addresses(
+            zcash_protocol::consensus::Network::MainNetwork,
+            [(1, vec![address_info_of(address)])],
+        );
 
         let other_address = Address::Transparent(transparent_address_for_tag(9));
         let result = wallet.find_account_for_address(
@@ -3752,14 +3533,17 @@ mod tests {
         let sapling_address = sapling_address_for_tag(11);
         let orchard_address = orchard_address(13);
 
-        let wallet = TestWalletDb::new([(
-            1,
-            vec![
-                address_info_of(Address::Transparent(transparent_address)),
-                address_info_of(Address::Sapling(sapling_address)),
-                address_info_of(unified_account_with(None, None, Some(orchard_address))),
-            ],
-        )]);
+        let wallet = MockWalletDb::from_account_addresses(
+            zcash_protocol::consensus::Network::MainNetwork,
+            [(
+                1,
+                vec![
+                    address_info_of(Address::Transparent(transparent_address)),
+                    address_info_of(Address::Sapling(sapling_address)),
+                    address_info_of(unified_account_with(None, None, Some(orchard_address))),
+                ],
+            )],
+        );
 
         let ua_with_all_addresses = unified_account_with(
             Some(transparent_address),
@@ -3778,14 +3562,17 @@ mod tests {
     #[cfg(feature = "orchard")]
     #[test]
     fn find_account_for_unified_address_returns_none_when_no_receiver_matches() {
-        let wallet = TestWalletDb::new([(
-            1,
-            vec![
-                address_info_of(Address::Transparent(transparent_address_for_tag(1))),
-                address_info_of(Address::Sapling(sapling_address_for_tag(2))),
-                address_info_of(unified_account_with(None, None, Some(orchard_address(3)))),
-            ],
-        )]);
+        let wallet = MockWalletDb::from_account_addresses(
+            zcash_protocol::consensus::Network::MainNetwork,
+            [(
+                1,
+                vec![
+                    address_info_of(Address::Transparent(transparent_address_for_tag(1))),
+                    address_info_of(Address::Sapling(sapling_address_for_tag(2))),
+                    address_info_of(unified_account_with(None, None, Some(orchard_address(3)))),
+                ],
+            )],
+        );
 
         let ua_with_different_receivers = unified_account_with(
             Some(transparent_address_for_tag(10)),
@@ -3807,13 +3594,16 @@ mod tests {
         let transparent_address = transparent_address_for_tag(21);
         let sapling_address = sapling_address_for_tag(22);
 
-        let wallet = TestWalletDb::new([
-            (
-                1,
-                vec![address_info_of(Address::Transparent(transparent_address))],
-            ),
-            (2, vec![address_info_of(Address::Sapling(sapling_address))]),
-        ]);
+        let wallet = MockWalletDb::from_account_addresses(
+            zcash_protocol::consensus::Network::MainNetwork,
+            [
+                (
+                    1,
+                    vec![address_info_of(Address::Transparent(transparent_address))],
+                ),
+                (2, vec![address_info_of(Address::Sapling(sapling_address))]),
+            ],
+        );
 
         let invalid_unified_address =
             unified_account_with(Some(transparent_address), Some(sapling_address), None);

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1734,15 +1734,15 @@ pub trait WalletRead {
         params: &P,
         address: &zcash_keys::address::Address,
     ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
-        let mut baseline_acc_id: Option<Self::AccountId> = None;
+        let mut found_acc_id: Option<Self::AccountId> = None;
 
         if let Address::Unified(ua) = address {
             for acc_id in self.get_account_ids()? {
                 for addr_info in self.list_addresses(acc_id)? {
                     let stored = addr_info.address();
                     if address_receiver_matches_ua(stored, ua, params) {
-                        match baseline_acc_id {
-                            None => baseline_acc_id = Some(acc_id),
+                        match found_acc_id {
+                            None => found_acc_id = Some(acc_id),
                             Some(prev) if prev == acc_id => {}
                             Some(_) => {
                                 return Err(FindAccountForAddressError::UnifiedAddressConflict);
@@ -1754,14 +1754,20 @@ pub trait WalletRead {
         } else {
             for acc_id in self.get_account_ids()? {
                 for addr_info in self.list_addresses(acc_id)? {
-                    if addr_info.address() == address {
+                    let stored = addr_info.address();
+                    if stored == address {
                         return Ok(Some(acc_id));
+                    }
+                    if let Address::Unified(stored_ua) = stored {
+                        if address_receiver_matches_ua(address, stored_ua, params) {
+                            return Ok(Some(acc_id));
+                        }
                     }
                 }
             }
         }
 
-        Ok(baseline_acc_id)
+        Ok(found_acc_id)
     }
 
     /// Returns the most recently generated unified address for the specified account that conforms
@@ -3468,13 +3474,13 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "orchard")]
     fn unified_account_with(
         transparent: Option<TransparentAddress>,
         sapling: Option<sapling::PaymentAddress>,
-        orchard: Option<orchard::Address>,
+        #[cfg(feature = "orchard")] orchard: Option<orchard::Address>,
     ) -> Address {
         UnifiedAddress::from_receivers(
+            #[cfg(feature = "orchard")]
             Some(orchard).flatten(),
             Some(sapling).flatten(),
             transparent,
@@ -3507,6 +3513,52 @@ mod tests {
             &Address::Transparent(transparent_address_for_tag(1)),
         );
         assert_eq!(result.unwrap(), Some(1));
+    }
+
+    #[test]
+    fn find_account_for_transparent_receiver_in_unified_address_returns_matching_account() {
+        let transparent = transparent_address_for_tag(1);
+        let sapling_address = sapling_address_for_tag(11);
+
+        #[cfg(feature = "orchard")]
+        {
+            let wallet = MockWalletDb::from_account_addresses(
+                zcash_protocol::consensus::Network::MainNetwork,
+                [(
+                    1,
+                    vec![address_info_of(unified_account_with(
+                        Some(transparent),
+                        Some(sapling_address),
+                        None,
+                    ))],
+                )],
+            );
+            let result = wallet.find_account_for_address(
+                &zcash_protocol::consensus::Network::MainNetwork,
+                &Address::Transparent(transparent),
+            );
+            assert_eq!(result.unwrap(), Some(1));
+        }
+        #[cfg(not(feature = "orchard"))]
+        {
+            let wallet = MockWalletDb::from_account_addresses(
+                zcash_protocol::consensus::Network::MainNetwork,
+                [(
+                    1,
+                    vec![crate::data_api::tests::address_info_of(
+                        crate::data_api::tests::unified_account_with(
+                            Some(transparent.clone()),
+                            Some(sapling_address),
+                        ),
+                    )],
+                )],
+            );
+            let result = wallet.find_account_for_address(
+                &zcash_protocol::consensus::Network::MainNetwork,
+                &Address::Transparent(transparent),
+            );
+            assert_eq!(result.unwrap(), Some(1));
+        }
     }
 
     #[test]

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -84,7 +84,7 @@ use zcash_keys::{
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
 use zcash_protocol::{
     PoolType, ShieldedProtocol, TxId,
-    consensus::{BlockHeight, TxIndex},
+    consensus::{self, BlockHeight, TxIndex},
     memo::{Memo, MemoBytes},
     value::{BalanceError, Zatoshis},
 };
@@ -1622,39 +1622,17 @@ impl<E> From<E> for FindAccountForAddressError<E> {
 
 /// Returns `true` if `address` contains any receiver that matches the given `ua`'s
 /// receivers.
-pub fn address_receiver_matches_ua(address: &Address, ua: &UnifiedAddress) -> bool {
-    match address {
-        Address::Transparent(t) => ua.transparent().map(|nt| nt == t).unwrap_or(false),
-        Address::Sapling(s) => ua.sapling().map(|ns| ns == s).unwrap_or(false),
-        Address::Unified(ua2) => {
-            let matches_transparent = ua
-                .transparent()
-                .zip(ua2.transparent())
-                .map(|(a, b)| a == b)
-                .unwrap_or(false);
-            let matches_sapling = ua
-                .sapling()
-                .zip(ua2.sapling())
-                .map(|(a, b)| a == b)
-                .unwrap_or(false);
-            let matches_orchard = {
-                #[cfg(feature = "orchard")]
-                {
-                    ua.orchard()
-                        .zip(ua2.orchard())
-                        .map(|(a, b)| a == b)
-                        .unwrap_or(false)
-                }
-                #[cfg(not(feature = "orchard"))]
-                {
-                    false
-                }
-            };
-            matches_transparent || matches_sapling || matches_orchard
-        }
-        // TEX addresses can never appear as a receiver inside a UnifiedAddress
-        _ => false,
-    }
+pub fn address_receiver_matches_ua<P: consensus::Parameters>(
+    address: &Address,
+    ua: &UnifiedAddress,
+    params: &P,
+) -> bool {
+    let zcash_address = address.to_zcash_address(params);
+    let ua_receivers = ua.as_understood_receivers();
+
+    ua_receivers
+        .iter()
+        .any(|ua_receiver| ua_receiver.corresponds(&zcash_address))
 }
 
 /// Read-only operations required for light wallet functions.
@@ -1751,8 +1729,9 @@ pub trait WalletRead {
     ///   backend error.
     /// - `Err(FindAccountForAddressError::UnifiedAddressConflict)` if the provided address
     ///   is a Unified Address whose receiver components map to different accounts.
-    fn find_account_for_address(
+    fn find_account_for_address<P: consensus::Parameters>(
         &self,
+        params: &P,
         address: &zcash_keys::address::Address,
     ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
         let mut baseline_acc_id: Option<Self::AccountId> = None;
@@ -1761,7 +1740,7 @@ pub trait WalletRead {
             for acc_id in self.get_account_ids()? {
                 for addr_info in self.list_addresses(acc_id)? {
                     let stored = addr_info.address();
-                    if address_receiver_matches_ua(stored, ua) {
+                    if address_receiver_matches_ua(stored, ua, params) {
                         match baseline_acc_id {
                             None => baseline_acc_id = Some(acc_id),
                             Some(prev) if prev == acc_id => {}
@@ -3745,8 +3724,10 @@ mod tests {
                 ))],
             ),
         ]);
-        let result =
-            wallet.find_account_for_address(&Address::Transparent(transparent_address_for_tag(1)));
+        let result = wallet.find_account_for_address(
+            &zcash_protocol::consensus::Network::MainNetwork,
+            &Address::Transparent(transparent_address_for_tag(1)),
+        );
         assert_eq!(result.unwrap(), Some(1));
     }
 
@@ -3756,7 +3737,10 @@ mod tests {
         let wallet = TestWalletDb::new([(1, vec![address_info_of(address)])]);
 
         let other_address = Address::Transparent(transparent_address_for_tag(9));
-        let result = wallet.find_account_for_address(&other_address);
+        let result = wallet.find_account_for_address(
+            &zcash_protocol::consensus::Network::MainNetwork,
+            &other_address,
+        );
 
         assert_eq!(result.unwrap(), None);
     }
@@ -3783,7 +3767,10 @@ mod tests {
             Some(orchard_address),
         );
 
-        let result = wallet.find_account_for_address(&ua_with_all_addresses);
+        let result = wallet.find_account_for_address(
+            &zcash_protocol::consensus::Network::MainNetwork,
+            &ua_with_all_addresses,
+        );
 
         assert_eq!(result.unwrap(), Some(1));
     }
@@ -3806,7 +3793,10 @@ mod tests {
             Some(orchard_address(12)),
         );
 
-        let result = wallet.find_account_for_address(&ua_with_different_receivers);
+        let result = wallet.find_account_for_address(
+            &zcash_protocol::consensus::Network::MainNetwork,
+            &ua_with_different_receivers,
+        );
 
         assert_eq!(result.unwrap(), None);
     }
@@ -3828,7 +3818,10 @@ mod tests {
         let invalid_unified_address =
             unified_account_with(Some(transparent_address), Some(sapling_address), None);
 
-        let result = wallet.find_account_for_address(&invalid_unified_address);
+        let result = wallet.find_account_for_address(
+            &zcash_protocol::consensus::Network::MainNetwork,
+            &invalid_unified_address,
+        );
 
         assert!(matches!(
             result,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2577,6 +2577,8 @@ pub struct MockWalletDb {
         { ORCHARD_SHARD_HEIGHT * 2 },
         ORCHARD_SHARD_HEIGHT,
     >,
+    account_ids: Vec<u32>,
+    addresses_by_account: HashMap<u32, Vec<AddressInfo>>,
 }
 
 impl MockWalletDb {
@@ -2587,7 +2589,23 @@ impl MockWalletDb {
             sapling_tree: ShardTree::new(MemoryShardStore::empty(), 100),
             #[cfg(feature = "orchard")]
             orchard_tree: ShardTree::new(MemoryShardStore::empty(), 100),
+            account_ids: vec![],
+            addresses_by_account: HashMap::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_account_addresses(
+        network: Network,
+        entries: impl IntoIterator<Item = (u32, Vec<AddressInfo>)>,
+    ) -> Self {
+        let mut wallet = Self::new(network);
+        for (account_id, addresses) in entries {
+            wallet.account_ids.push(account_id);
+            wallet.addresses_by_account.insert(account_id, addresses);
+        }
+        wallet.account_ids.sort_unstable();
+        wallet
     }
 }
 
@@ -2645,7 +2663,7 @@ impl WalletRead for MockWalletDb {
     type Account = (Self::AccountId, UnifiedFullViewingKey, BlockHeight);
 
     fn get_account_ids(&self) -> Result<Vec<Self::AccountId>, Self::Error> {
-        Ok(Vec::new())
+        Ok(self.account_ids.clone())
     }
 
     fn get_account(
@@ -2684,8 +2702,12 @@ impl WalletRead for MockWalletDb {
         Ok(None)
     }
 
-    fn list_addresses(&self, _account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error> {
-        Ok(vec![])
+    fn list_addresses(&self, account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error> {
+        Ok(self
+           .addresses_by_account
+           .get(&account)
+           .cloned()
+           .unwrap_or_default())
     }
 
     fn get_last_generated_address_matching(

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2704,10 +2704,10 @@ impl WalletRead for MockWalletDb {
 
     fn list_addresses(&self, account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error> {
         Ok(self
-           .addresses_by_account
-           .get(&account)
-           .cloned()
-           .unwrap_or_default())
+            .addresses_by_account
+            .get(&account)
+            .cloned()
+            .unwrap_or_default())
     }
 
     fn get_last_generated_address_matching(

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,9 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `WalletDb` now overrides `WalletRead::find_account_for_address` with a single SQL query,
+  replacing the `O(accounts × addresses)` scan that the default trait implementation would
+  require.
 - The following columns have been added to the exposed `v_tx_outputs` view:
   - `transaction_id`
   - `tx_mined_height`

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,9 +11,6 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- `WalletDb` now overrides `WalletRead::find_account_for_address` with a single SQL query,
-  replacing the `O(accounts × addresses)` scan that the default trait implementation would
-  require.
 - The following columns have been added to the exposed `v_tx_outputs` view:
   - `transaction_id`
   - `tx_mined_height`
@@ -35,6 +32,7 @@ workspace.
   database transaction overhead).
 
 ### Changed
+- Migrated to `zcash_client_backend 0.22`
 - The `accounts` table now stores IVK item caches instead of FVK item caches for
   collision detection. A new `p2sh_ivk_item_cache` column is reserved for future
   ZIP 316 Revision 2 P2SH support.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -57,10 +57,10 @@ use zcash_client_backend::{
     TransferType,
     data_api::{
         self, Account, AccountBirthday, AccountMeta, AccountPurpose, AccountSource, AddressInfo,
-        BlockMetadata, DecryptedTransaction, InputSource, NoteFilter, NullifierQuery,
-        ReceivedNotes, ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, ScannedBlock,
-        SeedRelevance, SentTransaction, TargetValue, TransactionDataRequest, WalletCommitmentTrees,
-        WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
+        BlockMetadata, DecryptedTransaction, FindAccountForAddressError, InputSource, NoteFilter,
+        NullifierQuery, ReceivedNotes, ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT,
+        ScannedBlock, SeedRelevance, SentTransaction, TargetValue, TransactionDataRequest,
+        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
         ll::{
             self, LowLevelWalletRead, LowLevelWalletWrite, ReceivedSaplingOutput,
@@ -750,6 +750,17 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
 
     fn list_addresses(&self, account: Self::AccountId) -> Result<Vec<AddressInfo>, Self::Error> {
         wallet::list_addresses(self.conn.borrow(), &self.params, account)
+    }
+
+    /// Overrides the default implementation with a single SQL query, avoiding the
+    /// O(accounts × addresses) scan that `get_account_ids` + `list_addresses` would
+    /// require.  See [`zcash_client_backend::data_api::WalletRead::find_account_for_address`]
+    /// for the query design.
+    fn find_account_for_address(
+        &self,
+        address: &zcash_keys::address::Address,
+    ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
+        wallet::find_account_for_address(self.conn.borrow(), &self.params, address)
     }
 
     fn get_last_generated_address_matching(
@@ -2661,22 +2672,26 @@ mod tests {
     use secrecy::{ExposeSecret, Secret, SecretVec};
     use uuid::Uuid;
     use zcash_client_backend::data_api::{
-        Account, AccountBirthday, AccountPurpose, AccountSource, WalletRead, WalletTest,
-        WalletWrite,
+        Account, AccountBirthday, AccountPurpose, AccountSource, FindAccountForAddressError,
+        WalletRead, WalletTest, WalletWrite,
         chain::ChainState,
         testing::{TestBuilder, TestState},
     };
+    use zcash_keys::address::UnifiedAddress;
     use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey};
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::consensus;
+    use zip32::DiversifierIndex;
 
     use crate::{
         AccountUuid, error::SqliteClientError, testing::db::TestDbFactory, util::Clock as _,
         wallet::MIN_SHIELDED_DIVERSIFIER_OFFSET,
     };
 
+    use crate::testing::db::TestDb;
     #[cfg(feature = "unstable")]
     use zcash_keys::keys::sapling;
+    use zcash_protocol::local_consensus::LocalNetwork;
 
     #[test]
     fn validate_seed() {
@@ -3372,5 +3387,328 @@ mod tests {
         assert_eq!(st.cache().find_block(h1).unwrap(), Some(meta1.block_meta));
         assert_eq!(st.cache().find_block(h2).unwrap(), None);
         assert_eq!(st.cache().find_block(h2 + 1).unwrap(), None);
+    }
+
+    #[test]
+    fn find_account_for_address_returns_matching_account_for_own_ua() {
+        use zcash_keys::address::Address;
+
+        // Create a test wallet with one account and expose one of its own UAs
+        let mut state = create_test_wallet_with_one_account();
+        let account = state.test_account().cloned().unwrap();
+
+        state
+            .wallet_mut()
+            .update_chain_tip(account.birthday().height())
+            .unwrap();
+
+        let (ua, _) = generate_unified_address_with_all_available_keys(&mut state, account.id());
+
+        // Asserts that looking up the exact same UA returns the owning account
+        let result = state
+            .wallet()
+            .find_account_for_address(&Address::Unified(ua));
+
+        assert_eq!(result.unwrap(), Some(account.id()));
+    }
+
+    #[test]
+    fn find_account_for_address_returns_none_for_unknown_address() {
+        use zcash_keys::address::Address;
+
+        // Create a test wallet with one account
+        let st = create_test_wallet_with_one_account();
+
+        // Build a transparent address that is not present in the wallet DB
+        let unknown_address = Address::Transparent(
+            ::transparent::address::TransparentAddress::PublicKeyHash([0u8; 20]),
+        );
+
+        // Asserts that an unrelated address does not resolve to any account
+        assert_eq!(
+            st.wallet()
+                .find_account_for_address(&unknown_address)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[cfg(all(feature = "orchard", feature = "transparent-inputs"))]
+    #[test]
+    fn find_account_for_ua_finds_via_transparent_receiver_cache() {
+        use crate::AccountRef;
+        use crate::wallet::transparent;
+        use ::transparent::keys::{NonHardenedChildIndex, TransparentKeyScope};
+        use zcash_keys::address::{Address, UnifiedAddress};
+        use zcash_keys::keys::ReceiverRequirement::*;
+
+        // Create a test wallet with one account
+        let mut state = create_test_wallet_with_one_account();
+        let account = state.test_account().cloned().unwrap();
+        let acc1_id = account.id();
+
+        let account_rowid = remove_account_from_db(&mut state, acc1_id);
+
+        // Inserts in the DB one row representing a transparent address of that account
+        let t1 =
+            UnifiedSpendingKey::from_seed(&state.network(), &[7u8; 32], zip32::AccountId::ZERO)
+                .expect("valid seed")
+                .to_unified_full_viewing_key()
+                .default_address(UnifiedAddressRequest::unsafe_custom(Omit, Require, Require))
+                .unwrap()
+                .0
+                .transparent()
+                .cloned()
+                .expect("UA must have transparent receiver");
+
+        state
+            .wallet_mut()
+            .update_chain_tip(account.birthday().height())
+            .unwrap();
+
+        state
+            .wallet_mut()
+            .db_mut()
+            .transactionally(|wdb| {
+                transparent::store_address_range(
+                    wdb.conn.0,
+                    wdb.params(),
+                    AccountRef(account_rowid),
+                    TransparentKeyScope::EXTERNAL,
+                    vec![(Address::Transparent(t1), t1, NonHardenedChildIndex::ZERO)],
+                )?;
+                transparent::reserve_next_n_addresses(
+                    wdb.conn.0,
+                    wdb.params(),
+                    AccountRef(account_rowid),
+                    TransparentKeyScope::EXTERNAL,
+                    20,
+                    1,
+                )?;
+                Ok::<_, SqliteClientError>(())
+            })
+            .unwrap();
+
+        // Builds a new UA that shares the transparent receiver, but also has an
+        // Orchard receiver coming from a different seed
+        let usk_external =
+            UnifiedSpendingKey::from_seed(&state.network(), &[99u8; 32], zip32::AccountId::ZERO)
+                .expect("valid seed");
+
+        let o_external = usk_external
+            .to_unified_full_viewing_key()
+            .default_address(UnifiedAddressRequest::AllAvailableKeys)
+            .expect("default address must be derivable")
+            .0
+            .orchard()
+            .cloned()
+            .expect("orchard receiver must be present");
+        let address = Address::Unified(
+            UnifiedAddress::from_receivers(Some(o_external), None, Some(t1))
+                .expect("orchard+transparent UA must be valid"),
+        );
+
+        // Asserts that the unique possible account is found anyways, based on the transparent address,
+        // since there are no UA conflicts.
+        let result = state.wallet().find_account_for_address(&address);
+        assert_eq!(result.unwrap(), Some(acc1_id));
+    }
+
+    #[test]
+    fn find_account_for_ua_finds_via_sapling() {
+        use zcash_keys::address::{Address, UnifiedAddress};
+
+        // Create a test wallet with one account
+        let mut state = create_test_wallet_with_one_account();
+
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(state.network().sapling.unwrap() - 1, BlockHash([0; 32])),
+            None,
+        );
+        let sapling_activation = state.network().sapling.unwrap();
+
+        let (acc1_id, _) = state
+            .wallet_mut()
+            .create_account("", &Secret::new(vec![0u8; 32]), &birthday, None)
+            .unwrap();
+
+        state
+            .wallet_mut()
+            .update_chain_tip(sapling_activation)
+            .unwrap();
+
+        // Expose a normal UA for that account and keep only its Orchard receiver
+        let (ua1, _) = generate_unified_address_with_all_available_keys(&mut state, acc1_id);
+
+        let sapling_receiver = ua1
+            .sapling()
+            .cloned()
+            .expect("UA must have sapling receiver");
+
+        let address = Address::Unified(
+            {
+                #[cfg(feature = "orchard")]
+                {
+                    UnifiedAddress::from_receivers(None, Some(sapling_receiver), None)
+                }
+
+                #[cfg(not(feature = "orchard"))]
+                {
+                    UnifiedAddress::from_receivers(Some(sapling_receiver), None)
+                }
+            }
+            .expect("sapling-only UA must be valid"),
+        );
+
+        // Asserts that the account is still found via the shielded receiver flags path
+        let result = state.wallet().find_account_for_address(&address);
+
+        assert_eq!(result.unwrap(), Some(acc1_id));
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn find_account_for_ua_finds_via_orchard() {
+        use zcash_keys::address::{Address, UnifiedAddress};
+
+        // Create a test wallet with one account
+        let mut state = create_test_wallet_with_one_account();
+
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(state.network().sapling.unwrap() - 1, BlockHash([0; 32])),
+            None,
+        );
+        let sapling_activation = state.network().sapling.unwrap();
+
+        let (acc1_id, _) = state
+            .wallet_mut()
+            .create_account("", &Secret::new(vec![0u8; 32]), &birthday, None)
+            .unwrap();
+
+        state
+            .wallet_mut()
+            .update_chain_tip(sapling_activation)
+            .unwrap();
+
+        // Expose a normal UA for that account and keep only its Orchard receiver
+        let (ua1, _) = generate_unified_address_with_all_available_keys(&mut state, acc1_id);
+
+        let orchard_receiver = ua1
+            .orchard()
+            .cloned()
+            .expect("UA must have orchard receiver");
+
+        let address = Address::Unified(
+            UnifiedAddress::from_receivers(Some(orchard_receiver), None, None)
+                .expect("orchard-only UA must be valid"),
+        );
+
+        // Asserts that the account is still found via the shielded receiver flags path
+        let result = state.wallet().find_account_for_address(&address);
+
+        assert_eq!(result.unwrap(), Some(acc1_id));
+    }
+
+    /// A UA whose Sapling receiver belongs to account 1 and whose Orchard receiver
+    /// belongs to account 2 must produce a `UnifiedAddressConflict` error.
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn find_account_for_ua_errors_when_receivers_map_to_different_accounts() {
+        use zcash_keys::address::{Address, UnifiedAddress};
+
+        // Create a test wallet with two different accounts
+        let mut state = create_test_wallet_with_one_account();
+
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(state.network().sapling.unwrap() - 1, BlockHash([0; 32])),
+            None,
+        );
+        let sapling_activation = state.network().sapling.unwrap();
+
+        let seed1 = Secret::new(vec![0u8; 32]);
+        let seed2 = Secret::new(vec![1u8; 32]);
+
+        let (acc1_id, _) = state
+            .wallet_mut()
+            .create_account("", &seed1, &birthday, None)
+            .unwrap();
+        let (acc2_id, _) = state
+            .wallet_mut()
+            .create_account("", &seed2, &birthday, None)
+            .unwrap();
+
+        state
+            .wallet_mut()
+            .update_chain_tip(sapling_activation)
+            .unwrap();
+
+        let (ua1, _) = generate_unified_address_with_all_available_keys(&mut state, acc1_id);
+        let (ua2, _) = generate_unified_address_with_all_available_keys(&mut state, acc2_id);
+
+        // Build a synthetic UA that mixes receivers from two different accounts
+        let sapling_receiver_1 = ua1.sapling().cloned().unwrap();
+        let orchard_receiver_2 = ua2.orchard().cloned().unwrap();
+
+        let invalid_address = Address::Unified(
+            UnifiedAddress::from_receivers(
+                Some(orchard_receiver_2),
+                Some(sapling_receiver_1),
+                None,
+            )
+            .expect("sapling+orchard UA must be valid"),
+        );
+
+        // Asserts that the lookup reports a conflict instead of arbitrarily choosing one account
+        let result = state.wallet().find_account_for_address(&invalid_address);
+        assert!(matches!(
+            result,
+            Err(FindAccountForAddressError::UnifiedAddressConflict)
+        ));
+    }
+
+    fn create_test_wallet_with_one_account() -> TestState<(), TestDb, LocalNetwork> {
+        TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build()
+    }
+
+    fn generate_unified_address_with_all_available_keys(
+        state: &mut TestState<(), TestDb, LocalNetwork>,
+        account_id: AccountUuid,
+    ) -> (UnifiedAddress, DiversifierIndex) {
+        state
+            .wallet_mut()
+            .get_next_available_address(account_id, UnifiedAddressRequest::AllAvailableKeys)
+            .unwrap()
+            .expect("address generation for account 1 must succeed")
+    }
+
+    fn remove_account_from_db(
+        state: &mut TestState<(), TestDb, LocalNetwork>,
+        acc1_id: AccountUuid,
+    ) -> i64 {
+        use rusqlite::named_params;
+
+        // Remove from the DB all the addresses associated to the account
+        let account_rowid: i64 = state
+            .wallet()
+            .conn()
+            .query_row(
+                "SELECT id FROM accounts WHERE uuid = :uuid",
+                named_params![":uuid": acc1_id.expose_uuid()],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        state
+            .wallet()
+            .conn()
+            .execute(
+                "DELETE FROM addresses WHERE account_id = :account_id",
+                named_params![":account_id": account_rowid],
+            )
+            .unwrap();
+        account_rowid
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -3434,6 +3434,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn find_account_for_address_returns_matching_account_for_receivers_of_own_ua() {
+        use zcash_keys::address::Address;
+        // Create a test wallet with one account and expose one of its own UAs
+        let mut state = create_test_wallet_with_one_account();
+        let account = state.test_account().cloned().unwrap();
+        state
+            .wallet_mut()
+            .update_chain_tip(account.birthday().height())
+            .unwrap();
+        let (ua, _) = generate_unified_address_with_all_available_keys(&mut state, account.id());
+        // Asserts that looking up a receiver address extracted from the stored UA
+        // returns the owning account via the non-UA query path.
+        if let Some(taddr) = ua.transparent() {
+            let result = state
+                .wallet()
+                .find_account_for_address(state.network(), &Address::Transparent(taddr.clone()));
+            assert_eq!(result.unwrap(), Some(account.id()));
+        }
+        if let Some(pa) = ua.sapling() {
+            let result = state
+                .wallet()
+                .find_account_for_address(state.network(), &Address::Sapling(pa.clone()));
+            assert_eq!(result.unwrap(), Some(account.id()));
+        }
+    }
+
     #[cfg(all(feature = "orchard", feature = "transparent-inputs"))]
     #[test]
     fn find_account_for_ua_finds_via_transparent_receiver_cache() {
@@ -3451,7 +3478,7 @@ mod tests {
         let account_rowid = remove_account_from_db(&mut state, acc1_id);
 
         // Inserts in the DB one row representing a transparent address of that account
-        let t1 =
+        let transparent_address =
             UnifiedSpendingKey::from_seed(&state.network(), &[7u8; 32], zip32::AccountId::ZERO)
                 .expect("valid seed")
                 .to_unified_full_viewing_key()
@@ -3476,7 +3503,11 @@ mod tests {
                     wdb.params(),
                     AccountRef(account_rowid),
                     TransparentKeyScope::EXTERNAL,
-                    vec![(Address::Transparent(t1), t1, NonHardenedChildIndex::ZERO)],
+                    vec![(
+                        Address::Transparent(transparent_address),
+                        transparent_address,
+                        NonHardenedChildIndex::ZERO,
+                    )],
                 )?;
                 transparent::reserve_next_n_addresses(
                     wdb.conn.0,
@@ -3505,7 +3536,7 @@ mod tests {
             .cloned()
             .expect("orchard receiver must be present");
         let address = Address::Unified(
-            UnifiedAddress::from_receivers(Some(o_external), None, Some(t1))
+            UnifiedAddress::from_receivers(Some(o_external), None, Some(transparent_address))
                 .expect("orchard+transparent UA must be valid"),
         );
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -3540,7 +3540,7 @@ mod tests {
             .update_chain_tip(sapling_activation)
             .unwrap();
 
-        // Expose a normal UA for that account and keep only its Orchard receiver
+        // Expose a normal UA for that account and keep only its Sapling receiver
         let (ua1, _) = generate_unified_address_with_all_available_keys(&mut state, acc1_id);
 
         let sapling_receiver = ua1

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -756,11 +756,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
     /// O(accounts × addresses) scan that `get_account_ids` + `list_addresses` would
     /// require.  See [`zcash_client_backend::data_api::WalletRead::find_account_for_address`]
     /// for the query design.
-    fn find_account_for_address(
+    fn find_account_for_address<Q: consensus::Parameters>(
         &self,
+        params: &Q,
         address: &zcash_keys::address::Address,
     ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
-        wallet::find_account_for_address(self.conn.borrow(), &self.params, address)
+        wallet::find_account_for_address(self.conn.borrow(), params, address)
     }
 
     fn get_last_generated_address_matching(
@@ -3407,7 +3408,7 @@ mod tests {
         // Asserts that looking up the exact same UA returns the owning account
         let result = state
             .wallet()
-            .find_account_for_address(&Address::Unified(ua));
+            .find_account_for_address(state.network(), &Address::Unified(ua));
 
         assert_eq!(result.unwrap(), Some(account.id()));
     }
@@ -3427,7 +3428,7 @@ mod tests {
         // Asserts that an unrelated address does not resolve to any account
         assert_eq!(
             st.wallet()
-                .find_account_for_address(&unknown_address)
+                .find_account_for_address(st.network(), &unknown_address)
                 .unwrap(),
             None
         );
@@ -3510,7 +3511,9 @@ mod tests {
 
         // Asserts that the unique possible account is found anyways, based on the transparent address,
         // since there are no UA conflicts.
-        let result = state.wallet().find_account_for_address(&address);
+        let result = state
+            .wallet()
+            .find_account_for_address(state.network(), &address);
         assert_eq!(result.unwrap(), Some(acc1_id));
     }
 
@@ -3561,7 +3564,9 @@ mod tests {
         );
 
         // Asserts that the account is still found via the shielded receiver flags path
-        let result = state.wallet().find_account_for_address(&address);
+        let result = state
+            .wallet()
+            .find_account_for_address(state.network(), &address);
 
         assert_eq!(result.unwrap(), Some(acc1_id));
     }
@@ -3604,7 +3609,9 @@ mod tests {
         );
 
         // Asserts that the account is still found via the shielded receiver flags path
-        let result = state.wallet().find_account_for_address(&address);
+        let result = state
+            .wallet()
+            .find_account_for_address(state.network(), &address);
 
         assert_eq!(result.unwrap(), Some(acc1_id));
     }
@@ -3659,7 +3666,9 @@ mod tests {
         );
 
         // Asserts that the lookup reports a conflict instead of arbitrarily choosing one account
-        let result = state.wallet().find_account_for_address(&invalid_address);
+        let result = state
+            .wallet()
+            .find_account_for_address(state.network(), &invalid_address);
         assert!(matches!(
             result,
             Err(FindAccountForAddressError::UnifiedAddressConflict)

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -33,7 +33,7 @@ use zcash_primitives::{
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
-    ShieldedProtocol, consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo,
+    ShieldedProtocol, consensus, consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo,
 };
 use zip32::DiversifierIndex;
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -89,9 +89,10 @@ use zcash_client_backend::{
     DecryptedOutput,
     data_api::{
         Account as _, AccountBalance, AccountBirthday, AccountPurpose, AccountSource, AddressInfo,
-        AddressSource, BlockMetadata, Progress, Ratio, ReceivedTransactionOutput,
-        SAPLING_SHARD_HEIGHT, SentTransaction, SentTransactionOutput, TransactionDataRequest,
-        TransactionStatus, WalletSummary, Zip32Derivation,
+        AddressSource, BlockMetadata, FindAccountForAddressError, Progress, Ratio,
+        ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, SentTransaction, SentTransactionOutput,
+        TransactionDataRequest, TransactionStatus, WalletSummary, Zip32Derivation,
+        address_receiver_matches_ua,
         chain::ChainState,
         scanning::{ScanPriority, ScanRange},
         wallet::{ConfirmationsPolicy, TargetHeight},
@@ -1150,6 +1151,111 @@ pub(crate) fn list_addresses<P: consensus::Parameters>(
     }
 
     Ok(addrs)
+}
+
+/// Returns the wallet account that controls the given address, if any.
+///
+/// This is the SQLite-optimized implementation of
+/// [`zcash_client_backend::data_api::WalletRead::find_account_for_address`].
+/// It issues a single SQL query instead of the double for loop required by the default
+/// implementation, using `receiver_flags` and the `cached_transparent_receiver_address`
+/// column to narrow candidates before performing Rust-level receiver verification.
+///
+/// For non-Unified addresses an exact match on the `address` column is sufficient.
+/// For Unified Addresses the query fetches every stored address that could share
+/// at least one receiver with the unified address (via transparent cache or shielded-receiver
+/// flags), then [`address_receiver_matches_ua`] confirms the actual overlap.
+pub(crate) fn find_account_for_address<P: consensus::Parameters>(
+    conn: &rusqlite::Connection,
+    params: &P,
+    address: &Address,
+) -> Result<Option<AccountUuid>, FindAccountForAddressError<SqliteClientError>> {
+    use FindAccountForAddressError as E;
+
+    if let Address::Unified(unified_address) = address {
+        let ua_str = address.encode(params);
+
+        // NULL when the unified_address has no transparent component
+        let taddr_str = unified_address
+            .transparent()
+            .map(|t| Address::Transparent(*t).encode(params));
+
+        // Build the shielded-receiver bitmask.
+        // We are not using the `ReceiverFlags::from` method because we only want the bits related to
+        // shielded addresses, not the transparent bit.
+        let mut shielded_flags = ReceiverFlags::empty();
+        if unified_address.has_sapling() {
+            shielded_flags |= ReceiverFlags::SAPLING;
+        }
+        #[cfg(feature = "orchard")]
+        if unified_address.has_orchard() {
+            shielded_flags |= ReceiverFlags::ORCHARD;
+        }
+
+        let mut base_query = conn
+            .prepare_cached(
+                "SELECT accounts.uuid, addresses.address
+                 FROM addresses
+                 JOIN accounts ON accounts.id = addresses.account_id
+                 WHERE exposed_at_height IS NOT NULL
+                 AND (
+                    address = :ua_str
+                    OR cached_transparent_receiver_address = :taddr_str
+                    OR ((:shielded_flags & receiver_flags) != 0)
+                 )",
+            )
+            .map_err(|e| E::Backend(e.into()))?;
+        let mut rows = base_query
+            .query(named_params![
+                ":ua_str": ua_str,
+                ":taddr_str": taddr_str,
+                ":shielded_flags": shielded_flags.bits(),
+            ])
+            .map_err(|e| E::Backend(e.into()))?;
+
+        let mut found_account_uuid: Option<AccountUuid> = None;
+
+        while let Some(row) = rows
+            .next()
+            .map_err(|e| E::Backend(SqliteClientError::from(e)))?
+        {
+            let row_account_uuid: Uuid = row.get(0).map_err(|e| E::Backend(e.into()))?;
+            let addr_str: String = row.get(1).map_err(|e| E::Backend(e.into()))?;
+
+            let row_address = Address::decode(params, &addr_str).ok_or_else(|| {
+                E::Backend(SqliteClientError::CorruptedData(
+                    "Not a valid Zcash recipient address".to_owned(),
+                ))
+            })?;
+
+            if address_receiver_matches_ua(&row_address, unified_address) {
+                let row_account_uuid = AccountUuid::from_uuid(row_account_uuid);
+                match found_account_uuid {
+                    None => found_account_uuid = Some(row_account_uuid),
+                    Some(prev) if prev == row_account_uuid => {}
+                    Some(_) => return Err(E::UnifiedAddressConflict),
+                }
+            }
+        }
+
+        Ok(found_account_uuid)
+    } else {
+        // For non-UA addresses a single exact-match lookup suffices.
+        let addr_str = address.encode(params);
+        conn.query_row(
+            "SELECT accounts.uuid
+             FROM addresses
+             JOIN accounts ON accounts.id = addresses.account_id
+             WHERE exposed_at_height IS NOT NULL
+             AND address = :addr_str
+             LIMIT 1",
+            named_params![":addr_str": addr_str],
+            |row| row.get::<_, Uuid>(0),
+        )
+        .optional()
+        .map(|opt| opt.map(AccountUuid::from_uuid))
+        .map_err(|e| FindAccountForAddressError::Backend(e.into()))
+    }
 }
 
 pub(crate) fn get_last_generated_address_matching<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1161,7 +1161,10 @@ pub(crate) fn list_addresses<P: consensus::Parameters>(
 /// implementation, using `receiver_flags` and the `cached_transparent_receiver_address`
 /// column to narrow candidates before performing Rust-level receiver verification.
 ///
-/// For non-Unified addresses an exact match on the `address` column is sufficient.
+/// For non-Unified addresses an exact match on the `address` column (or the
+/// `cached_transparent_receiver_address` column for transparent receivers of stored UAs) is
+/// tried first; if that misses, shielded address types fall back to scanning stored UAs whose
+/// `receiver_flags` indicate a matching receiver.
 /// For Unified Addresses the query fetches every stored address that could share
 /// at least one receiver with the unified address (via transparent cache or shielded-receiver
 /// flags), then [`address_receiver_matches_ua`] confirms the actual overlap.
@@ -1170,31 +1173,114 @@ pub(crate) fn find_account_for_address<P: consensus::Parameters>(
     params: &P,
     address: &Address,
 ) -> Result<Option<AccountUuid>, FindAccountForAddressError<SqliteClientError>> {
-    use FindAccountForAddressError as E;
+    let addr_str = address.encode(params);
 
     if let Address::Unified(unified_address) = address {
-        let ua_str = address.encode(params);
+        find_account_for_unified_address(conn, params, &addr_str, unified_address)
+    } else {
+        find_account_for_non_unified_address(conn, params, address, addr_str)
+    }
+}
 
-        // NULL when the unified_address has no transparent component
-        let taddr_str = unified_address
-            .transparent()
-            .map(|t| Address::Transparent(*t).encode(params));
+fn find_account_for_non_unified_address<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    address: &Address,
+    addr_str: String,
+) -> Result<Option<AccountUuid>, FindAccountForAddressError<SqliteClientError>> {
+    use FindAccountForAddressError as E;
 
-        // Build the shielded-receiver bitmask.
-        // We are not using the `ReceiverFlags::from` method because we only want the bits related to
-        // shielded addresses, not the transparent bit.
-        let mut shielded_flags = ReceiverFlags::empty();
-        if unified_address.has_sapling() {
-            shielded_flags |= ReceiverFlags::SAPLING;
+    // For non-UA addresses, first try an exact match (also covers transparent receivers
+    // cached in `cached_transparent_receiver_address`).
+    let exact_match = conn
+        .query_row(
+            "SELECT accounts.uuid
+                 FROM addresses
+                 JOIN accounts ON accounts.id = addresses.account_id
+                 WHERE exposed_at_height IS NOT NULL
+                 AND (address = :addr_str OR cached_transparent_receiver_address = :addr_str)
+                 LIMIT 1",
+            named_params![":addr_str": addr_str],
+            |row| row.get::<_, Uuid>(0),
+        )
+        .optional()
+        .map(|opt| opt.map(AccountUuid::from_uuid))
+        .map_err(|e| E::Backend(e.into()))?;
+
+    if exact_match.is_some() {
+        return Ok(exact_match);
+    }
+
+    // For shielded address types, the address may be a receiver embedded in a stored UA.
+    // Query candidate UAs via `receiver_flags` and verify at the Rust level.
+    let shielded_flag: ReceiverFlags = match address {
+        Address::Sapling(_) => ReceiverFlags::SAPLING,
+        _ => return Ok(None),
+    };
+
+    let mut stmt = conn
+        .prepare_cached(
+            "SELECT accounts.uuid, addresses.address
+                 FROM addresses
+                 JOIN accounts ON accounts.id = addresses.account_id
+                 WHERE exposed_at_height IS NOT NULL
+                 AND (receiver_flags & :shielded_flag) != 0",
+        )
+        .map_err(|e| E::Backend(e.into()))?;
+
+    let mut rows = stmt
+        .query(named_params![":shielded_flag": shielded_flag.bits()])
+        .map_err(|e| E::Backend(e.into()))?;
+
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| E::Backend(SqliteClientError::from(e)))?
+    {
+        let row_uuid: Uuid = row.get(0).map_err(|e| E::Backend(e.into()))?;
+        let stored_addr_str: String = row.get(1).map_err(|e| E::Backend(e.into()))?;
+        let stored = Address::decode(params, &stored_addr_str).ok_or_else(|| {
+            E::Backend(SqliteClientError::CorruptedData(
+                "Not a valid Zcash recipient address".to_owned(),
+            ))
+        })?;
+        if let Address::Unified(stored_ua) = stored {
+            if address_receiver_matches_ua(address, &stored_ua, params) {
+                return Ok(Some(AccountUuid::from_uuid(row_uuid)));
+            }
         }
-        #[cfg(feature = "orchard")]
-        if unified_address.has_orchard() {
-            shielded_flags |= ReceiverFlags::ORCHARD;
-        }
+    }
 
-        let mut base_query = conn
-            .prepare_cached(
-                "SELECT accounts.uuid, addresses.address
+    Ok(None)
+}
+
+fn find_account_for_unified_address<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    addr_str: &String,
+    unified_address: &UnifiedAddress,
+) -> Result<Option<AccountUuid>, FindAccountForAddressError<SqliteClientError>> {
+    use FindAccountForAddressError as E;
+
+    // NULL when the unified_address has no transparent component
+    let taddr_str = unified_address
+        .transparent()
+        .map(|t| Address::Transparent(*t).encode(params));
+
+    // Build the shielded-receiver bitmask.
+    // We are not using the `ReceiverFlags::from` method because we only want the bits related to
+    // shielded addresses, not the transparent bit.
+    let mut shielded_flags = ReceiverFlags::empty();
+    if unified_address.has_sapling() {
+        shielded_flags |= ReceiverFlags::SAPLING;
+    }
+    #[cfg(feature = "orchard")]
+    if unified_address.has_orchard() {
+        shielded_flags |= ReceiverFlags::ORCHARD;
+    }
+
+    let mut base_query = conn
+        .prepare_cached(
+            "SELECT accounts.uuid, addresses.address
                  FROM addresses
                  JOIN accounts ON accounts.id = addresses.account_id
                  WHERE exposed_at_height IS NOT NULL
@@ -1203,59 +1289,42 @@ pub(crate) fn find_account_for_address<P: consensus::Parameters>(
                     OR cached_transparent_receiver_address = :taddr_str
                     OR ((:shielded_flags & receiver_flags) != 0)
                  )",
-            )
-            .map_err(|e| E::Backend(e.into()))?;
-        let mut rows = base_query
-            .query(named_params![
-                ":ua_str": ua_str,
-                ":taddr_str": taddr_str,
-                ":shielded_flags": shielded_flags.bits(),
-            ])
-            .map_err(|e| E::Backend(e.into()))?;
+        )
+        .map_err(|e| E::Backend(e.into()))?;
+    let mut rows = base_query
+        .query(named_params![
+            ":ua_str": addr_str,
+            ":taddr_str": taddr_str,
+            ":shielded_flags": shielded_flags.bits(),
+        ])
+        .map_err(|e| E::Backend(e.into()))?;
 
-        let mut found_account_uuid: Option<AccountUuid> = None;
+    let mut found_account_uuid: Option<AccountUuid> = None;
 
-        while let Some(row) = rows
-            .next()
-            .map_err(|e| E::Backend(SqliteClientError::from(e)))?
-        {
-            let row_account_uuid: Uuid = row.get(0).map_err(|e| E::Backend(e.into()))?;
-            let addr_str: String = row.get(1).map_err(|e| E::Backend(e.into()))?;
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| E::Backend(SqliteClientError::from(e)))?
+    {
+        let row_account_uuid: Uuid = row.get(0).map_err(|e| E::Backend(e.into()))?;
+        let addr_str: String = row.get(1).map_err(|e| E::Backend(e.into()))?;
 
-            let row_address = Address::decode(params, &addr_str).ok_or_else(|| {
-                E::Backend(SqliteClientError::CorruptedData(
-                    "Not a valid Zcash recipient address".to_owned(),
-                ))
-            })?;
+        let row_address = Address::decode(params, &addr_str).ok_or_else(|| {
+            E::Backend(SqliteClientError::CorruptedData(
+                "Not a valid Zcash recipient address".to_owned(),
+            ))
+        })?;
 
-            if address_receiver_matches_ua(&row_address, unified_address, params) {
-                let row_account_uuid = AccountUuid::from_uuid(row_account_uuid);
-                match found_account_uuid {
-                    None => found_account_uuid = Some(row_account_uuid),
-                    Some(prev) if prev == row_account_uuid => {}
-                    Some(_) => return Err(E::UnifiedAddressConflict),
-                }
+        if address_receiver_matches_ua(&row_address, unified_address, params) {
+            let row_account_uuid = AccountUuid::from_uuid(row_account_uuid);
+            match found_account_uuid {
+                None => found_account_uuid = Some(row_account_uuid),
+                Some(prev) if prev == row_account_uuid => {}
+                Some(_) => return Err(E::UnifiedAddressConflict),
             }
         }
-
-        Ok(found_account_uuid)
-    } else {
-        // For non-UA addresses a single exact-match lookup suffices.
-        let addr_str = address.encode(params);
-        conn.query_row(
-            "SELECT accounts.uuid
-             FROM addresses
-             JOIN accounts ON accounts.id = addresses.account_id
-             WHERE exposed_at_height IS NOT NULL
-             AND address = :addr_str
-             LIMIT 1",
-            named_params![":addr_str": addr_str],
-            |row| row.get::<_, Uuid>(0),
-        )
-        .optional()
-        .map(|opt| opt.map(AccountUuid::from_uuid))
-        .map_err(|e| FindAccountForAddressError::Backend(e.into()))
     }
+
+    Ok(found_account_uuid)
 }
 
 pub(crate) fn get_last_generated_address_matching<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1228,7 +1228,7 @@ pub(crate) fn find_account_for_address<P: consensus::Parameters>(
                 ))
             })?;
 
-            if address_receiver_matches_ua(&row_address, unified_address) {
+            if address_receiver_matches_ua(&row_address, unified_address, params) {
                 let row_account_uuid = AccountUuid::from_uuid(row_account_uuid);
                 match found_account_uuid {
                     None => found_account_uuid = Some(row_account_uuid),


### PR DESCRIPTION
• Add WalletRead::find_account_for_address to resolve the owning account for a wallet address, including Unified Address receiver-aware matching. 
• Introduce FindAccountForAddressError with Backend and UnifiedAddressConflict variants. 
• Add address_receiver_matches_ua and a default trait implementation in zcash_client_backend.
• Override in zcash_client_sqlite::WalletDb with a single-query implementation (instead of scanning all accounts/addresses). 
• Add backend and sqlite tests for transparent, Sapling, Orchard, unknown-address, and cross-account UA conflict cases. 
• Update zcash_client_backend and zcash_client_sqlite changelogs.

Co-authored-by: @LorenzoRD2003
Fixes: Issue [#1944](https://github.com/zcash/librustzcash/issues/1944)