### PR TITLE
zcash_client_backend: External-only batch trial decryption with targeted Internal IVK fallback

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -68,6 +68,15 @@ workspace.
     having no economic value in `zcash_client_sqlite`.
   - `chain::scan_cached_blocks` now requires `DbT::AccountId: Sync` (in addition
     to its existing `Send + 'static` bounds).
+  - `chain::scan_cached_blocks` now uses External-only IVKs for batch trial
+    decryption when the scan range extends the fully-scanned chain tip
+    (`from_height == block_fully_scanned() + 1`). Internal-scope change notes
+    are recovered by a targeted per-transaction pass triggered by a nullifier
+    match, an External-IVK match, or the shielding pattern (transparent inputs
+    + shielded outputs + no shielded spends). Non-contiguous scan ranges
+    continue to use both IVKs in the batch. This halves ECDH key-agreement
+    work per output for the common ongoing-sync case without changing
+    wallet-visible behavior.
   - `error::Error::MemoForbidden` has been replaced by
     `Error::Payment(zip321::PaymentError)`, which can represent both
     memo-to-transparent and zero-valued-transparent-output errors.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -162,7 +162,14 @@ pub const ORCHARD_SHARD_HEIGHT: u8 = { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8
 /// An enumeration of constraints that can be applied when querying for nullifiers for notes
 /// belonging to the wallet.
 pub enum NullifierQuery {
+    /// Return nullifiers for notes that have not been confirmed spent by a transaction mined on
+    /// the chain.
+    ///
+    /// This is intended for scan relevance. It may include nullifiers for notes that are locked
+    /// by locally-created transactions that have not yet been mined, and therefore must not be
+    /// used as a spendability query.
     Unspent,
+    /// Return nullifiers for every note known to the wallet.
     All,
 }
 

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -613,12 +613,10 @@ where
     // etc.), blocks may be scanned out of order, which means the wallet might not yet
     // know the nullifiers being spent. In that case, fall back to both IVKs for
     // correctness.
-    let fully_scanned = data_db
-        .block_fully_scanned()
-        .map_err(Error::Wallet)?;
+    let fully_scanned = data_db.block_fully_scanned().map_err(Error::Wallet)?;
     let is_contiguous = fully_scanned
         .as_ref()
-        .map_or(false, |meta| from_height == meta.block_height() + 1);
+        .is_some_and(|meta| from_height == meta.block_height() + 1);
 
     let scopes = if is_contiguous {
         tracing::debug!(
@@ -641,10 +639,7 @@ where
         &scopes,
     );
     let internal_keys = if is_contiguous {
-        ScanningKeys::from_account_ufvks_with_scopes(
-            account_ufvks,
-            &[Scope::Internal],
-        )
+        ScanningKeys::from_account_ufvks_with_scopes(account_ufvks, &[Scope::Internal])
     } else {
         // Both scopes are already in scanning_keys; no separate Internal pass needed.
         drop(account_ufvks);

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -157,6 +157,7 @@ use incrementalmerkletree::frontier::Frontier;
 use subtle::ConditionallySelectable;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{self, BlockHeight};
+use zip32::Scope;
 
 use crate::{
     data_api::WalletWrite,
@@ -603,7 +604,52 @@ where
     let account_ufvks = data_db
         .get_unified_full_viewing_keys()
         .map_err(Error::Wallet)?;
-    let scanning_keys = ScanningKeys::from_account_ufvks(account_ufvks);
+
+    // Determine whether this scan range is contiguous with the wallet's fully-scanned
+    // chain tip. If so, blocks are being appended linearly (the common case for ongoing
+    // sync) and we can safely use External-only IVKs for the batch — Internal/change
+    // notes are recovered by the targeted three-trigger check inside
+    // scan_block_with_runners. If non-contiguous (ChainTip jump, FoundNote backfill,
+    // etc.), blocks may be scanned out of order, which means the wallet might not yet
+    // know the nullifiers being spent. In that case, fall back to both IVKs for
+    // correctness.
+    let fully_scanned = data_db
+        .block_fully_scanned()
+        .map_err(Error::Wallet)?;
+    let is_contiguous = fully_scanned
+        .as_ref()
+        .map_or(false, |meta| from_height == meta.block_height() + 1);
+
+    let scopes = if is_contiguous {
+        tracing::debug!(
+            "scan_cached_blocks: EXTERNAL-ONLY batch from height {} (contiguous with fully-scanned {})",
+            from_height,
+            fully_scanned.as_ref().map(|m| m.block_height()).unwrap(),
+        );
+        vec![Scope::External]
+    } else {
+        tracing::debug!(
+            "scan_cached_blocks: BOTH IVKs batch from height {} (non-contiguous, fully-scanned: {:?})",
+            from_height,
+            fully_scanned.as_ref().map(|m| m.block_height()),
+        );
+        vec![Scope::External, Scope::Internal]
+    };
+
+    let scanning_keys = ScanningKeys::from_account_ufvks_with_scopes(
+        account_ufvks.iter().map(|(id, ufvk)| (*id, ufvk.clone())),
+        &scopes,
+    );
+    let internal_keys = if is_contiguous {
+        ScanningKeys::from_account_ufvks_with_scopes(
+            account_ufvks,
+            &[Scope::Internal],
+        )
+    } else {
+        // Both scopes are already in scanning_keys; no separate Internal pass needed.
+        drop(account_ufvks);
+        ScanningKeys::empty()
+    };
     let mut runners = BatchRunners::<_, (), ()>::for_keys(100, &scanning_keys);
 
     block_source.with_blocks::<_, DbT::Error>(Some(from_height), Some(limit), |block| {
@@ -633,6 +679,7 @@ where
                 params,
                 block,
                 &scanning_keys,
+                &internal_keys,
                 &nullifiers,
                 prior_block_metadata.as_ref(),
                 Some(&mut runners),

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -16,7 +16,7 @@ use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::{
     block::BlockHash,
     transaction::{
-        Transaction,
+        Transaction, TxId,
         fees::zip317::{FeeRule as Zip317FeeRule, MARGINAL_FEE, MINIMUM_FEE},
     },
 };
@@ -72,7 +72,7 @@ use {
         keys::{NonHardenedChildIndex, TransparentKeyScope},
     },
     zcash_primitives::transaction::fees::zip317,
-    zcash_protocol::{TxId, value::ZatBalance},
+    zcash_protocol::value::ZatBalance,
 };
 
 #[cfg(feature = "orchard")]
@@ -4858,6 +4858,138 @@ pub fn scan_cached_blocks_finds_change_notes<T: ShieldedPoolTester, Dsf>(
     assert_eq!(
         st.get_total_balance(account.id()),
         (value - value2).unwrap()
+    );
+}
+
+pub fn scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_spend<
+    T: ShieldedPoolTester,
+    Dsf,
+>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+    make_non_expiring: impl FnOnce(&mut Dsf::DataStore, TxId),
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+
+    let value = Zatoshis::const_from_u64(100_000);
+    st.add_a_single_note_checking_balance(value);
+
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let to = T::fvk_default_address(&not_our_key);
+    let send_value = Zatoshis::const_from_u64(20_000);
+    let req = TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
+
+    let txid = st
+        .spend(
+            &input_selector,
+            &change_strategy,
+            account.usk(),
+            req,
+            OvkPolicy::Sender,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap()[0];
+
+    make_non_expiring(st.wallet_mut(), txid);
+    assert_eq!(st.wallet().get_tx_height(txid).unwrap(), None);
+
+    let (spent_height, _) = st.generate_next_block_including(txid);
+    let summary = st.scan_cached_blocks(spent_height, 1);
+
+    assert_eq!(summary.scanned_range().start, spent_height);
+    assert_eq!(summary.scanned_range().end, spent_height + 1);
+    assert_eq!(T::received_note_count(&summary), 1);
+    assert_eq!(st.wallet().get_tx_height(txid).unwrap(), Some(spent_height));
+
+    let tx_summary = st.get_tx_from_history(txid).unwrap().unwrap();
+    assert_eq!(tx_summary.spent_note_count(), 1);
+    assert!(tx_summary.has_change());
+
+    assert_eq!(
+        st.get_total_balance(account.id()),
+        (value - (send_value + MINIMUM_FEE).unwrap()).unwrap()
+    );
+}
+
+pub fn scan_cached_blocks_recovers_internal_change_after_mined_status_update<
+    T: ShieldedPoolTester,
+    Dsf,
+>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+
+    let value = Zatoshis::const_from_u64(100_000);
+    let (funding_height, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let not_our_key = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let to = T::fvk_default_address(&not_our_key);
+    let send_value = Zatoshis::const_from_u64(20_000);
+    let req = TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        send_value,
+    )])
+    .unwrap();
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
+
+    let txid = st
+        .spend(
+            &input_selector,
+            &change_strategy,
+            account.usk(),
+            req,
+            OvkPolicy::Sender,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap()[0];
+
+    let spent_height = funding_height + 1;
+
+    // Status enhancement can learn that a transaction was mined before compact scanning reaches
+    // the containing block. The scan still needs the spent note's nullifier so it can recognize
+    // the transaction as wallet-relevant and repair the internally addressed change output.
+    st.wallet_mut()
+        .set_transaction_status(txid, data_api::TransactionStatus::Mined(spent_height))
+        .unwrap();
+
+    let (generated_spent_height, _) = st.generate_next_block_including(txid);
+    assert_eq!(generated_spent_height, spent_height);
+
+    let summary = st.scan_cached_blocks(spent_height, 1);
+
+    assert_eq!(summary.scanned_range().start, spent_height);
+    assert_eq!(summary.scanned_range().end, spent_height + 1);
+    assert_eq!(T::received_note_count(&summary), 1);
+
+    let tx_summary = st.get_tx_from_history(txid).unwrap().unwrap();
+    assert_eq!(tx_summary.spent_note_count(), 1);
+    assert!(tx_summary.has_change());
+
+    assert_eq!(
+        st.get_total_balance(account.id()),
+        (value - (send_value + MINIMUM_FEE).unwrap()).unwrap()
     );
 }
 

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -272,6 +272,23 @@ impl<AccountId: Copy + Eq + Hash + Send + Sync + 'static>
     pub fn from_account_ufvks(
         ufvks: impl IntoIterator<Item = (AccountId, UnifiedFullViewingKey)>,
     ) -> Self {
+        Self::from_account_ufvks_with_scopes(ufvks, &[Scope::External, Scope::Internal])
+    }
+
+    /// Constructs a [`ScanningKeys`] from an iterator of [`UnifiedFullViewingKey`]s,
+    /// using only the specified scopes for key derivation.
+    ///
+    /// Passing `&[Scope::External]` omits internal (change) keys from the key set,
+    /// which is used by [`scan_cached_blocks`] to halve the key-agreement work per
+    /// output during batch trial decryption. Change notes are instead recovered by
+    /// a targeted Internal-IVK pass on wallet-relevant transactions identified by
+    /// nullifier matching, External-IVK matching, or the shielding transaction pattern.
+    ///
+    /// [`scan_cached_blocks`]: crate::data_api::chain::scan_cached_blocks
+    pub(crate) fn from_account_ufvks_with_scopes(
+        ufvks: impl IntoIterator<Item = (AccountId, UnifiedFullViewingKey)>,
+        scopes: &[Scope],
+    ) -> Self {
         #![allow(clippy::type_complexity)]
 
         let mut sapling: HashMap<
@@ -290,7 +307,7 @@ impl<AccountId: Copy + Eq + Hash + Send + Sync + 'static>
 
         for (account_id, ufvk) in ufvks {
             if let Some(dfvk) = ufvk.sapling() {
-                for scope in [Scope::External, Scope::Internal] {
+                for &scope in scopes {
                     sapling.insert(
                         (account_id, scope),
                         Box::new(ScanningKey {
@@ -305,7 +322,7 @@ impl<AccountId: Copy + Eq + Hash + Send + Sync + 'static>
 
             #[cfg(feature = "orchard")]
             if let Some(fvk) = ufvk.orchard() {
-                for scope in [Scope::External, Scope::Internal] {
+                for &scope in scopes {
                     orchard.insert(
                         (account_id, scope),
                         Box::new(ScanningKey {
@@ -606,10 +623,15 @@ where
     AccountId: Default + Eq + Hash + ConditionallySelectable + Send + Sync + 'static,
     IvkTag: Copy + std::hash::Hash + Eq + Send + 'static,
 {
+    // The legacy scan_block API passes both External + Internal IVKs in
+    // scanning_keys, so no targeted Internal pass is needed. Pass an empty
+    // ScanningKeys for internal_keys.
+    let empty_internal = ScanningKeys::empty();
     compact::scan_block_with_runners::<_, _, _, (), ()>(
         params,
         block,
         scanning_keys,
+        &empty_internal,
         nullifiers,
         prior_block_metadata,
         None,
@@ -687,7 +709,7 @@ fn find_spent<
 
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
-fn find_received<
+pub(crate) fn find_received<
     AccountId: Copy + Eq + Hash,
     D: BatchDomain,
     M,

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::hash::Hash;
 
-use incrementalmerkletree::Retention;
+use incrementalmerkletree::{Marking, Retention};
 use sapling::note_encryption::{CompactOutputDescription, SaplingDomain};
 use subtle::ConditionallySelectable;
 
@@ -177,6 +177,7 @@ pub(crate) fn scan_block_with_runners<P, AccountId, IvkTag, TS, TO>(
     params: &P,
     block: CompactBlock,
     scanning_keys: &ScanningKeys<AccountId, IvkTag>,
+    internal_keys: &ScanningKeys<AccountId, IvkTag>,
     nullifiers: &Nullifiers<AccountId>,
     prior_block_metadata: Option<&BlockMetadata>,
     mut batch_runners: Option<&mut BatchRunners<IvkTag, TS, TO>>,
@@ -279,7 +280,7 @@ where
             spent_from_accounts.chain(orchard_spends.iter().map(|spend| spend.account_id()));
         let spent_from_accounts = spent_from_accounts.copied().collect::<HashSet<_>>();
 
-        let (sapling_outputs, mut sapling_nc) = find_received(
+        let (mut sapling_outputs, mut sapling_nc) = find_received(
             cur_height,
             pos_tracker.compact_tx_contains_last_sapling_outputs_in_block(&tx),
             txid,
@@ -315,10 +316,9 @@ where
             |output| sapling::Node::from_cmu(&output.cmu),
         );
         sapling_note_commitments.append(&mut sapling_nc);
-        let has_sapling = !(sapling_spends.is_empty() && sapling_outputs.is_empty());
 
         #[cfg(feature = "orchard")]
-        let (orchard_outputs, mut orchard_nc) = find_received(
+        let (mut orchard_outputs, mut orchard_nc) = find_received(
             cur_height,
             pos_tracker.compact_tx_contains_last_orchard_actions_in_block(&tx),
             txid,
@@ -354,6 +354,161 @@ where
         #[cfg(feature = "orchard")]
         orchard_note_commitments.append(&mut orchard_nc);
 
+        // Targeted Internal IVK pass: when a transaction is identified as
+        // wallet-relevant (by nullifier match, External-IVK match, or the
+        // shielding-transaction pattern), try Internal IVK on its shielded
+        // outputs to recover change notes. This avoids trying Internal IVK on
+        // every output in the block while still finding all wallet notes.
+        let has_shielded_outputs = !tx.outputs.is_empty();
+        #[cfg(feature = "orchard")]
+        let has_shielded_outputs = has_shielded_outputs || !tx.actions.is_empty();
+
+        let trigger_nullifier = !sapling_spends.is_empty();
+        #[cfg(feature = "orchard")]
+        let trigger_nullifier = trigger_nullifier || !orchard_spends.is_empty();
+
+        let trigger_external = !sapling_outputs.is_empty();
+        #[cfg(feature = "orchard")]
+        let trigger_external = trigger_external || !orchard_outputs.is_empty();
+
+        // Shielding pattern: transparent inputs + shielded outputs + no
+        // shielded spends. This catches transactions that convert transparent
+        // funds to Internal-scope shielded notes and would otherwise be
+        // invisible to External-only scanning.
+        let has_no_shielded_spends = tx.spends.is_empty();
+        #[cfg(feature = "orchard")]
+        let has_no_shielded_spends = has_no_shielded_spends && orchard_spends.is_empty();
+
+        let trigger_shielding = !tx.vin.is_empty()
+            && has_shielded_outputs
+            && has_no_shielded_spends;
+
+        if (trigger_nullifier || trigger_external || trigger_shielding)
+            && has_shielded_outputs
+        {
+            tracing::debug!(
+                "Targeted Internal IVK on tx {} at height {} (triggers: nullifier={}, external={}, shielding={})",
+                txid, cur_height, trigger_nullifier, trigger_external, trigger_shielding,
+            );
+            // Try Internal IVK on Sapling outputs of this transaction.
+            if !tx.outputs.is_empty() {
+                let decoded_sapling: Vec<_> = tx
+                    .outputs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, output)| {
+                        Ok((
+                            SaplingDomain::new(zip212_enforcement),
+                            CompactOutputDescription::try_from(output).map_err(|_| {
+                                ScanError::EncodingInvalid {
+                                    at_height: cur_height,
+                                    txid,
+                                    pool_type: ShieldedProtocol::Sapling,
+                                    index: i,
+                                }
+                            })?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                if !decoded_sapling.is_empty() {
+                    let (mut internal_sapling_outputs, _) = find_received(
+                        cur_height,
+                        false, // not last commitments — already tracked
+                        txid,
+                        |output_idx| pos_tracker.sapling_note_position(output_idx),
+                        &internal_keys.sapling,
+                        &spent_from_accounts,
+                        &decoded_sapling,
+                        None::<fn(zcash_primitives::transaction::TxId) -> std::collections::HashMap<usize, super::DecryptedOutput<IvkTag, SaplingDomain, ()>>>,
+                        |ivks, outputs| {
+                            batch::try_compact_note_decryption(ivks, outputs)
+                                .into_iter()
+                                .map(|opt| opt.map(|((note, recipient), i)| ((note, recipient, ()), i)))
+                                .collect()
+                        },
+                        |output| sapling::Node::from_cmu(&output.cmu),
+                    );
+
+                    // Update note commitment retention for any newly-matched outputs.
+                    let nc_offset = sapling_note_commitments.len() - tx.outputs.len();
+                    for output in &internal_sapling_outputs {
+                        let idx = nc_offset + output.index();
+                        if let Some((_, retention)) = sapling_note_commitments.get_mut(idx) {
+                            match retention {
+                                Retention::Ephemeral => *retention = Retention::Marked,
+                                Retention::Checkpoint { marking, .. } => {
+                                    *marking = Marking::Marked;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    sapling_outputs.append(&mut internal_sapling_outputs);
+                }
+            }
+
+            // Try Internal IVK on Orchard actions of this transaction.
+            #[cfg(feature = "orchard")]
+            if !tx.actions.is_empty() {
+                let decoded_orchard: Vec<_> = tx
+                    .actions
+                    .iter()
+                    .enumerate()
+                    .map(|(i, action)| {
+                        let action = CompactAction::try_from(action).map_err(|_| {
+                            ScanError::EncodingInvalid {
+                                at_height: cur_height,
+                                txid,
+                                pool_type: ShieldedProtocol::Orchard,
+                                index: i,
+                            }
+                        })?;
+                        Ok((OrchardDomain::for_compact_action(&action), action))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                if !decoded_orchard.is_empty() {
+                    let (mut internal_orchard_outputs, _) = find_received(
+                        cur_height,
+                        false,
+                        txid,
+                        |output_idx| pos_tracker.orchard_note_position(output_idx),
+                        &internal_keys.orchard,
+                        &spent_from_accounts,
+                        &decoded_orchard,
+                        None::<fn(zcash_primitives::transaction::TxId) -> std::collections::HashMap<usize, super::DecryptedOutput<IvkTag, OrchardDomain, ()>>>,
+                        |ivks, outputs| {
+                            batch::try_compact_note_decryption(ivks, outputs)
+                                .into_iter()
+                                .map(|opt| opt.map(|((note, recipient), i)| ((note, recipient, ()), i)))
+                                .collect()
+                        },
+                        |output| MerkleHashOrchard::from_cmx(&output.cmx()),
+                    );
+
+                    let nc_offset = orchard_note_commitments.len() - tx.actions.len();
+                    for output in &internal_orchard_outputs {
+                        let idx = nc_offset + output.index();
+                        if let Some((_, retention)) = orchard_note_commitments.get_mut(idx) {
+                            match retention {
+                                Retention::Ephemeral => *retention = Retention::Marked,
+                                Retention::Checkpoint { marking, .. } => {
+                                    *marking = Marking::Marked;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    orchard_outputs.append(&mut internal_orchard_outputs);
+                }
+            }
+        }
+
+        // Recompute wallet-relevance after the Internal IVK pass.
+        let has_sapling = !(sapling_spends.is_empty() && sapling_outputs.is_empty());
         #[cfg(feature = "orchard")]
         let has_orchard = !(orchard_spends.is_empty() && orchard_outputs.is_empty());
         #[cfg(not(feature = "orchard"))]
@@ -630,10 +785,12 @@ mod tests {
                 None
             };
 
+            let empty_internal = ScanningKeys::empty();
             let scanned_block = scan_block_with_runners(
                 &network,
                 cb,
                 &scanning_keys,
+                &empty_internal,
                 &Nullifiers::empty(),
                 Some(&BlockMetadata::from_parts(
                     BlockHeight::from(0),
@@ -716,10 +873,12 @@ mod tests {
                 None
             };
 
+            let empty_internal = ScanningKeys::empty();
             let scanned_block = scan_block_with_runners(
                 &network,
                 cb,
                 &scanning_keys,
+                &empty_internal,
                 &Nullifiers::empty(),
                 None,
                 batch_runners.as_mut(),

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -379,16 +379,17 @@ where
         #[cfg(feature = "orchard")]
         let has_no_shielded_spends = has_no_shielded_spends && orchard_spends.is_empty();
 
-        let trigger_shielding = !tx.vin.is_empty()
-            && has_shielded_outputs
-            && has_no_shielded_spends;
+        let trigger_shielding =
+            !tx.vin.is_empty() && has_shielded_outputs && has_no_shielded_spends;
 
-        if (trigger_nullifier || trigger_external || trigger_shielding)
-            && has_shielded_outputs
-        {
+        if (trigger_nullifier || trigger_external || trigger_shielding) && has_shielded_outputs {
             tracing::debug!(
                 "Targeted Internal IVK on tx {} at height {} (triggers: nullifier={}, external={}, shielding={})",
-                txid, cur_height, trigger_nullifier, trigger_external, trigger_shielding,
+                txid,
+                cur_height,
+                trigger_nullifier,
+                trigger_external,
+                trigger_shielding,
             );
             // Try Internal IVK on Sapling outputs of this transaction.
             if !tx.outputs.is_empty() {
@@ -420,11 +421,20 @@ where
                         &internal_keys.sapling,
                         &spent_from_accounts,
                         &decoded_sapling,
-                        None::<fn(zcash_primitives::transaction::TxId) -> std::collections::HashMap<usize, super::DecryptedOutput<IvkTag, SaplingDomain, ()>>>,
+                        None::<
+                            fn(
+                                zcash_primitives::transaction::TxId,
+                            ) -> std::collections::HashMap<
+                                usize,
+                                super::DecryptedOutput<IvkTag, SaplingDomain, ()>,
+                            >,
+                        >,
                         |ivks, outputs| {
                             batch::try_compact_note_decryption(ivks, outputs)
                                 .into_iter()
-                                .map(|opt| opt.map(|((note, recipient), i)| ((note, recipient, ()), i)))
+                                .map(|opt| {
+                                    opt.map(|((note, recipient), i)| ((note, recipient, ()), i))
+                                })
                                 .collect()
                         },
                         |output| sapling::Node::from_cmu(&output.cmu),
@@ -478,11 +488,20 @@ where
                         &internal_keys.orchard,
                         &spent_from_accounts,
                         &decoded_orchard,
-                        None::<fn(zcash_primitives::transaction::TxId) -> std::collections::HashMap<usize, super::DecryptedOutput<IvkTag, OrchardDomain, ()>>>,
+                        None::<
+                            fn(
+                                zcash_primitives::transaction::TxId,
+                            ) -> std::collections::HashMap<
+                                usize,
+                                super::DecryptedOutput<IvkTag, OrchardDomain, ()>,
+                            >,
+                        >,
                         |ivks, outputs| {
                             batch::try_compact_note_decryption(ivks, outputs)
                                 .into_iter()
-                                .map(|opt| opt.map(|((note, recipient), i)| ((note, recipient, ()), i)))
+                                .map(|opt| {
+                                    opt.map(|((note, recipient), i)| ((note, recipient, ()), i))
+                                })
                                 .collect()
                         },
                         |output| MerkleHashOrchard::from_cmx(&output.cmx()),

--- a/zcash_client_memory/src/wallet_read.rs
+++ b/zcash_client_memory/src/wallet_read.rs
@@ -580,14 +580,12 @@ impl<P: consensus::Parameters> WalletRead for MemoryWalletDb<P> {
                 .collect(),
             NullifierQuery::Unspent => nullifiers
                 .filter_map(|(account_id, _, nf)| {
-                    // find any tx we know of that spends this nullifier and if so require that it is unmined or expired
+                    // Scan relevance only excludes nullifiers spent by transactions confirmed mined.
                     if let Some((height, tx_index)) = self.nullifiers.get(&Nullifier::Sapling(nf)) {
                         if let Some(spending_tx) =
                             self.tx_table.get_by_height_and_index(*height, *tx_index)
                         {
-                            if matches!(spending_tx.status(), TransactionStatus::Mined(_))
-                                || spending_tx.expiry_height().is_none()
-                            {
+                            if matches!(spending_tx.status(), TransactionStatus::Mined(_)) {
                                 None
                             } else {
                                 Some((account_id, nf))
@@ -616,14 +614,12 @@ impl<P: consensus::Parameters> WalletRead for MemoryWalletDb<P> {
                 .collect(),
             NullifierQuery::Unspent => nullifiers
                 .filter_map(|(account_id, _, nf)| {
-                    // find any tx we know of that spends this nullifier and if so require that it is unmined or expired
+                    // Scan relevance only excludes nullifiers spent by transactions confirmed mined.
                     if let Some((height, tx_index)) = self.nullifiers.get(&Nullifier::Orchard(nf)) {
                         if let Some(spending_tx) =
                             self.tx_table.get_by_height_and_index(*height, *tx_index)
                         {
-                            if matches!(spending_tx.status(), TransactionStatus::Mined(_))
-                                || spending_tx.expiry_height().is_none()
-                            {
+                            if matches!(spending_tx.status(), TransactionStatus::Mined(_)) {
                                 None
                             } else {
                                 Some((account_id, nf))

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- Scanning now recovers internal change from wallet-created shielded spends
+  whose stored transaction has no expiry height, and from spends whose mined
+  status is learned before their containing block has been scanned.
+
 ### Added
 - The following columns have been added to the exposed `v_tx_outputs` view:
   - `transaction_id`

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -446,6 +446,36 @@ mod tests {
     }
 
     #[test]
+    fn scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_sapling_spend() {
+        testing::pool::scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_spend::<
+            SaplingPoolTester,
+        >()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_orchard_spend() {
+        testing::pool::scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_spend::<
+            OrchardPoolTester,
+        >()
+    }
+
+    #[test]
+    fn scan_cached_blocks_recovers_internal_change_after_mined_sapling_status_update() {
+        testing::pool::scan_cached_blocks_recovers_internal_change_after_mined_status_update::<
+            SaplingPoolTester,
+        >()
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn scan_cached_blocks_recovers_internal_change_after_mined_orchard_status_update() {
+        testing::pool::scan_cached_blocks_recovers_internal_change_after_mined_status_update::<
+            OrchardPoolTester,
+        >()
+    }
+
+    #[test]
     fn scan_cached_blocks_detects_spends_out_of_order_sapling() {
         testing::pool::scan_cached_blocks_detects_spends_out_of_order::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -355,6 +355,38 @@ pub(crate) fn scan_cached_blocks_finds_change_notes<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_spend<
+    T: ShieldedPoolTester,
+>() {
+    use rusqlite::named_params;
+
+    zcash_client_backend::data_api::testing::pool::scan_cached_blocks_recovers_internal_change_for_unmined_non_expiring_spend::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+        |db, txid| {
+            db.conn_mut()
+                .execute(
+                    "UPDATE transactions
+                     SET expiry_height = 0
+                     WHERE txid = :txid",
+                    named_params! {
+                        ":txid": txid.as_ref(),
+                    },
+                )
+                .unwrap();
+        },
+    )
+}
+
+pub(crate) fn scan_cached_blocks_recovers_internal_change_after_mined_status_update<
+    T: ShieldedPoolTester,
+>() {
+    zcash_client_backend::data_api::testing::pool::scan_cached_blocks_recovers_internal_change_after_mined_status_update::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn scan_cached_blocks_detects_spends_out_of_order<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::scan_cached_blocks_detects_spends_out_of_order::<
         T,

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -142,16 +142,17 @@ fn unscanned_tip_exists(
     )
 }
 
-/// Retrieves the set of nullifiers for "potentially spendable" notes that the wallet is tracking.
+/// Retrieves the set of nullifiers for notes that the wallet is tracking and that have not been
+/// confirmed spent.
 ///
-/// "Potentially spendable" means:
+/// "Not confirmed spent" means:
 /// - The transaction in which the note was created has been observed as mined.
 /// - No transaction in which the note's nullifier appears has been observed as mined.
 ///
 /// This may over-select nullifiers and return those that have been spent in un-mined transactions
-/// that have not yet expired, or for which the expiry height is unknown. This is fine because
-/// these nullifiers are primarily used to detect the spends of our own notes in scanning; if we
-/// select a few too many nullifiers, it's not a big deal.
+/// regardless of whether they will expire. This is fine because these nullifiers are primarily
+/// used to detect the spends of our own notes in scanning; if we select a few too many nullifiers,
+/// it's not a big deal.
 pub(crate) fn get_nullifiers<N, F: Fn(&[u8]) -> Result<N, SqliteClientError>>(
     conn: &Connection,
     protocol: ShieldedProtocol,
@@ -164,7 +165,11 @@ pub(crate) fn get_nullifiers<N, F: Fn(&[u8]) -> Result<N, SqliteClientError>>(
     let mut stmt_fetch_nullifiers = match query {
         NullifierQuery::Unspent => conn.prepare(&format!(
             // See the method documentation for why this does not use `spent_notes_clause`.
-            // We prefer to be more restrictive in determining whether a note is spent here.
+            // Scan nullifiers drive wallet relevance while compact blocks are being scanned.
+            // A wallet can learn `mined_height` for a spend before it has scanned the compact
+            // block that contains it, so we keep that nullifier available until the spending
+            // transaction has been associated with a scanned block. This lets the scan detect the
+            // spend and run any targeted internal-IVK recovery needed to finish storing change.
             "SELECT a.uuid, rn.nf
                  FROM {table_prefix}_received_notes rn
                  JOIN accounts a ON a.id = rn.account_id
@@ -175,8 +180,7 @@ pub(crate) fn get_nullifiers<N, F: Fn(&[u8]) -> Result<N, SqliteClientError>>(
                    SELECT rns.{table_prefix}_received_note_id
                    FROM {table_prefix}_received_note_spends rns
                    JOIN transactions stx ON stx.id_tx = rns.transaction_id
-                   WHERE stx.mined_height IS NOT NULL  -- the spending tx is mined
-                   OR stx.expiry_height = 0 -- the spending tx will not expire
+                   WHERE stx.block IS NOT NULL  -- the spending tx's block has been scanned
                  )"
         )),
         NullifierQuery::All => conn.prepare(&format!(

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -308,10 +308,10 @@ pub(crate) fn put_received_note<
     Ok(account_id)
 }
 
-/// Retrieves the set of nullifiers for "potentially spendable" Orchard notes that the
-/// wallet is tracking.
+/// Retrieves the set of nullifiers for Orchard notes that the wallet is tracking and that have
+/// not been confirmed spent.
 ///
-/// "Potentially spendable" means:
+/// "Not confirmed spent" means:
 /// - The transaction in which the note was created has been observed as mined.
 /// - No transaction in which the note's nullifier appears has been observed as mined.
 pub(crate) fn get_orchard_nullifiers(

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -190,10 +190,10 @@ pub(crate) fn select_unspent_note_meta(
     )
 }
 
-/// Retrieves the set of nullifiers for "potentially spendable" Sapling notes that the
-/// wallet is tracking.
+/// Retrieves the set of nullifiers for Sapling notes that the wallet is tracking and that have
+/// not been confirmed spent.
 ///
-/// "Potentially spendable" means:
+/// "Not confirmed spent" means:
 /// - The transaction in which the note was created has been observed as mined.
 /// - No transaction in which the note's nullifier appears has been observed as mined.
 pub(crate) fn get_sapling_nullifiers(


### PR DESCRIPTION
## Summary

The batch uses External IVK only when it extends the wallet's contiguous scan from birthday by one block (`from_height == block_fully_scanned() + 1`). Internal IVK then runs per-transaction on ones the scan already flagged as wallet-relevant: spends of a known wallet note, outputs that match an External IVK, or shielding transactions (transparent in + shielded out + no shielded spends). Halves the ECDH work per output.

Non-contiguous batches keep using both IVKs. That covers fresh-wallet startup, `FoundNote` backfills that start below the tip, post-reorg `Verify` ranges with a gap, and the rescan queued when a new account is added with an earlier birthday. The check is structural, not priority-based: a `ChainTip` range starting at `fully_scanned + 1` is contiguous.

Almost every block ends up on the External-only path. Ongoing sync always picks up from the tip, so every batch is a linear extension. On fresh-wallet initial sync the ChainTip priority batches and the first Historic batch still use both IVKs, because the queue doesn't yet have a Scanned range from birthday; every Historic batch after that is a linear extension and takes the fast path.

Safety: wallet nullifiers up to `fully_scanned` are already loaded before the batch. Change notes recovered mid-batch have their nullifiers added as each block is scanned, so a later block in the range that spends one of them still matches the nullifier trigger.

## Testing

Aside from the existing tests, I loaded this onto zodl and re-added my wallet. I saw historic scanning using only the external IVK, and the final balance matched the correct value.

I compared the trial decryption over sandblast heights and we see the speedup:

<img width="1090" height="519" alt="Screenshot 2026-04-16 at 4 25 13 PM" src="https://github.com/user-attachments/assets/91f3829d-2f4c-4ccd-a06f-4a4409ca0145" />

<img width="1103" height="284" alt="Screenshot 2026-04-16 at 4 23 37 PM" src="https://github.com/user-attachments/assets/de512bd3-905c-4ae0-abc9-ceb89bc09535" />

<img width="1103" height="262" alt="Screenshot 2026-04-16 at 4 24 11 PM" src="https://github.com/user-attachments/assets/ab9534bb-f1c5-4418-960e-9ca063757ffd" />