### PR TITLE
zcash_client_backend: Deprecate `WalletWrite::truncate_to_height`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,6 +8,12 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [Unreleased]
+
+### Deprecated
+- `zcash_client_backend::data_api::WalletWrite::truncate_to_height` has been
+  deprecated. Use `truncate_to_chain_state` or `rewind_to_height` instead.
+
 ## [0.22.0] - 2026-04-27
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3230,6 +3230,7 @@ pub trait WalletWrite: WalletRead {
     /// There may be restrictions on heights to which it is possible to truncate. Specifically, it
     /// will only be possible to truncate to heights at which is is possible to create a witness
     /// given the current state of the wallet's note commitment tree.
+    #[deprecated(note = "use truncate_to_chain_state or rewind_to_height instead")]
     fn truncate_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error>;
 
     /// Truncates the wallet database to the specified chain state.

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -807,8 +807,8 @@ where
     /// Truncates the test wallet and block cache to the specified height, discarding all data from
     /// blocks at heights greater than the specified height, excluding transaction data that may
     /// not be recoverable from the chain.
-    pub fn truncate_to_height(&mut self, height: BlockHeight) {
-        self.wallet_mut().truncate_to_height(height).unwrap();
+    pub fn rewind_to_height(&mut self, height: BlockHeight) {
+        self.wallet_mut().rewind_to_height(height).unwrap();
         self.cache.truncate_to_height(height);
         self.cached_blocks.split_off(&(height + 1));
         self.latest_block_height = Some(height);
@@ -818,7 +818,7 @@ where
     /// height but does not truncate the block cache. This is useful for circumstances when you
     /// want to re-scan a set of cached blocks.
     pub fn truncate_to_height_retaining_cache(&mut self, height: BlockHeight) {
-        self.wallet_mut().truncate_to_height(height).unwrap();
+        self.wallet_mut().rewind_to_height(height).unwrap();
         self.latest_block_height = Some(height);
     }
 }
@@ -2986,10 +2986,7 @@ impl WalletWrite for MockWalletDb {
         Ok(())
     }
 
-    fn truncate_to_height(
-        &mut self,
-        _block_height: BlockHeight,
-    ) -> Result<BlockHeight, Self::Error> {
+    fn rewind_to_height(&mut self, _block_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
         Err(())
     }
 
@@ -2997,7 +2994,8 @@ impl WalletWrite for MockWalletDb {
         Err(())
     }
 
-    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+    #[allow(deprecated)]
+    fn truncate_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
         Err(())
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4207,6 +4207,7 @@ pub fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>(
     );
 }
 
+#[allow(deprecated)]
 pub fn data_db_truncation<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
 where
     Dsf: DataStoreFactory,
@@ -4268,6 +4269,7 @@ where
     );
 }
 
+#[allow(deprecated)]
 pub fn truncate_to_chain_state<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
 where
     Dsf: DataStoreFactory,
@@ -5593,7 +5595,7 @@ where
 
     // Now, fully truncate back to the reorg height. This should leave the tree in a state
     // where it can be added to with arbitrary notes.
-    st.truncate_to_height(reorg_height);
+    st.rewind_to_height(reorg_height);
 
     // Generate some new random blocks
     for _ in 0..10 {

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -301,9 +301,7 @@ where
     );
 
     // Unmine the shielding transaction via a reorg.
-    st.wallet_mut()
-        .truncate_to_height(mined_height - 1)
-        .unwrap();
+    st.wallet_mut().rewind_to_height(mined_height - 1).unwrap();
     assert_eq!(st.wallet().chain_height().unwrap(), Some(mined_height - 1));
 
     // The wallet should still have zero transparent balance.

--- a/zcash_client_backend/src/sync.rs
+++ b/zcash_client_backend/src/sync.rs
@@ -415,7 +415,7 @@ where
 
             // Rewind to the chosen height.
             db_data
-                .truncate_to_height(rewind_height)
+                .rewind_to_height(rewind_height)
                 .map_err(Error::Wallet)?;
 
             // Delete cached blocks from rewind_height onwards.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1324,6 +1324,7 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.store_transactions_to_be_sent(transactions))
     }
 
+    #[allow(deprecated)]
     fn truncate_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
         self.transactionally(|wdb| wdb.truncate_to_height(max_height))
     }

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -1,3 +1,6 @@
+// Required to avoid warnings on deprecated `Delegate`'d trait methods.
+#![allow(deprecated)]
+
 use ambassador::Delegate;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;


### PR DESCRIPTION
Height-based truncation is tricky to use due to the need to find a height that the note commitment tree can be pruned to. With the combination of `rewind_to_height` and `truncate_to_chain_state` we should no longer need it.