### PR TITLE
Persist Orchard note versions in SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,9 +2966,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36733033adae631acacf46f542f027d508d9025d14797d9b35059494c99eb3"
+version = "0.13.1"
+source = "git+https://github.com/valargroup/qr_orchard?rev=f0f108e230c81f66caa6d895b1553dcece3ccece#f0f108e230c81f66caa6d895b1553dcece3ccece"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.13.1"
-source = "git+https://github.com/valargroup/qr_orchard?rev=f0f108e230c81f66caa6d895b1553dcece3ccece#f0f108e230c81f66caa6d895b1553dcece3ccece"
+source = "git+https://github.com/valargroup/qr_orchard?rev=0f4175428957348117b5b666038e4d4baee7cfc9#0f4175428957348117b5b666038e4d4baee7cfc9"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.13.1"
-source = "git+https://github.com/valargroup/qr_orchard?rev=0f4175428957348117b5b666038e4d4baee7cfc9#0f4175428957348117b5b666038e4d4baee7cfc9"
+source = "git+https://github.com/valargroup/qr_orchard?rev=9f046f22a46dd644aeed070968e51add57478973#9f046f22a46dd644aeed070968e51add57478973"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { version = "0.13", default-features = false }
+orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "f0f108e230c81f66caa6d895b1553dcece3ccece", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "0f4175428957348117b5b666038e4d4baee7cfc9", default-features = false }
+orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "9f046f22a46dd644aeed070968e51add57478973", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "f0f108e230c81f66caa6d895b1553dcece3ccece", default-features = false }
+orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "0f4175428957348117b5b666038e4d4baee7cfc9", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -9,6 +9,13 @@ represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
 ## [Unreleased]
+### Added
+- `pczt::orchard::NotePlaintextVersion`, representing Orchard note plaintext
+  versions in serialized PCZT data.
+- `pczt::orchard::Spend::note_version` and
+  `pczt::orchard::Output::note_version` getters. These fields are used to
+  reconstruct Orchard note commitments with the intended note plaintext
+  version.
 
 ## [0.6.0] - 2026-04-27
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -16,6 +16,38 @@ use crate::{
     roles::combiner::{merge_map, merge_optional},
 };
 
+/// Orchard note plaintext version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotePlaintextVersion {
+    /// The original Orchard note plaintext version.
+    V2,
+    /// The quantum-recoverable Orchard note plaintext version defined in
+    /// [ZIP 2005].
+    ///
+    /// [ZIP 2005]: https://zips.z.cash/zip-2005
+    V3,
+}
+
+#[cfg(feature = "orchard")]
+impl From<NotePlaintextVersion> for orchard::note::NoteVersion {
+    fn from(version: NotePlaintextVersion) -> Self {
+        match version {
+            NotePlaintextVersion::V2 => Self::V2,
+            NotePlaintextVersion::V3 => Self::V3,
+        }
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl From<orchard::note::NoteVersion> for NotePlaintextVersion {
+    fn from(version: orchard::note::NoteVersion) -> Self {
+        match version {
+            orchard::note::NoteVersion::V2 => Self::V2,
+            orchard::note::NoteVersion::V3 => Self::V3,
+        }
+    }
+}
+
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Bundle {
@@ -145,6 +177,13 @@ pub struct Spend {
     /// - This is required by the Prover.
     pub(crate) rseed: Option<[u8; 32]>,
 
+    /// The plaintext version of the note being spent.
+    ///
+    /// This is set by the Constructor, and is required by Verifiers and
+    /// Provers to reconstruct the note commitment.
+    #[getset(get = "pub")]
+    pub(crate) note_version: NotePlaintextVersion,
+
     /// The full viewing key that received the note being spent.
     ///
     /// - This is set by the Updater.
@@ -194,6 +233,12 @@ pub struct Output {
     //
     #[getset(get = "pub")]
     pub(crate) cmx: [u8; 32],
+    /// The plaintext version of the note being created.
+    ///
+    /// This is set by the Constructor, and is required by Verifiers and
+    /// Provers to reconstruct the note commitment.
+    #[getset(get = "pub")]
+    pub(crate) note_version: NotePlaintextVersion,
     #[getset(get = "pub")]
     pub(crate) ephemeral_key: [u8; 32],
     /// The encrypted note plaintext for the output.
@@ -341,6 +386,7 @@ impl Bundle {
                         value,
                         rho,
                         rseed,
+                        note_version: spend_note_version,
                         fvk,
                         witness,
                         alpha,
@@ -351,6 +397,7 @@ impl Bundle {
                 output:
                     Output {
                         cmx,
+                        note_version: output_note_version,
                         ephemeral_key,
                         enc_ciphertext,
                         out_ciphertext,
@@ -368,7 +415,9 @@ impl Bundle {
             if lhs.cv_net != cv_net
                 || lhs.spend.nullifier != nullifier
                 || lhs.spend.rk != rk
+                || lhs.spend.note_version != spend_note_version
                 || lhs.output.cmx != cmx
+                || lhs.output.note_version != output_note_version
                 || lhs.output.ephemeral_key != ephemeral_key
                 || lhs.output.enc_ciphertext != enc_ciphertext
                 || lhs.output.out_ciphertext != out_ciphertext
@@ -419,6 +468,7 @@ impl Bundle {
                     action.spend.value,
                     action.spend.rho,
                     action.spend.rseed,
+                    action.spend.note_version.into(),
                     action.spend.fvk,
                     action.spend.witness,
                     action.spend.alpha,
@@ -439,6 +489,7 @@ impl Bundle {
                 let output = orchard::pczt::Output::parse(
                     *spend.nullifier(),
                     action.output.cmx,
+                    action.output.note_version.into(),
                     action.output.ephemeral_key,
                     action.output.enc_ciphertext,
                     action.output.out_ciphertext,
@@ -495,6 +546,7 @@ impl Bundle {
                         value: spend.value().map(|value| value.inner()),
                         rho: spend.rho().map(|rho| rho.to_bytes()),
                         rseed: spend.rseed().map(|rseed| *rseed.as_bytes()),
+                        note_version: (*spend.note_version()).into(),
                         fvk: spend.fvk().as_ref().map(|fvk| fvk.to_bytes()),
                         witness: spend.witness().as_ref().map(|witness| {
                             (
@@ -528,6 +580,7 @@ impl Bundle {
                     },
                     output: Output {
                         cmx: output.cmx().to_bytes(),
+                        note_version: (*output.note_version()).into(),
                         ephemeral_key: output.encrypted_note().epk_bytes,
                         enc_ciphertext: output.encrypted_note().enc_ciphertext.to_vec(),
                         out_ciphertext: output.encrypted_note().out_ciphertext.to_vec(),

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -19,7 +19,10 @@ use crate::{
 /// Orchard note plaintext version.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NotePlaintextVersion {
-    /// The original Orchard note plaintext version.
+    /// The [ZIP 212] Orchard note plaintext format, identified by lead byte
+    /// `0x02`.
+    ///
+    /// [ZIP 212]: https://zips.z.cash/zip-0212
     V2,
     /// The quantum-recoverable Orchard note plaintext version defined in
     /// [ZIP 2005].

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -121,7 +121,8 @@ impl Creator {
             zcash_primitives::transaction::TxVersion::Sprout(_)
             | zcash_primitives::transaction::TxVersion::V3 => None,
             zcash_primitives::transaction::TxVersion::V4 => Some(V4_TX_VERSION),
-            zcash_primitives::transaction::TxVersion::V5 => Some(V5_TX_VERSION),
+            zcash_primitives::transaction::TxVersion::V5
+            | zcash_primitives::transaction::TxVersion::V5_Qr => Some(V5_TX_VERSION),
             #[cfg(zcash_unstable = "nu7")]
             zcash_primitives::transaction::TxVersion::V6 => Some(V6_TX_VERSION),
             #[cfg(zcash_unstable = "zfuture")]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -119,6 +119,11 @@ workspace.
     - `{propose_transfer, propose_standard_transfer_to_address}`. When set,
       input selection avoids pools incompatible with the requested transaction
       version.
+    - Passing `Some(TxVersion::V5_Qr)` causes generated Orchard change outputs
+      to use quantum recoverable note commitment randomness. Use
+      `Some(TxVersion::V5)` for transaction construction flows that require
+      compatibility with software that has not yet added support for quantum
+      recoverable Orchard notes.
     - `input_selection::InputSelector::propose_transaction` trait method.
   - Trait `Account` has added method `birthday_height`
 - `zcash_client_backend::data_api::wallet::ConfirmationsPolicy::new` now returns

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -916,6 +916,13 @@ impl SpendingKeys {
 /// step is not supported, because the ultimate positions of those notes in the global note
 /// commitment tree cannot be known until the transaction that produces those notes is mined,
 /// and therefore the required spend proofs for such notes cannot be constructed.
+///
+/// Under the `unstable` feature, `proposed_version` can be used to request a
+/// particular transaction version. Passing [`TxVersion::V5_Qr`] constructs
+/// Orchard change outputs as quantum recoverable notes. Passing
+/// [`TxVersion::V5`] preserves the usual v5 Orchard note version, which should
+/// be used for transaction construction flows that depend on software that does
+/// not yet support quantum recoverable Orchard notes.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn create_proposed_transactions<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>(
@@ -1600,12 +1607,12 @@ where
                     #[cfg(feature = "unstable")]
                     let orchard_change_note_version = if proposed_version == Some(TxVersion::V5_Qr)
                     {
-                        orchard::note::NoteVersion::V3_Qr
+                        orchard::note::NoteVersion::V3
                     } else {
-                        orchard::note::NoteVersion::V2
+                        orchard::note::DEFAULT_NOTE_VERSION
                     };
                     #[cfg(not(feature = "unstable"))]
-                    let orchard_change_note_version = orchard::note::NoteVersion::V2;
+                    let orchard_change_note_version = orchard::note::DEFAULT_NOTE_VERSION;
 
                     builder.add_versioned_orchard_output(
                         internal_ovk.map(|k| k.into()),

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -126,6 +126,17 @@ const PROPRIETARY_PROPOSAL_INFO: &str = "zcash_client_backend:proposal_info";
 #[cfg(feature = "pczt")]
 const PROPRIETARY_OUTPUT_INFO: &str = "zcash_client_backend:output_info";
 
+#[cfg(all(feature = "pczt", feature = "orchard"))]
+fn orchard_note_from_pczt_parts(
+    recipient: orchard::Address,
+    value: orchard::value::NoteValue,
+    rho: orchard::note::Rho,
+    rseed: orchard::note::RandomSeed,
+    note_version: orchard::note::NoteVersion,
+) -> Option<orchard::Note> {
+    orchard::Note::from_parts_with_version(recipient, value, rho, rseed, note_version).into()
+}
+
 #[cfg(feature = "pczt")]
 fn serialize_target_height<S>(
     target_height: &TargetHeight,
@@ -2269,7 +2280,13 @@ where
                     orchard::note::RandomSeed::from_bytes(*rseed, &rho).into_option()
                 })?;
 
-                orchard::Note::from_parts(recipient, value, rho, rseed).into_option()
+                orchard_note_from_pczt_parts(
+                    recipient,
+                    value,
+                    rho,
+                    rseed,
+                    (*act.output().note_version()).into(),
+                )
             };
 
             let external_address = act
@@ -2690,4 +2707,41 @@ where
         #[cfg(feature = "unstable")]
         None,
     )
+}
+
+#[cfg(all(test, feature = "pczt", feature = "orchard"))]
+mod tests {
+    use orchard::{
+        keys::{FullViewingKey, Scope, SpendingKey},
+        note::{ExtractedNoteCommitment, NoteVersion, RandomSeed, Rho},
+        value::NoteValue,
+    };
+
+    use super::orchard_note_from_pczt_parts;
+
+    fn test_rseed(rho: &Rho) -> RandomSeed {
+        (0u8..=u8::MAX)
+            .find_map(|b| RandomSeed::from_bytes([b; 32], rho).into())
+            .expect("at least one test rseed is valid")
+    }
+
+    #[test]
+    fn pczt_orchard_note_reconstruction_preserves_note_version() {
+        let sk = SpendingKey::from_bytes([7; 32]).unwrap();
+        let recipient = FullViewingKey::from(&sk).address_at(0u32, Scope::External);
+        let value = NoteValue::from_raw(50_000);
+        let rho = Rho::from_bytes(&[1; 32]).unwrap();
+        let rseed = test_rseed(&rho);
+
+        let note =
+            orchard_note_from_pczt_parts(recipient, value, rho, rseed, NoteVersion::V3).unwrap();
+        let default_note = orchard::Note::from_parts(recipient, value, rho, rseed).unwrap();
+
+        assert_eq!(note.version(), NoteVersion::V3);
+        assert_eq!(default_note.version(), NoteVersion::V2);
+        assert_ne!(
+            ExtractedNoteCommitment::from(note.commitment()),
+            ExtractedNoteCommitment::from(default_note.commitment())
+        );
+    }
 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1609,10 +1609,10 @@ where
                     {
                         orchard::note::NoteVersion::V3
                     } else {
-                        orchard::note::DEFAULT_NOTE_VERSION
+                        orchard::note::NoteVersion::DEFAULT
                     };
                     #[cfg(not(feature = "unstable"))]
-                    let orchard_change_note_version = orchard::note::DEFAULT_NOTE_VERSION;
+                    let orchard_change_note_version = orchard::note::NoteVersion::DEFAULT;
 
                     builder.add_versioned_orchard_output(
                         internal_ovk.map(|k| k.into()),

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1597,13 +1597,24 @@ where
 
                 #[cfg(feature = "orchard")]
                 {
-                    builder.add_orchard_output(
+                    #[cfg(feature = "unstable")]
+                    let orchard_change_note_version = if proposed_version == Some(TxVersion::V5_Qr)
+                    {
+                        orchard::note::NoteVersion::V3_Qr
+                    } else {
+                        orchard::note::NoteVersion::V2
+                    };
+                    #[cfg(not(feature = "unstable"))]
+                    let orchard_change_note_version = orchard::note::NoteVersion::V2;
+
+                    builder.add_versioned_orchard_output(
                         internal_ovk.map(|k| k.into()),
                         ufvk.orchard()
                             .ok_or(Error::KeyNotAvailable(PoolType::ORCHARD))?
                             .address_at(0u32, orchard::keys::Scope::Internal),
                         change_value.value(),
                         memo.clone(),
+                        orchard_change_note_version,
                     )?;
                     orchard_output_meta.push((
                         BuildRecipient::InternalAccount {

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -52,7 +52,7 @@ const ORCHARD_TABLE_CONSTANTS: TableConstants = TableConstants {
     table_prefix: ORCHARD_TABLES_PREFIX,
     output_index_col: "action_index",
     output_count_col: "orchard_action_count",
-    note_reconstruction_cols: "rho, rseed",
+    note_reconstruction_cols: "rn.rho AS rho, rn.rseed AS rseed, rn.note_version AS note_version",
     shard_height: ORCHARD_SHARD_HEIGHT,
 };
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -52,7 +52,7 @@ const ORCHARD_TABLE_CONSTANTS: TableConstants = TableConstants {
     table_prefix: ORCHARD_TABLES_PREFIX,
     output_index_col: "action_index",
     output_count_col: "orchard_action_count",
-    note_reconstruction_cols: "rn.rho AS rho, rn.rseed AS rseed, rn.note_version AS note_version",
+    note_reconstruction_cols: "rho, rseed, note_version",
     shard_height: ORCHARD_SHARD_HEIGHT,
 };
 

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -433,7 +433,6 @@ CREATE INDEX idx_sapling_received_note_spends_transaction_id ON sapling_received
 /// - `value`: the value of the note
 /// - `rho`: the rho value used to derive the nullifier of the note
 /// - `rseed`: the rseed value used to generate the note
-/// - `note_version`: the Orchard note plaintext version used to derive the note commitment
 /// - `nf`: the nullifier that will be exposed when the note is spent
 /// - `is_change`: a flag indicating whether the note was received in a transaction where
 ///   the receiving account also spent notes.
@@ -445,6 +444,7 @@ CREATE INDEX idx_sapling_received_note_spends_transaction_id ON sapling_received
 /// - `address_id`: a foreign key to the address that this note was sent to; null in the
 ///   case that the note was sent to an internally-scoped address (we never store addresses
 ///   containing internal Orchard receivers in the `addresses` table).
+/// - `note_version`: the Orchard note plaintext version used to derive the note commitment
 pub(super) const TABLE_ORCHARD_RECEIVED_NOTES: &str = r#"
 CREATE TABLE "orchard_received_notes" (
     id INTEGER PRIMARY KEY,
@@ -457,7 +457,6 @@ CREATE TABLE "orchard_received_notes" (
     value INTEGER NOT NULL,
     rho BLOB NOT NULL,
     rseed BLOB NOT NULL,
-    note_version INTEGER NOT NULL DEFAULT 2,
     nf BLOB UNIQUE,
     is_change INTEGER NOT NULL,
     memo BLOB,
@@ -466,6 +465,7 @@ CREATE TABLE "orchard_received_notes" (
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
+    note_version INTEGER NOT NULL DEFAULT 2,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -433,6 +433,7 @@ CREATE INDEX idx_sapling_received_note_spends_transaction_id ON sapling_received
 /// - `value`: the value of the note
 /// - `rho`: the rho value used to derive the nullifier of the note
 /// - `rseed`: the rseed value used to generate the note
+/// - `note_version`: the Orchard note plaintext version used to derive the note commitment
 /// - `nf`: the nullifier that will be exposed when the note is spent
 /// - `is_change`: a flag indicating whether the note was received in a transaction where
 ///   the receiving account also spent notes.
@@ -456,6 +457,7 @@ CREATE TABLE "orchard_received_notes" (
     value INTEGER NOT NULL,
     rho BLOB NOT NULL,
     rseed BLOB NOT NULL,
+    note_version INTEGER NOT NULL DEFAULT 2,
     nf BLOB UNIQUE,
     is_change INTEGER NOT NULL,
     memo BLOB,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -25,6 +25,7 @@ mod full_account_ids;
 mod initial_setup;
 mod ivk_item_cache;
 mod nullifier_map;
+mod orchard_note_versions;
 mod orchard_received_notes;
 mod orchard_shardtree;
 mod received_notes_nullable_nf;
@@ -231,6 +232,7 @@ pub(super) fn all_migrations<
         Box::new(witness_stabilized_notes::Migration {
             params: params.clone(),
         }),
+        Box::new(orchard_note_versions::Migration),
     ]
 }
 
@@ -374,7 +376,7 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
-    witness_stabilized_notes::MIGRATION_ID,
+    orchard_note_versions::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_versions.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_versions.rs
@@ -1,0 +1,61 @@
+//! Stores the Orchard note plaintext version for received notes.
+//!
+//! QR Orchard notes use a different note commitment randomness derivation from
+//! ordinary Orchard notes. Persisting the version is required so wallets can
+//! reconstruct spendable notes after reopening the database.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::witness_stabilized_notes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x2fc818c6_b900_4980_ae8e_d12ca17bc346);
+
+const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds the Orchard note plaintext version to received notes."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "ALTER TABLE orchard_received_notes
+               ADD COLUMN note_version INTEGER NOT NULL DEFAULT 2;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -502,12 +502,19 @@ pub(crate) fn mark_orchard_note_spent(
 pub(crate) mod tests {
 
     use orchard::note::NoteVersion;
-    use zcash_client_backend::data_api::testing::{
-        orchard::OrchardPoolTester, sapling::SaplingPoolTester,
+    use zcash_client_backend::data_api::{
+        Account as _,
+        testing::{
+            AddressType, TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
+            sapling::SaplingPoolTester,
+        },
+        wallet::TargetHeight,
     };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::value::Zatoshis;
 
     use super::{decode_note_version, encode_note_version};
-    use crate::testing::{self};
+    use crate::testing::{self, BlockCache, db::TestDbFactory};
 
     #[test]
     fn orchard_note_version_storage_codes_roundtrip() {
@@ -516,6 +523,38 @@ pub(crate) mod tests {
         assert_eq!(decode_note_version(2).unwrap(), NoteVersion::V2);
         assert_eq!(decode_note_version(3).unwrap(), NoteVersion::V3);
         assert!(decode_note_version(4).is_err());
+    }
+
+    #[test]
+    fn persisted_orchard_note_version_controls_reconstruction() {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let dfvk = OrchardPoolTester::test_account_fvk(&st);
+        let value = Zatoshis::const_from_u64(50000);
+        let (height, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(height, 1);
+
+        let target_height = TargetHeight::from(height + 1);
+        let notes =
+            OrchardPoolTester::select_unspent_notes(&st, account.id(), target_height, &[]).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].note().version(), NoteVersion::V2);
+
+        st.wallet()
+            .conn()
+            .execute("UPDATE orchard_received_notes SET note_version = 3", [])
+            .unwrap();
+
+        let notes =
+            OrchardPoolTester::select_unspent_notes(&st, account.id(), target_height, &[]).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].note().version(), NoteVersion::V3);
+        assert_eq!(notes[0].note_value().unwrap(), value);
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, rc::Rc};
 use incrementalmerkletree::Position;
 use orchard::{
     keys::Diversifier,
-    note::{Note, Nullifier, RandomSeed, Rho},
+    note::{Note, NoteVersion, Nullifier, RandomSeed, Rho},
 };
 use rusqlite::{Connection, Row, named_params, types::Value};
 
@@ -28,6 +28,23 @@ use crate::{AccountRef, AccountUuid, AddressRef, ReceivedNoteId, TxRef, error::S
 use super::{
     KeyScope, common::UnspentNoteMeta, get_account, get_account_ref, memo_repr, upsert_address,
 };
+
+fn encode_note_version(version: NoteVersion) -> i64 {
+    match version {
+        NoteVersion::V2 => 2,
+        NoteVersion::V3 => 3,
+    }
+}
+
+fn decode_note_version(version: i64) -> Result<NoteVersion, SqliteClientError> {
+    match version {
+        2 => Ok(NoteVersion::V2),
+        3 => Ok(NoteVersion::V3),
+        _ => Err(SqliteClientError::CorruptedData(format!(
+            "Invalid Orchard note version {version}."
+        ))),
+    }
+}
 
 pub(crate) fn to_received_note<P: consensus::Parameters>(
     params: &P,
@@ -64,6 +81,7 @@ pub(crate) fn to_received_note<P: consensus::Parameters>(
             SqliteClientError::CorruptedData("Invalid Orchard random seed.".to_string())
         })
     }?;
+    let note_version = decode_note_version(row.get("note_version")?)?;
 
     let note_commitment_tree_position = Position::from(
         u64::try_from(row.get::<_, i64>("commitment_tree_position")?).map_err(|_| {
@@ -105,11 +123,12 @@ pub(crate) fn to_received_note<P: consensus::Parameters>(
                     SqliteClientError::CorruptedData("Diversifier invalid.".to_owned())
                 })?;
 
-            let note = Option::from(Note::from_parts(
+            let note = Option::from(Note::from_parts_with_version(
                 recipient,
                 orchard::value::NoteValue::from_raw(note_value),
                 rho,
                 rseed,
+                note_version,
             ))
             .ok_or_else(|| SqliteClientError::CorruptedData("Invalid Orchard note.".to_string()))?;
 
@@ -202,7 +221,8 @@ pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Param
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT
              rn.id AS id, t.txid, rn.action_index,
-             rn.diversifier, rn.value, rn.rho, rn.rseed, rn.commitment_tree_position,
+             rn.diversifier, rn.value, rn.rho, rn.rseed, rn.note_version,
+             rn.commitment_tree_position,
              accounts.ufvk AS ufvk, rn.recipient_key_scope,
              t.mined_height,
              NULL AS max_shielding_input_height
@@ -312,13 +332,13 @@ pub(crate) fn put_received_note<
     let mut stmt_upsert_received_note = conn.prepare_cached(
         "INSERT INTO orchard_received_notes (
             transaction_id, action_index, account_id, address_id,
-            diversifier, value, rho, rseed, memo, nf,
+            diversifier, value, rho, rseed, note_version, memo, nf,
             is_change, commitment_tree_position,
             recipient_key_scope
         )
         VALUES (
             :transaction_id, :action_index, :account_id, :address_id,
-            :diversifier, :value, :rho, :rseed, :memo, :nf,
+            :diversifier, :value, :rho, :rseed, :note_version, :memo, :nf,
             :is_change, :commitment_tree_position,
             :recipient_key_scope
         )
@@ -329,6 +349,7 @@ pub(crate) fn put_received_note<
             value = :value,
             rho = :rho,
             rseed = :rseed,
+            note_version = :note_version,
             nf = IFNULL(:nf, nf),
             memo = IFNULL(:memo, memo),
             is_change = MAX(:is_change, is_change),
@@ -350,6 +371,7 @@ pub(crate) fn put_received_note<
         ":value": output.note().value().inner(),
         ":rho": output.note().rho().to_bytes(),
         ":rseed": &rseed.as_bytes(),
+        ":note_version": encode_note_version(output.note().version()),
         ":nf": output.nullifier().map(|nf| nf.to_bytes()),
         ":memo": memo_repr(output.memo()),
         ":is_change": output.is_change(),
@@ -479,11 +501,22 @@ pub(crate) fn mark_orchard_note_spent(
 #[cfg(test)]
 pub(crate) mod tests {
 
+    use orchard::note::NoteVersion;
     use zcash_client_backend::data_api::testing::{
         orchard::OrchardPoolTester, sapling::SaplingPoolTester,
     };
 
+    use super::{decode_note_version, encode_note_version};
     use crate::testing::{self};
+
+    #[test]
+    fn orchard_note_version_storage_codes_roundtrip() {
+        assert_eq!(encode_note_version(NoteVersion::V2), 2);
+        assert_eq!(encode_note_version(NoteVersion::V3), 3);
+        assert_eq!(decode_note_version(2).unwrap(), NoteVersion::V2);
+        assert_eq!(decode_note_version(3).unwrap(), NoteVersion::V3);
+        assert!(decode_note_version(4).is_err());
+    }
 
     #[test]
     fn send_single_step_proposed_transfer() {

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,6 +8,18 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [0.28.0] - PLANNED
+
+### Added
+- `zcash_primitives::transaction`:
+  - `TxVersion::V5_Qr`, a builder-level selector that serializes identically
+    to `TxVersion::V5` but enables quantum recoverable Orchard change outputs
+    when used by wallet construction APIs.
+- `zcash_primitives::transaction::builder`:
+  - `Builder::add_versioned_orchard_output`, enabling callers to explicitly
+    select the [`orchard::note::NoteVersion`] used to construct an Orchard
+    output.
+
 ## [0.27.0] - 2026-04-23
 
 ### Added

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -572,8 +572,8 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
     }
 
     /// Adds an Orchard recipient to the transaction.
-    /// Defaults to the note version that is standard in the current protocol;
-    /// this default may change across wallet SDK updates as the protocol evolves.
+    ///
+    /// This uses [`orchard::note::DEFAULT_NOTE_VERSION`].
     pub fn add_orchard_output<FE>(
         &mut self,
         ovk: Option<orchard::keys::OutgoingViewingKey>,
@@ -586,12 +586,12 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
             recipient,
             value,
             memo,
-            orchard::note::NoteVersion::V2,
+            orchard::note::DEFAULT_NOTE_VERSION,
         )
     }
 
-    /// Adds an Orchard recipient to the transaction,
-    /// using the specified note version for rcm derivation.
+    /// Adds an Orchard recipient to the transaction, using the specified note
+    /// plaintext version.
     pub fn add_versioned_orchard_output<FE>(
         &mut self,
         ovk: Option<orchard::keys::OutgoingViewingKey>,

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -573,7 +573,7 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
 
     /// Adds an Orchard recipient to the transaction.
     ///
-    /// This uses [`orchard::note::DEFAULT_NOTE_VERSION`].
+    /// This uses [`orchard::note::NoteVersion::DEFAULT`].
     pub fn add_orchard_output<FE>(
         &mut self,
         ovk: Option<orchard::keys::OutgoingViewingKey>,
@@ -586,7 +586,7 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
             recipient,
             value,
             memo,
-            orchard::note::DEFAULT_NOTE_VERSION,
+            orchard::note::NoteVersion::DEFAULT,
         )
     }
 
@@ -603,7 +603,7 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
         self.orchard_builder
             .as_mut()
             .ok_or(Error::OrchardBuilderNotAvailable)?
-            .add_versioned_output(
+            .add_output_with_version(
                 ovk,
                 recipient,
                 orchard::value::NoteValue::from_raw(value.into()),

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -572,6 +572,8 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
     }
 
     /// Adds an Orchard recipient to the transaction.
+    /// Defaults to the note version that is standard in the current protocol;
+    /// this default may change across wallet SDK updates as the protocol evolves.
     pub fn add_orchard_output<FE>(
         &mut self,
         ovk: Option<orchard::keys::OutgoingViewingKey>,
@@ -579,14 +581,34 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
         value: Zatoshis,
         memo: MemoBytes,
     ) -> Result<(), Error<FE>> {
+        self.add_versioned_orchard_output(
+            ovk,
+            recipient,
+            value,
+            memo,
+            orchard::note::NoteVersion::V2,
+        )
+    }
+
+    /// Adds an Orchard recipient to the transaction,
+    /// using the specified note version for rcm derivation.
+    pub fn add_versioned_orchard_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+        note_version: orchard::note::NoteVersion,
+    ) -> Result<(), Error<FE>> {
         self.orchard_builder
             .as_mut()
             .ok_or(Error::OrchardBuilderNotAvailable)?
-            .add_output(
+            .add_versioned_output(
                 ovk,
                 recipient,
                 orchard::value::NoteValue::from_raw(value.into()),
                 memo.into_bytes(),
+                note_version,
             )
             .map_err(Error::OrchardRecipient)
     }

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -80,6 +80,14 @@ pub enum TxVersion {
     /// It is specified in [§ 7.1 Transaction Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#txnencoding)
     /// and [ZIP 225](https://zips.z.cash/zip-0225).
     V5,
+    /// Transaction version 5, with Orchard change outputs constructed as QR notes.
+    ///
+    /// This is serialized identically to [`TxVersion::V5`]. It exists as a builder-level selector
+    /// for wallets that want to opt into QR Orchard change notes while remaining compatible with the
+    /// current v5 transaction format. For now this only affects change notes; a future upgrade may
+    /// also use this selector for QR sends.
+    #[allow(non_camel_case_types)]
+    V5_Qr,
     /// Transaction version 6, specified in [ZIP 230](https://zips.z.cash/zip-0230).
     #[cfg(zcash_unstable = "nu7")]
     V6,
@@ -134,7 +142,7 @@ impl TxVersion {
                 TxVersion::Sprout(v) => *v,
                 TxVersion::V3 => V3_TX_VERSION,
                 TxVersion::V4 => V4_TX_VERSION,
-                TxVersion::V5 => V5_TX_VERSION,
+                TxVersion::V5 | TxVersion::V5_Qr => V5_TX_VERSION,
                 #[cfg(zcash_unstable = "nu7")]
                 TxVersion::V6 => V6_TX_VERSION,
                 #[cfg(zcash_unstable = "zfuture")]
@@ -147,7 +155,7 @@ impl TxVersion {
             TxVersion::Sprout(_) => 0,
             TxVersion::V3 => V3_VERSION_GROUP_ID,
             TxVersion::V4 => V4_VERSION_GROUP_ID,
-            TxVersion::V5 => V5_VERSION_GROUP_ID,
+            TxVersion::V5 | TxVersion::V5_Qr => V5_VERSION_GROUP_ID,
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => V6_VERSION_GROUP_ID,
             #[cfg(zcash_unstable = "zfuture")]
@@ -168,7 +176,7 @@ impl TxVersion {
         match self {
             TxVersion::Sprout(v) => *v >= 2u32,
             TxVersion::V3 | TxVersion::V4 => true,
-            TxVersion::V5 => false,
+            TxVersion::V5 | TxVersion::V5_Qr => false,
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => false,
             #[cfg(zcash_unstable = "zfuture")]
@@ -185,7 +193,7 @@ impl TxVersion {
         match self {
             TxVersion::Sprout(_) | TxVersion::V3 => false,
             TxVersion::V4 => true,
-            TxVersion::V5 => true,
+            TxVersion::V5 | TxVersion::V5_Qr => true,
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => true,
             #[cfg(zcash_unstable = "zfuture")]
@@ -197,7 +205,7 @@ impl TxVersion {
     pub fn has_orchard(&self) -> bool {
         match self {
             TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => false,
-            TxVersion::V5 => true,
+            TxVersion::V5 | TxVersion::V5_Qr => true,
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => true,
             #[cfg(zcash_unstable = "zfuture")]
@@ -211,7 +219,11 @@ impl TxVersion {
     ))]
     pub fn has_zip233(&self) -> bool {
         match self {
-            TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => false,
+            TxVersion::Sprout(_)
+            | TxVersion::V3
+            | TxVersion::V4
+            | TxVersion::V5
+            | TxVersion::V5_Qr => false,
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => true,
             #[cfg(zcash_unstable = "zfuture")]
@@ -259,7 +271,7 @@ impl TxVersion {
                 #[cfg(zcash_unstable = "zfuture")]
                 ZFuture => false, // ZIP 2003
             },
-            TxVersion::V5 => match consensus_branch_id {
+            TxVersion::V5 | TxVersion::V5_Qr => match consensus_branch_id {
                 Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy => false,
                 Nu5 | Nu6 | Nu6_1 => true,
                 #[cfg(zcash_unstable = "nu7")]
@@ -765,7 +777,7 @@ impl Transaction {
     fn from_data(data: TransactionData<Authorized>) -> io::Result<Self> {
         match data.version {
             TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => Self::from_data_v4(data),
-            TxVersion::V5 => Ok(Self::from_data_v5(data)),
+            TxVersion::V5 | TxVersion::V5_Qr => Ok(Self::from_data_v5(data)),
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => Ok(Self::from_data_v6(data)),
             #[cfg(zcash_unstable = "zfuture")]
@@ -821,7 +833,7 @@ impl Transaction {
             TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => {
                 Self::read_v4(reader, version, consensus_branch_id)
             }
-            TxVersion::V5 => Self::read_v5(reader.into_base_reader(), version),
+            TxVersion::V5 | TxVersion::V5_Qr => Self::read_v5(reader.into_base_reader(), version),
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => Self::read_v6(reader.into_base_reader(), version),
             #[cfg(zcash_unstable = "zfuture")]
@@ -1071,7 +1083,7 @@ impl Transaction {
     pub fn write<W: Write>(&self, writer: W) -> io::Result<()> {
         match self.version {
             TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => self.write_v4(writer),
-            TxVersion::V5 => self.write_v5(writer),
+            TxVersion::V5 | TxVersion::V5_Qr => self.write_v5(writer),
             #[cfg(zcash_unstable = "nu7")]
             TxVersion::V6 => self.write_v6(writer),
             #[cfg(zcash_unstable = "zfuture")]

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -80,12 +80,18 @@ pub enum TxVersion {
     /// It is specified in [§ 7.1 Transaction Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#txnencoding)
     /// and [ZIP 225](https://zips.z.cash/zip-0225).
     V5,
-    /// Transaction version 5, with Orchard change outputs constructed as QR notes.
+    /// Transaction version 5, with Orchard change outputs constructed as
+    /// quantum recoverable notes.
     ///
-    /// This is serialized identically to [`TxVersion::V5`]. It exists as a builder-level selector
-    /// for wallets that want to opt into QR Orchard change notes while remaining compatible with the
-    /// current v5 transaction format. For now this only affects change notes; a future upgrade may
-    /// also use this selector for QR sends.
+    /// This is serialized identically to [`TxVersion::V5`]. It exists as a
+    /// builder-level selector for wallets that want to opt into quantum
+    /// recoverable Orchard change notes while remaining compatible with the
+    /// current v5 transaction format. For now this only affects change notes; a
+    /// future librustzcash upgrade may also use this selector for quantum
+    /// recoverable sends.
+    ///
+    /// Wallet APIs that accept this selector are exposed behind their
+    /// `unstable` feature flag.
     #[allow(non_camel_case_types)]
     V5_Qr,
     /// Transaction version 6, specified in [ZIP 230](https://zips.z.cash/zip-0230).

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -60,7 +60,7 @@ pub fn signature_hash<
             v4_signature_hash(tx, signable_input)
         }
 
-        TxVersion::V5 => v5_signature_hash(tx, signable_input, txid_parts),
+        TxVersion::V5 | TxVersion::V5_Qr => v5_signature_hash(tx, signable_input, txid_parts),
 
         #[cfg(zcash_unstable = "nu7")]
         TxVersion::V6 => v6_signature_hash(tx, signable_input, txid_parts),

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -3,9 +3,9 @@ use proptest::prelude::*;
 #[cfg(test)]
 use {
     crate::transaction::{
-        Authorization, Transaction, TransactionData, TxDigests, TxIn, sighash::SignableInput,
-        sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash, testing::arb_tx, transparent,
-        txid::TxIdDigester,
+        Authorization, Transaction, TransactionData, TxDigests, TxIn, TxVersion,
+        sighash::SignableInput, sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash,
+        testing::arb_tx, transparent, txid::TxIdDigester,
     },
     ::transparent::{
         address::Script, sighash::SighashType, sighash::TransparentAuthorizingContext,
@@ -38,6 +38,22 @@ fn tx_read_write() {
     let mut encoded = Vec::with_capacity(data.len());
     tx.write(&mut encoded).unwrap();
     assert_eq!(&data[..], &encoded[..]);
+}
+
+#[test]
+fn suggested_version_for_v5_branches_is_not_qr() {
+    assert_eq!(
+        TxVersion::suggested_for_branch(BranchId::Nu5),
+        TxVersion::V5
+    );
+    assert_eq!(
+        TxVersion::suggested_for_branch(BranchId::Nu6),
+        TxVersion::V5
+    );
+    assert_eq!(
+        TxVersion::suggested_for_branch(BranchId::Nu6_1),
+        TxVersion::V5
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- persist Orchard note plaintext versions in the wallet SQLite schema
- use the persisted version when reconstructing Orchard notes for spending
- preserve PCZT Orchard output note versions when storing finalized transactions

## Base note
This branch is currently based on the QR transaction selector work in [zcash/librustzcash#2345](https://github.com/zcash/librustzcash/pull/2345), so the draft diff includes that prerequisite work. Once that PR is merged, this branch can be rebased onto `main` and the diff should shrink to the Orchard note-version persistence changes.

## Validation
- `cargo fmt --check`
- `cargo test -p zcash_client_backend --features "pczt orchard" pczt_orchard_note_reconstruction_preserves_note_version`
- `cargo test -p zcash_client_backend --features "pczt orchard" --no-run`
- `cargo test -p zcash_client_backend --features pczt --no-run`
- `cargo test -p zcash_client_sqlite --features orchard orchard_note_version_storage_codes_roundtrip`
- `cargo test -p zcash_client_sqlite --features orchard persisted_orchard_note_version_controls_reconstruction`
- `cargo test -p zcash_client_sqlite --features orchard wallet::init::migrations::orchard_note_versions::tests::migrate`
- `cargo test -p zcash_client_sqlite --features orchard wallet::init::tests::verify_schema`
- `cargo test -p zcash_client_sqlite --features orchard wallet::init::migrations::tests::migrate_between_releases_without_data`
- `cargo test -p zcash_client_sqlite --features "orchard pczt-tests transparent-inputs" pczt_single_step_orchard_only`
- `cargo test -p zcash_client_sqlite --features orchard --no-run`