### PR TITLE
zcash_client_backend: let callers pin `expiry_height` on `create_pczt_from_proposal`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -134,6 +134,10 @@ workspace.
   - `zcash_client_backend::data_api::WalletWrite::notify_output_verified_unspent`,
     which records that a transparent outpoint was confirmed unspent as of a given
     height.
+- `zcash_client_backend::data_api::error::Error::ExpiryHeightBelowTargetHeight`
+  (behind the `pczt` feature flag), returned by `create_pczt_from_proposal`
+  when the caller-supplied `target_expiry_height` is a nonzero height below
+  the proposal's minimum target height.
 
 ### Changed
 - `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
@@ -219,6 +223,23 @@ workspace.
   unspendable data outputs and skipped silently, instead of being logged as
   unsupported script kinds. Other unrecognized transparent script kinds continue to
   be logged.
+- `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes
+  an additional `target_expiry_height: Option<BlockHeight>` argument. When set,
+  it replaces the builder-derived expiry on `PcztParts` before the Creator runs,
+  so the IO Finalizer signs dummy actions against the caller-pinned sighash. A
+  post-Creator Updater that mutates `Global::expiry_height` cannot reach the
+  same result because `IoFinalizer::finalize_io` consumes each dummy's
+  `dummy_sk`, leaving the dummy `spend_auth_sig` over a stale sighash and the
+  Extractor returning `SighashMismatch`. Existing callers should pass `None`
+  to preserve the prior behaviour. A nonzero `target_expiry_height` below the
+  proposal's minimum target height is rejected with
+  `Error::ExpiryHeightBelowTargetHeight` before any transaction building
+  occurs; a `target_expiry_height` of zero, which disables expiry, is exempt.
+- The signature of
+  `zcash_client_backend::data_api::testing::TestState::create_pczt_from_proposal`
+  now takes the same `target_expiry_height: Option<BlockHeight>` argument as
+  `create_pczt_from_proposal`. This only affects users of the
+  `test-dependencies` feature.
 
 ### Removed
 - `zcash_client_backend::data_api::WalletUtxo` (use `WalletTransparentOutput`

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -224,22 +224,11 @@ workspace.
   unsupported script kinds. Other unrecognized transparent script kinds continue to
   be logged.
 - `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes
-  an additional `target_expiry_height: Option<BlockHeight>` argument. When set,
-  it replaces the builder-derived expiry on `PcztParts` before the Creator runs,
-  so the IO Finalizer signs dummy actions against the caller-pinned sighash. A
-  post-Creator Updater that mutates `Global::expiry_height` cannot reach the
-  same result because `IoFinalizer::finalize_io` consumes each dummy's
-  `dummy_sk`, leaving the dummy `spend_auth_sig` over a stale sighash and the
-  Extractor returning `SighashMismatch`. Existing callers should pass `None`
-  to preserve the prior behaviour. A nonzero `target_expiry_height` below the
-  proposal's minimum target height is rejected with
-  `Error::ExpiryHeightBelowTargetHeight` before any transaction building
-  occurs; a `target_expiry_height` of zero, which disables expiry, is exempt.
-- The signature of
-  `zcash_client_backend::data_api::testing::TestState::create_pczt_from_proposal`
-  now takes the same `target_expiry_height: Option<BlockHeight>` argument as
-  `create_pczt_from_proposal`. This only affects users of the
-  `test-dependencies` feature.
+  an additional `target_expiry_height: Option<BlockHeight>` argument. `Some`
+  pins the PCZT expiry before finalization, while `None` preserves the
+  builder-derived expiry. Nonzero heights below the proposal's minimum target
+  height are rejected with `Error::ExpiryHeightBelowTargetHeight`; zero still
+  disables expiry. The `test-dependencies` helper mirrors this signature.
 
 ### Removed
 - `zcash_client_backend::data_api::WalletUtxo` (use `WalletTransparentOutput`

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -104,6 +104,16 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
     #[cfg(feature = "transparent-inputs")]
     AddressNotRecognized(TransparentAddress),
 
+    /// The caller requested a PCZT expiry height below the proposal's minimum target
+    /// height, which would produce a transaction that is already expired at the
+    /// earliest height at which it could be mined. A zero expiry height, which
+    /// disables expiry entirely, is exempt from this check.
+    #[cfg(feature = "pczt")]
+    ExpiryHeightBelowTargetHeight {
+        expiry_height: BlockHeight,
+        min_target_height: BlockHeight,
+    },
+
     /// An error occurred while working with PCZTs.
     #[cfg(feature = "pczt")]
     Pczt(PcztError),
@@ -307,6 +317,16 @@ where
                     "The specified transparent address was not recognized as belonging to the wallet."
                 )
             }
+            #[cfg(feature = "pczt")]
+            Error::ExpiryHeightBelowTargetHeight {
+                expiry_height,
+                min_target_height,
+            } => write!(
+                f,
+                "The requested PCZT expiry height {expiry_height} is below the proposal's \
+                 minimum target height {min_target_height}; the transaction would already be \
+                 expired at the earliest height at which it could be mined."
+            ),
             #[cfg(feature = "pczt")]
             Error::Pczt(e) => write!(f, "PCZT error: {e}"),
         }

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -104,10 +104,8 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
     #[cfg(feature = "transparent-inputs")]
     AddressNotRecognized(TransparentAddress),
 
-    /// The caller requested a PCZT expiry height below the proposal's minimum target
-    /// height, which would produce a transaction that is already expired at the
-    /// earliest height at which it could be mined. A zero expiry height, which
-    /// disables expiry entirely, is exempt from this check.
+    /// The caller requested a nonzero PCZT expiry height below the proposal's
+    /// minimum target height. Zero remains valid because it disables expiry.
     #[cfg(feature = "pczt")]
     ExpiryHeightBelowTargetHeight {
         expiry_height: BlockHeight,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1284,6 +1284,7 @@ where
         spend_from_account: <DbT as InputSource>::AccountId,
         ovk_policy: OvkPolicy,
         proposal: &Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
+        target_expiry_height: Option<BlockHeight>,
     ) -> Result<
         pczt::Pczt,
         super::wallet::CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, DbT::NoteRef>,
@@ -1302,6 +1303,7 @@ where
             spend_from_account,
             ovk_policy,
             proposal,
+            target_expiry_height,
         )
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6106,6 +6106,7 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
 pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     ds_factory: Dsf,
     cache: impl TestCache,
+    pin_expiry_above_target: Option<u32>,
 ) where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: serde::Serialize + serde::de::DeserializeOwned,
@@ -6176,13 +6177,32 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         )
         .unwrap();
 
-    let _min_target_height = proposal0.min_target_height();
+    let min_target_height = proposal0.min_target_height();
     assert_eq!(proposal0.steps().len(), 1);
+
+    let target_expiry_height =
+        pin_expiry_above_target.map(|delta| BlockHeight::from(min_target_height) + delta);
+
+    if target_expiry_height.is_some() {
+        // A nonzero expiry below the proposal's minimum target height must be rejected
+        // before any transaction building occurs, so this earlier call has no effect on
+        // note selection for the successful call below.
+        assert_matches!(
+            st.create_pczt_from_proposal::<Infallible, _, Infallible>(
+                account.id(),
+                OvkPolicy::Sender,
+                &proposal0,
+                Some(min_target_height.saturating_sub(1)),
+            ),
+            Err(Error::ExpiryHeightBelowTargetHeight { .. })
+        );
+    }
 
     let create_proposed_result = st.create_pczt_from_proposal::<Infallible, _, Infallible>(
         account.id(),
         OvkPolicy::Sender,
         &proposal0,
+        target_expiry_height,
     );
     assert_matches!(&create_proposed_result, Ok(_));
     let pczt_created = create_proposed_result.unwrap();
@@ -6229,6 +6249,11 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     let extract_and_store_result = st.extract_and_store_transaction_from_pczt(pczt_authorized);
     assert_matches!(&extract_and_store_result, Ok(_));
     let txid = extract_and_store_result.unwrap();
+
+    if let Some(expiry_height) = target_expiry_height {
+        let tx = st.wallet().get_transaction(txid).unwrap().unwrap();
+        assert_eq!(tx.expiry_height(), expiry_height);
+    }
 
     let (h, _) = st.generate_next_block_including(txid);
     st.scan_cached_blocks(h, 1);

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6184,9 +6184,8 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         pin_expiry_above_target.map(|delta| BlockHeight::from(min_target_height) + delta);
 
     if target_expiry_height.is_some() {
-        // A nonzero expiry below the proposal's minimum target height must be rejected
-        // before any transaction building occurs, so this earlier call has no effect on
-        // note selection for the successful call below.
+        // This is rejected before transaction building, so the successful call below
+        // can reuse the same proposal.
         assert_matches!(
             st.create_pczt_from_proposal::<Infallible, _, Infallible>(
                 account.id(),

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2289,22 +2289,14 @@ where
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
 ///
-/// `target_expiry_height`, when set, replaces the builder-derived expiry on the
-/// resulting `PcztParts` before the Creator role produces the [`pczt::Pczt`].
-/// This is the only stage at which `expiry_height` can be changed without
-/// invalidating the dummy spends that the IO Finalizer signs immediately
-/// afterwards: the IO Finalizer computes the shielded sighash over the PCZT
-/// global it sees, signs every dummy action with its `dummy_sk` against that
-/// sighash, and then consumes `dummy_sk` from the PCZT. A wire-format Updater
-/// that mutates `Global::expiry_height` post-finalization produces dummy
-/// `spend_auth_sig`s that no longer verify, and the failure surfaces later as
-/// [`pczt::roles::tx_extractor::Error::SighashMismatch`] at extraction time.
+/// `target_expiry_height`, when set, replaces the builder-derived expiry before
+/// the PCZT is finalized. Applying this override after finalization can invalidate
+/// dummy spend signatures.
 ///
 /// A nonzero `target_expiry_height` below the proposal's
 /// [`min_target_height`](Proposal::min_target_height) is rejected with
-/// [`Error::ExpiryHeightBelowTargetHeight`], since it would produce a transaction that
-/// is already expired at the earliest height at which it could be mined. A
-/// `target_expiry_height` of zero, which disables expiry, is exempt from this check.
+/// [`Error::ExpiryHeightBelowTargetHeight`]. A `target_expiry_height` of zero,
+/// which disables expiry, is exempt from this check.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "pczt")]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2288,6 +2288,23 @@ where
 ///
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
+///
+/// `target_expiry_height`, when set, replaces the builder-derived expiry on the
+/// resulting `PcztParts` before the Creator role produces the [`pczt::Pczt`].
+/// This is the only stage at which `expiry_height` can be changed without
+/// invalidating the dummy spends that the IO Finalizer signs immediately
+/// afterwards: the IO Finalizer computes the shielded sighash over the PCZT
+/// global it sees, signs every dummy action with its `dummy_sk` against that
+/// sighash, and then consumes `dummy_sk` from the PCZT. A wire-format Updater
+/// that mutates `Global::expiry_height` post-finalization produces dummy
+/// `spend_auth_sig`s that no longer verify, and the failure surfaces later as
+/// [`pczt::roles::tx_extractor::Error::SighashMismatch`] at extraction time.
+///
+/// A nonzero `target_expiry_height` below the proposal's
+/// [`min_target_height`](Proposal::min_target_height) is rejected with
+/// [`Error::ExpiryHeightBelowTargetHeight`], since it would produce a transaction that
+/// is already expired at the earliest height at which it could be mined. A
+/// `target_expiry_height` of zero, which disables expiry, is exempt from this check.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "pczt")]
@@ -2297,6 +2314,7 @@ pub fn create_pczt_from_proposal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT,
     account_id: <DbT as WalletRead>::AccountId,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
+    target_expiry_height: Option<BlockHeight>,
 ) -> Result<pczt::Pczt, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -2319,6 +2337,17 @@ where
     }
     let fee_rule = proposal.fee_rule();
     let min_target_height = proposal.min_target_height();
+
+    if let Some(expiry_height) = target_expiry_height {
+        let min_target_height = BlockHeight::from(min_target_height);
+        if expiry_height != consensus::H0 && expiry_height < min_target_height {
+            return Err(Error::ExpiryHeightBelowTargetHeight {
+                expiry_height,
+                min_target_height,
+            });
+        }
+    }
+
     let prior_step_results = &[];
     let proposal_step = proposal.steps().first();
     let unused_transparent_outputs = &mut HashMap::new();
@@ -2341,7 +2370,11 @@ where
     )?;
 
     // Build the transaction with the specified fee rule
-    let build_result = build_state.builder.build_for_pczt(OsRng, fee_rule)?;
+    let mut build_result = build_state.builder.build_for_pczt(OsRng, fee_rule)?;
+
+    if let Some(target) = target_expiry_height {
+        build_result.pczt_parts.expiry_height = target;
+    }
 
     if build_result.pczt_parts.ironwood.is_some() {
         return Err(Error::ProposalNotSupported);

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -673,10 +673,13 @@ pub(crate) fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester>() {
 }
 
 #[cfg(feature = "pczt-tests")]
-pub(crate) fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester>() {
+pub(crate) fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
+    pin_expiry_above_target: Option<u32>,
+) {
     zcash_client_backend::data_api::testing::pool::pczt_single_step::<P0, P1, _>(
         TestDbFactory::default(),
         BlockCache::new(),
+        pin_expiry_above_target,
     )
 }
 

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -734,11 +734,7 @@ pub(crate) mod tests {
         testing::pool::pczt_single_step::<OrchardPoolTester, SaplingPoolTester>(None)
     }
 
-    /// Regression test: pinning `target_expiry_height` on a proposal whose Orchard
-    /// bundle pads to two actions must not invalidate the `spend_auth_sig` that the
-    /// IO Finalizer computes over the dummy second action's sighash. The Prover ->
-    /// Signer -> Extractor pipeline must still succeed, and the extracted
-    /// transaction must carry the pinned expiry height.
+    // Regression: pinned expiry must still extract when Orchard adds a dummy action.
     #[cfg(feature = "pczt-tests")]
     #[test]
     fn pczt_single_step_orchard_pinned_expiry() {

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -725,13 +725,24 @@ pub(crate) mod tests {
     #[cfg(feature = "pczt-tests")]
     #[test]
     fn pczt_single_step_orchard_only() {
-        testing::pool::pczt_single_step::<OrchardPoolTester, OrchardPoolTester>()
+        testing::pool::pczt_single_step::<OrchardPoolTester, OrchardPoolTester>(None)
     }
 
     #[cfg(feature = "pczt-tests")]
     #[test]
     fn pczt_single_step_orchard_to_sapling() {
-        testing::pool::pczt_single_step::<OrchardPoolTester, SaplingPoolTester>()
+        testing::pool::pczt_single_step::<OrchardPoolTester, SaplingPoolTester>(None)
+    }
+
+    /// Regression test: pinning `target_expiry_height` on a proposal whose Orchard
+    /// bundle pads to two actions must not invalidate the `spend_auth_sig` that the
+    /// IO Finalizer computes over the dummy second action's sighash. The Prover ->
+    /// Signer -> Extractor pipeline must still succeed, and the extracted
+    /// transaction must carry the pinned expiry height.
+    #[cfg(feature = "pczt-tests")]
+    #[test]
+    fn pczt_single_step_orchard_pinned_expiry() {
+        testing::pool::pczt_single_step::<OrchardPoolTester, OrchardPoolTester>(Some(100))
     }
 
     #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -626,13 +626,13 @@ pub(crate) mod tests {
     #[cfg(feature = "pczt-tests")]
     #[test]
     fn pczt_single_step_sapling_only() {
-        testing::pool::pczt_single_step::<SaplingPoolTester, SaplingPoolTester>()
+        testing::pool::pczt_single_step::<SaplingPoolTester, SaplingPoolTester>(None)
     }
 
     #[cfg(all(feature = "orchard", feature = "pczt-tests"))]
     #[test]
     fn pczt_single_step_sapling_to_orchard() {
-        testing::pool::pczt_single_step::<SaplingPoolTester, OrchardPoolTester>()
+        testing::pool::pczt_single_step::<SaplingPoolTester, OrchardPoolTester>(None)
     }
 
     #[cfg(feature = "transparent-inputs")]


### PR DESCRIPTION
Refs #2380. Complements #2398: that PR adds expiry control on the `Builder` and proposal helpers, while this one covers the PCZT path (`create_pczt_from_proposal`), where the `Builder` is built internally and never reaches the caller.

## Why

A caller that wants to commit to a specific `expiry_height` on a PCZT today has no way to do it through `create_pczt_from_proposal`: that function derives the expiry from `Builder::new`'s `target_height + DEFAULT_TX_EXPIRY_DELTA`. The natural workaround (mutate `Global::expiry_height` later via a wire-format Updater) silently breaks dummy orchard actions: `IoFinalizer::finalize_io` signs every dummy with its `dummy_sk` against the at-finalization shielded sighash, then `Option::take`s `dummy_sk` from the PCZT. The dummy's `spend_auth_sig` is now fixed against a sighash the caller cannot reproduce, and there is no key left to re-sign it. The Signer adds the real spend's `spend_auth_sig` later against the post-mutation sighash, so its verify passes at extract time; the dummy's verify fails, and the whole pipeline returns `pczt::roles::tx_extractor::Error::SighashMismatch`.

## Approach

Take the expiry through the only door that survives `IoFinalizer`. Add an optional `target_expiry_height: Option<BlockHeight>`. When set, assign it to `build_result.pczt_parts.expiry_height` between `build_for_pczt` and `Creator::build_from_parts`. `Creator` copies `PcztParts::expiry_height` into `Global::expiry_height`, then `IoFinalizer` computes its sighash from that global and signs the dummies against the value the caller pinned. `PcztParts::expiry_height` is already `pub`, so the change is purely additive at the API boundary.

Existing callers pass `None` for the new argument. The testing helper at `testing::TestState::create_pczt_from_proposal` keeps its surface unchanged by threading `None` through.

## Why not alternatives

- A wire-format `Updater` that mutates `Global::expiry_height` after the existing `create_pczt_from_proposal` runs cannot fix this. `IoFinalizer` runs inside the same call and has already consumed `dummy_sk`.
- Exposing a separate setter on `Pczt` would let a caller mutate the global, but the same `dummy_sk` consumption blocks the dummy re-sign.
- Splitting `create_pczt_from_proposal` into separate `creator`, `set_expiry`, `io_finalizer` steps would let callers reorder, but that is a much larger surface change and the `target_expiry_height` argument captures the same intent on the existing API.

## Repro (without this PR)

Build a PCZT with one orchard spend and at least one dummy orchard action through `create_pczt_from_proposal`. Then mutate `Global::expiry_height` via any out-of-band Updater (e.g. a postcard-layer mirror of `Global`). Run the standard `Prover` → `Signer` → `TransactionExtractor::extract` pipeline. The Extractor returns `SighashMismatch`. Instrumented per-action verify shows the real spend passing and the dummy failing under the recomputed sighash.

With this PR, the same flow with `target_expiry_height = Some(target)` succeeds end-to-end: `IoFinalizer`'s sighash already reflects `target`, so the dummy's `spend_auth_sig` matches the sighash the Extractor recomputes.