### PR TITLE
feat: Mark notes as `witness_stabilized` and enable using them even after truncation

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -46,6 +46,12 @@ workspace.
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`, `zip321 0.7`.
+- `zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT` is now available
+  unconditionally; the value (`16`) is still pinned against
+  `orchard::NOTE_COMMITMENT_TREE_DEPTH / 2` by a compile-time assertion when
+  the `orchard` feature is enabled. Downstream code that targets the Orchard
+  note tables regardless of feature state can now use this constant as a
+  single source of truth.
 - `zcash_client_backend::data_api`:
   - Changes to the `WalletRead` trait:
     - `WalletRead::get_transparent_balances` now returns `TransparentBalances`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -156,8 +156,16 @@ pub const SAPLING_SHARD_HEIGHT: u8 = sapling::NOTE_COMMITMENT_TREE_DEPTH / 2;
 ///
 /// This conforms to the structure of subtree data returned by
 /// `lightwalletd` when using the `GetSubtreeRoots` GRPC call.
+///
+/// Exposed unconditionally so downstream consumers (e.g. SQL code that targets the
+/// Orchard note tables regardless of whether the `orchard` feature is enabled) can
+/// rely on a single source of truth. The `const_assert` below pins this value
+/// against `orchard::NOTE_COMMITMENT_TREE_DEPTH / 2` whenever the feature is
+/// enabled, so any drift in the Orchard crate traps at compile time.
+pub const ORCHARD_SHARD_HEIGHT: u8 = 16;
+
 #[cfg(feature = "orchard")]
-pub const ORCHARD_SHARD_HEIGHT: u8 = { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 } / 2;
+const _: () = assert!(ORCHARD_SHARD_HEIGHT == orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 / 2);
 
 /// An enumeration of constraints that can be applied when querying for nullifiers for notes
 /// belonging to the wallet.

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4258,21 +4258,28 @@ where
     );
 }
 
-pub fn truncate_to_chain_state<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
-where
+pub fn truncate_to_chain_state_deep<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
-    // Test plan:
-    // 1. Set up test environment with account
+    // Deep-truncation test plan:
+    // 1. Set up test environment with a birthday-aligned account
     // 2. Generate and scan initial blocks to populate the note commitment tree
-    // 3. Capture the chain state at a specific height
-    // 4. Generate and scan blocks beyond PRUNING_DEPTH to ensure early checkpoints are pruned
-    // 5. Verify that normal truncate_to_height fails due to missing checkpoints
+    // 3. Capture the chain state at a specific height (the future truncation target)
+    // 4. Generate and scan strictly more than PRUNING_DEPTH extra blocks so that the
+    //    captured checkpoint is pruned AND the target lies below `tip - PRUNING_DEPTH`
+    //    (the "deep" branch of `truncate_to_height_internal`)
+    // 5. Verify that normal truncate_to_height fails due to the missing checkpoint
     // 6. Test that truncate_to_chain_state succeeds using the captured chain state
-    // 7. Verify wallet state after truncation
+    // 7. Verify wallet state after truncation: the scan_queue is rewound all the way
+    //    to the target, but blocks, transactions, tx_locator_map entries, and note
+    //    commitment trees are only rewound to `tip - (PRUNING_DEPTH - 1)` (the oldest
+    //    retained checkpoint)
 
-    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
 
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
 
@@ -4283,7 +4290,7 @@ where
 
     // Step 2: Generate and scan initial blocks to populate the note commitment tree.
     // We use an "other" fvk so that notes won't be tracked by the wallet (keeping the
-    // test focused on tree state rather than wallet balances).
+    // test focused on tree/block state rather than wallet balances).
     let seed = [1u8; 32];
     let other_sk = T::sk(&seed);
     let other_fvk = T::sk_to_fvk(&other_sk);
@@ -4309,9 +4316,154 @@ where
         .clone();
     assert_eq!(captured_chain_state.block_height(), capture_height);
 
-    // Step 4: Generate and scan blocks well beyond PRUNING_DEPTH so that the checkpoint
-    // at capture_height is pruned from the note commitment tree.
-    let extra_blocks = PRUNING_DEPTH + 10;
+    // Step 4: Generate and scan strictly more than PRUNING_DEPTH extra blocks so that
+    // the checkpoint at capture_height is pruned from the note commitment tree AND
+    // capture_height is below `tip - PRUNING_DEPTH`, which exercises the deep branch
+    // of `truncate_to_height_internal`.
+    let extra_blocks = PRUNING_DEPTH + 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(5000),
+        );
+    }
+    st.scan_cached_blocks(capture_height + 1, extra_blocks as usize);
+
+    let pre_truncation_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set");
+    assert!(
+        pre_truncation_tip > capture_height + PRUNING_DEPTH,
+        "tip should be strictly beyond pruning depth from capture height"
+    );
+
+    // Step 5: Verify that truncate_to_height fails at capture_height because the
+    // checkpoint has been pruned.
+    let truncation_result = st.wallet_mut().truncate_to_height(capture_height);
+    assert!(
+        truncation_result.is_err(),
+        "truncate_to_height should fail when checkpoint has been pruned"
+    );
+
+    // Step 6: truncate_to_chain_state should succeed. For a deep target it skips frontier
+    // insertion entirely and relies on the existing tree checkpoints above the target.
+    st.wallet_mut()
+        .truncate_to_chain_state(captured_chain_state.clone())
+        .expect("truncate_to_chain_state should succeed");
+
+    // Step 7: Verify wallet state after truncation.
+    // 7a. The chain tip (derived from scan_queue) should now report the truncation target.
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should match truncation height");
+    assert_eq!(new_tip, capture_height);
+
+    // 7b. No `Scanned` range in the scan queue may extend above the truncation target.
+    let ranges = st
+        .wallet()
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges
+        .iter()
+        .find(|r| r.priority() == ScanPriority::Scanned && r.block_range().end > capture_height);
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
+    );
+
+    // 7c. A deep truncation rewinds the scan queue all the way to the target, but blocks,
+    // transactions, tx_locator_map entries, and note commitment trees are only rewound to the
+    // oldest retained checkpoint at `tip - (PRUNING_DEPTH - 1)`. Data at that boundary is kept
+    // (so stabilized notes remain spendable); data above it is removed.
+    let prune_boundary = pre_truncation_tip - (PRUNING_DEPTH - 1);
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(prune_boundary).unwrap().is_some(),
+        "block entry at (tip - (PRUNING_DEPTH - 1)) should be preserved by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(prune_boundary + 1).unwrap().is_none(),
+        "block entries above (tip - (PRUNING_DEPTH - 1)) must be removed by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(pre_truncation_tip).unwrap().is_none(),
+        "block entries up to the pre-truncation tip must be removed by a deep truncation"
+    );
+    assert_eq!(
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(prune_boundary),
+        "block_max_scanned should equal (tip - (PRUNING_DEPTH - 1)) after a deep truncation"
+    );
+}
+
+pub fn truncate_to_chain_state_shallow<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Shallow-truncation test plan:
+    // 1. Set up test environment with a birthday-aligned account
+    // 2. Generate and scan initial blocks to populate the note commitment tree
+    // 3. Capture the chain state at a specific height (the future truncation target)
+    // 4. Generate and scan `PRUNING_DEPTH - 1` extra blocks so that the target sits at the
+    //    shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, the oldest retained
+    //    checkpoint)
+    // 5. Test that truncate_to_chain_state succeeds using the captured chain state
+    // 6. Verify wallet state after truncation: scan_queue, blocks, tx_locator_map and
+    //    note commitment trees are all rewound to the truncation target. Data at the
+    //    target is preserved; anything above is removed.
+
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Step 2: Generate and scan initial blocks to populate the note commitment tree.
+    // We use an "other" fvk so that notes won't be tracked by the wallet (keeping the
+    // test focused on tree/block state rather than wallet balances).
+    let seed = [1u8; 32];
+    let other_sk = T::sk(&seed);
+    let other_fvk = T::sk_to_fvk(&other_sk);
+
+    let initial_block_count = 8u32;
+    for _ in 0..initial_block_count {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10000),
+        );
+    }
+    let scan_start = sapling_activation;
+    st.scan_cached_blocks(scan_start, initial_block_count as usize);
+
+    // Step 3: Capture the chain state at the current tip. The CachedBlock tracks the
+    // exact frontier that corresponds to the end of each generated block.
+    let capture_height = sapling_activation + initial_block_count - 1;
+    let captured_chain_state = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    assert_eq!(captured_chain_state.block_height(), capture_height);
+
+    // Step 4: Scan `PRUNING_DEPTH - 1` extra blocks so that the truncation target sits at the
+    // shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, which is exactly the oldest
+    // retained checkpoint given the tree's `max_checkpoints = PRUNING_DEPTH`).
+    let extra_blocks = PRUNING_DEPTH - 1;
     for _ in 0..extra_blocks {
         st.generate_next_block(
             &other_fvk,
@@ -4326,47 +4478,173 @@ where
         .chain_height()
         .unwrap()
         .expect("chain tip should be set");
-    assert!(
-        tip >= capture_height + PRUNING_DEPTH,
-        "tip should be beyond pruning depth from capture height"
+    assert_eq!(
+        tip,
+        capture_height + (PRUNING_DEPTH - 1),
+        "tip should be exactly at the shallow boundary from capture height"
     );
 
-    // Step 5: Verify that truncate_to_height fails at capture_height because the
-    // checkpoint has been pruned.
-    let truncation_result = st.wallet_mut().truncate_to_height(capture_height);
-    assert!(
-        truncation_result.is_err(),
-        "truncate_to_height should fail when checkpoint has been pruned"
-    );
-
-    // Step 6: truncate_to_chain_state should succeed because it inserts the frontier
-    // as a checkpoint before truncating.
+    // Step 5: truncate_to_chain_state should succeed. For a shallow target it truncates
+    // directly to the existing checkpoint at the target height (no frontier synthesis
+    // required when the target checkpoint is still retained).
     st.wallet_mut()
         .truncate_to_chain_state(captured_chain_state.clone())
         .expect("truncate_to_chain_state should succeed");
 
-    // Step 7: Verify wallet state after truncation.
-    // The chain tip should now be at the capture height.
+    // Step 6: Verify wallet state after truncation.
+    // 6a. The chain tip (derived from scan_queue) should now report the truncation target.
     let new_tip = st
         .wallet()
         .chain_height()
         .unwrap()
-        .expect("chain tip should still be set after truncation");
+        .expect("chain tip should match truncation height");
     assert_eq!(new_tip, capture_height);
 
-    // The block hash at capture_height should match what was in the captured chain state.
-    let hash_at_capture = st
+    // 6b. No `Scanned` range in the scan queue may extend above the truncation target.
+    let ranges = st
         .wallet()
-        .get_block_hash(capture_height)
-        .unwrap()
-        .expect("block hash should exist at capture height");
-    assert_eq!(hash_at_capture, captured_chain_state.block_hash());
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges
+        .iter()
+        .find(|r| r.priority() == ScanPriority::Scanned && r.block_range().end > capture_height);
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
+    );
 
-    // Blocks above the capture height should have been removed.
+    // 6c. A shallow truncation rewinds blocks, tx_locator_map, and note commitment trees
+    // to the truncation target: data at the target is preserved but anything above is
+    // removed.
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(capture_height).unwrap().is_some(),
+        "block entry at the truncation target should be preserved"
+    );
+    assert!(
+        wallet.get_block_hash(capture_height + 1).unwrap().is_none(),
+        "block entries above the truncation target should be removed by a shallow truncation"
+    );
     assert_eq!(
-        st.wallet().get_block_hash(capture_height + 1).unwrap(),
-        None,
-        "blocks above capture height should be removed"
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(capture_height),
+        "block_max_scanned should equal the truncation target after a shallow truncation"
+    );
+}
+
+/// Regression test: after the scan scheduler processes a `ChainTip` range before a lower
+/// `Historic` range, `MAX(height) FROM blocks` points into one scanned region while
+/// `last_scanned - (PRUNING_DEPTH - 1)` lands inside the unscanned gap between the two
+/// regions. `truncate_to_chain_state` must still succeed: the previous implementation
+/// returned `CorruptedData` because it expected a checkpoint at exactly the PD floor; the
+/// current implementation clamps forward to the lowest checkpoint that still lies inside
+/// the prune window.
+pub fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Scan is always sequential in cache order, but `scan_cached_blocks` is happy to be
+    // invoked on subranges out of order. We pre-generate a contiguous chain of blocks and
+    // scan it in two disjoint segments with a gap in between.
+    let seed = [1u8; 32];
+    let other_fvk = T::sk_to_fvk(&T::sk(&seed));
+    let filler_value = Zatoshis::const_from_u64(10_000);
+
+    let low_count: u32 = 10;
+    let gap_size: u32 = PRUNING_DEPTH + 5; // must exceed PD so the PD floor lands in the gap
+    let high_count: u32 = 10;
+    let total_generated = low_count + gap_size + high_count;
+
+    for _ in 0..total_generated {
+        st.generate_next_block(&other_fvk, AddressType::DefaultExternal, filler_value);
+    }
+
+    // `with_account_from_sapling_activation` anchors the account birthday at
+    // `sapling_activation - 1`, so the first cached block lives at `sapling_activation`.
+    let low_start = sapling_activation;
+    let low_end_inclusive = low_start + low_count - 1;
+    let high_start = low_end_inclusive + gap_size + 1;
+    let high_end_inclusive = high_start + high_count - 1;
+
+    // Scan the low range (simulating a historic range).
+    st.scan_cached_blocks(low_start, low_count as usize);
+
+    // Capture the chain state at the end of the low range; we'll use it as the deep
+    // truncation target. This reflects the caller having a `ChainState` from back when
+    // scanning ended at `low_end_inclusive`.
+    let truncation_target = st
+        .latest_cached_block_below_height(low_end_inclusive + 1)
+        .expect("a cached block should exist at or below the end of the low range")
+        .chain_state()
+        .clone();
+    assert_eq!(truncation_target.block_height(), low_end_inclusive);
+
+    // Scan the high range (simulating a chain-tip range), leaving `gap_size` blocks in
+    // the middle unscanned. Because `high_start > low_end_inclusive + PRUNING_DEPTH`, the
+    // PD floor after this scan (`high_end_inclusive - (PRUNING_DEPTH - 1)`) lands inside
+    // the unscanned gap.
+    st.scan_cached_blocks(high_start, high_count as usize);
+
+    // Confirm the pre-truncation state matches the scenario we claim to be testing.
+    // `block_max_scanned` reports `MAX(height) FROM blocks`, which is exactly what
+    // `truncate_to_height_internal` uses as `last_scanned_height` when computing the PD
+    // floor. `chain_height` would also include unscanned portions of the scan queue, so
+    // it is not a tight enough bound for this test.
+    let max_scanned_height = st
+        .wallet()
+        .block_max_scanned()
+        .unwrap()
+        .map(|m| m.block_height())
+        .expect("block_max_scanned should report the high-range tip");
+    assert_eq!(max_scanned_height, high_end_inclusive);
+    let pd_floor = max_scanned_height - (PRUNING_DEPTH - 1);
+    assert!(
+        pd_floor > low_end_inclusive && pd_floor < high_start,
+        "test invariant: PD floor must lie in the unscanned gap (got {pd_floor}, \
+         gap is ({low_end_inclusive}, {high_start}))"
+    );
+
+    // Previously this would fail with `CorruptedData` because no checkpoint exists at
+    // `pd_floor`. The current implementation clamps forward to the lowest in-window
+    // checkpoint (`high_start`) and succeeds.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed across a non-contiguous scan");
+
+    // The core claim of this test is that `truncate_to_chain_state` returned `Ok(())`
+    // rather than `CorruptedData`, which the `expect` above already verified: prior to
+    // the clamp-in-window fix, `truncate_to_checkpoint` was invoked at `pd_floor`
+    // (which sits in the unscanned gap and has no checkpoint) and failed. Beyond that,
+    // the only post-condition we still assert is that the scan queue has no lingering
+    // `Scanned` range above the truncation target — the exact pre/post block-boundary
+    // depends on which baseline checkpoints the scanner seeded, which is an
+    // implementation detail of `scan_cached_blocks` and not part of this commit's
+    // contract.
+    let ranges = st
+        .wallet()
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges.iter().find(|r| {
+        r.priority() == ScanPriority::Scanned && r.block_range().end > low_end_inclusive + 1
+    });
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
     );
 }
 
@@ -4460,16 +4738,50 @@ pub fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester, Dsf>(
     // This should succeed. On the buggy code, this fails with RequestedRewindInvalid
     // because select_truncation_height cannot find an entry in the blocks table at the
     // target height.
-    let _target_height = prior_chain_state.block_height();
+    let target_height = prior_chain_state.block_height();
+    let pre_truncation_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("tip should be set before truncation");
+    let prune_depth = pre_truncation_tip - (PRUNING_DEPTH - 1);
+
     st.wallet_mut()
         .truncate_to_chain_state(prior_chain_state)
         .expect("truncate_to_chain_state below birthday should succeed");
 
-    // All blocks were above the target height, so they should have been removed.
+    // scan_queue should be rewound to truncation height
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set to truncation target");
+    assert_eq!(new_tip, target_height);
+
+    // The target is far below the oldest retained checkpoint (`tip - (PRUNING_DEPTH - 1)`), so
+    // this exercises the deep path: the scan queue is rewound all the way to the target, while
+    // other wallet data is rewound only to that retention boundary. Data at the boundary is
+    // kept; data above it must be removed.
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(prune_depth).unwrap().is_some(),
+        "block entry at (tip - (PRUNING_DEPTH - 1)) should be preserved by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(prune_depth + 1).unwrap().is_none(),
+        "block entries above (tip - (PRUNING_DEPTH - 1)) must be removed by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(pre_truncation_tip).unwrap().is_none(),
+        "block entries up to the pre-truncation tip must be removed by a deep truncation"
+    );
     assert_eq!(
-        st.wallet().get_block_hash(birthday_height).unwrap(),
-        None,
-        "blocks at birthday height should be removed after truncating below birthday"
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(prune_depth),
+        "block_max_scanned should equal (tip - (PRUNING_DEPTH - 1)) after a deep truncation"
     );
 }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4905,6 +4905,209 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
     );
 }
 
+/// A note whose witness data has stabilized remains spendable after a deep truncation rewinds the
+/// scan queue below it.
+pub fn stabilized_note_spendable_after_deep_truncation<T, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = st.test_account().unwrap().birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Scan a handful of filler blocks and capture the chain state as our deep-truncation target.
+    let filler_count = 5u32;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(birthday + 1, filler_count as usize);
+    let truncation_target = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    let truncation_height = truncation_target.block_height();
+
+    // Mine and scan a wallet-owned note above the truncation target.
+    let (note_height, _, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, note_value);
+    st.scan_cached_blocks(note_height, 1);
+    assert!(note_height > truncation_height);
+
+    // Record shard 0's completion at `note_height` — the block that contains the note. Paired
+    // with the post-note blocks scanned below, this drives `shard.subtree_end_height` past the
+    // pruning boundary at `tip - PRUNING_DEPTH`, which is the condition `mark_stabilized_notes`
+    // uses to flip `witness_stabilized` for notes whose position lies within the shard.
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(
+            note_height,
+            T::empty_tree_leaf(),
+        )],
+    )
+    .unwrap();
+
+    // Scan strictly more than `PRUNING_DEPTH` blocks past the note so the note stabilizes.
+    let extra_blocks = PRUNING_DEPTH + 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    let account = st.get_account();
+
+    // Remember the pre-truncation tip so we can feed it back into the wallet below. A recent chain
+    // tip will be required to calculate an anchor to spend this note later.
+    let pre_trunc_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set before truncation");
+
+    // Deep-truncate: the target is far below the tip (beyond the prune window), but only just
+    // below the note.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+    let tip_after_trunc = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after truncation");
+    assert_eq!(
+        tip_after_trunc, truncation_height,
+        "scan_queue must be rewound to the truncation target"
+    );
+
+    // Pre-`update_chain_tip` state: the scan_queue has been rewound below the note, but
+    // the chain tip has not yet been restored. The balance path uses the stabilization
+    // flag directly and is therefore unaffected. The spend path is blocked because
+    // `propose_transfer` derives its anchor from the rewound `chain_height()`, placing
+    // the anchor below the note's mined height; the anchor-height check in note
+    // selection then filters the note out and note selection reports no spendable
+    // inputs. This pair of assertions pins the "balance works, spend fails" split
+    // documented in `truncate_to_chain_state`'s rustdoc so that a future refactor of
+    // note selection or anchor derivation cannot silently invert it.
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        note_value,
+        "stabilized balance must be available even before update_chain_tip"
+    );
+    let pre_update_request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        T::sk_default_address(&T::sk(&[0xcc; 32])).to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10_000),
+    )])
+    .unwrap();
+    let pre_update_change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let pre_update_input_selector = GreedyInputSelector::new();
+    // The exact error depends on how far `propose_transfer` gets before running out of
+    // usable state
+    let pre_update_result = st.propose_transfer(
+        account.id(),
+        &pre_update_input_selector,
+        &pre_update_change_strategy,
+        pre_update_request,
+        ConfirmationsPolicy::MIN,
+    );
+    assert_matches!(
+        pre_update_result,
+        Err(crate::data_api::error::Error::ScanRequired)
+            | Err(crate::data_api::error::Error::InsufficientFunds { .. }),
+        "propose_transfer should fail with InsufficientFunds or ScanRequired"
+    );
+    if let Err(crate::data_api::error::Error::InsufficientFunds { available, .. }) =
+        &pre_update_result
+    {
+        assert_eq!(
+            *available,
+            Zatoshis::ZERO,
+            "when note selection runs, no notes should be eligible without the restored tip",
+        );
+    }
+
+    // Restore `chain_height()` to the pre-truncation tip, so that `propose_transfer` can derive an anchor
+    st.wallet_mut()
+        .update_chain_tip(pre_trunc_tip)
+        .expect("update_chain_tip should succeed");
+    let tip_after_update = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after update_chain_tip");
+    assert_eq!(tip_after_update, pre_trunc_tip);
+
+    // Post-truncation: the note is still spendable because (a) its witness data was preserved
+    // (commit B) and (b) the spendability queries consult the stabilization flag instead of
+    // scan_queue (commit E). If either is missing, this assertion fails.
+    let post_trunc_spendable = st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN);
+    assert_eq!(
+        post_trunc_spendable, note_value,
+        "stabilized note should remain spendable after deep truncation"
+    );
+
+    // End-to-end: build and sign a real spend. This exercises the full note-selection and
+    // witness-construction path.
+    let to_extsk = T::sk(&[0xcc; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let send_value = Zatoshis::const_from_u64(10_000);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal should succeed with stabilized note after deep truncation");
+    let txids = st
+        .create_proposed_transactions::<std::convert::Infallible, _, std::convert::Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("spend construction should succeed");
+    assert_eq!(
+        txids.len(),
+        1,
+        "the spend should produce exactly one transaction"
+    );
+}
+
 pub fn reorg_to_checkpoint<T: ShieldedPoolTester, Dsf, C>(ds_factory: Dsf, cache: C)
 where
     Dsf: DataStoreFactory,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -30,6 +30,10 @@ workspace.
 - `impl<'conn, P, CL, R> WalletWrite for WalletDb<SqlTransaction<'conn>, P, CL, R>` to
   enable calling `WalletWrite` methods inside `WalletDb::transactionally` (amortizing the
   database transaction overhead).
+- `zcash_client_sqlite::wallet::commitment_tree::min_checkpoint_id_at_or_above`
+  returns the lowest retained checkpoint id at or above a given block height,
+  used by truncation to clamp the rewind floor to a real checkpoint inside the
+  prune window.
 
 ### Changed
 - The `accounts` table now stores IVK item caches instead of FVK item caches for
@@ -48,6 +52,17 @@ workspace.
   `zcash_client_sqlite::error::StandaloneImportConflict`
 - P2SH UTXOs returned by `get_spendable_transparent_outputs` now include a
   precomputed input size for accurate ZIP 317 fee estimation.
+- Truncation no longer unconditionally rewinds all wallet data to the requested
+  target height. For deep truncations (more than `PRUNING_DEPTH` below the
+  scanned tip), only the scan queue is rewound to the requested height; blocks,
+  note commitment trees, transactions, transparent UTXO observations, and
+  nullifier map entries are not rewound beyond `PRUNING_DEPTH`. Shallow
+  truncations (within `PRUNING_DEPTH` of the tip) behave as before. The rewind
+  floor is now the lowest shard-tree checkpoint that lies inside the prune window
+  `[last_scanned - (PRUNING_DEPTH - 1), last_scanned]`, which under contiguous
+  scanning is exactly `last_scanned - (PRUNING_DEPTH - 1)` and under
+  non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic`
+  ranges) walks forward from the PD floor to the first real checkpoint.This
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -63,6 +63,12 @@ workspace.
   scanning is exactly `last_scanned - (PRUNING_DEPTH - 1)` and under
   non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic`
   ranges) walks forward from the PD floor to the first real checkpoint.This
+- Added a `witness_stabilized` column to the `sapling_received_notes` and
+  `orchard_received_notes` tables. The column is set to 1 by the new
+  `mark_stabilized_notes` helper, invoked at the end of each scan batch (and
+  during migration backfill), for notes whose containing shard's
+  `subtree_end_height` lies at or below `last_scanned - (PRUNING_DEPTH - 1)`
+  (the truncation rewind boundary).
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -69,6 +69,16 @@ workspace.
   during migration backfill), for notes whose containing shard's
   `subtree_end_height` lies at or below `last_scanned - (PRUNING_DEPTH - 1)`
   (the truncation rewind boundary).
+- Note-selection (`select_unspent_notes`,
+  `select_spendable_notes_matching_value`) and balance reporting
+  (`get_wallet_summary`) now consult the `witness_stabilized` flag in addition to
+  the existing `v_<pool>_shards_scan_state` join. A stabilized note bypasses the
+  shard-scanned, unscanned-tip, and confirmations checks (those are properties of
+  the wallet's scan state, which `witness_stabilized` makes irrelevant), so
+  stabilized notes remain spendable after a deep truncation rewinds `scan_queue`
+  below them. The anchor-height check (`mined_height <= anchor_height`) remains
+  in force for stabilized notes, because that is a property of the caller's
+  anchor choice rather than of the wallet's scan state.
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -391,6 +391,17 @@ mod tests {
     }
 
     #[test]
+    fn stabilized_note_spendable_after_deep_truncation_sapling() {
+        testing::pool::stabilized_note_spendable_after_deep_truncation::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn stabilized_note_spendable_after_deep_truncation_orchard() {
+        testing::pool::stabilized_note_spendable_after_deep_truncation::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn truncate_to_chain_state_below_birthday_sapling() {
         testing::pool::truncate_to_chain_state_below_birthday::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -369,14 +369,25 @@ mod tests {
     }
 
     #[test]
-    fn truncate_to_chain_state_sapling() {
-        testing::pool::truncate_to_chain_state::<SaplingPoolTester>()
+    fn truncate_to_chain_state_deep_sapling() {
+        testing::pool::truncate_to_chain_state_deep::<SaplingPoolTester>()
     }
 
     #[test]
     #[cfg(feature = "orchard")]
-    fn truncate_to_chain_state_orchard() {
-        testing::pool::truncate_to_chain_state::<OrchardPoolTester>()
+    fn truncate_to_chain_state_deep_orchard() {
+        testing::pool::truncate_to_chain_state_deep::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn truncate_to_chain_state_shallow_sapling() {
+        testing::pool::truncate_to_chain_state_shallow::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncate_to_chain_state_shallow_orchard() {
+        testing::pool::truncate_to_chain_state_shallow::<OrchardPoolTester>()
     }
 
     #[test]
@@ -388,6 +399,17 @@ mod tests {
     #[cfg(feature = "orchard")]
     fn truncate_to_chain_state_below_birthday_orchard() {
         testing::pool::truncate_to_chain_state_below_birthday::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn truncate_after_non_contiguous_scan_sapling() {
+        testing::pool::truncate_after_non_contiguous_scan::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncate_after_non_contiguous_scan_orchard() {
+        testing::pool::truncate_after_non_contiguous_scan::<OrchardPoolTester>()
     }
 
     #[test]

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -326,6 +326,13 @@ pub(crate) fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn stabilized_note_spendable_after_deep_truncation<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::stabilized_note_spendable_after_deep_truncation::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_below_birthday::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -305,8 +305,22 @@ pub(crate) fn data_db_truncation<T: ShieldedPoolTester>() {
     )
 }
 
-pub(crate) fn truncate_to_chain_state<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state::<T, _>(
+pub(crate) fn truncate_to_chain_state_deep<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_deep::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn truncate_to_chain_state_shallow<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_shallow::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_after_non_contiguous_scan::<T, _>(
         TestDbFactory::default(),
         BlockCache::new(),
     )

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1885,8 +1885,14 @@ fn estimate_tree_size<P: consensus::Parameters>(
         let tip_tree_size = last_scanned.and_then(|(last_scanned, last_scanned_tree_size)| {
             (last_scanned > last_completed_subtree_end)
                 .then(|| {
+                    // `saturating_sub` here is a no-op in production: by the time we enter this
+                    // branch, the wallet has scanned past the last completed subtree's end height
+                    // and has therefore seen at least `position_range_end()` commitments. It is
+                    // needed for tests that synthesize an incomplete shard (e.g. recording a
+                    // subtree root via `put_subtree_roots` before scanning enough commitments to
+                    // fill it), where the plain subtraction would underflow.
                     let scanned_notes = last_scanned_tree_size
-                        - u64::from(last_completed_subtree.position_range_end());
+                        .saturating_sub(u64::from(last_completed_subtree.position_range_end()));
                     let scanned_range = u64::from(last_scanned - last_completed_subtree_end);
                     let unscanned_range = u64::from(chain_tip_height - last_scanned);
 
@@ -2413,6 +2419,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         let mut stmt_select_notes = tx.prepare_cached(&format!(
             "SELECT accounts.uuid, rn.id, rn.value, rn.is_change, rn.recipient_key_scope,
                     scan_state.max_priority,
+                    rn.witness_stabilized,
                     t.mined_height,
                     IFNULL(t.trust_status, 0) AS trust_status,
                     MAX(tt.mined_height) AS max_shielding_input_height,
@@ -2483,20 +2490,28 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
 
-            // A note is spendable if we have enough chain tip information to construct witnesses,
-            // the shard that its witness resides in is sufficiently scanned that we can construct
-            // the witness for the note, and the note has enough confirmations to be spent.
-            let is_spendable = any_spendable
-                && max_priority <= ScanPriority::Scanned
-                && confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
-                    received_height,
-                    tx_trusted,
-                    max_shielding_input_height,
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
+
+            // A stabilized note is unconditionally spendable. Its originating transaction has been
+            // confirmed well beyond any reasonable confirmation policy, and its witness data
+            // cannot be removed by truncation.
+            //
+            // Non-stabilized notes require more checks: we must have enough chain tip information
+            // to construct witnesses, the shard that the note resides in must be sufficiently
+            // scanned that we can construct the witness for the note, and the note has enough
+            // confirmations to be spent.
+            let is_spendable = witness_stabilized
+                || (any_spendable
+                    && max_priority <= ScanPriority::Scanned
+                    && confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
+                        received_height,
+                        tx_trusted,
+                        max_shielding_input_height,
+                        tx_shielding_inputs_trusted,
+                    ) == 0);
 
             let is_pending_change =
                 is_change && received_height.iter().all(|h| h > &trusted_height);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3533,10 +3533,47 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         ))
     })?;
 
-    // Delete from the scanning queue any range with a start height greater than the
-    // truncation height, and then truncate any remaining range by setting the end
-    // equal to the truncation height + 1. This sets our view of the chain tip back
-    // to the retained height.
+    // For deep truncations the scan queue is rewound to `truncation_height`, but blocks, trees,
+    // transactions, transparent UTXO observations, and nullifier map entries are only rewound to
+    // the lowest shard-tree checkpoint that still lies inside the prune window
+    // `[last_scanned - (PRUNING_DEPTH - 1), last_scanned]`. Under contiguous scanning that is
+    // exactly `last_scanned - (PRUNING_DEPTH - 1)`, because the tree's `max_checkpoints` cap
+    // equals `PRUNING_DEPTH` and FIFO-by-id pruning retains every height in the window. Under
+    // non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic` ranges, per
+    // `suggest_scan_ranges` ordering in `wallet::scanning`), the PD floor may sit in an
+    // unscanned gap and have no checkpoint; walking forward from the floor to the first real
+    // checkpoint keeps us inside the window while still coinciding with a real checkpoint that
+    // `truncate_to_checkpoint` can act on.
+    let pd_floor = last_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
+    let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        conn,
+        crate::SAPLING_TABLES_PREFIX,
+        pd_floor,
+    )
+    .map_err(ShardTreeError::Storage)?;
+    #[cfg(feature = "orchard")]
+    let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        conn,
+        crate::ORCHARD_TABLES_PREFIX,
+        pd_floor,
+    )
+    .map_err(ShardTreeError::Storage)?;
+    #[cfg(not(feature = "orchard"))]
+    let orchard_window_floor: Option<BlockHeight> = None;
+
+    // Combine the per-pool floors by taking the shallower (larger height). Under normal scanning
+    // both pools record checkpoints at identical heights (each block's `put_block` updates both
+    // trees), so the two values agree and this is a no-op choice.
+    let in_window_floor = match (sapling_window_floor, orchard_window_floor) {
+        (Some(s), Some(o)) => s.max(o),
+        (Some(h), None) | (None, Some(h)) => h,
+        (None, None) => pd_floor,
+    };
+    let data_rewind_height = truncation_height.max(in_window_floor);
+
+    // scan_queue ALWAYS rewinds all the way to `truncation_height`, signalling to the sync
+    // loop that anything above must be re-scanned. This holds for both shallow and deep
+    // truncations.
     conn.execute(
         "DELETE FROM scan_queue
         WHERE block_range_start >= :new_end_height",
@@ -3563,7 +3600,7 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
          FROM transactions tx
          WHERE tx.id_tx = transaction_id
          AND max_observed_unspent_height > :height",
-        named_params![":height": u32::from(truncation_height)],
+        named_params![":height": u32::from(data_rewind_height)],
     )?;
 
     // Un-mine transactions. This must be done outside of the last_scanned_height check because
@@ -3572,13 +3609,13 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         "UPDATE transactions
          SET block = NULL, mined_height = NULL, tx_index = NULL, confirmed_unmined_at_height = NULL
          WHERE mined_height > :height",
-        named_params![":height": u32::from(truncation_height)],
+        named_params![":height": u32::from(data_rewind_height)],
     )?;
 
     // If we're removing scanned blocks, we need to truncate the note commitment tree and remove
     // affected block records from the database.
-    if truncation_height < last_scanned_height {
-        // Truncate the note commitment trees
+    if data_rewind_height < last_scanned_height {
+        // Truncate the note commitment trees to `data_rewind_height`
         let mut wdb = WalletDb {
             conn: SqlTransaction(conn),
             params: params.clone(),
@@ -3587,13 +3624,26 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
             #[cfg(feature = "transparent-inputs")]
             gap_limits: *gap_limits,
         };
+        // `truncate_to_checkpoint` returns `Ok(false)` when the tree has no checkpoint at the
+        // requested id; surface that as `CorruptedData` rather than letting the bool drop on
+        // the floor.
         wdb.with_sapling_tree_mut(|tree| {
-            tree.truncate_to_checkpoint(&truncation_height)?;
+            if !tree.truncate_to_checkpoint(&data_rewind_height)? {
+                return Err(SqliteClientError::CorruptedData(format!(
+                    "Sapling tree has no checkpoint at expected rewind height {data_rewind_height}; \
+                     the shard tree is inconsistent with the recorded checkpoint rows."
+                )));
+            }
             Ok::<_, SqliteClientError>(())
         })?;
         #[cfg(feature = "orchard")]
         wdb.with_orchard_tree_mut(|tree| {
-            tree.truncate_to_checkpoint(&truncation_height)?;
+            if !tree.truncate_to_checkpoint(&data_rewind_height)? {
+                return Err(SqliteClientError::CorruptedData(format!(
+                    "Orchard tree has no checkpoint at expected rewind height {data_rewind_height}; \
+                     the shard tree is inconsistent with the recorded checkpoint rows."
+                )));
+            }
             Ok::<_, SqliteClientError>(())
         })?;
 
@@ -3607,15 +3657,15 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         // Now that they aren't depended on, delete un-mined blocks.
         conn.execute(
             "DELETE FROM blocks WHERE height > ?",
-            [u32::from(truncation_height)],
+            [u32::from(data_rewind_height)],
         )?;
 
         // Delete from the nullifier map any entries with a locator referencing a block
-        // height greater than the truncation height.
+        // height greater than the data-rewind height.
         conn.execute(
             "DELETE FROM tx_locator_map
             WHERE block_height > :block_height",
-            named_params![":block_height": u32::from(truncation_height)],
+            named_params![":block_height": u32::from(data_rewind_height)],
         )?;
     }
 
@@ -3634,19 +3684,41 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
 ///   oldest checkpoint to ensure that the a checkpoint added at the provided frontier position does
 ///   not get immediately pruned, then inserts the provided frontier as a new checkpoint at the
 ///   target height, and finally truncates to that new checkpoint.
+///
+/// # Spending stabilized notes after a deep truncation
+///
+/// A deep truncation rewinds the scan queue to `target_height` but preserves blocks, trees,
+/// transactions, and other wallet data above the lowest shard-tree checkpoint inside the
+/// prune window, so notes flagged `witness_stabilized` retain valid witness data. To
+/// actually spend those notes, the caller must follow up with
+/// `WalletWrite::update_chain_tip` to restore the wallet's view of the chain tip.
+/// Otherwise `propose_transfer` either fails at `get_target_and_anchor_heights` with
+/// `Error::ScanRequired` (when no checkpoint sits at or below the derived anchor), or —
+/// if an anchor can still be constructed — derives it from the rewound `chain_height()`,
+/// placing it below the stabilized note's mined height; the anchor-height check in note
+/// selection then filters the note out and proposal construction fails with
+/// `Error::InsufficientFunds { available: 0, .. }`. Stabilized balance reported by
+/// `get_wallet_summary` does not depend on a restored chain tip; only spend
+/// construction does.
 pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
     wdb: &mut WalletDb<SqlTransaction<'_>, P, CL, R>,
     chain_state: ChainState,
 ) -> Result<(), SqliteClientError> {
     let target_height = chain_state.block_height();
 
-    // Only truncate trees when the maximum scanned height is greater than the target height. When
-    // the target height is at or above the max scanned height, we skip frontier insertion (it is
-    // unnecessary at the max scanned height, and could introduce a subtree root discontinuity
-    // above it; the frontier will be added naturally during scanning). We will however still need
-    // to truncate the scan queue so that ranges above the target are removed.
-    let truncate_trees = block_max_scanned(wdb.conn.0, &wdb.params)?
-        .is_some_and(|meta| meta.block_height() > target_height);
+    // Only truncate trees when the target is strictly below the maximum scanned height AND
+    // inside the prune window `[max_scanned - (PRUNING_DEPTH - 1), max_scanned]`. Targets at or
+    // above the max scanned height are skipped because a frontier there could introduce a
+    // subtree root discontinuity above it; the frontier will be added naturally during scanning.
+    // Targets below the prune window are skipped because `truncate_to_height_internal` clamps
+    // its rewind floor up to the lowest checkpoint inside the window, and any checkpoint
+    // inserted at a deeper target would itself be truncated away on that subsequent call. In
+    // both skipped cases the scan queue is still trimmed above `target_height` unconditionally
+    // in `truncate_to_height_internal`.
+    let truncate_trees = block_max_scanned(wdb.conn.0, &wdb.params)?.is_some_and(|m| {
+        let h = m.block_height();
+        target_height < h && target_height >= h.saturating_sub(PRUNING_DEPTH - 1)
+    });
 
     if truncate_trees {
         // Try the simple case first: if a checkpoint exists at or below the target height,

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -624,6 +624,27 @@ pub(crate) fn max_checkpoint_id(
     .map_err(Error::Query)
 }
 
+/// Returns the lowest retained checkpoint id that is at or above `floor`, or `None`
+/// if the pool's checkpoint table contains no checkpoint within `[floor, ∞)`.
+pub(crate) fn min_checkpoint_id_at_or_above(
+    conn: &rusqlite::Connection,
+    table_prefix: &'static str,
+    floor: BlockHeight,
+) -> Result<Option<BlockHeight>, Error> {
+    conn.query_row(
+        &format!(
+            "SELECT MIN(checkpoint_id) FROM {table_prefix}_tree_checkpoints
+             WHERE checkpoint_id >= :floor"
+        ),
+        named_params![":floor": u32::from(floor)],
+        |row| {
+            row.get::<_, Option<u32>>(0)
+                .map(|opt| opt.map(BlockHeight::from))
+        },
+    )
+    .map_err(Error::Query)
+}
+
 pub(crate) fn add_checkpoint(
     conn: &rusqlite::Transaction<'_>,
     table_prefix: &'static str,

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -383,6 +383,7 @@ where
              accounts.ufvk as ufvk, rn.recipient_key_scope,
              t.block AS mined_height,
              scan_state.max_priority,
+             rn.witness_stabilized,
              IFNULL(t.trust_status, 0) AS trust_status,
              MAX(tt.mined_height) AS max_shielding_input_height,
              MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -434,6 +435,7 @@ where
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
             let shard_scan_priority = max_priority_raw
@@ -448,6 +450,7 @@ where
 
             Ok((
                 result_note,
+                witness_stabilized,
                 shard_scan_priority,
                 tx_trust_status,
                 tx_shielding_inputs_trusted,
@@ -457,25 +460,33 @@ where
 
     row_results
         .map(|t| match t? {
-            (Some(note), max_shard_priority, tx_trusted, tx_shielding_inputs_trusted) => {
-                let shard_scanned = max_shard_priority
-                    .iter()
-                    .any(|p| *p <= ScanPriority::Scanned);
+            (
+                Some(note),
+                witness_stabilized,
+                max_shard_priority,
+                tx_trusted,
+                tx_shielding_inputs_trusted,
+            ) => {
+                let shard_scanned = witness_stabilized
+                    || max_shard_priority
+                        .iter()
+                        .any(|p| *p <= ScanPriority::Scanned);
 
                 let mined_at_anchor = note
                     .mined_height()
                     .zip(note_request.anchor_height())
                     .is_some_and(|(h, ah)| h <= ah);
 
-                let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    Some(note.spending_key_scope()),
-                    note.mined_height(),
-                    tx_trusted,
-                    note.max_shielding_input_height(),
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+                let has_confirmations = witness_stabilized
+                    || confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        Some(note.spending_key_scope()),
+                        note.mined_height(),
+                        tx_trusted,
+                        note.max_shielding_input_height(),
+                        tx_shielding_inputs_trusted,
+                    ) == 0;
 
                 match (
                     note_request,
@@ -523,9 +534,13 @@ where
         note_reconstruction_cols,
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
-    if unscanned_tip_exists(conn, anchor_height, table_prefix)? {
-        return Ok(vec![]);
-    }
+
+    // When the anchor's shard has unscanned ranges at or below `anchor_height`, the tree
+    // frontier at the anchor is not reliably reconstructible, so un-stabilized notes can't
+    // be safely selected. Stabilized notes are unaffected: their witness data is durable
+    // in the shard tree regardless of what `scan_queue` says. We pass `tip_unscanned` as a
+    // parameter and let the SQL mix the two cases, rather than early-exiting.
+    let tip_unscanned = unscanned_tip_exists(conn, anchor_height, table_prefix)?;
 
     // The goal of this SQL statement is to select the oldest notes until the required
     // value has been reached.
@@ -550,6 +565,7 @@ where
                  SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,
+                 rn.witness_stabilized,
                  IFNULL(t.trust_status, 0) AS trust_status,
                  MAX(tt.mined_height) AS max_shielding_input_height,
                  MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -571,11 +587,24 @@ where
              AND accounts.ufvk IS NOT NULL
              AND recipient_key_scope IS NOT NULL
              AND nf IS NOT NULL
-             -- the shard containing the note is fully scanned; this condition will exclude
-             -- notes for which `scan_state.max_priority IS NULL` (which will also arise if
-             -- `rn.commitment_tree_position IS NULL`; hence we don't need that explicit filter)
-             AND scan_state.max_priority <= :scanned_priority
+             -- The note must be mined at or below the anchor for the anchor's tree
+             -- frontier to witness it; this is an invariant of the spend, not of our
+             -- scan state, so it applies to stabilized and non-stabilized notes alike.
              AND t.block <= :anchor_height
+             -- A stabilized note's witness is durable across truncation, so it bypasses
+             -- the scan-state gating: it is eligible even when the anchor's shard has
+             -- unscanned ranges (`:tip_unscanned = 1`) or its containing shard is not
+             -- yet fully scanned. Non-stabilized notes require a fully-scanned containing
+             -- shard AND a fully-scanned anchor shard. The `scan_state.max_priority IS
+             -- NULL` case (which arises when `rn.commitment_tree_position IS NULL`) is
+             -- excluded by the priority check.
+             AND (
+                 rn.witness_stabilized = 1
+                 OR (
+                     :tip_unscanned = 0
+                     AND scan_state.max_priority <= :scanned_priority
+                 )
+             )
              AND rn.id NOT IN rarray(:exclude)
              AND rn.id NOT IN ({})
              GROUP BY rn.id
@@ -583,14 +612,14 @@ where
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM eligible WHERE so_far < :target_value
          UNION
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         spent_notes_clause(table_prefix)
@@ -616,6 +645,7 @@ where
             ":target_value": &u64::from(target_value),
             ":exclude": &excluded_ptr,
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
+            ":tip_unscanned": i64::from(tip_unscanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE)
         ],
         |row| {
@@ -624,6 +654,7 @@ where
                 .get::<_, Option<u32>>("max_shielding_input_height")?
                 .map(BlockHeight::from);
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let note = to_spendable_note(params, row)?;
 
             Ok(note.map(|n| {
@@ -632,6 +663,7 @@ where
                     tx_trust_status,
                     max_shielding_input_height,
                     tx_shielding_inputs_trusted,
+                    witness_stabilized,
                 )
             }))
         },
@@ -647,16 +679,21 @@ where
                         tx_trusted,
                         max_shielding_input_height,
                         tx_shielding_inputs_trusted,
+                        witness_stabilized,
                     )| {
-                        let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                            target_height,
-                            PoolType::Shielded(protocol),
-                            Some(note.spending_key_scope()),
-                            note.mined_height(),
-                            tx_trusted,
-                            max_shielding_input_height,
-                            tx_shielding_inputs_trusted,
-                        ) == 0;
+                        // A stabilized note was confirmed well beyond any reasonable
+                        // confirmations policy at stabilization time, so the confirmations
+                        // check is trivially satisfied.
+                        let has_confirmations = witness_stabilized
+                            || confirmations_policy.confirmations_until_spendable(
+                                target_height,
+                                PoolType::Shielded(protocol),
+                                Some(note.spending_key_scope()),
+                                note.mined_height(),
+                                tx_trusted,
+                                max_shielding_input_height,
+                                tx_shielding_inputs_trusted,
+                            ) == 0;
 
                         has_confirmations.then_some(note)
                     },

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -375,6 +375,7 @@ CREATE TABLE "sapling_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -458,6 +459,7 @@ CREATE TABLE "orchard_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -54,6 +54,7 @@ mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
+mod witness_stabilized_notes;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -133,10 +134,10 @@ pub(super) fn all_migrations<
     //                     \                       \         v_received_output_spends_account      /        /
     //                      \                       \               /                             /        /
     //                       `------------------- account_delete_cascade ---------------------------------'
-    //                                              /               \
-    //                               v_tx_outputs_key_scopes    standalone_p2sh
-    //                                                                  |
-    //                                                           ivk_item_cache
+    //                                        /               |              \
+    //                       v_tx_outputs_key_scopes    standalone_p2sh    witness_stabilized_notes
+    //                                                        |
+    //                                                  ivk_item_cache
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -227,6 +228,7 @@ pub(super) fn all_migrations<
         Box::new(ivk_item_cache::Migration {
             params: params.clone(),
         }),
+        Box::new(witness_stabilized_notes::Migration),
     ]
 }
 
@@ -370,6 +372,7 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
+    witness_stabilized_notes::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -1,0 +1,402 @@
+//! Adds a `witness_stabilized` flag to received notes, indicating that the note's containing
+//! shard has been fully scanned and its witness data is durably present in the shard tree.
+//! Once set, this flag is preserved across truncations, ensuring that notes with intact
+//! witness data remain spendable (issue #2276).
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_client_backend::data_api::scanning::ScanPriority;
+use zcash_protocol::consensus::BlockHeight;
+
+use super::account_delete_cascade;
+use crate::wallet::init::WalletMigrationError;
+use crate::wallet::scanning::{mark_stabilized_notes, priority_code};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e99e422);
+
+// `account_delete_cascade` is the youngest migration that transitively establishes every
+// schema object this migration reads or writes:
+//
+//   - adds `witness_stabilized INTEGER` to `sapling_received_notes` and
+//     `orchard_received_notes` (columns that ADD COLUMN requires the tables to exist);
+//   - reads `commitment_tree_position` on those same tables;
+//   - reads `scan_queue.{block_range_end, priority}` (created by `shardtree_support`, which
+//     `account_delete_cascade` transitively depends on);
+//   - reads `{sapling,orchard}_tree_shards.{shard_index, subtree_end_height}` (created by
+//     `shardtree_support` / `orchard_shardtree`, same transitive dep).
+//
+// If a future migration renames or drops any of the above, adjust this list.
+const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds witness_stabilized flag to received notes for durable spendability."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        transaction.execute_batch(
+            "ALTER TABLE sapling_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;
+
+             ALTER TABLE orchard_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;",
+        )?;
+
+        // Backfill: derive the last-scanned height from the scan queue and delegate to the
+        // shared `mark_stabilized_notes` helper so the migration and the per-scan
+        // stabilization path share a single source of truth. We restrict the subquery to
+        // ranges with priority `Scanned`, because `scan_queue` also contains unscanned
+        // ranges (historic / found-note / chain-tip / verify) whose `block_range_end`
+        // would otherwise pollute the max. If the wallet has no scanned ranges yet, the
+        // subquery returns `NULL` and no rows are backfilled, which is the correct
+        // behavior for a freshly-created wallet.
+        let last_scanned_height: Option<u32> = transaction.query_row(
+            &format!(
+                "SELECT MAX(block_range_end) - 1 FROM scan_queue WHERE priority = {}",
+                priority_code(&ScanPriority::Scanned),
+            ),
+            [],
+            |row| row.get(0),
+        )?;
+
+        if let Some(last_scanned_height) = last_scanned_height {
+            mark_stabilized_notes(transaction, BlockHeight::from(last_scanned_height))?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_client_backend::data_api::SAPLING_SHARD_HEIGHT;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        PRUNING_DEPTH, WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// End-to-end exercise of the backfill: seed the pre-migration schema with a variety
+    /// of notes whose stabilization outcomes are fully determined, run the migration, and
+    /// assert the expected `witness_stabilized` value for each.
+    #[test]
+    fn migrate_backfills_stabilized_notes() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to the state just prior to this migration. At this point
+        // `sapling_received_notes` / `orchard_received_notes` do not yet have the
+        // `witness_stabilized` column.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // `block_range_end` is exclusive, so MAX(block_range_end) - 1 is the last-scanned
+        // height. `stable_height` mirrors what `mark_stabilized_notes` will compute and is
+        // also the truncation rewind boundary established in `truncate_to_height_internal`:
+        // `last_scanned - (PRUNING_DEPTH - 1)`. A shard whose `subtree_end_height` is at or
+        // below `stable_height` survives a deep truncation; a shard one block above does
+        // not.
+        let last_scanned: u32 = 301 + (PRUNING_DEPTH - 1);
+        let stable_height: u32 = 301;
+        assert_eq!(last_scanned - (PRUNING_DEPTH - 1), stable_height);
+
+        // Seed a minimal account (schema per `add_account_uuids`). The UFVK/UIVK must be
+        // real encoded values because `verify_network_compatibility` parses them when the
+        // migrator opens the database.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+
+        // Seed a single transaction; none of the backfill logic cares about the block
+        // column, only that there is an `id_tx` the note rows can reference.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES (1, :block_range_end, 10)",
+                named_params![":block_range_end": last_scanned + 1],
+            )
+            .unwrap();
+
+        // Tree shards. Shard 0 sits exactly at the stabilization boundary and shard 1 sits
+        // exactly one block above it, so the test fails if `mark_stabilized_notes` picks
+        // either neighbour of `<= stable_height`:
+        //   shard 0: end height == stable_height           (notes here SHOULD stabilize)
+        //   shard 1: end height == stable_height + 1       (notes here should NOT stabilize)
+        //   shard 2: end height NULL                       (notes here should NOT stabilize)
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height,
+                    ":above": stable_height + 1,
+                ],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO orchard_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height,
+                    ":above": stable_height + 1,
+                ],
+            )
+            .unwrap();
+
+        // Sapling seed rows cover every branch of the backfill predicate.
+        // `(commitment_tree_position >> SAPLING_SHARD_HEIGHT)` picks the shard for a given
+        // position.
+        let sapling_pos_shard_0: i64 = 1;
+        let sapling_pos_shard_1: i64 = 1 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_2: i64 = 2 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_99: i64 = 99 << SAPLING_SHARD_HEIGHT; // no shard row
+
+        for (output_index, position, _label) in [
+            (0, Some(sapling_pos_shard_0), "shard at boundary"),
+            (
+                1,
+                Some(sapling_pos_shard_1),
+                "shard one block above boundary",
+            ),
+            (2, Some(sapling_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(sapling_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO sapling_received_notes (
+                         transaction_id, output_index, account_id,
+                         diversifier, value, rcm, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :output_index, 1, X'00', 0, X'00', 0, :position)",
+                    named_params![
+                        ":output_index": output_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        let orchard_pos_shard_0: i64 = 3;
+        let orchard_pos_shard_1: i64 = 1 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_2: i64 = 2 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_99: i64 = 99 << ORCHARD_SHARD_HEIGHT;
+
+        for (action_index, position, _label) in [
+            (0, Some(orchard_pos_shard_0), "shard at boundary"),
+            (
+                1,
+                Some(orchard_pos_shard_1),
+                "shard one block above boundary",
+            ),
+            (2, Some(orchard_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(orchard_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO orchard_received_notes (
+                         transaction_id, action_index, account_id,
+                         diversifier, value, rho, rseed, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :action_index, 1, X'00', 0, X'00', X'00', 0, :position)",
+                    named_params![
+                        ":action_index": action_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let read = |table: &str, key_col: &str| -> Vec<(i64, i64)> {
+            let mut stmt = db_data
+                .conn
+                .prepare(&format!(
+                    "SELECT {key_col}, witness_stabilized FROM {table} ORDER BY {key_col}"
+                ))
+                .unwrap();
+            let rows: Vec<(i64, i64)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            rows
+        };
+
+        // Only output 0 (shard exactly at the boundary) should have been stabilized; output
+        // 1 (shard one block above the boundary) must NOT be, which catches an off-by-one
+        // in either direction.
+        assert_eq!(
+            read("sapling_received_notes", "output_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "sapling backfill should stabilize only the note whose shard's \
+             subtree_end_height <= stable_height and whose commitment_tree_position \
+             maps to that shard",
+        );
+
+        assert_eq!(
+            read("orchard_received_notes", "action_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "orchard backfill must match the sapling behavior",
+        );
+    }
+
+    /// When no rows have been inserted into `scan_queue`, the `MAX(...)` subquery returns
+    /// `NULL`; the migration must treat this as a no-op and not stabilize any notes — even
+    /// ones whose shards have finite `subtree_end_height` values.
+    #[test]
+    fn migrate_empty_scan_queue_is_noop() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_received_notes (
+                     transaction_id, output_index, account_id,
+                     diversifier, value, rcm, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let stabilized: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT witness_stabilized FROM sapling_received_notes WHERE output_index = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stabilized, 0,
+            "empty scan_queue must cause the backfill to be a no-op",
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -25,11 +25,10 @@ use crate::{
 use super::common::table_constants;
 use super::wallet_birthday;
 
-#[cfg(feature = "orchard")]
-use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
 #[cfg(not(feature = "orchard"))]
 use zcash_protocol::PoolType;
+
+use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
 pub(crate) fn priority_code(priority: &ScanPriority) -> i64 {
     use ScanPriority::*;
@@ -369,6 +368,57 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         .chain(extended_after);
 
     replace_queue_entries::<SqliteClientError>(conn, &query_range, replacement, false)?;
+
+    // Mark any notes whose containing shard has now been confirmed beyond the pruning depth.
+    let last_scanned_height = range.end - 1;
+    mark_stabilized_notes(conn, last_scanned_height)?;
+
+    Ok(())
+}
+
+/// Marks notes as stabilized when their containing shard is complete and the shard's end
+/// height lies at or below the truncation rewind boundary
+/// (`last_scanned_height - (PRUNING_DEPTH - 1)`). Once stabilized, a note's witness data is
+/// considered durable and will be preserved across truncation.
+pub(crate) fn mark_stabilized_notes(
+    conn: &rusqlite::Transaction<'_>,
+    last_scanned_height: BlockHeight,
+) -> Result<(), SqliteClientError> {
+    let stable_height = u32::from(last_scanned_height).saturating_sub(PRUNING_DEPTH - 1);
+
+    conn.execute(
+        &format!(
+            "UPDATE sapling_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM sapling_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            SAPLING_SHARD_HEIGHT,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
+
+    conn.execute(
+        &format!(
+            "UPDATE orchard_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM orchard_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            ORCHARD_SHARD_HEIGHT,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR modifies truncation to respect the `PRUNING_DEPTH`, adds a `witness_stabilized` flag to notes, and modifies note selection criteria to use that flag in place of chain data, to allow using notes even during truncation.

Truncation will still reset the scan queue to the requested height, but other chain data will only be rewound as far back as the pruning depth. This ensures that any witness data necessary to spend a transaction will be available up to `tip - PRUNING_DEPTH`. Notes after the pruning depth will trivially become spendable as the wallet need only scan the most recent blocks to recover the remaining witness data up to the tip.

Resolves: https://github.com/zcash/librustzcash/issues/2276
Resolves: [COR-1192](https://linear.app/zodl/issue/COR-1192/featzcash-client-sqlite-retain-stable-witness-data-during-truncation)