### PR TITLE
zcash_client_backend: expose custom ZIP 317 fee and expiry-delta APIs

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -33,6 +33,16 @@ workspace.
 - `zcash_client_backend::data_api::wallet::ProposeShieldingCoinbaseErrT` type
   alias, parallel to `ProposeShieldingErrT` but parameterized on a `FeeRule`
   instead of a `ChangeStrategy`.
+- `zcash_client_backend::data_api::wallet::propose_zip317_transfer_to_address`,
+  which proposes a transfer using an explicit
+  `zcash_primitives::transaction::fees::zip317::FeeRule`, behind the
+  `non-standard-fees` feature flag.
+- `zcash_client_backend::data_api::wallet::propose_zip317_transfer_to_address_with_marginal_fee`,
+  which proposes a transfer using a ZIP 317 fee rule with an explicit marginal fee,
+  behind the `non-standard-fees` feature flag.
+- `zcash_client_backend::data_api::wallet::create_proposed_transactions_with_expiry_delta`,
+  for executing proposals with an explicit transaction expiry height delta.
+- `zcash_client_backend::data_api::wallet::{CreateWithExpiryDeltaError, CreateWithExpiryDeltaErrT}`
 
 ### Changed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -57,6 +57,7 @@ use super::{
     scanning::ScanRange,
     wallet::{
         ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
+        create_proposed_transactions_with_expiry_delta,
         input_selection::{GreedyInputSelector, InputSelector},
         propose_send_max_transfer, propose_standard_transfer_to_address, propose_transfer,
     },
@@ -1196,6 +1197,37 @@ where
             &SpendingKeys::from_unified_spending_key(usk.clone()),
             ovk_policy,
             proposal,
+            #[cfg(feature = "unstable")]
+            None,
+        )
+    }
+
+    /// Invokes [`create_proposed_transactions_with_expiry_delta`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    pub fn create_proposed_transactions_with_expiry_delta<InputsErrT, FeeRuleT, ChangeErrT, N>(
+        &mut self,
+        usk: &UnifiedSpendingKey,
+        ovk_policy: OvkPolicy,
+        proposal: &Proposal<FeeRuleT, N>,
+        expiry_height_delta: NonZeroU32,
+    ) -> Result<
+        NonEmpty<TxId>,
+        super::wallet::CreateWithExpiryDeltaErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>,
+    >
+    where
+        FeeRuleT: FeeRule,
+    {
+        let prover = LocalTxProver::bundled();
+        let network = self.network().clone();
+        create_proposed_transactions_with_expiry_delta(
+            self.wallet_mut(),
+            &network,
+            &prover,
+            &prover,
+            &SpendingKeys::from_unified_spending_key(usk.clone()),
+            ovk_policy,
+            proposal,
+            expiry_height_delta,
             #[cfg(feature = "unstable")]
             None,
         )

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -18,6 +18,7 @@ use zcash_primitives::{
     block::BlockHash,
     transaction::{
         Transaction,
+        builder::MAX_TX_EXPIRY_HEIGHT,
         fees::zip317::{FeeRule as Zip317FeeRule, MARGINAL_FEE, MINIMUM_FEE},
     },
 };
@@ -347,6 +348,53 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
     assert_matches!(
         decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, None),
         Ok(_)
+    );
+}
+
+/// Tests that the expiry-delta transaction creation helper rejects deltas that
+/// would exceed the ZIP 203 non-time-based expiry height range.
+pub fn expiry_delta_rejects_expiry_above_maximum<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60_000));
+
+    let to = T::random_address(st.rng_mut());
+    let account = st.get_account();
+    let proposal = st
+        .propose_standard_transfer::<Infallible>(
+            account.id(),
+            StandardFeeRule::Zip317,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(10_000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        )
+        .unwrap();
+
+    let expiry_height_delta = NonZeroU32::new(
+        u32::from(MAX_TX_EXPIRY_HEIGHT) - u32::from(proposal.min_target_height()) + 1,
+    )
+    .expect("computed delta is nonzero");
+
+    assert_matches!(
+        st.create_proposed_transactions_with_expiry_delta::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+            expiry_height_delta,
+        ),
+        Err(crate::data_api::wallet::CreateWithExpiryDeltaError::ExpiryHeightTooHigh {
+            min_target_height,
+            expiry_height_delta: actual_delta,
+            max_expiry_height,
+        }) if min_target_height == proposal.min_target_height()
+            && actual_delta == expiry_height_delta
+            && max_expiry_height == MAX_TX_EXPIRY_HEIGHT
     );
 }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -37,6 +37,7 @@ to a wallet-internal shielded address, as described in [ZIP 316](https://zips.z.
 use nonempty::NonEmpty;
 use rand_core::OsRng;
 use std::{
+    fmt,
     num::NonZeroU32,
     ops::{Add, Sub},
 };
@@ -46,6 +47,8 @@ use shardtree::error::{QueryError, ShardTreeError};
 use super::InputSource;
 #[cfg(feature = "transparent-inputs")]
 use super::TransparentOutputFilter;
+#[cfg(feature = "non-standard-fees")]
+use crate::fees::zip317;
 use crate::{
     data_api::{
         Account, MaxSpendMode, SentTransaction, SentTransactionOutput, WalletCommitmentTrees,
@@ -68,9 +71,11 @@ use zcash_keys::{
     address::Address,
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
 };
+#[cfg(feature = "non-standard-fees")]
+use zcash_primitives::transaction::fees::zip317 as prim_zip317;
 use zcash_primitives::transaction::{
     Transaction, TxId,
-    builder::{BuildConfig, BuildResult, Builder},
+    builder::{BuildConfig, BuildResult, Builder, MAX_TX_EXPIRY_HEIGHT},
     components::sapling::zip212_enforcement,
     fees::FeeRule,
 };
@@ -272,6 +277,56 @@ pub type CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N> = Error<
     ChangeErrT,
     N,
 >;
+
+/// Errors that may be generated when executing proposals with an explicit expiry height delta.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum CreateWithExpiryDeltaError<E> {
+    /// The requested expiry height delta produces an expiry height that exceeds the maximum
+    /// allowed for non-coinbase transactions.
+    ExpiryHeightTooHigh {
+        /// The minimum target height from the proposal.
+        min_target_height: TargetHeight,
+        /// The requested expiry height delta.
+        expiry_height_delta: NonZeroU32,
+        /// The maximum allowed expiry height for non-coinbase transactions.
+        max_expiry_height: BlockHeight,
+    },
+    /// An error occurred while executing the proposal.
+    Create(E),
+}
+
+impl<E: fmt::Display> fmt::Display for CreateWithExpiryDeltaError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CreateWithExpiryDeltaError::ExpiryHeightTooHigh {
+                min_target_height,
+                expiry_height_delta,
+                max_expiry_height,
+            } => write!(
+                f,
+                "Expiry height delta {} from proposal minimum target height {} exceeds maximum {}",
+                expiry_height_delta,
+                u32::from(*min_target_height),
+                u32::from(*max_expiry_height)
+            ),
+            CreateWithExpiryDeltaError::Create(e) => e.fmt(f),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for CreateWithExpiryDeltaError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreateWithExpiryDeltaError::ExpiryHeightTooHigh { .. } => None,
+            CreateWithExpiryDeltaError::Create(e) => Some(e),
+        }
+    }
+}
+
+/// Errors that may be generated when executing proposals with an explicit expiry height delta.
+pub type CreateWithExpiryDeltaErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N> =
+    CreateWithExpiryDeltaError<CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>;
 
 /// Errors that may be generated in the execution of proposals that may send shielded inputs.
 pub type TransferErrT<DbT, InputsT, ChangeT> = Error<
@@ -760,6 +815,152 @@ where
     )
 }
 
+/// Proposes making a payment to the specified address from the given account,
+/// using an explicit ZIP 317 fee rule.
+///
+/// Returns the proposal, which may then be executed using [`create_proposed_transactions`]
+/// or [`create_proposed_transactions_with_expiry_delta`]. The resulting proposal
+/// carries its fee rule in memory as
+/// [`zip317::FeeRule`](zcash_primitives::transaction::fees::zip317::FeeRule); this helper does
+/// not add serialization support for non-standard fee rule parameters.
+///
+/// Depending upon the recipient address, more than one transaction may be constructed
+/// in the execution of the returned proposal.
+///
+/// This method uses the basic [`GreedyInputSelector`] for input selection.
+#[cfg(feature = "non-standard-fees")]
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+pub fn propose_zip317_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    fee_rule: prim_zip317::FeeRule,
+    spend_from_account: <DbT as InputSource>::AccountId,
+    confirmations_policy: ConfirmationsPolicy,
+    to: &Address,
+    amount: Zatoshis,
+    memo: Option<MemoBytes>,
+    change_memo: Option<MemoBytes>,
+    fallback_change_pool: ShieldedProtocol,
+    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
+) -> Result<
+    Proposal<prim_zip317::FeeRule, DbT::NoteRef>,
+    ProposeTransferErrT<
+        DbT,
+        CommitmentTreeErrT,
+        GreedyInputSelector<DbT>,
+        zip317::SingleOutputChangeStrategy<prim_zip317::FeeRule, DbT>,
+    >,
+>
+where
+    ParamsT: consensus::Parameters + Clone,
+    DbT: InputSource,
+    DbT: WalletRead<Error = <DbT as InputSource>::Error, AccountId = <DbT as InputSource>::AccountId>,
+    DbT::NoteRef: Copy + Eq + Ord,
+{
+    let request = zip321::TransactionRequest::new(vec![
+        Payment::new(
+            to.to_zcash_address(params),
+            Some(amount),
+            memo,
+            None,
+            None,
+            vec![],
+        )
+        .map_err(Error::Payment)?,
+    ])
+    .expect(
+        "It should not be possible for this to violate ZIP 321 request construction invariants.",
+    );
+
+    let input_selector = GreedyInputSelector::<DbT>::new();
+    let change_strategy = zip317::SingleOutputChangeStrategy::<prim_zip317::FeeRule, DbT>::new(
+        fee_rule,
+        change_memo,
+        fallback_change_pool,
+        DustOutputPolicy::default(),
+    );
+
+    propose_transfer(
+        wallet_db,
+        params,
+        spend_from_account,
+        &input_selector,
+        &change_strategy,
+        request,
+        confirmations_policy,
+        #[cfg(feature = "unstable")]
+        proposed_version,
+    )
+}
+
+/// Proposes making a payment to the specified address from the given account,
+/// using a ZIP 317 fee rule with an explicit marginal fee.
+///
+/// This is a convenience wrapper around [`propose_zip317_transfer_to_address`].
+/// It constructs a non-standard ZIP 317 fee rule using `marginal_fee` and the
+/// standard ZIP 317 values for grace actions and P2PKH input/output sizes. This
+/// helper does not add serialization support for non-standard fee rule parameters.
+///
+/// # Privacy
+///
+/// Non-standard fee values can make transactions distinguishable from other ZIP
+/// 317 transactions. Callers should only use this API when they have accounted
+/// for the resulting fingerprinting risk.
+#[cfg(feature = "non-standard-fees")]
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+pub fn propose_zip317_transfer_to_address_with_marginal_fee<DbT, ParamsT, CommitmentTreeErrT>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    marginal_fee: Zatoshis,
+    spend_from_account: <DbT as InputSource>::AccountId,
+    confirmations_policy: ConfirmationsPolicy,
+    to: &Address,
+    amount: Zatoshis,
+    memo: Option<MemoBytes>,
+    change_memo: Option<MemoBytes>,
+    fallback_change_pool: ShieldedProtocol,
+    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
+) -> Result<
+    Proposal<prim_zip317::FeeRule, DbT::NoteRef>,
+    ProposeTransferErrT<
+        DbT,
+        CommitmentTreeErrT,
+        GreedyInputSelector<DbT>,
+        zip317::SingleOutputChangeStrategy<prim_zip317::FeeRule, DbT>,
+    >,
+>
+where
+    ParamsT: consensus::Parameters + Clone,
+    DbT: InputSource,
+    DbT: WalletRead<Error = <DbT as InputSource>::Error, AccountId = <DbT as InputSource>::AccountId>,
+    DbT::NoteRef: Copy + Eq + Ord,
+{
+    let fee_rule = prim_zip317::FeeRule::non_standard(
+        marginal_fee,
+        prim_zip317::GRACE_ACTIONS,
+        prim_zip317::P2PKH_STANDARD_INPUT_SIZE,
+        prim_zip317::P2PKH_STANDARD_OUTPUT_SIZE,
+    )
+    .expect("ZIP 317 standard P2PKH input and output sizes are non-zero");
+
+    propose_zip317_transfer_to_address(
+        wallet_db,
+        params,
+        fee_rule,
+        spend_from_account,
+        confirmations_policy,
+        to,
+        amount,
+        memo,
+        change_memo,
+        fallback_change_pool,
+        #[cfg(feature = "unstable")]
+        proposed_version,
+    )
+}
+
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that would spend all available funds from the given `spend_pool`s that can then
 /// be authorized and made ready for submission to the network with [`create_proposed_transactions`].
@@ -1016,6 +1217,111 @@ where
     ParamsT: consensus::Parameters + Clone,
     FeeRuleT: FeeRule,
 {
+    create_proposed_transactions_internal(
+        wallet_db,
+        params,
+        spend_prover,
+        output_prover,
+        spending_keys,
+        ovk_policy,
+        proposal,
+        None,
+        #[cfg(feature = "unstable")]
+        proposed_version,
+    )
+}
+
+/// Construct, prove, and sign a transaction or series of transactions using the inputs supplied by
+/// the given proposal and an explicit expiry height delta, and persist it to the wallet database.
+///
+/// Returns the database identifier for each newly constructed transaction, or an error if
+/// `proposal.min_target_height() + expiry_height_delta` exceeds [`MAX_TX_EXPIRY_HEIGHT`], or if an
+/// error occurs in transaction construction, proving, or signing.
+///
+/// # Privacy
+///
+/// The expiry height is committed to the transaction ID. Using an expiry delta
+/// other than the wallet default can make transactions distinguishable from
+/// transactions created with the standard wallet policy.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+pub fn create_proposed_transactions_with_expiry_delta<
+    DbT,
+    ParamsT,
+    InputsErrT,
+    FeeRuleT,
+    ChangeErrT,
+    N,
+>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    spend_prover: &impl SpendProver,
+    output_prover: &impl OutputProver,
+    spending_keys: &SpendingKeys,
+    ovk_policy: OvkPolicy,
+    proposal: &Proposal<FeeRuleT, N>,
+    expiry_height_delta: NonZeroU32,
+    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
+) -> Result<NonEmpty<TxId>, CreateWithExpiryDeltaErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
+where
+    DbT: WalletWrite + WalletCommitmentTrees,
+    ParamsT: consensus::Parameters + Clone,
+    FeeRuleT: FeeRule,
+{
+    let expiry_height =
+        expiry_height_from_delta(proposal.min_target_height(), expiry_height_delta)?;
+
+    create_proposed_transactions_internal(
+        wallet_db,
+        params,
+        spend_prover,
+        output_prover,
+        spending_keys,
+        ovk_policy,
+        proposal,
+        Some(expiry_height),
+        #[cfg(feature = "unstable")]
+        proposed_version,
+    )
+    .map_err(CreateWithExpiryDeltaError::Create)
+}
+
+fn expiry_height_from_delta<E>(
+    min_target_height: TargetHeight,
+    expiry_height_delta: NonZeroU32,
+) -> Result<BlockHeight, CreateWithExpiryDeltaError<E>> {
+    let min_target_height_u32 = u32::from(min_target_height);
+    let expiry_height = min_target_height_u32
+        .checked_add(expiry_height_delta.get())
+        .filter(|height| *height <= u32::from(MAX_TX_EXPIRY_HEIGHT))
+        .map(BlockHeight::from_u32)
+        .ok_or(CreateWithExpiryDeltaError::ExpiryHeightTooHigh {
+            min_target_height,
+            expiry_height_delta,
+            max_expiry_height: MAX_TX_EXPIRY_HEIGHT,
+        })?;
+
+    Ok(expiry_height)
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+fn create_proposed_transactions_internal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>(
+    wallet_db: &mut DbT,
+    params: &ParamsT,
+    spend_prover: &impl SpendProver,
+    output_prover: &impl OutputProver,
+    spending_keys: &SpendingKeys,
+    ovk_policy: OvkPolicy,
+    proposal: &Proposal<FeeRuleT, N>,
+    expiry_height: Option<BlockHeight>,
+    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
+) -> Result<NonEmpty<TxId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
+where
+    DbT: WalletWrite + WalletCommitmentTrees,
+    ParamsT: consensus::Parameters + Clone,
+    FeeRuleT: FeeRule,
+{
     // The set of transparent `StepOutput`s available and unused from prior steps.
     // When a transparent `StepOutput` is created, it is added to the map. When it
     // is consumed, it is removed from the map.
@@ -1040,6 +1346,7 @@ where
             ovk_policy.clone(),
             proposal.fee_rule(),
             proposal.min_target_height(),
+            expiry_height,
             &step_results,
             step,
             #[cfg(feature = "transparent-inputs")]
@@ -1774,6 +2081,7 @@ fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N
     ovk_policy: OvkPolicy,
     fee_rule: &FeeRuleT,
     min_target_height: TargetHeight,
+    expiry_height: Option<BlockHeight>,
     prior_step_results: &[(&Step<N>, StepResult<<DbT as WalletRead>::AccountId>)],
     proposal_step: &Step<N>,
     #[cfg(feature = "transparent-inputs")] unused_transparent_outputs: &mut HashMap<
@@ -1790,7 +2098,7 @@ where
     ParamsT: consensus::Parameters + Clone,
     FeeRuleT: FeeRule,
 {
-    let build_state = build_proposed_transaction::<_, _, _, FeeRuleT, _, _>(
+    let mut build_state = build_proposed_transaction::<_, _, _, FeeRuleT, _, _>(
         wallet_db,
         params,
         &spending_keys.usk.to_unified_full_viewing_key(),
@@ -1804,6 +2112,16 @@ where
         #[cfg(feature = "unstable")]
         proposed_version,
     )?;
+
+    if let Some(expiry_height) = expiry_height {
+        // `expiry_height` is only provided by `create_proposed_transactions_with_expiry_delta`,
+        // which computes it from a `NonZeroU32` delta, checks it against
+        // `MAX_TX_EXPIRY_HEIGHT`, and uses the standard non-coinbase build path.
+        build_state
+            .builder
+            .set_expiry_height(expiry_height)
+            .expect("explicit expiry height must have been validated by the public API");
+    }
 
     // Build the transaction with the specified fee rule
     #[cfg_attr(not(feature = "transparent-inputs"), allow(unused_mut))]
@@ -2755,4 +3073,59 @@ where
         #[cfg(feature = "unstable")]
         None,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use assert_matches::assert_matches;
+    use zcash_primitives::transaction::builder::MAX_TX_EXPIRY_HEIGHT;
+
+    use super::{CreateWithExpiryDeltaError, TargetHeight, expiry_height_from_delta};
+
+    #[test]
+    fn expiry_height_from_delta_accepts_maximum_expiry_height() {
+        let delta = NonZeroU32::new(1).expect("1 is nonzero");
+        let min_target_height = TargetHeight::from(u32::from(MAX_TX_EXPIRY_HEIGHT) - delta.get());
+
+        assert_matches!(
+            expiry_height_from_delta::<()>(min_target_height, delta),
+            Ok(height) if height == MAX_TX_EXPIRY_HEIGHT
+        );
+    }
+
+    #[test]
+    fn expiry_height_from_delta_rejects_expiry_above_maximum() {
+        let delta = NonZeroU32::new(1).expect("1 is nonzero");
+        let min_target_height = TargetHeight::from(u32::from(MAX_TX_EXPIRY_HEIGHT));
+
+        assert_matches!(
+            expiry_height_from_delta::<()>(min_target_height, delta),
+            Err(CreateWithExpiryDeltaError::ExpiryHeightTooHigh {
+                min_target_height: actual_min_target_height,
+                expiry_height_delta: actual_delta,
+                max_expiry_height,
+            }) if actual_min_target_height == min_target_height
+                && actual_delta == delta
+                && max_expiry_height == MAX_TX_EXPIRY_HEIGHT
+        );
+    }
+
+    #[test]
+    fn expiry_height_from_delta_rejects_overflow() {
+        let delta = NonZeroU32::new(1).expect("1 is nonzero");
+        let min_target_height = TargetHeight::from(u32::MAX);
+
+        assert_matches!(
+            expiry_height_from_delta::<()>(min_target_height, delta),
+            Err(CreateWithExpiryDeltaError::ExpiryHeightTooHigh {
+                min_target_height: actual_min_target_height,
+                expiry_height_delta: actual_delta,
+                max_expiry_height,
+            }) if actual_min_target_height == min_target_height
+                && actual_delta == delta
+                && max_expiry_height == MAX_TX_EXPIRY_HEIGHT
+        );
+    }
 }

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -37,6 +37,13 @@ pub(crate) fn send_single_step_proposed_transfer<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn expiry_delta_rejects_expiry_above_maximum<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::expiry_delta_rejects_expiry_above_maximum::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn spend_max_spendable_single_step_proposed_transfer<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::spend_max_spendable_single_step_proposed_transfer::<
         T,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -434,6 +434,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn expiry_delta_rejects_expiry_above_maximum() {
+        testing::pool::expiry_delta_rejects_expiry_above_maximum::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn spend_max_spendable_single_step_proposed_transfer() {
         testing::pool::spend_max_spendable_single_step_proposed_transfer::<SaplingPoolTester>()
     }

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_primitives::transaction::builder::Builder::expiry_height` and
+  `Builder::set_expiry_height`, for inspecting and explicitly setting transaction
+  expiry height while preserving the coinbase expiry-height consensus invariant.
+- `zcash_primitives::transaction::builder::MAX_TX_EXPIRY_HEIGHT`
+- `zcash_primitives::transaction::builder::ExpiryHeightError`
+
 ## [0.27.1] - 2026-05-14
 
 ### Fixed

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -64,6 +64,15 @@ use super::components::sapling::zip212_enforcement;
 /// <https://zips.z.cash/zip-0203#changes-for-blossom>
 pub const DEFAULT_TX_EXPIRY_DELTA: u32 = 40;
 
+/// The maximum transaction expiry height for non-coinbase transactions.
+///
+/// `nExpiryHeight` is in the range `1..=499_999_999`, or `0` to disable expiry.
+/// Coinbase transactions are an exception: from NU5 activation onward, their expiry
+/// height must equal the block height and this upper bound does not apply.
+///
+/// <https://zips.z.cash/zip-0203#changes-for-nu5>
+pub const MAX_TX_EXPIRY_HEIGHT: BlockHeight = BlockHeight::from_u32(499_999_999);
+
 /// Errors that can occur during fee calculation.
 #[derive(Debug)]
 pub enum FeeError<FE> {
@@ -168,6 +177,59 @@ impl<FE: fmt::Display> fmt::Display for Error<FE> {
 
 #[cfg(feature = "std")]
 impl<FE: fmt::Debug + fmt::Display> std::error::Error for Error<FE> {}
+
+/// Errors that can occur when setting a custom transaction expiry height.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpiryHeightError {
+    /// The expiry height was set to `0`, which disables transaction expiry.
+    NoExpiry,
+    /// Coinbase transaction expiry height must be equal to the target height.
+    Coinbase {
+        /// The requested expiry height.
+        expiry_height: BlockHeight,
+        /// The block height for which the coinbase transaction is being built.
+        target_height: BlockHeight,
+    },
+    /// The expiry height exceeds the maximum allowed for non-coinbase transactions.
+    ExceedsMaximum {
+        /// The requested expiry height.
+        expiry_height: BlockHeight,
+        /// The maximum allowed expiry height for non-coinbase transactions.
+        max_expiry_height: BlockHeight,
+    },
+}
+
+impl fmt::Display for ExpiryHeightError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExpiryHeightError::NoExpiry => {
+                write!(f, "Transaction expiry height must not be 0")
+            }
+            ExpiryHeightError::Coinbase {
+                expiry_height,
+                target_height,
+            } => write!(
+                f,
+                "Coinbase transaction expiry height {} must equal target height {}",
+                u32::from(*expiry_height),
+                u32::from(*target_height)
+            ),
+            ExpiryHeightError::ExceedsMaximum {
+                expiry_height,
+                max_expiry_height,
+            } => write!(
+                f,
+                "Transaction expiry height {} exceeds maximum {}",
+                u32::from(*expiry_height),
+                u32::from(*max_expiry_height)
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ExpiryHeightError {}
 
 impl<FE> From<BalanceError> for Error<FE> {
     fn from(e: BalanceError) -> Self {
@@ -369,6 +431,49 @@ impl<P, U> Builder<'_, P, U> {
         self.target_height
     }
 
+    /// Returns the expiry height of the transaction under construction.
+    pub fn expiry_height(&self) -> BlockHeight {
+        self.expiry_height
+    }
+
+    /// Sets the expiry height of the transaction under construction.
+    ///
+    /// Returns [`ExpiryHeightError::NoExpiry`] if `expiry_height` is `0`, because that
+    /// disables transaction expiry. Returns [`ExpiryHeightError::Coinbase`] if this
+    /// builder is configured for a coinbase transaction and `expiry_height` is not
+    /// equal to [`Builder::target_height`]. Returns [`ExpiryHeightError::ExceedsMaximum`]
+    /// if a non-coinbase transaction expiry height exceeds [`MAX_TX_EXPIRY_HEIGHT`].
+    ///
+    /// For non-coinbase transactions this method validates consensus bounds, but it
+    /// does not reject expiry heights below the builder's target height. Callers
+    /// that want "expires after N blocks" semantics should compute the expiry
+    /// height relative to their selected target height.
+    pub fn set_expiry_height(
+        &mut self,
+        expiry_height: BlockHeight,
+    ) -> Result<(), ExpiryHeightError> {
+        if expiry_height == BlockHeight::from_u32(0) {
+            return Err(ExpiryHeightError::NoExpiry);
+        }
+
+        if self.build_config.is_coinbase() && expiry_height != self.target_height {
+            return Err(ExpiryHeightError::Coinbase {
+                expiry_height,
+                target_height: self.target_height,
+            });
+        }
+
+        if !self.build_config.is_coinbase() && expiry_height > MAX_TX_EXPIRY_HEIGHT {
+            return Err(ExpiryHeightError::ExceedsMaximum {
+                expiry_height,
+                max_expiry_height: MAX_TX_EXPIRY_HEIGHT,
+            });
+        }
+
+        self.expiry_height = expiry_height;
+        Ok(())
+    }
+
     /// Returns the set of transparent inputs currently committed to be consumed
     /// by the transaction.
     #[cfg(feature = "transparent-inputs")]
@@ -457,8 +562,9 @@ impl<'a, P: consensus::Parameters> Builder<'a, P, ()> {
     ///
     /// # Default values
     ///
-    /// The expiry height will be set to the given height plus the default transaction
-    /// expiry delta (20 blocks).
+    /// For non-coinbase transactions, the expiry height will be set to the given
+    /// height plus [`DEFAULT_TX_EXPIRY_DELTA`]. For coinbase transactions, the
+    /// expiry height will be set to the given height.
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
             build_config
@@ -1374,7 +1480,7 @@ mod testing {
 mod tests {
     #[cfg(feature = "circuits")]
     use {
-        super::{Builder, Error},
+        super::{Builder, DEFAULT_TX_EXPIRY_DELTA, Error, ExpiryHeightError, MAX_TX_EXPIRY_HEIGHT},
         crate::transaction::builder::BuildConfig,
         ::sapling::{Node, Rseed, zip32::ExtendedSpendingKey},
         ::transparent::{address::TransparentAddress, builder::TransparentSigningSet},
@@ -1384,7 +1490,7 @@ mod tests {
         incrementalmerkletree::{frontier::CommitmentTree, witness::IncrementalWitness},
         rand_core::OsRng,
         zcash_protocol::{
-            consensus::{NetworkUpgrade, Parameters, TEST_NETWORK},
+            consensus::{BlockHeight, NetworkUpgrade, Parameters, TEST_NETWORK},
             memo::MemoBytes,
             value::{BalanceError, ZatBalance, Zatoshis},
         },
@@ -1396,11 +1502,91 @@ mod tests {
 
     #[cfg(feature = "transparent-inputs")]
     use {
-        crate::transaction::{OutPoint, TxOut, TxVersion, builder::DEFAULT_TX_EXPIRY_DELTA},
+        crate::transaction::{OutPoint, TxOut, TxVersion},
         ::transparent::keys::{AccountPrivKey, IncomingViewingKey},
         zcash_protocol::consensus::BranchId,
         zip32::AccountId,
     };
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn expiry_height_can_be_overridden() {
+        let tx_height = TEST_NETWORK
+            .activation_height(NetworkUpgrade::Sapling)
+            .unwrap();
+        let custom_expiry_height = tx_height + 7;
+        let build_config = BuildConfig::Standard {
+            sapling_anchor: Some(sapling::Anchor::empty_tree()),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+        };
+        let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
+
+        assert_eq!(builder.expiry_height(), tx_height + DEFAULT_TX_EXPIRY_DELTA);
+        assert_eq!(builder.set_expiry_height(custom_expiry_height), Ok(()));
+        assert_eq!(builder.expiry_height(), custom_expiry_height);
+    }
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn expiry_height_rejects_no_expiry() {
+        let tx_height = TEST_NETWORK
+            .activation_height(NetworkUpgrade::Sapling)
+            .unwrap();
+        let build_config = BuildConfig::Standard {
+            sapling_anchor: Some(sapling::Anchor::empty_tree()),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+        };
+        let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
+
+        assert_eq!(
+            builder.set_expiry_height(BlockHeight::from_u32(0)),
+            Err(ExpiryHeightError::NoExpiry)
+        );
+        assert_eq!(builder.expiry_height(), tx_height + DEFAULT_TX_EXPIRY_DELTA);
+    }
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn expiry_height_rejects_values_above_maximum() {
+        let tx_height = TEST_NETWORK
+            .activation_height(NetworkUpgrade::Sapling)
+            .unwrap();
+        let build_config = BuildConfig::Standard {
+            sapling_anchor: Some(sapling::Anchor::empty_tree()),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+        };
+        let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
+        let expiry_height = MAX_TX_EXPIRY_HEIGHT + 1;
+
+        assert_eq!(
+            builder.set_expiry_height(expiry_height),
+            Err(ExpiryHeightError::ExceedsMaximum {
+                expiry_height,
+                max_expiry_height: MAX_TX_EXPIRY_HEIGHT,
+            })
+        );
+        assert_eq!(builder.set_expiry_height(MAX_TX_EXPIRY_HEIGHT), Ok(()));
+    }
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn coinbase_expiry_height_must_equal_target_height() {
+        let tx_height = TEST_NETWORK
+            .activation_height(NetworkUpgrade::Sapling)
+            .unwrap();
+        let build_config = BuildConfig::Coinbase { miner_data: None };
+        let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
+
+        assert_eq!(builder.expiry_height(), tx_height);
+        assert_eq!(
+            builder.set_expiry_height(tx_height + 1),
+            Err(ExpiryHeightError::Coinbase {
+                expiry_height: tx_height + 1,
+                target_height: tx_height,
+            })
+        );
+        assert_eq!(builder.set_expiry_height(tx_height), Ok(()));
+    }
 
     // This test only works with the transparent_inputs feature because we have to
     // be able to create a tx with a valid balance, without using Sapling inputs.


### PR DESCRIPTION
## Summary

This PR adds additive, backward-compatible APIs that expose two transaction
parameters which are currently not reachable through the high-level wallet
APIs: ZIP 317 fee rules (including an explicit marginal fee) and the transaction
expiry window. It implements the proposal discussed in #2380.

Opened as a **Draft** for early feedback, per `CONTRIBUTING.md`. I'm happy to
adjust naming, feature-gating, or the API surface before this is taken to
"Ready for review".

Refs #2380

## Motivation

Downstream wallets want to offer a *resend* flow: after a transaction fails to
mine, recreate a replacement with the same payment details but a higher fee
policy and a deliberately shorter expiry window. Today neither the ZIP 317
marginal fee nor an explicit/relative expiry can be driven through the
high-level proposal and execution helpers, so wallets cannot build this on top
of the public API.

## What's added

### `zcash_primitives` (`transaction::builder`)
- `Builder::expiry_height` and `Builder::set_expiry_height` — inspect and
  explicitly set the transaction expiry height, while preserving the coinbase
  expiry-height consensus invariant.
- `MAX_TX_EXPIRY_HEIGHT` constant.
- `ExpiryHeightError` for the new validation.

### `zcash_client_backend` (`data_api::wallet`)
- `propose_zip317_transfer_to_address` — propose a transfer using an explicit
  `zip317::FeeRule` (behind the `non-standard-fees` feature).
- `propose_zip317_transfer_to_address_with_marginal_fee` — propose a transfer
  using a ZIP 317 fee rule with an explicit marginal fee (behind the
  `non-standard-fees` feature).
- `create_proposed_transactions_with_expiry_delta` — execute a proposal with an
  explicit transaction expiry-height delta.
- `CreateWithExpiryDeltaError` / `CreateWithExpiryDeltaErrT` error types.

## Compatibility

- No existing signatures are changed.
- No serialization formats are changed.
- The non-standard fee helpers are gated behind the existing `non-standard-fees`
  feature; default behavior is unchanged.
- These are SemVer-compatible (additive) changes.

## Testing

- Added builder-level expiry-height bounds tests.
- Added proposal/execution tests across pools in the `data_api` testing
  harness and the `zcash_client_sqlite` testing harness.

## Notes for reviewers

- `CHANGELOG.md` updated for both `zcash_client_backend` and `zcash_primitives`.
- The work is currently a single commit; happy to split it per crate
  (`zcash_primitives` vs `zcash_client_backend`) if preferred.
- Branched from `main`; let me know if you'd rather have additive changes based
  off the previous major version tag for multi-version release support.
