### PR TITLE
feat: WalletWrite::mark_transparent_addresses_exposed

### DIFF
--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -7,7 +7,7 @@ use core::convert::{TryFrom, TryInto};
 
 /// The set of known Receivers for Unified Addresses.
 ///
-/// Defined in [ZIP 316][zip-0316].
+/// Defined in [ZIP 316](https://zips.z.cash/zip-0316).
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Receiver {
     Orchard([u8; 43]),
@@ -475,7 +475,10 @@ mod tests {
         // Unknown receiver does not count for any pool type
         let with_unknown = Address(vec![
             Receiver::Orchard([0; 43]),
-            Receiver::Unknown { typecode: 0xAA, data: vec![0; 32] },
+            Receiver::Unknown {
+                typecode: 0xAA,
+                data: vec![0; 32],
+            },
         ]);
         assert!(!with_unknown.has_receiver_of_type(PoolType::SAPLING));
         // Unknown receiver is NOT counted as transparent

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -69,6 +69,7 @@ workspace.
     - Added `WalletWrite::import_standalone_transparent_script` method.
     - Added `WalletWrite::truncate_to_chain_state` method.
     - Added `WalletWrite::rewind_to_height` method.
+    - Added `WalletWrite::mark_transparent_addresses_exposed` method.
   - Type parameters to `DecryptedTransaction` have been modified. It now
     abstracts over the transaction type, to permit use with partial or compact
     transaction data instead of full transactions.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3316,6 +3316,31 @@ pub trait WalletWrite: WalletRead {
         )
     }
 
+    /// Informs the wallet backend that the given transparent addresses are known to have been
+    /// exposed externally at or before the block height paired with each address.
+    ///
+    /// This method is intended for use when a wallet has learned, through means outside the
+    /// observation of the chain by this backend, that addresses under the wallet's control have
+    /// been disclosed to an external party. Calling this method ensures that the wallet's exposure
+    /// metadata accounts for the earlier disclosures.
+    ///
+    /// If the wallet already tracks an earlier exposure for an address, the earlier height is
+    /// retained.
+    ///
+    /// The operation is atomic: if any address in `exposures` is not known to the wallet,
+    /// implementations must roll back all updates performed during the call and return an
+    /// implementation-defined error identifying the first unrecognized address.
+    /// Passing an empty slice is a no-op.
+    #[cfg(feature = "transparent-inputs")]
+    fn mark_transparent_addresses_exposed(
+        &mut self,
+        _exposures: &[(TransparentAddress, BlockHeight)],
+    ) -> Result<(), Self::Error> {
+        unimplemented!(
+            "WalletWrite::mark_transparent_addresses_exposed must be overridden for wallets to use the `transparent-inputs` feature"
+        )
+    }
+
     /// Notifies the wallet backend that the given query for transactions involving a particular
     /// address has completed evaluation.
     ///

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1219,3 +1219,204 @@ where
         (value - fee).unwrap(),
     );
 }
+
+/// Tests [`WalletWrite::mark_transparent_addresses_exposed`] by observing the effect on the
+/// address's exposure metadata via
+/// [`WalletRead::get_transparent_address_metadata`](crate::data_api::WalletRead::get_transparent_address_metadata).
+pub fn mark_transparent_addresses_exposed<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    use crate::{data_api::WalletRead, wallet::Exposure};
+    use zcash_protocol::consensus::BlockHeight;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let taddr = *st
+        .wallet()
+        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap()
+        .transparent()
+        .unwrap();
+
+    let exposure_of = |st: &TestState<_, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+                       addr: &TransparentAddress|
+     -> Exposure {
+        st.wallet()
+            .get_transparent_address_metadata(account_id, addr)
+            .unwrap()
+            .unwrap()
+            .exposure()
+    };
+
+    // Calling with a very high height does not raise an already-recorded exposure,
+    // and records the provided height if no prior exposure was tracked.
+    let initial = exposure_of(&st, &taddr);
+    let very_high = BlockHeight::from(u32::MAX);
+    st.wallet_mut()
+        .mark_transparent_addresses_exposed(&[(taddr, very_high)])
+        .unwrap();
+    match initial {
+        Exposure::Exposed { at_height, .. } => assert_matches!(
+            exposure_of(&st, &taddr),
+            Exposure::Exposed { at_height: h, .. } if h == at_height
+        ),
+        Exposure::Unknown | Exposure::CannotKnow => assert_matches!(
+            exposure_of(&st, &taddr),
+            Exposure::Exposed { at_height: h, .. } if h == very_high
+        ),
+    }
+
+    // Calling with a lower height lowers the recorded exposure.
+    st.wallet_mut()
+        .mark_transparent_addresses_exposed(&[(taddr, BlockHeight::from(0))])
+        .unwrap();
+    assert_matches!(
+        exposure_of(&st, &taddr),
+        Exposure::Exposed { at_height, .. } if at_height == BlockHeight::from(0)
+    );
+
+    // Calling with a higher height does not raise the recorded exposure.
+    st.wallet_mut()
+        .mark_transparent_addresses_exposed(&[(taddr, BlockHeight::from(100))])
+        .unwrap();
+    assert_matches!(
+        exposure_of(&st, &taddr),
+        Exposure::Exposed { at_height, .. } if at_height == BlockHeight::from(0)
+    );
+
+    // An address not tracked by the wallet must return an error.
+    let unknown = TransparentAddress::PublicKeyHash([0u8; 20]);
+    assert!(
+        st.wallet_mut()
+            .mark_transparent_addresses_exposed(&[(unknown, BlockHeight::from(1))])
+            .is_err()
+    );
+
+    // An empty input is a no-op.
+    st.wallet_mut()
+        .mark_transparent_addresses_exposed(&[])
+        .unwrap();
+}
+
+/// Tests that [`WalletWrite::mark_transparent_addresses_exposed`] correctly handles bulk
+/// input: all addresses in a successful call must be marked, and an unrecognized address
+/// must cause the entire call to be rolled back.
+pub fn mark_transparent_addresses_exposed_bulk<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    use crate::{data_api::WalletRead, wallet::Exposure};
+    use zcash_protocol::consensus::BlockHeight;
+
+    let gap_limits = GapLimits::new(5, 2, 2);
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_gap_limits(gap_limits)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let mut receivers = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap()
+        .into_iter()
+        .filter_map(|(addr, meta)| {
+            let exposure = meta.exposure();
+            meta.address_index().map(|i| (i.index(), addr, exposure))
+        })
+        .collect::<Vec<_>>();
+    receivers.sort_by_key(|(i, _, _)| *i);
+
+    // Use known-unexposed receivers for the bulk-success test, so that the post-call
+    // recorded height is exactly the one we pass in regardless of any default exposure
+    // that address generation may set on other receivers.
+    let unexposed = receivers
+        .iter()
+        .copied()
+        .filter(|(_, _, exposure)| matches!(exposure, Exposure::Unknown))
+        .collect::<Vec<_>>();
+    assert!(
+        unexposed.len() >= 2,
+        "account should have at least 2 unexposed derived receivers"
+    );
+
+    // Mark two unexposed addresses at distinct heights in a single bulk call.
+    let (_idx_a, addr_a, _) = unexposed[0];
+    let (_idx_b, addr_b, _) = unexposed[1];
+    let height_a = BlockHeight::from(10);
+    let height_b = BlockHeight::from(20);
+    st.wallet_mut()
+        .mark_transparent_addresses_exposed(&[(addr_a, height_a), (addr_b, height_b)])
+        .unwrap();
+
+    let exposure_of = |st: &TestState<_, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+                       addr: &TransparentAddress|
+     -> Exposure {
+        st.wallet()
+            .get_transparent_address_metadata(account_id, addr)
+            .unwrap()
+            .unwrap()
+            .exposure()
+    };
+    assert_matches!(
+        exposure_of(&st, &addr_a),
+        Exposure::Exposed { at_height, .. } if at_height == height_a
+    );
+    assert_matches!(
+        exposure_of(&st, &addr_b),
+        Exposure::Exposed { at_height, .. } if at_height == height_b
+    );
+
+    // Now attempt a bulk call where the second entry is unrecognized. The whole call must
+    // fail, and the first entry must not have been partially applied. Pick a third
+    // receiver distinct from `addr_a`/`addr_b` — its prior exposure state is irrelevant
+    // since the assertion is preservation, not a specific height.
+    let (idx_c, addr_c, _) = *receivers
+        .iter()
+        .find(|(_, addr, _)| *addr != addr_a && *addr != addr_b)
+        .expect("account should have a third derived receiver");
+    let before = exposure_of(&st, &addr_c);
+    let unknown = TransparentAddress::PublicKeyHash([0x7u8; 20]);
+    assert!(
+        st.wallet_mut()
+            .mark_transparent_addresses_exposed(&[
+                (addr_c, BlockHeight::from(5)),
+                (unknown, BlockHeight::from(5)),
+            ])
+            .is_err()
+    );
+    assert_eq!(
+        exposure_of(&st, &addr_c),
+        before,
+        "exposure at index {idx_c} must not change when bulk call fails atomically"
+    );
+}
+
+/// Tests that [`WalletWrite::mark_transparent_addresses_exposed`] returns an error when
+/// asked to mark an address that the wallet does not track.
+pub fn mark_transparent_addresses_exposed_unknown_address<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    use zcash_protocol::consensus::BlockHeight;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let unknown = TransparentAddress::PublicKeyHash([0u8; 20]);
+    assert!(
+        st.wallet_mut()
+            .mark_transparent_addresses_exposed(&[(unknown, BlockHeight::from(1))])
+            .is_err()
+    );
+}

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -46,6 +46,12 @@ workspace.
     most likely has not synced through that height).
   Shard-read failures continue to surface via the existing
   `SqliteClientError::CommitmentTree` variant.
+- `impl zcash_client_backend::data_api::WalletWrite::mark_transparent_addresses_exposed()`
+  (behind the `transparent-inputs` feature flag). Updates the `exposed_at_height`
+  column of each provided transparent address to the lesser of the existing
+  value and the provided height. The operation is atomic: if any address is not
+  tracked by the wallet, no updates are applied and the call returns
+  `SqliteClientError::AddressNotRecognized` identifying the first such address.
 
 ### Changed
 - Migrated to `sapling-crypto 0.7`, `orchard 0.13`, `zcash_encoding 0.4`, 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1363,6 +1363,14 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
     }
 
     #[cfg(feature = "transparent-inputs")]
+    fn mark_transparent_addresses_exposed(
+        &mut self,
+        exposures: &[(TransparentAddress, BlockHeight)],
+    ) -> Result<(), Self::Error> {
+        self.transactionally(|wdb| wdb.mark_transparent_addresses_exposed(exposures))
+    }
+
+    #[cfg(feature = "transparent-inputs")]
     fn notify_address_checked(
         &mut self,
         request: TransactionsInvolvingAddress,
@@ -1727,6 +1735,18 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
             &mut self.rng,
             address,
             offset_seconds,
+        )
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    fn mark_transparent_addresses_exposed(
+        &mut self,
+        exposures: &[(TransparentAddress, BlockHeight)],
+    ) -> Result<(), Self::Error> {
+        wallet::transparent::mark_transparent_addresses_exposed(
+            self.conn.0,
+            &self.params,
+            exposures,
         )
     }
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1688,6 +1688,45 @@ pub(crate) fn schedule_next_check<P: consensus::Parameters, C: Clock, R: RngCore
         .map_err(SqliteClientError::from)
 }
 
+/// Marks each of the given transparent addresses as having been exposed to an external party
+/// at or before its paired block height. For any address whose wallet row already tracks an
+/// earlier exposure, that earlier height is retained.
+///
+/// The operation is atomic: if any address in `exposures` does not match a wallet row, the
+/// call returns [`SqliteClientError::AddressNotRecognized`] for the first such address and
+/// relies on the enclosing transaction being rolled back by the caller.
+pub(crate) fn mark_transparent_addresses_exposed<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    exposures: &[(TransparentAddress, BlockHeight)],
+) -> Result<(), SqliteClientError> {
+    if exposures.is_empty() {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare_cached(
+        "UPDATE addresses
+         SET exposed_at_height = MIN(
+             IFNULL(exposed_at_height, :height),
+             :height
+         )
+         WHERE cached_transparent_receiver_address = :addr_str",
+    )?;
+
+    for (address, exposure_height) in exposures {
+        let updated = stmt.execute(named_params! {
+            ":height": u32::from(*exposure_height),
+            ":addr_str": address.encode(params),
+        })?;
+
+        if updated == 0 {
+            return Err(SqliteClientError::AddressNotRecognized(*address));
+        }
+    }
+
+    Ok(())
+}
+
 /// Returns the vector of [`TransactionDataRequest`]s that represents the information needed by the
 /// wallet backend in order to be able to present a complete view of wallet history and memo data.
 ///
@@ -2485,5 +2524,26 @@ mod tests {
         let account1_id = get_account_ref(&st.wallet().db().conn, account1_uuid).unwrap();
         assert_ne!(account0_id, account1_id);
         check(st.wallet().db(), account1_id);
+    }
+
+    #[test]
+    fn mark_transparent_addresses_exposed() {
+        zcash_client_backend::data_api::testing::transparent::mark_transparent_addresses_exposed(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    fn mark_transparent_addresses_exposed_bulk() {
+        zcash_client_backend::data_api::testing::transparent::mark_transparent_addresses_exposed_bulk(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    fn mark_transparent_addresses_exposed_unknown_address() {
+        zcash_client_backend::data_api::testing::transparent::mark_transparent_addresses_exposed_unknown_address(
+            TestDbFactory::default(),
+        );
     }
 }


### PR DESCRIPTION
Allows wallet callers to inform the backend that a transparent address has been exposed externally, for reasons outside the purview of librustzcash. The SQLite implementation updates `exposed_at_height` to the lesser of the existing value and the provided height, and returns `AddressNotRecognized` when the address is not tracked by the wallet.

Resolves: https://github.com/zcash/librustzcash/issues/2304
Resolves: [COR-1200](https://linear.app/zodl/issue/COR-1200/featzcash-client-backend-walletwrite-method-to-report-address-exposure)