### PR TITLE
configure CI with nu7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+    env:
+      RUSTFLAGS: '--cfg zcash_unstable="nu7"'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -433,6 +435,8 @@ jobs:
     permissions:
       checks: write
     continue-on-error: true
+    env:
+      RUSTFLAGS: '--cfg zcash_unstable="nu7"'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
The helpers I added in [this commit](https://github.com/tachyon-zcash/librustzcash/pull/5/changes/8cecd44de076c9629f03460b2c5702f5b7460a27#diff-71369c332c1eb91ce7040f885fcd771b4de446f6347d242630be401a2aa3e371R35) throw unused warnings that cause the linter to throw. Easiest fix is just to have CI enable tachyon, which also lets it check our code.