### PR TITLE
fix: align propose_shielding_coinbase fee with builder bundle minimums

### DIFF
--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6699,3 +6699,78 @@ pub fn propose_shielding_coinbase_with_zero_limit_insufficient_funds<T: Shielded
     // `available: 0, required: fee`.
     assert_matches!(result, Err(Error::InsufficientFunds { .. }));
 }
+
+/// Regression test for the propose-fee/build-fee mismatch fixed in #2375.
+///
+/// Both `sapling::builder::BundleType::DEFAULT` and
+/// `orchard::builder::BundleType::DEFAULT` pad up to a minimum of 2
+/// outputs/actions (`MIN_SHIELDED_OUTPUTS` / `MIN_ACTIONS`). Before the fix,
+/// `propose_shielding_coinbase` hardcoded `(1, 0)` / `(0, 1)` when asking the
+/// fee rule what fee to charge, so the proposal underestimated the fee by
+/// exactly one ZIP-317 marginal unit (5000 zat). The proposal succeeded, but
+/// `create_proposed_transactions` then failed at build time with
+/// `Insufficient funds for transaction construction; need an additional
+/// ZatBalance(5000) zatoshis`.
+///
+/// This test verifies the propose-and-build round trip succeeds for both
+/// Sapling and Orchard destinations (parameterized by `T`).
+#[cfg(all(feature = "pczt", feature = "transparent-inputs"))]
+pub fn propose_and_build_shielding_coinbase_succeeds<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let account = st.get_account();
+    let (t_addr, _) = account.usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(50000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    // Coinbase outputs require 100 confirmations.
+    st.add_empty_blocks(100);
+
+    // The destination is a shielded address controlled by a separate spending key.
+    let to_extsk = T::sk(&[0xcd; 32]);
+    let to_address = T::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let proposal = st
+        .propose_shielding_coinbase(
+            &GreedyInputSelector::new(),
+            &StandardFeeRule::Zip317,
+            Zatoshis::ZERO,
+            &[t_addr],
+            to_address,
+            None,
+            None,
+        )
+        .expect("propose_shielding_coinbase should succeed");
+
+    // The actual regression: prior to #2375 this would fail at build time
+    // with `Insufficient funds for transaction construction; need an
+    // additional ZatBalance(5000) zatoshis` because the proposal-stage fee
+    // was computed assuming N output/action slots but the builder
+    // materializes N+1 (after `MIN_*` padding).
+    let build_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(
+        &build_result,
+        Ok(txids) if txids.len() == 1,
+        "create_proposed_transactions must succeed for proposal {:?}",
+        proposal,
+    );
+}

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1245,11 +1245,29 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         // Compute the fee directly from the fee rule. This method produces no
         // change in any pool, so there is no change-strategy or wallet-metadata
         // computation to perform. The proposal will carry exactly one shielded
-        // output (in `destination_pool`) and zero transparent outputs.
+        // payment output (in `destination_pool`) and zero transparent outputs.
+        //
+        // Both Sapling and Orchard transactional bundles pad up to a minimum
+        // of 2 outputs/actions when any output is added (see `MIN_ACTIONS` /
+        // `MIN_SHIELDED_OUTPUTS` in the respective crates). The proposal fee
+        // must reflect the *padded* counts that the builder will actually
+        // produce, otherwise the subsequent `create_proposed_transactions`
+        // call fails with `InsufficientFunds(need additional <marginal_fee>)`.
+        // We query each bundle type for the count it will materialize.
         let (sapling_output_count, orchard_action_count) = match destination_pool {
-            PoolType::SAPLING => (1usize, 0usize),
+            PoolType::SAPLING => {
+                let count = ::sapling::builder::BundleType::DEFAULT
+                    .num_outputs(0, 1)
+                    .expect("sapling DEFAULT bundle type permits any (spends, outputs) count");
+                (count, 0usize)
+            }
             #[cfg(feature = "orchard")]
-            PoolType::ORCHARD => (0usize, 1usize),
+            PoolType::ORCHARD => {
+                let count = orchard::builder::BundleType::DEFAULT
+                    .num_actions(0, 1)
+                    .expect("orchard DEFAULT bundle type permits any (spends, outputs) count");
+                (0usize, count)
+            }
             // Unreachable: `resolve_shielded_destination` rejects transparent
             // destinations earlier with `ShieldingRequiresShieldedRecipient`.
             _ => {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -511,3 +511,11 @@ pub(crate) fn propose_shielding_coinbase_with_zero_limit_insufficient_funds<
         BlockCache::new(),
     );
 }
+
+#[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+pub(crate) fn propose_and_build_shielding_coinbase_succeeds<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::propose_and_build_shielding_coinbase_succeeds::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -742,6 +742,12 @@ pub(crate) mod tests {
         >();
     }
 
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_and_build_shielding_coinbase_succeeds() {
+        testing::pool::propose_and_build_shielding_coinbase_succeeds::<OrchardPoolTester>();
+    }
+
     #[test]
     #[cfg(feature = "orchard")]
     fn get_unspent_orchard_notes_at_historical_height_boundary_heights() {

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -688,4 +688,10 @@ pub(crate) mod tests {
             SaplingPoolTester,
         >();
     }
+
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn propose_and_build_shielding_coinbase_succeeds() {
+        testing::pool::propose_and_build_shielding_coinbase_succeeds::<SaplingPoolTester>();
+    }
 }


### PR DESCRIPTION
Fixes #2374.
Fixes [COR-1261](https://linear.app/zodl/issue/COR-1261/propose-shielding-coinbase-underestimates-fee-by-one-marginal-unit).

`propose_shielding_coinbase` (added in #2353) hardcoded the shielded output / action counts it passes to `FeeRule::fee_required`:

```rust
let (sapling_output_count, orchard_action_count) = match destination_pool {
    PoolType::SAPLING => (1usize, 0usize),
    PoolType::ORCHARD  => (0usize, 1usize),
    ...
};
```

But both `sapling::builder::BundleType::DEFAULT` and `orchard::builder::BundleType::DEFAULT` pad up to a minimum of 2 outputs / actions when any output is added (`MIN_SHIELDED_OUTPUTS` and `MIN_ACTIONS` respectively). The proposal therefore underestimates the fee by exactly one ZIP-317 marginal unit (5000 zat). The proposal succeeds, then \`create_proposed_transactions\` fails at build time with:

> Insufficient funds for transaction construction; need an additional ZatBalance(5000) zatoshis

This makes \`z_shieldcoinbase\` (in zallet) unable to actually build a shielding tx end-to-end in either pool destination.

This fix queries each bundle type for the real count instead of hardcoding it, matching the pattern used by \`single_change_output_balance\` in \`fees/common.rs\`. The \`.expect()\` calls are safe because \`BundleType::DEFAULT\` is \`Transactional\` with both flags enabled, which permits any \`(num_spends, num_outputs)\` combination.

## Test plan

Verified end-to-end against a zaino-backed regtest wallet running \`z_shieldcoinbase\` to an Orchard receiver: before this fix the build step fails with the 5000-zat shortfall; after the fix the tx builds and confirms. Full integration test suite in zcash/integration-tests covering this and other code paths is green against this commit.

Co-Authored-By: Claude <noreply@anthropic.com>