### PR TITLE
pczt: Add public getter for shielded sighash

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -14,10 +14,11 @@ workspace.
 - `pczt::ExtractError`
 - `pczt::EffectsOnly`
 - `pczt::roles::signer`:
-  - `Signer::sighash`
   - `Signer::append_transparent_signature`
-  - `Signer::apply_sapling_signature`
   - `Signer::apply_orchard_signature`
+  - `Signer::apply_sapling_signature`
+  - `Signer::shielded_sighash`
+  - `Signer::sighash`
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`.

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::roles::signer::Signer::shielded_sighash` getter.
+
 ## [0.4.1, 0.5.1] - 2026-02-26
 
 ### Fixed

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -108,6 +108,14 @@ impl Signer {
         })
     }
 
+    /// Returns the shielded (Orchard + Sapling) sighash.
+    ///
+    /// This can be used to produce signatures externally (e.g. via a
+    /// hardware wallet) for authorizing shielded spends.
+    pub fn shielded_sighash(&self) -> [u8; 32] {
+        self.shielded_sighash
+    }
+
     /// Signs the transparent spend at the given index with the given spending key.
     ///
     /// It is the caller's responsibility to perform any semantic validity checks on the

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -95,6 +95,14 @@ impl Signer {
         })
     }
 
+    /// Returns the shielded (Orchard + Sapling) sighash.
+    ///
+    /// This can be used to produce signatures externally (e.g. via a
+    /// hardware wallet) for authorizing shielded spends.
+    pub fn shielded_sighash(&self) -> [u8; 32] {
+        self.shielded_sighash
+    }
+
     /// Signs the transparent spend at the given index with the given spending key.
     ///
     /// It is the caller's responsibility to perform any semantic validity checks on the


### PR DESCRIPTION
Based on `maint/pczt-0.5.x` (branched from `pczt-0.5.0` series). This is a
SemVer-compatible addition intended for a `0.5.x` point release.

Backports the `Signer::shielded_sighash` accessor from main (added in zcash/librustzcash#2047) to the 0.5.x series, enabling downstream consumers to obtain the sighash for producing signatures externally (e.g. via a hardware wallet).

## How We Use It

Token Holder Voting.

We use `shielded_sighash()` to extract the ZIP-244 transaction digest from the finalized PCZT so that both signing paths (software key derivation and Keystone hardware) produce a spend-auth signature over the same canonical hash.

See full summary of the integration: https://hackmd.io/@TJGUVkqNQYieiMqJQQBDeA/rJ0mU1v3Wl