### PR TITLE
fix: COR-1209 eip681 arb non numeric url encoded string

### DIFF
--- a/components/eip681/CHANGELOG.md
+++ b/components/eip681/CHANGELOG.md
@@ -11,6 +11,18 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `error::ParseError::NumberMissingDigits` (non-exhaustive): emitted internally
+  by `Value::parse` when a `Number` candidate has no mantissa digits.
+
+### Fixed
+- `Value::parse` no longer classifies inputs that lack any integer digits and
+  any decimal part (e.g. the lone alphabetic inputs `"e"` and `"E"`) as
+  `Value::Number`. Such inputs now correctly parse as `Value::String`, matching
+  the intent of the EIP-681 `value = number / ethereum_address / STRING`
+  grammar. `Number::parse` itself remains permissive for its standalone
+  callers.
+
 ## [0.1.0] - Tue 31 March 2026
 
 - Initial release!

--- a/components/eip681/proptest-regressions/parse.txt
+++ b/components/eip681/proptest-regressions/parse.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f12fb9ce023ce84d2402f820bbf7c75270ae3222382fbdf016b26ebbc782e3a1

--- a/components/eip681/src/error.rs
+++ b/components/eip681/src/error.rs
@@ -63,6 +63,14 @@ pub enum ParseError<'a> {
     /// Unexpected leftover input after parsing.
     #[snafu(display("Unexpected leftover input: {input}"))]
     UnexpectedLeftoverInput { input: &'a str },
+
+    /// A [`Number`] candidate had no mantissa digits (no integer digits and no
+    /// decimal part), and so does not represent the `number` alternative of
+    /// the `value` grammar production.
+    ///
+    /// [`Number`]: crate::parse::Number
+    #[snafu(display("Number candidate has no mantissa digits at: {input}"))]
+    NumberMissingDigits { input: &'a str },
 }
 
 impl<'a> nom::error::ParseError<&'a str> for ParseError<'a> {

--- a/components/eip681/src/parse.rs
+++ b/components/eip681/src/parse.rs
@@ -464,6 +464,20 @@ impl Number {
             .parse(i)
     }
 
+    /// Returns `true` if this [`Number`] has at least one integer digit or a
+    /// decimal part.
+    ///
+    /// [`Number::parse`] is intentionally permissive and will accept inputs
+    /// such as `""`, `"-"`, `"e"`, or `"+E"` that contain no mantissa digits
+    /// at all. Such inputs are only meaningful via [`Number`]'s standalone API
+    /// (where they round-trip as the number zero); when resolving the
+    /// `value = number / ethereum_address / STRING` production in
+    /// [`Value::parse`], a digit-less candidate does not represent the
+    /// `number` alternative and should fall through to `STRING`.
+    pub(crate) fn has_mantissa_digits(&self) -> bool {
+        !self.integer.places.is_empty() || self.decimal.is_some()
+    }
+
     /// Returns the value of the integer portion of the number.
     ///
     /// ## Errors
@@ -810,6 +824,12 @@ impl Value {
         // Here there are some interesting corner cases:
         //
         // 1. In `number`'s spec, absolutely everything is optional, so it _never_ fails.
+        //   However, a [`Number`] that contains no mantissa digits (i.e. no integer
+        //   digits and no decimal part, such as `""`, `"-"`, `"e"`, or `"+E"`) does not
+        //   represent the `number` alternative of the `value` production, so we reject
+        //   such candidates here and let them fall through to `STRING`. This keeps
+        //   [`Number::parse`] permissive for its own callers while making [`Value::parse`]
+        //   grammar-correct.
         // 2. `ethereum_address` may be prefixed with `0` (in the hex-address case), so both number
         //   and address could be parsed. Because of 1, `number` always wins if it comes first, but
         //   even if the minimum was 1 digit `number` would still win by parsing "0", so
@@ -822,7 +842,15 @@ impl Value {
         // In practice this should be fine because values either end with `&` (in the case of
         // more parameters after it) or with the end of the input.
 
-        let mut results = [number.parse(i), ethereum_address.parse(i), string.parse(i)];
+        let number_result = match number.parse(i) {
+            Ok((_rest, Value::Number(n))) if !n.has_mantissa_digits() => {
+                Err(nom::Err::Error(ParseError::NumberMissingDigits {
+                    input: i,
+                }))
+            }
+            other => other,
+        };
+        let mut results = [number_result, ethereum_address.parse(i), string.parse(i)];
         results.sort_by_key(|a| {
             // Sort by the amount of input left over, smallest first
             a.as_ref().ok().map(|(i, _)| i.len()).unwrap_or(usize::MAX)
@@ -1689,16 +1717,11 @@ mod test {
     /// 2. serialize to "0"
     /// 3. parse from "0" produces `output = Number(0)`
     /// 4. input != output
-    ///
-    /// Also excludes the exponent markers `e` and `E`, since the [`Number`] grammar allows a
-    /// number to consist of nothing but an exponent marker (with 0 integer digits and 0 exponent
-    /// digits). Alphanumeric source chars pass through URL encoding unchanged, so a single `"E"`
-    /// would round-trip to a [`Number`] instead of a [`UrlEncodedUnicodeString`].
     fn arb_non_numeric_url_encoded_string() -> impl Strategy<Value = UrlEncodedUnicodeString> {
         {
             let min = 1;
             let max = 1024;
-            proptest::string::string_regex(&format!("[^\\deE]{{{min},{max}}}")).unwrap()
+            proptest::string::string_regex(&format!("[^\\d]{{{min},{max}}}")).unwrap()
         }
         .prop_map(UrlEncodedUnicodeString::encode)
     }
@@ -1851,6 +1874,44 @@ mod test {
         let input = expected.to_string();
         let (_output, seen) = Value::parse(&input).unwrap();
         pretty_assertions::assert_eq!(expected, seen);
+    }
+
+    /// [`Number::parse`] is deliberately permissive and will happily consume a
+    /// lone `"e"` or `"E"` (as a `Number` with no integer digits, no decimal
+    /// part, and an exponent marker with no digits). Those alphabetic inputs
+    /// are valid [`UrlEncodedUnicodeString`] content and must resolve to
+    /// [`Value::String`] under the `value = number / ethereum_address / STRING`
+    /// production, not to [`Value::Number`].
+    #[test]
+    fn parse_value_lone_exponent_marker_is_string() {
+        for input in ["e", "E"] {
+            let (rest, seen) = Value::parse(input).unwrap();
+            assert_eq!(
+                "", rest,
+                "`input` {input:?} was not fully consumed. Parsed '{seen:?}'"
+            );
+            assert_eq!(
+                Value::String(UrlEncodedUnicodeString(input.to_string())),
+                seen,
+                "expected lone exponent marker {input:?} to parse as Value::String"
+            );
+        }
+    }
+
+    /// Sanity: inputs that *do* have mantissa digits still resolve to [`Value::Number`].
+    #[test]
+    fn parse_value_number_with_mantissa_digits() {
+        for input in ["0", "1", "1e18", "666.0", "2.014e18"] {
+            let (rest, seen) = Value::parse(input).unwrap();
+            assert_eq!(
+                "", rest,
+                "`input` {input:?} was not fully consumed. Parsed '{seen:?}'"
+            );
+            assert!(
+                matches!(seen, Value::Number(_)),
+                "expected {input:?} to parse as Value::Number, got {seen:?}"
+            );
+        }
     }
 
     proptest! {

--- a/components/eip681/src/parse.rs
+++ b/components/eip681/src/parse.rs
@@ -1689,11 +1689,16 @@ mod test {
     /// 2. serialize to "0"
     /// 3. parse from "0" produces `output = Number(0)`
     /// 4. input != output
+    ///
+    /// Also excludes the exponent markers `e` and `E`, since the [`Number`] grammar allows a
+    /// number to consist of nothing but an exponent marker (with 0 integer digits and 0 exponent
+    /// digits). Alphanumeric source chars pass through URL encoding unchanged, so a single `"E"`
+    /// would round-trip to a [`Number`] instead of a [`UrlEncodedUnicodeString`].
     fn arb_non_numeric_url_encoded_string() -> impl Strategy<Value = UrlEncodedUnicodeString> {
         {
             let min = 1;
             let max = 1024;
-            proptest::string::string_regex(&format!("[^\\d]{{{min},{max}}}")).unwrap()
+            proptest::string::string_regex(&format!("[^\\deE]{{{min},{max}}}")).unwrap()
         }
         .prop_map(UrlEncodedUnicodeString::encode)
     }


### PR DESCRIPTION
@nullcopy found a `proptest` failure in the `eip681` crate where roundtrips were broken because certain strings without any digits were being parsed as `Value::Number`. 

These changes fix that by changing the way `Value` is parsed. Previously the `Value::Number` variant parsing followed the ambiguous EIP-681 ABNF syntax and treated strings like "E", "e", "+" and "-" as the number `0`. This is (at least to me) obviously wrong. It's my opinion these should be treated as strings, not numbers.

## breakdown
b3c18d5e7b — cherry-picked upstream 6108185a (attribution to nullcopy and Co-Authored-By: Claude Opus 4.7 (1M context) preserved). Adds the CI-discovered proptest seed and the now-superseded generator tweak.
c0c7fc941f — the real fix, co-authored. Three files changed, +88/-7:
- components/eip681/src/parse.rs — restores the generator regex to [^\d], adds Number::has_mantissa_digits(), and filters digit-less Number candidates out of Value::parse so they fall through to STRING. Adds two unit tests (parse_value_lone_exponent_marker_is_string, parse_value_number_with_mantissa_digits).
- components/eip681/src/error.rs — adds ParseError::NumberMissingDigits variant (non-exhaustive enum, so no SemVer break).
- components/eip681/CHANGELOG.md — Added + Fixed entries under [Unreleased].