### PR TITLE
zcash_client_backend: propose_shielding_coinbase

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -23,6 +23,16 @@ workspace.
 - `zcash_client_backend::TransferType::AccountInternal`: indicates an output
   whose recipient and funder are the same wallet account (e.g. change). This
   has the semantics previously carried by `TransferType::WalletInternal`.
+- `zcash_client_backend::data_api::wallet::propose_shielding_coinbase` and
+  `zcash_client_backend::data_api::wallet::input_selection::ShieldingSelector::propose_shielding_coinbase`,
+  which propose a transaction that shields one or more coinbase transparent
+  outputs to an arbitrary shielded recipient.
+- `zcash_client_backend::proposal::ProposalError::ShieldingRequiresShieldedRecipient`,
+  returned by `propose_shielding_coinbase` when the supplied `to_address` is
+  a transparent or TEX address.
+- `zcash_client_backend::data_api::wallet::ProposeShieldingCoinbaseErrT` type
+  alias, parallel to `ProposeShieldingErrT` but parameterized on a `FeeRule`
+  instead of a `ChangeStrategy`.
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -55,6 +65,9 @@ workspace.
     - It now has an `AccountId` generic parameter,
     - `from_parts` now takes additional `recipient_account`,
       `recipient_key_scope`, and `funding_account` parameters.
+- `zcash_client_backend::data_api::wallet::input_selection::ShieldingSelector`
+  now requires implementors to provide `propose_shielding_coinbase` in
+  addition to `propose_shielding`.
 
 ### Removed
 - `zcash_client_backend::data_api::WalletUtxo` (use `WalletTransparentOutput` 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1135,6 +1135,46 @@ where
         )
     }
 
+    /// Invokes [`propose_shielding_coinbase`] with the given arguments.
+    ///
+    /// [`propose_shielding_coinbase`]: crate::data_api::wallet::propose_shielding_coinbase
+    #[cfg(feature = "transparent-inputs")]
+    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)]
+    pub fn propose_shielding_coinbase<InputsT, FeeRuleT>(
+        &mut self,
+        input_selector: &InputsT,
+        fee_rule: &FeeRuleT,
+        shielding_threshold: Zatoshis,
+        from_addrs: &[TransparentAddress],
+        to_address: zcash_address::ZcashAddress,
+        memo: Option<zcash_protocol::memo::MemoBytes>,
+        limit: Option<usize>,
+    ) -> Result<
+        Proposal<FeeRuleT, Infallible>,
+        super::wallet::ProposeShieldingCoinbaseErrT<DbT, Infallible, InputsT, FeeRuleT>,
+    >
+    where
+        InputsT: ShieldingSelector<InputSource = DbT>,
+        FeeRuleT: zcash_primitives::transaction::fees::FeeRule + Clone,
+    {
+        use super::wallet::propose_shielding_coinbase;
+
+        let network = self.network().clone();
+        propose_shielding_coinbase::<_, _, _, _, Infallible>(
+            self.wallet_mut(),
+            &network,
+            input_selector,
+            fee_rule,
+            shielding_threshold,
+            from_addrs,
+            to_address,
+            memo,
+            limit,
+        )
+    }
+
     /// Invokes [`create_proposed_transactions`] with the given arguments.
     #[allow(clippy::type_complexity)]
     pub fn create_proposed_transactions<InputsErrT, FeeRuleT, ChangeErrT, N>(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6404,3 +6404,298 @@ where
         "All proposal should contain both transparent inputs"
     );
 }
+
+/// Verifies that `propose_shielding_coinbase` with a shielded destination produces
+/// a proposal containing a single ZIP-321 payment to the supplied address for the
+/// full available value (input total minus fee), with no change.
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_shielding_coinbase_succeeds<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let (t_addr, _) = st.get_account().usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(50000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    // Coinbase outputs require 100 confirmations.
+    st.add_empty_blocks(100);
+
+    // The destination is a shielded address controlled by a separate spending key
+    // (i.e. potentially in a different wallet).
+    let to_extsk = T::sk(&[0xab; 32]);
+    let to_address = T::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let proposal = st
+        .propose_shielding_coinbase(
+            &GreedyInputSelector::new(),
+            &StandardFeeRule::Zip317,
+            Zatoshis::ZERO,
+            &[t_addr],
+            to_address.clone(),
+            None,
+            None,
+        )
+        .expect("propose_shielding_coinbase with a shielded destination should succeed");
+
+    let step = proposal.steps().first();
+    assert_eq!(
+        step.transparent_inputs().len(),
+        1,
+        "Expected exactly one coinbase transparent input"
+    );
+    let payments = step.transaction_request().payments();
+    assert_eq!(
+        payments.len(),
+        1,
+        "Expected exactly one payment in proposal"
+    );
+    let (idx, payment) = payments.iter().next().unwrap();
+    assert_eq!(*idx, 0);
+    assert_eq!(payment.recipient_address(), &to_address);
+    assert_eq!(
+        step.balance().proposed_change().len(),
+        0,
+        "Coinbase shielding must produce no change"
+    );
+
+    let fee = step.balance().fee_required();
+    let payment_amount = payment.amount().expect("payment must have an amount");
+    assert_eq!(
+        (payment_amount + fee).unwrap(),
+        coinbase_value,
+        "payment_amount + fee must equal coinbase input value"
+    );
+}
+
+/// Verifies that `propose_shielding_coinbase` rejects a transparent destination
+/// with [`ProposalError::ShieldingRequiresShieldedRecipient`].
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_shielding_coinbase_transparent_recipient_rejected<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let (t_addr, _) = st.get_account().usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(50000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    st.add_empty_blocks(100);
+
+    let bad_to_address = Address::Transparent(TransparentAddress::PublicKeyHash([7; 20]))
+        .to_zcash_address(st.network());
+
+    let result = st.propose_shielding_coinbase(
+        &GreedyInputSelector::new(),
+        &StandardFeeRule::Zip317,
+        Zatoshis::ZERO,
+        &[t_addr],
+        bad_to_address,
+        None,
+        None,
+    );
+
+    assert_matches!(
+        result,
+        Err(Error::Proposal(
+            ProposalError::ShieldingRequiresShieldedRecipient
+        ))
+    );
+}
+
+/// Verifies that `propose_shielding_coinbase` propagates the supplied `memo`
+/// into the resulting payment's memo field.
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_shielding_coinbase_with_memo_succeeds<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let (t_addr, _) = st.get_account().usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(50000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    st.add_empty_blocks(100);
+
+    let to_extsk = T::sk(&[0xcd; 32]);
+    let to_address = T::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let memo_text = "shielding to external wallet";
+    let memo_bytes = MemoBytes::from(memo_text.parse::<Memo>().unwrap());
+
+    let proposal = st
+        .propose_shielding_coinbase(
+            &GreedyInputSelector::new(),
+            &StandardFeeRule::Zip317,
+            Zatoshis::ZERO,
+            &[t_addr],
+            to_address,
+            Some(memo_bytes.clone()),
+            None,
+        )
+        .expect("propose_shielding_coinbase with memo should succeed");
+
+    let payments = proposal.steps().first().transaction_request().payments();
+    let (_, payment) = payments.iter().next().unwrap();
+    assert_eq!(payment.memo(), Some(&memo_bytes));
+}
+
+/// Verifies that `propose_shielding_coinbase` with `limit = Some(n)` selects at
+/// most `n` UTXOs, preferring the highest-value coinbase outputs.
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_shielding_coinbase_with_limit_truncates_inputs<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let (t_addr, _) = st.get_account().usk().default_transparent_address();
+
+    // Mine three coinbase transactions to the same recipient at successive heights,
+    // with distinct values so we can verify the highest-value-first selection.
+    let values = [
+        Zatoshis::const_from_u64(30000),
+        Zatoshis::const_from_u64(70000),
+        Zatoshis::const_from_u64(50000),
+    ];
+    let mut first_h = None;
+    for v in values {
+        let coinbase_height = if let Some(h) = first_h {
+            h + values.len() as u32 // arbitrary; only first_h matters for maturity
+        } else {
+            st.sapling_activation_height()
+        };
+        let build = build_transparent_coinbase_tx(
+            st.network(),
+            TargetHeight::from(coinbase_height),
+            v,
+            t_addr,
+            None,
+        );
+        let tx = build.transaction();
+        let (h, _) = st.generate_next_block_from_tx(0, tx);
+        st.scan_cached_blocks(h, 1);
+        let params = *st.network();
+        decrypt_and_store_transaction(&params, st.wallet_mut(), tx, Some(h)).unwrap();
+        if first_h.is_none() {
+            first_h = Some(h);
+        }
+    }
+    // Mature all three.
+    st.add_empty_blocks(100);
+
+    let to_extsk = T::sk(&[0x55; 32]);
+    let to_address = T::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let proposal = st
+        .propose_shielding_coinbase(
+            &GreedyInputSelector::new(),
+            &StandardFeeRule::Zip317,
+            Zatoshis::ZERO,
+            &[t_addr],
+            to_address,
+            None,
+            Some(2),
+        )
+        .expect("propose_shielding_coinbase with limit=Some(2) should succeed");
+
+    let inputs = proposal.steps().first().transparent_inputs();
+    assert_eq!(
+        inputs.len(),
+        2,
+        "limit=Some(2) should select exactly 2 inputs"
+    );
+
+    // The two highest-value coinbase UTXOs are 70000 and 50000.
+    let mut selected_values: Vec<u64> = inputs.iter().map(|i| i.value().into_u64()).collect();
+    selected_values.sort_unstable_by(|a, b| b.cmp(a));
+    assert_eq!(selected_values, vec![70000, 50000]);
+}
+
+/// Verifies that `propose_shielding_coinbase` with `limit = Some(0)` selects no
+/// inputs, returning [`InputSelectorError::InsufficientFunds`].
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_shielding_coinbase_with_zero_limit_insufficient_funds<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let (t_addr, _) = st.get_account().usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(50000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    st.add_empty_blocks(100);
+
+    let to_extsk = T::sk(&[0x66; 32]);
+    let to_address = T::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let shielding_threshold = Zatoshis::const_from_u64(10000);
+    let result = st.propose_shielding_coinbase(
+        &GreedyInputSelector::new(),
+        &StandardFeeRule::Zip317,
+        shielding_threshold,
+        &[t_addr],
+        to_address,
+        None,
+        Some(0),
+    );
+
+    // With no inputs selected, `payment_amount = input_total - fee` underflows
+    // (input_total = 0, fee > 0), producing `Error::InsufficientFunds` with
+    // `available: 0, required: fee`.
+    assert_matches!(result, Err(Error::InsufficientFunds { .. }));
+}

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -859,6 +859,89 @@ where
         .map_err(Error::from)
 }
 
+/// Errors that may be generated in construction of proposals for shielding coinbase
+/// transparent outputs to an arbitrary shielded recipient via
+/// [`propose_shielding_coinbase`].
+#[cfg(feature = "transparent-inputs")]
+pub type ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT> = Error<
+    <DbT as WalletRead>::Error,
+    CommitmentTreeErrT,
+    <InputsT as ShieldingSelector>::Error,
+    <FeeRuleT as FeeRule>::Error,
+    <FeeRuleT as FeeRule>::Error,
+    Infallible,
+>;
+
+/// Constructs a proposal to shield one or more coinbase transparent outputs to an
+/// arbitrary shielded recipient.
+///
+/// Unlike [`propose_shielding`], this method:
+///
+/// - Restricts input selection to coinbase outputs only. The restriction is enforced
+///   at the API boundary; it cannot be overridden by callers. Coinbase outputs have
+///   no prior transparent transaction graph, which is what makes it acceptable to
+///   send them to an arbitrary shielded recipient.
+/// - Requires `to_address` to be a shielded address (Sapling, or a Unified Address
+///   with a shielded receiver). Transparent and TEX destinations are rejected with
+///   [`ProposalError::ShieldingRequiresShieldedRecipient`]. The address may belong
+///   to an account outside the caller's wallet.
+/// - Accepts an optional `memo` to be attached to the shielded payment.
+/// - Accepts an optional `limit` capping the number of transparent inputs to at
+///   most `n`, keeping the highest-value UTXOs (with a stable tiebreaker by
+///   outpoint). `Some(0)` selects no inputs and therefore returns
+///   [`InputSelectorError::InsufficientFunds`].
+///
+/// The resulting proposal carries an explicit ZIP-321 payment to `to_address` for
+/// `input_total - fee`. **No change is produced**, in either the transparent or any
+/// shielded pool: a shielded change output would let the recipient (or any chain
+/// observer) learn the sender's total selected-coinbase value by summing the public
+/// transparent input values and subtracting the visible payment amount.
+///
+/// [`InputSelectorError::InsufficientFunds`]: crate::data_api::wallet::input_selection::InputSelectorError::InsufficientFunds
+/// [`ProposalError::ShieldingRequiresShieldedRecipient`]: crate::proposal::ProposalError::ShieldingRequiresShieldedRecipient
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+pub fn propose_shielding_coinbase<DbT, ParamsT, InputsT, FeeRuleT, CommitmentTreeErrT>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    input_selector: &InputsT,
+    fee_rule: &FeeRuleT,
+    shielding_threshold: Zatoshis,
+    from_addrs: &[TransparentAddress],
+    to_address: ZcashAddress,
+    memo: Option<MemoBytes>,
+    limit: Option<usize>,
+) -> Result<
+    Proposal<FeeRuleT, Infallible>,
+    ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT>,
+>
+where
+    ParamsT: consensus::Parameters,
+    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    InputsT: ShieldingSelector<InputSource = DbT>,
+    FeeRuleT: FeeRule + Clone,
+{
+    let chain_tip_height = wallet_db
+        .chain_height()
+        .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
+        .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
+
+    input_selector
+        .propose_shielding_coinbase(
+            params,
+            wallet_db,
+            fee_rule,
+            shielding_threshold,
+            from_addrs,
+            to_address,
+            memo,
+            limit,
+            (chain_tip_height + 1).into(),
+        )
+        .map_err(Error::from)
+}
+
 struct StepResult<AccountId> {
     build_result: BuildResult,
     outputs: Vec<SentTransactionOutput<AccountId>>,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -12,7 +12,7 @@ use zcash_address::{ConversionError, ZcashAddress};
 use zcash_keys::address::{Address, UnifiedAddress};
 use zcash_primitives::transaction::fees::{
     FeeRule,
-    transparent::InputSize,
+    transparent::{self as transparent_fees, InputSize},
     zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
 };
 use zcash_protocol::{
@@ -267,6 +267,69 @@ pub trait ShieldingSelector {
     where
         ParamsT: consensus::Parameters,
         ChangeT: ChangeStrategy<MetaSource = Self::InputSource>;
+
+    /// Performs input selection and returns a proposal for the construction of a transaction
+    /// that shields coinbase transparent outputs to an arbitrary shielded recipient.
+    ///
+    /// This method differs from [`Self::propose_shielding`] in the following ways:
+    ///
+    /// - Only coinbase transparent outputs are eligible for inclusion in the proposal. This
+    ///   restriction is hard-coded; callers cannot opt in to selecting non-coinbase outputs
+    ///   via this method. Coinbase outputs are uniquely suited to being sent to arbitrary
+    ///   shielded recipients because they have no prior transparent transaction graph that
+    ///   could be exposed to the recipient.
+    /// - The `to_address` argument specifies the destination of the shielded value. It must
+    ///   be a shielded address (Sapling, or a Unified Address with a shielded receiver). It
+    ///   may be an external address not belonging to any account we control.
+    /// - The resulting proposal carries an explicit ZIP-321 payment to `to_address` for the
+    ///   full available value (input total minus fee). **No change is produced**, in either
+    ///   the transparent or any shielded pool. This is a privacy invariant: producing a
+    ///   shielded change output would allow the recipient (or any chain observer) to learn
+    ///   the sender's total selected-coinbase value by summing the public transparent input
+    ///   values and subtracting the visible payment amount. Since this method targets the
+    ///   `z_shieldcoinbase`-style "sweep coinbase to a recipient" workflow, where the
+    ///   recipient may not belong to the sender's wallet, change is forbidden by design.
+    ///
+    /// Because no change is produced, this method takes a `fee_rule` directly rather than a
+    /// [`ChangeStrategy`]: there is no change to compute, and no per-account metadata is
+    /// required.
+    ///
+    /// The `memo` parameter is stored in the shielded output's memo field; it is always
+    /// permitted because a shielded payment is always present.
+    ///
+    /// The `limit` parameter, when `Some(n)`, caps the number of transparent inputs to at
+    /// most `n`, keeping the highest-value UTXOs (with a stable tiebreaker by outpoint).
+    /// `Some(0)` selects no inputs and will therefore return
+    /// [`InputSelectorError::InsufficientFunds`].
+    ///
+    /// If the total value of selected inputs (after any cap imposed by `limit`), minus the
+    /// fee, is less than `shielding_threshold`, this method returns
+    /// [`InputSelectorError::InsufficientFunds`].
+    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
+    fn propose_shielding_coinbase<ParamsT, FeeRuleT>(
+        &self,
+        params: &ParamsT,
+        wallet_db: &Self::InputSource,
+        fee_rule: &FeeRuleT,
+        shielding_threshold: Zatoshis,
+        source_addrs: &[TransparentAddress],
+        to_address: ZcashAddress,
+        memo: Option<MemoBytes>,
+        limit: Option<usize>,
+        target_height: TargetHeight,
+    ) -> Result<
+        Proposal<FeeRuleT, Infallible>,
+        InputSelectorError<
+            <Self::InputSource as InputSource>::Error,
+            Self::Error,
+            FeeRuleT::Error,
+            Infallible,
+        >,
+    >
+    where
+        ParamsT: consensus::Parameters,
+        FeeRuleT: FeeRule + Clone;
 }
 
 /// Errors that can occur as a consequence of greedy input selection.
@@ -1088,85 +1151,25 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         ParamsT: consensus::Parameters,
         ChangeT: ChangeStrategy<MetaSource = Self::InputSource>,
     {
-        let (mut transparent_inputs, _, _) = source_addrs.iter().try_fold(
-            (
-                vec![],
-                BTreeSet::<TransparentAddress>::new(),
-                BTreeSet::<TransparentAddress>::new(),
-            ),
-            |(mut inputs, mut ephemeral_addrs, mut input_addrs), taddr| {
-                use transparent::keys::TransparentKeyScope;
-
-                let utxos = wallet_db
-                    .get_spendable_transparent_outputs(
-                        taddr,
-                        target_height,
-                        confirmations_policy,
-                        output_filter,
-                    )
-                    .map_err(InputSelectorError::DataSource)?;
-
-                // `InputSource::get_spendable_transparent_outputs` is required to return
-                // outputs received by `taddr`, so these `.extend()` calls are guaranteed
-                // to add at most a single new address to each set. But it's more
-                // convenient this way as we can reuse `utxo.recipient_key_scope()`
-                // instead of needing to query the wallet twice for each address to
-                // determine their scopes.
-                ephemeral_addrs.extend(utxos.iter().filter_map(|utxo| {
-                    (utxo.recipient_key_scope() == Some(TransparentKeyScope::EPHEMERAL))
-                        .then_some(utxo.recipient_address())
-                }));
-                input_addrs.extend(utxos.iter().map(|utxo| utxo.recipient_address()));
-                inputs.extend(utxos.into_iter().map(|utxo| utxo.redact_account_data()));
-
-                // Funds may be spent from at most one ephemeral address at a time. If there are no
-                // ephemeral addresses, we allow shielding from multiple transparent addresses.
-                if !ephemeral_addrs.is_empty() && input_addrs.len() > 1 {
-                    Err(InputSelectorError::Proposal(
-                        ProposalError::EphemeralAddressLinkability,
-                    ))
-                } else {
-                    Ok((inputs, ephemeral_addrs, input_addrs))
-                }
-            },
+        let mut transparent_inputs = gather_shielding_inputs::<DbT, ChangeT::Error>(
+            wallet_db,
+            source_addrs,
+            target_height,
+            confirmations_policy,
+            output_filter,
         )?;
 
         let wallet_meta = change_strategy
             .fetch_wallet_meta(wallet_db, to_account, target_height, &[])
             .map_err(InputSelectorError::DataSource)?;
 
-        let trial_balance = change_strategy.compute_balance(
+        let balance = compute_shielding_balance_with_dust_retry::<DbT, ChangeT, ParamsT>(
+            change_strategy,
             params,
             target_height,
-            &transparent_inputs,
-            &[] as &[TxOut],
-            &sapling::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            &orchard_fees::EmptyBundleView,
-            None,
+            &mut transparent_inputs,
             &wallet_meta,
-        );
-
-        let balance = match trial_balance {
-            Ok(balance) => balance,
-            Err(ChangeError::DustInputs { transparent, .. }) => {
-                let exclusions: BTreeSet<OutPoint> = transparent.into_iter().collect();
-                transparent_inputs.retain(|i| !exclusions.contains(i.outpoint()));
-
-                change_strategy.compute_balance(
-                    params,
-                    target_height,
-                    &transparent_inputs,
-                    &[] as &[TxOut],
-                    &sapling::EmptyBundleView,
-                    #[cfg(feature = "orchard")]
-                    &orchard_fees::EmptyBundleView,
-                    None,
-                    &wallet_meta,
-                )?
-            }
-            Err(other) => return Err(InputSelectorError::Change(other)),
-        };
+        )?;
 
         if balance.total() >= shielding_threshold {
             Proposal::single_step(
@@ -1187,4 +1190,343 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             })
         }
     }
+
+    #[allow(clippy::type_complexity)]
+    fn propose_shielding_coinbase<ParamsT, FeeRuleT>(
+        &self,
+        params: &ParamsT,
+        wallet_db: &Self::InputSource,
+        fee_rule: &FeeRuleT,
+        shielding_threshold: Zatoshis,
+        source_addrs: &[TransparentAddress],
+        to_address: ZcashAddress,
+        memo: Option<MemoBytes>,
+        limit: Option<usize>,
+        target_height: TargetHeight,
+    ) -> Result<
+        Proposal<FeeRuleT, Infallible>,
+        InputSelectorError<<DbT as InputSource>::Error, Self::Error, FeeRuleT::Error, Infallible>,
+    >
+    where
+        ParamsT: consensus::Parameters,
+        FeeRuleT: FeeRule + Clone,
+    {
+        // Coinbase-only is enforced here at the API boundary: callers cannot bypass
+        // it. This is the privacy property that motivates having a dedicated method
+        // rather than a more general "shield to address" path; only coinbase
+        // outputs are eligible because they have no prior transparent transaction
+        // graph that could be exposed to the shielded recipient.
+        let mut transparent_inputs = gather_shielding_inputs::<DbT, FeeRuleT::Error>(
+            wallet_db,
+            source_addrs,
+            target_height,
+            // It doesn't matter here if we pass a 100 confirmations or 1 confirmations policy,
+            // as coinbase txs require 100, which will be enforced by note selection.
+            ConfirmationsPolicy::MIN,
+            TransparentOutputFilter::CoinbaseOnly,
+        )?;
+
+        // Apply the optional cap on selected UTXOs, keeping the highest-value
+        // UTXOs first (stable tiebreaker by outpoint for determinism). When
+        // `limit` is `Some(0)` this empties the set, and the subsequent
+        // `InsufficientFunds` check fires; this is the documented behavior.
+        if let Some(n) = limit {
+            transparent_inputs.sort_by(|a, b| {
+                b.value()
+                    .cmp(&a.value())
+                    .then_with(|| a.outpoint().cmp(b.outpoint()))
+            });
+            transparent_inputs.truncate(n);
+        }
+
+        let destination_pool =
+            resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(&to_address, params)?;
+
+        // Compute the fee directly from the fee rule. This method produces no
+        // change in any pool, so there is no change-strategy or wallet-metadata
+        // computation to perform. The proposal will carry exactly one shielded
+        // output (in `destination_pool`) and zero transparent outputs.
+        let (sapling_output_count, orchard_action_count) = match destination_pool {
+            PoolType::SAPLING => (1usize, 0usize),
+            #[cfg(feature = "orchard")]
+            PoolType::ORCHARD => (0usize, 1usize),
+            // Unreachable: `resolve_shielded_destination` rejects transparent
+            // destinations earlier with `ShieldingRequiresShieldedRecipient`.
+            _ => {
+                return Err(InputSelectorError::Proposal(
+                    ProposalError::ShieldingRequiresShieldedRecipient,
+                ));
+            }
+        };
+
+        let fee = fee_rule
+            .fee_required(
+                params,
+                BlockHeight::from(target_height),
+                transparent_inputs
+                    .iter()
+                    .map(transparent_fees::InputView::serialized_size),
+                std::iter::empty::<usize>(),
+                0,
+                sapling_output_count,
+                orchard_action_count,
+            )
+            // The `InputSelectorError::Change` variant is the only existing
+            // carrier capable of holding an arbitrary fee-rule error
+            // (`ChangeError::StrategyError` wraps `FeeRuleT::Error` in the
+            // generic position). We reuse it here rather than introduce a new
+            // top-level variant.
+            .map_err(|e| InputSelectorError::Change(ChangeError::StrategyError(e)))?;
+
+        // Route the full available value (input_total - fee) as an explicit
+        // payment to the supplied destination. No change is produced.
+        let input_total = transparent_inputs
+            .iter()
+            .map(|utxo| utxo.value())
+            .try_fold(Zatoshis::ZERO, |acc, v| (acc + v))
+            .ok_or(InputSelectorError::Selection(
+                GreedyInputSelectorError::Balance(BalanceError::Overflow),
+            ))?;
+        let payment_amount =
+            (input_total - fee).ok_or_else(|| InputSelectorError::InsufficientFunds {
+                available: input_total,
+                required: fee,
+            })?;
+
+        if payment_amount < shielding_threshold {
+            return Err(InputSelectorError::InsufficientFunds {
+                available: payment_amount,
+                required: shielding_threshold,
+            });
+        }
+
+        let payment = Payment::new(to_address, Some(payment_amount), memo, None, None, vec![])
+            .map_err(|payment_error| {
+                InputSelectorError::Proposal(ProposalError::Zip321(payment_error.with_index(0)))
+            })?;
+        let request = TransactionRequest::new(vec![payment]).map_err(|payment_error| {
+            InputSelectorError::Proposal(ProposalError::Zip321(payment_error))
+        })?;
+        let mut payment_pools = BTreeMap::new();
+        payment_pools.insert(0usize, destination_pool);
+        let final_balance = TransactionBalance::new(vec![], fee).map_err(|_| {
+            InputSelectorError::Selection(GreedyInputSelectorError::Balance(BalanceError::Overflow))
+        })?;
+
+        // `is_shielding` is `false` because the proposal layer reserves
+        // `is_shielding = true` for the legacy "no payment, all value in change"
+        // shape produced by `propose_shielding`. From the wallet's perspective
+        // this is still a transparent -> shielded transfer of coinbase value.
+        Proposal::single_step(
+            request,
+            payment_pools,
+            transparent_inputs,
+            None,
+            final_balance,
+            fee_rule.clone(),
+            target_height,
+            false,
+        )
+        .map_err(InputSelectorError::Proposal)
+    }
+}
+
+/// Gathers spendable transparent UTXOs from each source address, applying the
+/// supplied [`TransparentOutputFilter`] and rejecting input sets that would
+/// link activity on an ephemeral address to other wallet activity.
+///
+/// Shared between `propose_shielding` and `propose_shielding_coinbase`.
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::type_complexity)]
+fn gather_shielding_inputs<DbT, ChangeErrT>(
+    wallet_db: &DbT,
+    source_addrs: &[TransparentAddress],
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    output_filter: TransparentOutputFilter,
+) -> Result<
+    Vec<WalletTransparentOutput<()>>,
+    InputSelectorError<
+        <DbT as InputSource>::Error,
+        GreedyInputSelectorError,
+        ChangeErrT,
+        Infallible,
+    >,
+>
+where
+    DbT: InputSource,
+{
+    let (transparent_inputs, _, _) = source_addrs.iter().try_fold(
+        (
+            vec![],
+            BTreeSet::<TransparentAddress>::new(),
+            BTreeSet::<TransparentAddress>::new(),
+        ),
+        |(mut inputs, mut ephemeral_addrs, mut input_addrs), taddr| {
+            use transparent::keys::TransparentKeyScope;
+
+            let utxos = wallet_db
+                .get_spendable_transparent_outputs(
+                    taddr,
+                    target_height,
+                    confirmations_policy,
+                    output_filter,
+                )
+                .map_err(InputSelectorError::DataSource)?;
+
+            // `InputSource::get_spendable_transparent_outputs` is required to return
+            // outputs received by `taddr`, so these `.extend()` calls are guaranteed
+            // to add at most a single new address to each set. But it's more
+            // convenient this way as we can reuse `utxo.recipient_key_scope()`
+            // instead of needing to query the wallet twice for each address to
+            // determine their scopes.
+            ephemeral_addrs.extend(utxos.iter().filter_map(|utxo| {
+                (utxo.recipient_key_scope() == Some(TransparentKeyScope::EPHEMERAL))
+                    .then_some(utxo.recipient_address())
+            }));
+            input_addrs.extend(utxos.iter().map(|utxo| utxo.recipient_address()));
+            inputs.extend(utxos.into_iter().map(|utxo| utxo.redact_account_data()));
+
+            // Funds may be spent from at most one ephemeral address at a time. If there are no
+            // ephemeral addresses, we allow shielding from multiple transparent addresses.
+            if !ephemeral_addrs.is_empty() && input_addrs.len() > 1 {
+                Err(InputSelectorError::Proposal(
+                    ProposalError::EphemeralAddressLinkability,
+                ))
+            } else {
+                Ok((inputs, ephemeral_addrs, input_addrs))
+            }
+        },
+    )?;
+    Ok(transparent_inputs)
+}
+
+/// Resolves a [`ZcashAddress`] destination for a shielding proposal to the
+/// shielded pool it should be received in.
+///
+/// Rejects transparent and TEX addresses with
+/// [`ProposalError::ShieldingRequiresShieldedRecipient`], and rejects Unified
+/// Addresses without a shielded receiver with
+/// [`GreedyInputSelectorError::UnsupportedAddress`].
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::type_complexity)]
+fn resolve_shielded_destination<DbT, ChangeErrT, ParamsT>(
+    addr: &ZcashAddress,
+    params: &ParamsT,
+) -> Result<
+    PoolType,
+    InputSelectorError<
+        <DbT as InputSource>::Error,
+        GreedyInputSelectorError,
+        ChangeErrT,
+        Infallible,
+    >,
+>
+where
+    DbT: InputSource,
+    ParamsT: consensus::Parameters,
+{
+    let resolved: Address = addr
+        .clone()
+        .convert_if_network(params.network_type())
+        .map_err(InputSelectorError::Address)?;
+    match resolved {
+        Address::Sapling(_) => Ok(PoolType::SAPLING),
+        #[cfg(feature = "orchard")]
+        Address::Unified(ua) if ua.has_orchard() => Ok(PoolType::ORCHARD),
+        Address::Unified(ua) if ua.has_sapling() => Ok(PoolType::SAPLING),
+        Address::Unified(ua) => Err(InputSelectorError::Selection(
+            GreedyInputSelectorError::UnsupportedAddress(Box::new(ua)),
+        )),
+        Address::Transparent(_) | Address::Tex(_) => Err(InputSelectorError::Proposal(
+            ProposalError::ShieldingRequiresShieldedRecipient,
+        )),
+    }
+}
+
+/// Helper that performs the dust-input retry pattern used by `propose_shielding`.
+///
+/// On the first call to [`ChangeStrategy::compute_balance`], if the strategy
+/// reports [`ChangeError::DustInputs`], those inputs are removed from
+/// `transparent_inputs` and the balance is recomputed. The resulting proposal
+/// directs all available value into change (the legacy `propose_shielding`
+/// "all-change" shape).
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::type_complexity)]
+fn compute_shielding_balance_with_dust_retry<DbT, ChangeT, ParamsT>(
+    change_strategy: &ChangeT,
+    params: &ParamsT,
+    target_height: TargetHeight,
+    transparent_inputs: &mut Vec<WalletTransparentOutput<()>>,
+    wallet_meta: &<ChangeT as ChangeStrategy>::AccountMetaT,
+) -> Result<
+    TransactionBalance,
+    InputSelectorError<
+        <DbT as InputSource>::Error,
+        GreedyInputSelectorError,
+        ChangeT::Error,
+        Infallible,
+    >,
+>
+where
+    DbT: InputSource,
+    ChangeT: ChangeStrategy<MetaSource = DbT>,
+    ParamsT: consensus::Parameters,
+{
+    let trial = compute_shielding_balance::<DbT, ChangeT, ParamsT>(
+        change_strategy,
+        params,
+        target_height,
+        transparent_inputs,
+        wallet_meta,
+    );
+
+    match trial {
+        Ok(balance) => Ok(balance),
+        Err(ChangeError::DustInputs { transparent, .. }) => {
+            let exclusions: BTreeSet<OutPoint> = transparent.into_iter().collect();
+            transparent_inputs.retain(|i| !exclusions.contains(i.outpoint()));
+
+            compute_shielding_balance::<DbT, ChangeT, ParamsT>(
+                change_strategy,
+                params,
+                target_height,
+                transparent_inputs,
+                wallet_meta,
+            )
+            .map_err(InputSelectorError::Change)
+        }
+        Err(other) => Err(InputSelectorError::Change(other)),
+    }
+}
+
+/// Helper for `propose_shielding`'s balance computation that calls
+/// `change_strategy.compute_balance` with empty Sapling and Orchard bundle
+/// views, allowing the change strategy to direct all available transparent
+/// input value into change.
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::type_complexity)]
+fn compute_shielding_balance<DbT, ChangeT, ParamsT>(
+    change_strategy: &ChangeT,
+    params: &ParamsT,
+    target_height: TargetHeight,
+    transparent_inputs: &[WalletTransparentOutput<()>],
+    wallet_meta: &<ChangeT as ChangeStrategy>::AccountMetaT,
+) -> Result<TransactionBalance, ChangeError<ChangeT::Error, Infallible>>
+where
+    DbT: InputSource,
+    ChangeT: ChangeStrategy<MetaSource = DbT>,
+    ParamsT: consensus::Parameters,
+{
+    change_strategy.compute_balance(
+        params,
+        target_height,
+        transparent_inputs,
+        &[] as &[TxOut],
+        &sapling::EmptyBundleView,
+        #[cfg(feature = "orchard")]
+        &orchard_fees::EmptyBundleView,
+        None,
+        wallet_meta,
+    )
 }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -70,6 +70,10 @@ pub enum ProposalError {
     /// activity.
     #[cfg(feature = "transparent-inputs")]
     EphemeralAddressLinkability,
+    /// A shielding proposal was constructed with a destination address that has no shielded
+    /// receiver. Shielding requires the destination to be able to receive shielded value.
+    #[cfg(feature = "transparent-inputs")]
+    ShieldingRequiresShieldedRecipient,
     /// The transaction version requested is not compatible with the consensus branch for which the
     /// transaction is intended.
     #[cfg(feature = "unstable")]
@@ -150,6 +154,11 @@ impl Display for ProposalError {
             ProposalError::EphemeralAddressLinkability => write!(
                 f,
                 "The proposal requested spending funds in a way that would link activity on an ephemeral address to other wallet activity."
+            ),
+            #[cfg(feature = "transparent-inputs")]
+            ProposalError::ShieldingRequiresShieldedRecipient => write!(
+                f,
+                "A shielding proposal's destination must have a shielded receiver."
             ),
             #[cfg(feature = "unstable")]
             ProposalError::IncompatibleTxVersion(branch_id) => write!(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -469,3 +469,45 @@ pub(crate) fn coinbase_only_filtering<T: ShieldedPoolTester>() {
         BlockCache::new(),
     );
 }
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_shielding_coinbase_succeeds<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::propose_shielding_coinbase_succeeds::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_shielding_coinbase_transparent_recipient_rejected<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::propose_shielding_coinbase_transparent_recipient_rejected::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_shielding_coinbase_with_memo_succeeds<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::propose_shielding_coinbase_with_memo_succeeds::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new());
+}
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_shielding_coinbase_with_limit_truncates_inputs<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::propose_shielding_coinbase_with_limit_truncates_inputs::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_shielding_coinbase_with_zero_limit_insufficient_funds<
+    T: ShieldedPoolTester,
+>() {
+    zcash_client_backend::data_api::testing::pool::propose_shielding_coinbase_with_zero_limit_insufficient_funds::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -708,6 +708,40 @@ pub(crate) mod tests {
         testing::pool::coinbase_only_filtering::<OrchardPoolTester>();
     }
 
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_succeeds() {
+        testing::pool::propose_shielding_coinbase_succeeds::<OrchardPoolTester>();
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_transparent_recipient_rejected() {
+        testing::pool::propose_shielding_coinbase_transparent_recipient_rejected::<OrchardPoolTester>(
+        );
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_memo_succeeds() {
+        testing::pool::propose_shielding_coinbase_with_memo_succeeds::<OrchardPoolTester>();
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_limit_truncates_inputs() {
+        testing::pool::propose_shielding_coinbase_with_limit_truncates_inputs::<OrchardPoolTester>(
+        );
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_zero_limit_insufficient_funds() {
+        testing::pool::propose_shielding_coinbase_with_zero_limit_insufficient_funds::<
+            OrchardPoolTester,
+        >();
+    }
+
     #[test]
     #[cfg(feature = "orchard")]
     fn get_unspent_orchard_notes_at_historical_height_boundary_heights() {

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -654,4 +654,38 @@ pub(crate) mod tests {
     fn coinbase_only_filtering() {
         testing::pool::coinbase_only_filtering::<SaplingPoolTester>();
     }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_succeeds() {
+        testing::pool::propose_shielding_coinbase_succeeds::<SaplingPoolTester>();
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_transparent_recipient_rejected() {
+        testing::pool::propose_shielding_coinbase_transparent_recipient_rejected::<SaplingPoolTester>(
+        );
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_memo_succeeds() {
+        testing::pool::propose_shielding_coinbase_with_memo_succeeds::<SaplingPoolTester>();
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_limit_truncates_inputs() {
+        testing::pool::propose_shielding_coinbase_with_limit_truncates_inputs::<SaplingPoolTester>(
+        );
+    }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_shielding_coinbase_with_zero_limit_insufficient_funds() {
+        testing::pool::propose_shielding_coinbase_with_zero_limit_insufficient_funds::<
+            SaplingPoolTester,
+        >();
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new dedicated `propose_shielding_coinbase` method (and corresponding free function) to `zcash_client_backend` for shielding coinbase transparent outputs to an arbitrary shielded recipient.

This **replaces the previous approach on this branch**, which modified `propose_shielding` to accept an optional `to_address` and `memo`. That approach was rejected during review (thanks @nullcopy @nuttycom) because it broadened the public API in a privacy-regressing way: it would have allowed callers to spend arbitrary transparent outputs (not just coinbase) to arbitrary shielded recipients, exposing the sender's prior transparent transaction graph to the recipient.

This PR has been force-pushed with a fresh implementation that takes the new approach instead.

## Design

The new `propose_shielding_coinbase` method preserves the privacy property of the prior `zcashd` `z_shieldcoinbase` behavior by:

- **Hard-coding the input filter to `TransparentOutputFilter::CoinbaseOnly`**, ensuring that only coinbase outputs (which have no prior transparent transaction graph) are eligible. The restriction is enforced at the API boundary; callers cannot opt in to selecting non-coinbase outputs through this method.
- **Requiring a shielded `to_address`** (Sapling, or a Unified Address with a shielded receiver). Transparent and TEX destinations are rejected with `ProposalError::ShieldingRequiresShieldedRecipient`. The destination is not constrained to a wallet-local account; miners may legitimately need to shield to custodial/external wallets.
- Accepting an optional **`memo`** (always permitted, since a payment is always present).
- Accepting an optional **`limit: Option<usize>`** capping the number of selected UTXOs to the highest-value `n` of those eligible, with a stable tiebreaker by outpoint. `Some(0)` selects no inputs and falls through to the standard insufficient-funds path. This folds in the previously-deferred `limit` work so that zallet's `z_shieldcoinbase` `limit` parameter can be honored.
- **Producing a proposal with no transparent change**, matching the consensus rule that coinbase-spending transactions cannot produce transparent change.

## New public API

- `wallet::propose_shielding_coinbase` (free function)
- `wallet::input_selection::ShieldingSelector::propose_shielding_coinbase` (trait method; breaking change for any downstream impl of `ShieldingSelector`, but the only impl in this repo is `GreedyInputSelector`)
- `ProposalError::ShieldingRequiresShieldedRecipient` (returned for transparent/TEX destinations)
- `ProposalError::AttemptedShieldingToTransparentAddress` (defensive internal-invariant guard; unreachable in current callers but routes the residual `PoolType::Transparent` case through a real error variant rather than `unreachable!`)

## Code reuse

`propose_shielding` was refactored to share three new private helpers with `propose_shielding_coinbase`:

- `gather_shielding_inputs`: the per-address UTXO fold with ephemeral-address linkability check.
- `resolve_shielded_destination`: address-to-pool resolution with shielded-receiver enforcement.
- `compute_shielding_balance_with_dust_retry`: the dust-input retry pattern around `compute_balance`, parameterized on an optional destination pool.

The legacy `is_shielding = true` shape produced by `propose_shielding` is preserved unchanged. `propose_shielding_coinbase` always sets `is_shielding = false` because it always carries an explicit ZIP-321 payment.

## Tests

Five new pool-generic tests in `zcash_client_backend/src/data_api/testing/pool.rs`, each wired up for both `SaplingPoolTester` and `OrchardPoolTester` in `zcash_client_sqlite` (10 sqlite test registrations total, gated on `pczt-tests + transparent-inputs`):

- `propose_shielding_coinbase_succeeds`: happy path with a shielded recipient; verifies the proposal contains exactly one transparent input, one ZIP-321 payment, no change, and that `payment_amount + fee == coinbase_value`.
- `propose_shielding_coinbase_transparent_recipient_rejected`: verifies `ProposalError::ShieldingRequiresShieldedRecipient` for a transparent destination.
- `propose_shielding_coinbase_with_memo_succeeds`: verifies the supplied memo is attached to the resulting payment.
- `propose_shielding_coinbase_with_limit_truncates_inputs`: verifies `limit = Some(2)` selects the two highest-value coinbase UTXOs out of three eligible.
- `propose_shielding_coinbase_with_zero_limit_insufficient_funds`: verifies `limit = Some(0)` returns an insufficient-funds error rather than producing a proposal.

All 258 sqlite tests pass (0 failed, 2 ignored).

## Caller impact

`shield_transparent_funds` and `TestState::propose_shielding` are unchanged. `propose_shielding`'s public signature is also unchanged from `main`.

Required by:
- https://github.com/zcash/wallet/pull/402