### PR TITLE
zcash_client_sqlite: Handle pre-Sapling chain tips in `update_chain_tip`

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -38,6 +38,8 @@ workspace.
 - Notes are now consistently treated as having "uneconomic value" if their value is less
   than **or equal to** the marginal fee. Previously, some call sites only considered
   note uneconomic if their value was less than the marginal fee.
+- `zcash_client_sqlite::WalletDb::update_chain_tip` now correctly handles tips prior to
+  Sapling activation.
 
 ## [0.19.5] - 2026-03-10
 

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -391,12 +391,6 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
     params: &P,
     new_tip: BlockHeight,
 ) -> Result<(), SqliteClientError> {
-    // If the caller provided a chain tip that is before Sapling activation, do nothing.
-    let sapling_activation = match params.activation_height(NetworkUpgrade::Sapling) {
-        Some(h) if h <= new_tip => h,
-        _ => return Ok(()),
-    };
-
     // Read the previous max scanned height from the blocks table
     let max_scanned = block_height_extrema(conn)?.map(|range| *range.end());
 
@@ -458,7 +452,12 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
             wallet_birthday.map_or_else(
                 // We don't have a wallet birthday, which means we have no accounts yet.
                 // We can therefore ignore all blocks up to the chain tip.
-                || ScanRange::from_parts(sapling_activation..chain_end, ScanPriority::Ignored),
+                || {
+                    ScanRange::from_parts(
+                        BlockHeight::from_u32(0)..chain_end,
+                        ScanPriority::Ignored,
+                    )
+                },
                 // We have a wallet birthday, so mark all blocks between that and the
                 // chain tip as `Historic` (performing wallet recovery).
                 |wallet_birthday| {


### PR DESCRIPTION
This can occur normally in older integration tests, or if the backing full node is still syncing.

Part of #2217.