### PR TITLE
zcash_client_backend: Replace `rewind_to_height` with `rewind_to_chain_state`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,6 +8,22 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [0.23.0] - PLANNED
+
+### Added
+- `zcash_client_backend::data_api::error::RewindError`
+
+### Changed
+- `zcash_client_backend::data_api::WalletWrite`:
+  - `rewind_to_height` has been replaced by `rewind_to_chain_state`. Callers
+    that previously passed a `BlockHeight` should now construct a
+    `ChainState` for the rewind target. The new method returns `Result<(),
+    RewindError<Self::AccountId, Self::Error>>`. If the rewind target is
+    below the birthday height of any account in the wallet, the call will
+    fail with `RewindError::RewindBeyondBirthdays`; the caller should re-try
+    with the affected account ids included in the `reset_account_birthdays`
+    argument to acknowledge that those birthdays will be lowered.
+
 ## [0.22.0] - 2026-04-27
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -65,7 +65,7 @@
 use nonempty::NonEmpty;
 use secrecy::SecretVec;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
     io,
@@ -95,7 +95,10 @@ use self::{
     scanning::ScanRange,
 };
 use crate::{
-    data_api::wallet::{ConfirmationsPolicy, TargetHeight},
+    data_api::{
+        error::RewindError,
+        wallet::{ConfirmationsPolicy, TargetHeight},
+    },
     decrypt::DecryptedOutput,
     proto::service::TreeState,
     wallet::{Note, NoteId, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
@@ -3241,27 +3244,47 @@ pub trait WalletWrite: WalletRead {
     /// [`truncate_to_height`]: WalletWrite::truncate_to_height
     fn truncate_to_chain_state(&mut self, chain_state: ChainState) -> Result<(), Self::Error>;
 
-    /// Rewinds the wallet to at most the given block height, preserving any wallet data which has
-    /// been confirmed beyond the pruning depth.
+    /// Rewinds the wallet to the specified chain state, preserving wallet data which has been
+    /// confirmed beyond the pruning depth, and lowering the birthday height of selected accounts
+    /// to the block following the chain state.
     ///
-    /// In contrast to [`truncate_to_height`], which unconditionally deletes wallet state above
-    /// `max_height` (transaction & note data is retained, but committment trees, blocks, etc are
-    /// removed to the truncation height), this rewinds the scan queue to `max_height` but only
-    /// rewinds blocks, note commitment trees, transactions, transparent UTXO observations, and
-    /// nullifier-map entries as far back as the pruning floor (`chain_tip - (PRUNING_DEPTH - 1)`).
-    /// Data at or below that height is preserved. Because `PRUNING_DEPTH` is a property of chain
-    /// depth, the floor is derived from the wallet's view of the chain tip rather than from
-    /// `MAX(blocks.height)`.
+    /// In contrast to [`truncate_to_chain_state`], which unconditionally removes wallet state
+    /// above `chain_state.block_height()`, this rewinds the scan queue to the target height but
+    /// only rewinds blocks, note commitment trees, transactions, transparent UTXO observations,
+    /// and nullifier-map entries as far back as the implementation's pruning floor; data at or
+    /// below that floor is preserved.
     ///
-    /// The floor is clamped to an actual shard-tree checkpoint at or above the pruning floor so
-    /// that the underlying truncation has a real checkpoint to truncate to under non-contiguous
-    /// scan orders.
+    /// `reset_account_birthdays` selects which accounts (if any) may have their birthday
+    /// metadata lowered as a result of this rewind. The semantics are:
     ///
-    /// Returns the actual scan-queue rewind height (`max_height` clamped to the max scanned height
-    /// when `max_height` is above it).
+    /// - Every account in `reset_account_birthdays` has its birthday metadata updated to
+    ///   `chain_state.block_height() + 1` (with corresponding tree sizes taken from
+    ///   `chain_state`) if and only if the new birthday is less than the account's existing
+    ///   birthday. Existing birthdays are never raised by this method.
+    /// - Accounts that are *not* in `reset_account_birthdays` are never modified, regardless of
+    ///   the rewind target. Note that this only governs per-account birthday metadata:
+    ///   rescanning of blocks that re-enter the scan queue applies to *all* accounts in the
+    ///   wallet, since scanning is performed against all viewing keys.
+    /// - If `reset_account_birthdays` is empty and *every* account in the wallet has a birthday
+    ///   greater than `chain_state.block_height() + 1` (the value to which a reset birthday
+    ///   would be lowered), this method returns [`RewindError::RewindBeyondBirthdays`] and no
+    ///   other state is modified. So long as at least one account in the wallet already has a
+    ///   birthday at or below `chain_state.block_height() + 1`, this error is not returned —
+    ///   such an account already provides the wallet with an anchor at or below the new
+    ///   birthday floor, so no reset is required. The reported map contains every account in
+    ///   the wallet along with its existing birthday height; the caller may re-invoke the
+    ///   method with any subset of those accounts included in `reset_account_birthdays`.
     ///
-    /// [`truncate_to_height`]: WalletWrite::truncate_to_height
-    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error>;
+    /// Implementations may also return an [`Err`] (typically via [`RewindError::DataSource`])
+    /// if `reset_account_birthdays` contains identifiers that do not correspond to accounts in
+    /// the wallet.
+    ///
+    /// [`truncate_to_chain_state`]: WalletWrite::truncate_to_chain_state
+    fn rewind_to_chain_state(
+        &mut self,
+        chain_state: ChainState,
+        reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>>;
 
     /// Reserves the next `n` available ephemeral addresses for the given account.
     /// This cannot be undone, so as far as possible, errors associated with transaction

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -1,12 +1,15 @@
 //! Types for wallet error handling.
 
+use std::collections::HashMap;
 use std::error;
 use std::fmt::{self, Debug, Display};
+use std::hash::Hash;
 
 use shardtree::error::ShardTreeError;
 use zcash_address::ConversionError;
 use zcash_keys::address::UnifiedAddress;
 use zcash_primitives::transaction::builder;
+use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::{
     PoolType,
     value::{BalanceError, Zatoshis},
@@ -104,6 +107,61 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
     /// An error occurred while working with PCZTs.
     #[cfg(feature = "pczt")]
     Pczt(PcztError),
+}
+
+/// Errors that may occur when rewinding the wallet to a previous chain state.
+pub enum RewindError<AccountId: Hash + Eq, E> {
+    /// An error occurred retrieving data from the underlying data source.
+    DataSource(E),
+    /// Every account in the wallet has a birthday height greater than the height to which any
+    /// reset birthday would be lowered (the chain state's block height plus one), and the
+    /// `reset_account_birthdays` argument supplied by the caller was empty. So long as at
+    /// least one account already has a birthday at or below the new birthday floor, the
+    /// rewind proceeds without lowering any birthdays even when `reset_account_birthdays` is
+    /// empty. The caller should re-try the rewind, providing a non-empty set of accounts
+    /// whose birthday metadata should be lowered to the new birthday floor.
+    ///
+    /// The reported map contains every account in the wallet along with its existing birthday
+    /// height. The caller may include any subset of these in the next call's
+    /// `reset_account_birthdays`; accounts not included will retain their existing birthday
+    /// metadata. (Rescanning of any blocks above the rewind target is performed against all
+    /// wallet viewing keys regardless of which accounts' birthday metadata is reset.)
+    RewindBeyondBirthdays(HashMap<AccountId, BlockHeight>),
+}
+
+impl<AccountId: Hash + Eq + Debug, E: Debug> Debug for RewindError<AccountId, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RewindError::DataSource(e) => f.debug_tuple("DataSource").field(e).finish(),
+            RewindError::RewindBeyondBirthdays(birthdays) => f
+                .debug_tuple("RewindBeyondBirthdays")
+                .field(birthdays)
+                .finish(),
+        }
+    }
+}
+
+impl<AccountId: Hash + Eq + Debug, E: Display> Display for RewindError<AccountId, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RewindError::DataSource(e) => write!(f, "Wallet data source error: {e}"),
+            RewindError::RewindBeyondBirthdays(birthdays) => write!(
+                f,
+                "Rewind would precede the birthday height of one or more accounts: {birthdays:?}"
+            ),
+        }
+    }
+}
+
+impl<AccountId: Hash + Eq + Debug, E: error::Error + 'static> error::Error
+    for RewindError<AccountId, E>
+{
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            RewindError::DataSource(e) => Some(e),
+            RewindError::RewindBeyondBirthdays(_) => None,
+        }
+    }
 }
 
 /// Errors that can occur while working with PCZTs.

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1,7 +1,7 @@
 //! Utilities for testing wallets based upon the [`crate::data_api`] traits.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::Infallible,
     fmt,
     hash::Hash,
@@ -62,7 +62,7 @@ use super::{
     },
 };
 use crate::{
-    data_api::{MaxSpendMode, TargetValue, wallet::TargetHeight},
+    data_api::{MaxSpendMode, TargetValue, error::RewindError, wallet::TargetHeight},
     fees::{
         ChangeStrategy, DustOutputPolicy, StandardFeeRule,
         standard::{self, SingleOutputChangeStrategy},
@@ -2997,8 +2997,12 @@ impl WalletWrite for MockWalletDb {
         Err(())
     }
 
-    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
-        Err(())
+    fn rewind_to_chain_state(
+        &mut self,
+        _chain_state: ChainState,
+        _reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>> {
+        Err(RewindError::DataSource(()))
     }
 
     /// Adds a transparent UTXO received by the wallet to the data store.

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4688,18 +4688,20 @@ pub fn rewind_to_chain_state_deep<T: ShieldedPoolTester, Dsf>(
         )
         .expect("rewind_to_chain_state should succeed for a deep target");
 
-    // The chain tip (derived from scan_queue) should now report the rewind target.
+    // The chain tip (derived from scan_queue) should still report the pre-rewind tip:
+    // `rewind_to_chain_state` overwrites the scan-queue range above the rewind target
+    // with a `Historic` rescan range that extends up to the pre-rewind tip.
     let new_tip = st
         .wallet()
         .chain_height()
         .unwrap()
-        .expect("chain tip should match rewind target");
-    assert_eq!(new_tip, rewind_target);
+        .expect("chain tip should still be set after rewind");
+    assert_eq!(new_tip, pre_rewind_tip);
 
-    // A deep rewind keeps the scan queue rewound to the target, while blocks,
-    // transactions, tx_locator_map entries, and note commitment trees are only rewound
-    // to the oldest retained checkpoint at `tip - (PRUNING_DEPTH - 1)`. Data at that
-    // boundary is kept (so stabilized notes remain spendable); data above it is removed.
+    // A deep rewind preserves block, transaction, tx_locator_map, and note commitment tree
+    // data only as far back as the oldest retained checkpoint at `tip - (PRUNING_DEPTH - 1)`.
+    // Data at that boundary is kept (so stabilized notes remain spendable); data above it is
+    // removed.
     let wallet = st.wallet();
     assert_eq!(
         wallet.get_block_hash(prune_boundary).unwrap(),
@@ -4802,12 +4804,15 @@ pub fn rewind_to_chain_state_shallow<T: ShieldedPoolTester, Dsf>(
         )
         .expect("rewind_to_chain_state should succeed for a shallow target");
 
+    // The chain tip (derived from scan_queue) should still report the pre-rewind tip:
+    // `rewind_to_chain_state` overwrites the scan-queue range above the rewind target with
+    // a `Historic` rescan range that extends up to the pre-rewind tip.
     let new_tip = st
         .wallet()
         .chain_height()
         .unwrap()
-        .expect("chain tip should match rewind target");
-    assert_eq!(new_tip, rewind_target);
+        .expect("chain tip should still be set after rewind");
+    assert_eq!(new_tip, tip);
 
     // A shallow rewind truncates blocks, tx_locator_map, and note commitment trees
     // directly to the rewind target: data at the target is preserved (with the same
@@ -5091,93 +5096,27 @@ where
 
     let account = st.test_account().unwrap().clone();
 
-    // Remember the pre-rewind tip; we restore it in Step 7 to provide an anchor
-    // for `propose_transfer`.
-    let pre_rewind_tip = st
-        .wallet()
-        .chain_height()
-        .unwrap()
-        .expect("chain tip should be set before rewind");
-
-    // Step 5: deep-rewind to the target and confirm scan_queue followed it. The rewind
-    // target is below the account birthday, so the account must be included in the
-    // reset set for the birthday to be lowered.
+    // Step 5: deep-rewind to the target. The rewind target is below the account birthday,
+    // so the account must be included in the reset set for the birthday to be lowered.
+    // `rewind_to_chain_state` overwrites the scan-queue range above the rewind target with
+    // a `Historic` rescan range, so the chain tip remains observable as the pre-rewind tip
+    // and notes whose `witness_stabilized = 1` flag survives can still be spent.
     st.wallet_mut()
         .rewind_to_chain_state(
             ChainState::empty(rewind_target, BlockHash([0; 32])),
             HashSet::from([account.id()]),
         )
         .expect("rewind_to_chain_state should succeed");
-    let tip_after_rewind = st
-        .wallet()
-        .chain_height()
-        .unwrap()
-        .expect("chain tip should be set after rewind");
-    assert!(
-        tip_after_rewind <= rewind_target,
-        "scan_queue must be rewound at or below the rewind target"
-    );
 
-    // Step 6: before `update_chain_tip`, balance must reflect all three stabilized
-    // notes, but the spend path must fail because no anchor can be derived.
+    // Step 6: balance reflects all three stabilized notes, and a spend can be proposed
+    // immediately because the chain tip is preserved by the rewind.
     assert_eq!(
         st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
         total_note_value,
-        "stabilized balance must be available even before update_chain_tip"
-    );
-    let pre_update_request = zip321::TransactionRequest::new(vec![Payment::without_memo(
-        T::sk_default_address(&T::sk(&[0xcc; 32])).to_zcash_address(st.network()),
-        Zatoshis::const_from_u64(10_000),
-    )])
-    .unwrap();
-    let pre_update_change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
-    let pre_update_input_selector = GreedyInputSelector::new();
-    let pre_update_result = st.propose_transfer(
-        account.id(),
-        &pre_update_input_selector,
-        &pre_update_change_strategy,
-        pre_update_request,
-        ConfirmationsPolicy::MIN,
-    );
-    assert_matches!(
-        pre_update_result,
-        Err(crate::data_api::error::Error::ScanRequired)
-            | Err(crate::data_api::error::Error::InsufficientFunds { .. }),
-        "propose_transfer should fail with InsufficientFunds or ScanRequired"
-    );
-    if let Err(crate::data_api::error::Error::InsufficientFunds { available, .. }) =
-        &pre_update_result
-    {
-        assert_eq!(
-            *available,
-            Zatoshis::ZERO,
-            "when note selection runs, no notes should be eligible without the restored tip",
-        );
-    }
-
-    // Step 7: restore the chain tip so `propose_transfer` can derive an anchor,
-    // and confirm balance is still the full three-note sum.
-    st.wallet_mut()
-        .update_chain_tip(pre_rewind_tip)
-        .expect("update_chain_tip should succeed");
-    let tip_after_update = st
-        .wallet()
-        .chain_height()
-        .unwrap()
-        .expect("chain tip should be set after update_chain_tip");
-    assert_eq!(tip_after_update, pre_rewind_tip);
-    let post_rewind_spendable = st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN);
-    assert_eq!(
-        post_rewind_spendable, total_note_value,
         "all stabilized notes should remain spendable after deep rewind"
     );
 
-    // Step 8: build and sign a real spend end-to-end.
+    // Step 7: build and sign a real spend end-to-end.
     let to_extsk = T::sk(&[0xcc; 32]);
     let to: Address = T::sk_default_address(&to_extsk);
     let send_value = Zatoshis::const_from_u64(10_000);

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Eq,
+    collections::HashSet,
     convert::Infallible,
     hash::Hash,
     num::{NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize},
@@ -66,7 +67,7 @@ use {
         wallet::WalletTransparentOutput,
     },
     nonempty::NonEmpty,
-    std::{collections::HashSet, str::FromStr},
+    std::str::FromStr,
     transparent::{
         bundle::{OutPoint, TxOut},
         keys::{NonHardenedChildIndex, TransparentKeyScope},
@@ -4603,8 +4604,10 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
     );
 }
 
-pub fn rewind_to_height_deep<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
-where
+pub fn rewind_to_chain_state_deep<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
@@ -4614,7 +4617,7 @@ where
     // 3. Pick a rewind target well below the future prune floor.
     // 4. Generate and scan more than PRUNING_DEPTH extra blocks so that the checkpoint at the
     //    target is pruned AND the target lies below `tip - PRUNING_DEPTH` (the "deep" branch).
-    // 5. Call `rewind_to_height(target)` and verify:
+    // 5. Call `rewind_to_chain_state(target)` and verify:
     //    - the scan queue is rewound all the way to `target`;
     //    - blocks, transactions, tx_locator_map entries, and note commitment trees are
     //      only rewound to `tip - (PRUNING_DEPTH - 1)` (the oldest retained checkpoint).
@@ -4677,12 +4680,13 @@ where
         .unwrap()
         .expect("block at prune boundary should be present before rewind");
 
-    // `rewind_to_height` must succeed at the same target.
-    let rewound_to = st
-        .wallet_mut()
-        .rewind_to_height(rewind_target)
-        .expect("rewind_to_height should succeed for a deep target");
-    assert_eq!(rewound_to, rewind_target);
+    // `rewind_to_chain_state` must succeed at the same target.
+    st.wallet_mut()
+        .rewind_to_chain_state(
+            ChainState::empty(rewind_target, BlockHash([0; 32])),
+            HashSet::new(),
+        )
+        .expect("rewind_to_chain_state should succeed for a deep target");
 
     // The chain tip (derived from scan_queue) should now report the rewind target.
     let new_tip = st
@@ -4720,8 +4724,10 @@ where
     );
 }
 
-pub fn rewind_to_height_shallow<T: ShieldedPoolTester, Dsf>(ds_factory: Dsf, cache: impl TestCache)
-where
+pub fn rewind_to_chain_state_shallow<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: std::fmt::Debug,
 {
@@ -4732,7 +4738,7 @@ where
     // 4. Generate and scan `PRUNING_DEPTH - 1` extra blocks so that the target sits at
     //    the shallow boundary (`target == tip - (PRUNING_DEPTH - 1)`, exactly the oldest
     //    retained checkpoint).
-    // 5. Call `rewind_to_height(target)` and verify all wallet data is rewound to the
+    // 5. Call `rewind_to_chain_state(target)` and verify all wallet data is rewound to the
     //    target: data at the target is preserved, anything above is removed.
 
     use crate::data_api::ll::wallet::PRUNING_DEPTH;
@@ -4789,11 +4795,12 @@ where
         .unwrap()
         .expect("block at the rewind target should be present before rewind");
 
-    let rewound_to = st
-        .wallet_mut()
-        .rewind_to_height(rewind_target)
-        .expect("rewind_to_height should succeed for a shallow target");
-    assert_eq!(rewound_to, rewind_target);
+    st.wallet_mut()
+        .rewind_to_chain_state(
+            ChainState::empty(rewind_target, BlockHash([0; 32])),
+            HashSet::new(),
+        )
+        .expect("rewind_to_chain_state should succeed for a shallow target");
 
     let new_tip = st
         .wallet()
@@ -4835,7 +4842,7 @@ pub fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
     // Regression test: after the scan scheduler processes a `ChainTip` range before a
     // lower `Historic` range, `MAX(height) FROM blocks` points into one scanned region
     // while `last_scanned - (PRUNING_DEPTH - 1)` lands inside the unscanned gap between
-    // the two regions. `rewind_to_height` must still succeed: an implementation that
+    // the two regions. `rewind_to_chain_state` must still succeed: an implementation that
     // expected a checkpoint at exactly the PD floor would return `CorruptedData` via
     // `truncate_to_checkpoint`; clamping forward to the lowest checkpoint inside the
     // prune window keeps us aligned with a real checkpoint.
@@ -4893,16 +4900,19 @@ pub fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester, Dsf>(
          gap is ({low_end_inclusive}, {high_start}))"
     );
 
-    // `rewind_to_height` must return `Ok(_)` rather than `CorruptedData`: clamping
+    // `rewind_to_chain_state` must return `Ok(_)` rather than `CorruptedData`: clamping
     // forward to the lowest checkpoint inside the window (which sits at `high_start`)
     // keeps us aligned with a real checkpoint.
     st.wallet_mut()
-        .rewind_to_height(low_end_inclusive)
-        .expect("rewind_to_height should succeed across a non-contiguous scan");
+        .rewind_to_chain_state(
+            ChainState::empty(low_end_inclusive, BlockHash([0; 32])),
+            HashSet::new(),
+        )
+        .expect("rewind_to_chain_state should succeed across a non-contiguous scan");
 }
 
 /// Multiple wallet notes in a stabilized shard remain spendable after a deep
-/// `rewind_to_height` moves the scan queue below them.
+/// `rewind_to_chain_state` moves the scan queue below them.
 pub fn stabilized_note_spendable_after_deep_rewind<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
 where
     T: ShieldedPoolTester,
@@ -5089,10 +5099,15 @@ where
         .unwrap()
         .expect("chain tip should be set before rewind");
 
-    // Step 5: deep-rewind to the target and confirm scan_queue followed it.
+    // Step 5: deep-rewind to the target and confirm scan_queue followed it. The rewind
+    // target is below the account birthday, so the account must be included in the
+    // reset set for the birthday to be lowered.
     st.wallet_mut()
-        .rewind_to_height(rewind_target)
-        .expect("rewind_to_height should succeed");
+        .rewind_to_chain_state(
+            ChainState::empty(rewind_target, BlockHash([0; 32])),
+            HashSet::from([account.id()]),
+        )
+        .expect("rewind_to_chain_state should succeed");
     let tip_after_rewind = st
         .wallet()
         .chain_height()
@@ -5205,7 +5220,7 @@ where
 /// the ensuing re-scan discovers the new account's previously-unknown notes
 /// and `scan_complete → mark_stabilized_notes` flags them `witness_stabilized`
 /// on the fly, so they remain spendable across a subsequent deep
-/// `rewind_to_height`.
+/// `rewind_to_chain_state`.
 pub fn newly_discovered_notes_become_stabilized<T, Dsf>(ds_factory: Dsf, cache: impl TestCache)
 where
     T: ShieldedPoolTester,
@@ -5454,8 +5469,11 @@ where
     // stabilized would drop out of the balance here.
     let rewind_target = account_a.birthday().height() - 100;
     st.wallet_mut()
-        .rewind_to_height(rewind_target)
-        .expect("rewind_to_height should succeed");
+        .rewind_to_chain_state(
+            ChainState::empty(rewind_target, BlockHash([0; 32])),
+            HashSet::from([account_a.id(), account_b.id()]),
+        )
+        .expect("rewind_to_chain_state should succeed");
 
     assert_eq!(
         st.get_spendable_balance(account_a.id(), ConfirmationsPolicy::MIN),

--- a/zcash_client_memory/src/wallet_write.rs
+++ b/zcash_client_memory/src/wallet_write.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     ops::Range,
 };
 
@@ -20,6 +20,7 @@ use zcash_client_backend::{
         AccountPurpose, AccountSource, SAPLING_SHARD_HEIGHT, TransactionStatus,
         WalletCommitmentTrees as _, Zip32Derivation,
         chain::ChainState,
+        error::RewindError,
         scanning::{ScanPriority, ScanRange},
     },
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -1065,7 +1066,11 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
         todo!()
     }
 
-    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+    fn rewind_to_chain_state(
+        &mut self,
+        _chain_state: ChainState,
+        _reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>> {
         todo!()
     }
 

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -402,25 +402,25 @@ mod tests {
     }
 
     #[test]
-    fn rewind_to_height_deep_sapling() {
-        testing::pool::rewind_to_height_deep::<SaplingPoolTester>()
+    fn rewind_to_chain_state_deep_sapling() {
+        testing::pool::rewind_to_chain_state_deep::<SaplingPoolTester>()
     }
 
     #[test]
     #[cfg(feature = "orchard")]
-    fn rewind_to_height_deep_orchard() {
-        testing::pool::rewind_to_height_deep::<OrchardPoolTester>()
+    fn rewind_to_chain_state_deep_orchard() {
+        testing::pool::rewind_to_chain_state_deep::<OrchardPoolTester>()
     }
 
     #[test]
-    fn rewind_to_height_shallow_sapling() {
-        testing::pool::rewind_to_height_shallow::<SaplingPoolTester>()
+    fn rewind_to_chain_state_shallow_sapling() {
+        testing::pool::rewind_to_chain_state_shallow::<SaplingPoolTester>()
     }
 
     #[test]
     #[cfg(feature = "orchard")]
-    fn rewind_to_height_shallow_orchard() {
-        testing::pool::rewind_to_height_shallow::<OrchardPoolTester>()
+    fn rewind_to_chain_state_shallow_orchard() {
+        testing::pool::rewind_to_chain_state_shallow::<OrchardPoolTester>()
     }
 
     #[test]

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -41,7 +41,7 @@ use shardtree::{ShardTree, error::ShardTreeError, store::ShardStore};
 use std::{
     borrow::{Borrow, BorrowMut},
     cmp::{max, min},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::AsRef,
     fmt,
     num::NonZeroU32,
@@ -62,7 +62,7 @@ use zcash_client_backend::{
         SeedRelevance, SentTransaction, TargetValue, TransactionDataRequest, WalletCommitmentTrees,
         WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
-        error::FindAccountForAddressError,
+        error::{FindAccountForAddressError, RewindError},
         ll::{
             self, LowLevelWalletRead, LowLevelWalletWrite, ReceivedSaplingOutput,
             wallet::store_decrypted_tx,
@@ -114,7 +114,7 @@ use {
         bundle::OutPoint,
         keys::{NonHardenedChildIndex, TransparentKeyScope},
     },
-    std::{collections::HashSet, time::SystemTime},
+    std::time::SystemTime,
     zcash_client_backend::{
         data_api::{
             TransactionsInvolvingAddress, TransparentBalances, TransparentOutputFilter, WalletUtxo,
@@ -1332,8 +1332,29 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.truncate_to_chain_state(chain_state))
     }
 
-    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
-        self.transactionally(|wdb| wdb.rewind_to_height(max_height))
+    fn rewind_to_chain_state(
+        &mut self,
+        chain_state: ChainState,
+        reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>> {
+        let tx = self
+            .conn
+            .borrow_mut()
+            .transaction()
+            .map_err(|e| RewindError::DataSource(SqliteClientError::from(e)))?;
+        let result = wallet::rewind_to_chain_state(
+            &tx,
+            &self.params,
+            #[cfg(feature = "transparent-inputs")]
+            &self.gap_limits,
+            &chain_state,
+            reset_account_birthdays,
+        );
+        if result.is_ok() {
+            tx.commit()
+                .map_err(|e| RewindError::DataSource(SqliteClientError::from(e)))?;
+        }
+        result
     }
 
     #[cfg(feature = "transparent-inputs")]
@@ -1678,13 +1699,18 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         wallet::truncate_to_chain_state(self, chain_state)
     }
 
-    fn rewind_to_height(&mut self, max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
-        wallet::rewind_to_height(
+    fn rewind_to_chain_state(
+        &mut self,
+        chain_state: ChainState,
+        reset_account_birthdays: HashSet<Self::AccountId>,
+    ) -> Result<(), RewindError<Self::AccountId, Self::Error>> {
+        wallet::rewind_to_chain_state(
             self.conn.0,
             &self.params,
             #[cfg(feature = "transparent-inputs")]
             &self.gap_limits,
-            max_height,
+            &chain_state,
+            reset_account_birthdays,
         )
     }
 

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -4,7 +4,10 @@ use rand_chacha::ChaChaRng;
 use rusqlite::Connection;
 use std::num::NonZeroU32;
 use std::time::Duration;
-use std::{collections::HashMap, time::SystemTime};
+use std::{
+    collections::{HashMap, HashSet},
+    time::SystemTime,
+};
 use uuid::Uuid;
 
 use tempfile::NamedTempFile;
@@ -17,6 +20,7 @@ use zcash_client_backend::{
     data_api::{
         TargetValue,
         chain::{ChainState, CommitmentTreeRoot},
+        error::RewindError,
         scanning::ScanRange,
         testing::{DataStoreFactory, Reset, TestState},
         wallet::{ConfirmationsPolicy, TargetHeight},

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -326,15 +326,15 @@ pub(crate) fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester>() {
     )
 }
 
-pub(crate) fn rewind_to_height_deep<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::rewind_to_height_deep::<T, _>(
+pub(crate) fn rewind_to_chain_state_deep<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::rewind_to_chain_state_deep::<T, _>(
         TestDbFactory::default(),
         BlockCache::new(),
     )
 }
 
-pub(crate) fn rewind_to_height_shallow<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::rewind_to_height_shallow::<T, _>(
+pub(crate) fn rewind_to_chain_state_shallow<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::rewind_to_chain_state_shallow::<T, _>(
         TestDbFactory::default(),
         BlockCache::new(),
     )

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3941,6 +3941,12 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
 
     let target_height = chain_state.block_height();
     let new_birthday = target_height + 1;
+    // An empty `reset_account_birthdays` is the caller's explicit assertion that the
+    // requested rewind should not require lowering any account's birthday. Honor that:
+    // if the rewind would land below every account's birthday — meaning the caller's
+    // assertion is wrong — surface `RewindBeyondBirthdays` so the caller can decide
+    // which accounts (if any) to acknowledge for lowering. A non-empty set is the
+    // caller's acknowledgement that the listed accounts may be lowered.
     let birthday_reset_required =
         account_birthdays.values().all(|b| b > &new_birthday) && reset_account_birthdays.is_empty();
 
@@ -5728,6 +5734,103 @@ mod tests {
             "scan numerator {n} exceeds denominator {d}",
             n = scan.numerator(),
             d = scan.denominator(),
+        );
+    }
+
+    /// `rewind_to_chain_state` must return `RewindBeyondBirthdays` when the rewind would
+    /// land below every account's birthday and the caller has not provided any accounts in
+    /// `reset_account_birthdays` to acknowledge the lowering.
+    #[test]
+    fn rewind_to_chain_state_below_all_birthdays_with_empty_reset_returns_error() {
+        use std::collections::HashSet;
+        use zcash_client_backend::data_api::{WalletWrite, chain::ChainState, error::RewindError};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        let original_birthday = st.test_account().unwrap().birthday().height();
+        // Pick a target whose `new_birthday = target + 1` is strictly below every
+        // account's birthday, so the safeguard fires when the caller hasn't
+        // acknowledged any reset.
+        let target_height = original_birthday - 10;
+
+        let result = st.wallet_mut().rewind_to_chain_state(
+            ChainState::empty(target_height, BlockHash([0; 32])),
+            HashSet::new(),
+        );
+
+        assert_matches!(
+            result,
+            Err(RewindError::RewindBeyondBirthdays(birthdays))
+                if birthdays.get(&account_id) == Some(&original_birthday)
+        );
+    }
+
+    /// When the rewind target is below every account's birthday but the caller acknowledges
+    /// the lowering by including the account in `reset_account_birthdays`, the rewind
+    /// proceeds and the listed account's birthday is lowered to the new floor.
+    #[test]
+    fn rewind_to_chain_state_below_all_birthdays_with_account_in_reset_succeeds() {
+        use std::collections::HashSet;
+        use zcash_client_backend::data_api::{WalletWrite, chain::ChainState};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        let original_birthday = st.test_account().unwrap().birthday().height();
+        // Pick a target whose `new_birthday = target + 1` is strictly below every
+        // account's birthday, so the safeguard fires when the caller hasn't
+        // acknowledged any reset.
+        let target_height = original_birthday - 10;
+
+        st.wallet_mut()
+            .rewind_to_chain_state(
+                ChainState::empty(target_height, BlockHash([0; 32])),
+                HashSet::from([account_id]),
+            )
+            .expect("rewind_to_chain_state should succeed when the account is in reset");
+
+        // The account's birthday is now lowered to `target_height + 1`.
+        assert_matches!(
+            account_birthday(st.wallet().conn(), account_id),
+            Ok(b) if b == target_height + 1
+        );
+    }
+
+    /// `rewind_to_chain_state` must reject `reset_account_birthdays` containing an
+    /// `AccountUuid` that does not correspond to an account in the wallet, surfacing the
+    /// error via `RewindError::DataSource(CorruptedData)`.
+    #[test]
+    fn rewind_to_chain_state_with_unknown_uuid_in_reset_returns_data_source_error() {
+        use std::collections::HashSet;
+        use zcash_client_backend::data_api::{WalletWrite, chain::ChainState, error::RewindError};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let original_birthday = st.test_account().unwrap().birthday().height();
+        // Pick a target whose `new_birthday = target + 1` is strictly below every
+        // account's birthday, so the safeguard fires when the caller hasn't
+        // acknowledged any reset.
+        let target_height = original_birthday - 10;
+
+        let bogus_uuid = AccountUuid(Uuid::from_u128(0xDEADBEEF));
+        let result = st.wallet_mut().rewind_to_chain_state(
+            ChainState::empty(target_height, BlockHash([0; 32])),
+            HashSet::from([bogus_uuid]),
+        );
+
+        assert_matches!(
+            result,
+            Err(RewindError::DataSource(SqliteClientError::CorruptedData(_)))
         );
     }
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -65,7 +65,7 @@
 //! - `memo` the shielded memo associated with the output, if any.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::TryFrom,
     io::{self, Cursor},
     num::NonZeroU32,
@@ -94,7 +94,7 @@ use zcash_client_backend::{
         TransactionStatus, WalletSummary, Zip32Derivation,
         chain::ChainState,
         defaults::address_receiver_matches_ua,
-        error::FindAccountForAddressError,
+        error::{FindAccountForAddressError, RewindError},
         scanning::{ScanPriority, ScanRange},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
@@ -143,7 +143,6 @@ use {
         bundle::{OutPoint, TxOut},
         keys::{IncomingViewingKey as _, NonHardenedChildIndex, TransparentKeyScope},
     },
-    std::collections::HashSet,
     zcash_client_backend::{data_api::DecryptedTransaction, wallet::WalletTransparentOutput},
 };
 
@@ -3912,92 +3911,181 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
     Ok(())
 }
 
-/// Rewinds the wallet to at most the given block height, preserving any wallet data which has been
-/// confirmed beyond the pruning depth.
+/// Rewinds the wallet to the specified chain state, preserving wallet data which has been
+/// confirmed beyond the pruning depth, and resetting the birthday height of specified accounts
+/// to the block following the chain state.
 ///
-/// In contrast to [`truncate_to_height`], which unconditionally deletes wallet state above
-/// `max_height` (transaction & note data is retained, but committment trees, blocks, etc are
-/// removed to the truncation height), this rewinds the scan queue to `max_height` but only rewinds
-/// blocks, note commitment trees, transactions, transparent UTXO observations, and nullifier-map
-/// entries as far back as the pruning floor (`chain_tip - (PRUNING_DEPTH - 1)`). Data at or below
-/// that height is preserved. Because `PRUNING_DEPTH` is a property of chain depth, the floor is
-/// derived from the wallet's view of the chain tip rather than from `MAX(blocks.height)`.
-///
+/// In contrast to [`truncate_to_chain_state`], which unconditionally removes wallet state above
+/// `chain_state.block_height()` (transaction & note data is retained, but commitment trees,
+/// blocks, etc. are removed to the truncation height), this rewinds the scan queue to the
+/// target height but only rewinds blocks, note commitment trees, transactions, transparent UTXO
+/// observations, and nullifier-map entries as far back as the pruning floor (`chain_tip -
+/// (PRUNING_DEPTH - 1)`). Data at or below that height is preserved. Because `PRUNING_DEPTH` is
+/// a property of chain depth, the floor is derived from the wallet's view of the chain tip
+/// rather than from `MAX(blocks.height)`.
 ///
 /// The floor is clamped to an actual shard-tree checkpoint at or above the pruning floor (via
-/// [`commitment_tree::min_checkpoint_id_at_or_above`]) so that [`truncate_to_height_internal`] has
-/// a real checkpoint to truncate to under non-contiguous scan orders.
+/// [`commitment_tree::min_checkpoint_id_at_or_above`]) so that [`truncate_to_height_internal`]
+/// has a real checkpoint to truncate to under non-contiguous scan orders.
 ///
-/// Returns the actual scan-queue rewind height (`max_height` clamped to the max scanned height when
-/// `max_height` is above it).
-pub(crate) fn rewind_to_height<P: consensus::Parameters>(
+/// The birthday height is reset for an account in `reset_account_birthdays` only when the new
+/// birthday (`chain_state.block_height() + 1`) is strictly less than the existing birthday
+/// height; the existing birthday is never raised by this method.
+///
+/// Returns `Err(RewindError::RewindBeyondBirthdays(_))` if any account in the wallet has a
+/// birthday greater than `chain_state.block_height()` and is not present in
+/// `reset_account_birthdays`.
+pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
     #[cfg(feature = "transparent-inputs")] gap_limits: &GapLimits,
-    max_height: BlockHeight,
-) -> Result<BlockHeight, SqliteClientError> {
-    let max_scanned_height = block_max_scanned(conn, params)?
+    chain_state: &ChainState,
+    reset_account_birthdays: HashSet<AccountUuid>,
+) -> Result<(), RewindError<AccountUuid, SqliteClientError>> {
+    // Find account birthdays. We need to check that we either we have an account with a birthday
+    // less than or equal to the new birthday height, or that there is an intersection between the
+    // account birthdays to be reset and the accounts in the wallet.
+    let account_birthdays: HashMap<AccountUuid, BlockHeight> = {
+        let mut stmt = conn
+            .prepare("SELECT uuid, birthday_height FROM accounts")
+            .map_err(|e| RewindError::DataSource(e.into()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let uuid: Uuid = row.get(0)?;
+                let h: u32 = row.get(1)?;
+                Ok((AccountUuid(uuid), BlockHeight::from(h)))
+            })
+            .map_err(|e| RewindError::DataSource(e.into()))?;
+
+        rows.collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| RewindError::DataSource(e.into()))?
+    };
+
+    let reset_valid = reset_account_birthdays
+        .iter()
+        .all(|uuid| account_birthdays.contains_key(uuid));
+
+    if !reset_valid {
+        return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
+            "Account UUIDs provided for birthday reset do not exist in the wallet database."
+                .to_string(),
+        )));
+    }
+
+    let target_height = chain_state.block_height();
+    let new_birthday = target_height + 1;
+    let birthday_reset_required =
+        account_birthdays.values().all(|b| b > &new_birthday) && reset_account_birthdays.is_empty();
+
+    if birthday_reset_required {
+        return Err(RewindError::RewindBeyondBirthdays(account_birthdays));
+    }
+
+    // Truncate wallet data above the pruning floor only when the target is below the wallet's
+    // max scanned height; if the target is at or above the max scanned height, the wallet has
+    // not yet scanned past the rewind point and there is nothing above it to remove.
+    if let Some(max_scanned_height) = block_max_scanned(conn, params)
+        .map_err(RewindError::DataSource)?
         .map(|m| m.block_height())
-        .unwrap_or_else(|| {
-            params
-                .activation_height(NetworkUpgrade::Sapling)
-                // Fall back to the genesis block in regtest mode.
-                .map_or(BlockHeight::from_u32(0), |h| h - 1)
-        });
-
-    // Compute the floor height of the pruning window
-    let pruning_floor = max_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
-    let truncation_target = max_height.max(pruning_floor);
-
-    // Determine the minimum sapling and orchard checkpoints within the pruning window
-    let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
-        conn,
-        crate::SAPLING_TABLES_PREFIX,
-        truncation_target,
-    )
-    .map_err(ShardTreeError::Storage)?;
-
-    #[cfg(feature = "orchard")]
     {
-        // Check that Orchard checkpoint matches the Sapling checkpoint.
-        // These should always match, unless the database is corrupted.
-        let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
-            conn,
-            crate::ORCHARD_TABLES_PREFIX,
-            truncation_target,
-        )
-        .map_err(ShardTreeError::Storage)?;
-        if orchard_window_floor != sapling_window_floor {
-            return Err(SqliteClientError::CorruptedData(
-                "Sapling and Orchard should have the same checkpoints".into(),
-            ));
+        if target_height < max_scanned_height {
+            // Compute the floor height of the pruning window.
+            let pruning_floor = max_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
+            let truncation_target = target_height.max(pruning_floor);
+
+            // Determine the minimum sapling and orchard checkpoints within the pruning window.
+            let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+                conn,
+                crate::SAPLING_TABLES_PREFIX,
+                truncation_target,
+            )
+            .map_err(ShardTreeError::Storage)
+            .map_err(SqliteClientError::from)
+            .map_err(RewindError::DataSource)?;
+
+            #[cfg(feature = "orchard")]
+            {
+                // Check that Orchard checkpoint matches the Sapling checkpoint. These should
+                // always match unless the database is corrupted.
+                let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+                    conn,
+                    crate::ORCHARD_TABLES_PREFIX,
+                    truncation_target,
+                )
+                .map_err(ShardTreeError::Storage)
+                .map_err(SqliteClientError::from)
+                .map_err(RewindError::DataSource)?;
+                if orchard_window_floor != sapling_window_floor {
+                    return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
+                        "Sapling and Orchard should have the same checkpoints".into(),
+                    )));
+                }
+            }
+
+            // Combine the per-pool floors by taking the shallower (larger height).
+            let truncation_height = sapling_window_floor.unwrap_or(pruning_floor);
+
+            // Use `truncate_to_height_internal` to perform full truncation of data within the
+            // pruning window.
+            truncate_to_height_internal(
+                conn,
+                params,
+                #[cfg(feature = "transparent-inputs")]
+                gap_limits,
+                truncation_height,
+            )
+            .map_err(RewindError::DataSource)?;
         }
     }
 
-    // Combine the per-pool floors by taking the shallower (larger height).
-    let truncation_height = sapling_window_floor.unwrap_or(pruning_floor);
+    // When the caller asked to rewind below the truncation_height floor, trim the scan queue
+    // the rest of the way down to `target_height` so the sync loop will re-scan the blocks
+    // between `target_height` and the truncation height.
+    trim_scan_queue_to(conn, target_height).map_err(RewindError::DataSource)?;
 
-    // Use `truncate_to_height_internal` perform full truncation of data within the pruning window
-    truncate_to_height_internal(
-        conn,
-        params,
-        #[cfg(feature = "transparent-inputs")]
-        gap_limits,
-        truncation_height,
-    )?;
+    let new_sapling_tree_size: u64 = chain_state.final_sapling_tree().tree_size();
+    #[cfg(feature = "orchard")]
+    let new_orchard_tree_size: u64 = chain_state.final_orchard_tree().tree_size();
 
-    // When the caller asked to rewind below the truncation_height floor, trim the scan queue the
-    // rest of the way down to `max_height` so the sync loop will re-scan the blocks between
-    // `max_height` and `data_rewind_height`.
-    trim_scan_queue_to(conn, max_height)?;
+    for uuid in &reset_account_birthdays {
+        #[cfg(feature = "orchard")]
+        conn.execute(
+            "UPDATE accounts
+             SET birthday_height = :new_birthday,
+                 birthday_sapling_tree_size = :new_sapling_tree_size,
+                 birthday_orchard_tree_size = :new_orchard_tree_size
+             WHERE uuid = :uuid AND birthday_height > :new_birthday",
+            named_params![
+                ":new_birthday": u32::from(new_birthday),
+                ":new_sapling_tree_size": new_sapling_tree_size,
+                ":new_orchard_tree_size": new_orchard_tree_size,
+                ":uuid": uuid.0,
+            ],
+        )
+        .map_err(|e| RewindError::DataSource(e.into()))?;
+        #[cfg(not(feature = "orchard"))]
+        conn.execute(
+            "UPDATE accounts
+             SET birthday_height = :new_birthday,
+                 birthday_sapling_tree_size = :new_sapling_tree_size
+             WHERE uuid = :uuid AND birthday_height > :new_birthday",
+            named_params![
+                ":new_birthday": u32::from(new_birthday),
+                ":new_sapling_tree_size": new_sapling_tree_size,
+                ":uuid": uuid.0,
+            ],
+        )
+        .map_err(|e| RewindError::DataSource(e.into()))?;
+    }
 
-    Ok(max_height.min(max_scanned_height))
+    Ok(())
 }
 
 /// Trims the `scan_queue` so that no range extends above `max_height`.
 ///
 /// Deletes any range whose start is above `max_height`, and clamps the upper bound of any
-/// remaining range that extends past `max_height`. Used by [`rewind_to_height`] to push the
+/// remaining range that extends past `max_height`. Used by [`rewind_to_chain_state`] to push the
 /// scan-queue rewind below the data-truncation floor without disturbing the wallet data
 /// preserved within the pruning window.
 pub(crate) fn trim_scan_queue_to(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -80,8 +80,8 @@ use encoding::{
 use incrementalmerkletree::{Marking, Retention};
 use rusqlite::{self, Connection, OptionalExtension, named_params, params};
 use secrecy::{ExposeSecret, SecretVec};
-use shardtree::{ShardTree, error::ShardTreeError, store::ShardStore};
-use tracing::{debug, warn};
+use shardtree::{error::ShardTreeError, store::ShardStore};
+use tracing::warn;
 use uuid::Uuid;
 
 use zcash_address::ZcashAddress;
@@ -572,61 +572,36 @@ pub(crate) fn add_account<P: consensus::Parameters>(
         birthday: birthday.height(),
     };
 
-    // If birthday frontiers are available and the birthday height is less than or equal to the
-    // max-scanned height, insert them into the note commitment trees. Otherwise, we don't need to
-    // do anything.
-    if block_max_scanned(conn, params)?.is_some_and(|m| m.block_height() > birthday.height()) {
-        if let Some(frontier) = birthday.sapling_frontier().value() {
-            debug!("Inserting Sapling frontier into ShardTree: {:?}", frontier);
-            let shard_store =
-                SqliteShardStore::<_, ::sapling::Node, SAPLING_SHARD_HEIGHT>::from_connection(
-                    conn,
-                    crate::SAPLING_TABLES_PREFIX,
-                )?;
-            let mut shard_tree: ShardTree<
-                _,
-                { ::sapling::NOTE_COMMITMENT_TREE_DEPTH },
-                SAPLING_SHARD_HEIGHT,
-            > = ShardTree::new(shard_store, PRUNING_DEPTH.try_into().unwrap());
-            shard_tree.insert_frontier_nodes(
-                frontier.clone(),
-                Retention::Checkpoint {
-                    // This subtraction is safe, because all leaves in the tree appear in blocks, and
-                    // the invariant that birthday.height() always corresponds to the block for which
-                    // `frontier` is the tree state at the start of the block. Together, this means
-                    // there exists a prior block for which frontier is the tree state at the end of
-                    // the block.
-                    id: birthday.height() - 1,
-                    marking: Marking::Reference,
-                },
-            )?;
-        }
-
-        #[cfg(feature = "orchard")]
-        if let Some(frontier) = birthday.orchard_frontier().value() {
-            debug!("Inserting Orchard frontier into ShardTree: {:?}", frontier);
-            let shard_store = SqliteShardStore::<
-                _,
-                ::orchard::tree::MerkleHashOrchard,
-                ORCHARD_SHARD_HEIGHT,
-            >::from_connection(conn, crate::ORCHARD_TABLES_PREFIX)?;
-            let mut shard_tree: ShardTree<
-                _,
-                { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-                ORCHARD_SHARD_HEIGHT,
-            > = ShardTree::new(shard_store, PRUNING_DEPTH.try_into().unwrap());
-            shard_tree.insert_frontier_nodes(
-                frontier.clone(),
-                Retention::Checkpoint {
-                    // This subtraction is safe, because all leaves in the tree appear in blocks, and
-                    // the invariant that birthday.height() always corresponds to the block for which
-                    // `frontier` is the tree state at the start of the block. Together, this means
-                    // there exists a prior block for which frontier is the tree state at the end of
-                    // the block.
-                    id: birthday.height() - 1,
-                    marking: Marking::Reference,
-                },
-            )?;
+    // Bring the wallet's note commitment tree, scan queue, and birthday metadata into a state
+    // consistent with the new account's birthday by rewinding to the chain state prior to the
+    // birthday height. The new account is the only entry in `reset_account_birthdays`;
+    // existing accounts retain their own birthdays.
+    //
+    // This handles two concerns that the previous manual implementation couldn't address
+    // safely together:
+    //   - Note commitment tree data above the pruning floor is removed so that subsequent
+    //     re-scanning cannot conflict with stale tree state from prior scans.
+    //   - The scan queue above `birthday.height() - 1` is overwritten with a `Historic`
+    //     rescan range so that blocks that must be re-scanned for the new account's notes
+    //     are queued.
+    match rewind_to_chain_state(
+        conn,
+        params,
+        #[cfg(feature = "transparent-inputs")]
+        gap_limits,
+        birthday.prior_chain_state(),
+        std::iter::once(account_uuid).collect(),
+    ) {
+        Ok(()) => {}
+        Err(RewindError::DataSource(e)) => return Err(e),
+        Err(RewindError::RewindBeyondBirthdays(_)) => {
+            // Cannot occur: `reset_account_birthdays` is non-empty (it contains the new
+            // account), so `rewind_to_chain_state`'s contract specifies that this variant is
+            // not returned.
+            unreachable!(
+                "rewind_to_chain_state cannot return RewindBeyondBirthdays with a non-empty \
+                 reset_account_birthdays set"
+            );
         }
     }
 
@@ -651,23 +626,6 @@ pub(crate) fn add_account<P: consensus::Parameters>(
             false,
         )?;
     };
-
-    // Rewrite the scan ranges from the birthday height up to the chain tip so that we'll ensure we
-    // re-scan to find any notes that might belong to the newly added account.
-    if let Some(t) = chain_tip_height(conn)? {
-        let rescan_range = birthday.height()..(t + 1);
-
-        replace_queue_entries::<SqliteClientError>(
-            conn,
-            &rescan_range,
-            Some(ScanRange::from_parts(
-                rescan_range.clone(),
-                ScanPriority::Historic,
-            ))
-            .into_iter(),
-            true, // force rescan
-        )?;
-    }
 
     // Always derive the default Unified Address for the account. If the account's viewing
     // key has fewer components than the wallet supports (most likely due to this being an
@@ -3917,24 +3875,32 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
 ///
 /// In contrast to [`truncate_to_chain_state`], which unconditionally removes wallet state above
 /// `chain_state.block_height()` (transaction & note data is retained, but commitment trees,
-/// blocks, etc. are removed to the truncation height), this rewinds the scan queue to the
-/// target height but only rewinds blocks, note commitment trees, transactions, transparent UTXO
-/// observations, and nullifier-map entries as far back as the pruning floor (`chain_tip -
-/// (PRUNING_DEPTH - 1)`). Data at or below that height is preserved. Because `PRUNING_DEPTH` is
-/// a property of chain depth, the floor is derived from the wallet's view of the chain tip
-/// rather than from `MAX(blocks.height)`.
+/// blocks, etc. are removed to the truncation height), this rewinds blocks, note commitment
+/// trees, transactions, transparent UTXO observations, and nullifier-map entries only as far
+/// back as the pruning floor (`chain_tip - (PRUNING_DEPTH - 1)`). Data at or below that height
+/// is preserved. Because `PRUNING_DEPTH` is a property of chain depth, the floor is derived
+/// from the wallet's view of the chain tip rather than from `MAX(blocks.height)`.
 ///
 /// The floor is clamped to an actual shard-tree checkpoint at or above the pruning floor (via
 /// [`commitment_tree::min_checkpoint_id_at_or_above`]) so that [`truncate_to_height_internal`]
 /// has a real checkpoint to truncate to under non-contiguous scan orders.
 ///
+/// The scan-queue range above the rewind target is overwritten with a `Historic` rescan range
+/// extending up to the wallet's pre-rewind chain tip (computed from `MAX(block_range_end)` of
+/// the scan queue prior to mutation). This forces re-scanning of any blocks above the rewind
+/// target while preserving the wallet's view of the chain tip; existing scan-queue entries
+/// with priority strictly greater than `Historic` (`ChainTip`, `OpenAdjacent`, `FoundNote`,
+/// `Verify`) are preserved by the spanning-tree merge.
+///
 /// The birthday height is reset for an account in `reset_account_birthdays` only when the new
 /// birthday (`chain_state.block_height() + 1`) is strictly less than the existing birthday
 /// height; the existing birthday is never raised by this method.
 ///
-/// Returns `Err(RewindError::RewindBeyondBirthdays(_))` if any account in the wallet has a
-/// birthday greater than `chain_state.block_height()` and is not present in
-/// `reset_account_birthdays`.
+/// Returns `Err(RewindError::RewindBeyondBirthdays(_))` only when `reset_account_birthdays` is
+/// empty *and* every account in the wallet has a birthday greater than
+/// `chain_state.block_height() + 1`. Returns `Err(RewindError::DataSource(_))` (with a
+/// `CorruptedData` payload) if `reset_account_birthdays` contains any account UUID that is not
+/// present in the wallet.
 pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
@@ -3942,9 +3908,9 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     chain_state: &ChainState,
     reset_account_birthdays: HashSet<AccountUuid>,
 ) -> Result<(), RewindError<AccountUuid, SqliteClientError>> {
-    // Find account birthdays. We need to check that we either we have an account with a birthday
-    // less than or equal to the new birthday height, or that there is an intersection between the
-    // account birthdays to be reset and the accounts in the wallet.
+    // Load every account's birthday so we can validate `reset_account_birthdays` against the
+    // wallet's accounts and check whether at least one existing birthday is at or below the
+    // proposed new birthday floor.
     let account_birthdays: HashMap<AccountUuid, BlockHeight> = {
         let mut stmt = conn
             .prepare("SELECT uuid, birthday_height FROM accounts")
@@ -3981,6 +3947,10 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     if birthday_reset_required {
         return Err(RewindError::RewindBeyondBirthdays(account_birthdays));
     }
+
+    // Capture the chain tip from the scan queue before any mutation; we use it as the upper
+    // bound of the rescan range we install above the rewind target.
+    let chain_tip = chain_tip_height(conn).map_err(|e| RewindError::DataSource(e.into()))?;
 
     // Truncate wallet data above the pruning floor only when the target is below the wallet's
     // max scanned height; if the target is at or above the max scanned height, the wallet has
@@ -4039,17 +4009,38 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
         }
     }
 
-    // When the caller asked to rewind below the truncation_height floor, trim the scan queue
-    // the rest of the way down to `target_height` so the sync loop will re-scan the blocks
-    // between `target_height` and the truncation height.
-    trim_scan_queue_to(conn, target_height).map_err(RewindError::DataSource)?;
+    // Overwrite the scan-queue range above the rewind target with a `Historic` rescan range,
+    // forcing re-scan of any blocks that previously appeared above the target. This both
+    // re-queues the blocks above the truncation floor (which truncate_to_height_internal
+    // already trimmed) and overrides any `Scanned`/`Historic` entries in the
+    // `(target_height, truncation_height]` window that survived a deep rewind, so the sync
+    // loop will re-scan them. With `force_rescans = true` the only entries this preserves are
+    // those whose priority would dominate `Historic` even under a forced rescan
+    // (`ChainTip`, `OpenAdjacent`, `FoundNote`, `Verify`); `Ignored` is the lowest priority
+    // and cannot overwrite anything.
+    if let Some(t) = chain_tip {
+        if target_height < t {
+            let rescan_range = (target_height + 1)..(t + 1);
+            replace_queue_entries::<SqliteClientError>(
+                conn,
+                &rescan_range,
+                std::iter::once(ScanRange::from_parts(
+                    rescan_range.clone(),
+                    ScanPriority::Historic,
+                )),
+                true,
+            )
+            .map_err(RewindError::DataSource)?;
+        }
+    }
 
     let new_sapling_tree_size: u64 = chain_state.final_sapling_tree().tree_size();
     #[cfg(feature = "orchard")]
-    let new_orchard_tree_size: u64 = chain_state.final_orchard_tree().tree_size();
+    let new_orchard_tree_size = Some(chain_state.final_orchard_tree().tree_size());
+    #[cfg(not(feature = "orchard"))]
+    let new_orchard_tree_size: Option<u64> = None;
 
     for uuid in &reset_account_birthdays {
-        #[cfg(feature = "orchard")]
         conn.execute(
             "UPDATE accounts
              SET birthday_height = :new_birthday,
@@ -4064,19 +4055,6 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
             ],
         )
         .map_err(|e| RewindError::DataSource(e.into()))?;
-        #[cfg(not(feature = "orchard"))]
-        conn.execute(
-            "UPDATE accounts
-             SET birthday_height = :new_birthday,
-                 birthday_sapling_tree_size = :new_sapling_tree_size
-             WHERE uuid = :uuid AND birthday_height > :new_birthday",
-            named_params![
-                ":new_birthday": u32::from(new_birthday),
-                ":new_sapling_tree_size": new_sapling_tree_size,
-                ":uuid": uuid.0,
-            ],
-        )
-        .map_err(|e| RewindError::DataSource(e.into()))?;
     }
 
     Ok(())
@@ -4085,9 +4063,8 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
 /// Trims the `scan_queue` so that no range extends above `max_height`.
 ///
 /// Deletes any range whose start is above `max_height`, and clamps the upper bound of any
-/// remaining range that extends past `max_height`. Used by [`rewind_to_chain_state`] to push the
-/// scan-queue rewind below the data-truncation floor without disturbing the wallet data
-/// preserved within the pruning window.
+/// remaining range that extends past `max_height`. Used by [`truncate_to_height_internal`] to
+/// remove scan-queue entries above the truncation height.
 pub(crate) fn trim_scan_queue_to(
     conn: &rusqlite::Transaction,
     max_height: BlockHeight,


### PR DESCRIPTION
The `rewind_to_height` function did not provide sufficient information to update wallet account birthday metadata, which has the potential to break a lot of invariants in the wallet that assume correct birthday height information. This PR repairs that problem, and additionally reuses the `rewind_to_chain_state` logic to effect rewinds that occur on account addition; previously, this used a strategy of resetting the scan queue without altering note commitment tree data, but this introduced a potential failure due to possible block and note commitment tree conflicts under reorg scenarios. Using `rewind_to_chain_state` consistently avoids this potential issue. 