### PR TITLE
zcash_transparent-0.6.4 post-release merge.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bip32",
  "blake2b_simd",

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -8,7 +8,7 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## [0.6.4] - PLANNED
+## [0.6.4] - 2026-04-16
 
 ### Added
 - `zcash_transparent::sighash::SighashType::from_raw`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -8,6 +8,11 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [0.6.4] - PLANNED
+
+### Added
+- `zcash_transparent::sighash::SighashType::from_raw`
+
 ## [0.6.3] - 2025-12-17
 
 ### Added

--- a/zcash_transparent/Cargo.toml
+++ b/zcash_transparent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_transparent"
 description = "Rust implementations of the Zcash transparent protocol"
-version = "0.6.3"
+version = "0.6.4"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",

--- a/zcash_transparent/src/sighash.rs
+++ b/zcash_transparent/src/sighash.rs
@@ -34,6 +34,12 @@ impl SighashType {
         }
     }
 
+    /// Constructs a `SighashType` from a raw pre-V5 `hash_type` byte
+    /// without applying ZIP 244 strictness.
+    pub fn from_raw(hash_type: u8) -> Self {
+        Self(hash_type)
+    }
+
     /// Encodes this `SighashType` using the [ZIP 244] rules.
     ///
     /// [ZIP 244]: https://zips.z.cash/zip-0244#s-2a-hash-type


### PR DESCRIPTION
This subsumes #2298 to resolve merge conflicts with `main`.