### PR TITLE
pczt: Add public getter for spend_auth_sig

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,6 +13,7 @@ workspace.
 ### Added
 - `pczt::ExtractError`
 - `pczt::EffectsOnly`
+- `pczt::orchard::Spend::spend_auth_sig` getter (via `getset`).
 - `pczt::roles::signer`:
   - `Signer::sighash`
   - `Signer::append_transparent_signature`

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::orchard::Spend::spend_auth_sig` getter (via `getset`).
+
 ## [0.4.1, 0.5.1] - 2026-02-26
 
 ### Fixed

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -111,6 +111,7 @@ pub struct Spend {
     ///
     /// This is set by the Signer.
     #[serde_as(as = "Option<[_; 64]>")]
+    #[getset(get = "pub")]
     pub(crate) spend_auth_sig: Option<[u8; 64]>,
 
     /// The [raw encoding] of the Orchard payment address that received the note being spent.


### PR DESCRIPTION
Based on `maint/pczt-0.5.x` (branched from `pczt-0.5.0` series). This is a
SemVer-compatible addition intended for a `0.5.x` point release.

Expose the Orchard spend authorization signature via `getset`, enabling downstream consumers to read back the signature after signing 

## How We Use It

Token Holder Voting.

We use spend_auth_sig() as a read-only accessor to extract the 64-byte spend authorization signature from a Keystone-signed PCZT, so it can be forwarded to the cosmos chain as part of the delegation transaction.

See full summary of the integration: https://hackmd.io/@TJGUVkqNQYieiMqJQQBDeA/rJ0mU1v3Wl