### PR TITLE
zcash_keys: lower minimum seed length from 32 to 16 bytes (closes #2363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,10 +7484,10 @@ dependencies = [
 
 [[package]]
 name = "zip32"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ff9ea444cdbce820211f91e6aa3d3a56bde7202d3c0961b7c38f793abf5637"
+version = "0.2.1"
+source = "git+https://github.com/dianaravenborne/zip32?branch=relax-seed-minimum-to-16-bytes#e663768f9ad24dcbfac2d60f5bdbaebd24727827"
 dependencies = [
+ "bech32",
  "blake2b_simd",
  "memuse",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,3 +228,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(zcash_unstable, values("zfuture", "nu7"))',
   'cfg(live_network_tests)',
 ] }
+
+# Pull the matching `zip32` relaxation directly from the companion PR while
+# both PRs are in review. Remove this `[patch]` section once the upstream
+# zip32 release containing https://github.com/zcash/zip32/pull/31 is published.
+[patch.crates-io]
+zip32 = { git = "https://github.com/dianaravenborne/zip32", branch = "relax-seed-minimum-to-16-bytes" }

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -9,6 +9,19 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The minimum seed length accepted by ZIP 32 key derivation has been reduced
+  from 32 bytes to 16 bytes, matching the minimum wallet seed entropy required
+  by [ZIP 315]. This enables import of 128-bit master secrets such as those
+  produced by 20-word SLIP-39 shares. Affected APIs:
+  - `zcash_keys::keys::sapling::spending_key` (panic threshold lowered)
+  - `zcash_keys::keys::UnifiedSpendingKey::from_seed` (panic threshold lowered)
+
+  Requires the corresponding relaxation in `zip32`. The transparent derivation
+  path via `bip32` already supports 16-byte seeds.
+
+[ZIP 315]: https://zips.z.cash/zip-0315#wallet-seeds
+
 ## [0.13.0] - 2026-04-27
 
 ### Added

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -55,7 +55,7 @@ pub mod sapling {
     ///
     /// # Panics
     ///
-    /// Panics if `seed` is shorter than 32 bytes.
+    /// Panics if `seed` is shorter than 16 bytes.
     ///
     /// # Examples
     ///
@@ -68,8 +68,8 @@ pub mod sapling {
     /// ```
     /// [`ExtendedSpendingKey`]: sapling::zip32::ExtendedSpendingKey
     pub fn spending_key(seed: &[u8], coin_type: u32, account: AccountId) -> ExtendedSpendingKey {
-        if seed.len() < 32 {
-            panic!("ZIP 32 seeds MUST be at least 32 bytes");
+        if seed.len() < 16 {
+            panic!("ZIP 32 seeds MUST be at least 16 bytes");
         }
 
         ExtendedSpendingKey::from_path(
@@ -239,8 +239,8 @@ impl UnifiedSpendingKey {
         seed: &[u8],
         _account: AccountId,
     ) -> Result<UnifiedSpendingKey, DerivationError> {
-        if seed.len() < 32 {
-            panic!("ZIP 32 seeds MUST be at least 32 bytes");
+        if seed.len() < 16 {
+            panic!("ZIP 32 seeds MUST be at least 16 bytes");
         }
 
         UnifiedSpendingKey::from_checked_parts(
@@ -1932,7 +1932,15 @@ mod tests {
     #[should_panic]
     #[cfg(feature = "sapling")]
     fn spending_key_panics_on_short_seed() {
-        let _ = sapling::spending_key(&[0; 31][..], 0, AccountId::ZERO);
+        let _ = sapling::spending_key(&[0; 15][..], 0, AccountId::ZERO);
+    }
+
+    #[test]
+    #[cfg(feature = "sapling")]
+    fn spending_key_accepts_16_byte_seed() {
+        // 16 bytes is the minimum entropy required by ZIP 315 for wallet seeds,
+        // matching e.g. 20-word SLIP-39 master secrets.
+        let _ = sapling::spending_key(&[0x42; 16][..], 0, AccountId::ZERO);
     }
 
     #[cfg(feature = "transparent-inputs")]


### PR DESCRIPTION
Closes #2363.

Lower the minimum seed length accepted by ZIP 32 key derivation in `zcash_keys` from 32 bytes to 16 bytes, matching the minimum wallet-seed entropy required by [ZIP 315]. This unblocks import of 128-bit master secrets such as those produced by 20-word SLIP-39 shares into Zcash-aware hardware wallets.

## Companion PR

This depends on **zcash/zip32#31**, which lowers the matching minimum in the four `zip32` enforcement points (`SeedFingerprint::from_seed`, `with_ikm`, `registered::SecretKey::from_subpath`, `registered::cryptovalue_from_subpath`).

A `[patch.crates-io]` entry temporarily resolves `zip32` from that PR's branch so this workspace exercises the relaxation end-to-end. The patch should be dropped once a `zip32` release containing the upstream change is published.

## Changes in `zcash_keys`

- `keys::sapling::spending_key` — panic threshold lowered from 32 to 16 bytes, doc comment updated.
- `keys::UnifiedSpendingKey::from_seed` — panic threshold lowered from 32 to 16 bytes.
- `keys::tests::spending_key_panics_on_short_seed` — lowered from `[0; 31]` to `[0; 15]` so it still trips the (now lower) bound.
- New `keys::tests::spending_key_accepts_16_byte_seed` — positive test confirming the new minimum.
- CHANGELOG entry under `[Unreleased]`.

The transparent derivation path via `bip32 0.6.0-pre.1` already accepts 16-byte seeds (`if ![16, 32, 64].contains(&seed.as_ref().len())`), so no change is needed for the transparent pool.

## Tests

`cargo test -p zcash_keys --all-features` — 28 unit tests + 7 doc tests pass:

```
test keys::tests::spending_key_accepts_16_byte_seed ... ok
test keys::tests::spending_key_panics_on_short_seed - should panic ... ok
... (all 26 others passing)
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Security notes

- **Domain separation.** The seed length byte is bound into the BLAKE2b IKM (`zip32::with_ikm`, `SeedFingerprint::from_seed`), so 16-byte and 32-byte seeds with identical prefixes produce distinct outputs. A test in the companion zip32 PR asserts this.
- **Entropy floor.** Accepting 16-byte seeds reduces the worst-case multi-target attack work bound to ≥2^125 derived per ZIP 315's stated threat model, which is the documented minimum. Wallets that want a 256-bit seed floor can continue to enforce that at the call site; this change only removes the unconditional library-level rejection.
- **Spec interop.** ZIP-32 spec text still says ≥32. Cross-implementation interop (Zashi, Ywallet, zcashd) is preserved for 32-byte seeds; 16-byte seeds will only round-trip across implementations that adopt the same relaxation. That's a deliberate trade-off for hardware-wallet vendors that need to support import flows producing 128-bit secrets.

## Checklist for review

- [x] Tests pass (`cargo test -p zcash_keys --all-features`)
- [x] CHANGELOG updated
- [x] AI disclosure: drafted with Claude (Anthropic) under direction of @nullcopy; commit includes `Co-Authored-By` trailer per `AGENTS.md`
- [ ] zcash/zip32#31 merged + released (PR is draft until then)
- [ ] `[patch.crates-io]` entry removed once `zip32` release is published

[ZIP 315]: https://zips.z.cash/zip-0315#wallet-seeds
