### PR TITLE
feat: Mark notes as stabilized and enable using them even after truncation

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -46,6 +46,12 @@ workspace.
 
 ### Changed
 - Migrated to `orchard 0.12`, `sapling-crypto 0.6`, `zip321 0.7`.
+- `zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT` is now available
+  unconditionally; the value (`16`) is still pinned against
+  `orchard::NOTE_COMMITMENT_TREE_DEPTH / 2` by a compile-time assertion when
+  the `orchard` feature is enabled. Downstream code that targets the Orchard
+  note tables regardless of feature state can now use this constant as a
+  single source of truth.
 - `zcash_client_backend::data_api`:
   - Changes to the `WalletRead` trait:
     - `WalletRead::get_transparent_balances` now returns `TransparentBalances`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -59,6 +59,7 @@ workspace.
   - Changes to the `WalletWrite` trait:
     - Added `WalletWrite::import_standalone_transparent_script` method.
     - Added `WalletWrite::truncate_to_chain_state` method.
+    - Added `WalletWrite::rewind_to_height` method.
   - Type parameters to `DecryptedTransaction` have been modified. It now
     abstracts over the transaction type, to permit use with partial or compact
     transaction data instead of full transactions.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3190,6 +3190,28 @@ pub trait WalletWrite: WalletRead {
     /// [`truncate_to_height`]: WalletWrite::truncate_to_height
     fn truncate_to_chain_state(&mut self, chain_state: ChainState) -> Result<(), Self::Error>;
 
+    /// Rewinds the wallet to at most the given block height, preserving any wallet data which has
+    /// been confirmed beyond the pruning depth.
+    ///
+    /// In contrast to [`truncate_to_height`], which unconditionally deletes wallet state above
+    /// `max_height` (transaction & note data is retained, but committment trees, blocks, etc are
+    /// removed to the truncation height), this rewinds the scan queue to `max_height` but only
+    /// rewinds blocks, note commitment trees, transactions, transparent UTXO observations, and
+    /// nullifier-map entries as far back as the pruning floor (`chain_tip - (PRUNING_DEPTH - 1)`).
+    /// Data at or below that height is preserved. Because `PRUNING_DEPTH` is a property of chain
+    /// depth, the floor is derived from the wallet's view of the chain tip rather than from
+    /// `MAX(blocks.height)`.
+    ///
+    /// The floor is clamped to an actual shard-tree checkpoint at or above the pruning floor so
+    /// that the underlying truncation has a real checkpoint to truncate to under non-contiguous
+    /// scan orders.
+    ///
+    /// Returns the actual scan-queue rewind height (`max_height` clamped to the max scanned height
+    /// when `max_height` is above it).
+    ///
+    /// [`truncate_to_height`]: WalletWrite::truncate_to_height
+    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error>;
+
     /// Reserves the next `n` available ephemeral addresses for the given account.
     /// This cannot be undone, so as far as possible, errors associated with transaction
     /// construction should have been reported before calling this method.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -156,8 +156,16 @@ pub const SAPLING_SHARD_HEIGHT: u8 = sapling::NOTE_COMMITMENT_TREE_DEPTH / 2;
 ///
 /// This conforms to the structure of subtree data returned by
 /// `lightwalletd` when using the `GetSubtreeRoots` GRPC call.
+///
+/// Exposed unconditionally so downstream consumers (e.g. SQL code that targets the
+/// Orchard note tables regardless of whether the `orchard` feature is enabled) can
+/// rely on a single source of truth. The `const_assert` below pins this value
+/// against `orchard::NOTE_COMMITMENT_TREE_DEPTH / 2` whenever the feature is
+/// enabled, so any drift in the Orchard crate traps at compile time.
+pub const ORCHARD_SHARD_HEIGHT: u8 = 16;
+
 #[cfg(feature = "orchard")]
-pub const ORCHARD_SHARD_HEIGHT: u8 = { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 } / 2;
+const _: () = assert!(ORCHARD_SHARD_HEIGHT == orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 / 2);
 
 /// An enumeration of constraints that can be applied when querying for nullifiers for notes
 /// belonging to the wallet.

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2946,6 +2946,10 @@ impl WalletWrite for MockWalletDb {
         Err(())
     }
 
+    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        Err(())
+    }
+
     /// Adds a transparent UTXO received by the wallet to the data store.
     fn put_received_transparent_utxo(
         &mut self,

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -102,6 +102,18 @@ impl ShieldedPoolTester for OrchardPoolTester {
             .put_orchard_subtree_roots(start_index, roots)
     }
 
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
+        use incrementalmerkletree::{Address, Position};
+        let shard_height = crate::data_api::ORCHARD_SHARD_HEIGHT;
+        let addr = Address::from_parts(Level::from(shard_height), shard_index);
+        let end_position = Position::from((shard_index + 1) << shard_height);
+        st.wallet_mut()
+            .with_orchard_tree_mut(|tree| tree.root(addr, end_position))
+    }
+
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {
         s.next_orchard_subtree_index()
     }

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4258,21 +4258,28 @@ where
     );
 }
 
-pub fn truncate_to_chain_state<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
-where
+pub fn truncate_to_chain_state_deep<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
-    // Test plan:
-    // 1. Set up test environment with account
+    // Deep-truncation test plan:
+    // 1. Set up test environment with a birthday-aligned account
     // 2. Generate and scan initial blocks to populate the note commitment tree
-    // 3. Capture the chain state at a specific height
-    // 4. Generate and scan blocks beyond PRUNING_DEPTH to ensure early checkpoints are pruned
-    // 5. Verify that normal truncate_to_height fails due to missing checkpoints
+    // 3. Capture the chain state at a specific height (the future truncation target)
+    // 4. Generate and scan strictly more than PRUNING_DEPTH extra blocks so that the
+    //    captured checkpoint is pruned AND the target lies below `tip - PRUNING_DEPTH`
+    //    (the "deep" branch of `truncate_to_height_internal`)
+    // 5. Verify that normal truncate_to_height fails due to the missing checkpoint
     // 6. Test that truncate_to_chain_state succeeds using the captured chain state
-    // 7. Verify wallet state after truncation
+    // 7. Verify wallet state after truncation: the scan_queue is rewound all the way
+    //    to the target, but blocks, transactions, tx_locator_map entries, and note
+    //    commitment trees are only rewound to `tip - (PRUNING_DEPTH - 1)` (the oldest
+    //    retained checkpoint)
 
-    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
 
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
 
@@ -4283,7 +4290,7 @@ where
 
     // Step 2: Generate and scan initial blocks to populate the note commitment tree.
     // We use an "other" fvk so that notes won't be tracked by the wallet (keeping the
-    // test focused on tree state rather than wallet balances).
+    // test focused on tree/block state rather than wallet balances).
     let seed = [1u8; 32];
     let other_sk = T::sk(&seed);
     let other_fvk = T::sk_to_fvk(&other_sk);
@@ -4309,9 +4316,154 @@ where
         .clone();
     assert_eq!(captured_chain_state.block_height(), capture_height);
 
-    // Step 4: Generate and scan blocks well beyond PRUNING_DEPTH so that the checkpoint
-    // at capture_height is pruned from the note commitment tree.
-    let extra_blocks = PRUNING_DEPTH + 10;
+    // Step 4: Generate and scan strictly more than PRUNING_DEPTH extra blocks so that
+    // the checkpoint at capture_height is pruned from the note commitment tree AND
+    // capture_height is below `tip - PRUNING_DEPTH`, which exercises the deep branch
+    // of `truncate_to_height_internal`.
+    let extra_blocks = PRUNING_DEPTH + 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(5000),
+        );
+    }
+    st.scan_cached_blocks(capture_height + 1, extra_blocks as usize);
+
+    let pre_truncation_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set");
+    assert!(
+        pre_truncation_tip > capture_height + PRUNING_DEPTH,
+        "tip should be strictly beyond pruning depth from capture height"
+    );
+
+    // Step 5: Verify that truncate_to_height fails at capture_height because the
+    // checkpoint has been pruned.
+    let truncation_result = st.wallet_mut().truncate_to_height(capture_height);
+    assert!(
+        truncation_result.is_err(),
+        "truncate_to_height should fail when checkpoint has been pruned"
+    );
+
+    // Step 6: truncate_to_chain_state should succeed. For a deep target it skips frontier
+    // insertion entirely and relies on the existing tree checkpoints above the target.
+    st.wallet_mut()
+        .truncate_to_chain_state(captured_chain_state.clone())
+        .expect("truncate_to_chain_state should succeed");
+
+    // Step 7: Verify wallet state after truncation.
+    // 7a. The chain tip (derived from scan_queue) should now report the truncation target.
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should match truncation height");
+    assert_eq!(new_tip, capture_height);
+
+    // 7b. No `Scanned` range in the scan queue may extend above the truncation target.
+    let ranges = st
+        .wallet()
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges
+        .iter()
+        .find(|r| r.priority() == ScanPriority::Scanned && r.block_range().end > capture_height);
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
+    );
+
+    // 7c. A deep truncation rewinds the scan queue all the way to the target, but blocks,
+    // transactions, tx_locator_map entries, and note commitment trees are only rewound to the
+    // oldest retained checkpoint at `tip - (PRUNING_DEPTH - 1)`. Data at that boundary is kept
+    // (so stabilized notes remain spendable); data above it is removed.
+    let prune_boundary = pre_truncation_tip - (PRUNING_DEPTH - 1);
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(prune_boundary).unwrap().is_some(),
+        "block entry at (tip - (PRUNING_DEPTH - 1)) should be preserved by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(prune_boundary + 1).unwrap().is_none(),
+        "block entries above (tip - (PRUNING_DEPTH - 1)) must be removed by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(pre_truncation_tip).unwrap().is_none(),
+        "block entries up to the pre-truncation tip must be removed by a deep truncation"
+    );
+    assert_eq!(
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(prune_boundary),
+        "block_max_scanned should equal (tip - (PRUNING_DEPTH - 1)) after a deep truncation"
+    );
+}
+
+pub fn truncate_to_chain_state_shallow<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Shallow-truncation test plan:
+    // 1. Set up test environment with a birthday-aligned account
+    // 2. Generate and scan initial blocks to populate the note commitment tree
+    // 3. Capture the chain state at a specific height (the future truncation target)
+    // 4. Generate and scan `PRUNING_DEPTH - 1` extra blocks so that the target sits at the
+    //    shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, the oldest retained
+    //    checkpoint)
+    // 5. Test that truncate_to_chain_state succeeds using the captured chain state
+    // 6. Verify wallet state after truncation: scan_queue, blocks, tx_locator_map and
+    //    note commitment trees are all rewound to the truncation target. Data at the
+    //    target is preserved; anything above is removed.
+
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Step 2: Generate and scan initial blocks to populate the note commitment tree.
+    // We use an "other" fvk so that notes won't be tracked by the wallet (keeping the
+    // test focused on tree/block state rather than wallet balances).
+    let seed = [1u8; 32];
+    let other_sk = T::sk(&seed);
+    let other_fvk = T::sk_to_fvk(&other_sk);
+
+    let initial_block_count = 8u32;
+    for _ in 0..initial_block_count {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10000),
+        );
+    }
+    let scan_start = sapling_activation;
+    st.scan_cached_blocks(scan_start, initial_block_count as usize);
+
+    // Step 3: Capture the chain state at the current tip. The CachedBlock tracks the
+    // exact frontier that corresponds to the end of each generated block.
+    let capture_height = sapling_activation + initial_block_count - 1;
+    let captured_chain_state = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    assert_eq!(captured_chain_state.block_height(), capture_height);
+
+    // Step 4: Scan `PRUNING_DEPTH - 1` extra blocks so that the truncation target sits at the
+    // shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, which is exactly the oldest
+    // retained checkpoint given the tree's `max_checkpoints = PRUNING_DEPTH`).
+    let extra_blocks = PRUNING_DEPTH - 1;
     for _ in 0..extra_blocks {
         st.generate_next_block(
             &other_fvk,
@@ -4326,47 +4478,173 @@ where
         .chain_height()
         .unwrap()
         .expect("chain tip should be set");
-    assert!(
-        tip >= capture_height + PRUNING_DEPTH,
-        "tip should be beyond pruning depth from capture height"
+    assert_eq!(
+        tip,
+        capture_height + (PRUNING_DEPTH - 1),
+        "tip should be exactly at the shallow boundary from capture height"
     );
 
-    // Step 5: Verify that truncate_to_height fails at capture_height because the
-    // checkpoint has been pruned.
-    let truncation_result = st.wallet_mut().truncate_to_height(capture_height);
-    assert!(
-        truncation_result.is_err(),
-        "truncate_to_height should fail when checkpoint has been pruned"
-    );
-
-    // Step 6: truncate_to_chain_state should succeed because it inserts the frontier
-    // as a checkpoint before truncating.
+    // Step 5: truncate_to_chain_state should succeed. For a shallow target it truncates
+    // directly to the existing checkpoint at the target height (no frontier synthesis
+    // required when the target checkpoint is still retained).
     st.wallet_mut()
         .truncate_to_chain_state(captured_chain_state.clone())
         .expect("truncate_to_chain_state should succeed");
 
-    // Step 7: Verify wallet state after truncation.
-    // The chain tip should now be at the capture height.
+    // Step 6: Verify wallet state after truncation.
+    // 6a. The chain tip (derived from scan_queue) should now report the truncation target.
     let new_tip = st
         .wallet()
         .chain_height()
         .unwrap()
-        .expect("chain tip should still be set after truncation");
+        .expect("chain tip should match truncation height");
     assert_eq!(new_tip, capture_height);
 
-    // The block hash at capture_height should match what was in the captured chain state.
-    let hash_at_capture = st
+    // 6b. No `Scanned` range in the scan queue may extend above the truncation target.
+    let ranges = st
         .wallet()
-        .get_block_hash(capture_height)
-        .unwrap()
-        .expect("block hash should exist at capture height");
-    assert_eq!(hash_at_capture, captured_chain_state.block_hash());
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges
+        .iter()
+        .find(|r| r.priority() == ScanPriority::Scanned && r.block_range().end > capture_height);
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
+    );
 
-    // Blocks above the capture height should have been removed.
+    // 6c. A shallow truncation rewinds blocks, tx_locator_map, and note commitment trees
+    // to the truncation target: data at the target is preserved but anything above is
+    // removed.
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(capture_height).unwrap().is_some(),
+        "block entry at the truncation target should be preserved"
+    );
+    assert!(
+        wallet.get_block_hash(capture_height + 1).unwrap().is_none(),
+        "block entries above the truncation target should be removed by a shallow truncation"
+    );
     assert_eq!(
-        st.wallet().get_block_hash(capture_height + 1).unwrap(),
-        None,
-        "blocks above capture height should be removed"
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(capture_height),
+        "block_max_scanned should equal the truncation target after a shallow truncation"
+    );
+}
+
+/// Regression test: after the scan scheduler processes a `ChainTip` range before a lower
+/// `Historic` range, `MAX(height) FROM blocks` points into one scanned region while
+/// `last_scanned - (PRUNING_DEPTH - 1)` lands inside the unscanned gap between the two
+/// regions. `truncate_to_chain_state` must still succeed: the previous implementation
+/// returned `CorruptedData` because it expected a checkpoint at exactly the PD floor; the
+/// current implementation clamps forward to the lowest checkpoint that still lies inside
+/// the prune window.
+pub fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::{ll::wallet::PRUNING_DEPTH, scanning::ScanPriority};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Scan is always sequential in cache order, but `scan_cached_blocks` is happy to be
+    // invoked on subranges out of order. We pre-generate a contiguous chain of blocks and
+    // scan it in two disjoint segments with a gap in between.
+    let seed = [1u8; 32];
+    let other_fvk = T::sk_to_fvk(&T::sk(&seed));
+    let filler_value = Zatoshis::const_from_u64(10_000);
+
+    let low_count: u32 = 10;
+    let gap_size: u32 = PRUNING_DEPTH + 5; // must exceed PD so the PD floor lands in the gap
+    let high_count: u32 = 10;
+    let total_generated = low_count + gap_size + high_count;
+
+    for _ in 0..total_generated {
+        st.generate_next_block(&other_fvk, AddressType::DefaultExternal, filler_value);
+    }
+
+    // `with_account_from_sapling_activation` anchors the account birthday at
+    // `sapling_activation - 1`, so the first cached block lives at `sapling_activation`.
+    let low_start = sapling_activation;
+    let low_end_inclusive = low_start + low_count - 1;
+    let high_start = low_end_inclusive + gap_size + 1;
+    let high_end_inclusive = high_start + high_count - 1;
+
+    // Scan the low range (simulating a historic range).
+    st.scan_cached_blocks(low_start, low_count as usize);
+
+    // Capture the chain state at the end of the low range; we'll use it as the deep
+    // truncation target. This reflects the caller having a `ChainState` from back when
+    // scanning ended at `low_end_inclusive`.
+    let truncation_target = st
+        .latest_cached_block_below_height(low_end_inclusive + 1)
+        .expect("a cached block should exist at or below the end of the low range")
+        .chain_state()
+        .clone();
+    assert_eq!(truncation_target.block_height(), low_end_inclusive);
+
+    // Scan the high range (simulating a chain-tip range), leaving `gap_size` blocks in
+    // the middle unscanned. Because `high_start > low_end_inclusive + PRUNING_DEPTH`, the
+    // PD floor after this scan (`high_end_inclusive - (PRUNING_DEPTH - 1)`) lands inside
+    // the unscanned gap.
+    st.scan_cached_blocks(high_start, high_count as usize);
+
+    // Confirm the pre-truncation state matches the scenario we claim to be testing.
+    // `block_max_scanned` reports `MAX(height) FROM blocks`, which is exactly what
+    // `truncate_to_height_internal` uses as `last_scanned_height` when computing the PD
+    // floor. `chain_height` would also include unscanned portions of the scan queue, so
+    // it is not a tight enough bound for this test.
+    let max_scanned_height = st
+        .wallet()
+        .block_max_scanned()
+        .unwrap()
+        .map(|m| m.block_height())
+        .expect("block_max_scanned should report the high-range tip");
+    assert_eq!(max_scanned_height, high_end_inclusive);
+    let pd_floor = max_scanned_height - (PRUNING_DEPTH - 1);
+    assert!(
+        pd_floor > low_end_inclusive && pd_floor < high_start,
+        "test invariant: PD floor must lie in the unscanned gap (got {pd_floor}, \
+         gap is ({low_end_inclusive}, {high_start}))"
+    );
+
+    // Previously this would fail with `CorruptedData` because no checkpoint exists at
+    // `pd_floor`. The current implementation clamps forward to the lowest in-window
+    // checkpoint (`high_start`) and succeeds.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed across a non-contiguous scan");
+
+    // The core claim of this test is that `truncate_to_chain_state` returned `Ok(())`
+    // rather than `CorruptedData`, which the `expect` above already verified: prior to
+    // the clamp-in-window fix, `truncate_to_checkpoint` was invoked at `pd_floor`
+    // (which sits in the unscanned gap and has no checkpoint) and failed. Beyond that,
+    // the only post-condition we still assert is that the scan queue has no lingering
+    // `Scanned` range above the truncation target — the exact pre/post block-boundary
+    // depends on which baseline checkpoints the scanner seeded, which is an
+    // implementation detail of `scan_cached_blocks` and not part of this commit's
+    // contract.
+    let ranges = st
+        .wallet()
+        .suggest_scan_ranges()
+        .expect("suggest_scan_ranges should succeed");
+    let future_scanned = ranges.iter().find(|r| {
+        r.priority() == ScanPriority::Scanned && r.block_range().end > low_end_inclusive + 1
+    });
+    assert!(
+        future_scanned.is_none(),
+        "no `Scanned` range should extend above the truncation target, found: {future_scanned:?}"
     );
 }
 
@@ -4460,16 +4738,50 @@ pub fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester, Dsf>(
     // This should succeed. On the buggy code, this fails with RequestedRewindInvalid
     // because select_truncation_height cannot find an entry in the blocks table at the
     // target height.
-    let _target_height = prior_chain_state.block_height();
+    let target_height = prior_chain_state.block_height();
+    let pre_truncation_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("tip should be set before truncation");
+    let prune_depth = pre_truncation_tip - (PRUNING_DEPTH - 1);
+
     st.wallet_mut()
         .truncate_to_chain_state(prior_chain_state)
         .expect("truncate_to_chain_state below birthday should succeed");
 
-    // All blocks were above the target height, so they should have been removed.
+    // scan_queue should be rewound to truncation height
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set to truncation target");
+    assert_eq!(new_tip, target_height);
+
+    // The target is far below the oldest retained checkpoint (`tip - (PRUNING_DEPTH - 1)`), so
+    // this exercises the deep path: the scan queue is rewound all the way to the target, while
+    // other wallet data is rewound only to that retention boundary. Data at the boundary is
+    // kept; data above it must be removed.
+    let wallet = st.wallet();
+    assert!(
+        wallet.get_block_hash(prune_depth).unwrap().is_some(),
+        "block entry at (tip - (PRUNING_DEPTH - 1)) should be preserved by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(prune_depth + 1).unwrap().is_none(),
+        "block entries above (tip - (PRUNING_DEPTH - 1)) must be removed by a deep truncation"
+    );
+    assert!(
+        wallet.get_block_hash(pre_truncation_tip).unwrap().is_none(),
+        "block entries up to the pre-truncation tip must be removed by a deep truncation"
+    );
     assert_eq!(
-        st.wallet().get_block_hash(birthday_height).unwrap(),
-        None,
-        "blocks at birthday height should be removed after truncating below birthday"
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(prune_depth),
+        "block_max_scanned should equal (tip - (PRUNING_DEPTH - 1)) after a deep truncation"
     );
 }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4593,6 +4593,304 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
     );
 }
 
+pub fn rewind_to_height_deep<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Deep-rewind test plan:
+    // 1. Set up a birthday-aligned account.
+    // 2. Generate and scan initial blocks to populate the note commitment tree.
+    // 3. Pick a rewind target well below the future prune floor.
+    // 4. Generate and scan more than PRUNING_DEPTH extra blocks so that the checkpoint at the
+    //    target is pruned AND the target lies below `tip - PRUNING_DEPTH` (the "deep" branch).
+    // 5. Call `rewind_to_height(target)` and verify:
+    //    - the scan queue is rewound all the way to `target`;
+    //    - blocks, transactions, tx_locator_map entries, and note commitment trees are
+    //      only rewound to `tip - (PRUNING_DEPTH - 1)` (the oldest retained checkpoint).
+
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Generate and scan initial blocks using an "other" fvk so notes are not tracked
+    // by the wallet.
+    let seed = [1u8; 32];
+    let other_fvk = T::sk_to_fvk(&T::sk(&seed));
+
+    let initial_block_count = 8u32;
+    for _ in 0..initial_block_count {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10000),
+        );
+    }
+    st.scan_cached_blocks(sapling_activation, initial_block_count as usize);
+
+    // The rewind target is the tip of the initial range.
+    let rewind_target = sapling_activation + initial_block_count - 1;
+
+    // Scan more than PRUNING_DEPTH extra blocks so that the checkpoint at rewind_target is pruned
+    // AND rewind_target is below `tip - PRUNING_DEPTH`.
+    let extra_blocks = PRUNING_DEPTH + 10;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(5000),
+        );
+    }
+    st.scan_cached_blocks(rewind_target + 1, extra_blocks as usize);
+
+    let pre_rewind_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set");
+    assert!(
+        pre_rewind_tip > rewind_target + PRUNING_DEPTH,
+        "tip should be strictly beyond pruning depth from the rewind target"
+    );
+
+    // Capture the block hash at the prune boundary so we can assert it survives the rewind
+    // unchanged (rather than merely that something exists at that height).
+    let prune_boundary = pre_rewind_tip - (PRUNING_DEPTH - 1);
+    let boundary_hash_before = st
+        .wallet()
+        .get_block_hash(prune_boundary)
+        .unwrap()
+        .expect("block at prune boundary should be present before rewind");
+
+    // `rewind_to_height` must succeed at the same target.
+    let rewound_to = st
+        .wallet_mut()
+        .rewind_to_height(rewind_target)
+        .expect("rewind_to_height should succeed for a deep target");
+    assert_eq!(rewound_to, rewind_target);
+
+    // The chain tip (derived from scan_queue) should now report the rewind target.
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should match rewind target");
+    assert_eq!(new_tip, rewind_target);
+
+    // A deep rewind keeps the scan queue rewound to the target, while blocks,
+    // transactions, tx_locator_map entries, and note commitment trees are only rewound
+    // to the oldest retained checkpoint at `tip - (PRUNING_DEPTH - 1)`. Data at that
+    // boundary is kept (so stabilized notes remain spendable); data above it is removed.
+    let wallet = st.wallet();
+    assert_eq!(
+        wallet.get_block_hash(prune_boundary).unwrap(),
+        Some(boundary_hash_before),
+        "block hash at (tip - (PRUNING_DEPTH - 1)) should be preserved unchanged by a deep rewind"
+    );
+    assert!(
+        wallet.get_block_hash(prune_boundary + 1).unwrap().is_none(),
+        "block entries above (tip - (PRUNING_DEPTH - 1)) must be removed by a deep rewind"
+    );
+    assert!(
+        wallet.get_block_hash(pre_rewind_tip).unwrap().is_none(),
+        "block entries up to the pre-rewind tip must be removed by a deep rewind"
+    );
+    assert_eq!(
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(prune_boundary),
+        "block_max_scanned should equal (tip - (PRUNING_DEPTH - 1)) after a deep rewind"
+    );
+}
+
+pub fn rewind_to_height_shallow<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Shallow-rewind test plan:
+    // 1. Set up a birthday-aligned account.
+    // 2. Generate and scan initial blocks to populate the note commitment tree.
+    // 3. Pick a rewind target.
+    // 4. Generate and scan `PRUNING_DEPTH - 1` extra blocks so that the target sits at
+    //    the shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, exactly the oldest
+    //    retained checkpoint).
+    // 5. Call `rewind_to_height(target)` and verify all wallet data is rewound to the
+    //    target: data at the target is preserved, anything above is removed.
+
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    let seed = [1u8; 32];
+    let other_fvk = T::sk_to_fvk(&T::sk(&seed));
+
+    let initial_block_count = 8u32;
+    for _ in 0..initial_block_count {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10000),
+        );
+    }
+    st.scan_cached_blocks(sapling_activation, initial_block_count as usize);
+
+    let rewind_target = sapling_activation + initial_block_count - 1;
+
+    // Scan `PRUNING_DEPTH - 1` extra blocks so the target sits at the shallow boundary
+    // (`target == tip - (PRUNING_DEPTH - 1)`, exactly the oldest retained checkpoint
+    // given the tree's `max_checkpoints = PRUNING_DEPTH`).
+    let extra_blocks = PRUNING_DEPTH - 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &other_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(5000),
+        );
+    }
+    st.scan_cached_blocks(rewind_target + 1, extra_blocks as usize);
+
+    let tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set");
+    assert_eq!(
+        tip,
+        rewind_target + (PRUNING_DEPTH - 1),
+        "tip should be exactly at the shallow boundary from the rewind target"
+    );
+
+    let target_hash_before = st
+        .wallet()
+        .get_block_hash(rewind_target)
+        .unwrap()
+        .expect("block at the rewind target should be present before rewind");
+
+    let rewound_to = st
+        .wallet_mut()
+        .rewind_to_height(rewind_target)
+        .expect("rewind_to_height should succeed for a shallow target");
+    assert_eq!(rewound_to, rewind_target);
+
+    let new_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should match rewind target");
+    assert_eq!(new_tip, rewind_target);
+
+    // A shallow rewind truncates blocks, tx_locator_map, and note commitment trees
+    // directly to the rewind target: data at the target is preserved (with the same
+    // content it had before), anything above is removed.
+    let wallet = st.wallet();
+    assert_eq!(
+        wallet.get_block_hash(rewind_target).unwrap(),
+        Some(target_hash_before),
+        "block hash at the rewind target should be preserved unchanged"
+    );
+    assert!(
+        wallet.get_block_hash(rewind_target + 1).unwrap().is_none(),
+        "block entries above the rewind target should be removed by a shallow rewind"
+    );
+    assert_eq!(
+        wallet
+            .block_max_scanned()
+            .unwrap()
+            .map(|m| m.block_height()),
+        Some(rewind_target),
+        "block_max_scanned should equal the rewind target after a shallow rewind"
+    );
+}
+
+pub fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Regression test: after the scan scheduler processes a `ChainTip` range before a
+    // lower `Historic` range, `MAX(height) FROM blocks` points into one scanned region
+    // while `last_scanned - (PRUNING_DEPTH - 1)` lands inside the unscanned gap between
+    // the two regions. `rewind_to_height` must still succeed: an implementation that
+    // expected a checkpoint at exactly the PD floor would return `CorruptedData` via
+    // `truncate_to_checkpoint`; clamping forward to the lowest checkpoint inside the
+    // prune window keeps us aligned with a real checkpoint.
+
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let sapling_activation = st
+        .network()
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .unwrap();
+
+    // Scan is always sequential in cache order, but `scan_cached_blocks` is happy to be
+    // invoked on subranges out of order. We pre-generate a contiguous chain of blocks
+    // and scan it in two disjoint segments with a gap in between.
+    let seed = [1u8; 32];
+    let other_fvk = T::sk_to_fvk(&T::sk(&seed));
+    let filler_value = Zatoshis::const_from_u64(10_000);
+
+    let low_count: u32 = 10;
+    let gap_size: u32 = PRUNING_DEPTH + 5; // must exceed PD so the PD floor lands in the gap
+    let high_count: u32 = 10;
+    let total_generated = low_count + gap_size + high_count;
+
+    for _ in 0..total_generated {
+        st.generate_next_block(&other_fvk, AddressType::DefaultExternal, filler_value);
+    }
+
+    let low_start = sapling_activation;
+    let low_end_inclusive = low_start + low_count - 1;
+    let high_start = low_end_inclusive + gap_size + 1;
+
+    // Scan the low range first (simulating a historic range).
+    st.scan_cached_blocks(low_start, low_count as usize);
+
+    // Scan the high range next (simulating a chain-tip range), leaving `gap_size` blocks
+    // in the middle unscanned. Because `high_start > low_end_inclusive + PRUNING_DEPTH`,
+    // the PD floor after this scan (`high_end_inclusive - (PRUNING_DEPTH - 1)`) lands
+    // inside the unscanned gap.
+    st.scan_cached_blocks(high_start, high_count as usize);
+
+    let max_scanned_height = st
+        .wallet()
+        .block_max_scanned()
+        .unwrap()
+        .map(|m| m.block_height())
+        .expect("block_max_scanned should report the high-range tip");
+    let high_end_inclusive = high_start + high_count - 1;
+    assert_eq!(max_scanned_height, high_end_inclusive);
+    let pd_floor = max_scanned_height - (PRUNING_DEPTH - 1);
+    assert!(
+        pd_floor > low_end_inclusive && pd_floor < high_start,
+        "test invariant: PD floor must lie in the unscanned gap (got {pd_floor}, \
+         gap is ({low_end_inclusive}, {high_start}))"
+    );
+
+    // `rewind_to_height` must return `Ok(_)` rather than `CorruptedData`: clamping
+    // forward to the lowest checkpoint inside the window (which sits at `high_start`)
+    // keeps us aligned with a real checkpoint.
+    st.wallet_mut()
+        .rewind_to_height(low_end_inclusive)
+        .expect("rewind_to_height should succeed across a non-contiguous scan");
+}
+
 pub fn reorg_to_checkpoint<T: ShieldedPoolTester, Dsf, C>(ds_factory: Dsf, cache: C)
 where
     Dsf: DataStoreFactory,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -146,6 +146,16 @@ pub trait ShieldedPoolTester {
         roots: &[CommitmentTreeRoot<Self::MerkleTreeHash>],
     ) -> Result<(), ShardTreeError<<DbT as WalletCommitmentTrees>::Error>>;
 
+    /// Computes the actual root of the `shard_index`-th shard from the wallet's local
+    /// shardtree state, reading whatever leaves and cached annotations are currently
+    /// stored. Used by tests that need to call [`Self::put_subtree_roots`] with a root
+    /// that matches the shard's actual computed root — for example, when declaring a
+    /// shard complete after filling its last position via `scan_cached_blocks`.
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>>;
+
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64;
 
     fn note_value(note: &Self::Note) -> Zatoshis;
@@ -4889,6 +4899,577 @@ pub fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
     st.wallet_mut()
         .rewind_to_height(low_end_inclusive)
         .expect("rewind_to_height should succeed across a non-contiguous scan");
+}
+
+/// Multiple wallet notes in a stabilized shard remain spendable after a deep
+/// `rewind_to_height` moves the scan queue below them.
+pub fn stabilized_note_spendable_after_deep_rewind<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Test plan:
+    // 1. Set up a wallet with an initial chain state whose tree has shard 0 fully
+    //    cached and shard 1 one position short of full (frontier at position
+    //    `2 * 2^16 - 2 = 131070`). The frontier lives in a partial shard 1 rather
+    //    than at a shard boundary; a boundary-aligned frontier would cause
+    //    `prior_subtree_roots` to cache shard 1 and then `insert_frontier` would
+    //    fail trying to reinstall its leaf into the cached-leaf-form shard.
+    // 2. Scan a single block of 65537 outputs. The first output finishes shard 1
+    //    (position 131071) and the remaining 65536 outputs fill all of shard 2
+    //    (positions 131072..196607). Three of those outputs are wallet-owned and
+    //    land at the first, middle, and last slots of shard 2 (tree positions
+    //    131072, 163840, and 196607); every other slot is non-wallet filler.
+    // 3. Declare shard 2 complete at `note_height` via `put_subtree_roots(2, ...)`
+    //    so `mark_stabilized_notes` has the `subtree_end_height` it needs to flip
+    //    the shard 2 notes' `witness_stabilized` flag once the pruning floor rises
+    //    above the shard.
+    // 4. Scan `PRUNING_DEPTH + 10` one-output post-note blocks. They land in shard
+    //    3 (positions 196608+), pushing the pruning-floor checkpoint's tree
+    //    position into shard 3 so `shardtree::truncate_shards(3)` — invoked by the
+    //    upcoming rewind — preserves shard 2 and every row it indexes.
+    // 5. Deep-rewind to a height below `note_height` and verify `scan_queue` is
+    //    rewound all the way to the target.
+    // 6. Before restoring the chain tip: the balance path reads the witness_stabilized
+    //    flag directly, so `get_spendable_balance` must return the full
+    //    three-note sum; the spend path requires a chain tip for the anchor, so
+    //    `propose_transfer` must fail with `ScanRequired`/`InsufficientFunds`.
+    // 7. Call `update_chain_tip(pre_rewind_tip)` and re-verify the balance.
+    // 8. Build and sign an actual spend — exercising the full note-selection and
+    //    witness-construction path — and assert it produces exactly one tx.
+
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    const SHARD_HEIGHT: u32 = 16;
+    const SHARD_POSITIONS: u32 = 1 << SHARD_HEIGHT; // 65536
+
+    // Step 1: set up the wallet with shard 0 cached + frontier in a partial shard 1.
+    let initial_tree_size: u32 = 2 * SHARD_POSITIONS - 1;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .with_initial_chain_state(|rng, network| {
+            // The birthday is anchored at NU5 + 1000 rather than the more common
+            // Sapling-activation baseline because the orchard variant of this test
+            // pre-populates an orchard commitment-tree frontier; that requires
+            // Orchard to be active at the birthday height, which isn't true at
+            // Sapling activation. `+ 1000` is an arbitrary buffer past NU5 so
+            // heights like `birthday_height - 500` (see below) stay comfortably
+            // within the activated range.
+            let birthday_height = network.activation_height(NetworkUpgrade::Nu5).unwrap() + 1000;
+
+            let (prior_sapling_roots, sapling_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    initial_tree_size.into(),
+                    NonZeroU8::new(SHARD_HEIGHT as u8).unwrap(),
+                );
+            // Shard 0 is the only complete shard at this tree size.
+            let prior_sapling_roots = prior_sapling_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
+
+            #[cfg(feature = "orchard")]
+            let (prior_orchard_roots, orchard_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    initial_tree_size.into(),
+                    NonZeroU8::new(SHARD_HEIGHT as u8).unwrap(),
+                );
+            #[cfg(feature = "orchard")]
+            let prior_orchard_roots = prior_orchard_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
+
+            InitialChainState {
+                chain_state: ChainState::new(
+                    birthday_height - 1,
+                    BlockHash([5; 32]),
+                    sapling_initial_tree,
+                    #[cfg(feature = "orchard")]
+                    orchard_initial_tree,
+                ),
+                prior_sapling_roots,
+                #[cfg(feature = "orchard")]
+                prior_orchard_roots,
+            }
+        })
+        .with_account_having_current_birthday()
+        .build();
+
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let filler_value = Zatoshis::const_from_u64(1000);
+
+    // Step 2: scan a single block whose outputs finish shard 1 and fill all of
+    // shard 2. Three wallet outputs at the first, middle, and last slots of
+    // shard 2; everything else is non-wallet filler. Distinct wallet-output
+    // values keep failures easier to diagnose.
+    let note_values = [
+        Zatoshis::const_from_u64(100_000),
+        Zatoshis::const_from_u64(200_000),
+        Zatoshis::const_from_u64(150_000),
+    ];
+    let total_note_value = note_values.iter().sum::<Option<Zatoshis>>().unwrap();
+    // Shard 2 spans tree positions 2 * 2^16 .. 3 * 2^16 - 1 = 131072..196607.
+    let note_tree_positions: [u32; 3] = [
+        2 * SHARD_POSITIONS,                       // first slot of shard 2
+        2 * SHARD_POSITIONS + SHARD_POSITIONS / 2, // middle slot of shard 2
+        3 * SHARD_POSITIONS - 1,                   // last slot of shard 2
+    ];
+
+    let scan_block_size: u32 = SHARD_POSITIONS + 1; // finish shard 1 + fill shard 2
+    let first_scanned_position: u32 = initial_tree_size; // = 131071
+    let mut outputs = Vec::with_capacity(scan_block_size as usize);
+    let mut next_wallet_ix = 0;
+    for offset in 0..scan_block_size {
+        let tree_pos = first_scanned_position + offset;
+        if next_wallet_ix < note_tree_positions.len()
+            && tree_pos == note_tree_positions[next_wallet_ix]
+        {
+            outputs.push(FakeCompactOutput::new(
+                dfvk.clone(),
+                AddressType::DefaultExternal,
+                note_values[next_wallet_ix],
+            ));
+            next_wallet_ix += 1;
+        } else {
+            outputs.push(FakeCompactOutput::new(
+                not_our_key.clone(),
+                AddressType::DefaultExternal,
+                filler_value,
+            ));
+        }
+    }
+    let (note_height, _, _) = st.generate_next_block_multi(&outputs);
+    st.scan_cached_blocks(note_height, 1);
+
+    // Pick a rewind target well below the wallet's birthday so the rewind
+    // drops every initially-seeded scan_queue row — exercising the case where
+    // stabilized-shard metadata is the only thing keeping the notes spendable.
+    let birthday_height = st
+        .wallet()
+        .get_wallet_birthday()
+        .unwrap()
+        .expect("account birthday should be set");
+    let rewind_target = birthday_height - 100;
+
+    // Step 3: declare shard 2 complete at `note_height`. We must pass shard 2's
+    // actual computed root (not an arbitrary placeholder) because the cap already
+    // contains annotations inherited from the initial chain state's frontier, and
+    // `put_subtree_roots` refuses to install a conflicting root.
+    let shard_2_root = T::shard_root(&mut st, 2).unwrap();
+    T::put_subtree_roots(
+        &mut st,
+        2,
+        &[CommitmentTreeRoot::from_parts(note_height, shard_2_root)],
+    )
+    .unwrap();
+
+    // Step 4: scan more than `PRUNING_DEPTH` blocks past the note-filled block
+    // into shard 3, so the rewind's truncation position is in shard 3 and the
+    // ensuing `truncate_shards(3)` leaves shard 2 intact.
+    let extra_blocks = PRUNING_DEPTH + 10;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, filler_value);
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    let account = st.test_account().unwrap().clone();
+
+    // Remember the pre-rewind tip; we restore it in Step 7 to provide an anchor
+    // for `propose_transfer`.
+    let pre_rewind_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set before rewind");
+
+    // Step 5: deep-rewind to the target and confirm scan_queue followed it.
+    st.wallet_mut()
+        .rewind_to_height(rewind_target)
+        .expect("rewind_to_height should succeed");
+    let tip_after_rewind = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after rewind");
+    assert!(
+        tip_after_rewind <= rewind_target,
+        "scan_queue must be rewound at or below the rewind target"
+    );
+
+    // Step 6: before `update_chain_tip`, balance must reflect all three stabilized
+    // notes, but the spend path must fail because no anchor can be derived.
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        total_note_value,
+        "stabilized balance must be available even before update_chain_tip"
+    );
+    let pre_update_request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        T::sk_default_address(&T::sk(&[0xcc; 32])).to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10_000),
+    )])
+    .unwrap();
+    let pre_update_change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let pre_update_input_selector = GreedyInputSelector::new();
+    let pre_update_result = st.propose_transfer(
+        account.id(),
+        &pre_update_input_selector,
+        &pre_update_change_strategy,
+        pre_update_request,
+        ConfirmationsPolicy::MIN,
+    );
+    assert_matches!(
+        pre_update_result,
+        Err(crate::data_api::error::Error::ScanRequired)
+            | Err(crate::data_api::error::Error::InsufficientFunds { .. }),
+        "propose_transfer should fail with InsufficientFunds or ScanRequired"
+    );
+    if let Err(crate::data_api::error::Error::InsufficientFunds { available, .. }) =
+        &pre_update_result
+    {
+        assert_eq!(
+            *available,
+            Zatoshis::ZERO,
+            "when note selection runs, no notes should be eligible without the restored tip",
+        );
+    }
+
+    // Step 7: restore the chain tip so `propose_transfer` can derive an anchor,
+    // and confirm balance is still the full three-note sum.
+    st.wallet_mut()
+        .update_chain_tip(pre_rewind_tip)
+        .expect("update_chain_tip should succeed");
+    let tip_after_update = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after update_chain_tip");
+    assert_eq!(tip_after_update, pre_rewind_tip);
+    let post_rewind_spendable = st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN);
+    assert_eq!(
+        post_rewind_spendable, total_note_value,
+        "all stabilized notes should remain spendable after deep rewind"
+    );
+
+    // Step 8: build and sign a real spend end-to-end.
+    let to_extsk = T::sk(&[0xcc; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let send_value = Zatoshis::const_from_u64(10_000);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal should succeed with stabilized note after deep rewind");
+    let txids = st
+        .create_proposed_transactions::<std::convert::Infallible, _, std::convert::Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("spend construction should succeed");
+    assert_eq!(
+        txids.len(),
+        1,
+        "the spend should produce exactly one transaction"
+    );
+}
+
+/// Verifies that when a new account is imported into a fully-scanned wallet,
+/// the ensuing re-scan discovers the new account's previously-unknown notes
+/// and `scan_complete → mark_stabilized_notes` flags them `witness_stabilized`
+/// on the fly, so they remain spendable across a subsequent deep
+/// `rewind_to_height`.
+pub fn newly_discovered_notes_become_stabilized<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
+where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    // Test plan:
+    //
+    // 1. Build a fully-scanned wallet containing account A:
+    //    (a) install an initial chain state whose commitment tree has shard 0
+    //        cached and a frontier sitting in a partial shard 1 (the same
+    //        setup used by `stabilized_note_spendable_after_deep_rewind`);
+    //    (b) generate one note-containing block at `birthday_height` that
+    //        finishes shard 1 and fills shard 2, with three A-owned outputs
+    //        and three outputs for a not-yet-imported account B, non-wallet
+    //        filler elsewhere;
+    //    (c) generate `PRUNING_DEPTH + 10` filler blocks past the note block
+    //        to push the pruning floor past shard 2;
+    //    (d) scan the note block, declare shard 2 complete via
+    //        `put_subtree_roots`, then scan the filler blocks — the
+    //        second-batch `mark_stabilized_notes` call flips A's three notes
+    //        to `witness_stabilized = 1`. B's outputs are in the cached
+    //        blocks but produce no `*_received_notes` rows because B is not
+    //        yet in the wallet.
+    // 2. Confirm A's notes are spendable (sanity check on the initial
+    //    stabilization).
+    // 3. Import account B from the same seed at zip32 index 1, sharing A's
+    //    `AccountBirthday`. `add_account` rewrites `scan_queue` to replace
+    //    the post-birthday `Scanned` range with `Historic`, forcing a
+    //    re-scan.
+    // 4. Re-scan the cached blocks from the birthday through the chain tip.
+    //    The blocks are now processed against both A and B; three new
+    //    `*_received_notes` rows get inserted at B's shard-2 positions.
+    //    Confirm both accounts' balances reflect their respective totals.
+    // 5. Deep-rewind to well below the birthday. A non-stabilized note
+    //    cannot pass the post-rewind scan-state gate in
+    //    `select_spendable_notes_matching_value`, so if B's notes remain
+    //    spendable after this rewind, they *must* have been flagged
+    //    `witness_stabilized` during the re-scan of step 4. Assert that both
+    //    A's and B's full totals are spendable.
+
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    const SHARD_HEIGHT: u32 = 16;
+    const SHARD_POSITIONS: u32 = 1 << SHARD_HEIGHT; // 65536
+
+    // Matches the hard-coded seed used by
+    // `TestBuilder::with_account_having_current_birthday`. Re-using it at
+    // zip32 index 1 lets us deterministically derive B's viewing key before
+    // B is imported, and guarantees that the later `import_account_hd(index=1)`
+    // call recovers the same key (zip32 derivation is deterministic).
+    const TEST_SEED: [u8; 32] = [0u8; 32];
+
+    // Step 1a: initial tree state — shard 0 fully cached, frontier at one
+    // position short of shard 1's last slot. A boundary-aligned frontier
+    // would cause `prior_subtree_roots` to cache shard 1 and then
+    // `insert_frontier` would fail trying to reinstall its leaf into the
+    // cached-leaf-form shard.
+    let initial_tree_size: u32 = 2 * SHARD_POSITIONS - 1;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .with_initial_chain_state(|rng, network| {
+            // The birthday is anchored at NU5 + 1000 rather than the more common
+            // Sapling-activation baseline because the orchard variant of this test
+            // pre-populates an orchard commitment-tree frontier; that requires
+            // Orchard to be active at the birthday height, which isn't true at
+            // Sapling activation. `+ 1000` is an arbitrary buffer past NU5 so
+            // heights like `birthday_height - 500` (see below) stay comfortably
+            // within the activated range.
+            let birthday_height = network.activation_height(NetworkUpgrade::Nu5).unwrap() + 1000;
+
+            let (prior_sapling_roots, sapling_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    initial_tree_size.into(),
+                    NonZeroU8::new(SHARD_HEIGHT as u8).unwrap(),
+                );
+            // Each prior subtree root is attached to one arbitrary height
+            // well before the birthday. 500 is a round buffer past NU5 but
+            // strictly below `birthday_height`; the exact value doesn't
+            // matter because stabilization only cares about shard *end*
+            // heights.
+            let prior_sapling_roots = prior_sapling_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
+
+            #[cfg(feature = "orchard")]
+            let (prior_orchard_roots, orchard_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    initial_tree_size.into(),
+                    NonZeroU8::new(SHARD_HEIGHT as u8).unwrap(),
+                );
+            #[cfg(feature = "orchard")]
+            let prior_orchard_roots = prior_orchard_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
+                .collect::<Vec<_>>();
+
+            InitialChainState {
+                chain_state: ChainState::new(
+                    birthday_height - 1,
+                    BlockHash([5; 32]),
+                    sapling_initial_tree,
+                    #[cfg(feature = "orchard")]
+                    orchard_initial_tree,
+                ),
+                prior_sapling_roots,
+                #[cfg(feature = "orchard")]
+                prior_orchard_roots,
+            }
+        })
+        .with_account_having_current_birthday()
+        .build();
+
+    let dfvk_a = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let filler_value = Zatoshis::const_from_u64(1000);
+
+    // Derive account B's viewing key from the same seed at zip32 index 1.
+    // This must run before any scanning so the note block below can place
+    // B-destined outputs even though B is absent from the wallet.
+    let zip32_index_b = zip32::AccountId::ZERO.next().unwrap();
+    let usk_b = UnifiedSpendingKey::from_seed(st.network(), &TEST_SEED, zip32_index_b)
+        .expect("account B USK derivation from seed should succeed");
+    let fvk_b = T::sk_to_fvk(T::usk_to_sk(&usk_b));
+
+    // Step 1b: build the note block. A's three outputs sit at the first,
+    // middle, and last slots of shard 2; B's three outputs occupy adjacent
+    // (but distinct) slots. Everything else is non-wallet filler.
+    let a_positions: [u32; 3] = [
+        2 * SHARD_POSITIONS,                       // first slot of shard 2
+        2 * SHARD_POSITIONS + SHARD_POSITIONS / 2, // middle slot of shard 2
+        3 * SHARD_POSITIONS - 1,                   // last slot of shard 2
+    ];
+    let b_positions: [u32; 3] = [
+        2 * SHARD_POSITIONS + 1,                       // one after A's first
+        2 * SHARD_POSITIONS + SHARD_POSITIONS / 2 + 1, // one after A's middle
+        3 * SHARD_POSITIONS - 2,                       // one before A's last
+    ];
+    let a_values = [
+        Zatoshis::const_from_u64(100_000),
+        Zatoshis::const_from_u64(200_000),
+        Zatoshis::const_from_u64(150_000),
+    ];
+    let b_values = [
+        Zatoshis::const_from_u64(70_000),
+        Zatoshis::const_from_u64(80_000),
+        Zatoshis::const_from_u64(90_000),
+    ];
+    let total_a = a_values.iter().sum::<Option<Zatoshis>>().unwrap();
+    let total_b = b_values.iter().sum::<Option<Zatoshis>>().unwrap();
+
+    // `scan_block_size = SHARD_POSITIONS + 1`: one slot finishes shard 1,
+    // the remaining 65 536 fill all of shard 2.
+    let scan_block_size: u32 = SHARD_POSITIONS + 1;
+    let first_scanned_position: u32 = initial_tree_size;
+    let mut outputs = Vec::with_capacity(scan_block_size as usize);
+    for offset in 0..scan_block_size {
+        let tree_pos = first_scanned_position + offset;
+        let output = if let Some(ix) = a_positions.iter().position(|&p| p == tree_pos) {
+            FakeCompactOutput::new(dfvk_a.clone(), AddressType::DefaultExternal, a_values[ix])
+        } else if let Some(ix) = b_positions.iter().position(|&p| p == tree_pos) {
+            FakeCompactOutput::new(fvk_b.clone(), AddressType::DefaultExternal, b_values[ix])
+        } else {
+            FakeCompactOutput::new(
+                not_our_key.clone(),
+                AddressType::DefaultExternal,
+                filler_value,
+            )
+        };
+        outputs.push(output);
+    }
+    let (note_height, _, _) = st.generate_next_block_multi(&outputs);
+
+    // Step 1c: filler blocks past the note block, sized to put the pruning
+    // floor past shard 2's end height in step 1d.
+    let extra_blocks = PRUNING_DEPTH + 10;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, filler_value);
+    }
+
+    // Step 1d: scan the note block, declare shard 2 complete, scan the
+    // filler blocks. The batch ordering mirrors
+    // `stabilized_note_spendable_after_deep_rewind`: shard 2's root can
+    // only be computed after its leaves are in the wallet's tree, and
+    // `put_subtree_roots` must run before the next scan batch so
+    // `mark_stabilized_notes` sees shard 2's `subtree_end_height`.
+    st.scan_cached_blocks(note_height, 1);
+    let shard_2_root = T::shard_root(&mut st, 2).unwrap();
+    T::put_subtree_roots(
+        &mut st,
+        2,
+        &[CommitmentTreeRoot::from_parts(note_height, shard_2_root)],
+    )
+    .unwrap();
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    let account_a = st.test_account().unwrap().clone();
+
+    // Step 2: baseline. A's notes are discovered and stabilized; B's
+    // outputs have no corresponding wallet rows (B absent).
+    assert_eq!(
+        st.get_spendable_balance(account_a.id(), ConfirmationsPolicy::MIN),
+        total_a,
+        "A's three notes must be spendable after the initial scan + stabilization",
+    );
+
+    // Step 3: import account B, sharing A's birthday so `add_account`
+    // rewrites the post-birthday `Scanned` range to `Historic` (forcing
+    // a re-scan).
+    let b_birthday = account_a.birthday().clone();
+    let seed = Secret::new(TEST_SEED.to_vec());
+    let (account_b, _usk_b) = st
+        .wallet_mut()
+        .import_account_hd("account B", &seed, zip32_index_b, &b_birthday, None)
+        .expect("account B import should succeed");
+
+    // Step 4: re-scan every cached block at or after the birthday. The
+    // blocks were previously processed only against A; now they're
+    // processed against B too, inserting three new `*_received_notes`
+    // rows at B's shard-2 positions. After this batch
+    // `mark_stabilized_notes` runs and should flip B's new rows to
+    // `witness_stabilized = 1`.
+    st.scan_cached_blocks(note_height, (1 + extra_blocks) as usize);
+
+    assert_eq!(
+        st.get_spendable_balance(account_b.id(), ConfirmationsPolicy::MIN),
+        total_b,
+        "B's three newly-discovered notes must be spendable after the re-scan",
+    );
+    assert_eq!(
+        st.get_spendable_balance(account_a.id(), ConfirmationsPolicy::MIN),
+        total_a,
+        "A's notes must remain spendable across B's import and re-scan",
+    );
+
+    // Step 5: deep-rewind. The rewind target sits well below the wallet's
+    // birthday so `scan_queue` is rewound all the way out of any range
+    // covering shard 2. Only notes flagged `witness_stabilized = 1` can
+    // pass the post-rewind scan-state gate in
+    // `select_spendable_notes_matching_value`; any B note that was never
+    // stabilized would drop out of the balance here.
+    let rewind_target = account_a.birthday().height() - 100;
+    st.wallet_mut()
+        .rewind_to_height(rewind_target)
+        .expect("rewind_to_height should succeed");
+
+    assert_eq!(
+        st.get_spendable_balance(account_a.id(), ConfirmationsPolicy::MIN),
+        total_a,
+        "A's notes must survive the deep rewind, confirming they were and \
+         remain witness_stabilized",
+    );
+    assert_eq!(
+        st.get_spendable_balance(account_b.id(), ConfirmationsPolicy::MIN),
+        total_b,
+        "B's three re-scan-discovered notes must survive the deep rewind, \
+         confirming that mark_stabilized_notes fired on the freshly-inserted \
+         B rows during the re-scan",
+    );
 }
 
 pub fn reorg_to_checkpoint<T: ShieldedPoolTester, Dsf, C>(ds_factory: Dsf, cache: C)

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4905,6 +4905,209 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
     );
 }
 
+/// A note whose witness data has stabilized remains spendable after a deep truncation rewinds the
+/// scan queue below it.
+pub fn stabilized_note_spendable_after_deep_truncation<T, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let dfvk = T::test_account_fvk(&st);
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let birthday = st.test_account().unwrap().birthday().height();
+    let note_value = Zatoshis::const_from_u64(500_000);
+
+    // Scan a handful of filler blocks and capture the chain state as our deep-truncation target.
+    let filler_count = 5u32;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(birthday + 1, filler_count as usize);
+    let truncation_target = st
+        .latest_cached_block()
+        .expect("should have cached blocks")
+        .chain_state()
+        .clone();
+    let truncation_height = truncation_target.block_height();
+
+    // Mine and scan a wallet-owned note above the truncation target.
+    let (note_height, _, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, note_value);
+    st.scan_cached_blocks(note_height, 1);
+    assert!(note_height > truncation_height);
+
+    // Record shard 0's completion at `note_height` — the block that contains the note. Paired
+    // with the post-note blocks scanned below, this drives `shard.subtree_end_height` past the
+    // pruning boundary at `tip - PRUNING_DEPTH`, which is the condition `mark_stabilized_notes`
+    // uses to flip `witness_stabilized` for notes whose position lies within the shard.
+    T::put_subtree_roots(
+        &mut st,
+        0,
+        &[CommitmentTreeRoot::from_parts(
+            note_height,
+            T::empty_tree_leaf(),
+        )],
+    )
+    .unwrap();
+
+    // Scan strictly more than `PRUNING_DEPTH` blocks past the note so the note stabilizes.
+    let extra_blocks = PRUNING_DEPTH + 1;
+    for _ in 0..extra_blocks {
+        st.generate_next_block(
+            &not_our_key,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(1000),
+        );
+    }
+    st.scan_cached_blocks(note_height + 1, extra_blocks as usize);
+
+    let account = st.get_account();
+
+    // Remember the pre-truncation tip so we can feed it back into the wallet below. A recent chain
+    // tip will be required to calculate an anchor to spend this note later.
+    let pre_trunc_tip = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set before truncation");
+
+    // Deep-truncate: the target is far below the tip (beyond the prune window), but only just
+    // below the note.
+    st.wallet_mut()
+        .truncate_to_chain_state(truncation_target)
+        .expect("truncate_to_chain_state should succeed");
+    let tip_after_trunc = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after truncation");
+    assert_eq!(
+        tip_after_trunc, truncation_height,
+        "scan_queue must be rewound to the truncation target"
+    );
+
+    // Pre-`update_chain_tip` state: the scan_queue has been rewound below the note, but
+    // the chain tip has not yet been restored. The balance path uses the stabilization
+    // flag directly and is therefore unaffected. The spend path is blocked because
+    // `propose_transfer` derives its anchor from the rewound `chain_height()`, placing
+    // the anchor below the note's mined height; the anchor-height check in note
+    // selection then filters the note out and note selection reports no spendable
+    // inputs. This pair of assertions pins the "balance works, spend fails" split
+    // documented in `truncate_to_chain_state`'s rustdoc so that a future refactor of
+    // note selection or anchor derivation cannot silently invert it.
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        note_value,
+        "stabilized balance must be available even before update_chain_tip"
+    );
+    let pre_update_request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        T::sk_default_address(&T::sk(&[0xcc; 32])).to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10_000),
+    )])
+    .unwrap();
+    let pre_update_change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let pre_update_input_selector = GreedyInputSelector::new();
+    // The exact error depends on how far `propose_transfer` gets before running out of
+    // usable state
+    let pre_update_result = st.propose_transfer(
+        account.id(),
+        &pre_update_input_selector,
+        &pre_update_change_strategy,
+        pre_update_request,
+        ConfirmationsPolicy::MIN,
+    );
+    assert_matches!(
+        pre_update_result,
+        Err(crate::data_api::error::Error::ScanRequired)
+            | Err(crate::data_api::error::Error::InsufficientFunds { .. }),
+        "propose_transfer should fail with InsufficientFunds or ScanRequired"
+    );
+    if let Err(crate::data_api::error::Error::InsufficientFunds { available, .. }) =
+        &pre_update_result
+    {
+        assert_eq!(
+            *available,
+            Zatoshis::ZERO,
+            "when note selection runs, no notes should be eligible without the restored tip",
+        );
+    }
+
+    // Restore `chain_height()` to the pre-truncation tip, so that `propose_transfer` can derive an anchor
+    st.wallet_mut()
+        .update_chain_tip(pre_trunc_tip)
+        .expect("update_chain_tip should succeed");
+    let tip_after_update = st
+        .wallet()
+        .chain_height()
+        .unwrap()
+        .expect("chain tip should be set after update_chain_tip");
+    assert_eq!(tip_after_update, pre_trunc_tip);
+
+    // Post-truncation: the note is still spendable because (a) its witness data was preserved
+    // (commit B) and (b) the spendability queries consult the stabilization flag instead of
+    // scan_queue (commit E). If either is missing, this assertion fails.
+    let post_trunc_spendable = st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN);
+    assert_eq!(
+        post_trunc_spendable, note_value,
+        "stabilized note should remain spendable after deep truncation"
+    );
+
+    // End-to-end: build and sign a real spend. This exercises the full note-selection and
+    // witness-construction path.
+    let to_extsk = T::sk(&[0xcc; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let send_value = Zatoshis::const_from_u64(10_000);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal should succeed with stabilized note after deep truncation");
+    let txids = st
+        .create_proposed_transactions::<std::convert::Infallible, _, std::convert::Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("spend construction should succeed");
+    assert_eq!(
+        txids.len(),
+        1,
+        "the spend should produce exactly one transaction"
+    );
+}
+
 pub fn reorg_to_checkpoint<T: ShieldedPoolTester, Dsf, C>(ds_factory: Dsf, cache: C)
 where
     Dsf: DataStoreFactory,

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -86,6 +86,18 @@ impl ShieldedPoolTester for SaplingPoolTester {
             .put_sapling_subtree_roots(start_index, roots)
     }
 
+    fn shard_root<Cache, DbT: WalletTest + WalletCommitmentTrees, P>(
+        st: &mut TestState<Cache, DbT, P>,
+        shard_index: u64,
+    ) -> Result<Self::MerkleTreeHash, ShardTreeError<<DbT as WalletCommitmentTrees>::Error>> {
+        use incrementalmerkletree::{Address, Position};
+        let shard_height = crate::data_api::SAPLING_SHARD_HEIGHT;
+        let addr = Address::from_parts(Level::from(shard_height), shard_index);
+        let end_position = Position::from((shard_index + 1) << shard_height);
+        st.wallet_mut()
+            .with_sapling_tree_mut(|tree| tree.root(addr, end_position))
+    }
+
     fn next_subtree_index<A: Hash + Eq>(s: &WalletSummary<A>) -> u64 {
         s.next_sapling_subtree_index()
     }

--- a/zcash_client_memory/src/wallet_write.rs
+++ b/zcash_client_memory/src/wallet_write.rs
@@ -1065,6 +1065,10 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
         todo!()
     }
 
+    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        todo!()
+    }
+
     fn import_account_hd(
         &mut self,
         _account_name: &str,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -30,6 +30,10 @@ workspace.
 - `impl<'conn, P, CL, R> WalletWrite for WalletDb<SqlTransaction<'conn>, P, CL, R>` to
   enable calling `WalletWrite` methods inside `WalletDb::transactionally` (amortizing the
   database transaction overhead).
+- `zcash_client_sqlite::wallet::commitment_tree::min_checkpoint_id_at_or_above`
+  returns the lowest retained checkpoint id at or above a given block height,
+  used by truncation to clamp the rewind floor to a real checkpoint inside the
+  prune window.
 
 ### Changed
 - The `accounts` table now stores IVK item caches instead of FVK item caches for
@@ -48,6 +52,17 @@ workspace.
   `zcash_client_sqlite::error::StandaloneImportConflict`
 - P2SH UTXOs returned by `get_spendable_transparent_outputs` now include a
   precomputed input size for accurate ZIP 317 fee estimation.
+- Truncation no longer unconditionally rewinds all wallet data to the requested
+  target height. For deep truncations (more than `PRUNING_DEPTH` below the
+  scanned tip), only the scan queue is rewound to the requested height; blocks,
+  note commitment trees, transactions, transparent UTXO observations, and
+  nullifier map entries are not rewound beyond `PRUNING_DEPTH`. Shallow
+  truncations (within `PRUNING_DEPTH` of the tip) behave as before. The rewind
+  floor is now the lowest shard-tree checkpoint that lies inside the prune window
+  `[last_scanned - (PRUNING_DEPTH - 1), last_scanned]`, which under contiguous
+  scanning is exactly `last_scanned - (PRUNING_DEPTH - 1)` and under
+  non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic`
+  ranges) walks forward from the PD floor to the first real checkpoint.This
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -63,6 +63,12 @@ workspace.
   scanning is exactly `last_scanned - (PRUNING_DEPTH - 1)` and under
   non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic`
   ranges) walks forward from the PD floor to the first real checkpoint.This
+- Added a `witness_stabilized` column to the `sapling_received_notes` and
+  `orchard_received_notes` tables. The column is set to 1 by the new
+  `mark_stabilized_notes` helper, invoked at the end of each scan batch (and
+  during migration backfill), for notes whose containing shard's
+  `subtree_end_height` lies at or below `last_scanned - (PRUNING_DEPTH - 1)`
+  (the truncation rewind boundary).
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -48,6 +48,11 @@ workspace.
   `zcash_client_sqlite::error::StandaloneImportConflict`
 - P2SH UTXOs returned by `get_spendable_transparent_outputs` now include a
   precomputed input size for accurate ZIP 317 fee estimation.
+- Added a `witness_stabilized` column to the `sapling_received_notes` and
+  `orchard_received_notes` tables. The column is set to 1 at the end of each
+  scan batch (and once as a backfill by the `witness_stabilized_notes`
+  migration) for notes whose containing shard is fully Scanned and whose
+  `subtree_end_height` has received at least `PRUNING_DEPTH` confirmations.
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -69,6 +69,16 @@ workspace.
   during migration backfill), for notes whose containing shard's
   `subtree_end_height` lies at or below `last_scanned - (PRUNING_DEPTH - 1)`
   (the truncation rewind boundary).
+- Note-selection (`select_unspent_notes`,
+  `select_spendable_notes_matching_value`) and balance reporting
+  (`get_wallet_summary`) now consult the `witness_stabilized` flag in addition to
+  the existing `v_<pool>_shards_scan_state` join. A stabilized note bypasses the
+  shard-scanned, unscanned-tip, and confirmations checks (those are properties of
+  the wallet's scan state, which `witness_stabilized` makes irrelevant), so
+  stabilized notes remain spendable after a deep truncation rewinds `scan_queue`
+  below them. The anchor-height check (`mined_height <= anchor_height`) remains
+  in force for stabilized notes, because that is a property of the caller's
+  anchor choice rather than of the wallet's scan state.
 
 ### Removed
 - `zcash_client_sqlite::GapLimits` use `zcash_keys::keys::transparent::GapLimits` instead.

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -435,6 +435,28 @@ mod tests {
     }
 
     #[test]
+    fn stabilized_note_spendable_after_deep_rewind_sapling() {
+        testing::pool::stabilized_note_spendable_after_deep_rewind::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn stabilized_note_spendable_after_deep_rewind_orchard() {
+        testing::pool::stabilized_note_spendable_after_deep_rewind::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn newly_discovered_notes_become_stabilized_sapling() {
+        testing::pool::newly_discovered_notes_become_stabilized::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn newly_discovered_notes_become_stabilized_orchard() {
+        testing::pool::newly_discovered_notes_become_stabilized::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn reorg_to_checkpoint_sapling() {
         testing::pool::reorg_to_checkpoint::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -402,6 +402,39 @@ mod tests {
     }
 
     #[test]
+    fn rewind_to_height_deep_sapling() {
+        testing::pool::rewind_to_height_deep::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn rewind_to_height_deep_orchard() {
+        testing::pool::rewind_to_height_deep::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn rewind_to_height_shallow_sapling() {
+        testing::pool::rewind_to_height_shallow::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn rewind_to_height_shallow_orchard() {
+        testing::pool::rewind_to_height_shallow::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn rewind_after_non_contiguous_scan_sapling() {
+        testing::pool::rewind_after_non_contiguous_scan::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn rewind_after_non_contiguous_scan_orchard() {
+        testing::pool::rewind_after_non_contiguous_scan::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn reorg_to_checkpoint_sapling() {
         testing::pool::reorg_to_checkpoint::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -391,6 +391,17 @@ mod tests {
     }
 
     #[test]
+    fn stabilized_note_spendable_after_deep_truncation_sapling() {
+        testing::pool::stabilized_note_spendable_after_deep_truncation::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn stabilized_note_spendable_after_deep_truncation_orchard() {
+        testing::pool::stabilized_note_spendable_after_deep_truncation::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn truncate_to_chain_state_below_birthday_sapling() {
         testing::pool::truncate_to_chain_state_below_birthday::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -369,14 +369,25 @@ mod tests {
     }
 
     #[test]
-    fn truncate_to_chain_state_sapling() {
-        testing::pool::truncate_to_chain_state::<SaplingPoolTester>()
+    fn truncate_to_chain_state_deep_sapling() {
+        testing::pool::truncate_to_chain_state_deep::<SaplingPoolTester>()
     }
 
     #[test]
     #[cfg(feature = "orchard")]
-    fn truncate_to_chain_state_orchard() {
-        testing::pool::truncate_to_chain_state::<OrchardPoolTester>()
+    fn truncate_to_chain_state_deep_orchard() {
+        testing::pool::truncate_to_chain_state_deep::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn truncate_to_chain_state_shallow_sapling() {
+        testing::pool::truncate_to_chain_state_shallow::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncate_to_chain_state_shallow_orchard() {
+        testing::pool::truncate_to_chain_state_shallow::<OrchardPoolTester>()
     }
 
     #[test]
@@ -388,6 +399,17 @@ mod tests {
     #[cfg(feature = "orchard")]
     fn truncate_to_chain_state_below_birthday_orchard() {
         testing::pool::truncate_to_chain_state_below_birthday::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn truncate_after_non_contiguous_scan_sapling() {
+        testing::pool::truncate_after_non_contiguous_scan::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncate_after_non_contiguous_scan_orchard() {
+        testing::pool::truncate_after_non_contiguous_scan::<OrchardPoolTester>()
     }
 
     #[test]

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1318,6 +1318,10 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.truncate_to_chain_state(chain_state))
     }
 
+    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        self.transactionally(|wdb| wdb.rewind_to_height(max_height))
+    }
+
     #[cfg(feature = "transparent-inputs")]
     fn reserve_next_n_ephemeral_addresses(
         &mut self,
@@ -1650,6 +1654,16 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
 
     fn truncate_to_chain_state(&mut self, chain_state: ChainState) -> Result<(), Self::Error> {
         wallet::truncate_to_chain_state(self, chain_state)
+    }
+
+    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        wallet::rewind_to_height(
+            self.conn.0,
+            &self.params,
+            #[cfg(feature = "transparent-inputs")]
+            &self.gap_limits,
+            max_height,
+        )
     }
 
     #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -347,6 +347,20 @@ pub(crate) fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn stabilized_note_spendable_after_deep_rewind<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::stabilized_note_spendable_after_deep_rewind::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn newly_discovered_notes_become_stabilized<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::newly_discovered_notes_become_stabilized::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn reorg_to_checkpoint<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::reorg_to_checkpoint::<T, _, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -326,6 +326,13 @@ pub(crate) fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn stabilized_note_spendable_after_deep_truncation<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::stabilized_note_spendable_after_deep_truncation::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_below_birthday::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -305,8 +305,22 @@ pub(crate) fn data_db_truncation<T: ShieldedPoolTester>() {
     )
 }
 
-pub(crate) fn truncate_to_chain_state<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state::<T, _>(
+pub(crate) fn truncate_to_chain_state_deep<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_deep::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn truncate_to_chain_state_shallow<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_to_chain_state_shallow::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn truncate_after_non_contiguous_scan<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::truncate_after_non_contiguous_scan::<T, _>(
         TestDbFactory::default(),
         BlockCache::new(),
     )

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -326,6 +326,27 @@ pub(crate) fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn rewind_to_height_deep<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::rewind_to_height_deep::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn rewind_to_height_shallow<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::rewind_to_height_shallow::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::rewind_after_non_contiguous_scan::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn reorg_to_checkpoint<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::reorg_to_checkpoint::<T, _, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1886,7 +1886,7 @@ fn estimate_tree_size<P: consensus::Parameters>(
             (last_scanned > last_completed_subtree_end)
                 .then(|| {
                     let scanned_notes = last_scanned_tree_size
-                        - u64::from(last_completed_subtree.position_range_end());
+                        .saturating_sub(u64::from(last_completed_subtree.position_range_end()));
                     let scanned_range = u64::from(last_scanned - last_completed_subtree_end);
                     let unscanned_range = u64::from(chain_tip_height - last_scanned);
 
@@ -2413,6 +2413,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         let mut stmt_select_notes = tx.prepare_cached(&format!(
             "SELECT accounts.uuid, rn.id, rn.value, rn.is_change, rn.recipient_key_scope,
                     scan_state.max_priority,
+                    rn.witness_stabilized,
                     t.mined_height,
                     IFNULL(t.trust_status, 0) AS trust_status,
                     MAX(tt.mined_height) AS max_shielding_input_height,
@@ -2483,20 +2484,28 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
 
-            // A note is spendable if we have enough chain tip information to construct witnesses,
-            // the shard that its witness resides in is sufficiently scanned that we can construct
-            // the witness for the note, and the note has enough confirmations to be spent.
-            let is_spendable = any_spendable
-                && max_priority <= ScanPriority::Scanned
-                && confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
-                    received_height,
-                    tx_trusted,
-                    max_shielding_input_height,
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
+
+            // A stabilized note is unconditionally spendable. Its originating transaction has been
+            // confirmed well beyond any reasonable confirmation policy, and its witness data
+            // cannot be removed by truncation.
+            //
+            // Non-stabilized notes require more checks: we must have enough chain tip information
+            // to construct witnesses, the shard that the note resides in must be sufficiently
+            // scanned that we can construct the witness for the note, and the note has enough
+            // confirmations to be spent.
+            let is_spendable = witness_stabilized
+                || (any_spendable
+                    && max_priority <= ScanPriority::Scanned
+                    && confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
+                        received_height,
+                        tx_trusted,
+                        max_shielding_input_height,
+                        tx_shielding_inputs_trusted,
+                    ) == 0);
 
             let is_pending_change =
                 is_change && received_height.iter().all(|h| h > &trusted_height);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3734,6 +3734,88 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
     Ok(())
 }
 
+/// Rewinds the wallet to at most the given block height, preserving any wallet data which has been
+/// confirmed beyond the pruning depth.
+///
+/// In contrast to [`truncate_to_height`], which unconditionally deletes wallet state above
+/// `max_height` (transaction & note data is retained, but committment trees, blocks, etc are
+/// removed to the truncation height), this rewinds the scan queue to `max_height` but only rewinds
+/// blocks, note commitment trees, transactions, transparent UTXO observations, and nullifier-map
+/// entries as far back as the pruning floor (`chain_tip - (PRUNING_DEPTH - 1)`). Data at or below
+/// that height is preserved. Because `PRUNING_DEPTH` is a property of chain depth, the floor is
+/// derived from the wallet's view of the chain tip rather than from `MAX(blocks.height)`.
+///
+///
+/// The floor is clamped to an actual shard-tree checkpoint at or above the pruning floor (via
+/// [`commitment_tree::min_checkpoint_id_at_or_above`]) so that [`truncate_to_height_internal`] has
+/// a real checkpoint to truncate to under non-contiguous scan orders.
+///
+/// Returns the actual scan-queue rewind height (`max_height` clamped to the max scanned height when
+/// `max_height` is above it).
+pub(crate) fn rewind_to_height<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    #[cfg(feature = "transparent-inputs")] gap_limits: &GapLimits,
+    max_height: BlockHeight,
+) -> Result<BlockHeight, SqliteClientError> {
+    let max_scanned_height = block_max_scanned(conn, params)?
+        .map(|m| m.block_height())
+        .unwrap_or_else(|| {
+            params
+                .activation_height(NetworkUpgrade::Sapling)
+                // Fall back to the genesis block in regtest mode.
+                .map_or(BlockHeight::from_u32(0), |h| h - 1)
+        });
+
+    // Compute the floor height of the pruning window
+    let pruning_floor = max_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
+    let truncation_target = max_height.max(pruning_floor);
+
+    // Determine the minimum sapling and orchard checkpoints within the pruning window
+    let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        conn,
+        crate::SAPLING_TABLES_PREFIX,
+        truncation_target,
+    )
+    .map_err(ShardTreeError::Storage)?;
+
+    #[cfg(feature = "orchard")]
+    {
+        // Check that Orchard checkpoint matches the Sapling checkpoint.
+        // These should always match, unless the database is corrupted.
+        let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+            conn,
+            crate::ORCHARD_TABLES_PREFIX,
+            truncation_target,
+        )
+        .map_err(ShardTreeError::Storage)?;
+        if orchard_window_floor != sapling_window_floor {
+            return Err(SqliteClientError::CorruptedData(
+                "Sapling and Orchard should have the same checkpoints".into(),
+            ));
+        }
+    }
+
+    // Combine the per-pool floors by taking the shallower (larger height).
+    let truncation_height = sapling_window_floor.unwrap_or(pruning_floor);
+
+    // Use `truncate_to_height_internal` perform full truncation of data within the pruning window
+    truncate_to_height_internal(
+        conn,
+        params,
+        #[cfg(feature = "transparent-inputs")]
+        gap_limits,
+        truncation_height,
+    )?;
+
+    // When the caller asked to rewind below the truncation_height floor, trim the scan queue the
+    // rest of the way down to `max_height` so the sync loop will re-scan the blocks between
+    // `max_height` and `data_rewind_height`.
+    trim_scan_queue_to(conn, max_height)?;
+
+    Ok(max_height.min(max_scanned_height))
+}
+
 /// Trims the `scan_queue` so that no range extends above `max_height`.
 ///
 /// Deletes any range whose start is above `max_height`, and clamps the upper bound of any

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1885,8 +1885,14 @@ fn estimate_tree_size<P: consensus::Parameters>(
         let tip_tree_size = last_scanned.and_then(|(last_scanned, last_scanned_tree_size)| {
             (last_scanned > last_completed_subtree_end)
                 .then(|| {
+                    // `saturating_sub` here is a no-op in production: by the time we enter this
+                    // branch, the wallet has scanned past the last completed subtree's end height
+                    // and has therefore seen at least `position_range_end()` commitments. It is
+                    // needed for tests that synthesize an incomplete shard (e.g. recording a
+                    // subtree root via `put_subtree_roots` before scanning enough commitments to
+                    // fill it), where the plain subtraction would underflow.
                     let scanned_notes = last_scanned_tree_size
-                        - u64::from(last_completed_subtree.position_range_end());
+                        .saturating_sub(u64::from(last_completed_subtree.position_range_end()));
                     let scanned_range = u64::from(last_scanned - last_completed_subtree_end);
                     let unscanned_range = u64::from(chain_tip_height - last_scanned);
 
@@ -2413,6 +2419,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         let mut stmt_select_notes = tx.prepare_cached(&format!(
             "SELECT accounts.uuid, rn.id, rn.value, rn.is_change, rn.recipient_key_scope,
                     scan_state.max_priority,
+                    rn.witness_stabilized,
                     t.mined_height,
                     IFNULL(t.trust_status, 0) AS trust_status,
                     MAX(tt.mined_height) AS max_shielding_input_height,
@@ -2483,20 +2490,28 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
 
-            // A note is spendable if we have enough chain tip information to construct witnesses,
-            // the shard that its witness resides in is sufficiently scanned that we can construct
-            // the witness for the note, and the note has enough confirmations to be spent.
-            let is_spendable = any_spendable
-                && max_priority <= ScanPriority::Scanned
-                && confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
-                    received_height,
-                    tx_trusted,
-                    max_shielding_input_height,
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
+
+            // A stabilized note is unconditionally spendable. Its originating transaction has been
+            // confirmed well beyond any reasonable confirmation policy, and its witness data
+            // cannot be removed by truncation.
+            //
+            // Non-stabilized notes require more checks: we must have enough chain tip information
+            // to construct witnesses, the shard that the note resides in must be sufficiently
+            // scanned that we can construct the witness for the note, and the note has enough
+            // confirmations to be spent.
+            let is_spendable = witness_stabilized
+                || (any_spendable
+                    && max_priority <= ScanPriority::Scanned
+                    && confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        recipient_key_scope.and_then(|k| zip32::Scope::try_from(k).ok()),
+                        received_height,
+                        tx_trusted,
+                        max_shielding_input_height,
+                        tx_shielding_inputs_trusted,
+                    ) == 0);
 
             let is_pending_change =
                 is_change && received_height.iter().all(|h| h > &trusted_height);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3537,17 +3537,7 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
     // truncation height, and then truncate any remaining range by setting the end
     // equal to the truncation height + 1. This sets our view of the chain tip back
     // to the retained height.
-    conn.execute(
-        "DELETE FROM scan_queue
-        WHERE block_range_start >= :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
-    conn.execute(
-        "UPDATE scan_queue
-        SET block_range_end = :new_end_height
-        WHERE block_range_end > :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
+    trim_scan_queue_to(conn, truncation_height)?;
 
     // Mark transparent utxos as un-mined. Since the TXO is now not mined, it would ideally be
     // considered to have been returned to the mempool; it _might_ be spendable in this state, but
@@ -3741,6 +3731,31 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
 
     assert_eq!(truncated_height, target_height);
 
+    Ok(())
+}
+
+/// Trims the `scan_queue` so that no range extends above `max_height`.
+///
+/// Deletes any range whose start is above `max_height`, and clamps the upper bound of any
+/// remaining range that extends past `max_height`. Used by [`rewind_to_height`] to push the
+/// scan-queue rewind below the data-truncation floor without disturbing the wallet data
+/// preserved within the pruning window.
+pub(crate) fn trim_scan_queue_to(
+    conn: &rusqlite::Transaction,
+    max_height: BlockHeight,
+) -> Result<(), SqliteClientError> {
+    let new_end_height = u32::from(max_height + 1);
+    conn.execute(
+        "DELETE FROM scan_queue
+         WHERE block_range_start >= :new_end_height",
+        named_params![":new_end_height": new_end_height],
+    )?;
+    conn.execute(
+        "UPDATE scan_queue
+         SET block_range_end = :new_end_height
+         WHERE block_range_end > :new_end_height",
+        named_params![":new_end_height": new_end_height],
+    )?;
     Ok(())
 }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3533,10 +3533,47 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         ))
     })?;
 
-    // Delete from the scanning queue any range with a start height greater than the
-    // truncation height, and then truncate any remaining range by setting the end
-    // equal to the truncation height + 1. This sets our view of the chain tip back
-    // to the retained height.
+    // For deep truncations the scan queue is rewound to `truncation_height`, but blocks, trees,
+    // transactions, transparent UTXO observations, and nullifier map entries are only rewound to
+    // the lowest shard-tree checkpoint that still lies inside the prune window
+    // `[last_scanned - (PRUNING_DEPTH - 1), last_scanned]`. Under contiguous scanning that is
+    // exactly `last_scanned - (PRUNING_DEPTH - 1)`, because the tree's `max_checkpoints` cap
+    // equals `PRUNING_DEPTH` and FIFO-by-id pruning retains every height in the window. Under
+    // non-contiguous scanning (e.g. `ChainTip` range scanned before `Historic` ranges, per
+    // `suggest_scan_ranges` ordering in `wallet::scanning`), the PD floor may sit in an
+    // unscanned gap and have no checkpoint; walking forward from the floor to the first real
+    // checkpoint keeps us inside the window while still coinciding with a real checkpoint that
+    // `truncate_to_checkpoint` can act on.
+    let pd_floor = last_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
+    let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        conn,
+        crate::SAPLING_TABLES_PREFIX,
+        pd_floor,
+    )
+    .map_err(ShardTreeError::Storage)?;
+    #[cfg(feature = "orchard")]
+    let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        conn,
+        crate::ORCHARD_TABLES_PREFIX,
+        pd_floor,
+    )
+    .map_err(ShardTreeError::Storage)?;
+    #[cfg(not(feature = "orchard"))]
+    let orchard_window_floor: Option<BlockHeight> = None;
+
+    // Combine the per-pool floors by taking the shallower (larger height). Under normal scanning
+    // both pools record checkpoints at identical heights (each block's `put_block` updates both
+    // trees), so the two values agree and this is a no-op choice.
+    let in_window_floor = match (sapling_window_floor, orchard_window_floor) {
+        (Some(s), Some(o)) => s.max(o),
+        (Some(h), None) | (None, Some(h)) => h,
+        (None, None) => pd_floor,
+    };
+    let data_rewind_height = truncation_height.max(in_window_floor);
+
+    // scan_queue ALWAYS rewinds all the way to `truncation_height`, signalling to the sync
+    // loop that anything above must be re-scanned. This holds for both shallow and deep
+    // truncations.
     conn.execute(
         "DELETE FROM scan_queue
         WHERE block_range_start >= :new_end_height",
@@ -3563,7 +3600,7 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
          FROM transactions tx
          WHERE tx.id_tx = transaction_id
          AND max_observed_unspent_height > :height",
-        named_params![":height": u32::from(truncation_height)],
+        named_params![":height": u32::from(data_rewind_height)],
     )?;
 
     // Un-mine transactions. This must be done outside of the last_scanned_height check because
@@ -3572,13 +3609,13 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         "UPDATE transactions
          SET block = NULL, mined_height = NULL, tx_index = NULL, confirmed_unmined_at_height = NULL
          WHERE mined_height > :height",
-        named_params![":height": u32::from(truncation_height)],
+        named_params![":height": u32::from(data_rewind_height)],
     )?;
 
     // If we're removing scanned blocks, we need to truncate the note commitment tree and remove
     // affected block records from the database.
-    if truncation_height < last_scanned_height {
-        // Truncate the note commitment trees
+    if data_rewind_height < last_scanned_height {
+        // Truncate the note commitment trees to `data_rewind_height`
         let mut wdb = WalletDb {
             conn: SqlTransaction(conn),
             params: params.clone(),
@@ -3587,13 +3624,26 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
             #[cfg(feature = "transparent-inputs")]
             gap_limits: *gap_limits,
         };
+        // `truncate_to_checkpoint` returns `Ok(false)` when the tree has no checkpoint at the
+        // requested id; surface that as `CorruptedData` rather than letting the bool drop on
+        // the floor.
         wdb.with_sapling_tree_mut(|tree| {
-            tree.truncate_to_checkpoint(&truncation_height)?;
+            if !tree.truncate_to_checkpoint(&data_rewind_height)? {
+                return Err(SqliteClientError::CorruptedData(format!(
+                    "Sapling tree has no checkpoint at expected rewind height {data_rewind_height}; \
+                     the shard tree is inconsistent with the recorded checkpoint rows."
+                )));
+            }
             Ok::<_, SqliteClientError>(())
         })?;
         #[cfg(feature = "orchard")]
         wdb.with_orchard_tree_mut(|tree| {
-            tree.truncate_to_checkpoint(&truncation_height)?;
+            if !tree.truncate_to_checkpoint(&data_rewind_height)? {
+                return Err(SqliteClientError::CorruptedData(format!(
+                    "Orchard tree has no checkpoint at expected rewind height {data_rewind_height}; \
+                     the shard tree is inconsistent with the recorded checkpoint rows."
+                )));
+            }
             Ok::<_, SqliteClientError>(())
         })?;
 
@@ -3607,15 +3657,15 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         // Now that they aren't depended on, delete un-mined blocks.
         conn.execute(
             "DELETE FROM blocks WHERE height > ?",
-            [u32::from(truncation_height)],
+            [u32::from(data_rewind_height)],
         )?;
 
         // Delete from the nullifier map any entries with a locator referencing a block
-        // height greater than the truncation height.
+        // height greater than the data-rewind height.
         conn.execute(
             "DELETE FROM tx_locator_map
             WHERE block_height > :block_height",
-            named_params![":block_height": u32::from(truncation_height)],
+            named_params![":block_height": u32::from(data_rewind_height)],
         )?;
     }
 
@@ -3634,19 +3684,41 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
 ///   oldest checkpoint to ensure that the a checkpoint added at the provided frontier position does
 ///   not get immediately pruned, then inserts the provided frontier as a new checkpoint at the
 ///   target height, and finally truncates to that new checkpoint.
+///
+/// # Spending stabilized notes after a deep truncation
+///
+/// A deep truncation rewinds the scan queue to `target_height` but preserves blocks, trees,
+/// transactions, and other wallet data above the lowest shard-tree checkpoint inside the
+/// prune window, so notes flagged `witness_stabilized` retain valid witness data. To
+/// actually spend those notes, the caller must follow up with
+/// `WalletWrite::update_chain_tip` to restore the wallet's view of the chain tip.
+/// Otherwise `propose_transfer` either fails at `get_target_and_anchor_heights` with
+/// `Error::ScanRequired` (when no checkpoint sits at or below the derived anchor), or —
+/// if an anchor can still be constructed — derives it from the rewound `chain_height()`,
+/// placing it below the stabilized note's mined height; the anchor-height check in note
+/// selection then filters the note out and proposal construction fails with
+/// `Error::InsufficientFunds { available: 0, .. }`. Stabilized balance reported by
+/// `get_wallet_summary` does not depend on a restored chain tip; only spend
+/// construction does.
 pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
     wdb: &mut WalletDb<SqlTransaction<'_>, P, CL, R>,
     chain_state: ChainState,
 ) -> Result<(), SqliteClientError> {
     let target_height = chain_state.block_height();
 
-    // Only truncate trees when the maximum scanned height is greater than the target height. When
-    // the target height is at or above the max scanned height, we skip frontier insertion (it is
-    // unnecessary at the max scanned height, and could introduce a subtree root discontinuity
-    // above it; the frontier will be added naturally during scanning). We will however still need
-    // to truncate the scan queue so that ranges above the target are removed.
-    let truncate_trees = block_max_scanned(wdb.conn.0, &wdb.params)?
-        .is_some_and(|meta| meta.block_height() > target_height);
+    // Only truncate trees when the target is strictly below the maximum scanned height AND
+    // inside the prune window `[max_scanned - (PRUNING_DEPTH - 1), max_scanned]`. Targets at or
+    // above the max scanned height are skipped because a frontier there could introduce a
+    // subtree root discontinuity above it; the frontier will be added naturally during scanning.
+    // Targets below the prune window are skipped because `truncate_to_height_internal` clamps
+    // its rewind floor up to the lowest checkpoint inside the window, and any checkpoint
+    // inserted at a deeper target would itself be truncated away on that subsequent call. In
+    // both skipped cases the scan queue is still trimmed above `target_height` unconditionally
+    // in `truncate_to_height_internal`.
+    let truncate_trees = block_max_scanned(wdb.conn.0, &wdb.params)?.is_some_and(|m| {
+        let h = m.block_height();
+        target_height < h && target_height >= h.saturating_sub(PRUNING_DEPTH - 1)
+    });
 
     if truncate_trees {
         // Try the simple case first: if a checkpoint exists at or below the target height,

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -624,6 +624,27 @@ pub(crate) fn max_checkpoint_id(
     .map_err(Error::Query)
 }
 
+/// Returns the lowest retained checkpoint id that is at or above `floor`, or `None`
+/// if the pool's checkpoint table contains no checkpoint within `[floor, ∞)`.
+pub(crate) fn min_checkpoint_id_at_or_above(
+    conn: &rusqlite::Connection,
+    table_prefix: &'static str,
+    floor: BlockHeight,
+) -> Result<Option<BlockHeight>, Error> {
+    conn.query_row(
+        &format!(
+            "SELECT MIN(checkpoint_id) FROM {table_prefix}_tree_checkpoints
+             WHERE checkpoint_id >= :floor"
+        ),
+        named_params![":floor": u32::from(floor)],
+        |row| {
+            row.get::<_, Option<u32>>(0)
+                .map(|opt| opt.map(BlockHeight::from))
+        },
+    )
+    .map_err(Error::Query)
+}
+
 pub(crate) fn add_checkpoint(
     conn: &rusqlite::Transaction<'_>,
     table_prefix: &'static str,

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -351,7 +351,7 @@ where
 /// - Notes with individual value *below* the ``MARGINAL_FEE`` will be ignored
 /// - Note spendability is determined using the `target_height`. If the note is mined at a height
 ///   greater than or equal to the target height, it will still be returned by this query.
-/// - The `to_spendable_note` function is expected to return `Ok(None)` in the case that spending
+/// - The `to_received_note` function is expected to return `Ok(None)` in the case that spending
 ///   key details cannot be determined.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn select_unspent_notes<P: consensus::Parameters, F, Note>(
@@ -383,6 +383,7 @@ where
              accounts.ufvk as ufvk, rn.recipient_key_scope,
              t.block AS mined_height,
              scan_state.max_priority,
+             rn.witness_stabilized,
              IFNULL(t.trust_status, 0) AS trust_status,
              MAX(tt.mined_height) AS max_shielding_input_height,
              MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -434,6 +435,7 @@ where
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
             let shard_scan_priority = max_priority_raw
@@ -448,6 +450,7 @@ where
 
             Ok((
                 result_note,
+                witness_stabilized,
                 shard_scan_priority,
                 tx_trust_status,
                 tx_shielding_inputs_trusted,
@@ -457,29 +460,35 @@ where
 
     row_results
         .map(|t| match t? {
-            (Some(note), max_shard_priority, tx_trusted, tx_shielding_inputs_trusted) => {
-                let shard_scanned = max_shard_priority
-                    .iter()
-                    .any(|p| *p <= ScanPriority::Scanned);
+            (
+                Some(note),
+                witness_stabilized,
+                max_shard_priority,
+                tx_trusted,
+                tx_shielding_inputs_trusted,
+            ) => {
+                let shard_witness_available = witness_stabilized
+                    || max_shard_priority.is_some_and(|p| p <= ScanPriority::Scanned);
 
                 let mined_at_anchor = note
                     .mined_height()
                     .zip(note_request.anchor_height())
                     .is_some_and(|(h, ah)| h <= ah);
 
-                let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    Some(note.spending_key_scope()),
-                    note.mined_height(),
-                    tx_trusted,
-                    note.max_shielding_input_height(),
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+                let has_confirmations = witness_stabilized
+                    || confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        Some(note.spending_key_scope()),
+                        note.mined_height(),
+                        tx_trusted,
+                        note.max_shielding_input_height(),
+                        tx_shielding_inputs_trusted,
+                    ) == 0;
 
                 match (
                     note_request,
-                    shard_scanned && mined_at_anchor && has_confirmations,
+                    shard_witness_available && mined_at_anchor && has_confirmations,
                 ) {
                     (NoteRequest::UnspentOrError { .. }, false) => {
                         Err(SqliteClientError::IneligibleNotes)
@@ -523,9 +532,10 @@ where
         note_reconstruction_cols,
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
-    if unscanned_tip_exists(conn, anchor_height, table_prefix)? {
-        return Ok(vec![]);
-    }
+
+    // When an anchor exists within an unscanned range, nodes without stabilized witness data will
+    // not be reliably constructable. The selection query will use this to filter out such notes.
+    let tip_unscanned = unscanned_tip_exists(conn, anchor_height, table_prefix)?;
 
     // The goal of this SQL statement is to select the oldest notes until the required
     // value has been reached.
@@ -550,6 +560,7 @@ where
                  SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,
+                 rn.witness_stabilized,
                  IFNULL(t.trust_status, 0) AS trust_status,
                  MAX(tt.mined_height) AS max_shielding_input_height,
                  MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -571,11 +582,18 @@ where
              AND accounts.ufvk IS NOT NULL
              AND recipient_key_scope IS NOT NULL
              AND nf IS NOT NULL
-             -- the shard containing the note is fully scanned; this condition will exclude
-             -- notes for which `scan_state.max_priority IS NULL` (which will also arise if
-             -- `rn.commitment_tree_position IS NULL`; hence we don't need that explicit filter)
-             AND scan_state.max_priority <= :scanned_priority
+             -- The note must be mined at or below the anchor for the anchor's tree
+             -- frontier to witness it
              AND t.block <= :anchor_height
+             -- A stabilized note's witness is durable across rewinds, so it bypasses
+             -- the scan-state gating
+             AND (
+                 rn.witness_stabilized = 1
+                 OR (
+                     :tip_unscanned = 0 -- the tip shard has no unscanned ranges
+                     AND scan_state.max_priority <= :scanned_priority -- the note shard is fully scanned or ignored
+                 )
+             )
              AND rn.id NOT IN rarray(:exclude)
              AND rn.id NOT IN ({})
              GROUP BY rn.id
@@ -583,14 +601,14 @@ where
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM eligible WHERE so_far < :target_value
          UNION
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         spent_notes_clause(table_prefix)
@@ -616,6 +634,7 @@ where
             ":target_value": &u64::from(target_value),
             ":exclude": &excluded_ptr,
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
+            ":tip_unscanned": i64::from(tip_unscanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE)
         ],
         |row| {
@@ -624,6 +643,7 @@ where
                 .get::<_, Option<u32>>("max_shielding_input_height")?
                 .map(BlockHeight::from);
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let note = to_spendable_note(params, row)?;
 
             Ok(note.map(|n| {
@@ -632,6 +652,7 @@ where
                     tx_trust_status,
                     max_shielding_input_height,
                     tx_shielding_inputs_trusted,
+                    witness_stabilized,
                 )
             }))
         },
@@ -647,16 +668,21 @@ where
                         tx_trusted,
                         max_shielding_input_height,
                         tx_shielding_inputs_trusted,
+                        witness_stabilized,
                     )| {
-                        let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                            target_height,
-                            PoolType::Shielded(protocol),
-                            Some(note.spending_key_scope()),
-                            note.mined_height(),
-                            tx_trusted,
-                            max_shielding_input_height,
-                            tx_shielding_inputs_trusted,
-                        ) == 0;
+                        // A stabilized note was confirmed well beyond any reasonable
+                        // confirmations policy at stabilization time, so the confirmations
+                        // check is trivially satisfied.
+                        let has_confirmations = witness_stabilized
+                            || confirmations_policy.confirmations_until_spendable(
+                                target_height,
+                                PoolType::Shielded(protocol),
+                                Some(note.spending_key_scope()),
+                                note.mined_height(),
+                                tx_trusted,
+                                max_shielding_input_height,
+                                tx_shielding_inputs_trusted,
+                            ) == 0;
 
                         has_confirmations.then_some(note)
                     },

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -383,6 +383,7 @@ where
              accounts.ufvk as ufvk, rn.recipient_key_scope,
              t.block AS mined_height,
              scan_state.max_priority,
+             rn.witness_stabilized,
              IFNULL(t.trust_status, 0) AS trust_status,
              MAX(tt.mined_height) AS max_shielding_input_height,
              MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -434,6 +435,7 @@ where
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
             let shard_scan_priority = max_priority_raw
@@ -448,6 +450,7 @@ where
 
             Ok((
                 result_note,
+                witness_stabilized,
                 shard_scan_priority,
                 tx_trust_status,
                 tx_shielding_inputs_trusted,
@@ -457,25 +460,33 @@ where
 
     row_results
         .map(|t| match t? {
-            (Some(note), max_shard_priority, tx_trusted, tx_shielding_inputs_trusted) => {
-                let shard_scanned = max_shard_priority
-                    .iter()
-                    .any(|p| *p <= ScanPriority::Scanned);
+            (
+                Some(note),
+                witness_stabilized,
+                max_shard_priority,
+                tx_trusted,
+                tx_shielding_inputs_trusted,
+            ) => {
+                let shard_scanned = witness_stabilized
+                    || max_shard_priority
+                        .iter()
+                        .any(|p| *p <= ScanPriority::Scanned);
 
                 let mined_at_anchor = note
                     .mined_height()
                     .zip(note_request.anchor_height())
                     .is_some_and(|(h, ah)| h <= ah);
 
-                let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                    target_height,
-                    PoolType::Shielded(protocol),
-                    Some(note.spending_key_scope()),
-                    note.mined_height(),
-                    tx_trusted,
-                    note.max_shielding_input_height(),
-                    tx_shielding_inputs_trusted,
-                ) == 0;
+                let has_confirmations = witness_stabilized
+                    || confirmations_policy.confirmations_until_spendable(
+                        target_height,
+                        PoolType::Shielded(protocol),
+                        Some(note.spending_key_scope()),
+                        note.mined_height(),
+                        tx_trusted,
+                        note.max_shielding_input_height(),
+                        tx_shielding_inputs_trusted,
+                    ) == 0;
 
                 match (
                     note_request,
@@ -523,9 +534,13 @@ where
         note_reconstruction_cols,
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
-    if unscanned_tip_exists(conn, anchor_height, table_prefix)? {
-        return Ok(vec![]);
-    }
+
+    // When the anchor's shard has unscanned ranges at or below `anchor_height`, the tree
+    // frontier at the anchor is not reliably reconstructible, so un-stabilized notes can't
+    // be safely selected. Stabilized notes are unaffected: their witness data is durable
+    // in the shard tree regardless of what `scan_queue` says. We pass `tip_unscanned` as a
+    // parameter and let the SQL mix the two cases, rather than early-exiting.
+    let tip_unscanned = unscanned_tip_exists(conn, anchor_height, table_prefix)?;
 
     // The goal of this SQL statement is to select the oldest notes until the required
     // value has been reached.
@@ -550,6 +565,7 @@ where
                  SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,
+                 rn.witness_stabilized,
                  IFNULL(t.trust_status, 0) AS trust_status,
                  MAX(tt.mined_height) AS max_shielding_input_height,
                  MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
@@ -571,11 +587,24 @@ where
              AND accounts.ufvk IS NOT NULL
              AND recipient_key_scope IS NOT NULL
              AND nf IS NOT NULL
-             -- the shard containing the note is fully scanned; this condition will exclude
-             -- notes for which `scan_state.max_priority IS NULL` (which will also arise if
-             -- `rn.commitment_tree_position IS NULL`; hence we don't need that explicit filter)
-             AND scan_state.max_priority <= :scanned_priority
+             -- The note must be mined at or below the anchor for the anchor's tree
+             -- frontier to witness it; this is an invariant of the spend, not of our
+             -- scan state, so it applies to stabilized and non-stabilized notes alike.
              AND t.block <= :anchor_height
+             -- A stabilized note's witness is durable across truncation, so it bypasses
+             -- the scan-state gating: it is eligible even when the anchor's shard has
+             -- unscanned ranges (`:tip_unscanned = 1`) or its containing shard is not
+             -- yet fully scanned. Non-stabilized notes require a fully-scanned containing
+             -- shard AND a fully-scanned anchor shard. The `scan_state.max_priority IS
+             -- NULL` case (which arises when `rn.commitment_tree_position IS NULL`) is
+             -- excluded by the priority check.
+             AND (
+                 rn.witness_stabilized = 1
+                 OR (
+                     :tip_unscanned = 0
+                     AND scan_state.max_priority <= :scanned_priority
+                 )
+             )
              AND rn.id NOT IN rarray(:exclude)
              AND rn.id NOT IN ({})
              GROUP BY rn.id
@@ -583,14 +612,14 @@ where
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM eligible WHERE so_far < :target_value
          UNION
          SELECT id, txid, {output_index_col},
                 diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
                 ufvk, recipient_key_scope,
-                mined_height, trust_status,
+                mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
         spent_notes_clause(table_prefix)
@@ -616,6 +645,7 @@ where
             ":target_value": &u64::from(target_value),
             ":exclude": &excluded_ptr,
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
+            ":tip_unscanned": i64::from(tip_unscanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE)
         ],
         |row| {
@@ -624,6 +654,7 @@ where
                 .get::<_, Option<u32>>("max_shielding_input_height")?
                 .map(BlockHeight::from);
             let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
             let note = to_spendable_note(params, row)?;
 
             Ok(note.map(|n| {
@@ -632,6 +663,7 @@ where
                     tx_trust_status,
                     max_shielding_input_height,
                     tx_shielding_inputs_trusted,
+                    witness_stabilized,
                 )
             }))
         },
@@ -647,16 +679,21 @@ where
                         tx_trusted,
                         max_shielding_input_height,
                         tx_shielding_inputs_trusted,
+                        witness_stabilized,
                     )| {
-                        let has_confirmations = confirmations_policy.confirmations_until_spendable(
-                            target_height,
-                            PoolType::Shielded(protocol),
-                            Some(note.spending_key_scope()),
-                            note.mined_height(),
-                            tx_trusted,
-                            max_shielding_input_height,
-                            tx_shielding_inputs_trusted,
-                        ) == 0;
+                        // A stabilized note was confirmed well beyond any reasonable
+                        // confirmations policy at stabilization time, so the confirmations
+                        // check is trivially satisfied.
+                        let has_confirmations = witness_stabilized
+                            || confirmations_policy.confirmations_until_spendable(
+                                target_height,
+                                PoolType::Shielded(protocol),
+                                Some(note.spending_key_scope()),
+                                note.mined_height(),
+                                tx_trusted,
+                                max_shielding_input_height,
+                                tx_shielding_inputs_trusted,
+                            ) == 0;
 
                         has_confirmations.then_some(note)
                     },

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -375,6 +375,7 @@ CREATE TABLE "sapling_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -458,6 +459,7 @@ CREATE TABLE "orchard_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -375,6 +375,7 @@ CREATE TABLE "sapling_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -388,6 +389,10 @@ CREATE INDEX idx_sapling_received_notes_address ON sapling_received_notes (
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_TX: &str = r#"
 CREATE INDEX idx_sapling_received_notes_tx ON sapling_received_notes (
     transaction_id ASC
+)"#;
+pub(super) const INDEX_SAPLING_RECEIVED_NOTES_WITNESS_STABILIZED: &str = r#"
+CREATE INDEX idx_sapling_received_notes_witness_stabilized ON sapling_received_notes (
+    witness_stabilized
 )"#;
 
 /// A junction table between received Sapling notes and the transactions that spend them.
@@ -458,6 +463,7 @@ CREATE TABLE "orchard_received_notes" (
     recipient_key_scope INTEGER,
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
+    witness_stabilized INTEGER NOT NULL DEFAULT 0,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -471,6 +477,10 @@ CREATE INDEX idx_orchard_received_notes_address ON orchard_received_notes (
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_TX: &str = r#"
 CREATE INDEX idx_orchard_received_notes_tx ON orchard_received_notes (
     transaction_id ASC
+)"#;
+pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_WITNESS_STABILIZED: &str = r#"
+CREATE INDEX idx_orchard_received_notes_witness_stabilized ON orchard_received_notes (
+    witness_stabilized
 )"#;
 
 /// A junction table between received Orchard notes and the transactions that spend them.

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -837,11 +837,13 @@ mod tests {
             db::INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT,
             db::INDEX_ORCHARD_RECEIVED_NOTES_ADDRESS,
             db::INDEX_ORCHARD_RECEIVED_NOTES_TX,
+            db::INDEX_ORCHARD_RECEIVED_NOTES_WITNESS_STABILIZED,
             db::INDEX_SAPLING_RNS_NOTE,
             db::INDEX_SAPLING_RNS_TX,
             db::INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT,
             db::INDEX_SAPLING_RECEIVED_NOTES_ADDRESS,
             db::INDEX_SAPLING_RECEIVED_NOTES_TX,
+            db::INDEX_SAPLING_RECEIVED_NOTES_WITNESS_STABILIZED,
             db::INDEX_SENT_NOTES_FROM_ACCOUNT,
             db::INDEX_SENT_NOTES_TO_ACCOUNT,
             db::INDEX_SENT_NOTES_TX,
@@ -1169,7 +1171,8 @@ mod tests {
 
             // add a sapling sent note
             wdb.conn.execute(
-                "INSERT INTO blocks (height, hash, time, sapling_tree) VALUES (0, 0, 0, x'000000')",
+                "INSERT INTO blocks (height, hash, time, sapling_tree) \
+                 VALUES (0, x'0000000000000000000000000000000000000000000000000000000000000000', 0, x'000000')",
                 [],
             )?;
 
@@ -1367,7 +1370,8 @@ mod tests {
                 )
                 .encode(&wdb.params);
                 wdb.conn.execute(
-                    "INSERT INTO blocks (height, hash, time, sapling_tree) VALUES (0, 0, 0, x'000000')",
+                    "INSERT INTO blocks (height, hash, time, sapling_tree) \
+                 VALUES (0, x'0000000000000000000000000000000000000000000000000000000000000000', 0, x'000000')",
                     [],
                 )?;
                 wdb.conn.execute(

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -54,6 +54,7 @@ mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
+mod witness_stabilized_notes;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -133,10 +134,10 @@ pub(super) fn all_migrations<
     //                     \                       \         v_received_output_spends_account      /        /
     //                      \                       \               /                             /        /
     //                       `------------------- account_delete_cascade ---------------------------------'
-    //                                              /               \
-    //                               v_tx_outputs_key_scopes    standalone_p2sh
-    //                                                                  |
-    //                                                           ivk_item_cache
+    //                                        /               |              \
+    //                       v_tx_outputs_key_scopes    standalone_p2sh    witness_stabilized_notes
+    //                                                        |
+    //                                                  ivk_item_cache
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -225,6 +226,9 @@ pub(super) fn all_migrations<
         Box::new(v_tx_outputs_key_scopes::Migration),
         Box::new(standalone_p2sh::Migration),
         Box::new(ivk_item_cache::Migration {
+            params: params.clone(),
+        }),
+        Box::new(witness_stabilized_notes::Migration {
             params: params.clone(),
         }),
     ]
@@ -370,6 +374,7 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
+    witness_stabilized_notes::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -54,6 +54,7 @@ mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
+mod witness_stabilized_notes;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -133,10 +134,10 @@ pub(super) fn all_migrations<
     //                     \                       \         v_received_output_spends_account      /        /
     //                      \                       \               /                             /        /
     //                       `------------------- account_delete_cascade ---------------------------------'
-    //                                              /               \
-    //                               v_tx_outputs_key_scopes    standalone_p2sh
-    //                                                                  |
-    //                                                           ivk_item_cache
+    //                                        /               |              \
+    //                       v_tx_outputs_key_scopes    standalone_p2sh    witness_stabilized_notes
+    //                                                        |
+    //                                                  ivk_item_cache
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -227,6 +228,7 @@ pub(super) fn all_migrations<
         Box::new(ivk_item_cache::Migration {
             params: params.clone(),
         }),
+        Box::new(witness_stabilized_notes::Migration),
     ]
 }
 
@@ -370,6 +372,7 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
+    witness_stabilized_notes::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
@@ -13,6 +13,7 @@ use crate::{
     wallet::{
         SqlTransaction, WalletDb,
         init::{WalletMigrationError, migrations::support_legacy_sqlite},
+        trim_scan_queue_to,
     },
 };
 
@@ -172,17 +173,7 @@ fn truncate_to_height<P: consensus::Parameters>(
     // truncation height, and then truncate any remaining range by setting the end
     // equal to the truncation height + 1. This sets our view of the chain tip back
     // to the retained height.
-    conn.execute(
-        "DELETE FROM scan_queue
-        WHERE block_range_start >= :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
-    conn.execute(
-        "UPDATE scan_queue
-        SET block_range_end = :new_end_height
-        WHERE block_range_end > :new_end_height",
-        named_params![":new_end_height": u32::from(truncation_height + 1)],
-    )?;
+    trim_scan_queue_to(conn, truncation_height)?;
 
     // Mark transparent utxos as un-mined. Since the TXO is now not mined, it would ideally be
     // considered to have been returned to the mempool; it _might_ be spendable in this state, but

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -1,0 +1,402 @@
+//! Adds a `witness_stabilized` flag to received notes, indicating that the note's containing
+//! shard has been fully scanned and its witness data is durably present in the shard tree.
+//! Once set, this flag is preserved across truncations, ensuring that notes with intact
+//! witness data remain spendable (issue #2276).
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_client_backend::data_api::scanning::ScanPriority;
+use zcash_protocol::consensus::BlockHeight;
+
+use super::account_delete_cascade;
+use crate::wallet::init::WalletMigrationError;
+use crate::wallet::scanning::{mark_stabilized_notes, priority_code};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e99e422);
+
+// `account_delete_cascade` is the youngest migration that transitively establishes every
+// schema object this migration reads or writes:
+//
+//   - adds `witness_stabilized INTEGER` to `sapling_received_notes` and
+//     `orchard_received_notes` (columns that ADD COLUMN requires the tables to exist);
+//   - reads `commitment_tree_position` on those same tables;
+//   - reads `scan_queue.{block_range_end, priority}` (created by `shardtree_support`, which
+//     `account_delete_cascade` transitively depends on);
+//   - reads `{sapling,orchard}_tree_shards.{shard_index, subtree_end_height}` (created by
+//     `shardtree_support` / `orchard_shardtree`, same transitive dep).
+//
+// If a future migration renames or drops any of the above, adjust this list.
+const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds witness_stabilized flag to received notes for durable spendability."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        transaction.execute_batch(
+            "ALTER TABLE sapling_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;
+
+             ALTER TABLE orchard_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;",
+        )?;
+
+        // Backfill: derive the last-scanned height from the scan queue and delegate to the
+        // shared `mark_stabilized_notes` helper so the migration and the per-scan
+        // stabilization path share a single source of truth. We restrict the subquery to
+        // ranges with priority `Scanned`, because `scan_queue` also contains unscanned
+        // ranges (historic / found-note / chain-tip / verify) whose `block_range_end`
+        // would otherwise pollute the max. If the wallet has no scanned ranges yet, the
+        // subquery returns `NULL` and no rows are backfilled, which is the correct
+        // behavior for a freshly-created wallet.
+        let last_scanned_height: Option<u32> = transaction.query_row(
+            &format!(
+                "SELECT MAX(block_range_end) - 1 FROM scan_queue WHERE priority = {}",
+                priority_code(&ScanPriority::Scanned),
+            ),
+            [],
+            |row| row.get(0),
+        )?;
+
+        if let Some(last_scanned_height) = last_scanned_height {
+            mark_stabilized_notes(transaction, BlockHeight::from(last_scanned_height))?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_client_backend::data_api::SAPLING_SHARD_HEIGHT;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        PRUNING_DEPTH, WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// End-to-end exercise of the backfill: seed the pre-migration schema with a variety
+    /// of notes whose stabilization outcomes are fully determined, run the migration, and
+    /// assert the expected `witness_stabilized` value for each.
+    #[test]
+    fn migrate_backfills_stabilized_notes() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to the state just prior to this migration. At this point
+        // `sapling_received_notes` / `orchard_received_notes` do not yet have the
+        // `witness_stabilized` column.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // `block_range_end` is exclusive, so MAX(block_range_end) - 1 is the last-scanned
+        // height. `stable_height` mirrors what `mark_stabilized_notes` will compute and is
+        // also the truncation rewind boundary established in `truncate_to_height_internal`:
+        // `last_scanned - (PRUNING_DEPTH - 1)`. A shard whose `subtree_end_height` is at or
+        // below `stable_height` survives a deep truncation; a shard one block above does
+        // not.
+        let last_scanned: u32 = 301 + (PRUNING_DEPTH - 1);
+        let stable_height: u32 = 301;
+        assert_eq!(last_scanned - (PRUNING_DEPTH - 1), stable_height);
+
+        // Seed a minimal account (schema per `add_account_uuids`). The UFVK/UIVK must be
+        // real encoded values because `verify_network_compatibility` parses them when the
+        // migrator opens the database.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+
+        // Seed a single transaction; none of the backfill logic cares about the block
+        // column, only that there is an `id_tx` the note rows can reference.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES (1, :block_range_end, 10)",
+                named_params![":block_range_end": last_scanned + 1],
+            )
+            .unwrap();
+
+        // Tree shards. Shard 0 sits exactly at the stabilization boundary and shard 1 sits
+        // exactly one block above it, so the test fails if `mark_stabilized_notes` picks
+        // either neighbour of `<= stable_height`:
+        //   shard 0: end height == stable_height           (notes here SHOULD stabilize)
+        //   shard 1: end height == stable_height + 1       (notes here should NOT stabilize)
+        //   shard 2: end height NULL                       (notes here should NOT stabilize)
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height,
+                    ":above": stable_height + 1,
+                ],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO orchard_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, :stable), (1, :above), (2, NULL)",
+                named_params![
+                    ":stable": stable_height,
+                    ":above": stable_height + 1,
+                ],
+            )
+            .unwrap();
+
+        // Sapling seed rows cover every branch of the backfill predicate.
+        // `(commitment_tree_position >> SAPLING_SHARD_HEIGHT)` picks the shard for a given
+        // position.
+        let sapling_pos_shard_0: i64 = 1;
+        let sapling_pos_shard_1: i64 = 1 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_2: i64 = 2 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_99: i64 = 99 << SAPLING_SHARD_HEIGHT; // no shard row
+
+        for (output_index, position, _label) in [
+            (0, Some(sapling_pos_shard_0), "shard at boundary"),
+            (
+                1,
+                Some(sapling_pos_shard_1),
+                "shard one block above boundary",
+            ),
+            (2, Some(sapling_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(sapling_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO sapling_received_notes (
+                         transaction_id, output_index, account_id,
+                         diversifier, value, rcm, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :output_index, 1, X'00', 0, X'00', 0, :position)",
+                    named_params![
+                        ":output_index": output_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        let orchard_pos_shard_0: i64 = 3;
+        let orchard_pos_shard_1: i64 = 1 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_2: i64 = 2 << ORCHARD_SHARD_HEIGHT;
+        let orchard_pos_shard_99: i64 = 99 << ORCHARD_SHARD_HEIGHT;
+
+        for (action_index, position, _label) in [
+            (0, Some(orchard_pos_shard_0), "shard at boundary"),
+            (
+                1,
+                Some(orchard_pos_shard_1),
+                "shard one block above boundary",
+            ),
+            (2, Some(orchard_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(orchard_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO orchard_received_notes (
+                         transaction_id, action_index, account_id,
+                         diversifier, value, rho, rseed, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :action_index, 1, X'00', 0, X'00', X'00', 0, :position)",
+                    named_params![
+                        ":action_index": action_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let read = |table: &str, key_col: &str| -> Vec<(i64, i64)> {
+            let mut stmt = db_data
+                .conn
+                .prepare(&format!(
+                    "SELECT {key_col}, witness_stabilized FROM {table} ORDER BY {key_col}"
+                ))
+                .unwrap();
+            let rows: Vec<(i64, i64)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            rows
+        };
+
+        // Only output 0 (shard exactly at the boundary) should have been stabilized; output
+        // 1 (shard one block above the boundary) must NOT be, which catches an off-by-one
+        // in either direction.
+        assert_eq!(
+            read("sapling_received_notes", "output_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "sapling backfill should stabilize only the note whose shard's \
+             subtree_end_height <= stable_height and whose commitment_tree_position \
+             maps to that shard",
+        );
+
+        assert_eq!(
+            read("orchard_received_notes", "action_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "orchard backfill must match the sapling behavior",
+        );
+    }
+
+    /// When no rows have been inserted into `scan_queue`, the `MAX(...)` subquery returns
+    /// `NULL`; the migration must treat this as a no-op and not stabilize any notes — even
+    /// ones whose shards have finite `subtree_end_height` values.
+    #[test]
+    fn migrate_empty_scan_queue_is_noop() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_received_notes (
+                     transaction_id, output_index, account_id,
+                     diversifier, value, rcm, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let stabilized: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT witness_stabilized FROM sapling_received_notes WHERE output_index = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stabilized, 0,
+            "empty scan_queue must cause the backfill to be a no-op",
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -1,0 +1,650 @@
+//! Adds a `witness_stabilized` flag to received-note tables, indicating that the note's containing
+//! shard's block extent has been fully scanned and that the shard's end height has received at
+//! least `PRUNING_DEPTH` confirmations. Once set, the note has durable witness data. This can be
+//! used to indicate note spendability during a rewind, when the scan queue may not provide a
+//! usable indication.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_protocol::consensus;
+
+use super::account_delete_cascade;
+use crate::wallet::init::WalletMigrationError;
+use crate::wallet::scanning::mark_stabilized_notes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e99e422);
+
+const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
+
+impl<P> schemerz::Migration<Uuid> for Migration<P> {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds witness_stabilized flag to received notes for durable spendability."
+    }
+}
+
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        transaction.execute_batch(
+            "ALTER TABLE sapling_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;
+
+             ALTER TABLE orchard_received_notes
+               ADD COLUMN witness_stabilized INTEGER NOT NULL DEFAULT 0;
+
+             CREATE INDEX idx_sapling_received_notes_witness_stabilized
+                 ON sapling_received_notes (witness_stabilized);
+
+             CREATE INDEX idx_orchard_received_notes_witness_stabilized
+                 ON orchard_received_notes (witness_stabilized);",
+        )?;
+
+        // Backfill: Identify any notes which have stable witness data, and mark them as such.
+        mark_stabilized_notes(transaction, &self.params)?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_client_backend::data_api::SAPLING_SHARD_HEIGHT;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        PRUNING_DEPTH, WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    #[cfg(feature = "orchard")]
+    use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// End-to-end exercise of the backfill: seed the pre-migration schema with a variety
+    /// of notes whose stabilization outcomes are fully determined, run the migration, and
+    /// assert the expected `witness_stabilized` value for each.
+    #[test]
+    fn migrate_backfills_stabilized_notes() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to the state just prior to this migration. At this point
+        // `sapling_received_notes` / `orchard_received_notes` do not yet have the
+        // `witness_stabilized` column.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // Pick `last_scanned` so that the pruning floor `last_scanned - (PRUNING_DEPTH - 1)`
+        // equals `stable_block_height`. Place all heights well above the Sapling and NU5
+        // activation heights on TestNetwork (280,000 and 1,842,420 respectively) so that
+        // each shard's block extent — `(prev.subtree_end_height, subtree_end_height]` with
+        // `prev.subtree_end_height` defaulting to the pool's activation — actually
+        // overlaps the scan_queue range inserted below. Otherwise the view's INNER JOIN
+        // would return no rows for the shards and the test wouldn't exercise the
+        // unscanned-ranges check.
+        let base: u32 = 2_000_000;
+        let stable_block_height: u32 = base + 301;
+        let last_scanned: u32 = stable_block_height + (PRUNING_DEPTH - 1);
+        let birthday_height: u32 = base;
+
+        // Seed a minimal account. The UFVK/UIVK must be real encoded values because
+        // `verify_network_compatibility` parses them when the migrator opens the database.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, :birthday_height)",
+                named_params![
+                    ":ufvk": ufvk_str,
+                    ":uivk": uivk_str,
+                    ":birthday_height": birthday_height,
+                ],
+            )
+            .unwrap();
+
+        // Seed a single transaction; none of the backfill logic cares about the block
+        // column, only that there is an `id_tx` the note rows can reference.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+
+        // A single `Scanned` range covering every height from the birthday through
+        // `last_scanned` inclusive. Under this partition no non-Scanned range overlaps
+        // any shard post-birthday, so the view `v_{pool}_shard_unscanned_ranges` is empty.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES (:start, :end, 10)",
+                named_params![
+                    ":start": birthday_height,
+                    ":end": last_scanned + 1,
+                ],
+            )
+            .unwrap();
+
+        // A `blocks` row is needed for `block_max_scanned` to return `Some`.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO blocks (
+                     height, hash, time,
+                     sapling_tree, sapling_commitment_tree_size
+                 ) VALUES (:height, X'0000000000000000000000000000000000000000000000000000000000000000', 0,
+                          X'', 0)",
+                named_params![":height": last_scanned],
+            )
+            .unwrap();
+
+        // Tree shards. Shard 0 sits at the stabilization boundary and shard 1 sits one
+        // block above it, so the test fails if the backfill picks either neighbour of
+        // `<= pruning_floor`:
+        //   shard 0: end height == stable_block_height       (notes here SHOULD stabilize)
+        //   shard 1: end height == stable_block_height + 1   (notes here should NOT stabilize)
+        //   shard 2: end height NULL                         (notes here should NOT stabilize)
+        for pool in ["sapling", "orchard"] {
+            db_data
+                .conn
+                .execute(
+                    &format!(
+                        "INSERT INTO {pool}_tree_shards (shard_index, subtree_end_height)
+                         VALUES (0, :stable), (1, :above), (2, NULL)"
+                    ),
+                    named_params![
+                        ":stable": stable_block_height,
+                        ":above": stable_block_height + 1,
+                    ],
+                )
+                .unwrap();
+        }
+
+        // Sapling seed rows cover every branch of the backfill predicate.
+        // `(commitment_tree_position >> SAPLING_SHARD_HEIGHT)` picks the shard for a given
+        // position.
+        let sapling_pos_shard_0: i64 = 1;
+        let sapling_pos_shard_1: i64 = 1 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_2: i64 = 2 << SAPLING_SHARD_HEIGHT;
+        let sapling_pos_shard_99: i64 = 99 << SAPLING_SHARD_HEIGHT; // no shard row
+
+        for (output_index, position, _label) in [
+            (0, Some(sapling_pos_shard_0), "shard at boundary"),
+            (
+                1,
+                Some(sapling_pos_shard_1),
+                "shard one block above boundary",
+            ),
+            (2, Some(sapling_pos_shard_2), "null end-height shard"),
+            (3, None::<i64>, "null commitment_tree_position"),
+            (4, Some(sapling_pos_shard_99), "no matching shard row"),
+        ] {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO sapling_received_notes (
+                         transaction_id, output_index, account_id,
+                         diversifier, value, rcm, is_change,
+                         commitment_tree_position
+                     ) VALUES (1, :output_index, 1, X'00', 0, X'00', 0, :position)",
+                    named_params![
+                        ":output_index": output_index,
+                        ":position": position,
+                    ],
+                )
+                .unwrap();
+        }
+
+        // Orchard seed rows: identical coverage, with shard-height-appropriate positions.
+        // The `orchard` feature gates the `ORCHARD_SHARD_HEIGHT` constant, so without it
+        // this block is compiled out; the schema's `orchard_received_notes` table is
+        // still created unconditionally but no notes exist to stabilize.
+        #[cfg(feature = "orchard")]
+        {
+            let orchard_pos_shard_0: i64 = 1;
+            let orchard_pos_shard_1: i64 = 1 << ORCHARD_SHARD_HEIGHT;
+            let orchard_pos_shard_2: i64 = 2 << ORCHARD_SHARD_HEIGHT;
+            let orchard_pos_shard_99: i64 = 99 << ORCHARD_SHARD_HEIGHT;
+
+            for (action_index, position, _label) in [
+                (0, Some(orchard_pos_shard_0), "shard at boundary"),
+                (
+                    1,
+                    Some(orchard_pos_shard_1),
+                    "shard one block above boundary",
+                ),
+                (2, Some(orchard_pos_shard_2), "null end-height shard"),
+                (3, None::<i64>, "null commitment_tree_position"),
+                (4, Some(orchard_pos_shard_99), "no matching shard row"),
+            ] {
+                db_data
+                    .conn
+                    .execute(
+                        "INSERT INTO orchard_received_notes (
+                             transaction_id, action_index, account_id,
+                             diversifier, value, rho, rseed, is_change,
+                             commitment_tree_position
+                         ) VALUES (1, :action_index, 1, X'00', 0, X'00', X'00', 0, :position)",
+                        named_params![
+                            ":action_index": action_index,
+                            ":position": position,
+                        ],
+                    )
+                    .unwrap();
+            }
+        }
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let read = |table: &str, pk_col: &str| -> Vec<(i64, i64)> {
+            let mut stmt = db_data
+                .conn
+                .prepare(&format!(
+                    "SELECT {pk_col}, witness_stabilized FROM {table} ORDER BY {pk_col}"
+                ))
+                .unwrap();
+            let rows: Vec<(i64, i64)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap();
+            rows
+        };
+
+        // Only the note in the boundary shard (index 0) stabilizes; the other four
+        // branches (above-boundary shard, null end-height shard, null position, no
+        // matching shard row) must all remain unstabilized.
+        assert_eq!(
+            read("sapling_received_notes", "output_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "sapling backfill should stabilize only notes whose containing shard has \
+             subtree_end_height <= pruning_floor and no non-Scanned scan_queue overlap",
+        );
+
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            read("orchard_received_notes", "action_index"),
+            vec![(0, 1), (1, 0), (2, 0), (3, 0), (4, 0)],
+            "orchard backfill must match the sapling behavior",
+        );
+    }
+
+    /// When the wallet has no scan state yet — no `blocks` rows and no `scan_queue`
+    /// rows — `block_max_scanned` returns `None` and the backfill must be a no-op, even
+    /// for notes whose containing shard's `subtree_end_height` is finite.
+    #[test]
+    fn migrate_without_scan_state_is_noop() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_tree_shards (shard_index, subtree_end_height)
+                 VALUES (0, 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_received_notes (
+                     transaction_id, output_index, account_id,
+                     diversifier, value, rcm, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let stabilized: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT witness_stabilized FROM sapling_received_notes WHERE output_index = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stabilized, 0,
+            "absent scan state must cause the backfill to be a no-op",
+        );
+    }
+
+    /// Regression test: a note whose containing shard's `subtree_end_height` is known
+    /// (e.g. populated by `put_shard_roots`) and lies at or below the pruning floor must
+    /// NOT be treated as stabilized if any block inside the shard's extent is covered by
+    /// a non-Scanned `scan_queue` range. An earlier criterion that only required
+    /// `subtree_end_height <= last_scanned - (PRUNING_DEPTH - 1)` could spuriously
+    /// stabilize such a note even though the wallet was missing the intra-shard
+    /// commitments inside the unscanned gap, stranding the note at spend time. The fix is
+    /// the per-shard view-based check in `mark_stabilized_notes`.
+    #[test]
+    fn gap_in_scanned_coverage_prevents_stabilization() {
+        use zcash_client_backend::data_api::scanning::ScanPriority;
+
+        use crate::wallet::scanning::{mark_stabilized_notes, priority_code};
+
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate through `witness_stabilized_notes` so the schema is in its final state.
+        // Because there is no scan_queue / blocks / shards seeded yet, the migration's
+        // backfill is a no-op and the column default (0) applies to all rows we're about
+        // to insert.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // Scenario: the `scan_queue` partition covers `[birthday, chain_tip_exclusive)`
+        // with a non-Scanned (here: Historic) gap `[low_end, high_start)` in the middle.
+        // Shard 0's block extent is `(birthday, shard_end_height]`, which overlaps that
+        // gap. The shard's end lies below the pruning floor, so the only remaining
+        // barrier to stabilization is the view-based unscanned-range check.
+        //
+        //   birthday          low_end  gap    high_start           shard_end         max_scanned
+        //   |--- Scanned --------|---Historic---|--------- Scanned -------|-- Scanned -----|
+        //                                                 ^
+        //                                   shard 0's extent covers (birthday, shard_end],
+        //                                   which straddles the non-Scanned gap.
+        // All heights sit above the NU5 testnet activation height (1,842,420) so that each
+        // pool's shard scan-range view actually joins the shard to the scan_queue rows
+        // below — otherwise the shard's view-frame extent would be empty and the gap
+        // couldn't overlap.
+        let base: u32 = 2_000_000;
+        let birthday_height: u32 = base + 1;
+        let low_end: u32 = base + 150; // exclusive upper bound of the low Scanned range
+        let high_start: u32 = base + 200;
+        let shard_end_height: u32 = base + 250;
+        let max_scanned: u32 = shard_end_height + PRUNING_DEPTH + 50;
+        let chain_tip_exclusive: u32 = max_scanned + 1;
+        let pruning_floor: u32 = max_scanned - (PRUNING_DEPTH - 1);
+        assert!(
+            shard_end_height <= pruning_floor,
+            "test invariant: shard end must lie at or below the pruning floor so the \
+             only remaining barrier to stabilization is the unscanned-range check",
+        );
+        assert!(
+            low_end < high_start && high_start < shard_end_height,
+            "test invariant: non-Scanned gap must lie inside shard 0's extent",
+        );
+
+        // Seed a minimal account so `wallet_birthday(conn)` returns `Some(birthday_height)`.
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, &seed_bytes, zip32::AccountId::ZERO).unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind,
+                 hd_seed_fingerprint, hd_account_index,
+                 ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (1, X'0000000000000000000000000000AAAA', 0,
+                 X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, :birthday_height)",
+                named_params![
+                    ":ufvk": ufvk_str,
+                    ":uivk": uivk_str,
+                    ":birthday_height": birthday_height,
+                ],
+            )
+            .unwrap();
+
+        // Seed a single transaction; the note rows need an `id_tx` to reference.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height)
+                 VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+
+        // `scan_queue` is a partition of `[birthday, chain_tip_exclusive)`:
+        //   [birthday, low_end)       priority Scanned
+        //   [low_end, high_start)     priority Historic  <-- the non-Scanned gap
+        //   [high_start, chain_tip)   priority Scanned
+        let scanned = priority_code(&ScanPriority::Scanned);
+        let historic = priority_code(&ScanPriority::Historic);
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES
+                    (:start1, :end1, :scanned),
+                    (:start2, :end2, :historic),
+                    (:start3, :end3, :scanned)",
+                named_params![
+                    ":start1": birthday_height,
+                    ":end1": low_end,
+                    ":start2": low_end,
+                    ":end2": high_start,
+                    ":start3": high_start,
+                    ":end3": chain_tip_exclusive,
+                    ":scanned": scanned,
+                    ":historic": historic,
+                ],
+            )
+            .unwrap();
+
+        // A `blocks` row at `max_scanned` so `block_max_scanned` reflects the high range's
+        // tip and the helper can compute the pruning floor.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO blocks (
+                     height, hash, time,
+                     sapling_tree, sapling_commitment_tree_size
+                 ) VALUES
+                     (:max_scanned, X'0000000000000000000000000000000000000000000000000000000000000000', 0, X'', 0)",
+                named_params![":max_scanned": max_scanned],
+            )
+            .unwrap();
+
+        // Shard 0 with `subtree_end_height = shard_end_height`. Its block extent is
+        // `(birthday, shard_end_height]`, which overlaps the non-Scanned gap. Its end
+        // lies below the pruning floor, so the criterion's only remaining barrier is the
+        // view-based unscanned-range check.
+        for pool in ["sapling", "orchard"] {
+            db_data
+                .conn
+                .execute(
+                    &format!(
+                        "INSERT INTO {pool}_tree_shards (shard_index, subtree_end_height)
+                         VALUES (0, :end)"
+                    ),
+                    named_params![":end": shard_end_height],
+                )
+                .unwrap();
+        }
+
+        // One note per pool in shard 0. `commitment_tree_position = 1` places each note
+        // inside shard index 0 for both SAPLING_SHARD_HEIGHT and ORCHARD_SHARD_HEIGHT.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO sapling_received_notes (
+                     transaction_id, output_index, account_id,
+                     diversifier, value, rcm, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+        #[cfg(feature = "orchard")]
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO orchard_received_notes (
+                     transaction_id, action_index, account_id,
+                     diversifier, value, rho, rseed, is_change,
+                     commitment_tree_position
+                 ) VALUES (1, 0, 1, X'00', 0, X'00', X'00', 0, 1)",
+                [],
+            )
+            .unwrap();
+
+        let read_stabilized = |conn: &rusqlite::Connection, table: &str, pk_col: &str| -> i64 {
+            conn.query_row(
+                &format!("SELECT witness_stabilized FROM {table} WHERE {pk_col} = 0"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        // First call: the non-Scanned gap lies inside shard 0's extent, so the note must
+        // NOT stabilize.
+        let tx = db_data.conn.transaction().unwrap();
+        mark_stabilized_notes(&tx, &network).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(
+            read_stabilized(&db_data.conn, "sapling_received_notes", "output_index"),
+            0,
+            "sapling note must not be stabilized while a non-Scanned scan_queue \
+             range overlaps its containing shard's extent",
+        );
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            read_stabilized(&db_data.conn, "orchard_received_notes", "action_index"),
+            0,
+            "orchard note must not be stabilized while a non-Scanned scan_queue \
+             range overlaps its containing shard's extent",
+        );
+
+        // Replace the three ranges with a single contiguous Scanned range
+        // `[birthday, chain_tip_exclusive)`. The view should now return no rows for
+        // shard 0, so the note stabilizes.
+        db_data.conn.execute("DELETE FROM scan_queue", []).unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+                 VALUES (:start, :end, :priority)",
+                named_params![
+                    ":start": birthday_height,
+                    ":end": chain_tip_exclusive,
+                    ":priority": scanned,
+                ],
+            )
+            .unwrap();
+
+        let tx = db_data.conn.transaction().unwrap();
+        mark_stabilized_notes(&tx, &network).unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(
+            read_stabilized(&db_data.conn, "sapling_received_notes", "output_index"),
+            1,
+            "sapling note must be stabilized once the gap is filled",
+        );
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            read_stabilized(&db_data.conn, "orchard_received_notes", "action_index"),
+            1,
+            "orchard note must be stabilized once the gap is filled",
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::common::table_constants;
-use super::wallet_birthday;
+use super::{block_max_scanned, wallet_birthday};
 
 #[cfg(feature = "orchard")]
 use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
@@ -369,6 +369,58 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         .chain(extended_after);
 
     replace_queue_entries::<SqliteClientError>(conn, &query_range, replacement, false)?;
+
+    // Check for any newly stabilized notes, and mark them as stabilized
+    mark_stabilized_notes(conn, params)?;
+
+    Ok(())
+}
+
+/// Marks received notes as `witness_stabilized` once their containing shard's block extent is fully
+/// Scanned and the shard's end height has at least `PRUNING_DEPTH` confirmations.
+///
+/// This means that a note within the chain-tip shard can not be marked as `witness_stabilized`,
+/// because the tip shard is by definition not complete or confirmed to the `PRUNING_DEPTH`.
+pub(crate) fn mark_stabilized_notes<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction<'_>,
+    params: &P,
+) -> Result<(), SqliteClientError> {
+    fn mark_pool(
+        conn: &rusqlite::Transaction<'_>,
+        pool: &str,
+        shard_height: u8,
+        pruning_floor: u32,
+    ) -> Result<(), SqliteClientError> {
+        let sql = format!(
+            "UPDATE {pool}_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM {pool}_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :pruning_floor
+                     AND (commitment_tree_position >> :shard_height) = shard.shard_index
+                     AND shard.shard_index NOT IN (
+                         SELECT shard_index FROM v_{pool}_shard_unscanned_ranges
+                     )
+               )",
+        );
+        conn.execute(
+            &sql,
+            named_params![":pruning_floor": pruning_floor, ":shard_height": shard_height],
+        )?;
+        Ok(())
+    }
+
+    if let Some(max_scanned_height) = block_max_scanned(conn, params)?.map(|m| m.block_height()) {
+        let pruning_floor: u32 = u32::from(max_scanned_height).saturating_sub(PRUNING_DEPTH - 1);
+
+        // Mark stabilized notes in each pool
+        mark_pool(conn, "sapling", SAPLING_SHARD_HEIGHT, pruning_floor)?;
+        #[cfg(feature = "orchard")]
+        mark_pool(conn, "orchard", ORCHARD_SHARD_HEIGHT, pruning_floor)?;
+    }
 
     Ok(())
 }

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -25,11 +25,10 @@ use crate::{
 use super::common::table_constants;
 use super::wallet_birthday;
 
-#[cfg(feature = "orchard")]
-use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
 #[cfg(not(feature = "orchard"))]
 use zcash_protocol::PoolType;
+
+use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
 pub(crate) fn priority_code(priority: &ScanPriority) -> i64 {
     use ScanPriority::*;
@@ -369,6 +368,57 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         .chain(extended_after);
 
     replace_queue_entries::<SqliteClientError>(conn, &query_range, replacement, false)?;
+
+    // Mark any notes whose containing shard has now been confirmed beyond the pruning depth.
+    let last_scanned_height = range.end - 1;
+    mark_stabilized_notes(conn, last_scanned_height)?;
+
+    Ok(())
+}
+
+/// Marks notes as stabilized when their containing shard is complete and the shard's end
+/// height lies at or below the truncation rewind boundary
+/// (`last_scanned_height - (PRUNING_DEPTH - 1)`). Once stabilized, a note's witness data is
+/// considered durable and will be preserved across truncation.
+pub(crate) fn mark_stabilized_notes(
+    conn: &rusqlite::Transaction<'_>,
+    last_scanned_height: BlockHeight,
+) -> Result<(), SqliteClientError> {
+    let stable_height = u32::from(last_scanned_height).saturating_sub(PRUNING_DEPTH - 1);
+
+    conn.execute(
+        &format!(
+            "UPDATE sapling_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM sapling_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            SAPLING_SHARD_HEIGHT,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
+
+    conn.execute(
+        &format!(
+            "UPDATE orchard_received_notes
+             SET witness_stabilized = 1
+             WHERE witness_stabilized = 0
+               AND commitment_tree_position IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM orchard_tree_shards shard
+                   WHERE shard.subtree_end_height IS NOT NULL
+                     AND shard.subtree_end_height <= :stable_height
+                     AND (commitment_tree_position >> {}) = shard.shard_index
+               )",
+            ORCHARD_SHARD_HEIGHT,
+        ),
+        named_params![":stable_height": stable_height],
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR modifies truncation to respect the `PRUNING_DEPTH`, adds a `witness_stabilized` flag to notes, and modifies note selection criteria to use that flag in place of chain data, to allow using notes even during truncation.

Truncation will still reset the scan queue to the requested height, but other chain data will only be rewound as far back as the pruning depth. This ensures that any witness data necessary to spend a transaction will be available up to `tip - PRUNING_DEPTH`. Notes after the pruning depth will trivially become spendable as the wallet need only scan the most recent blocks to recover the remaining witness data up to the tip.

Resolves: https://github.com/zcash/librustzcash/issues/2276
Resolves: [COR-1192](https://linear.app/zodl/issue/COR-1192/featzcash-client-sqlite-retain-stable-witness-data-during-truncation)