### PR TITLE
zcash_client_backend: Support spending transparent UTXOs in propose_transaction

### DIFF
--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -14,6 +14,7 @@ use zcash_keys::{
 };
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::{local_consensus::LocalNetwork, value::Zatoshis};
+use zip321::{Payment, TransactionRequest};
 
 #[cfg(feature = "transparent-key-import")]
 use {
@@ -355,6 +356,116 @@ where
         ConfirmationsPolicy::MIN,
         &zero_or_one_conf_value,
     );
+}
+
+pub fn propose_t2t_with_only_transparent_funds<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let sender_account = st.test_account().cloned().unwrap();
+    let unified_addr = st
+        .wallet()
+        .get_last_generated_address_matching(
+            sender_account.id(),
+            UnifiedAddressRequest::AllAvailableKeys,
+        )
+        .unwrap()
+        .unwrap();
+    let transparent_addr = unified_addr.transparent().unwrap();
+
+    // Sync some chain data with notes that DO NOT belong to us so that target/anchor
+    // heights resolve while the account remains without any shielded notes. Without this,
+    // `propose_transfer` would fail with an unrelated error (unresolved heights) instead
+    // of exercising the transparent-UTXO selection path we want to test.
+    let some_viewing_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+    let a_thousand_zatoshis = Zatoshis::const_from_u64(10000);
+    let (start_height, _, _) = st.generate_next_block(
+        &some_viewing_key,
+        AddressType::DefaultExternal,
+        a_thousand_zatoshis,
+    );
+    for _ in 1..10 {
+        st.generate_next_block(
+            &some_viewing_key,
+            AddressType::DefaultExternal,
+            a_thousand_zatoshis,
+        );
+    }
+    st.scan_cached_blocks(start_height, 10);
+
+    // Fund the account with a transparent UTXO well above the marginal fee.
+    let utxo_value = Zatoshis::const_from_u64(100_000);
+    let txout = TxOut::new(utxo_value, transparent_addr.script().into());
+    let height = st.wallet().chain_height().unwrap().unwrap();
+    let utxo = WalletTransparentOutput::from_parts(
+        OutPoint::fake(),
+        txout,
+        Some(height),
+        Some(sender_account.id()),
+        Some(TransparentKeyScope::EXTERNAL),
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    // Build a t->t payment for less than the available transparent balance.
+    let recipient_transparent_address = TransparentAddress::PublicKeyHash([7u8; 20]);
+    let transfer_amount = Zatoshis::const_from_u64(40_000);
+    let transaction_request = TransactionRequest::new(vec![Payment::without_memo(
+        Address::Transparent(recipient_transparent_address).to_zcash_address(st.network()),
+        transfer_amount,
+    )])
+    .unwrap();
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedProtocol::Sapling,
+        DustOutputPolicy::default(),
+    );
+
+    let proposal = st
+        .propose_transfer(
+            sender_account.id(),
+            &input_selector,
+            &change_strategy,
+            transaction_request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("propose_transfer must succeed for transparent UTXOs");
+
+    // The transfer is a single step (no ZIP-320 ephemeral roundtrip is involved).
+    assert_eq!(proposal.steps().len(), 1);
+    let step = &proposal.steps().head;
+
+    // The funding UTXO must appear as a transparent input of the step
+    assert_eq!(
+        step.transparent_inputs().len(),
+        1,
+        "expected exactly one transparent input selected from the account's UTXOs",
+    );
+    assert_eq!(step.transparent_inputs()[0].outpoint(), utxo.outpoint());
+    assert_eq!(step.transparent_inputs()[0].txout().value(), utxo_value);
+
+    // Sanity-check the proposal balance. `TransactionBalance::total()` is `change + fee`, which
+    // by the balance equation equals the input total minus the explicit payment; so it must be
+    // `utxo_value - transfer_amount`. A non-zero fee must be charged, and the remainder of the
+    // funding UTXO must be returned to the wallet as a change output.
+    assert_eq!(
+        step.balance().total(),
+        (utxo_value - transfer_amount).unwrap(),
+    );
+    assert!(step.balance().fee_required() > Zatoshis::ZERO);
+    assert!(!step.balance().proposed_change().is_empty());
 }
 
 /// Regression test for [PRO-291]: shielding a transparent balance composed of many P2PKH

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -639,7 +639,8 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
 >
 where
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletRead<AccountId = <DbT as InputSource>::AccountId>
+        + InputSource<Error = <DbT as WalletRead>::Error>,
     <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
     ParamsT: consensus::Parameters + Clone,
     InputsT: InputSelector<InputSource = DbT>,
@@ -655,6 +656,17 @@ where
     let (target_height, anchor_height) =
         maybe_intial_heights.ok_or_else(|| InputSelectorError::SyncRequired)?;
 
+    // Enumerate the account's own transparent receivers (external, change, and standalone
+    // imported addresses) so that the input selector can spend the account's transparent UTXOs
+    // as a fallback when shielded funds are insufficient. Ephemeral receivers are intentionally
+    // excluded, as they are reserved for ZIP-320 round-trips.
+    #[cfg(feature = "transparent-inputs")]
+    let transparent_source_addrs: Vec<TransparentAddress> = wallet_db
+        .get_transparent_receivers(spend_from_account, true, true)
+        .map_err(InputSelectorError::DataSource)?
+        .into_keys()
+        .collect();
+
     let proposal = input_selector.propose_transaction(
         params,
         wallet_db,
@@ -664,6 +676,8 @@ where
         spend_from_account,
         request,
         change_strategy,
+        #[cfg(feature = "transparent-inputs")]
+        &transparent_source_addrs,
         #[cfg(feature = "unstable")]
         proposed_version,
     )?;

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -202,6 +202,7 @@ pub trait InputSelector {
         account: <Self::InputSource as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
+        #[cfg(feature = "transparent-inputs")] transparent_source_addrs: &[TransparentAddress],
         #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, <Self::InputSource as InputSource>::NoteRef>,
@@ -461,6 +462,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
+        #[cfg(feature = "transparent-inputs")] transparent_source_addrs: &[TransparentAddress],
         #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, DbT::NoteRef>,
@@ -586,6 +588,15 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         let mut amount_required = Zatoshis::ZERO;
         let mut exclude: Vec<DbT::NoteRef> = vec![];
 
+        // Transparent UTXOs belonging to the account are only brought into the selection as a
+        // fallback: we prefer a fully-shielded transaction for privacy, and only gather and spend
+        // transparent inputs once the shielded notes alone cannot cover the required amount. This
+        // also preserves the existing behavior for accounts that have sufficient shielded funds.
+        #[cfg(feature = "transparent-inputs")]
+        let mut transparent_inputs: Vec<WalletTransparentOutput<()>> = vec![];
+        #[cfg(feature = "transparent-inputs")]
+        let mut transparent_loaded = false;
+
         // This loop is guaranteed to terminate because on each iteration we check that the amount
         // of funds selected is strictly increasing. The loop will either return a successful
         // result or the wallet will eventually run out of funds to select.
@@ -696,12 +707,23 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 }
             };
 
+            // The account's spendable transparent UTXOs (only populated as a fallback once
+            // shielded funds are exhausted; see the selection loop below). When the
+            // `transparent-inputs` feature is disabled this is always an empty slice, preserving
+            // the previous shielded-only behaviour.
+            #[cfg(feature = "transparent-inputs")]
+            let tr0_transparent_inputs: &[WalletTransparentOutput<()>] = &transparent_inputs;
+            #[cfg(not(feature = "transparent-inputs"))]
+            let tr0_transparent_inputs: &[WalletTransparentOutput<
+                <DbT as InputSource>::AccountId,
+            >] = &[];
+
             // In the ZIP 320 case, this is the balance for transaction 0, taking into account
             // the ephemeral output.
             let tr0_balance = change_strategy.compute_balance(
                 params,
                 target_height,
-                &[] as &[WalletTransparentOutput<<DbT as InputSource>::AccountId>],
+                tr0_transparent_inputs,
                 &transparent_outputs,
                 &(
                     ::sapling::builder::BundleType::DEFAULT,
@@ -738,6 +760,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         transaction_request,
                         payment_pools,
                         #[cfg(feature = "transparent-inputs")]
+                        transparent_inputs,
+                        #[cfg(not(feature = "transparent-inputs"))]
+                        vec![],
+                        #[cfg(feature = "transparent-inputs")]
                         ephemeral_output_value.zip(tr1_balance_opt).map(
                             |(ephemeral_output_value, tr1_balance)| EphemeralStepConfig {
                                 ephemeral_output_value,
@@ -750,6 +776,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     .map_err(InputSelectorError::Proposal);
                 }
                 Err(ChangeError::DustInputs {
+                    #[cfg(feature = "transparent-inputs")]
+                    transparent,
                     mut sapling,
                     #[cfg(feature = "orchard")]
                     mut orchard,
@@ -758,6 +786,13 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     exclude.append(&mut sapling);
                     #[cfg(feature = "orchard")]
                     exclude.append(&mut orchard);
+                    // Drop any transparent inputs that the change strategy determined to be
+                    // uneconomic, so that the next iteration recomputes the balance without them.
+                    #[cfg(feature = "transparent-inputs")]
+                    {
+                        let dust: BTreeSet<OutPoint> = transparent.into_iter().collect();
+                        transparent_inputs.retain(|i| !dust.contains(i.outpoint()));
+                    }
                 }
                 Err(ChangeError::InsufficientFunds { required, .. }) => {
                     amount_required = required;
@@ -790,6 +825,23 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
 
             let new_available = shielded_inputs.total_value()?;
             if new_available <= prior_available {
+                // Shielded note selection can no longer make progress. Before reporting
+                // insufficient funds, bring the account's spendable transparent UTXOs into the
+                // selection (once) and retry: the next iteration will recompute the balance with
+                // those inputs included.
+                #[cfg(feature = "transparent-inputs")]
+                if !transparent_loaded {
+                    transparent_loaded = true;
+                    transparent_inputs = gather_account_transparent_inputs::<DbT, ChangeT::Error>(
+                        wallet_db,
+                        transparent_source_addrs,
+                        target_height,
+                        confirmations_policy,
+                    )?;
+                    if !transparent_inputs.is_empty() {
+                        continue;
+                    }
+                }
                 return Err(InputSelectorError::InsufficientFunds {
                     required: amount_required,
                     available: new_available,
@@ -1013,6 +1065,7 @@ where
         shielded_inputs,
         transaction_request,
         payment_pools,
+        vec![],
         #[cfg(feature = "transparent-inputs")]
         ephemeral_output_value
             .zip(tr1_fee)
@@ -1042,6 +1095,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
     shielded_inputs: Option<ShieldedInputs<NoteRef>>,
     transaction_request: TransactionRequest,
     payment_pools: BTreeMap<usize, PoolType>,
+    transparent_inputs: Vec<WalletTransparentOutput<()>>,
     #[cfg(feature = "transparent-inputs")] ephemeral_step_opt: Option<EphemeralStepConfig>,
 ) -> Result<Proposal<FeeRuleT, NoteRef>, ProposalError> {
     #[cfg(feature = "transparent-inputs")]
@@ -1087,7 +1141,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             &[],
             tr0,
             payment_pools,
-            vec![],
+            transparent_inputs,
             shielded_inputs,
             vec![],
             tr0_balance,
@@ -1117,7 +1171,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
     Proposal::single_step(
         transaction_request,
         payment_pools,
-        vec![],
+        transparent_inputs,
         shielded_inputs,
         tr0_balance,
         fee_rule.clone(),
@@ -1347,6 +1401,49 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         )
         .map_err(InputSelectorError::Proposal)
     }
+}
+
+/// Gathers the account's spendable transparent UTXOs from each of the provided source
+/// addresses, for use as inputs to a general (non-shielding) transfer.
+///
+/// Unlike [`gather_shielding_inputs`], the source addresses here are the account's own
+/// transparent receivers (enumerated by the caller via
+/// [`WalletRead::get_transparent_receivers`]), none of which are ephemeral, so no
+/// ephemeral-linkability check is required.
+///
+/// [`WalletRead::get_transparent_receivers`]: crate::data_api::WalletRead::get_transparent_receivers
+#[cfg(feature = "transparent-inputs")]
+#[allow(clippy::type_complexity)]
+fn gather_account_transparent_inputs<DbT, ChangeErrT>(
+    wallet_db: &DbT,
+    source_addrs: &[TransparentAddress],
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+) -> Result<
+    Vec<WalletTransparentOutput<()>>,
+    InputSelectorError<
+        <DbT as InputSource>::Error,
+        GreedyInputSelectorError,
+        ChangeErrT,
+        DbT::NoteRef,
+    >,
+>
+where
+    DbT: InputSource,
+{
+    let mut inputs = vec![];
+    for addr in source_addrs {
+        let utxos = wallet_db
+            .get_spendable_transparent_outputs(
+                addr,
+                target_height,
+                confirmations_policy,
+                TransparentOutputFilter::All,
+            )
+            .map_err(InputSelectorError::DataSource)?;
+        inputs.extend(utxos.into_iter().map(|utxo| utxo.redact_account_data()));
+    }
+    Ok(inputs)
 }
 
 /// Gathers spendable transparent UTXOs from each source address, applying the

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2404,6 +2404,14 @@ mod tests {
     }
 
     #[test]
+    fn propose_t2t_with_only_transparent_funds() {
+        zcash_client_backend::data_api::testing::transparent::propose_t2t_with_only_transparent_funds(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
     fn shielding_many_transparent_utxos() {
         zcash_client_backend::data_api::testing::transparent::shielding_many_transparent_utxos(
             TestDbFactory::default(),


### PR DESCRIPTION
Solves [issue 2350](https://github.com/zcash/librustzcash/issues/2350)

`propose_transaction` allows usage of transparent funds when shielded funds are not enough.

There is an optimization that should be considered in the future. Now that we are allowing transparent inputs, we should try using them by default when transfering to a TEX address instead of building an extra transaction. I didn't include it in this PR to limit the scope of this task. I could add an issue as a follow up for this.