### PR TITLE
zcash_primitives: Reject v4 tx with empty Sapling bundle and non-zero…

### DIFF
--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -32,6 +32,13 @@ workspace.
   Orchard and Ironwood bundles. Pass `orchard::builder::BundleType::DEFAULT` to keep
   the previous (padded) behavior.
 
+### Fixed
+- `zcash_primitives::transaction::Transaction::read` now rejects v4
+  transactions whose Sapling section contains zero spends and zero outputs
+  but a non-zero `valueBalanceSapling`, matching Zebra and post-v6.12.2
+  zcashd (consensus rule §7.1.2). Previously the value was silently
+  discarded, accepting an encoding that no consensus node will admit.
+
 ## [0.29.0-pre.0] - 2026-06-30
 
 ### Added
@@ -153,6 +160,7 @@ workspace.
   arbitrary data (GHSA-2x4w-pxqw-58v9). Proof-size enforcement is `Strict` for
   transactions parsed under NU6.2 and later consensus branches, and `Unenforced`
   for earlier branches to preserve the ability to parse historical transactions.
+
 ## [0.27.1] - 2026-05-14
 
 ### Fixed

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- `zcash_primitives::transaction::Transaction::read` now rejects v4
+  transactions whose Sapling section contains zero spends and zero outputs
+  but a non-zero `valueBalanceSapling`, matching Zebra and post-v6.12.2
+  zcashd (consensus rule §7.1.2). Previously the value was silently
+  discarded, accepting an encoding that no consensus node will admit.
+
 ## [0.30.1] - 2026-08-18
 
 ### Added
@@ -227,6 +234,7 @@ workspace.
   arbitrary data (GHSA-2x4w-pxqw-58v9). Proof-size enforcement is `Strict` for
   transactions parsed under NU6.2 and later consensus branches, and `Unenforced`
   for earlier branches to preserve the ability to parse historical transactions.
+
 ## [0.27.1] - 2026-05-14
 
 ### Fixed

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -342,6 +342,13 @@ pub(crate) fn read_v4_components<R: Read>(
         #[allow(clippy::redundant_closure)]
         let so: Vec<OutputDescription<GrothProofBytes>> =
             Vector::read(&mut reader, |r| read_output_v4(r))?;
+        if ss.is_empty() && so.is_empty() && vb != ZatBalance::zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Sapling v4: nShieldedSpend == 0 && nShieldedOutput == 0 \
+                 but valueBalanceSapling != 0 (consensus rule §7.1.2)",
+            ));
+        }
         Ok((vb, ss, so))
     } else {
         Ok((ZatBalance::zero(), vec![], vec![]))

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -397,6 +397,13 @@ pub(crate) fn read_v4_components<R: Read>(
         #[allow(clippy::redundant_closure)]
         let so: Vec<OutputDescription<GrothProofBytes>> =
             Vector::read(&mut reader, |r| read_output_v4(r))?;
+        if ss.is_empty() && so.is_empty() && vb != ZatBalance::zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Sapling v4: nShieldedSpend == 0 && nShieldedOutput == 0 \
+                 but valueBalanceSapling != 0 (consensus rule §7.1.2)",
+            ));
+        }
         Ok((vb, ss, so))
     } else {
         Ok((ZatBalance::zero(), vec![], vec![]))

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1195,3 +1195,69 @@ fn zip_0233() {
         );
     }
 }
+
+#[cfg(test)]
+mod v4_sapling_value_balance_consistency {
+    use alloc::vec::Vec;
+    use corez::io::Cursor;
+
+    use zcash_protocol::{
+        consensus::BranchId,
+        constants::{V4_TX_VERSION, V4_VERSION_GROUP_ID},
+    };
+
+    use crate::transaction::Transaction;
+
+    fn build_v4_empty_sapling_with_vb(vb: i64) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(64);
+
+        // Overwintered bit | v4 header, version group ID, 0 tx_in, 0 tx_out,
+        // lock_time, nExpiryHeight, valueBalanceSapling, 0 nShieldedSpend,
+        // 0 nShieldedOutput, 0 nJoinSplit. No binding signature follows since
+        // both Sapling vectors are empty.
+        let header: u32 = (1u32 << 31) | V4_TX_VERSION;
+        bytes.extend_from_slice(&header.to_le_bytes());
+        bytes.extend_from_slice(&V4_VERSION_GROUP_ID.to_le_bytes());
+        bytes.push(0x00);
+        bytes.push(0x00);
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&vb.to_le_bytes());
+        bytes.push(0x00);
+        bytes.push(0x00);
+        bytes.push(0x00);
+
+        bytes
+    }
+
+    #[test]
+    fn reject_v4_empty_sapling_bundle_with_nonzero_value_balance() {
+        let vb: i64 = 1_000_000;
+        let bytes = build_v4_empty_sapling_with_vb(vb);
+
+        let result = Transaction::read(Cursor::new(&bytes[..]), BranchId::Nu5);
+
+        assert!(
+            result.is_err(),
+            "v4 deserializer accepted an encoding with n_spends == 0, \
+             n_outputs == 0, value_balance == {vb} (non-zero); \
+             this violates the §7.1.2 consensus rule and diverges from Zebra. \
+             Got: {:?}",
+            result
+                .as_ref()
+                .map(|tx| (tx.sapling_bundle().is_some(), tx.txid())),
+        );
+    }
+
+    #[test]
+    fn accept_v4_empty_sapling_bundle_with_zero_value_balance() {
+        let bytes = build_v4_empty_sapling_with_vb(0);
+        let tx = Transaction::read(Cursor::new(&bytes[..]), BranchId::Nu5)
+            .expect("vb=0 / empty bundle is a valid v4 encoding");
+        assert!(tx.sapling_bundle().is_none());
+
+        let mut reserialized = Vec::new();
+        tx.write(&mut reserialized).unwrap();
+        assert_eq!(reserialized, bytes);
+    }
+}

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1183,3 +1183,69 @@ fn zip_0233() {
         );
     }
 }
+
+#[cfg(test)]
+mod v4_sapling_value_balance_consistency {
+    use alloc::vec::Vec;
+    use corez::io::Cursor;
+
+    use zcash_protocol::{
+        consensus::BranchId,
+        constants::{V4_TX_VERSION, V4_VERSION_GROUP_ID},
+    };
+
+    use crate::transaction::Transaction;
+
+    fn build_v4_empty_sapling_with_vb(vb: i64) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(64);
+
+        // Overwintered bit | v4 header, version group ID, 0 tx_in, 0 tx_out,
+        // lock_time, nExpiryHeight, valueBalanceSapling, 0 nShieldedSpend,
+        // 0 nShieldedOutput, 0 nJoinSplit. No binding signature follows since
+        // both Sapling vectors are empty.
+        let header: u32 = (1u32 << 31) | V4_TX_VERSION;
+        bytes.extend_from_slice(&header.to_le_bytes());
+        bytes.extend_from_slice(&V4_VERSION_GROUP_ID.to_le_bytes());
+        bytes.push(0x00);
+        bytes.push(0x00);
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&vb.to_le_bytes());
+        bytes.push(0x00);
+        bytes.push(0x00);
+        bytes.push(0x00);
+
+        bytes
+    }
+
+    #[test]
+    fn reject_v4_empty_sapling_bundle_with_nonzero_value_balance() {
+        let vb: i64 = 1_000_000;
+        let bytes = build_v4_empty_sapling_with_vb(vb);
+
+        let result = Transaction::read(Cursor::new(&bytes[..]), BranchId::Nu5);
+
+        assert!(
+            result.is_err(),
+            "v4 deserializer accepted an encoding with n_spends == 0, \
+             n_outputs == 0, value_balance == {vb} (non-zero); \
+             this violates the §7.1.2 consensus rule and diverges from Zebra. \
+             Got: {:?}",
+            result
+                .as_ref()
+                .map(|tx| (tx.sapling_bundle().is_some(), tx.txid())),
+        );
+    }
+
+    #[test]
+    fn accept_v4_empty_sapling_bundle_with_zero_value_balance() {
+        let bytes = build_v4_empty_sapling_with_vb(0);
+        let tx = Transaction::read(Cursor::new(&bytes[..]), BranchId::Nu5)
+            .expect("vb=0 / empty bundle is a valid v4 encoding");
+        assert!(tx.sapling_bundle().is_none());
+
+        let mut reserialized = Vec::new();
+        tx.write(&mut reserialized).unwrap();
+        assert_eq!(reserialized, bytes);
+    }
+}


### PR DESCRIPTION
… valueBalanceSapling

`read_v4_components` read `valueBalanceSapling` unconditionally when `tx_has_sapling`, and `read_v4` then dropped it whenever both Sapling vectors were empty (the empty-bundle branch synthesizes `sapling_bundle = None` via `binding_sig.and_then(...)`). The net effect was that a v4 encoding with `nShieldedSpend == 0 && nShieldedOutput == 0 && valueBalanceSapling != 0` was silently accepted, even though consensus rule §7.1.2 requires `valueBalanceSapling == 0` in that case. Zebra (`zebra-chain/src/transaction/serialize.rs:962-963`) and post-v6.12.2 zcashd both reject this encoding; `zcash_primitives` now agrees.

Add a regression test that constructs the wire bytes directly and asserts `Transaction::read` returns an error, plus a sanity test for the canonical `vb == 0` encoding's round-trip.