### PR TITLE
zcash_client_backend: propagate compact-block decoding errors from scan_block

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,14 @@ workspace.
 ## [0.23.0] - PLANNED
 
 ### Added
+- `zcash_client_backend::scanning::ScanError` variants:
+  - `BlockEncodingInvalid`: a block-level compact-format field (block hash,
+    parent hash, or height) could not be decoded from its protobuf
+    representation.
+  - `TxEncodingInvalid`: a transaction-level compact-format field
+    (transaction id, block-relative index, or nullifier) could not be decoded.
+- `zcash_client_backend::proto::CompactFormatError::OutOfRange` for numeric
+  fields whose values exceed their target type's range.
 - `zcash_client_backend::data_api::error::RewindError`
 - `zcash_client_backend::wallet::WalletTransparentOutput`:
   - `recipient_account`
@@ -35,6 +43,18 @@ workspace.
   instead of a `ChangeStrategy`.
 
 ### Changed
+- `zcash_client_backend::proto::compact_formats` accessors no longer panic on
+  malformed inputs; they now return `Result<_, CompactFormatError>` so that
+  `scan_block` can surface decoding failures via `ScanError` rather than
+  aborting the process. Affected methods:
+  - `CompactBlock::hash`, `CompactBlock::prev_hash`, `CompactBlock::height`
+  - `CompactTx::txid`
+  Internally, `CompactSaplingOutput::cmu` also no longer panics on a non-32
+  byte input; its (already `Result`-typed) signature is unchanged.
+- `zcash_client_backend::scanning::ScanError::at_height` now returns
+  `Option<BlockHeight>`. It returns `None` only when the height field of the
+  block itself failed to decode (the new `BlockEncodingInvalid` variant);
+  every other variant returns `Some(_)`.
 - `zcash_client_backend::data_api`:
   - Changes to the `InputSource` trait:
     - The result types of `InputSource::get_unspent_transparent_output` and

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -89,8 +89,9 @@
 //!                     // Pick a height to rewind to, which must be at least one block before
 //!                     // the height at which the error occurred, but may be an earlier height
 //!                     // determined based on heuristics such as the platform, available bandwidth,
-//!                     // size of recent CompactBlocks, etc.
-//!                     let rewind_height = err.at_height().saturating_sub(10);
+//!                     // size of recent CompactBlocks, etc. Continuity errors always carry a
+//!                     // height, so `err.at_height()` is `Some(_)` here.
+//!                     let rewind_height = err.at_height().expect("continuity errors carry a height").saturating_sub(10);
 //!
 //!                     // Rewind to the chosen height.
 //!                     wallet_db.truncate_to_height(rewind_height).map_err(Error::Wallet)?;
@@ -162,7 +163,7 @@ use crate::{
     data_api::WalletWrite,
     proto::compact_formats::CompactBlock,
     scanning::{
-        Nullifiers, ScanningKeys,
+        Nullifiers, ScanError, ScanningKeys,
         compact::{BatchRunners, scan_block_with_runners},
     },
 };
@@ -628,7 +629,14 @@ where
         Some(from_height),
         Some(limit),
         |block: CompactBlock| {
-            scan_summary.scanned_range.end = block.height() + 1;
+            let block_height =
+                block
+                    .height()
+                    .map_err(|error| ScanError::BlockEncodingInvalid {
+                        at_height: None,
+                        error,
+                    })?;
+            scan_summary.scanned_range.end = block_height + 1;
             let scanned_block = scan_block_with_runners::<_, _, _, (), ()>(
                 params,
                 block,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -303,7 +303,7 @@ impl CachedBlock {
     }
 
     fn roll_forward(&self, cb: &CompactBlock) -> Self {
-        assert_eq!(self.chain_state.block_height() + 1, cb.height());
+        assert_eq!(self.chain_state.block_height() + 1, cb.height().unwrap());
 
         let sapling_final_tree = cb.vtx.iter().flat_map(|tx| tx.outputs.iter()).fold(
             self.chain_state.final_sapling_tree().clone(),
@@ -331,8 +331,8 @@ impl CachedBlock {
 
         Self {
             chain_state: ChainState::new(
-                cb.height(),
-                cb.hash(),
+                cb.height().unwrap(),
+                cb.hash().unwrap(),
                 sapling_final_tree,
                 #[cfg(feature = "orchard")]
                 orchard_final_tree,
@@ -548,7 +548,7 @@ where
         compact_block: CompactBlock,
     ) -> Cache::InsertResult {
         self.cached_blocks.insert(
-            compact_block.height(),
+            compact_block.height().unwrap(),
             prev_block.roll_forward(&compact_block),
         );
         self.cache.insert(&compact_block)
@@ -707,7 +707,7 @@ where
             initial_orchard_tree_size,
             &mut self.rng,
         );
-        assert_eq!(cb.height(), height);
+        assert_eq!(cb.height().unwrap(), height);
 
         let res = self.cache_block(&prior_cached_block, cb);
         self.latest_block_height = Some(height);
@@ -742,7 +742,7 @@ where
             prior_cached_block.orchard_end_size,
             &mut self.rng,
         );
-        assert_eq!(cb.height(), height);
+        assert_eq!(cb.height().unwrap(), height);
 
         let res = self.cache_block(&prior_cached_block, cb);
         self.latest_block_height = Some(height);
@@ -796,7 +796,7 @@ where
             prior_cached_block.orchard_end_size,
             &mut self.rng,
         );
-        assert_eq!(cb.height(), height);
+        assert_eq!(cb.height().unwrap(), height);
 
         let res = self.cache_block(&prior_cached_block, cb);
         self.latest_block_height = Some(height);

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -58,40 +58,41 @@ pub mod service;
 impl compact_formats::CompactBlock {
     /// Returns the [`BlockHash`] for this block.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if [`field@Self::header`] is not set and
-    /// [`field@Self::hash`] is not exactly 32 bytes.
-    pub fn hash(&self) -> BlockHash {
+    /// Returns an error if [`field@Self::header`] is not set and [`field@Self::hash`] is not
+    /// exactly 32 bytes.
+    pub fn hash(&self) -> Result<BlockHash, CompactFormatError> {
         if let Some(header) = self.header() {
-            header.hash()
+            Ok(header.hash())
         } else {
-            BlockHash::from_slice(&self.hash)
+            let bytes: [u8; 32] = self.hash[..]
+                .try_into()
+                .map_err(CompactFormatError::InvalidLength)?;
+            Ok(BlockHash(bytes))
         }
     }
 
     /// Returns the [`BlockHash`] for this block's parent.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if [`field@Self::header`] is not set and
-    /// [`field@Self::prev_hash`] is not exactly 32 bytes.
-    pub fn prev_hash(&self) -> BlockHash {
+    /// Returns an error if [`field@Self::header`] is not set and [`field@Self::prev_hash`] is
+    /// not exactly 32 bytes.
+    pub fn prev_hash(&self) -> Result<BlockHash, CompactFormatError> {
         if let Some(header) = self.header() {
-            header.prev_block
+            Ok(header.prev_block)
         } else {
-            BlockHash::from_slice(&self.prev_hash)
+            let bytes: [u8; 32] = self.prev_hash[..]
+                .try_into()
+                .map_err(CompactFormatError::InvalidLength)?;
+            Ok(BlockHash(bytes))
         }
     }
 
     /// Returns the [`BlockHeight`] value for this block
     ///
-    /// # Panics
-    ///
-    /// This function will panic if [`field@Self::height`] is not representable within a
-    /// `u32`.
-    pub fn height(&self) -> BlockHeight {
-        self.height.try_into().unwrap()
+    /// Returns an error if [`field@Self::height`] is not representable within a `u32`.
+    pub fn height(&self) -> Result<BlockHeight, CompactFormatError> {
+        self.height
+            .try_into()
+            .map_err(|_| CompactFormatError::OutOfRange)
     }
 
     /// Returns the [`BlockHeader`] for this block if present.
@@ -107,11 +108,14 @@ impl compact_formats::CompactBlock {
 }
 
 impl compact_formats::CompactTx {
-    /// Returns the transaction Id
-    pub fn txid(&self) -> TxId {
-        let mut txid_bytes = [0u8; 32];
-        txid_bytes.copy_from_slice(&self.txid);
-        TxId::from_bytes(txid_bytes)
+    /// Returns the transaction Id.
+    ///
+    /// Returns an error if [`field@Self::txid`] is not exactly 32 bytes.
+    pub fn txid(&self) -> Result<TxId, CompactFormatError> {
+        let txid_bytes: [u8; 32] = self.txid[..]
+            .try_into()
+            .map_err(CompactFormatError::InvalidLength)?;
+        Ok(TxId::from_bytes(txid_bytes))
     }
 }
 
@@ -122,6 +126,8 @@ pub enum CompactFormatError {
     InvalidLength(TryFromSliceError),
     /// A field value did not represent a valid protocol element.
     InvalidValue,
+    /// A numeric field had a value out of range for the expected target type.
+    OutOfRange,
 }
 
 impl Display for CompactFormatError {
@@ -130,6 +136,12 @@ impl Display for CompactFormatError {
             CompactFormatError::InvalidLength(e) => write!(f, "Invalid compact format field: {e}"),
             CompactFormatError::InvalidValue => {
                 write!(f, "Compact format field is not a valid protocol element")
+            }
+            CompactFormatError::OutOfRange => {
+                write!(
+                    f,
+                    "Compact format field value is out of range for its target type"
+                )
             }
         }
     }
@@ -140,8 +152,9 @@ impl compact_formats::CompactSaplingOutput {
     ///
     /// A convenience method that parses [`field@Self::cmu`].
     pub fn cmu(&self) -> Result<ExtractedNoteCommitment, CompactFormatError> {
-        let mut repr = [0; 32];
-        repr.copy_from_slice(&self.cmu[..]);
+        let repr: [u8; 32] = self.cmu[..]
+            .try_into()
+            .map_err(CompactFormatError::InvalidLength)?;
         Option::from(ExtractedNoteCommitment::from_bytes(&repr))
             .ok_or(CompactFormatError::InvalidValue)
     }

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -20,7 +20,7 @@ use zip32::Scope;
 
 use crate::{
     data_api::{BlockMetadata, NullifierQuery, ScannedBlock, WalletRead},
-    proto::compact_formats::CompactBlock,
+    proto::{CompactFormatError, compact_formats::CompactBlock},
     scan::DecryptedOutput,
     wallet::WalletOutput,
 };
@@ -475,6 +475,24 @@ pub enum ScanError {
         index: usize,
     },
 
+    /// A block-level compact-format field (block hash, parent hash, or height) could not be
+    /// decoded from its protobuf representation.
+    BlockEncodingInvalid {
+        /// The block's height, if it was decodable. `None` indicates that decoding the height
+        /// itself was the failure.
+        at_height: Option<BlockHeight>,
+        error: CompactFormatError,
+    },
+
+    /// A transaction-level compact-format field (transaction id, block-relative index, or
+    /// nullifier) could not be decoded from its protobuf representation.
+    TxEncodingInvalid {
+        at_height: BlockHeight,
+        /// The 0-based position of the transaction within `block.vtx`.
+        block_index: usize,
+        error: CompactFormatError,
+    },
+
     /// The hash of the parent block given by a proposed new chain tip does not match the hash of
     /// the current chain tip.
     PrevHashMismatch { at_height: BlockHeight },
@@ -518,6 +536,8 @@ impl ScanError {
         use ScanError::*;
         match self {
             EncodingInvalid { .. } => false,
+            BlockEncodingInvalid { .. } => false,
+            TxEncodingInvalid { .. } => false,
             PrevHashMismatch { .. } => true,
             BlockHeightDiscontinuity { .. } => true,
             TreeSizeMismatch { .. } => true,
@@ -526,16 +546,21 @@ impl ScanError {
         }
     }
 
-    /// Returns the block height at which the scan error occurred
-    pub fn at_height(&self) -> BlockHeight {
+    /// Returns the block height at which the scan error occurred, if known.
+    ///
+    /// Returns `None` only for [`ScanError::BlockEncodingInvalid`] when the height field of the
+    /// block itself failed to decode.
+    pub fn at_height(&self) -> Option<BlockHeight> {
         use ScanError::*;
         match self {
-            EncodingInvalid { at_height, .. } => *at_height,
-            PrevHashMismatch { at_height } => *at_height,
-            BlockHeightDiscontinuity { new_height, .. } => *new_height,
-            TreeSizeMismatch { at_height, .. } => *at_height,
-            TreeSizeUnknown { at_height, .. } => *at_height,
-            TreeSizeInvalid { at_height, .. } => *at_height,
+            EncodingInvalid { at_height, .. } => Some(*at_height),
+            BlockEncodingInvalid { at_height, .. } => *at_height,
+            TxEncodingInvalid { at_height, .. } => Some(*at_height),
+            PrevHashMismatch { at_height } => Some(*at_height),
+            BlockHeightDiscontinuity { new_height, .. } => Some(*new_height),
+            TreeSizeMismatch { at_height, .. } => Some(*at_height),
+            TreeSizeUnknown { at_height, .. } => Some(*at_height),
+            TreeSizeInvalid { at_height, .. } => Some(*at_height),
         }
     }
 }
@@ -552,6 +577,24 @@ impl fmt::Display for ScanError {
             } => write!(
                 f,
                 "{pool_type:?} output {index} of transaction {txid} was improperly encoded."
+            ),
+            BlockEncodingInvalid { at_height, error } => match at_height {
+                Some(h) => write!(
+                    f,
+                    "Block-level field of compact block at height {h} was improperly encoded: {error}"
+                ),
+                None => write!(
+                    f,
+                    "Block-level field of compact block (height not decodable) was improperly encoded: {error}"
+                ),
+            },
+            TxEncodingInvalid {
+                at_height,
+                block_index,
+                error,
+            } => write!(
+                f,
+                "Transaction at block-index {block_index} in compact block at height {at_height} was improperly encoded: {error}"
             ),
             PrevHashMismatch { at_height } => write!(
                 f,

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -17,7 +17,10 @@ use zcash_protocol::{
 use super::{Nullifiers, PositionTracker, ScanError, ScanningKeys, find_received, find_spent};
 use crate::{
     data_api::{BlockMetadata, ScannedBlock, ScannedBundles},
-    proto::compact_formats::{ChainMetadata, CompactBlock, CompactTx},
+    proto::{
+        CompactFormatError,
+        compact_formats::{ChainMetadata, CompactBlock, CompactTx},
+    },
     scan::{Batch, BatchRunner, CompactDecryptor, Tasks},
     wallet::{WalletSpend, WalletTx},
 };
@@ -121,12 +124,25 @@ where
         P: consensus::Parameters + Send + 'static,
         IvkTag: Copy + Send + 'static,
     {
-        let block_hash = block.hash();
-        let block_height = block.height();
+        let block_height =
+            block
+                .height()
+                .map_err(|error| ScanError::BlockEncodingInvalid {
+                    at_height: None,
+                    error,
+                })?;
+        let block_hash = block.hash().map_err(|error| ScanError::BlockEncodingInvalid {
+            at_height: Some(block_height),
+            error,
+        })?;
         let zip212_enforcement = zip212_enforcement(params, block_height);
 
-        for tx in block.vtx.into_iter() {
-            let txid = tx.txid();
+        for (block_index, tx) in block.vtx.into_iter().enumerate() {
+            let txid = tx.txid().map_err(|error| ScanError::TxEncodingInvalid {
+                at_height: block_height,
+                block_index,
+                error,
+            })?;
 
             self.sapling.add_outputs(
                 block_hash,
@@ -188,45 +204,65 @@ where
     TS: SaplingTasks<IvkTag> + Sync,
     TO: OrchardTasks<IvkTag> + Sync,
 {
+    // Decode block-level fields up front so that any malformed field surfaces as a
+    // `BlockEncodingInvalid` error rather than panicking deeper in the scanner.
+    let cur_height = block
+        .height()
+        .map_err(|error| ScanError::BlockEncodingInvalid {
+            at_height: None,
+            error,
+        })?;
+    let cur_hash = block.hash().map_err(|error| ScanError::BlockEncodingInvalid {
+        at_height: Some(cur_height),
+        error,
+    })?;
+
     fn check_hash_continuity(
         block: &CompactBlock,
+        cur_height: BlockHeight,
         prior_block_metadata: Option<&BlockMetadata>,
-    ) -> Option<ScanError> {
+    ) -> Result<Option<ScanError>, ScanError> {
         if let Some(prev) = prior_block_metadata {
-            if block.height() != prev.block_height() + 1 {
+            if cur_height != prev.block_height() + 1 {
                 debug!(
                     "Block height discontinuity at {:?}, previous was {:?} ",
-                    block.height(),
+                    cur_height,
                     prev.block_height()
                 );
-                return Some(ScanError::BlockHeightDiscontinuity {
+                return Ok(Some(ScanError::BlockHeightDiscontinuity {
                     prev_height: prev.block_height(),
-                    new_height: block.height(),
-                });
+                    new_height: cur_height,
+                }));
             }
 
-            if block.prev_hash() != prev.block_hash() {
-                debug!("Block hash discontinuity at {:?}", block.height());
-                return Some(ScanError::PrevHashMismatch {
-                    at_height: block.height(),
-                });
+            let prev_hash =
+                block
+                    .prev_hash()
+                    .map_err(|error| ScanError::BlockEncodingInvalid {
+                        at_height: Some(cur_height),
+                        error,
+                    })?;
+            if prev_hash != prev.block_hash() {
+                debug!("Block hash discontinuity at {:?}", cur_height);
+                return Ok(Some(ScanError::PrevHashMismatch {
+                    at_height: cur_height,
+                }));
             }
         }
 
-        None
+        Ok(None)
     }
 
-    if let Some(scan_error) = check_hash_continuity(&block, prior_block_metadata) {
+    if let Some(scan_error) = check_hash_continuity(&block, cur_height, prior_block_metadata)? {
         return Err(scan_error);
     }
 
-    trace!("Block continuity okay at {:?}", block.height());
+    trace!("Block continuity okay at {:?}", cur_height);
 
-    let cur_height = block.height();
-    let cur_hash = block.hash();
     let zip212_enforcement = zip212_enforcement(params, cur_height);
 
-    let mut pos_tracker = PositionTracker::for_compact_block(params, &block, prior_block_metadata)?;
+    let mut pos_tracker =
+        PositionTracker::for_compact_block(params, &block, cur_height, prior_block_metadata)?;
 
     let mut wtxs: Vec<WalletTx<AccountId>> = vec![];
 
@@ -238,19 +274,34 @@ where
     #[cfg(feature = "orchard")]
     let mut orchard_note_commitments: Vec<(MerkleHashOrchard, Retention<BlockHeight>)> = vec![];
 
-    for tx in block.vtx.into_iter() {
-        let txid = tx.txid();
+    for (block_index, tx) in block.vtx.into_iter().enumerate() {
+        let txid = tx.txid().map_err(|error| ScanError::TxEncodingInvalid {
+            at_height: cur_height,
+            block_index,
+            error,
+        })?;
         let tx_index =
-            TxIndex::try_from(tx.index).expect("Cannot fit more than 2^16 transactions in a block");
+            TxIndex::try_from(tx.index).map_err(|_| ScanError::TxEncodingInvalid {
+                at_height: cur_height,
+                block_index,
+                error: CompactFormatError::OutOfRange,
+            })?;
 
+        let sapling_spend_nfs: Vec<sapling::Nullifier> = tx
+            .spends
+            .iter()
+            .map(|spend| {
+                spend.nf().map_err(|error| ScanError::TxEncodingInvalid {
+                    at_height: cur_height,
+                    block_index,
+                    error,
+                })
+            })
+            .collect::<Result<_, _>>()?;
         let (sapling_spends, sapling_unlinked_nullifiers) = find_spent(
-            &tx.spends,
+            &sapling_spend_nfs,
             &nullifiers.sapling,
-            |spend| {
-                spend.nf().expect(
-                    "Could not deserialize nullifier for spend from protobuf representation.",
-                )
-            },
+            |&nf| nf,
             WalletSpend::from_parts,
         );
 
@@ -258,14 +309,23 @@ where
 
         #[cfg(feature = "orchard")]
         let orchard_spends = {
+            let orchard_spend_nfs: Vec<orchard::note::Nullifier> = tx
+                .actions
+                .iter()
+                .map(|action| {
+                    action
+                        .nf()
+                        .map_err(|error| ScanError::TxEncodingInvalid {
+                            at_height: cur_height,
+                            block_index,
+                            error,
+                        })
+                })
+                .collect::<Result<_, _>>()?;
             let (orchard_spends, orchard_unlinked_nullifiers) = find_spent(
-                &tx.actions,
+                &orchard_spend_nfs,
                 &nullifiers.orchard,
-                |spend| {
-                    spend.nf().expect(
-                        "Could not deserialize nullifier for spend from protobuf representation.",
-                    )
-                },
+                |&nf| nf,
                 WalletSpend::from_parts,
             );
             orchard_nullifier_map.push((tx_index, txid, orchard_unlinked_nullifiers));
@@ -400,6 +460,7 @@ impl PositionTracker {
     fn for_compact_block<P>(
         params: &P,
         block: &CompactBlock,
+        at_height: BlockHeight,
         prior_block_metadata: Option<&BlockMetadata>,
     ) -> Result<Self, ScanError>
     where
@@ -411,6 +472,7 @@ impl PositionTracker {
         fn tree_sizes_around<P>(
             params: &P,
             block: &CompactBlock,
+            at_height: BlockHeight,
             prior_block_metadata: Option<&BlockMetadata>,
             protocol: ShieldedProtocol,
             activation_nu: NetworkUpgrade,
@@ -421,7 +483,6 @@ impl PositionTracker {
         where
             P: consensus::Parameters,
         {
-            let at_height = block.height();
 
             let start_tree_size = prior_block_metadata.and_then(prior_tree_size).map_or_else(
                 || {
@@ -485,6 +546,7 @@ impl PositionTracker {
         let (sapling_prior_tree_size, sapling_final_tree_size) = tree_sizes_around(
             params,
             block,
+            at_height,
             prior_block_metadata,
             ShieldedProtocol::Sapling,
             NetworkUpgrade::Sapling,
@@ -497,6 +559,7 @@ impl PositionTracker {
         let (orchard_prior_tree_size, orchard_final_tree_size) = tree_sizes_around(
             params,
             block,
+            at_height,
             prior_block_metadata,
             ShieldedProtocol::Orchard,
             NetworkUpgrade::Nu5,
@@ -810,6 +873,308 @@ mod tests {
                     marking: Marking::None
                 }
             ]
+        );
+    }
+
+    // Regression tests for GHSA-cx5g-7x2r-g5vc. Each test constructs a `CompactBlock` whose
+    // protobuf representation satisfies `compact_formats.proto` but encodes a field that
+    // previously triggered an unrecoverable panic inside `scan_block`. The expected behavior is
+    // that `scan_block` now returns the appropriate `ScanError::{Block,Tx,}EncodingInvalid` (or
+    // `EncodingInvalid` for output-level defects) variant.
+
+    use crate::{
+        proto::compact_formats::{
+            ChainMetadata as ProtoChainMetadata, CompactBlock as ProtoCompactBlock,
+            CompactSaplingOutput as ProtoCompactSaplingOutput,
+            CompactSaplingSpend as ProtoCompactSaplingSpend, CompactTx as ProtoCompactTx,
+        },
+        scanning::ScanError,
+    };
+
+    #[cfg(feature = "orchard")]
+    use crate::proto::compact_formats::CompactOrchardAction as ProtoCompactOrchardAction;
+
+    fn poc_well_formed_block() -> ProtoCompactBlock {
+        ProtoCompactBlock {
+            proto_version: 1,
+            height: 1,
+            hash: vec![1u8; 32],
+            prev_hash: vec![0u8; 32],
+            chain_metadata: Some(ProtoChainMetadata {
+                sapling_commitment_tree_size: 0,
+                orchard_commitment_tree_size: 0,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn poc_no_panic_on_tx_index_overflowing_u16() {
+        // Finding 01(a): tx.index is uint64 in protobuf but TxIndex is u16. A hostile
+        // lightwalletd that sends index >= 65536 used to panic the wallet at compact.rs:244.
+        let mut block = poc_well_formed_block();
+        block.vtx.push(ProtoCompactTx {
+            index: 65_536,
+            txid: vec![2u8; 32],
+            ..Default::default()
+        });
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            None,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ScanError::TxEncodingInvalid {
+                    block_index: 0,
+                    ..
+                })
+            ),
+            "expected TxEncodingInvalid at block_index 0",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_sapling_nf_wrong_length() {
+        // Finding 01(b): CompactSaplingSpend.nf is `bytes` in protobuf with no length
+        // constraint, but compact.rs:250 unwrapped the conversion to a 32-byte sapling::Nullifier
+        // and panicked on any other length.
+        let mut block = poc_well_formed_block();
+        let mut tx = ProtoCompactTx {
+            index: 0,
+            txid: vec![2u8; 32],
+            ..Default::default()
+        };
+        tx.spends.push(ProtoCompactSaplingSpend {
+            nf: vec![0u8; 31],
+        });
+        block.vtx.push(tx);
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            None,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ScanError::TxEncodingInvalid {
+                    block_index: 0,
+                    ..
+                })
+            ),
+            "expected TxEncodingInvalid at block_index 0",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_compact_block_hash_wrong_length() {
+        // Finding 01(g): CompactBlock.hash is bytes in protobuf with no length constraint.
+        // CompactBlock::hash() at proto.rs:65-70 called BlockHash::from_slice which panicked
+        // on a non-32-byte input.
+        let mut block = poc_well_formed_block();
+        block.hash = vec![0u8; 16];
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            None,
+        );
+        assert!(
+            matches!(result, Err(ScanError::BlockEncodingInvalid { .. })),
+            "expected BlockEncodingInvalid",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_compact_block_prev_hash_wrong_length() {
+        // Finding 01(h): CompactBlock.prev_hash is bytes in protobuf with no length constraint.
+        // CompactBlock::prev_hash() at proto.rs:79-84 called BlockHash::from_slice which panicked
+        // on a non-32-byte input. Reachable from check_hash_continuity when prior_block_metadata
+        // is Some.
+        let mut block = poc_well_formed_block();
+        block.height = 2;
+        block.prev_hash = vec![0u8; 16];
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let prior = BlockMetadata::from_parts(
+            BlockHeight::from(1),
+            BlockHash([0u8; 32]),
+            Some(0),
+            #[cfg(feature = "orchard")]
+            Some(0),
+        );
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            Some(&prior),
+        );
+        assert!(
+            matches!(result, Err(ScanError::BlockEncodingInvalid { .. })),
+            "expected BlockEncodingInvalid",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_compact_block_height_overflowing_u32() {
+        // Finding 01(d): CompactBlock.height is uint64 in protobuf. proto.rs:94 unwrapped the
+        // conversion to BlockHeight (a u32). A hostile lightwalletd could crash any wallet that
+        // called scan_block by setting height >= 2^32.
+        let mut block = poc_well_formed_block();
+        block.height = u64::from(u32::MAX) + 1;
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            None,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ScanError::BlockEncodingInvalid {
+                    at_height: None,
+                    ..
+                })
+            ),
+            "expected BlockEncodingInvalid with at_height=None",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_compact_tx_txid_wrong_length() {
+        // Finding 01(e): CompactTx.txid is bytes in protobuf with no length constraint.
+        // CompactTx::txid() at proto.rs:111-115 called copy_from_slice into a [0u8; 32] buffer,
+        // which panicked on any non-32 length input.
+        let mut block = poc_well_formed_block();
+        block.vtx.push(ProtoCompactTx {
+            index: 0,
+            txid: vec![0u8; 16],
+            ..Default::default()
+        });
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            None,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ScanError::TxEncodingInvalid {
+                    block_index: 0,
+                    ..
+                })
+            ),
+            "expected TxEncodingInvalid at block_index 0",
+        );
+    }
+
+    #[test]
+    fn poc_no_panic_on_compact_sapling_output_cmu_wrong_length() {
+        // Finding 01(f): CompactSaplingOutput::cmu() at proto.rs:142-147 called copy_from_slice
+        // into [0u8; 32] from `self.cmu`. Even though the function returns Result, the panic
+        // happened inside copy_from_slice on a length mismatch — the Result could never carry
+        // the InvalidLength signal because we panicked first. Reachable through find_received's
+        // CompactOutputDescription::try_from which calls value.cmu()?.
+        let mut block = poc_well_formed_block();
+        if let Some(meta) = block.chain_metadata.as_mut() {
+            meta.sapling_commitment_tree_size = 1;
+        }
+        let mut tx = ProtoCompactTx {
+            index: 0,
+            txid: vec![2u8; 32],
+            ..Default::default()
+        };
+        tx.outputs.push(ProtoCompactSaplingOutput {
+            cmu: vec![0u8; 16],
+            ephemeral_key: vec![0u8; 32],
+            ciphertext: vec![0u8; 52],
+        });
+        block.vtx.push(tx);
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let prior = BlockMetadata::from_parts(
+            BlockHeight::from(0),
+            BlockHash([0u8; 32]),
+            Some(0),
+            #[cfg(feature = "orchard")]
+            Some(0),
+        );
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            Some(&prior),
+        );
+        assert!(
+            matches!(result, Err(ScanError::EncodingInvalid { .. })),
+            "expected EncodingInvalid",
+        );
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn poc_no_panic_on_orchard_nf_wrong_length() {
+        // Finding 01(c): CompactOrchardAction.nullifier is `bytes` in protobuf with no length
+        // constraint. compact.rs:265 unwrapped the conversion to a 32-byte array. A 31-byte
+        // (or any non-32-byte) value panicked the wallet.
+        let mut block = poc_well_formed_block();
+        let mut tx = ProtoCompactTx {
+            index: 0,
+            txid: vec![2u8; 32],
+            ..Default::default()
+        };
+        tx.actions.push(ProtoCompactOrchardAction {
+            nullifier: vec![0u8; 31],
+            cmx: vec![0u8; 32],
+            ephemeral_key: vec![0u8; 32],
+            ciphertext: vec![0u8; 52],
+        });
+        block.vtx.push(tx);
+
+        let scanning_keys = ScanningKeys::<AccountId, Infallible>::empty();
+        let prior = BlockMetadata::from_parts(
+            BlockHeight::from(0),
+            BlockHash([0u8; 32]),
+            Some(0),
+            Some(0),
+        );
+        let result = scan_block(
+            &Network::TestNetwork,
+            block,
+            &scanning_keys,
+            &Nullifiers::empty(),
+            Some(&prior),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(ScanError::TxEncodingInvalid {
+                    block_index: 0,
+                    ..
+                })
+            ),
+            "expected TxEncodingInvalid at block_index 0",
         );
     }
 }

--- a/zcash_client_backend/src/sync.rs
+++ b/zcash_client_backend/src/sync.rs
@@ -405,12 +405,14 @@ where
             // Pick a height to rewind to, which must be at least one block before the
             // height at which the error occurred, but may be an earlier height determined
             // based on heuristics such as the platform, available bandwidth, size of
-            // recent CompactBlocks, etc.
-            let rewind_height = err.at_height().saturating_sub(10);
+            // recent CompactBlocks, etc. Continuity errors always carry a height.
+            let err_height = err
+                .at_height()
+                .expect("continuity errors always carry a height");
+            let rewind_height = err_height.saturating_sub(10);
             info!(
                 "Chain reorg detected at {}, rewinding to {}",
-                err.at_height(),
-                rewind_height,
+                err_height, rewind_height,
             );
 
             // Rewind to the chosen height.

--- a/zcash_client_memory/src/block_source.rs
+++ b/zcash_client_memory/src/block_source.rs
@@ -45,7 +45,7 @@ impl BlockSource for MemBlockCache {
             .iter()
             .filter(|(_, cb)| {
                 if let Some(from_height) = from_height {
-                    cb.height() >= from_height
+                    cb.height().map(|h| h >= from_height).unwrap_or(false)
                 } else {
                     true
                 }
@@ -70,7 +70,7 @@ impl BlockCache for MemBlockCache {
             let range = range.block_range();
             for h in (u32::from(range.start)..u32::from(range.end)).rev() {
                 if let Some(cb) = inner.get(&h.into()) {
-                    return Ok(Some(cb.height()));
+                    return Ok(cb.height().ok());
                 }
             }
         } else {
@@ -96,7 +96,9 @@ impl BlockCache for MemBlockCache {
     async fn insert(&self, compact_blocks: Vec<CompactBlock>) -> Result<(), Self::Error> {
         let mut inner = self.0.write().unwrap();
         compact_blocks.into_iter().for_each(|compact_block| {
-            inner.insert(compact_block.height(), compact_block);
+            if let Ok(height) = compact_block.height() {
+                inner.insert(height, compact_block);
+            }
         });
         Ok(())
     }

--- a/zcash_client_memory/src/testing/mod.rs
+++ b/zcash_client_memory/src/testing/mod.rs
@@ -84,8 +84,11 @@ impl TestCache for MemBlockCache {
     }
 
     fn insert(&mut self, cb: &CompactBlock) -> Self::InsertResult {
-        let txids = cb.vtx.iter().map(|tx| tx.txid()).collect();
-        self.0.write().unwrap().insert(cb.height(), cb.clone());
+        let txids = cb.vtx.iter().map(|tx| tx.txid().unwrap()).collect();
+        self.0
+            .write()
+            .unwrap()
+            .insert(cb.height().unwrap(), cb.clone());
         MemBlockCacheInsertionResult { txids }
     }
 

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -74,11 +74,14 @@ where
 
         let data: Vec<u8> = row.get(1).map_err(to_chain_error)?;
         let block = CompactBlock::decode(&data[..]).map_err(to_chain_error)?;
-        if block.height() != height {
+        let block_height = block.height().map_err(|_| {
+            to_chain_error(SqliteClientError::CorruptedData(format!(
+                "Cached block at expected height {height} had an out-of-range height field",
+            )))
+        })?;
+        if block_height != height {
             return Err(to_chain_error(SqliteClientError::CorruptedData(format!(
-                "Block height {} did not match row's height field value {}",
-                block.height(),
-                height
+                "Block height {block_height} did not match row's height field value {height}",
             ))));
         }
 
@@ -306,11 +309,16 @@ where
 
         let block = CompactBlock::decode(&block_data[..]).map_err(to_chain_error)?;
 
-        if block.height() != cbr.height {
+        let block_height = block.height().map_err(|_| {
+            to_chain_error(FsBlockDbError::CorruptedData(format!(
+                "Cached block at expected height {} had an out-of-range height field",
+                cbr.height,
+            )))
+        })?;
+        if block_height != cbr.height {
             return Err(to_chain_error(FsBlockDbError::CorruptedData(format!(
                 "Block height {} did not match row's height field value {}",
-                block.height(),
-                cbr.height
+                block_height, cbr.height,
             ))));
         }
 

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -78,12 +78,12 @@ impl TestCache for BlockCache {
             .0
             .execute(
                 "INSERT INTO compactblocks (height, data) VALUES (?, ?)",
-                params![u32::from(cb.height()), cb_bytes,],
+                params![u32::from(cb.height().unwrap()), cb_bytes,],
             )
             .unwrap();
 
         BlockCacheInsertionResult {
-            txids: cb.vtx.iter().map(|tx| tx.txid()).collect(),
+            txids: cb.vtx.iter().map(|tx| tx.txid().unwrap()).collect(),
             note_commitments,
         }
     }
@@ -146,10 +146,10 @@ impl TestCache for FsBlockCache {
     fn insert(&mut self, cb: &CompactBlock) -> Self::InsertResult {
         use std::io::Write;
 
-        let txids = cb.vtx.iter().map(|tx| tx.txid()).collect();
+        let txids = cb.vtx.iter().map(|tx| tx.txid().unwrap()).collect();
         let block_meta = BlockMeta {
-            height: cb.height(),
-            block_hash: cb.hash(),
+            height: cb.height().unwrap(),
+            block_hash: cb.hash().unwrap(),
             block_time: cb.time,
             sapling_outputs_count: cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum(),
             orchard_actions_count: cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum(),


### PR DESCRIPTION
Converts the eight panic sites in `scan_block` into `Result<_, CompactFormatError>` accessors on `proto::compact_formats::{CompactBlock, CompactTx, CompactSaplingOutput}`, plus two new `ScanError::{Block,Tx}EncodingInvalid` variants so that `scan_block` propagates malformed-input errors rather than aborting the wallet process. Adjusts downstream callers and adds eight regression tests covering each formerly-panicking site.

Breaking: `CompactBlock::{hash, prev_hash, height}` and `CompactTx::txid` now return `Result<_, CompactFormatError>`. `ScanError::at_height` now returns `Option<BlockHeight>`.