### PR TITLE
zcash_client_backend: add methods to count transparent inputs/amounts

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,10 @@ workspace.
 ## [0.23.0] - PLANNED
 
 ### Added
+- `zcash_client_backend::proposal::Proposal::transparent_input_count` and
+  `zcash_client_backend::proposal::Proposal::transparent_input_total`, which
+  report the number and total value of the transparent coins selected as
+  inputs across all steps of a proposal.
 - `zcash_client_backend::data_api::error::RewindError`
 - `zcash_client_backend::wallet::WalletTransparentOutput`:
   - `recipient_account`

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -354,6 +354,31 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     pub fn steps(&self) -> &NonEmpty<Step<NoteRef>> {
         &self.steps
     }
+
+    /// Returns the number of transparent coins selected as inputs across all steps of this
+    /// proposal.
+    pub fn transparent_input_count(&self) -> usize {
+        self.steps
+            .iter()
+            .map(|step| step.transparent_inputs().len())
+            .sum()
+    }
+
+    /// Returns the total value of the transparent coins selected as inputs across all steps of
+    /// this proposal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProposalError::Overflow`] if summing the transparent input values overflows the
+    /// valid range of [`Zatoshis`].
+    pub fn transparent_input_total(&self) -> Result<Zatoshis, ProposalError> {
+        self.steps
+            .iter()
+            .flat_map(|step| step.transparent_inputs())
+            .try_fold(Zatoshis::ZERO, |acc, utxo| {
+                (acc + utxo.value()).ok_or(ProposalError::Overflow)
+            })
+    }
 }
 
 impl<FeeRuleT: Debug, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {


### PR DESCRIPTION
Aims at simplifying https://github.com/zcash/wallet/pull/402/