### PR TITLE
zcash_transparent: P2PKH finalize_spends returns Err(InvalidSignature) on oversize signature

### DIFF
--- a/zcash_transparent/src/pczt/parse.rs
+++ b/zcash_transparent/src/pczt/parse.rs
@@ -13,7 +13,7 @@ use super::{Bip32Derivation, Bundle, Input, Output};
 /// Maximum size of a script push-value (`LargeValue::MAX_SIZE`, 520 bytes).
 /// `partial_signatures` entries are pushed as single script elements during
 /// spend finalization, so they cannot exceed this.
-const MAX_SCRIPT_PUSH_VALUE_LEN: usize = 520;
+pub(super) const MAX_SCRIPT_PUSH_VALUE_LEN: usize = 520;
 
 impl Bundle {
     /// Parses a PCZT bundle from its component parts.

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -33,8 +33,10 @@ impl super::Bundle {
                             } else {
                                 // P2PKH scriptSig
                                 input.script_sig = Some(script::Component(vec![
-                                    pv::push_value(sig_bytes).expect("short enough"),
-                                    pv::push_value(pubkey).expect("short enough"),
+                                    pv::push_value(sig_bytes)
+                                        .ok_or(SpendFinalizerError::InvalidSignature)?,
+                                    pv::push_value(pubkey)
+                                        .ok_or(SpendFinalizerError::InvalidSignature)?,
                                 ]));
                                 Ok(())
                             }
@@ -144,4 +146,88 @@ pub enum SpendFinalizerError {
     UnsupportedScriptPubkey,
     /// The `redeem_script` kind is unsupported.
     UnsupportedRedeemScript,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::SpendFinalizerError;
+    use crate::pczt::{Bundle, Input};
+
+    fn p2pkh_script_pubkey_bytes(pubkey_hash: [u8; 20]) -> Vec<u8> {
+        // OP_DUP OP_HASH160 OP_PUSH_20 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
+        let mut bytes = vec![0x76u8, 0xa9, 0x14];
+        bytes.extend_from_slice(&pubkey_hash);
+        bytes.push(0x88);
+        bytes.push(0xac);
+        bytes
+    }
+
+    /// Regression test: the P2PKH branch of `Bundle::finalize_spends` returns
+    /// `Err(InvalidSignature)` on an oversize `partial_signatures` entry,
+    /// because `pv::push_value(sig_bytes)` returns `None` for input larger than
+    /// `LargeValue::MAX_SIZE` (= 520 bytes) and the branch uses
+    /// `.ok_or(InvalidSignature)?` to surface the failure. The companion P2MS
+    /// branch in the same function handles the identical fallibility the same
+    /// way.
+    ///
+    /// Reachable from: serde wire (`pczt/src/transparent.rs`) →
+    /// `Input::parse` (no length check on `partial_signatures` entries) →
+    /// `SpendFinalizer::finalize_spends`.
+    #[test]
+    fn p2pkh_finalize_spends_rejects_oversize_signature() {
+        // Construct an arbitrary 33-byte value to use as the BTreeMap key. It
+        // need not be a valid secp256k1 point — the P2PKH branch only checks
+        // that hash160(pubkey) matches the script_pubkey hash, which we
+        // control on both sides.
+        let mut pubkey = [0u8; 33];
+        pubkey[0] = 0x02;
+        for (i, b) in pubkey.iter_mut().enumerate().skip(1) {
+            *b = i as u8;
+        }
+        let pubkey_hash = crate::util::hash160::hash(&pubkey);
+        let script_pubkey_bytes = p2pkh_script_pubkey_bytes(pubkey_hash);
+
+        // 521-byte signature: just one byte over LargeValue::MAX_SIZE (= 520).
+        // Any value > 520 triggers the InvalidSignature error.
+        let mut partial_signatures: BTreeMap<[u8; 33], Vec<u8>> = BTreeMap::new();
+        partial_signatures.insert(pubkey, vec![0x42u8; 521]);
+
+        let input = Input::parse(
+            [0u8; 32],           // prevout_txid
+            0,                   // prevout_index
+            None,                // sequence
+            None,                // required_time_lock_time
+            None,                // required_height_lock_time
+            None,                // script_sig
+            1_000,               // value
+            script_pubkey_bytes, // script_pubkey
+            None,                // redeem_script
+            partial_signatures,
+            0x01, // sighash_type = SIGHASH_ALL
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("input parse should succeed");
+
+        let mut bundle = Bundle {
+            inputs: vec![input],
+            outputs: vec![],
+        };
+
+        // Should return Err(InvalidSignature) from the P2PKH branch at
+        // `pv::push_value(sig_bytes).ok_or(InvalidSignature)?`.
+        let result = bundle.finalize_spends();
+        assert!(
+            matches!(result, Err(SpendFinalizerError::InvalidSignature)),
+            "expected Err(InvalidSignature), got {result:?}",
+        );
+    }
 }

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -35,8 +35,8 @@ impl super::Bundle {
                                 input.script_sig = Some(script::Component(vec![
                                     pv::push_value(sig_bytes)
                                         .ok_or(SpendFinalizerError::InvalidSignature)?,
-                                    // `pubkey` is a fixed 33-byte compressed key, so its push always fits.
-                                    pv::push_value(pubkey).expect("33-byte pubkey fits"),
+                                    pv::push_value(pubkey)
+                                        .ok_or(SpendFinalizerError::InvalidSignature)?,
                                 ]));
                                 Ok(())
                             }
@@ -146,4 +146,73 @@ pub enum SpendFinalizerError {
     UnsupportedScriptPubkey,
     /// The `redeem_script` kind is unsupported.
     UnsupportedRedeemScript,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+    use alloc::vec;
+
+    use zcash_script::{
+        pattern::pay_to_pubkey_hash,
+        script::{self, Evaluable},
+    };
+
+    use super::SpendFinalizerError;
+    use crate::{
+        pczt::{Bundle, Input, parse::MAX_SCRIPT_PUSH_VALUE_LEN},
+        sighash::SIGHASH_ALL,
+    };
+
+    /// The P2PKH branch of `Bundle::finalize_spends` returns
+    /// `Err(SpendFinalizerError::InvalidSignature)` for a `partial_signatures`
+    /// entry too large to fit in a single script push, rather than panicking.
+    ///
+    /// `Input::parse` rejects such entries, so the test constructs a valid input
+    /// and then replaces its `partial_signatures` directly.
+    #[test]
+    fn p2pkh_finalize_spends_rejects_oversize_signature() {
+        // Any 33-byte value works as the key: the P2PKH branch only checks that
+        // hash160(pubkey) matches the script_pubkey hash, and both sides of that
+        // comparison are derived from this value.
+        let pubkey = [0x02u8; 33];
+        let script_pubkey_bytes = script::Component(pay_to_pubkey_hash(&pubkey)).to_bytes();
+
+        let mut input = Input::parse(
+            [0u8; 32],           // prevout_txid
+            0,                   // prevout_index
+            None,                // sequence
+            None,                // required_time_lock_time
+            None,                // required_height_lock_time
+            None,                // script_sig
+            1_000,               // value
+            script_pubkey_bytes, // script_pubkey
+            None,                // redeem_script
+            BTreeMap::new(),     // partial_signatures
+            SIGHASH_ALL,
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("input parse should succeed");
+
+        // One byte over the largest value a single script push can carry.
+        input
+            .partial_signatures
+            .insert(pubkey, vec![0x42u8; MAX_SCRIPT_PUSH_VALUE_LEN + 1]);
+
+        let mut bundle = Bundle {
+            inputs: vec![input],
+            outputs: vec![],
+        };
+
+        let result = bundle.finalize_spends();
+        assert!(
+            matches!(result, Err(SpendFinalizerError::InvalidSignature)),
+            "expected Err(InvalidSignature), got {result:?}",
+        );
+    }
 }


### PR DESCRIPTION
## What

In `zcash_transparent::pczt::Bundle::finalize_spends()`, the P2PKH branch used `pv::push_value(...).expect("short enough")` while the P2MS-in-P2SH branch ~45 lines later already used `.ok_or(SpendFinalizerError::InvalidSignature)?` for the identical fallibility. This commits the P2PKH branch to the same pattern.

`pv::push_value` returns `None` for inputs > 520 bytes (`LargeValue::MAX_SIZE`). For P2PKH, the `sig_bytes` arg comes from `partial_signatures`, which `Input::parse` accepts as an arbitrary `Vec<u8>` with no length cap — so an oversize entry would reach the `.expect` and panic. After this PR it returns `Err(SpendFinalizerError::InvalidSignature)`.

The function already returns `Result<(), SpendFinalizerError>`, so this is a pure consistency change — no API impact.

## Test

A regression test in a new `#[cfg(test)] mod tests` block constructs an `Input` via `Input::parse(...)` with a 521-byte entry in `partial_signatures` and asserts the returned `Err`.

```sh
cargo test --lib -p zcash_transparent --features 'transparent-inputs' \
    pczt::spend_finalizer::tests::p2pkh_finalize_spends_rejects_oversize_signature
```