### PR TITLE
feat(zcash_client_sqlite): Retain stable witness data during truncation

### DIFF
--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -107,15 +107,16 @@ impl ShieldedPoolTester for OrchardPoolTester {
         shard_index: u64,
         truncate_at: Position,
     ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
-        st.wallet_mut().with_orchard_tree_mut::<_, _, ShardTreeError<_>>(|t| {
-            t.root(
-                incrementalmerkletree::Address::from_parts(
-                    Level::from(crate::data_api::ORCHARD_SHARD_HEIGHT),
-                    shard_index,
-                ),
-                truncate_at,
-            )
-        })
+        st.wallet_mut()
+            .with_orchard_tree_mut::<_, _, ShardTreeError<_>>(|t| {
+                t.root(
+                    incrementalmerkletree::Address::from_parts(
+                        Level::from(crate::data_api::ORCHARD_SHARD_HEIGHT),
+                        shard_index,
+                    ),
+                    truncate_at,
+                )
+            })
     }
 
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -5,7 +5,7 @@ use ::orchard::{
     note_encryption::OrchardDomain,
     tree::MerkleHashOrchard,
 };
-use incrementalmerkletree::{Hashable, Level};
+use incrementalmerkletree::{Hashable, Level, Position};
 use shardtree::error::ShardTreeError;
 
 use zcash_keys::{
@@ -100,6 +100,22 @@ impl ShieldedPoolTester for OrchardPoolTester {
     ) -> Result<(), ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
         st.wallet_mut()
             .put_orchard_subtree_roots(start_index, roots)
+    }
+
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+        truncate_at: Position,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
+        st.wallet_mut().with_orchard_tree_mut::<_, _, ShardTreeError<_>>(|t| {
+            t.root(
+                incrementalmerkletree::Address::from_parts(
+                    Level::from(crate::data_api::ORCHARD_SHARD_HEIGHT),
+                    shard_index,
+                ),
+                truncate_at,
+            )
+        })
     }
 
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4954,6 +4954,120 @@ where
     );
 }
 
+/// Regression test for the stabilized-note truncation behavior.
+///
+/// When a truncation occurs, accounts should be re-scanned from the truncation height. There was a
+/// regression while implementing note stabilization which broke the scan queue on truncation,
+/// causing accounts not to be re-scanned as expected. This test ensures re-scan behavior works as
+/// expected.
+pub fn truncate_reopens_scan_range_above_stabilized_notes<T, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = st.test_account().unwrap().birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Generate and scan 5 filler blocks, then capture the chain state as our truncation
+    // target. This height is where a caller wanting to trigger a re-scan would truncate to.
+    let filler_count = 5u32;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(birthday + 1, filler_count as usize);
+    let truncation_target = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    let truncation_height = truncation_target.block_height();
+
+    // Mine and scan a note owned by the wallet; this note's `mined_height` will be above
+    // `truncation_height`, and is what triggers the soft-truncate path.
+    let (note_height, _, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, note_value);
+    st.scan_cached_blocks(note_height, 1);
+    assert!(note_height > truncation_height);
+
+    // Fill shard 0 at birthday, far below any `stable_height` we will reach.
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(
+            birthday,
+            T::empty_tree_leaf(),
+        )],
+    )
+    .unwrap();
+
+    // Scan `PRUNING_DEPTH` more blocks so that the note is stabilized before truncation.
+    let extra_blocks = PRUNING_DEPTH;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    let pre_trunc_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set before truncation");
+    assert!(pre_trunc_tip > truncation_height);
+
+    // Truncate. The documented contract is that the chain tip is now `truncation_height`,
+    // regardless of how much stabilized data is retained above it.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+
+    let post_trunc_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should still be set after truncation");
+    assert_eq!(
+        post_trunc_tip, truncation_height,
+        "after truncate_to_chain_state, chain_height must report the truncation target so \
+         callers (and the sync loop) know to re-scan above it; leaving the scan queue intact \
+         to preserve stabilized-note data silently suppresses re-scan of the range that was \
+         truncated"
+    );
+
+    // And the scan queue must not claim the range above `truncation_height` is already
+    // `Scanned`, otherwise `suggest_scan_ranges` will report nothing to do and the caller
+    // will never re-scan. Any entry that extends above the truncation height with priority
+    // `Scanned` would defeat the truncation.
+    let ranges = st
+        .wallet()
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let covering_scanned = ranges.iter().find(|r| {
+        r.priority() == ScanPriority::Scanned && r.block_range().end > truncation_height + 1
+    });
+    assert!(
+        covering_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation height after truncation, \
+         but found: {covering_scanned:?}"
+    );
+}
+
 pub fn reorg_to_checkpoint<T: ShieldedPoolTester, Dsf, C>(ds_factory: Dsf, cache: C)
 where
     Dsf: DataStoreFactory,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4912,8 +4912,7 @@ where
     // whose ommer at shard-root level is this real root; a placeholder here would collide with
     // that real value when the cap is later updated. Shard 1 is deliberately left without a
     // `subtree_end_height`, so only the first of the two notes will be stabilized.
-    let shard_0_root =
-        T::shard_root(&mut st, 0, Position::from(u64::from(shard_size))).unwrap();
+    let shard_0_root = T::shard_root(&mut st, 0, Position::from(u64::from(shard_size))).unwrap();
     T::put_subtree_roots(
         &mut st,
         0,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -146,6 +146,14 @@ pub trait ShieldedPoolTester {
         roots: &[CommitmentTreeRoot<Self::MerkleTreeHash>],
     ) -> Result<(), ShardTreeError<<DbT as WalletCommitmentTrees>::Error>>;
 
+    /// Returns the root hash of the note commitment subtree rooted at the given shard address,
+    /// computing it from the wallet's shard tree state truncated at the given position.
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+        truncate_at: Position,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>>;
+
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64;
 
     fn note_value(note: &Self::Note) -> Zatoshis;
@@ -4590,6 +4598,360 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
     assert!(
         st.wallet().get_block_hash(max_scanned).unwrap().is_some(),
         "blocks at max_scanned should be preserved"
+    );
+}
+
+/// Note stabilization requires both a filled shard AND the shard's end height to be confirmed
+/// beyond the pruning depth. This test ensures notes do not get prematurely marked as stable when
+/// just the shard has filled.
+pub fn note_not_stabilized_until_prune_depth<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = account.birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Generate and scan 5 filler blocks, then capture the chain state as our
+    // truncation target.
+    let filler_count = 5u32;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(birthday + 1, filler_count as usize);
+    let truncation_target = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+
+    // Mine and scan the note.
+    let (note_height, note_block_insert, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, note_value);
+    let note_txid = note_block_insert.txids()[0];
+    st.scan_cached_blocks(note_height, 1);
+
+    // Fill shard 0 at the note's block height.
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(
+            note_height,
+            T::empty_tree_leaf(),
+        )],
+    )
+    .unwrap();
+
+    // Scan fewer than PRUNING_DEPTH extra blocks
+    let extra_blocks = PRUNING_DEPTH - 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    // Confirm the transaction is mined before truncation
+    let pre_trunc = st
+        .get_tx_from_history(note_txid)
+        .unwrap()
+        .expect("tx should appear in history");
+    assert_eq!(
+        pre_trunc.mined_height(),
+        Some(note_height),
+        "tx should be mined before truncation"
+    );
+
+    // Truncate the chain state
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+
+    // Confirm the note no longer has a mined height
+    let post_trunc = st
+        .get_tx_from_history(note_txid)
+        .unwrap()
+        .expect("tx should still appear in history after truncation");
+    assert_eq!(
+        post_trunc.mined_height(),
+        None,
+        "note in a filled-but-unconfirmed shard should be un-mined by truncation"
+    );
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO,
+        "un-mined transaction should yield zero spendable balance"
+    );
+    assert_eq!(
+        st.get_pending_shielded_balance(account.id(), ConfirmationsPolicy::MIN),
+        note_value,
+        "note should appear as pending (mined but unconfirmed at current tip)"
+    );
+}
+
+/// A note is stabilized once its shard is filled AND the shard's end height is
+/// confirmed beyond the pruning depth. Stabilized notes must be retained across truncation, and the
+/// retained notes must be spendable without re-scan.
+pub fn stabilized_notes_survive_truncation<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = account.birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Generate and scan 5 filler blocks, then capture the chain state as our
+    // truncation target.
+    let filler_count = 5u32;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(birthday + 1, filler_count as usize);
+    let truncation_target = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    let truncation_height = truncation_target.block_height();
+
+    // Mine and scan the note.
+    let (note_height, note_block_insert, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, note_value);
+    let note_txid = note_block_insert.txids()[0];
+    st.scan_cached_blocks(note_height, 1);
+    assert!(note_height > truncation_height);
+
+    // Record shard 0's completion at `birthday`, well below any `stable_height` we
+    // will reach.
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(
+            birthday,
+            T::empty_tree_leaf(),
+        )],
+    )
+    .unwrap();
+
+    // Scan PRUNING_DEPTH additional blocks to stabilize the note
+    let extra_blocks = PRUNING_DEPTH;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    // Confirm note is spendable before truncation
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        note_value,
+        "note should be spendable before truncation"
+    );
+
+    // Truncate below the note height, and confirm stabilized data has been retained
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+
+    let post_trunc = st
+        .get_tx_from_history(note_txid)
+        .unwrap()
+        .expect("tx should still appear in history after truncation");
+    assert_eq!(
+        post_trunc.mined_height(),
+        Some(note_height),
+        "stabilized transaction should retain its mined_height across truncation"
+    );
+    assert_eq!(
+        st.get_total_balance(account.id()),
+        note_value,
+        "stabilized transaction's note should remain in the total balance"
+    );
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        note_value,
+        "note should still be spendable"
+    );
+
+    // Build and sign a spending transaction with the retained note
+    let to_extsk = T::sk(&[0xcc; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let send_value = Zatoshis::const_from_u64(10_000);
+    let request = TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal should succeed after re-scan of stabilized note");
+    let txids = st
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("spend construction should succeed");
+    assert_eq!(
+        txids.len(),
+        1,
+        "one transaction should be produced by the spend"
+    );
+}
+
+/// Stabilization is tracked per-note: a transaction whose outputs straddle a shard boundary may
+/// end up with some notes stabilized and others not. Because witness data for the unstabilized
+/// note(s) cannot be preserved across truncation, any such mixed-state transaction must be
+/// un-mined by truncation, even though some of its notes *are* stabilized.
+pub fn mixed_stabilization_unmines_transaction<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::{SAPLING_SHARD_HEIGHT, ll::wallet::PRUNING_DEPTH};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = account.birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Position the pool's commitment tree such that the next block's two outputs will land at the
+    // last position of shard 0 and the first position of shard 1, respectively. We do this by
+    // invoking `generate_block_at` with a height gap; the intermediate phantom block's chain
+    // state is back-filled with `SHARD_SIZE - 1` real commitments. The phantom block also
+    // becomes our truncation target.
+    let shard_size: u32 = 1 << SAPLING_SHARD_HEIGHT;
+    let initial_tree_size: u32 = shard_size - 1;
+    let (sapling_initial_size, orchard_initial_size) = match T::SHIELDED_PROTOCOL {
+        ShieldedProtocol::Sapling => (initial_tree_size, 0),
+        ShieldedProtocol::Orchard => (0, initial_tree_size),
+    };
+    let tx_height = birthday + 1;
+    st.generate_block_at(
+        tx_height,
+        BlockHash([0; 32]),
+        &[
+            FakeCompactOutput::new(&dfvk, AddressType::DefaultExternal, note_value),
+            FakeCompactOutput::new(&dfvk, AddressType::Internal, note_value),
+        ],
+        sapling_initial_size,
+        orchard_initial_size,
+        false,
+    );
+
+    // The phantom block at `birthday` is our truncation target: its chain state has the pool's
+    // tree sized at `initial_tree_size`, leaving the next block's outputs to land at the shard
+    // boundary.
+    let truncation_target = st
+        .latest_cached_block_below_height(tx_height)
+        .expect("phantom block should have been inserted")
+        .chain_state()
+        .clone();
+
+    // Scan the TX block. The wallet's tree is brought up to shard 0's last position via the
+    // frontier carried in `from_state`, then the block's two outputs are inserted at positions
+    // (shard_size - 1) and shard_size, completing shard 0 and starting shard 1.
+    st.scan_cached_blocks(tx_height, 1);
+    let tx_txid = st
+        .wallet()
+        .get_tx_history()
+        .unwrap()
+        .into_iter()
+        .find(|tx| tx.mined_height() == Some(tx_height))
+        .expect("scanned TX should appear in history")
+        .txid();
+
+    // Record shard 0's completion at `birthday`, well below any `stable_height` we will reach.
+    // We must pass shard 0's actual root here because subsequent scans will produce frontiers
+    // whose ommer at shard-root level is this real root; a placeholder here would collide with
+    // that real value when the cap is later updated. Shard 1 is deliberately left without a
+    // `subtree_end_height`, so only the first of the two notes will be stabilized.
+    let shard_0_root =
+        T::shard_root(&mut st, 0, Position::from(u64::from(shard_size))).unwrap();
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(birthday, shard_0_root)],
+    )
+    .unwrap();
+
+    // Scan `PRUNING_DEPTH` more blocks so that `stable_height` crosses shard 0's
+    // `subtree_end_height`, marking the first note stabilized.
+    let extra_blocks = PRUNING_DEPTH;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(tx_height + 1, extra_blocks as usize);
+
+    // Truncate below the TX block. Because the TX contains a non-stabilized note, the un-mine
+    // logic should clear its `mined_height` even though the TX's first note *is* stabilized.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+
+    let post_trunc = st
+        .get_tx_from_history(tx_txid)
+        .unwrap()
+        .expect("tx should still appear in history after truncation");
+    assert_eq!(
+        post_trunc.mined_height(),
+        None,
+        "a transaction with any unstabilized note must be un-mined by truncation"
+    );
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO,
+        "un-mined transaction's notes should not be spendable"
     );
 }
 

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use incrementalmerkletree::{Hashable, Level};
+use incrementalmerkletree::{Hashable, Level, Position};
 use sapling::{
     note_encryption::try_sapling_output_recovery,
     zip32::{DiversifiableFullViewingKey, ExtendedSpendingKey},
@@ -84,6 +84,22 @@ impl ShieldedPoolTester for SaplingPoolTester {
     ) -> Result<(), ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
         st.wallet_mut()
             .put_sapling_subtree_roots(start_index, roots)
+    }
+
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+        truncate_at: Position,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
+        st.wallet_mut().with_sapling_tree_mut::<_, _, ShardTreeError<_>>(|t| {
+            t.root(
+                incrementalmerkletree::Address::from_parts(
+                    Level::from(crate::data_api::SAPLING_SHARD_HEIGHT),
+                    shard_index,
+                ),
+                truncate_at,
+            )
+        })
     }
 
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -91,15 +91,16 @@ impl ShieldedPoolTester for SaplingPoolTester {
         shard_index: u64,
         truncate_at: Position,
     ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
-        st.wallet_mut().with_sapling_tree_mut::<_, _, ShardTreeError<_>>(|t| {
-            t.root(
-                incrementalmerkletree::Address::from_parts(
-                    Level::from(crate::data_api::SAPLING_SHARD_HEIGHT),
-                    shard_index,
-                ),
-                truncate_at,
-            )
-        })
+        st.wallet_mut()
+            .with_sapling_tree_mut::<_, _, ShardTreeError<_>>(|t| {
+                t.root(
+                    incrementalmerkletree::Address::from_parts(
+                        Level::from(crate::data_api::SAPLING_SHARD_HEIGHT),
+                        shard_index,
+                    ),
+                    truncate_at,
+                )
+            })
     }
 
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -32,6 +32,14 @@ workspace.
   database transaction overhead).
 
 ### Changed
+- A `witness_stabilized` column has been added to the `sapling_received_notes`
+  and `orchard_received_notes` tables. A note is marked stabilized once its
+  containing shard is complete and the shard's end height is confirmed beyond
+  `PRUNING_DEPTH`. Stabilized notes retain their `mined_height` and `tx_index`
+  across `truncate_to_chain_state`, and remain spendable without requiring a
+  re-scan. `WalletSummary` balance queries and note selection treat a stabilized
+  note as trivially satisfying any confirmation policy, since at the point of
+  stabilization the note was already confirmed beyond `PRUNING_DEPTH`.
 - The `accounts` table now stores IVK item caches instead of FVK item caches for
   collision detection. A new `p2sh_ivk_item_cache` column is reserved for future
   ZIP 316 Revision 2 P2SH support.

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -488,4 +488,15 @@ mod tests {
     fn mixed_stabilization_unmines_transaction_orchard() {
         testing::pool::mixed_stabilization_unmines_transaction::<OrchardPoolTester>()
     }
+
+    #[test]
+    fn truncate_reopens_scan_range_above_stabilized_notes_sapling() {
+        testing::pool::truncate_reopens_scan_range_above_stabilized_notes::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncate_reopens_scan_range_above_stabilized_notes_orchard() {
+        testing::pool::truncate_reopens_scan_range_above_stabilized_notes::<OrchardPoolTester>()
+    }
 }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -402,6 +402,28 @@ mod tests {
     }
 
     #[test]
+    fn note_not_stabilized_until_prune_depth_sapling() {
+        testing::pool::note_not_stabilized_until_prune_depth::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn note_not_stabilized_until_prune_depth_orchard() {
+        testing::pool::note_not_stabilized_until_prune_depth::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn stabilized_notes_survive_truncation_sapling() {
+        testing::pool::stabilized_notes_survive_truncation::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn stabilized_notes_survive_truncation_orchard() {
+        testing::pool::stabilized_notes_survive_truncation::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn reorg_to_checkpoint_sapling() {
         testing::pool::reorg_to_checkpoint::<SaplingPoolTester>()
     }
@@ -454,5 +476,16 @@ mod tests {
     #[cfg(feature = "orchard")]
     fn scan_cached_blocks_detects_spends_out_of_order_orchard() {
         testing::pool::scan_cached_blocks_detects_spends_out_of_order::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn mixed_stabilization_unmines_transaction_sapling() {
+        testing::pool::mixed_stabilization_unmines_transaction::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn mixed_stabilization_unmines_transaction_orchard() {
+        testing::pool::mixed_stabilization_unmines_transaction::<OrchardPoolTester>()
     }
 }

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -333,6 +333,13 @@ pub(crate) fn mixed_stabilization_unmines_transaction<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn truncate_reopens_scan_range_above_stabilized_notes<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_reopens_scan_range_above_stabilized_notes::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_below_birthday::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -312,6 +312,27 @@ pub(crate) fn truncate_to_chain_state<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn note_not_stabilized_until_prune_depth<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::note_not_stabilized_until_prune_depth::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn stabilized_notes_survive_truncation<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::stabilized_notes_survive_truncation::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn mixed_stabilization_unmines_transaction<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::mixed_stabilization_unmines_transaction::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_below_birthday::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2413,6 +2413,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         let mut stmt_select_notes = tx.prepare_cached(&format!(
             "SELECT accounts.uuid, rn.id, rn.value, rn.is_change, rn.recipient_key_scope,
                     scan_state.max_priority,
+                    rn.witness_stabilized,
                     t.mined_height,
                     IFNULL(t.trust_status, 0) AS trust_status,
                     MAX(tt.mined_height) AS max_shielding_input_height,
@@ -2483,20 +2484,31 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
 
-            // A note is spendable if we have enough chain tip information to construct witnesses,
-            // the shard that its witness resides in is sufficiently scanned that we can construct
-            // the witness for the note, and the note has enough confirmations to be spent.
-            let is_spendable = any_spendable
-                && max_priority <= ScanPriority::Scanned
-                && confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
-                    received_height,
-                    tx_trusted,
-                    max_shielding_input_height,
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
+
+            // A stabilized note whose containing transaction is still mined is
+            // unconditionally spendable: at stabilization it was already confirmed beyond
+            // `PRUNING_DEPTH` (which exceeds any reasonable confirmation policy), and its
+            // witness data is durable in the shard tree. This remains true even when
+            // truncation has rolled the wallet's scanned chain tip back below the note's
+            // `mined_height`, because `truncate_to_height_internal` retains `mined_height`
+            // for fully-stabilized transactions. If the transaction has been un-mined —
+            // e.g. because some sibling note in the same tx was not stabilized — then the
+            // note is not currently spendable even if its own flag is still set.
+            // Non-stabilized notes require their shard to be sufficiently scanned and the
+            // usual confirmations policy to be met.
+            let is_spendable = (witness_stabilized && received_height.is_some())
+                || (any_spendable
+                    && max_priority <= ScanPriority::Scanned
+                    && confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
+                        received_height,
+                        tx_trusted,
+                        max_shielding_input_height,
+                        tx_shielding_inputs_trusted,
+                    ) == 0);
 
             let is_pending_change =
                 is_change && received_height.iter().all(|h| h > &trusted_height);
@@ -3513,6 +3525,31 @@ pub(crate) fn truncate_to_height<P: consensus::Parameters>(
     )
 }
 
+/// Returns `true` if the given pool has any received notes marked as `witness_stabilized`
+/// whose containing transaction is currently mined at a height strictly greater than
+/// `truncation_height`. Tree operations that would otherwise delete witness data above
+/// that height (namely `truncate_to_checkpoint` and `insert_frontier` at a position
+/// below `mined_height`) must be skipped for such pools.
+fn pool_has_stabilized_notes_above(
+    conn: &rusqlite::Transaction<'_>,
+    table_prefix: &'static str,
+    truncation_height: BlockHeight,
+) -> Result<bool, SqliteClientError> {
+    conn.query_row(
+        &format!(
+            "SELECT EXISTS (
+                 SELECT 1 FROM {table_prefix}_received_notes rn
+                 INNER JOIN transactions t ON t.id_tx = rn.transaction_id
+                 WHERE rn.witness_stabilized = 1
+                   AND t.mined_height > :height
+             )"
+        ),
+        named_params![":height": u32::from(truncation_height)],
+        |row| row.get::<_, bool>(0),
+    )
+    .map_err(SqliteClientError::from)
+}
+
 pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
@@ -3533,21 +3570,39 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         ))
     })?;
 
-    // Delete from the scanning queue any range with a start height greater than the
-    // truncation height, and then truncate any remaining range by setting the end
-    // equal to the truncation height + 1. This sets our view of the chain tip back
-    // to the retained height.
-    conn.execute(
-        "DELETE FROM scan_queue
-        WHERE block_range_start >= :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
-    conn.execute(
-        "UPDATE scan_queue
-        SET block_range_end = :new_end_height
-        WHERE block_range_end > :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
+    // If there are stabilized notes whose `mined_height` is above the truncation height,
+    // we perform a "soft" truncation that preserves the state needed to spend them
+    // without re-scanning: the scan queue is not trimmed (so `chain_tip_height` stays at
+    // the pre-truncation value), the note commitment trees are not truncated (so
+    // stabilized witness data remains queryable), and the `blocks` rows above the
+    // truncation height are retained. Non-stabilized transactions and un-mined blocks
+    // are handled by the tx-level un-mine SQL below regardless.
+    let sapling_has_stabilized_above =
+        pool_has_stabilized_notes_above(conn, crate::SAPLING_TABLES_PREFIX, truncation_height)?;
+    #[cfg(feature = "orchard")]
+    let orchard_has_stabilized_above =
+        pool_has_stabilized_notes_above(conn, crate::ORCHARD_TABLES_PREFIX, truncation_height)?;
+    #[cfg(not(feature = "orchard"))]
+    let orchard_has_stabilized_above = false;
+    let soft_truncate = sapling_has_stabilized_above || orchard_has_stabilized_above;
+
+    if !soft_truncate {
+        // Delete from the scanning queue any range with a start height greater than the
+        // truncation height, and then truncate any remaining range by setting the end
+        // equal to the truncation height + 1. This sets our view of the chain tip back
+        // to the retained height.
+        conn.execute(
+            "DELETE FROM scan_queue
+             WHERE block_range_start >= :new_end_height",
+            named_params![":new_end_height": u32::from(truncation_height + 1)],
+        )?;
+        conn.execute(
+            "UPDATE scan_queue
+             SET block_range_end = :new_end_height
+             WHERE block_range_end > :new_end_height",
+            named_params![":new_end_height": u32::from(truncation_height + 1)],
+        )?;
+    }
 
     // Mark transparent utxos as un-mined. Since the TXO is now not mined, it would ideally be
     // considered to have been returned to the mempool; it _might_ be spendable in this state, but
@@ -3566,18 +3621,53 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         named_params![":height": u32::from(truncation_height)],
     )?;
 
-    // Un-mine transactions. This must be done outside of the last_scanned_height check because
-    // transaction entries may be created as a consequence of receiving transparent TXOs.
+    // Un-mine transactions above the truncation height. For a hard truncation, the
+    // `block` FK is cleared because the `blocks` row is about to be deleted; for a soft
+    // truncation (when stabilized notes exist above `truncation_height`) the `blocks`
+    // rows are retained, so a fully-stabilized transaction also retains its FK. For
+    // "fully stabilized" transactions (at least one shielded received note AND zero
+    // unstabilized received notes across both shielded pools) we retain `mined_height`
+    // and `tx_index` so that the note remains associated with its mined block;
+    // `confirmed_unmined_at_height` is retained as well, but for preserved transactions
+    // it is NULL by construction (the `put_tx_meta` UPSERT clears it whenever
+    // `mined_height` is set). Everything else is fully un-mined.
     conn.execute(
-        "UPDATE transactions
-         SET block = NULL, mined_height = NULL, tx_index = NULL, confirmed_unmined_at_height = NULL
-         WHERE mined_height > :height",
-        named_params![":height": u32::from(truncation_height)],
+        "UPDATE transactions SET
+             block = CASE WHEN is_stabilized AND :soft_truncate THEN block ELSE NULL END,
+             mined_height = CASE WHEN is_stabilized THEN mined_height ELSE NULL END,
+             tx_index = CASE WHEN is_stabilized THEN tx_index ELSE NULL END,
+             confirmed_unmined_at_height =
+                 CASE WHEN is_stabilized THEN confirmed_unmined_at_height ELSE NULL END
+         FROM (
+             SELECT id_tx, (
+                 (EXISTS (SELECT 1 FROM sapling_received_notes WHERE transaction_id = id_tx)
+                  OR EXISTS (SELECT 1 FROM orchard_received_notes WHERE transaction_id = id_tx))
+                 AND NOT EXISTS (
+                     SELECT 1 FROM sapling_received_notes
+                     WHERE transaction_id = id_tx AND witness_stabilized = 0
+                 )
+                 AND NOT EXISTS (
+                     SELECT 1 FROM orchard_received_notes
+                     WHERE transaction_id = id_tx AND witness_stabilized = 0
+                 )
+             ) AS is_stabilized
+             FROM transactions
+             WHERE mined_height > :height
+         ) AS stab
+         WHERE transactions.id_tx = stab.id_tx",
+        named_params![
+            ":height": u32::from(truncation_height),
+            ":soft_truncate": soft_truncate,
+        ],
     )?;
 
     // If we're removing scanned blocks, we need to truncate the note commitment tree and remove
-    // affected block records from the database.
-    if truncation_height < last_scanned_height {
+    // affected block records from the database. When we are performing a soft truncation
+    // (a stabilized note lives above `truncation_height` in at least one pool) we skip
+    // all of this: the tree must retain the stabilized note's witness data, the blocks
+    // above must remain so that the tree data stays consistent with the chain, and the
+    // scan queue was already left untouched above so there is nothing new to rescan.
+    if truncation_height < last_scanned_height && !soft_truncate {
         // Truncate the note commitment trees
         let mut wdb = WalletDb {
             conn: SqlTransaction(conn),
@@ -3699,29 +3789,53 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
         };
 
         // Insert the frontier from the chain state, creating a checkpoint at the target
-        // height.
-        wdb.with_sapling_tree_mut(|tree| {
-            tree.insert_frontier(
-                chain_state.final_sapling_tree().clone(),
-                Retention::Checkpoint {
-                    id: target_height,
-                    marking: Marking::None,
-                },
-            )?;
-            Ok::<_, SqliteClientError>(())
-        })?;
+        // height — unless a soft truncation applies, in which case the tree is left
+        // intact (so its preserved checkpoints can still serve as anchors for spending
+        // stabilized notes, and the shard data holding their witness paths is not
+        // pruned by an `insert_frontier` at a position below those notes).
+        let soft_truncate_any_pool = pool_has_stabilized_notes_above(
+            wdb.conn.0,
+            crate::SAPLING_TABLES_PREFIX,
+            target_height,
+        )? || {
+            #[cfg(feature = "orchard")]
+            {
+                pool_has_stabilized_notes_above(
+                    wdb.conn.0,
+                    crate::ORCHARD_TABLES_PREFIX,
+                    target_height,
+                )?
+            }
+            #[cfg(not(feature = "orchard"))]
+            {
+                false
+            }
+        };
 
-        #[cfg(feature = "orchard")]
-        wdb.with_orchard_tree_mut(|tree| {
-            tree.insert_frontier(
-                chain_state.final_orchard_tree().clone(),
-                Retention::Checkpoint {
-                    id: target_height,
-                    marking: Marking::None,
-                },
-            )?;
-            Ok::<_, SqliteClientError>(())
-        })?;
+        if !soft_truncate_any_pool {
+            wdb.with_sapling_tree_mut(|tree| {
+                tree.insert_frontier(
+                    chain_state.final_sapling_tree().clone(),
+                    Retention::Checkpoint {
+                        id: target_height,
+                        marking: Marking::None,
+                    },
+                )?;
+                Ok::<_, SqliteClientError>(())
+            })?;
+
+            #[cfg(feature = "orchard")]
+            wdb.with_orchard_tree_mut(|tree| {
+                tree.insert_frontier(
+                    chain_state.final_orchard_tree().clone(),
+                    Retention::Checkpoint {
+                        id: target_height,
+                        marking: Marking::None,
+                    },
+                )?;
+                Ok::<_, SqliteClientError>(())
+            })?;
+        }
     }
 
     // Truncate wallet data to the target height. This always trims the scan queue so that
@@ -4726,7 +4840,12 @@ pub mod testing {
                     row.get("sent_note_count")?,
                     row.get("received_note_count")?,
                     row.get("memo_count")?,
-                    row.get("expired_unmined")?,
+                    // `expired_unmined` can be `NULL` when the view's `BETWEEN` expression
+                    // receives a `NULL` `expiry_height`; in SQL three-valued logic that
+                    // bubbles up to the whole boolean. Treat `NULL` as "not known to be
+                    // expired".
+                    row.get::<_, Option<bool>>("expired_unmined")?
+                        .unwrap_or(false),
                     row.get("is_shielding")?,
                 ))
             })?

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -1092,6 +1092,29 @@ pub(crate) fn put_shard_roots<
     }
     drop(put_roots);
 
+    // Freshly-finalized shards may now be eligible for witness stabilization. Because
+    // `put_shard_roots` is typically invoked when subtree roots are downloaded from the light
+    // wallet server, check here to see if they can be stabilized, rather than waiting for the next
+    // `scan_complete` call.
+    let last_scanned_height: Option<u32> = conn
+        .query_row(
+            "SELECT MAX(block_range_end) - 1 FROM scan_queue",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| ShardTreeError::Storage(Error::Query(e)))?;
+    if let Some(last_scanned_height) = last_scanned_height {
+        super::scanning::mark_stabilized_notes(conn, BlockHeight::from(last_scanned_height))
+            .map_err(|e| match e {
+                SqliteClientError::DbError(err) => ShardTreeError::Storage(Error::Query(err)),
+                other => {
+                    ShardTreeError::Storage(Error::Query(rusqlite::Error::ToSqlConversionFailure(
+                        Box::new(std::io::Error::other(format!("{other}"))),
+                    )))
+                }
+            })?;
+    }
+
     Ok(())
 }
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -381,8 +381,12 @@ where
              rn.id AS id, t.txid, rn.{output_index_col},
              rn.diversifier, rn.value, {note_reconstruction_cols}, rn.commitment_tree_position,
              accounts.ufvk as ufvk, rn.recipient_key_scope,
-             t.block AS mined_height,
+             -- Use `t.mined_height` rather than `t.block`: for a stabilized note whose tx
+             -- has been through truncation, `t.block` is NULL (the `blocks` row was
+             -- deleted) while `t.mined_height` is retained.
+             t.mined_height AS mined_height,
              scan_state.max_priority,
+             rn.witness_stabilized,
              IFNULL(t.trust_status, 0) AS trust_status,
              MAX(tt.mined_height) AS max_shielding_input_height,
              MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -434,6 +438,7 @@ where
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
             let shard_scan_priority = max_priority_raw
@@ -448,6 +453,7 @@ where
 
             Ok((
                 result_note,
+                witness_stabilized,
                 shard_scan_priority,
                 tx_trust_status,
                 tx_shielding_inputs_trusted,
@@ -457,25 +463,43 @@ where
 
     row_results
         .map(|t| match t? {
-            (Some(note), max_shard_priority, tx_trusted, tx_shielding_inputs_trusted) => {
-                let shard_scanned = max_shard_priority
-                    .iter()
-                    .any(|p| *p <= ScanPriority::Scanned);
+            (
+                Some(note),
+                witness_stabilized,
+                max_shard_priority,
+                tx_trusted,
+                tx_shielding_inputs_trusted,
+            ) => {
+                let shard_scanned = witness_stabilized
+                    || max_shard_priority
+                        .iter()
+                        .any(|p| *p <= ScanPriority::Scanned);
 
-                let mined_at_anchor = note
-                    .mined_height()
-                    .zip(note_request.anchor_height())
-                    .is_some_and(|(h, ah)| h <= ah);
+                // A stabilized note whose containing tx is still mined was confirmed beyond
+                // `PRUNING_DEPTH` at stabilization and has durable witness data, so it
+                // trivially satisfies both the anchor-height and confirmations checks. A
+                // stabilized note whose tx has been un-mined (e.g. because a sibling note
+                // in the same tx wasn't stabilized) does not short-circuit — it falls
+                // through to the normal checks, which will correctly reject it because
+                // `mined_height` is `None`.
+                let stabilized_and_mined = witness_stabilized && note.mined_height().is_some();
 
-                let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    Some(note.spending_key_scope()),
-                    note.mined_height(),
-                    tx_trusted,
-                    note.max_shielding_input_height(),
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+                let mined_at_anchor = stabilized_and_mined
+                    || note
+                        .mined_height()
+                        .zip(note_request.anchor_height())
+                        .is_some_and(|(h, ah)| h <= ah);
+
+                let has_confirmations = stabilized_and_mined
+                    || confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        Some(note.spending_key_scope()),
+                        note.mined_height(),
+                        tx_trusted,
+                        note.max_shielding_input_height(),
+                        tx_shielding_inputs_trusted,
+                    ) == 0;
 
                 match (
                     note_request,
@@ -523,9 +547,12 @@ where
         note_reconstruction_cols,
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
-    if unscanned_tip_exists(conn, anchor_height, table_prefix)? {
-        return Ok(vec![]);
-    }
+
+    // If the anchor's own shard has unscanned ranges at or below `anchor_height`, the
+    // tree frontier at the anchor may not be reliably reconstructible. Under that
+    // condition we must restrict selection to notes whose witness data has been
+    // stabilized; unstabilized notes require the anchor's shard to be fully scanned.
+    let tip_unscanned = unscanned_tip_exists(conn, anchor_height, table_prefix)?;
 
     // The goal of this SQL statement is to select the oldest notes until the required
     // value has been reached.
@@ -549,7 +576,8 @@ where
                  {note_reconstruction_cols}, rn.commitment_tree_position,
                  SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
-                 t.block AS mined_height,
+                 t.mined_height AS mined_height,
+                 rn.witness_stabilized,
                  IFNULL(t.trust_status, 0) AS trust_status,
                  MAX(tt.mined_height) AS max_shielding_input_height,
                  MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -571,11 +599,31 @@ where
              AND accounts.ufvk IS NOT NULL
              AND recipient_key_scope IS NOT NULL
              AND nf IS NOT NULL
-             -- the shard containing the note is fully scanned; this condition will exclude
-             -- notes for which `scan_state.max_priority IS NULL` (which will also arise if
-             -- `rn.commitment_tree_position IS NULL`; hence we don't need that explicit filter)
-             AND scan_state.max_priority <= :scanned_priority
-             AND t.block <= :anchor_height
+             -- The note is spendable if its witness is stabilized (durable across
+             -- truncation) OR the shard containing the note is fully scanned. The latter
+             -- branch additionally excludes notes for which `scan_state.max_priority IS
+             -- NULL` (which also arises if `rn.commitment_tree_position IS NULL`; hence
+             -- we don't need that explicit filter). When `tip_unscanned` is true the
+             -- non-stabilized branch is disabled — see the Rust-side guard above.
+             AND (
+                 rn.witness_stabilized = 1
+                 OR (:tip_unscanned = 0 AND scan_state.max_priority <= :scanned_priority)
+             )
+             -- The note's containing transaction must still be mined (i.e. not un-mined
+             -- by a recent truncation); for a stabilized note whose tx has been fully
+             -- un-mined — e.g. because a sibling received note was not stabilized —
+             -- the note is not currently spendable. Stabilized notes then bypass the
+             -- anchor-height filter: their witness data is durable across truncation,
+             -- so an anchor below `mined_height` is fine. Non-stabilized notes require
+             -- the containing transaction to be mined at or below the anchor. We use
+             -- `t.mined_height` (not `t.block`) because for stabilized notes
+             -- post-truncation the `blocks` FK has been cleared while `t.mined_height`
+             -- is retained.
+             AND t.mined_height IS NOT NULL
+             AND (
+                 rn.witness_stabilized = 1
+                 OR t.mined_height <= :anchor_height
+             )
              AND rn.id NOT IN rarray(:exclude)
              AND rn.id NOT IN ({})
              GROUP BY rn.id
@@ -583,14 +631,14 @@ where
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM eligible WHERE so_far < :target_value
          UNION
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         spent_notes_clause(table_prefix)
@@ -616,6 +664,7 @@ where
             ":target_value": &u64::from(target_value),
             ":exclude": &excluded_ptr,
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
+            ":tip_unscanned": i64::from(tip_unscanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE)
         ],
         |row| {
@@ -624,6 +673,7 @@ where
                 .get::<_, Option<u32>>("max_shielding_input_height")?
                 .map(BlockHeight::from);
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let note = to_spendable_note(params, row)?;
 
             Ok(note.map(|n| {
@@ -632,6 +682,7 @@ where
                     tx_trust_status,
                     max_shielding_input_height,
                     tx_shielding_inputs_trusted,
+                    witness_stabilized,
                 )
             }))
         },
@@ -647,16 +698,24 @@ where
                         tx_trusted,
                         max_shielding_input_height,
                         tx_shielding_inputs_trusted,
+                        witness_stabilized,
                     )| {
-                        let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                            target_height,
-                            PoolType::Shielded(protocol),
-                            Some(note.spending_key_scope()),
-                            note.mined_height(),
-                            tx_trusted,
-                            max_shielding_input_height,
-                            tx_shielding_inputs_trusted,
-                        ) == 0;
+                        // A stabilized note whose tx is still mined was confirmed beyond
+                        // `PRUNING_DEPTH` before it was marked stabilized, so it trivially
+                        // satisfies any confirmation policy. (The SQL filter above guarantees
+                        // `note.mined_height()` is `Some` when we reach this branch, but we
+                        // re-state the invariant explicitly here.)
+                        let has_confirmations = (witness_stabilized
+                            && note.mined_height().is_some())
+                            || confirmations_policy.confirmations_until_spendable(
+                                target_height,
+                                PoolType::Shielded(protocol),
+                                Some(note.spending_key_scope()),
+                                note.mined_height(),
+                                tx_trusted,
+                                max_shielding_input_height,
+                                tx_shielding_inputs_trusted,
+                            ) == 0;
 
                         has_confirmations.then_some(note)
                     },

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -357,6 +357,9 @@ CREATE TABLE "transactions" (
 /// - `address_id`: a foreign key to the address that this note was sent to; null in the
 ///   case that the note was sent to an internally-scoped address (we never store addresses
 ///   containing internal Sapling receivers in the `addresses` table).
+/// - `witness_stabilized`: a flag indicating that the note's containing shard is complete
+///   and confirmed beyond the pruning depth. Once set, the note's witness data is preserved
+///   across truncations.
 pub(super) const TABLE_SAPLING_RECEIVED_NOTES: &str = r#"
 CREATE TABLE "sapling_received_notes" (
     id INTEGER PRIMARY KEY,
@@ -375,6 +378,7 @@ CREATE TABLE "sapling_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -439,6 +443,9 @@ CREATE INDEX idx_sapling_received_note_spends_transaction_id ON sapling_received
 /// - `address_id`: a foreign key to the address that this note was sent to; null in the
 ///   case that the note was sent to an internally-scoped address (we never store addresses
 ///   containing internal Orchard receivers in the `addresses` table).
+/// - `witness_stabilized`: a flag indicating that the note's containing shard is complete
+///   and confirmed beyond the pruning depth. Once set, the note's witness data is preserved
+///   across truncations.
 pub(super) const TABLE_ORCHARD_RECEIVED_NOTES: &str = r#"
 CREATE TABLE "orchard_received_notes" (
     id INTEGER PRIMARY KEY,
@@ -458,6 +465,7 @@ CREATE TABLE "orchard_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -54,6 +54,7 @@ mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
+mod witness_stabilized_notes;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -133,10 +134,10 @@ pub(super) fn all_migrations<
     //                     \                       \         v_received_output_spends_account      /        /
     //                      \                       \               /                             /        /
     //                       `------------------- account_delete_cascade ---------------------------------'
-    //                                              /               \
-    //                               v_tx_outputs_key_scopes    standalone_p2sh
-    //                                                                  |
-    //                                                           ivk_item_cache
+    //                                          /       |        \
+    //                    v_tx_outputs_key_scopes  standalone_p2sh  witness_stabilized_notes
+    //                                                      |
+    //                                               ivk_item_cache
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -227,6 +228,7 @@ pub(super) fn all_migrations<
         Box::new(ivk_item_cache::Migration {
             params: params.clone(),
         }),
+        Box::new(witness_stabilized_notes::Migration),
     ]
 }
 
@@ -369,7 +371,9 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
+    standalone_p2sh::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
+    witness_stabilized_notes::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -1,0 +1,386 @@
+//! Adds a `witness_stabilized` flag to received notes, indicating that the note's containing shard
+//! has been fully scanned and its witness data is durably present in the shard tree. Once set, this
+//! flag is preserved across truncations, ensuring that notes with intact witness data remain
+//! spendable.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_protocol::consensus::BlockHeight;
+
+use super::account_delete_cascade;
+use crate::wallet::init::WalletMigrationError;
+use crate::wallet::scanning::mark_stabilized_notes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x688f7dd4_a8d4_45ba_94a3_dfc520fefed5);
+
+// This migration only touches the shielded received-notes tables and reads from
+// `scan_queue` / `<pool>_tree_shards`. The most recent migration to modify either
+// `sapling_received_notes` or `orchard_received_notes` is `account_delete_cascade`,
+// which transitively depends on `shardtree_support` and `orchard_shardtree` (where
+// the scan queue and shard tables are created). No other existing leaf migration
+// touches the schema we read or write here.
+const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds witness_stabilized flag to received notes for durable spendability."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // Add the column to both received notes tables.
+        transaction.execute_batch(
+            "ALTER TABLE sapling_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;
+
+             ALTER TABLE orchard_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;",
+        )?;
+
+        // Backfill: derive the last-scanned height from the scan queue and delegate to
+        // the shared `mark_stabilized_notes` helper so the migration and the per-scan
+        // stabilization path share a single source of truth.
+        //
+        // When the scan queue is empty the subquery returns `NULL` and no rows are
+        // backfilled, which is the correct behavior for a freshly-created wallet.
+        let last_scanned_height: Option<u32> = transaction.query_row(
+            "SELECT MAX(block_range_end) - 1 FROM scan_queue",
+            [],
+            |row| row.get(0),
+        )?;
+
+        if let Some(last_scanned_height) = last_scanned_height {
+            mark_stabilized_notes(transaction, BlockHeight::from(last_scanned_height))?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_client_backend::data_api::SAPLING_SHARD_HEIGHT;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        PRUNING_DEPTH, WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    // Local mirror of ORCHARD_SHARD_HEIGHT; see `mark_stabilized_notes` for why the
+    // migration's SQL is feature-agnostic.
+    const ORCHARD_SHARD_HEIGHT: u8 = 16;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// End-to-end exercise of the backfill:
+    /// seeds the pre-migration schema with a variety of notes whose stabilization
+    /// outcomes are fully determined, runs the migration, and asserts the expected
+    /// `witness_stabilized` value for each.
+    #[test]
+    fn migrate_backfills_stabilized_notes() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to database state just prior to this migration. At this point
+        // `sapling_received_notes` / `orchard_received_notes` do not yet have the
+        // `witness_stabilized` column.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // `block_range_end` is exclusive, so MAX(block_range_end) - 1 is the
+        // last-scanned height. Choose it so that stable_height = 200.
+        let last_scanned: u32 = 300 + PRUNING_DEPTH;
+        let stable_height: u32 = 300 - 1;
+        assert_eq!(last_scanned - 1 - PRUNING_DEPTH, stable_height);
+
+        // Seed a minimal account (schema per `add_account_uuids`). The UFVK/UIVK
+        // must be real encoded values because `verify_network_compatibility` parses
+        // them when the migrator opens the database.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+
+        // Seed a single transaction; none of the backfill logic cares about the
+        // block column, only that there is an `id_tx` the note rows can reference.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+
+        // Seed the scan queue so that MAX(block_range_end) - 1 - PRUNING_DEPTH = stable_height.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES (1, :block_range_end, 10)",
+                named_params![":block_range_end": last_scanned + 1],
+            )
+            .unwrap();
+
+        // Sapling shards:
+        //   shard 0: end height well below stable_height  (notes here should stabilize)
+        //   shard 1: end height above stable_height       (notes here should NOT stabilize)
+        //   shard 2: end height NULL                      (notes here should NOT stabilize)
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height - 10,
+                    ":above": stable_height + 50,
+                ],
+            )
+            .unwrap();
+
+        // Same layout for Orchard shards.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO orchard_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height - 10,
+                    ":above": stable_height + 50,
+                ],
+            )
+            .unwrap();
+
+        // The six sapling seed rows below cover every branch of the backfill
+        // predicate. `(commitment_tree_position >> SAPLING_SHARD_HEIGHT)` picks the
+        // shard for a given position.
+        let sapling_pos_shard_0: i64 = 1;
+        let sapling_pos_shard_1: i64 = 1 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_2: i64 = 2 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_99: i64 = 99 << SAPLING_SHARD_HEIGHT; // no shard row
+
+        for (output_index, position, label) in [
+            (0, Some(sapling_pos_shard_0), "stable shard"),
+            (1, Some(sapling_pos_shard_1), "unstable shard"),
+            (2, Some(sapling_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(sapling_pos_shard_99), "no matching shard row"),
+        ] {
+            let _ = label;
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO sapling_received_notes (
+                         transaction_id, output_index, account_id,
+                         diversifier, value, rcm, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :output_index, 1, X'00', 0, X'00', 0, :position)",
+                    named_params![
+                        ":output_index": output_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        // Same scenarios for orchard, reusing `action_index` in place of `output_index`.
+        let orchard_pos_shard_0: i64 = 3;
+        let orchard_pos_shard_1: i64 = 1 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_2: i64 = 2 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_99: i64 = 99 << ORCHARD_SHARD_HEIGHT;
+
+        for (action_index, position, _label) in [
+            (0, Some(orchard_pos_shard_0), "stable shard"),
+            (1, Some(orchard_pos_shard_1), "unstable shard"),
+            (2, Some(orchard_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(orchard_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO orchard_received_notes (
+                         transaction_id, action_index, account_id,
+                         diversifier, value, rho, rseed, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :action_index, 1, X'00', 0, X'00', X'00', 0, :position)",
+                    named_params![
+                        ":action_index": action_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        // Run the migration under test.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // Read back the witness_stabilized values by output_index / action_index.
+        let read = |table: &str, key_col: &str| -> Vec<(i64, i64)> {
+            let mut stmt = db_data
+                .conn
+                .prepare(&format!(
+                    "SELECT {key_col}, witness_stabilized FROM {table} ORDER BY {key_col}"
+                ))
+                .unwrap();
+            let rows: Vec<(i64, i64)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            rows
+        };
+
+        // Only output 0 (stable shard) should have been stabilized.
+        assert_eq!(
+            read("sapling_received_notes", "output_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "sapling backfill should stabilize only the note whose shard's \
+             subtree_end_height <= stable_height and whose commitment_tree_position \
+             maps to that shard",
+        );
+
+        assert_eq!(
+            read("orchard_received_notes", "action_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "orchard backfill must match the sapling behavior",
+        );
+    }
+
+    /// When no rows have been inserted into `scan_queue`, the `MAX(...)` subquery
+    /// returns `NULL`; the migration must treat this as a no-op and not stabilize
+    /// any notes — even ones whose shards have finite `subtree_end_height` values.
+    #[test]
+    fn migrate_empty_scan_queue_is_noop() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // Seed just enough for a received note, but leave scan_queue empty.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_received_notes (
+                     transaction_id, output_index, account_id,
+                     diversifier, value, rcm, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let stabilized: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT witness_stabilized FROM sapling_received_notes WHERE output_index = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stabilized, 0,
+            "empty scan_queue must cause the backfill to be a no-op",
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -31,6 +31,16 @@ use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 #[cfg(not(feature = "orchard"))]
 use zcash_protocol::PoolType;
 
+// Local mirror of `zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT` for use in the
+// feature-agnostic witness-stabilization path. The upstream constant is gated behind
+// the `orchard` feature because it is derived from `orchard::NOTE_COMMITMENT_TREE_DEPTH`,
+// but `mark_stabilized_notes` runs its `orchard_received_notes` UPDATE unconditionally
+// (the table is created by earlier migrations regardless of feature state).
+const ORCHARD_SHARD_HEIGHT_MIRROR: u8 = 16;
+
+#[cfg(feature = "orchard")]
+const _: () = assert!(ORCHARD_SHARD_HEIGHT_MIRROR == ORCHARD_SHARD_HEIGHT);
+
 pub(crate) fn priority_code(priority: &ScanPriority) -> i64 {
     use ScanPriority::*;
     match priority {
@@ -369,6 +379,61 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         .chain(extended_after);
 
     replace_queue_entries::<SqliteClientError>(conn, &query_range, replacement, false)?;
+
+    // Mark notes whose containing shard is complete and confirmed beyond the pruning depth.
+    let last_scanned_height = range.end - 1;
+    mark_stabilized_notes(conn, last_scanned_height)?;
+
+    Ok(())
+}
+
+/// Marks notes as stabilized when their containing shard is complete and the shard's end
+/// height has been confirmed beyond `PRUNING_DEPTH`. Once stabilized, a note's witness data
+/// is considered durable and will be preserved across truncation.
+pub(crate) fn mark_stabilized_notes(
+    conn: &rusqlite::Transaction<'_>,
+    last_scanned_height: BlockHeight,
+) -> Result<(), SqliteClientError> {
+    let stable_height = u32::from(last_scanned_height).saturating_sub(PRUNING_DEPTH);
+
+    conn.execute(
+        &format!(
+            "UPDATE sapling_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM sapling_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            SAPLING_SHARD_HEIGHT,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
+
+    // Not feature-gated on `orchard`: the `orchard_received_notes` table is created
+    // unconditionally by earlier migrations, so this UPDATE is safe (and is a no-op
+    // when no orchard rows exist). `ORCHARD_SHARD_HEIGHT_MIRROR` lets the SQL compile
+    // in `--no-default-features` builds where the upstream `ORCHARD_SHARD_HEIGHT` is
+    // gated behind the `orchard` feature.
+    conn.execute(
+        &format!(
+            "UPDATE orchard_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM orchard_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            ORCHARD_SHARD_HEIGHT_MIRROR,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Add a `witness_stabilized` flag to received notes that durably records when a note's shard has been fully scanned. Spendability queries use this flag instead of transient scan-queue state, so notes remain spendable when scan ranges are rewritten (e.g. importing a new account with an old birthday) or when the wallet is explicitly truncated.

Resolves: https://github.com/zcash/librustzcash/issues/2276
Resolves: [COR-1192](https://linear.app/zodl/issue/COR-1192/featzcash-client-sqlite-retain-stable-witness-data-during-truncation)