### PR TITLE
Reject Equihash parameters with unsupported collision bit lengths

### DIFF
--- a/components/equihash/src/params.rs
+++ b/components/equihash/src/params.rs
@@ -12,8 +12,15 @@ impl Params {
         // - k >= 3 so the encoded solutions have an exact byte length.
         // - k < n, so the collision bit length is at least 1.
         // - n is a multiple of k + 1, so we have an integer collision bit length.
+        // - the collision bit length is in the range expected by the minimal
+        //   solution encoding helpers.
         if (n % 8 == 0) && (k >= 3) && (k < n) && (n % (k + 1) == 0) {
-            Some(Params { n, k })
+            let collision_bit_length = n / (k + 1);
+            if (7..=24).contains(&collision_bit_length) {
+                Some(Params { n, k })
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/components/equihash/src/verify.rs
+++ b/components/equihash/src/verify.rs
@@ -288,6 +288,19 @@ mod tests {
     }
 
     #[test]
+    fn invalid_parameter_collision_bit_lengths_return_error() {
+        for (n, k) in [(8, 3), (104, 3), (256, 7)] {
+            let c_bit_len = n / (k + 1);
+            let soln_len = ((1 << k) * (c_bit_len + 1)) / 8;
+            let soln = vec![0; soln_len as usize];
+            let result = std::panic::catch_unwind(|| is_valid_solution(n, k, &[], &[], &soln));
+
+            assert!(result.is_ok(), "is_valid_solution({n}, {k}, ...) panicked");
+            assert!(result.unwrap().is_err());
+        }
+    }
+
+    #[test]
     fn all_bits_matter() {
         // Initialize the state according to one of the valid test vectors.
         let n = 96;


### PR DESCRIPTION
## Summary
- require Equihash collision bit length to be in the range supported by the minimal solution encoding helpers
- make invalid non-Zcash parameter sets return `InvalidParams` instead of reaching downstream assertions
- add a regression test for representative unsupported `(n, k)` pairs

## Testing
- `CARGO_TARGET_DIR=/tmp/librustzcash-equihash-target cargo test -p equihash invalid_parameter_collision_bit_lengths_return_error`