### PR TITLE
Add support for shielded voting

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,10 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::orchard::Spend::spend_auth_sig` getter (via `getset`).
+- `pczt::roles::signer::Signer::shielded_sighash` getter.
+
 ## [0.4.1, 0.5.1] - 2026-02-26
 
 ### Fixed

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -111,6 +111,7 @@ pub struct Spend {
     ///
     /// This is set by the Signer.
     #[serde_as(as = "Option<[_; 64]>")]
+    #[getset(get = "pub")]
     pub(crate) spend_auth_sig: Option<[u8; 64]>,
 
     /// The [raw encoding] of the Orchard payment address that received the note being spent.

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -95,6 +95,11 @@ impl Signer {
         })
     }
 
+    /// Returns the cached shielded (Orchard + Sapling) sighash.
+    pub fn shielded_sighash(&self) -> [u8; 32] {
+        self.shielded_sighash
+    }
+
     /// Signs the transparent spend at the given index with the given spending key.
     ///
     /// It is the caller's responsibility to perform any semantic validity checks on the

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,8 +13,12 @@ workspace.
 ### Added
 - `WalletDb::get_orchard_notes_at_snapshot` returns Orchard notes received
   and unspent as of a given height, for governance voting snapshots.
-- `WalletDb::generate_orchard_witnesses_at_frontier` generates Merkle
-  witnesses at a historical frontier using an ephemeral in-memory tree.
+- `WalletDb::conn()` provides access to the underlying connection handle.
+- `wallet::commitment_tree::create_orchard_tree_tables` creates the
+  Orchard commitment-tree schema in a given connection, enabling
+  construction of an ephemeral in-memory `SqliteShardStore`.
+- `wallet::commitment_tree::SqliteShardStore::from_connection` is now
+  publicly accessible.
 
 ## [0.19.5] - 2026-03-10
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,12 +13,8 @@ workspace.
 ### Added
 - `WalletDb::get_orchard_notes_at_snapshot` returns Orchard notes received
   and unspent as of a given height, for governance voting snapshots.
-- `WalletDb::conn()` provides access to the underlying connection handle.
-- `wallet::commitment_tree::create_orchard_tree_tables` creates the
-  Orchard commitment-tree schema in a given connection, enabling
-  construction of an ephemeral in-memory `SqliteShardStore`.
-- `wallet::commitment_tree::SqliteShardStore::from_connection` is now
-  publicly accessible.
+- `WalletDb::generate_orchard_witnesses_at_frontier` generates Merkle
+  witnesses at a historical frontier using an ephemeral in-memory tree.
 
 ## [0.19.5] - 2026-03-10
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -14,7 +14,8 @@ workspace.
 - `WalletDb::get_orchard_notes_at_snapshot` returns Orchard notes received
   and unspent as of a given height, for governance voting snapshots.
 - `WalletDb::generate_orchard_witnesses_at_frontier` generates Merkle
-  witnesses at a historical frontier using an ephemeral in-memory tree.
+  witnesses at a historical frontier using an ephemeral in-memory
+  `shardtree::store::memory::MemoryShardStore`.
 
 ## [0.19.5] - 2026-03-10
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,12 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `WalletDb::get_orchard_notes_at_snapshot` returns Orchard notes received
+  and unspent as of a given height, for governance voting snapshots.
+- `WalletDb::generate_orchard_witnesses_at_frontier` generates Merkle
+  witnesses at a historical frontier using an ephemeral in-memory tree.
+
 ## [0.19.5] - 2026-03-10
 
 ### Fixed

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -401,6 +401,11 @@ impl Borrow<rusqlite::Connection> for SqlTransaction<'_> {
 }
 
 impl<C, P, CL, R> WalletDb<C, P, CL, R> {
+    /// Returns a reference to the underlying connection handle.
+    pub fn conn(&self) -> &C {
+        &self.conn
+    }
+
     /// Returns the network parameters that this walletdb instance is bound to.
     pub fn params(&self) -> &P {
         &self.params
@@ -2313,8 +2318,8 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
 // --- Governance-specific methods ---
 //
 // These methods support Zcash shielded voting and are not part of the
-// general-purpose wallet traits. They provide backward-looking queries
-// (historical snapshot) and witness generation at an external frontier.
+// general-purpose wallet traits. They provide a backward-looking snapshot
+// query for historical note selection.
 
 #[cfg(feature = "orchard")]
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<C, P, CL, R> {
@@ -2335,37 +2340,6 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
             &self.params,
             account,
             snapshot_height,
-        )
-    }
-
-    /// Generate Orchard Merkle witnesses at a historical frontier.
-    ///
-    /// Copies the wallet's Orchard shard data into an ephemeral in-memory
-    /// database, inserts the provided frontier as a checkpoint, and generates
-    /// a witness for each of the given note positions.
-    ///
-    /// The wallet DB is strictly read-only — shard data is copied, not modified.
-    pub fn generate_orchard_witnesses_at_frontier(
-        &self,
-        note_positions: &[Position],
-        frontier: incrementalmerkletree::frontier::NonEmptyFrontier<
-            orchard::tree::MerkleHashOrchard,
-        >,
-        checkpoint_height: BlockHeight,
-    ) -> Result<
-        Vec<
-            incrementalmerkletree::MerklePath<
-                orchard::tree::MerkleHashOrchard,
-                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-            >,
-        >,
-        SqliteClientError,
-    > {
-        wallet::commitment_tree::generate_orchard_witnesses_at_frontier(
-            self.conn.borrow(),
-            note_positions,
-            frontier,
-            checkpoint_height,
         )
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2313,45 +2313,44 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
 // --- Governance-specific methods ---
 //
 // These methods support Zcash shielded voting and are not part of the
-// general-purpose wallet traits. They provide backward-looking queries
-// (historical snapshot) and witness generation at an external frontier.
+// general-purpose wallet traits. They provide note queries and witness
+// generation at a historical height.
 
 #[cfg(feature = "orchard")]
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<C, P, CL, R> {
-    /// Return all Orchard notes received at or before `snapshot_height` and
-    /// unspent as of that height, for the given account.
+    /// Return all Orchard notes received at or before `height`
+    /// and unspent as of that height, for the given account.
     ///
-    /// Unlike [`InputSource::select_unspent_notes`] which is forward-looking
-    /// (based on tx expiry), this is backward-looking: a note is included if
-    /// it was mined at or before `snapshot_height` and no spend of that note
-    /// was mined at or before `snapshot_height`.
-    pub fn get_orchard_notes_at_snapshot(
+    /// Unlike [`InputSource::select_unspent_notes`] (which applies confirmation,
+    /// dust, and expiry filters for transaction construction), this returns every
+    /// note that existed and was unspent at the given height.
+    pub fn get_orchard_notes_at_historical_height(
         &self,
         account: AccountUuid,
-        snapshot_height: BlockHeight,
+        height: BlockHeight,
     ) -> Result<Vec<ReceivedNote<ReceivedNoteId, orchard::note::Note>>, SqliteClientError> {
-        wallet::orchard::get_orchard_notes_at_snapshot(
+        wallet::orchard::get_orchard_notes_at_historical_height(
             self.conn.borrow(),
             &self.params,
             account,
-            snapshot_height,
+            height,
         )
     }
 
-    /// Generate Orchard Merkle witnesses at a historical frontier.
+    /// Generate Orchard Merkle witnesses at a historical height.
     ///
     /// Copies the wallet's Orchard shard data into an ephemeral in-memory
     /// database, inserts the provided frontier as a checkpoint, and generates
     /// a witness for each of the given note positions.
     ///
     /// The wallet DB is strictly read-only — shard data is copied, not modified.
-    pub fn generate_orchard_witnesses_at_frontier(
+    pub fn generate_orchard_witnesses_at_historical_height(
         &self,
         note_positions: &[Position],
-        frontier: incrementalmerkletree::frontier::NonEmptyFrontier<
+        frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
             orchard::tree::MerkleHashOrchard,
         >,
-        checkpoint_height: BlockHeight,
+        height: BlockHeight,
     ) -> Result<
         Vec<
             incrementalmerkletree::MerklePath<
@@ -2361,11 +2360,11 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
         >,
         SqliteClientError,
     > {
-        wallet::commitment_tree::generate_orchard_witnesses_at_frontier(
+        wallet::commitment_tree::generate_orchard_witnesses_at_historical_height(
             self.conn.borrow(),
             note_positions,
-            frontier,
-            checkpoint_height,
+            frontier_at_height,
+            height,
         )
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2324,12 +2324,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
     /// Unlike [`InputSource::select_unspent_notes`] (which applies confirmation,
     /// dust, and expiry filters for transaction construction), this returns every
     /// note that existed and was unspent at the given height.
-    pub fn get_orchard_notes_at_historical_height(
+    pub fn get_unspent_orchard_notes_at_historical_height(
         &self,
         account: AccountUuid,
         height: BlockHeight,
     ) -> Result<Vec<ReceivedNote<ReceivedNoteId, orchard::note::Note>>, SqliteClientError> {
-        wallet::orchard::get_orchard_notes_at_historical_height(
+        wallet::orchard::get_unspent_orchard_notes_at_historical_height(
             self.conn.borrow(),
             &self.params,
             account,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -401,11 +401,6 @@ impl Borrow<rusqlite::Connection> for SqlTransaction<'_> {
 }
 
 impl<C, P, CL, R> WalletDb<C, P, CL, R> {
-    /// Returns a reference to the underlying connection handle.
-    pub fn conn(&self) -> &C {
-        &self.conn
-    }
-
     /// Returns the network parameters that this walletdb instance is bound to.
     pub fn params(&self) -> &P {
         &self.params
@@ -2318,8 +2313,8 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
 // --- Governance-specific methods ---
 //
 // These methods support Zcash shielded voting and are not part of the
-// general-purpose wallet traits. They provide a backward-looking snapshot
-// query for historical note selection.
+// general-purpose wallet traits. They provide backward-looking queries
+// (historical snapshot) and witness generation at an external frontier.
 
 #[cfg(feature = "orchard")]
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<C, P, CL, R> {
@@ -2340,6 +2335,37 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
             &self.params,
             account,
             snapshot_height,
+        )
+    }
+
+    /// Generate Orchard Merkle witnesses at a historical frontier.
+    ///
+    /// Copies the wallet's Orchard shard data into an ephemeral in-memory
+    /// database, inserts the provided frontier as a checkpoint, and generates
+    /// a witness for each of the given note positions.
+    ///
+    /// The wallet DB is strictly read-only — shard data is copied, not modified.
+    pub fn generate_orchard_witnesses_at_frontier(
+        &self,
+        note_positions: &[Position],
+        frontier: incrementalmerkletree::frontier::NonEmptyFrontier<
+            orchard::tree::MerkleHashOrchard,
+        >,
+        checkpoint_height: BlockHeight,
+    ) -> Result<
+        Vec<
+            incrementalmerkletree::MerklePath<
+                orchard::tree::MerkleHashOrchard,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >,
+        >,
+        SqliteClientError,
+    > {
+        wallet::commitment_tree::generate_orchard_witnesses_at_frontier(
+            self.conn.borrow(),
+            note_positions,
+            frontier,
+            checkpoint_height,
         )
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2339,11 +2339,11 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
 
     /// Generate Orchard Merkle witnesses at a historical height.
     ///
-    /// Copies the wallet's Orchard shard data into an ephemeral in-memory
-    /// database, inserts the provided frontier as a checkpoint, and generates
-    /// a witness for each of the given note positions.
+    /// Loads the wallet's Orchard shard data into an ephemeral in-memory
+    /// `ShardStore`, inserts the provided frontier as a checkpoint, and
+    /// generates a witness for each of the given note positions.
     ///
-    /// The wallet DB is strictly read-only — shard data is copied, not modified.
+    /// The wallet DB is strictly read-only — shard data is read but not modified.
     pub fn generate_orchard_witnesses_at_historical_height(
         &self,
         note_positions: &[Position],

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2310,6 +2310,66 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
     }
 }
 
+// --- Governance-specific methods ---
+//
+// These methods support Zcash shielded voting and are not part of the
+// general-purpose wallet traits. They provide backward-looking queries
+// (historical snapshot) and witness generation at an external frontier.
+
+#[cfg(feature = "orchard")]
+impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<C, P, CL, R> {
+    /// Return all Orchard notes received at or before `snapshot_height` and
+    /// unspent as of that height, for the given account.
+    ///
+    /// Unlike [`InputSource::select_unspent_notes`] which is forward-looking
+    /// (based on tx expiry), this is backward-looking: a note is included if
+    /// it was mined at or before `snapshot_height` and no spend of that note
+    /// was mined at or before `snapshot_height`.
+    pub fn get_orchard_notes_at_snapshot(
+        &self,
+        account: AccountUuid,
+        snapshot_height: BlockHeight,
+    ) -> Result<Vec<ReceivedNote<ReceivedNoteId, orchard::note::Note>>, SqliteClientError> {
+        wallet::orchard::get_orchard_notes_at_snapshot(
+            self.conn.borrow(),
+            &self.params,
+            account,
+            snapshot_height,
+        )
+    }
+
+    /// Generate Orchard Merkle witnesses at a historical frontier.
+    ///
+    /// Copies the wallet's Orchard shard data into an ephemeral in-memory
+    /// database, inserts the provided frontier as a checkpoint, and generates
+    /// a witness for each of the given note positions.
+    ///
+    /// The wallet DB is strictly read-only — shard data is copied, not modified.
+    pub fn generate_orchard_witnesses_at_frontier(
+        &self,
+        note_positions: &[Position],
+        frontier: incrementalmerkletree::frontier::NonEmptyFrontier<
+            orchard::tree::MerkleHashOrchard,
+        >,
+        checkpoint_height: BlockHeight,
+    ) -> Result<
+        Vec<
+            incrementalmerkletree::MerklePath<
+                orchard::tree::MerkleHashOrchard,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >,
+        >,
+        SqliteClientError,
+    > {
+        wallet::commitment_tree::generate_orchard_witnesses_at_frontier(
+            self.conn.borrow(),
+            note_positions,
+            frontier,
+            checkpoint_height,
+        )
+    }
+}
+
 /// A handle for the SQLite block source.
 pub struct BlockDb(Connection);
 

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -9,9 +9,9 @@ use std::{
     sync::Arc,
 };
 
-use incrementalmerkletree::{Address, Hashable, Level, Position, Retention};
+use incrementalmerkletree::{Address, Hashable, Level, Marking, Position, Retention};
 use shardtree::{
-    LocatedPrunableTree, LocatedTree, PrunableTree, RetentionFlags,
+    LocatedPrunableTree, LocatedTree, PrunableTree, RetentionFlags, ShardTree,
     error::{QueryError, ShardTreeError},
     store::{Checkpoint, ShardStore, TreeState},
 };
@@ -26,7 +26,12 @@ use zcash_protocol::{ShieldedProtocol, consensus::BlockHeight};
 use crate::{error::SqliteClientError, sapling_tree};
 
 #[cfg(feature = "orchard")]
-use crate::orchard_tree;
+use shardtree::store::memory::MemoryShardStore;
+#[cfg(feature = "orchard")]
+use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+#[cfg(feature = "orchard")]
+use crate::{ORCHARD_TABLES_PREFIX, orchard_tree};
 
 use super::common::{TableConstants, table_constants};
 
@@ -1140,96 +1145,11 @@ pub(crate) fn check_witnesses(
     Ok(scan_ranges)
 }
 
-/// Create the shard-tree schema tables in an existing connection.
-///
-/// The four tables (`{prefix}_tree_shards`, `{prefix}_tree_cap`,
-/// `{prefix}_tree_checkpoints`, `{prefix}_tree_checkpoint_marks_removed`)
-/// match the schema used by [`SqliteShardStore`].
-#[cfg(feature = "orchard")]
-fn create_tree_tables(
-    conn: &rusqlite::Connection,
-    table_prefix: &str,
-) -> Result<(), rusqlite::Error> {
-    conn.execute_batch(&format!(
-        "CREATE TABLE {table_prefix}_tree_shards (
-            shard_index INTEGER PRIMARY KEY,
-            subtree_end_height INTEGER,
-            root_hash BLOB,
-            shard_data BLOB,
-            contains_marked INTEGER,
-            CONSTRAINT root_unique UNIQUE (root_hash)
-        );
-        CREATE TABLE {table_prefix}_tree_cap (
-            cap_id INTEGER PRIMARY KEY,
-            cap_data BLOB NOT NULL
-        );
-        CREATE TABLE {table_prefix}_tree_checkpoints (
-            checkpoint_id INTEGER PRIMARY KEY,
-            position INTEGER
-        );
-        CREATE TABLE {table_prefix}_tree_checkpoint_marks_removed (
-            checkpoint_id INTEGER NOT NULL,
-            mark_removed_position INTEGER NOT NULL,
-            FOREIGN KEY (checkpoint_id) REFERENCES {table_prefix}_tree_checkpoints(checkpoint_id)
-            ON DELETE CASCADE,
-            CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
-        );"
-    ))
-}
-
-/// Copy shard and cap data for a commitment tree from one connection to another.
-///
-/// Both connections must already have the `{prefix}_tree_shards` and
-/// `{prefix}_tree_cap` tables (see [`create_tree_tables`]).
-#[cfg(feature = "orchard")]
-fn copy_tree_data(
-    src: &rusqlite::Connection,
-    dst: &rusqlite::Connection,
-    table_prefix: &str,
-) -> Result<(), rusqlite::Error> {
-    use rusqlite::types::Value;
-
-    let mut stmt = src.prepare(&format!(
-        "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
-         FROM {table_prefix}_tree_shards"
-    ))?;
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        dst.execute(
-            &format!(
-                "INSERT INTO {table_prefix}_tree_shards
-                 (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
-                 VALUES (?1, ?2, ?3, ?4, ?5)"
-            ),
-            rusqlite::params![
-                row.get::<_, Value>(0)?,
-                row.get::<_, Value>(1)?,
-                row.get::<_, Value>(2)?,
-                row.get::<_, Value>(3)?,
-                row.get::<_, Value>(4)?,
-            ],
-        )?;
-    }
-
-    let mut stmt = src.prepare(&format!(
-        "SELECT cap_id, cap_data FROM {table_prefix}_tree_cap"
-    ))?;
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        dst.execute(
-            &format!("INSERT INTO {table_prefix}_tree_cap (cap_id, cap_data) VALUES (?1, ?2)"),
-            rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?],
-        )?;
-    }
-
-    Ok(())
-}
-
 /// Generate Orchard Merkle witnesses at a historical height.
 ///
-/// Copies the wallet's Orchard shard data into an ephemeral in-memory database,
-/// inserts the provided frontier at that height as a checkpoint, and
-/// generates a witness for each of the given note positions.
+/// Loads the wallet's Orchard shard data into an ephemeral in-memory
+/// [`MemoryShardStore`], inserts the provided frontier at that height as a
+/// checkpoint, and generates a witness for each of the given note positions.
 ///
 /// It is assumed that the caller provides the valid frontier at the given height.
 ///
@@ -1246,8 +1166,9 @@ fn copy_tree_data(
 /// These three components are sufficient to reconstruct the tree structure
 /// needed for witness generation even after pruning has occurred.
 ///
-/// The wallet DB is strictly read-only. Shard data is copied, not modified.
-/// An ephemeral in-memory database is created to avoid tampering with the primary wallet DB.
+/// The wallet DB is strictly read-only. Shard data is read, decoded, and
+/// inserted into an ephemeral in-memory [`ShardStore`] to avoid tampering with
+/// the primary wallet DB.
 ///
 /// Example application: token holder voting. The wallet tree may have advanced past
 /// the historical height, but we need witnesses anchored at that frontier.
@@ -1268,28 +1189,31 @@ pub fn generate_orchard_witnesses_at_historical_height(
     >,
     SqliteClientError,
 > {
-    use incrementalmerkletree::Marking;
-    use shardtree::ShardTree;
-    use shardtree::store::Checkpoint;
-    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
-    let table_prefix = "orchard";
     let frontier_position = frontier_at_height.position();
 
-    let mem_conn = rusqlite::Connection::open_in_memory().map_err(SqliteClientError::DbError)?;
-    create_tree_tables(&mem_conn, table_prefix).map_err(SqliteClientError::DbError)?;
-    copy_tree_data(conn, &mem_conn, table_prefix).map_err(SqliteClientError::DbError)?;
+    // `get_shard_roots` returns addresses ordered by shard index, matching the
+    // ascending insertion order required by `MemoryShardStore::put_shard`.
+    let mut store = MemoryShardStore::<orchard::tree::MerkleHashOrchard, BlockHeight>::empty();
+    let shard_root_level = Level::new(ORCHARD_SHARD_HEIGHT);
+    let shard_roots = get_shard_roots(conn, ORCHARD_TABLES_PREFIX, shard_root_level)
+        .map_err(ShardTreeError::Storage)?;
+    for shard_root in shard_roots {
+        if let Some(shard) =
+            get_shard::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX, shard_root)
+                .map_err(ShardTreeError::Storage)?
+        {
+            store.put_shard(shard).expect("put_shard is infallible");
+        }
+    }
+    let cap = get_cap::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX)
+        .map_err(ShardTreeError::Storage)?;
+    store.put_cap(cap).expect("put_cap is infallible");
 
-    let store = SqliteShardStore::<
-        _,
-        orchard::tree::MerkleHashOrchard,
-        ORCHARD_SHARD_HEIGHT,
-    >::from_connection(mem_conn, table_prefix)
-    .map_err(SqliteClientError::DbError)?;
-
+    // Only one checkpoint is needed (the historical frontier), but ShardTree
+    // requires a nonzero checkpoint limit.
     let mut tree =
         ShardTree::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>::new(
-            store, 100,
+            store, 1,
         );
 
     // Insert frontier + checkpoint
@@ -1306,9 +1230,7 @@ pub fn generate_orchard_witnesses_at_historical_height(
 
     tree.store_mut()
         .add_checkpoint(height, Checkpoint::at_position(frontier_position))
-        .map_err(|e| {
-            SqliteClientError::CorruptedData(format!("failed to add checkpoint: {}", e))
-        })?;
+        .expect("add_checkpoint is infallible");
 
     // Generate witness per note position
     let mut witnesses = Vec::with_capacity(note_positions.len());

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -1140,6 +1140,181 @@ pub(crate) fn check_witnesses(
     Ok(scan_ranges)
 }
 
+/// Generate Orchard Merkle witnesses at a historical frontier.
+///
+/// Copies the wallet's Orchard shard data into an ephemeral in-memory database,
+/// inserts the provided frontier (from lightwalletd) as a checkpoint, and
+/// generates a witness for each of the given note positions.
+///
+/// The wallet DB is strictly read-only — shard data is copied, not modified.
+///
+/// This is used by governance voting: the wallet tree may have advanced past
+/// the snapshot height, but we need witnesses anchored at the snapshot frontier.
+#[cfg(feature = "orchard")]
+pub fn generate_orchard_witnesses_at_frontier(
+    conn: &rusqlite::Connection,
+    note_positions: &[Position],
+    frontier: incrementalmerkletree::frontier::NonEmptyFrontier<orchard::tree::MerkleHashOrchard>,
+    checkpoint_height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
+    use incrementalmerkletree::Marking;
+    use shardtree::ShardTree;
+    use shardtree::store::Checkpoint;
+    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+    let frontier_position = frontier.position();
+
+    // Create in-memory DB with the tree schema
+    let mem_conn = rusqlite::Connection::open_in_memory().map_err(SqliteClientError::DbError)?;
+
+    mem_conn
+        .execute_batch(
+            "CREATE TABLE orchard_tree_shards (
+                shard_index INTEGER PRIMARY KEY,
+                subtree_end_height INTEGER,
+                root_hash BLOB,
+                shard_data BLOB,
+                contains_marked INTEGER,
+                CONSTRAINT root_unique UNIQUE (root_hash)
+            );
+            CREATE TABLE orchard_tree_cap (
+                cap_id INTEGER PRIMARY KEY,
+                cap_data BLOB NOT NULL
+            );
+            CREATE TABLE orchard_tree_checkpoints (
+                checkpoint_id INTEGER PRIMARY KEY,
+                position INTEGER
+            );
+            CREATE TABLE orchard_tree_checkpoint_marks_removed (
+                checkpoint_id INTEGER NOT NULL,
+                mark_removed_position INTEGER NOT NULL,
+                FOREIGN KEY (checkpoint_id) REFERENCES orchard_tree_checkpoints(checkpoint_id)
+                ON DELETE CASCADE,
+                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
+            );",
+        )
+        .map_err(SqliteClientError::DbError)?;
+
+    // Copy shard data from wallet into in-memory DB
+    {
+        use rusqlite::types::Value;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
+                 FROM orchard_tree_shards",
+            )
+            .map_err(SqliteClientError::DbError)?;
+        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
+        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
+            mem_conn
+                .execute(
+                    "INSERT INTO orchard_tree_shards
+                     (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![
+                        row.get::<_, Value>(0)?,
+                        row.get::<_, Value>(1)?,
+                        row.get::<_, Value>(2)?,
+                        row.get::<_, Value>(3)?,
+                        row.get::<_, Value>(4)?,
+                    ],
+                )
+                .map_err(SqliteClientError::DbError)?;
+        }
+    }
+
+    // Copy cap data
+    {
+        use rusqlite::types::Value;
+
+        let mut stmt = conn
+            .prepare("SELECT cap_id, cap_data FROM orchard_tree_cap")
+            .map_err(SqliteClientError::DbError)?;
+        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
+        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
+            mem_conn
+                .execute(
+                    "INSERT INTO orchard_tree_cap (cap_id, cap_data) VALUES (?1, ?2)",
+                    rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?,],
+                )
+                .map_err(SqliteClientError::DbError)?;
+        }
+    }
+
+    // Build ShardTree from in-memory store
+    let tx = mem_conn
+        .unchecked_transaction()
+        .map_err(SqliteClientError::DbError)?;
+
+    let store = SqliteShardStore::<
+        _,
+        orchard::tree::MerkleHashOrchard,
+        ORCHARD_SHARD_HEIGHT,
+    >::from_connection(&tx, "orchard")
+    .map_err(SqliteClientError::DbError)?;
+
+    let mut tree =
+        ShardTree::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>::new(
+            store, 100,
+        );
+
+    // Insert frontier + checkpoint
+    tree.insert_frontier_nodes(
+        frontier,
+        Retention::Checkpoint {
+            id: checkpoint_height,
+            marking: Marking::None,
+        },
+    )
+    .map_err(|e| {
+        SqliteClientError::CorruptedData(format!("failed to insert frontier nodes: {}", e))
+    })?;
+
+    tree.store_mut()
+        .add_checkpoint(
+            checkpoint_height,
+            Checkpoint::at_position(frontier_position),
+        )
+        .map_err(|e| {
+            SqliteClientError::CorruptedData(format!("failed to add checkpoint: {}", e))
+        })?;
+
+    // Generate witness per note position
+    let mut witnesses = Vec::with_capacity(note_positions.len());
+    for &pos in note_positions {
+        let merkle_path = tree
+            .witness_at_checkpoint_id(pos, &checkpoint_height)
+            .map_err(|e| {
+                SqliteClientError::CorruptedData(format!(
+                    "failed to generate witness for position {}: {} \
+                     (wallet may need to sync through snapshot height)",
+                    u64::from(pos),
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                SqliteClientError::CorruptedData(format!(
+                    "no witness available for position {} \
+                     (wallet missing shard data — sync through snapshot height)",
+                    u64::from(pos)
+                ))
+            })?;
+
+        witnesses.push(merkle_path);
+    }
+
+    Ok(witnesses)
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::NamedTempFile;
@@ -1224,6 +1399,11 @@ mod tests {
         #[test]
         fn rewind_remove_mark() {
             super::check_rewind_remove_mark(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn witnesses_at_frontier() {
+            super::witnesses_at_frontier()
         }
 
         #[test]
@@ -1341,5 +1521,98 @@ mod tests {
                 "________________________________"
             ]
         );
+    }
+
+    /// Test that `generate_orchard_witnesses_at_frontier` produces valid
+    /// witnesses when given a frontier extracted from an earlier tree state.
+    #[cfg(feature = "orchard")]
+    fn witnesses_at_frontier() {
+        use ::orchard::tree::MerkleHashOrchard;
+        use incrementalmerkletree::frontier::Frontier;
+        use rand::SeedableRng;
+        use rand_chacha::ChaChaRng;
+        use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+        data_file.keep().unwrap();
+
+        WalletMigrator::new().init_or_migrate(&mut db_data).unwrap();
+
+        let mut rng = ChaChaRng::seed_from_u64(0);
+
+        // Build a tree with some leaves, marking one as our note.
+        // We track the frontier separately to capture the tree state at a
+        // snapshot height, while the wallet DB holds the persistent shard data.
+        let mut frontier_tree: Frontier<MerkleHashOrchard, 32> = Frontier::empty();
+        let snapshot_height = BlockHeight::from(100);
+        let note_position;
+        let note_leaf;
+
+        {
+            let tx = db_data.conn.transaction().unwrap();
+            let store =
+                SqliteShardStore::<_, MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>::from_connection(
+                    &tx, "orchard",
+                )
+                .unwrap();
+            let mut tree = ShardTree::<
+                _,
+                { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+                ORCHARD_SHARD_HEIGHT,
+            >::new(store, 100);
+
+            // Insert 5 leaves. Mark leaf 2 as our note.
+            let mut saved_leaf = None;
+            for i in 0u64..5 {
+                let leaf = MerkleHashOrchard::random(&mut rng);
+                let retention = if i == 2 {
+                    saved_leaf = Some(leaf);
+                    Retention::Marked
+                } else {
+                    Retention::Ephemeral
+                };
+                tree.append(leaf, retention).unwrap();
+                frontier_tree.append(leaf);
+            }
+            note_position = Position::from(2);
+            note_leaf = saved_leaf.unwrap();
+
+            // Advance the tree past the snapshot height, simulating the
+            // wallet continuing to sync after the voting snapshot.
+            tree.checkpoint(snapshot_height).unwrap();
+            for _ in 0..5 {
+                let leaf = MerkleHashOrchard::random(&mut rng);
+                tree.append(leaf, Retention::Ephemeral).unwrap();
+            }
+            tree.checkpoint(BlockHeight::from(200)).unwrap();
+
+            tx.commit().unwrap();
+        }
+
+        // The frontier_tree captured the state after 5 leaves.
+        let expected_root = frontier_tree.root();
+        let frontier = frontier_tree.take().expect("frontier is non-empty");
+
+        // Generate witness using the function under test
+        let witnesses = super::generate_orchard_witnesses_at_frontier(
+            &db_data.conn,
+            &[note_position],
+            frontier,
+            snapshot_height,
+        )
+        .expect("witness generation should succeed");
+
+        assert_eq!(witnesses.len(), 1);
+
+        // The witness, combined with the note's leaf hash, must recompute
+        // to the tree root at the snapshot height.
+        assert_eq!(witnesses[0].root(note_leaf), expected_root);
     }
 }

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -1140,22 +1140,125 @@ pub(crate) fn check_witnesses(
     Ok(scan_ranges)
 }
 
-/// Generate Orchard Merkle witnesses at a historical frontier.
+/// Create the shard-tree schema tables in an existing connection.
+///
+/// The four tables (`{prefix}_tree_shards`, `{prefix}_tree_cap`,
+/// `{prefix}_tree_checkpoints`, `{prefix}_tree_checkpoint_marks_removed`)
+/// match the schema used by [`SqliteShardStore`].
+#[cfg(feature = "orchard")]
+fn create_tree_tables(
+    conn: &rusqlite::Connection,
+    table_prefix: &str,
+) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(&format!(
+        "CREATE TABLE {table_prefix}_tree_shards (
+            shard_index INTEGER PRIMARY KEY,
+            subtree_end_height INTEGER,
+            root_hash BLOB,
+            shard_data BLOB,
+            contains_marked INTEGER,
+            CONSTRAINT root_unique UNIQUE (root_hash)
+        );
+        CREATE TABLE {table_prefix}_tree_cap (
+            cap_id INTEGER PRIMARY KEY,
+            cap_data BLOB NOT NULL
+        );
+        CREATE TABLE {table_prefix}_tree_checkpoints (
+            checkpoint_id INTEGER PRIMARY KEY,
+            position INTEGER
+        );
+        CREATE TABLE {table_prefix}_tree_checkpoint_marks_removed (
+            checkpoint_id INTEGER NOT NULL,
+            mark_removed_position INTEGER NOT NULL,
+            FOREIGN KEY (checkpoint_id) REFERENCES {table_prefix}_tree_checkpoints(checkpoint_id)
+            ON DELETE CASCADE,
+            CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
+        );"
+    ))
+}
+
+/// Copy shard and cap data for a commitment tree from one connection to another.
+///
+/// Both connections must already have the `{prefix}_tree_shards` and
+/// `{prefix}_tree_cap` tables (see [`create_tree_tables`]).
+#[cfg(feature = "orchard")]
+fn copy_tree_data(
+    src: &rusqlite::Connection,
+    dst: &rusqlite::Connection,
+    table_prefix: &str,
+) -> Result<(), rusqlite::Error> {
+    use rusqlite::types::Value;
+
+    let mut stmt = src.prepare(&format!(
+        "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
+         FROM {table_prefix}_tree_shards"
+    ))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        dst.execute(
+            &format!(
+                "INSERT INTO {table_prefix}_tree_shards
+                 (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
+                 VALUES (?1, ?2, ?3, ?4, ?5)"
+            ),
+            rusqlite::params![
+                row.get::<_, Value>(0)?,
+                row.get::<_, Value>(1)?,
+                row.get::<_, Value>(2)?,
+                row.get::<_, Value>(3)?,
+                row.get::<_, Value>(4)?,
+            ],
+        )?;
+    }
+
+    let mut stmt = src.prepare(&format!(
+        "SELECT cap_id, cap_data FROM {table_prefix}_tree_cap"
+    ))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        dst.execute(
+            &format!("INSERT INTO {table_prefix}_tree_cap (cap_id, cap_data) VALUES (?1, ?2)"),
+            rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?],
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Generate Orchard Merkle witnesses at a historical height.
 ///
 /// Copies the wallet's Orchard shard data into an ephemeral in-memory database,
-/// inserts the provided frontier (from lightwalletd) as a checkpoint, and
+/// inserts the provided frontier at that height as a checkpoint, and
 /// generates a witness for each of the given note positions.
 ///
-/// The wallet DB is strictly read-only — shard data is copied, not modified.
+/// It is assumed that the caller provides the valid frontier at the given height.
 ///
-/// This is used by governance voting: the wallet tree may have advanced past
-/// the snapshot height, but we need witnesses anchored at the snapshot frontier.
+/// How it works:
+/// To construct witnesses at a historical height, we need:
+/// 1. Authentication path within each note's shard — the scanner marks the
+///    wallet's notes as MARKED, preventing them and their siblings within a
+///    shard from being pruned.
+/// 2. Cap — the upper tree above the shard level.
+/// 3. Frontier — the right edge at the historical height. It lets ShardTree
+///    know exactly where the tree ended at that height.
+///
+/// The wallet automatically prunes the tree after PRUNING_DEPTH checkpoints.
+/// These three components are sufficient to reconstruct the tree structure
+/// needed for witness generation even after pruning has occurred.
+///
+/// The wallet DB is strictly read-only. Shard data is copied, not modified.
+/// An ephemeral in-memory database is created to avoid tampering with the primary wallet DB.
+///
+/// Example application: token holder voting. The wallet tree may have advanced past
+/// the historical height, but we need witnesses anchored at that frontier.
 #[cfg(feature = "orchard")]
-pub fn generate_orchard_witnesses_at_frontier(
+pub fn generate_orchard_witnesses_at_historical_height(
     conn: &rusqlite::Connection,
     note_positions: &[Position],
-    frontier: incrementalmerkletree::frontier::NonEmptyFrontier<orchard::tree::MerkleHashOrchard>,
-    checkpoint_height: BlockHeight,
+    frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+        orchard::tree::MerkleHashOrchard,
+    >,
+    height: BlockHeight,
 ) -> Result<
     Vec<
         incrementalmerkletree::MerklePath<
@@ -1170,96 +1273,18 @@ pub fn generate_orchard_witnesses_at_frontier(
     use shardtree::store::Checkpoint;
     use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
-    let frontier_position = frontier.position();
+    let table_prefix = "orchard";
+    let frontier_position = frontier_at_height.position();
 
-    // Create in-memory DB with the tree schema
     let mem_conn = rusqlite::Connection::open_in_memory().map_err(SqliteClientError::DbError)?;
-
-    mem_conn
-        .execute_batch(
-            "CREATE TABLE orchard_tree_shards (
-                shard_index INTEGER PRIMARY KEY,
-                subtree_end_height INTEGER,
-                root_hash BLOB,
-                shard_data BLOB,
-                contains_marked INTEGER,
-                CONSTRAINT root_unique UNIQUE (root_hash)
-            );
-            CREATE TABLE orchard_tree_cap (
-                cap_id INTEGER PRIMARY KEY,
-                cap_data BLOB NOT NULL
-            );
-            CREATE TABLE orchard_tree_checkpoints (
-                checkpoint_id INTEGER PRIMARY KEY,
-                position INTEGER
-            );
-            CREATE TABLE orchard_tree_checkpoint_marks_removed (
-                checkpoint_id INTEGER NOT NULL,
-                mark_removed_position INTEGER NOT NULL,
-                FOREIGN KEY (checkpoint_id) REFERENCES orchard_tree_checkpoints(checkpoint_id)
-                ON DELETE CASCADE,
-                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
-            );",
-        )
-        .map_err(SqliteClientError::DbError)?;
-
-    // Copy shard data from wallet into in-memory DB
-    {
-        use rusqlite::types::Value;
-
-        let mut stmt = conn
-            .prepare(
-                "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
-                 FROM orchard_tree_shards",
-            )
-            .map_err(SqliteClientError::DbError)?;
-        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
-        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
-            mem_conn
-                .execute(
-                    "INSERT INTO orchard_tree_shards
-                     (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
-                     VALUES (?1, ?2, ?3, ?4, ?5)",
-                    rusqlite::params![
-                        row.get::<_, Value>(0)?,
-                        row.get::<_, Value>(1)?,
-                        row.get::<_, Value>(2)?,
-                        row.get::<_, Value>(3)?,
-                        row.get::<_, Value>(4)?,
-                    ],
-                )
-                .map_err(SqliteClientError::DbError)?;
-        }
-    }
-
-    // Copy cap data
-    {
-        use rusqlite::types::Value;
-
-        let mut stmt = conn
-            .prepare("SELECT cap_id, cap_data FROM orchard_tree_cap")
-            .map_err(SqliteClientError::DbError)?;
-        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
-        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
-            mem_conn
-                .execute(
-                    "INSERT INTO orchard_tree_cap (cap_id, cap_data) VALUES (?1, ?2)",
-                    rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?,],
-                )
-                .map_err(SqliteClientError::DbError)?;
-        }
-    }
-
-    // Build ShardTree from in-memory store
-    let tx = mem_conn
-        .unchecked_transaction()
-        .map_err(SqliteClientError::DbError)?;
+    create_tree_tables(&mem_conn, table_prefix).map_err(SqliteClientError::DbError)?;
+    copy_tree_data(conn, &mem_conn, table_prefix).map_err(SqliteClientError::DbError)?;
 
     let store = SqliteShardStore::<
         _,
         orchard::tree::MerkleHashOrchard,
         ORCHARD_SHARD_HEIGHT,
-    >::from_connection(&tx, "orchard")
+    >::from_connection(mem_conn, table_prefix)
     .map_err(SqliteClientError::DbError)?;
 
     let mut tree =
@@ -1269,9 +1294,9 @@ pub fn generate_orchard_witnesses_at_frontier(
 
     // Insert frontier + checkpoint
     tree.insert_frontier_nodes(
-        frontier,
+        frontier_at_height,
         Retention::Checkpoint {
-            id: checkpoint_height,
+            id: height,
             marking: Marking::None,
         },
     )
@@ -1280,10 +1305,7 @@ pub fn generate_orchard_witnesses_at_frontier(
     })?;
 
     tree.store_mut()
-        .add_checkpoint(
-            checkpoint_height,
-            Checkpoint::at_position(frontier_position),
-        )
+        .add_checkpoint(height, Checkpoint::at_position(frontier_position))
         .map_err(|e| {
             SqliteClientError::CorruptedData(format!("failed to add checkpoint: {}", e))
         })?;
@@ -1292,11 +1314,11 @@ pub fn generate_orchard_witnesses_at_frontier(
     let mut witnesses = Vec::with_capacity(note_positions.len());
     for &pos in note_positions {
         let merkle_path = tree
-            .witness_at_checkpoint_id(pos, &checkpoint_height)
+            .witness_at_checkpoint_id(pos, &height)
             .map_err(|e| {
                 SqliteClientError::CorruptedData(format!(
                     "failed to generate witness for position {}: {} \
-                     (wallet may need to sync through snapshot height)",
+                     (wallet may need to sync through historical height)",
                     u64::from(pos),
                     e
                 ))
@@ -1304,7 +1326,7 @@ pub fn generate_orchard_witnesses_at_frontier(
             .ok_or_else(|| {
                 SqliteClientError::CorruptedData(format!(
                     "no witness available for position {} \
-                     (wallet missing shard data — sync through snapshot height)",
+                     (wallet missing shard data — sync through historical height)",
                     u64::from(pos)
                 ))
             })?;
@@ -1402,8 +1424,8 @@ mod tests {
         }
 
         #[test]
-        fn witnesses_at_frontier() {
-            super::witnesses_at_frontier()
+        fn witnesses_at_historical_height() {
+            super::witnesses_at_historical_height()
         }
 
         #[test]
@@ -1523,10 +1545,10 @@ mod tests {
         );
     }
 
-    /// Test that `generate_orchard_witnesses_at_frontier` produces valid
+    /// Test that `generate_orchard_witnesses_at_historical_height` produces valid
     /// witnesses when given a frontier extracted from an earlier tree state.
     #[cfg(feature = "orchard")]
-    fn witnesses_at_frontier() {
+    fn witnesses_at_historical_height() {
         use ::orchard::tree::MerkleHashOrchard;
         use incrementalmerkletree::frontier::Frontier;
         use rand::SeedableRng;
@@ -1547,12 +1569,11 @@ mod tests {
 
         let mut rng = ChaChaRng::seed_from_u64(0);
 
-        // Build a tree with some leaves, marking one as our note.
-        // We track the frontier separately to capture the tree state at a
-        // snapshot height, while the wallet DB holds the persistent shard data.
+        // We build two parallel trees: the wallet's ShardTree (persisted to the DB)
+        // and a lightweight Frontier that captures the tree state at the historical height.
         let mut frontier_tree: Frontier<MerkleHashOrchard, 32> = Frontier::empty();
-        let snapshot_height = BlockHeight::from(100);
-        let note_position;
+        let historical_height = BlockHeight::from(100);
+        let note_position = Position::from(2);
         let note_leaf;
 
         {
@@ -1568,12 +1589,14 @@ mod tests {
                 ORCHARD_SHARD_HEIGHT,
             >::new(store, 100);
 
-            // Insert 5 leaves. Mark leaf 2 as our note.
-            let mut saved_leaf = None;
-            for i in 0u64..5 {
-                let leaf = MerkleHashOrchard::random(&mut rng);
-                let retention = if i == 2 {
-                    saved_leaf = Some(leaf);
+            let mut leaves = Vec::new();
+            for _ in 0u64..5 {
+                leaves.push(MerkleHashOrchard::random(&mut rng));
+            }
+            note_leaf = leaves[u64::from(note_position) as usize];
+
+            for (i, &leaf) in leaves.iter().enumerate() {
+                let retention = if i == u64::from(note_position) as usize {
                     Retention::Marked
                 } else {
                     Retention::Ephemeral
@@ -1581,38 +1604,31 @@ mod tests {
                 tree.append(leaf, retention).unwrap();
                 frontier_tree.append(leaf);
             }
-            note_position = Position::from(2);
-            note_leaf = saved_leaf.unwrap();
 
-            // Advance the tree past the snapshot height, simulating the
-            // wallet continuing to sync after the voting snapshot.
-            tree.checkpoint(snapshot_height).unwrap();
+            // Advance the tree past the historical height, simulating the
+            // wallet continuing to sync afterward.
+            tree.checkpoint(historical_height).unwrap();
             for _ in 0..5 {
-                let leaf = MerkleHashOrchard::random(&mut rng);
-                tree.append(leaf, Retention::Ephemeral).unwrap();
+                tree.append(MerkleHashOrchard::random(&mut rng), Retention::Ephemeral)
+                    .unwrap();
             }
             tree.checkpoint(BlockHeight::from(200)).unwrap();
 
             tx.commit().unwrap();
         }
 
-        // The frontier_tree captured the state after 5 leaves.
         let expected_root = frontier_tree.root();
         let frontier = frontier_tree.take().expect("frontier is non-empty");
 
-        // Generate witness using the function under test
-        let witnesses = super::generate_orchard_witnesses_at_frontier(
+        let witnesses = super::generate_orchard_witnesses_at_historical_height(
             &db_data.conn,
             &[note_position],
             frontier,
-            snapshot_height,
+            historical_height,
         )
         .expect("witness generation should succeed");
 
         assert_eq!(witnesses.len(), 1);
-
-        // The witness, combined with the note's leaf hash, must recompute
-        // to the tree root at the snapshot height.
         assert_eq!(witnesses[0].root(note_leaf), expected_root);
     }
 }

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -103,7 +103,10 @@ pub struct SqliteShardStore<C, H, const SHARD_HEIGHT: u8> {
 impl<C, H, const SHARD_HEIGHT: u8> SqliteShardStore<C, H, SHARD_HEIGHT> {
     const SHARD_ROOT_LEVEL: Level = Level::new(SHARD_HEIGHT);
 
-    pub fn from_connection(conn: C, table_prefix: &'static str) -> Result<Self, rusqlite::Error> {
+    pub(crate) fn from_connection(
+        conn: C,
+        table_prefix: &'static str,
+    ) -> Result<Self, rusqlite::Error> {
         Ok(SqliteShardStore {
             conn,
             table_prefix,
@@ -1137,23 +1140,179 @@ pub(crate) fn check_witnesses(
     Ok(scan_ranges)
 }
 
-/// Creates the Orchard commitment-tree tables in the given connection.
+/// Generate Orchard Merkle witnesses at a historical frontier.
 ///
-/// This enables constructing an ephemeral in-memory [`SqliteShardStore`] for
-/// operations like witness generation at a historical frontier, without
-/// requiring the full wallet schema.
+/// Copies the wallet's Orchard shard data into an ephemeral in-memory database,
+/// inserts the provided frontier (from lightwalletd) as a checkpoint, and
+/// generates a witness for each of the given note positions.
+///
+/// The wallet DB is strictly read-only — shard data is copied, not modified.
+///
+/// This is used by governance voting: the wallet tree may have advanced past
+/// the snapshot height, but we need witnesses anchored at the snapshot frontier.
 #[cfg(feature = "orchard")]
-pub fn create_orchard_tree_tables(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
-    use super::db::{
-        TABLE_ORCHARD_TREE_CAP, TABLE_ORCHARD_TREE_CHECKPOINT_MARKS_REMOVED,
-        TABLE_ORCHARD_TREE_CHECKPOINTS, TABLE_ORCHARD_TREE_SHARDS,
-    };
-    conn.execute_batch(&format!(
-        "{TABLE_ORCHARD_TREE_SHARDS};\
-         {TABLE_ORCHARD_TREE_CAP};\
-         {TABLE_ORCHARD_TREE_CHECKPOINTS};\
-         {TABLE_ORCHARD_TREE_CHECKPOINT_MARKS_REMOVED};",
-    ))
+pub fn generate_orchard_witnesses_at_frontier(
+    conn: &rusqlite::Connection,
+    note_positions: &[Position],
+    frontier: incrementalmerkletree::frontier::NonEmptyFrontier<orchard::tree::MerkleHashOrchard>,
+    checkpoint_height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
+    use incrementalmerkletree::Marking;
+    use shardtree::ShardTree;
+    use shardtree::store::Checkpoint;
+    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+    let frontier_position = frontier.position();
+
+    // Create in-memory DB with the tree schema
+    let mem_conn = rusqlite::Connection::open_in_memory().map_err(SqliteClientError::DbError)?;
+
+    mem_conn
+        .execute_batch(
+            "CREATE TABLE orchard_tree_shards (
+                shard_index INTEGER PRIMARY KEY,
+                subtree_end_height INTEGER,
+                root_hash BLOB,
+                shard_data BLOB,
+                contains_marked INTEGER,
+                CONSTRAINT root_unique UNIQUE (root_hash)
+            );
+            CREATE TABLE orchard_tree_cap (
+                cap_id INTEGER PRIMARY KEY,
+                cap_data BLOB NOT NULL
+            );
+            CREATE TABLE orchard_tree_checkpoints (
+                checkpoint_id INTEGER PRIMARY KEY,
+                position INTEGER
+            );
+            CREATE TABLE orchard_tree_checkpoint_marks_removed (
+                checkpoint_id INTEGER NOT NULL,
+                mark_removed_position INTEGER NOT NULL,
+                FOREIGN KEY (checkpoint_id) REFERENCES orchard_tree_checkpoints(checkpoint_id)
+                ON DELETE CASCADE,
+                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
+            );",
+        )
+        .map_err(SqliteClientError::DbError)?;
+
+    // Copy shard data from wallet into in-memory DB
+    {
+        use rusqlite::types::Value;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
+                 FROM orchard_tree_shards",
+            )
+            .map_err(SqliteClientError::DbError)?;
+        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
+        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
+            mem_conn
+                .execute(
+                    "INSERT INTO orchard_tree_shards
+                     (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![
+                        row.get::<_, Value>(0)?,
+                        row.get::<_, Value>(1)?,
+                        row.get::<_, Value>(2)?,
+                        row.get::<_, Value>(3)?,
+                        row.get::<_, Value>(4)?,
+                    ],
+                )
+                .map_err(SqliteClientError::DbError)?;
+        }
+    }
+
+    // Copy cap data
+    {
+        use rusqlite::types::Value;
+
+        let mut stmt = conn
+            .prepare("SELECT cap_id, cap_data FROM orchard_tree_cap")
+            .map_err(SqliteClientError::DbError)?;
+        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
+        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
+            mem_conn
+                .execute(
+                    "INSERT INTO orchard_tree_cap (cap_id, cap_data) VALUES (?1, ?2)",
+                    rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?,],
+                )
+                .map_err(SqliteClientError::DbError)?;
+        }
+    }
+
+    // Build ShardTree from in-memory store
+    let tx = mem_conn
+        .unchecked_transaction()
+        .map_err(SqliteClientError::DbError)?;
+
+    let store = SqliteShardStore::<
+        _,
+        orchard::tree::MerkleHashOrchard,
+        ORCHARD_SHARD_HEIGHT,
+    >::from_connection(&tx, "orchard")
+    .map_err(SqliteClientError::DbError)?;
+
+    let mut tree =
+        ShardTree::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>::new(
+            store, 100,
+        );
+
+    // Insert frontier + checkpoint
+    tree.insert_frontier_nodes(
+        frontier,
+        Retention::Checkpoint {
+            id: checkpoint_height,
+            marking: Marking::None,
+        },
+    )
+    .map_err(|e| {
+        SqliteClientError::CorruptedData(format!("failed to insert frontier nodes: {}", e))
+    })?;
+
+    tree.store_mut()
+        .add_checkpoint(
+            checkpoint_height,
+            Checkpoint::at_position(frontier_position),
+        )
+        .map_err(|e| {
+            SqliteClientError::CorruptedData(format!("failed to add checkpoint: {}", e))
+        })?;
+
+    // Generate witness per note position
+    let mut witnesses = Vec::with_capacity(note_positions.len());
+    for &pos in note_positions {
+        let merkle_path = tree
+            .witness_at_checkpoint_id(pos, &checkpoint_height)
+            .map_err(|e| {
+                SqliteClientError::CorruptedData(format!(
+                    "failed to generate witness for position {}: {} \
+                     (wallet may need to sync through snapshot height)",
+                    u64::from(pos),
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                SqliteClientError::CorruptedData(format!(
+                    "no witness available for position {} \
+                     (wallet missing shard data — sync through snapshot height)",
+                    u64::from(pos)
+                ))
+            })?;
+
+        witnesses.push(merkle_path);
+    }
+
+    Ok(witnesses)
 }
 
 #[cfg(test)]
@@ -1240,6 +1399,11 @@ mod tests {
         #[test]
         fn rewind_remove_mark() {
             super::check_rewind_remove_mark(new_tree::<OrchardPoolTester>);
+        }
+
+        #[test]
+        fn witnesses_at_frontier() {
+            super::witnesses_at_frontier()
         }
 
         #[test]
@@ -1357,5 +1521,98 @@ mod tests {
                 "________________________________"
             ]
         );
+    }
+
+    /// Test that `generate_orchard_witnesses_at_frontier` produces valid
+    /// witnesses when given a frontier extracted from an earlier tree state.
+    #[cfg(feature = "orchard")]
+    fn witnesses_at_frontier() {
+        use ::orchard::tree::MerkleHashOrchard;
+        use incrementalmerkletree::frontier::Frontier;
+        use rand::SeedableRng;
+        use rand_chacha::ChaChaRng;
+        use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+        data_file.keep().unwrap();
+
+        WalletMigrator::new().init_or_migrate(&mut db_data).unwrap();
+
+        let mut rng = ChaChaRng::seed_from_u64(0);
+
+        // Build a tree with some leaves, marking one as our note.
+        // We track the frontier separately to capture the tree state at a
+        // snapshot height, while the wallet DB holds the persistent shard data.
+        let mut frontier_tree: Frontier<MerkleHashOrchard, 32> = Frontier::empty();
+        let snapshot_height = BlockHeight::from(100);
+        let note_position;
+        let note_leaf;
+
+        {
+            let tx = db_data.conn.transaction().unwrap();
+            let store =
+                SqliteShardStore::<_, MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>::from_connection(
+                    &tx, "orchard",
+                )
+                .unwrap();
+            let mut tree = ShardTree::<
+                _,
+                { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+                ORCHARD_SHARD_HEIGHT,
+            >::new(store, 100);
+
+            // Insert 5 leaves. Mark leaf 2 as our note.
+            let mut saved_leaf = None;
+            for i in 0u64..5 {
+                let leaf = MerkleHashOrchard::random(&mut rng);
+                let retention = if i == 2 {
+                    saved_leaf = Some(leaf);
+                    Retention::Marked
+                } else {
+                    Retention::Ephemeral
+                };
+                tree.append(leaf, retention).unwrap();
+                frontier_tree.append(leaf);
+            }
+            note_position = Position::from(2);
+            note_leaf = saved_leaf.unwrap();
+
+            // Advance the tree past the snapshot height, simulating the
+            // wallet continuing to sync after the voting snapshot.
+            tree.checkpoint(snapshot_height).unwrap();
+            for _ in 0..5 {
+                let leaf = MerkleHashOrchard::random(&mut rng);
+                tree.append(leaf, Retention::Ephemeral).unwrap();
+            }
+            tree.checkpoint(BlockHeight::from(200)).unwrap();
+
+            tx.commit().unwrap();
+        }
+
+        // The frontier_tree captured the state after 5 leaves.
+        let expected_root = frontier_tree.root();
+        let frontier = frontier_tree.take().expect("frontier is non-empty");
+
+        // Generate witness using the function under test
+        let witnesses = super::generate_orchard_witnesses_at_frontier(
+            &db_data.conn,
+            &[note_position],
+            frontier,
+            snapshot_height,
+        )
+        .expect("witness generation should succeed");
+
+        assert_eq!(witnesses.len(), 1);
+
+        // The witness, combined with the note's leaf hash, must recompute
+        // to the tree root at the snapshot height.
+        assert_eq!(witnesses[0].root(note_leaf), expected_root);
     }
 }

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -103,10 +103,7 @@ pub struct SqliteShardStore<C, H, const SHARD_HEIGHT: u8> {
 impl<C, H, const SHARD_HEIGHT: u8> SqliteShardStore<C, H, SHARD_HEIGHT> {
     const SHARD_ROOT_LEVEL: Level = Level::new(SHARD_HEIGHT);
 
-    pub(crate) fn from_connection(
-        conn: C,
-        table_prefix: &'static str,
-    ) -> Result<Self, rusqlite::Error> {
+    pub fn from_connection(conn: C, table_prefix: &'static str) -> Result<Self, rusqlite::Error> {
         Ok(SqliteShardStore {
             conn,
             table_prefix,
@@ -1140,179 +1137,23 @@ pub(crate) fn check_witnesses(
     Ok(scan_ranges)
 }
 
-/// Generate Orchard Merkle witnesses at a historical frontier.
+/// Creates the Orchard commitment-tree tables in the given connection.
 ///
-/// Copies the wallet's Orchard shard data into an ephemeral in-memory database,
-/// inserts the provided frontier (from lightwalletd) as a checkpoint, and
-/// generates a witness for each of the given note positions.
-///
-/// The wallet DB is strictly read-only — shard data is copied, not modified.
-///
-/// This is used by governance voting: the wallet tree may have advanced past
-/// the snapshot height, but we need witnesses anchored at the snapshot frontier.
+/// This enables constructing an ephemeral in-memory [`SqliteShardStore`] for
+/// operations like witness generation at a historical frontier, without
+/// requiring the full wallet schema.
 #[cfg(feature = "orchard")]
-pub fn generate_orchard_witnesses_at_frontier(
-    conn: &rusqlite::Connection,
-    note_positions: &[Position],
-    frontier: incrementalmerkletree::frontier::NonEmptyFrontier<orchard::tree::MerkleHashOrchard>,
-    checkpoint_height: BlockHeight,
-) -> Result<
-    Vec<
-        incrementalmerkletree::MerklePath<
-            orchard::tree::MerkleHashOrchard,
-            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-        >,
-    >,
-    SqliteClientError,
-> {
-    use incrementalmerkletree::Marking;
-    use shardtree::ShardTree;
-    use shardtree::store::Checkpoint;
-    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
-    let frontier_position = frontier.position();
-
-    // Create in-memory DB with the tree schema
-    let mem_conn = rusqlite::Connection::open_in_memory().map_err(SqliteClientError::DbError)?;
-
-    mem_conn
-        .execute_batch(
-            "CREATE TABLE orchard_tree_shards (
-                shard_index INTEGER PRIMARY KEY,
-                subtree_end_height INTEGER,
-                root_hash BLOB,
-                shard_data BLOB,
-                contains_marked INTEGER,
-                CONSTRAINT root_unique UNIQUE (root_hash)
-            );
-            CREATE TABLE orchard_tree_cap (
-                cap_id INTEGER PRIMARY KEY,
-                cap_data BLOB NOT NULL
-            );
-            CREATE TABLE orchard_tree_checkpoints (
-                checkpoint_id INTEGER PRIMARY KEY,
-                position INTEGER
-            );
-            CREATE TABLE orchard_tree_checkpoint_marks_removed (
-                checkpoint_id INTEGER NOT NULL,
-                mark_removed_position INTEGER NOT NULL,
-                FOREIGN KEY (checkpoint_id) REFERENCES orchard_tree_checkpoints(checkpoint_id)
-                ON DELETE CASCADE,
-                CONSTRAINT spend_position_unique UNIQUE (checkpoint_id, mark_removed_position)
-            );",
-        )
-        .map_err(SqliteClientError::DbError)?;
-
-    // Copy shard data from wallet into in-memory DB
-    {
-        use rusqlite::types::Value;
-
-        let mut stmt = conn
-            .prepare(
-                "SELECT shard_index, subtree_end_height, root_hash, shard_data, contains_marked
-                 FROM orchard_tree_shards",
-            )
-            .map_err(SqliteClientError::DbError)?;
-        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
-        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
-            mem_conn
-                .execute(
-                    "INSERT INTO orchard_tree_shards
-                     (shard_index, subtree_end_height, root_hash, shard_data, contains_marked)
-                     VALUES (?1, ?2, ?3, ?4, ?5)",
-                    rusqlite::params![
-                        row.get::<_, Value>(0)?,
-                        row.get::<_, Value>(1)?,
-                        row.get::<_, Value>(2)?,
-                        row.get::<_, Value>(3)?,
-                        row.get::<_, Value>(4)?,
-                    ],
-                )
-                .map_err(SqliteClientError::DbError)?;
-        }
-    }
-
-    // Copy cap data
-    {
-        use rusqlite::types::Value;
-
-        let mut stmt = conn
-            .prepare("SELECT cap_id, cap_data FROM orchard_tree_cap")
-            .map_err(SqliteClientError::DbError)?;
-        let mut rows = stmt.query([]).map_err(SqliteClientError::DbError)?;
-        while let Some(row) = rows.next().map_err(SqliteClientError::DbError)? {
-            mem_conn
-                .execute(
-                    "INSERT INTO orchard_tree_cap (cap_id, cap_data) VALUES (?1, ?2)",
-                    rusqlite::params![row.get::<_, Value>(0)?, row.get::<_, Value>(1)?,],
-                )
-                .map_err(SqliteClientError::DbError)?;
-        }
-    }
-
-    // Build ShardTree from in-memory store
-    let tx = mem_conn
-        .unchecked_transaction()
-        .map_err(SqliteClientError::DbError)?;
-
-    let store = SqliteShardStore::<
-        _,
-        orchard::tree::MerkleHashOrchard,
-        ORCHARD_SHARD_HEIGHT,
-    >::from_connection(&tx, "orchard")
-    .map_err(SqliteClientError::DbError)?;
-
-    let mut tree =
-        ShardTree::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>::new(
-            store, 100,
-        );
-
-    // Insert frontier + checkpoint
-    tree.insert_frontier_nodes(
-        frontier,
-        Retention::Checkpoint {
-            id: checkpoint_height,
-            marking: Marking::None,
-        },
-    )
-    .map_err(|e| {
-        SqliteClientError::CorruptedData(format!("failed to insert frontier nodes: {}", e))
-    })?;
-
-    tree.store_mut()
-        .add_checkpoint(
-            checkpoint_height,
-            Checkpoint::at_position(frontier_position),
-        )
-        .map_err(|e| {
-            SqliteClientError::CorruptedData(format!("failed to add checkpoint: {}", e))
-        })?;
-
-    // Generate witness per note position
-    let mut witnesses = Vec::with_capacity(note_positions.len());
-    for &pos in note_positions {
-        let merkle_path = tree
-            .witness_at_checkpoint_id(pos, &checkpoint_height)
-            .map_err(|e| {
-                SqliteClientError::CorruptedData(format!(
-                    "failed to generate witness for position {}: {} \
-                     (wallet may need to sync through snapshot height)",
-                    u64::from(pos),
-                    e
-                ))
-            })?
-            .ok_or_else(|| {
-                SqliteClientError::CorruptedData(format!(
-                    "no witness available for position {} \
-                     (wallet missing shard data — sync through snapshot height)",
-                    u64::from(pos)
-                ))
-            })?;
-
-        witnesses.push(merkle_path);
-    }
-
-    Ok(witnesses)
+pub fn create_orchard_tree_tables(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
+    use super::db::{
+        TABLE_ORCHARD_TREE_CAP, TABLE_ORCHARD_TREE_CHECKPOINT_MARKS_REMOVED,
+        TABLE_ORCHARD_TREE_CHECKPOINTS, TABLE_ORCHARD_TREE_SHARDS,
+    };
+    conn.execute_batch(&format!(
+        "{TABLE_ORCHARD_TREE_SHARDS};\
+         {TABLE_ORCHARD_TREE_CAP};\
+         {TABLE_ORCHARD_TREE_CHECKPOINTS};\
+         {TABLE_ORCHARD_TREE_CHECKPOINT_MARKS_REMOVED};",
+    ))
 }
 
 #[cfg(test)]
@@ -1399,11 +1240,6 @@ mod tests {
         #[test]
         fn rewind_remove_mark() {
             super::check_rewind_remove_mark(new_tree::<OrchardPoolTester>);
-        }
-
-        #[test]
-        fn witnesses_at_frontier() {
-            super::witnesses_at_frontier()
         }
 
         #[test]
@@ -1521,98 +1357,5 @@ mod tests {
                 "________________________________"
             ]
         );
-    }
-
-    /// Test that `generate_orchard_witnesses_at_frontier` produces valid
-    /// witnesses when given a frontier extracted from an earlier tree state.
-    #[cfg(feature = "orchard")]
-    fn witnesses_at_frontier() {
-        use ::orchard::tree::MerkleHashOrchard;
-        use incrementalmerkletree::frontier::Frontier;
-        use rand::SeedableRng;
-        use rand_chacha::ChaChaRng;
-        use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data = WalletDb::for_path(
-            data_file.path(),
-            Network::TestNetwork,
-            test_clock(),
-            test_rng(),
-        )
-        .unwrap();
-        data_file.keep().unwrap();
-
-        WalletMigrator::new().init_or_migrate(&mut db_data).unwrap();
-
-        let mut rng = ChaChaRng::seed_from_u64(0);
-
-        // Build a tree with some leaves, marking one as our note.
-        // We track the frontier separately to capture the tree state at a
-        // snapshot height, while the wallet DB holds the persistent shard data.
-        let mut frontier_tree: Frontier<MerkleHashOrchard, 32> = Frontier::empty();
-        let snapshot_height = BlockHeight::from(100);
-        let note_position;
-        let note_leaf;
-
-        {
-            let tx = db_data.conn.transaction().unwrap();
-            let store =
-                SqliteShardStore::<_, MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>::from_connection(
-                    &tx, "orchard",
-                )
-                .unwrap();
-            let mut tree = ShardTree::<
-                _,
-                { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-                ORCHARD_SHARD_HEIGHT,
-            >::new(store, 100);
-
-            // Insert 5 leaves. Mark leaf 2 as our note.
-            let mut saved_leaf = None;
-            for i in 0u64..5 {
-                let leaf = MerkleHashOrchard::random(&mut rng);
-                let retention = if i == 2 {
-                    saved_leaf = Some(leaf);
-                    Retention::Marked
-                } else {
-                    Retention::Ephemeral
-                };
-                tree.append(leaf, retention).unwrap();
-                frontier_tree.append(leaf);
-            }
-            note_position = Position::from(2);
-            note_leaf = saved_leaf.unwrap();
-
-            // Advance the tree past the snapshot height, simulating the
-            // wallet continuing to sync after the voting snapshot.
-            tree.checkpoint(snapshot_height).unwrap();
-            for _ in 0..5 {
-                let leaf = MerkleHashOrchard::random(&mut rng);
-                tree.append(leaf, Retention::Ephemeral).unwrap();
-            }
-            tree.checkpoint(BlockHeight::from(200)).unwrap();
-
-            tx.commit().unwrap();
-        }
-
-        // The frontier_tree captured the state after 5 leaves.
-        let expected_root = frontier_tree.root();
-        let frontier = frontier_tree.take().expect("frontier is non-empty");
-
-        // Generate witness using the function under test
-        let witnesses = super::generate_orchard_witnesses_at_frontier(
-            &db_data.conn,
-            &[note_position],
-            frontier,
-            snapshot_height,
-        )
-        .expect("witness generation should succeed");
-
-        assert_eq!(witnesses.len(), 1);
-
-        // The witness, combined with the note's leaf hash, must recompute
-        // to the tree root at the snapshot height.
-        assert_eq!(witnesses[0].root(note_leaf), expected_root);
     }
 }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -244,6 +244,55 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     )
 }
 
+/// Return all Orchard notes that were received at or before `snapshot_height`
+/// and unspent as of `snapshot_height`, for the given account.
+///
+/// This is a backward-looking query used for governance voting snapshots,
+/// unlike `select_spendable_notes` which is forward-looking (via tx expiry).
+pub fn get_orchard_notes_at_snapshot<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    snapshot_height: BlockHeight,
+) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT
+             rn.id AS id, t.txid, rn.action_index,
+             rn.diversifier, rn.value, rn.rho, rn.rseed, rn.commitment_tree_position,
+             accounts.ufvk AS ufvk, rn.recipient_key_scope,
+             t.block AS mined_height,
+             NULL AS max_shielding_input_height
+         FROM orchard_received_notes rn
+         INNER JOIN accounts ON accounts.id = rn.account_id
+         INNER JOIN transactions t ON t.id_tx = rn.transaction_id
+         WHERE accounts.uuid = :account_uuid
+           AND t.block IS NOT NULL
+           AND t.block <= :snapshot_height
+           AND rn.nf IS NOT NULL
+           AND rn.commitment_tree_position IS NOT NULL
+           AND rn.recipient_key_scope IN (0, 1)
+           AND accounts.ufvk IS NOT NULL
+           AND rn.id NOT IN (
+               SELECT rns.orchard_received_note_id
+               FROM orchard_received_note_spends rns
+               JOIN transactions t_spend ON t_spend.id_tx = rns.transaction_id
+               WHERE t_spend.block IS NOT NULL
+                 AND t_spend.block <= :snapshot_height
+           )
+         ORDER BY rn.commitment_tree_position",
+    )?;
+
+    let rows = stmt.query_and_then(
+        named_params![
+            ":account_uuid": account.0,
+            ":snapshot_height": u32::from(snapshot_height),
+        ],
+        |row| to_received_note(params, row),
+    )?;
+
+    rows.filter_map(|r| r.transpose()).collect()
+}
+
 pub(crate) fn ensure_address<
     T: ReceivedOrchardOutput<AccountId = AccountUuid>,
     P: consensus::Parameters,
@@ -671,5 +720,74 @@ pub(crate) mod tests {
     #[test]
     fn receive_two_notes_with_same_value() {
         testing::pool::receive_two_notes_with_same_value::<OrchardPoolTester>();
+    }
+
+    #[test]
+    fn get_orchard_notes_at_snapshot_boundary_heights() {
+        use zcash_client_backend::data_api::Account;
+        use zcash_client_backend::data_api::testing::{
+            AddressType, TestBuilder, pool::ShieldedPoolTester,
+        };
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::value::Zatoshis;
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let dfvk = OrchardPoolTester::test_account_fvk(&st);
+
+        // Receive a note at h1
+        let value = Zatoshis::const_from_u64(50000);
+        let (h1, _, nf) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h1, 1);
+
+        // Spend that note at h2 (produces change back to us)
+        let not_our_key = OrchardPoolTester::sk_to_fvk(&OrchardPoolTester::sk(&[0xf5; 32]));
+        let to = OrchardPoolTester::fvk_default_address(&not_our_key);
+        let spend_value = Zatoshis::const_from_u64(20000);
+        let (h2, _) = st.generate_next_block_spending(&dfvk, (nf, value), to, spend_value);
+        st.scan_cached_blocks(h2, 1);
+
+        // Receive another note at h3
+        let value3 = Zatoshis::const_from_u64(70000);
+        let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value3);
+        st.scan_cached_blocks(h3, 1);
+
+        let db = st.wallet().db();
+
+        // Before any notes: nothing (h1 - 1 is before the note was mined)
+        let notes = db
+            .get_orchard_notes_at_snapshot(account.id(), h1 - 1)
+            .unwrap();
+        assert_eq!(notes.len(), 0);
+
+        // Snapshot at h1: original note received and unspent
+        let notes = db.get_orchard_notes_at_snapshot(account.id(), h1).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].note_value().unwrap(), value);
+
+        // Snapshot at h2: original spent, only change note remains
+        let notes = db.get_orchard_notes_at_snapshot(account.id(), h2).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(
+            notes[0].note_value().unwrap(),
+            (value - spend_value).unwrap()
+        );
+
+        // Snapshot at h3: change note + new note
+        let notes = db.get_orchard_notes_at_snapshot(account.id(), h3).unwrap();
+        assert_eq!(notes.len(), 2);
+        let total: Zatoshis = notes
+            .iter()
+            .map(|n| n.note_value().unwrap())
+            .sum::<Option<Zatoshis>>()
+            .unwrap();
+        assert_eq!(total, ((value - spend_value).unwrap() + value3).unwrap());
     }
 }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -250,7 +250,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
 /// Unlike `select_spendable_notes` (which applies confirmation, dust, and
 /// expiry filters for transaction construction), this returns every note
 /// that existed and was unspent at the given height.
-pub fn get_orchard_notes_at_historical_height<P: consensus::Parameters>(
+pub fn get_unspent_orchard_notes_at_historical_height<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
@@ -724,7 +724,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn get_orchard_notes_at_historical_height_boundary_heights() {
+    fn get_unspent_orchard_notes_at_historical_height_boundary_heights() {
         use zcash_client_backend::data_api::Account;
         use zcash_client_backend::data_api::testing::{
             AddressType, TestBuilder, pool::ShieldedPoolTester,
@@ -764,20 +764,20 @@ pub(crate) mod tests {
 
         // Before any notes: nothing (h1 - 1 is before the note was mined)
         let notes = db
-            .get_orchard_notes_at_historical_height(account.id(), h1 - 1)
+            .get_unspent_orchard_notes_at_historical_height(account.id(), h1 - 1)
             .unwrap();
         assert_eq!(notes.len(), 0);
 
         // At h1: original note received and unspent
         let notes = db
-            .get_orchard_notes_at_historical_height(account.id(), h1)
+            .get_unspent_orchard_notes_at_historical_height(account.id(), h1)
             .unwrap();
         assert_eq!(notes.len(), 1);
         assert_eq!(notes[0].note_value().unwrap(), value);
 
         // At h2: original spent, only change note remains
         let notes = db
-            .get_orchard_notes_at_historical_height(account.id(), h2)
+            .get_unspent_orchard_notes_at_historical_height(account.id(), h2)
             .unwrap();
         assert_eq!(notes.len(), 1);
         assert_eq!(
@@ -787,7 +787,7 @@ pub(crate) mod tests {
 
         // At h3: change note + new note
         let notes = db
-            .get_orchard_notes_at_historical_height(account.id(), h3)
+            .get_unspent_orchard_notes_at_historical_height(account.id(), h3)
             .unwrap();
         assert_eq!(notes.len(), 2);
         let total: Zatoshis = notes

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -244,16 +244,17 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     )
 }
 
-/// Return all Orchard notes that were received at or before `snapshot_height`
-/// and unspent as of `snapshot_height`, for the given account.
+/// Return all Orchard notes that were received at or before `height`
+/// and unspent as of `height`, for the given account.
 ///
-/// This is a backward-looking query used for governance voting snapshots,
-/// unlike `select_spendable_notes` which is forward-looking (via tx expiry).
-pub fn get_orchard_notes_at_snapshot<P: consensus::Parameters>(
+/// Unlike `select_spendable_notes` (which applies confirmation, dust, and
+/// expiry filters for transaction construction), this returns every note
+/// that existed and was unspent at the given height.
+pub fn get_orchard_notes_at_historical_height<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
-    snapshot_height: BlockHeight,
+    height: BlockHeight,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     let mut stmt = conn.prepare_cached(
         "SELECT
@@ -267,7 +268,7 @@ pub fn get_orchard_notes_at_snapshot<P: consensus::Parameters>(
          INNER JOIN transactions t ON t.id_tx = rn.transaction_id
          WHERE accounts.uuid = :account_uuid
            AND t.block IS NOT NULL
-           AND t.block <= :snapshot_height
+           AND t.block <= :height
            AND rn.nf IS NOT NULL
            AND rn.commitment_tree_position IS NOT NULL
            AND rn.recipient_key_scope IN (0, 1)
@@ -277,7 +278,7 @@ pub fn get_orchard_notes_at_snapshot<P: consensus::Parameters>(
                FROM orchard_received_note_spends rns
                JOIN transactions t_spend ON t_spend.id_tx = rns.transaction_id
                WHERE t_spend.block IS NOT NULL
-                 AND t_spend.block <= :snapshot_height
+                 AND t_spend.block <= :height
            )
          ORDER BY rn.commitment_tree_position",
     )?;
@@ -285,7 +286,7 @@ pub fn get_orchard_notes_at_snapshot<P: consensus::Parameters>(
     let rows = stmt.query_and_then(
         named_params![
             ":account_uuid": account.0,
-            ":snapshot_height": u32::from(snapshot_height),
+            ":height": u32::from(height),
         ],
         |row| to_received_note(params, row),
     )?;
@@ -723,7 +724,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn get_orchard_notes_at_snapshot_boundary_heights() {
+    fn get_orchard_notes_at_historical_height_boundary_heights() {
         use zcash_client_backend::data_api::Account;
         use zcash_client_backend::data_api::testing::{
             AddressType, TestBuilder, pool::ShieldedPoolTester,
@@ -763,25 +764,31 @@ pub(crate) mod tests {
 
         // Before any notes: nothing (h1 - 1 is before the note was mined)
         let notes = db
-            .get_orchard_notes_at_snapshot(account.id(), h1 - 1)
+            .get_orchard_notes_at_historical_height(account.id(), h1 - 1)
             .unwrap();
         assert_eq!(notes.len(), 0);
 
-        // Snapshot at h1: original note received and unspent
-        let notes = db.get_orchard_notes_at_snapshot(account.id(), h1).unwrap();
+        // At h1: original note received and unspent
+        let notes = db
+            .get_orchard_notes_at_historical_height(account.id(), h1)
+            .unwrap();
         assert_eq!(notes.len(), 1);
         assert_eq!(notes[0].note_value().unwrap(), value);
 
-        // Snapshot at h2: original spent, only change note remains
-        let notes = db.get_orchard_notes_at_snapshot(account.id(), h2).unwrap();
+        // At h2: original spent, only change note remains
+        let notes = db
+            .get_orchard_notes_at_historical_height(account.id(), h2)
+            .unwrap();
         assert_eq!(notes.len(), 1);
         assert_eq!(
             notes[0].note_value().unwrap(),
             (value - spend_value).unwrap()
         );
 
-        // Snapshot at h3: change note + new note
-        let notes = db.get_orchard_notes_at_snapshot(account.id(), h3).unwrap();
+        // At h3: change note + new note
+        let notes = db
+            .get_orchard_notes_at_historical_height(account.id(), h3)
+            .unwrap();
         assert_eq!(notes.len(), 2);
         let total: Zatoshis = notes
             .iter()


### PR DESCRIPTION
## Overview 
[Shielded Voting — Integration Architecture Changes Proposal](https://hackmd.io/@greg-nagy/voting-integration-architecture-changes-proposal)

### PCZT changes (`pczt` crate)

- **`Spend::spend_auth_sig` getter** — read back the hardware wallet signature after signing, so it can be threaded into a ZK delegation proof
- **`Signer::shielded_sighash()` getter** — expose the cached sighash (already on upstream main, backported here)

### Wallet changes (`zcash_client_sqlite` crate)

Two new governance-specific methods on `WalletDb` (inherent, not on wallet traits — these don't belong in the general-purpose API):

- **`get_orchard_notes_at_snapshot(account, height)`** — returns all Orchard notes received at or before `snapshot_height` and unspent as of that height. Backward-looking query for voting snapshots, unlike `select_unspent_notes` which is forward-looking (based on tx expiry).

- **`generate_orchard_witnesses_at_frontier(positions, frontier, height)`** — copies wallet shard data to an ephemeral in-memory database, inserts the lightwalletd frontier as a checkpoint, and generates Merkle witnesses at the snapshot anchor. The wallet DB is strictly read-only.

### Context

Governance protocols need to construct Orchard-only PCZTs for hardware wallet signing, query wallet notes at a historical snapshot, and generate witnesses anchored at that snapshot's frontier (even if the wallet has synced past it). These changes cleanly separate concerns: librustzcash owns the wallet domain, the voting library owns the voting domain, and the SDK wires them together.

Closes #2232.