### PR TITLE
Fix shielding failure with >=150 P2PKH UTXOs

### DIFF
--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -333,6 +333,97 @@ where
     );
 }
 
+/// Regression test for [PRO-291]: shielding a transparent balance composed of many P2PKH
+/// UTXOs must not fail with `ChangeRequired` due to fee disagreement between the proposal
+/// and builder layers.
+///
+/// At 150 P2PKH inputs the proposal-time fee computation (which uses
+/// `STANDARD_P2PKH = 150` bytes per input) starts to diverge from the builder-time
+/// fee computation (which historically used the actual serialized size, 149 bytes per
+/// input) due to the `ceildiv(t_in_total_size, 150)` term in the ZIP 317 fee formula.
+/// The discrepancy grows by one logical action (5000 zats) for every additional 150
+/// inputs.
+///
+/// [PRO-291]: https://linear.app/zodl/issue/PRO-291
+pub fn shielding_many_transparent_utxos<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    // Choose enough UTXOs to cross the first ceildiv(_, 150) boundary.
+    const NUM_UTXOS: usize = 160;
+    // Per-UTXO value comfortably above the marginal fee so none are treated as dust.
+    const PER_UTXO: u64 = 100_000;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account.id(), UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    // Initialize the wallet with chain data that has no shielded notes for us.
+    let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+    let not_our_value = Zatoshis::const_from_u64(10_000);
+    let (start_height, _, _) =
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    for _ in 1..10 {
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    }
+    st.scan_cached_blocks(start_height, 10);
+
+    // Add many distinct P2PKH UTXOs to the wallet, all at the same transparent address.
+    let value = Zatoshis::const_from_u64(PER_UTXO);
+    let txout = TxOut::new(value, taddr.script().into());
+    let height = st.wallet().chain_height().unwrap().unwrap();
+    for i in 0..NUM_UTXOS {
+        let mut hash = [0u8; 32];
+        hash[..4].copy_from_slice(&(i as u32).to_le_bytes());
+        let outpoint = OutPoint::new(hash, 0);
+        let utxo =
+            WalletTransparentOutput::from_parts(outpoint, txout.clone(), Some(height)).unwrap();
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .unwrap();
+    }
+
+    // Shield the transparent balance.
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedProtocol::Sapling,
+        DustOutputPolicy::default(),
+    );
+    let txids = st
+        .shield_transparent_funds(
+            &input_selector,
+            &change_strategy,
+            value,
+            account.usk(),
+            &[*taddr],
+            account.id(),
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("shielding many P2PKH UTXOs should succeed");
+    assert_eq!(txids.len(), 1);
+
+    // After shielding, the transparent balance should be zero.
+    check_balance::<DSF>(
+        &st,
+        &account,
+        taddr,
+        ConfirmationsPolicy::MIN,
+        &Balance::ZERO,
+    );
+}
+
 /// This test attempts to verify that transparent funds spendability is
 /// accounted for properly given the different minimum confirmations values
 /// that can be set when querying for balances.

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2330,6 +2330,14 @@ mod tests {
     }
 
     #[test]
+    fn shielding_many_transparent_utxos() {
+        zcash_client_backend::data_api::testing::transparent::shielding_many_transparent_utxos(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
     fn transparent_balance_spendability() {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_spendability(
             TestDbFactory::default(),

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,6 +8,17 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [Unreleased]
+
+### Fixed
+- `zcash_primitives::transaction::fees::transparent::InputView::serialized_size`:
+  the implementation for `TransparentInputInfo` now reports the ZIP 317 standard
+  size (`STANDARD_P2PKH` = 150 bytes) for P2PKH inputs, matching what
+  proposal-time fee computation already uses. Previously it reported the exact
+  serialized size (149 bytes), causing builds of transactions with `>= 150`
+  P2PKH inputs to fail with `Error::ChangeRequired` due to fee disagreement
+  across `ceildiv(t_in_total_size, 150)` boundaries.
+
 ## [0.27.0] - 2026-04-23
 
 ### Added

--- a/zcash_primitives/src/transaction/fees/transparent.rs
+++ b/zcash_primitives/src/transaction/fees/transparent.rs
@@ -12,7 +12,7 @@ use zcash_protocol::value::Zatoshis;
 use zcash_script::{script, solver};
 
 #[cfg(feature = "transparent-inputs")]
-use transparent::builder::TransparentInputInfo;
+use transparent::builder::{SpendInfo, TransparentInputInfo};
 
 /// The size of a transparent input, or the outpoint corresponding to the input
 /// if the size of the script required to spend that input is unknown.
@@ -65,10 +65,18 @@ impl InputView for TransparentInputInfo {
     }
 
     fn serialized_size(&self) -> InputSize {
-        self.serialized_len().map_or(
-            InputSize::Unknown(self.outpoint().clone()),
-            InputSize::Known,
-        )
+        // For P2PKH inputs, return the ZIP 317 standard size (150 bytes) rather than the
+        // exact serialized size (which is one byte smaller). The proposal layer accounts
+        // for fees using the standard size; the builder must agree, otherwise a
+        // shielding transaction with enough P2PKH inputs to cross a
+        // `ceildiv(t_in_total_size, 150)` boundary will fail with `ChangeRequired`.
+        match self.spend_info() {
+            SpendInfo::P2pkh { .. } => InputSize::STANDARD_P2PKH,
+            SpendInfo::P2sh { .. } => self.serialized_len().map_or(
+                InputSize::Unknown(self.outpoint().clone()),
+                InputSize::Known,
+            ),
+        }
     }
 }
 

--- a/zcash_transparent/src/builder.rs
+++ b/zcash_transparent/src/builder.rs
@@ -888,7 +888,7 @@ impl TransparentSignatureContext<'_, secp256k1::VerifyOnly> {
     }
 }
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(all(test, feature = "std", feature = "transparent-inputs"))]
 mod tests {
     use std::vec::Vec;
 


### PR DESCRIPTION
## Summary

Fixes #2346.

The proposal layer computes ZIP 317 fees using `STANDARD_P2PKH = 150` bytes per P2PKH input (via `WalletTransparentOutput::serialized_size`), but the builder was computing them using `TransparentInputInfo::serialized_len() = 149` bytes per P2PKH input. The two computations diverge by one logical action at every multiple of 150 inputs because `ceildiv(t_in_total_size, 150)` differs for `150*N` vs `149*N`. The proposal earmarks fee for one extra logical action that the builder does not include in its own fee computation, so the builder rejects the transaction with `Error::ChangeRequired(5000)`.

The user reports cited in the linked issue had ~216 transparent UTXOs from regular mining payouts, reproducing the 5000-zatoshi gap exactly.

### Commits

1. **`test: gate zcash_transparent builder tests on transparent-inputs`** — prerequisite: the `tests` module references `secp256k1`, `add_p2pkh_input`, and `prepare_transparent_signatures`, all gated behind `transparent-inputs`. Without the feature, `cargo test -p zcash_transparent` failed to build on `main`.
2. **`test: add regression test for shielding many P2PKH UTXOs`** — adds `shielding_many_transparent_utxos` (160 UTXOs) which fails on the parent commit with the exact error users report.
3. **`fix: align TransparentInputInfo P2PKH size with ZIP 317 standard`** — `TransparentInputInfo::serialized_size()` now returns `STANDARD_P2PKH` for P2PKH (matching the proposal layer and ZIP 317). P2SH continues to use `serialized_len()`.

## Test plan
- [x] `cargo test -p zcash_client_sqlite --features=transparent-inputs shielding_many_transparent_utxos` (new regression test passes after fix; fails before)
- [x] `cargo test -p zcash_client_sqlite --features=transparent-inputs shield` (existing shielding tests still pass)
- [x] `cargo test -p zcash_client_backend --features=transparent-inputs --lib` (all green)
- [x] `cargo test -p zcash_transparent` and `cargo test -p zcash_transparent --features=transparent-inputs` (both green; previously the default-feature run wouldn't build)
- [x] Verified each commit individually builds and the regression test transitions from failing → passing at the fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)