### PR TITLE
zcash_client_sqlite: use regex version from workspace

### DIFF
--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -79,7 +79,7 @@ schemerz.workspace = true
 schemerz-rusqlite.workspace = true
 time.workspace = true
 uuid = { workspace = true, features = ["v4"] }
-regex = "1.4"
+regex = { workspace = true }
 
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)


### PR DESCRIPTION
It seems that most of the dependencies are shared by the workspace, except a few. This is a small patch to get more uniformity.