### PR TITLE
fix(zcash_transparent): reject oversized PCZT partial_signatures at parse time

### DIFF
--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- `zcash_transparent::pczt::ParseError` has a new `InvalidPartialSignature`
+  variant. The `ParseError` enum is now marked `#[non_exhaustive]`.
+
+### Fixed
+- `zcash_transparent::pczt` spend finalization no longer panics on a
+  `partial_signatures` entry larger than the maximum script push-value size.
+  Such entries are now rejected at parse time.
+
 ## [0.9.0] - 2026-07-09
 
 ### Changed

--- a/zcash_transparent/src/pczt/parse.rs
+++ b/zcash_transparent/src/pczt/parse.rs
@@ -10,6 +10,11 @@ use crate::sighash::SighashType;
 
 use super::{Bip32Derivation, Bundle, Input, Output};
 
+/// Maximum size of a script push-value (`LargeValue::MAX_SIZE`, 520 bytes).
+/// `partial_signatures` entries are pushed as single script elements during
+/// spend finalization, so they cannot exceed this.
+const MAX_SCRIPT_PUSH_VALUE_LEN: usize = 520;
+
 impl Bundle {
     /// Parses a PCZT bundle from its component parts.
     pub fn parse(inputs: Vec<Input>, outputs: Vec<Output>) -> Result<Self, ParseError> {
@@ -66,6 +71,16 @@ impl Input {
 
         let sighash_type =
             SighashType::parse(sighash_type).ok_or(ParseError::InvalidSighashType)?;
+
+        // Each `partial_signatures` value is pushed as a single script element
+        // during spend finalization and cannot exceed the script push-value
+        // limit. Reject oversized entries at the parse boundary so no downstream
+        // role can be driven to panic on them.
+        for sig in partial_signatures.values() {
+            if sig.len() > MAX_SCRIPT_PUSH_VALUE_LEN {
+                return Err(ParseError::InvalidPartialSignature);
+            }
+        }
 
         Ok(Self {
             prevout_txid,
@@ -146,6 +161,7 @@ fn parse_script_sig(script_sig: Vec<u8>) -> Option<script::Sig> {
 
 /// Errors that can occur while parsing a PCZT bundle.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ParseError {
     /// An invalid `redeem_script` was provided.
     InvalidRedeemScript,
@@ -155,8 +171,55 @@ pub enum ParseError {
     InvalidScriptPubkey,
     /// An invalid `script_sig` was provided.
     InvalidScriptSig,
+    /// A `partial_signatures` entry exceeded the maximum script element size.
+    InvalidPartialSignature,
     /// An invalid `sighash_type` was provided.
     InvalidSighashType,
     /// An invalid `value` was provided.
     InvalidValue,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+    use alloc::vec;
+
+    use zcash_script::script::Evaluable;
+
+    use crate::address::TransparentAddress;
+    use crate::sighash::SIGHASH_ALL;
+
+    use super::{Input, ParseError};
+
+    #[test]
+    fn input_parse_rejects_oversized_partial_signature() {
+        let script_pubkey = TransparentAddress::PublicKeyHash([0; 20])
+            .script()
+            .to_bytes();
+        let mut partial_signatures = BTreeMap::new();
+        partial_signatures.insert([2; 33], vec![0; 521]);
+
+        assert!(matches!(
+            Input::parse(
+                [0; 32],
+                0,
+                None,
+                None,
+                None,
+                None,
+                1000,
+                script_pubkey,
+                None,
+                partial_signatures,
+                SIGHASH_ALL,
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+            ),
+            Err(ParseError::InvalidPartialSignature)
+        ));
+    }
 }

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -33,8 +33,10 @@ impl super::Bundle {
                             } else {
                                 // P2PKH scriptSig
                                 input.script_sig = Some(script::Component(vec![
-                                    pv::push_value(sig_bytes).expect("short enough"),
-                                    pv::push_value(pubkey).expect("short enough"),
+                                    pv::push_value(sig_bytes)
+                                        .ok_or(SpendFinalizerError::InvalidSignature)?,
+                                    // `pubkey` is a fixed 33-byte compressed key, so its push always fits.
+                                    pv::push_value(pubkey).expect("33-byte pubkey fits"),
                                 ]));
                                 Ok(())
                             }


### PR DESCRIPTION
Input::parse accepts partial_signatures values of arbitrary length, and the P2PKH branch of spend_finalizer.rs pushes them into a script via pv::push_value(...).expect("short enough"). push_value returns None for any element over the 520-byte script push-value limit, so a partial_signatures entry longer than 520 bytes aborts the finalizer. The P2SH/P2MS branch already handles this with .ok_or(InvalidSignature)?; P2PKH was inconsistent.

- parse.rs: reject oversized partial_signatures entries at parse time, with a new ParseError::InvalidPartialSignature. This closes it at the boundary for every role, not just P2PKH.
- spend_finalizer.rs: convert the P2PKH signature push to .ok_or(SpendFinalizerError::InvalidSignature)?, matching the P2MS branch. The pubkey is a fixed 33-byte key that always fits, so it keeps an expect with an accurate message.
- Add a regression test for parse-time rejection of a 521-byte partial_signatures value.

Validation:
- cargo fmt --all
- cargo build -p zcash_transparent on Linux
- cargo test -p zcash_transparent on Linux, 9 passed
