### PR TITLE
ci: skip rust-cache save on Windows all-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: msrv
-          save-if: ${{ matrix.state == 'all-features' }}
+          save-if: ${{ matrix.state == 'all-features' && matrix.target != 'Windows' }}
       - name: Run tests
         run: >
           cargo test


### PR DESCRIPTION
The Swatinem/rust-cache post-step seems to fail on large diffs for Windows, even though all tests pass