### PR TITLE
zcash_transparent pczt signer: add expected_amount param to Input::sign for compiler-enforced caller responsibility

### DIFF
--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -116,6 +116,11 @@ impl Signer {
     /// that consensus will reject. Caller derives `expected_amount` from already-trusted
     /// context (the spend record being signed) before invoking the signer. The check is
     /// compiler-enforced via [`transparent::pczt::SignerError::ValueMismatch`].
+    ///
+    /// This check does not replace the caller's broader responsibility to perform
+    /// semantic validity checks on the PCZT before signing. The caller must still
+    /// verify recipients, outputs, change amounts, fees, and any policy-specific
+    /// expectations against trusted context.
     pub fn sign_transparent(
         &mut self,
         index: usize,
@@ -174,8 +179,8 @@ impl Signer {
 
         // Consistency of input value is now checked at the input.sign() boundary via the
         // `expected_amount: Zatoshis` precondition; see `transparent::pczt::Input::sign`
-        // and `SignerError::ValueMismatch`. The closure `f` is responsible for threading
-        // the caller-supplied expected amount through to that check.
+        // and `SignerError::ValueMismatch`. Other semantic checks remain the caller's
+        // responsibility before invoking the signer.
 
         // Generate or apply the signature.
         f(input, &self.tx_data, &self.txid_parts, &self.secp).map_err(Error::TransparentSign)?;

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -21,6 +21,7 @@ use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE}
 use zcash_primitives::transaction::{
     TransactionData, TxDigests, sighash::SignableInput, txid::TxIdDigester,
 };
+use zcash_protocol::value::Zatoshis;
 
 use crate::{
     ExtractError, ParsedPczt, Pczt,
@@ -110,13 +111,16 @@ impl Signer {
 
     /// Signs the transparent spend at the given index with the given spending key.
     ///
-    /// It is the caller's responsibility to perform any semantic validity checks on the
-    /// PCZT (for example, comfirming that the change amounts are correct) before calling
-    /// this method.
+    /// `expected_amount` is the value the caller believes is being spent. ZIP-244 binds
+    /// the input amount into the sighash; passing the wrong amount produces a signature
+    /// that consensus will reject. Caller derives `expected_amount` from already-trusted
+    /// context (the spend record being signed) before invoking the signer. The check is
+    /// compiler-enforced via [`transparent::pczt::SignerError::ValueMismatch`].
     pub fn sign_transparent(
         &mut self,
         index: usize,
         sk: &secp256k1::SecretKey,
+        expected_amount: Zatoshis,
     ) -> Result<(), Error> {
         self.generate_or_append_transparent_signature(index, |input, tx_data, txid_parts, secp| {
             input.sign(
@@ -124,6 +128,7 @@ impl Signer {
                 |input| sighash(tx_data, &SignableInput::Transparent(input), txid_parts),
                 sk,
                 secp,
+                expected_amount,
             )
         })
     }
@@ -167,8 +172,10 @@ impl Signer {
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
 
-        // Check consistency of the input being signed.
-        // TODO
+        // Consistency of input value is now checked at the input.sign() boundary via the
+        // `expected_amount: Zatoshis` precondition; see `transparent::pczt::Input::sign`
+        // and `SignerError::ValueMismatch`. The closure `f` is responsible for threading
+        // the caller-supplied expected amount through to that check.
 
         // Generate or apply the signature.
         f(input, &self.tx_data, &self.txid_parts, &self.secp).map_err(Error::TransparentSign)?;

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -127,7 +127,9 @@ fn transparent_to_orchard() {
 
     // Apply signatures.
     let mut signer = Signer::new(pczt).unwrap();
-    signer.sign_transparent(0, &transparent_sk).unwrap();
+    signer
+        .sign_transparent(0, &transparent_sk, Zatoshis::const_from_u64(1_000_000))
+        .unwrap();
     let pczt = signer.finish();
     check_round_trip(&pczt);
 
@@ -292,7 +294,9 @@ fn transparent_p2sh_multisig_to_orchard() {
     // If we only sign with one of the signers, we can't finalize spends.
     {
         let mut signer = Signer::new(pczt.clone()).unwrap();
-        signer.sign_transparent(0, &transparent_sks[0]).unwrap();
+        signer
+            .sign_transparent(0, &transparent_sks[0], Zatoshis::const_from_u64(1_000_000))
+            .unwrap();
         assert!(matches!(
             SpendFinalizer::new(signer.finish()).finalize_spends(),
             Err(pczt::roles::spend_finalizer::Error::TransparentFinalize(
@@ -304,7 +308,9 @@ fn transparent_p2sh_multisig_to_orchard() {
     // Sign the input with all three signers.
     let mut signer = Signer::new(pczt).unwrap();
     for sk in &transparent_sks {
-        signer.sign_transparent(0, sk).unwrap();
+        signer
+            .sign_transparent(0, sk, Zatoshis::const_from_u64(1_000_000))
+            .unwrap();
     }
     let pczt = signer.finish();
     check_round_trip(&pczt);

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 
+use zcash_protocol::value::Zatoshis;
 use zcash_script::solver;
 
 use crate::{
@@ -45,10 +46,22 @@ impl super::Input {
         calculate_sighash: F,
         sk: &secp256k1::SecretKey,
         secp: &secp256k1::Secp256k1<C>,
+        expected_amount: Zatoshis,
     ) -> Result<(), SignerError>
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
+        // ZIP-244 binds the input amount into the sighash. If the updater-provided
+        // `self.value` differs from what the caller believes the amount to be, the
+        // signature will be rejected at consensus. Convert that documented
+        // caller-responsibility into a compiler-enforced precondition.
+        if self.value != expected_amount {
+            return Err(SignerError::ValueMismatch {
+                expected: expected_amount,
+                updater_provided: self.value,
+            });
+        }
+
         let pubkey = sk.public_key(secp).serialize();
         let p2pkh_addr = TransparentAddress::from_pubkey_bytes(&pubkey);
 
@@ -201,4 +214,13 @@ pub enum SignerError {
     /// The provided `sk` does not match any pubkey involved with spend control of the
     /// input's spent coin.
     WrongSpendingKey,
+    /// The updater-provided `Input::value` does not match the caller-supplied
+    /// `expected_amount`. ZIP-244 binds the amount into the sighash, so signing
+    /// with a mismatched value would produce a signature rejected at consensus.
+    /// The caller is expected to derive `expected_amount` from already-trusted
+    /// context (the spend record being signed) before invoking the signer.
+    ValueMismatch {
+        expected: Zatoshis,
+        updater_provided: Zatoshis,
+    },
 }

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -31,6 +31,8 @@ impl super::Input {
 
     /// Signs the transparent spend with the given spend authorizing key.
     ///
+    /// The `expected_amount` must be derived from a context trusted by the signer.
+    ///
     /// It is the caller's responsibility to perform any semantic validity checks on the
     /// PCZT (for example, comfirming that the change amounts are correct) before calling
     /// this method.
@@ -223,4 +225,68 @@ pub enum SignerError {
         expected: Zatoshis,
         updater_provided: Zatoshis,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+
+    use zcash_protocol::{value::Zatoshis, TxId};
+    use zcash_script::script;
+
+    use super::SignerError;
+    use crate::{pczt::Input, sighash::SighashType};
+
+    fn input_with_value(value: Zatoshis) -> Input {
+        Input {
+            prevout_txid: TxId::from_bytes([0; 32]),
+            prevout_index: 0,
+            sequence: None,
+            required_time_lock_time: None,
+            required_height_lock_time: None,
+            script_sig: None,
+            value,
+            script_pubkey: script::FromChain::parse(&script::Code(vec![])).unwrap(),
+            redeem_script: None,
+            partial_signatures: BTreeMap::new(),
+            sighash_type: SighashType::ALL,
+            bip32_derivation: BTreeMap::new(),
+            ripemd160_preimages: BTreeMap::new(),
+            sha256_preimages: BTreeMap::new(),
+            hash160_preimages: BTreeMap::new(),
+            hash256_preimages: BTreeMap::new(),
+            proprietary: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn sign_rejects_value_mismatch() {
+        let updater_provided = Zatoshis::from_u64(1000).unwrap();
+        let expected = Zatoshis::from_u64(2000).unwrap();
+        let mut input = input_with_value(updater_provided);
+
+        let secp = secp256k1::Secp256k1::new();
+        let sk = secp256k1::SecretKey::from_slice(&[1; 32]).unwrap();
+
+        let err = input
+            .sign(
+                0,
+                |_| panic!("value mismatch must fail before sighash calculation"),
+                &sk,
+                &secp,
+                expected,
+            )
+            .unwrap_err();
+
+        match err {
+            SignerError::ValueMismatch {
+                expected: err_expected,
+                updater_provided: err_updater_provided,
+            } => {
+                assert_eq!(err_expected, expected);
+                assert_eq!(err_updater_provided, updater_provided);
+            }
+            err => panic!("unexpected signer error: {err:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## summary

zcash_transparent::pczt::signer::Input::sign at zcash_transparent/src/pczt/signer.rs:42 trusts the updater-provided self.value blindly and signs whatever sighash the caller produces. caller-responsibility for amount validation is documented in the docstring at signer.rs:33-35 and as a literal TODO at pczt/src/roles/signer/mod.rs:158 ("Check consistency of the input being signed").

zip-244 binds input amounts into the sighash. if signer signs claimed-value and validator computes actual-value the signatures differ and the tx is rejected at consensus. self-correcting denial of broadcast not fund loss. but the failure mode is silent at the signer side and the caller has no compile-time signal that they are responsible for cross-checking value before calling.

this pr adds `expected_amount: Zatoshis` as a required parameter to `Input::sign`. the function returns `SignerError::ValueMismatch` if `self.value` differs from `expected_amount`. caller responsibility becomes compiler-enforced.

## changes

- `zcash_transparent/src/pczt/signer.rs` Input::sign signature gets `expected_amount: Zatoshis` param plus early `ValueMismatch` check.
- `zcash_transparent/src/pczt/signer.rs` SignerError gets `ValueMismatch { expected, updater_provided }` variant.
- `zcash_transparent/src/pczt/signer.rs` test added covering the mismatch path.
- `pczt/src/roles/signer/mod.rs` caller updated to pass expected_amount from already-trusted context. TODO at line 158 marked done.

## breaking change

yes. all callers of Input::sign must now pass expected_amount. internal callers in this PR are updated. external embedders see a one-line addition.

## context

found while filing the panic-on-untrusted-input GHSA family in librustzcash this week (GHSA-m8hw-x85c-j3qq, GHSA-7mqm-gq3v-pmcp, GHSA-f3vg-grqw-2q2g, GHSA-c66h-h8v6-c8pg, GHSA-9m3x-v6f2-mh47, GHSA-6r2c-r2qx-m358). this is the hardening companion. not a security advisory itself, self-correcting via consensus rejection. opens the contract for the caller earlier.
