### PR TITLE
Use From instead of widening as-casts (clippy::cast_lossless)

### DIFF
--- a/components/eip681/src/parse.rs
+++ b/components/eip681/src/parse.rs
@@ -82,7 +82,7 @@ impl Digits {
             total = total
                 .checked_mul(10)
                 .context(OverflowSnafu)?
-                .checked_add(*digit as u64)
+                .checked_add(u64::from(*digit))
                 .context(OverflowSnafu)?;
         }
         Ok(total)
@@ -518,7 +518,7 @@ impl Number {
             .context(IntegerSnafu)?;
         let multiplier = 10i128.checked_pow(exp).context(LargeExponentSnafu {
             expected: u128::MAX.ilog10() as usize,
-            seen: exp as u64,
+            seen: u64::from(exp),
         })?;
         // The exponent must be >= the number of decimal places to yield an integer result.
         let decimal_exp = exp
@@ -535,7 +535,7 @@ impl Number {
         //     (decimal_numerator * 10^(exp - decimal_places))
         // )
         // ```
-        let multiplied_integer = (integer as i128)
+        let multiplied_integer = i128::from(integer)
             .checked_mul(multiplier)
             .with_context(|| OverflowSnafu)?;
         let decimal_multiplier = match decimal_exp {
@@ -543,7 +543,7 @@ impl Number {
             Err(_) if decimal_numerator == 0 => 0,
             Err(e) => return Err(e),
         };
-        let multiplied_decimal = (decimal_numerator as i128)
+        let multiplied_decimal = i128::from(decimal_numerator)
             .checked_mul(decimal_multiplier)
             .with_context(|| OverflowSnafu)?;
         let value = multiplied_integer

--- a/components/equihash/src/minimal.rs
+++ b/components/equihash/src/minimal.rs
@@ -32,9 +32,9 @@ fn compress_array(array: &[u8], bit_len: usize, byte_pad: usize) -> Vec<u8> {
             for x in byte_pad..in_width {
                 acc_value |= (
                     // Apply bit_len_mask across byte boundaries
-                    (array[j + x] & ((bit_len_mask >> (8 * (in_width - x - 1))) as u8)) as u32
+                    u32::from(array[j + x] & ((bit_len_mask >> (8 * (in_width - x - 1))) as u8))
                 )
-                    .wrapping_shl(8 * (in_width - x - 1) as u32); // Big-endian
+                .wrapping_shl(8 * (in_width - x - 1) as u32); // Big-endian
             }
             j += in_width;
             acc_bits += bit_len;

--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -90,7 +90,7 @@ impl TryFrom<u32> for Typecode {
             0x02 => Ok(Typecode::Sapling),
             0x03 => Ok(Typecode::Orchard),
             0x04..=0x02000000 => Ok(Typecode::Unknown(typecode)),
-            0x02000001..=u32::MAX => Err(ParseError::InvalidTypecodeValue(typecode as u64)),
+            0x02000001..=u32::MAX => Err(ParseError::InvalidTypecodeValue(u64::from(typecode))),
         }
     }
 }

--- a/components/zcash_encoding/src/lib.rs
+++ b/components/zcash_encoding/src/lib.rs
@@ -36,7 +36,7 @@ impl CompactSize {
         let flag = flag_bytes[0];
 
         let result = if flag < 253 {
-            Ok(flag as u64)
+            Ok(u64::from(flag))
         } else if flag == 253 {
             let mut bytes = [0; 2];
             reader.read_exact(&mut bytes)?;
@@ -45,7 +45,7 @@ impl CompactSize {
                     io::ErrorKind::InvalidInput,
                     "non-canonical CompactSize",
                 )),
-                n => Ok(n as u64),
+                n => Ok(u64::from(n)),
             }
         } else if flag == 254 {
             let mut bytes = [0; 4];
@@ -55,7 +55,7 @@ impl CompactSize {
                     io::ErrorKind::InvalidInput,
                     "non-canonical CompactSize",
                 )),
-                n => Ok(n as u64),
+                n => Ok(u64::from(n)),
             }
         } else {
             let mut bytes = [0; 8];

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -77,7 +77,7 @@ impl TryFrom<u64> for BlockHeight {
 
 impl From<BlockHeight> for u64 {
     fn from(value: BlockHeight) -> u64 {
-        value.0 as u64
+        u64::from(value.0)
     }
 }
 
@@ -99,7 +99,7 @@ impl TryFrom<i64> for BlockHeight {
 
 impl From<BlockHeight> for i64 {
     fn from(value: BlockHeight) -> i64 {
-        value.0 as i64
+        i64::from(value.0)
     }
 }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2051,7 +2051,7 @@ impl TestFvk for DiversifiableFullViewingKey {
             compact_sapling_output(params, height, recipient, value, sender_ovk.copied(), rng);
         ctx.outputs.push(cout);
 
-        note.nf(&self.fvk().vk.nk, position as u64)
+        note.nf(&self.fvk().vk.nk, u64::from(position))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/zcash_client_memory/src/types/memory_wallet/mod.rs
+++ b/zcash_client_memory/src/types/memory_wallet/mod.rs
@@ -941,7 +941,10 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                 .fold(0, |sum, (_, block)| {
                     sum + block.sapling_output_count.unwrap_or(0)
                 });
-            Ok(Some(Ratio::new(outputs_sum as u64, outputs_sum as u64)))
+            Ok(Some(Ratio::new(
+                u64::from(outputs_sum),
+                u64::from(outputs_sum),
+            )))
         } else {
             // Get the starting note commitment tree size from the wallet birthday, or failing that
             // from the blocks table.
@@ -961,9 +964,10 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                         .iter()
                         .filter(|(height, _)| height <= &birthday_height)
                         .map(|(_, block)| {
-                            (block.sapling_commitment_tree_size.unwrap_or(0)
-                                - block.sapling_output_count.unwrap_or(0))
-                                as u64
+                            u64::from(
+                                block.sapling_commitment_tree_size.unwrap_or(0)
+                                    - block.sapling_output_count.unwrap_or(0),
+                            )
                         })
                         .max()
                 });
@@ -974,7 +978,7 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                 .iter()
                 .filter(|(height, _)| height > &birthday_height)
                 .fold(0_u64, |acc, (_, block)| {
-                    acc + block.sapling_output_count.unwrap_or(0) as u64
+                    acc + u64::from(block.sapling_output_count.unwrap_or(0))
                 });
 
             // We don't have complete information on how many outputs will exist in the shard at
@@ -1019,7 +1023,10 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                 .fold(0, |sum, (_, block)| {
                     sum + block.orchard_action_count.unwrap_or(0)
                 });
-            Ok(Some(Ratio::new(outputs_sum as u64, outputs_sum as u64)))
+            Ok(Some(Ratio::new(
+                u64::from(outputs_sum),
+                u64::from(outputs_sum),
+            )))
         } else {
             // Get the starting note commitment tree size from the wallet birthday, or failing that
             // from the blocks table.
@@ -1039,9 +1046,10 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                         .iter()
                         .filter(|(height, _)| height <= &birthday_height)
                         .map(|(_, block)| {
-                            (block.orchard_commitment_tree_size.unwrap_or(0)
-                                - block.orchard_action_count.unwrap_or(0))
-                                as u64
+                            u64::from(
+                                block.orchard_commitment_tree_size.unwrap_or(0)
+                                    - block.orchard_action_count.unwrap_or(0),
+                            )
                         })
                         .max()
                 });
@@ -1052,7 +1060,7 @@ impl<P: consensus::Parameters> MemoryWalletDb<P> {
                 .iter()
                 .filter(|(height, _)| height > &birthday_height)
                 .fold(0_u64, |acc, (_, block)| {
-                    acc + block.orchard_action_count.unwrap_or(0) as u64
+                    acc + u64::from(block.orchard_action_count.unwrap_or(0))
                 });
 
             // We don't have complete information on how many outputs will exist in the shard at

--- a/zcash_client_memory/src/types/notes/mod.rs
+++ b/zcash_client_memory/src/types/notes/mod.rs
@@ -32,7 +32,7 @@ mod serialization {
                         "Attempting to deserialize orchard supporting wallet using library built without orchard feature"
                     ),
                 },
-                output_index: note_id.output_index() as u32,
+                output_index: u32::from(note_id.output_index()),
             }
         }
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -538,7 +538,7 @@ pub(crate) fn add_account<P: consensus::Parameters>(
                 ":birthday_sapling_tree_size": birthday_sapling_tree_size,
                 ":birthday_orchard_tree_size": birthday_orchard_tree_size,
                 ":recover_until_height": birthday.recover_until().map(u32::from),
-                ":has_spend_key": spending_key_available as i64,
+                ":has_spend_key": i64::from(spending_key_available),
             ],
             |row| row.get(0).map(AccountRef),
         )


### PR DESCRIPTION
## Summary

Replaces widening integer `expr as T` casts with the value-identical
`T::from(expr)` across the workspace. These are lossless conversions (`u8`/
`u16`/`u32` -> `u64`, `u32` -> `i64`, `u16` -> `u32`, `bool` -> `i64`, etc.),
so there is no behaviour change. This resolves every `clippy::cast_lossless`
warning across the workspace under `--all-features`.

## Why

`as` casts silently become lossy if the operand type later widens; the `From`
form makes the conversion fail to compile instead, which is the safer default
for arithmetic-heavy code.

## Scope

Pure refactor, no public API or behaviour change. 9 files, +33/-25:

- `components/eip681`, `components/equihash`, `components/zcash_address`,
  `components/zcash_encoding`, `components/zcash_protocol`
- `zcash_client_backend` (testing utilities), `zcash_client_memory`,
  `zcash_client_sqlite`

## Verification

- `cargo clippy --workspace --lib --all-features -- -W clippy::cast_lossless`
  reports 0 warnings.
- Workspace compiles; existing tests for the affected crates pass.