### PR TITLE
zcash_primitives: Add feature flagging to enable `sapling` and `orchard` features to be independently enabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,27 @@ jobs:
             uuidparse -n -o uuid $U4 | sort | uniq | wc -l
           )
 
+  prim-feature-flags:
+    name: zcash_primitives protocol feature flags
+    runs-on: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - id: prepare
+        uses: ./.github/actions/prepare
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: prim-feature-flags
+      # Transaction parsing must read the same wire format and compute the same consensus
+      # txid / authorizing-data digests with each shielded protocol enabled or disabled.
+      - name: Test with both shielded protocols disabled
+        run: cargo test -p zcash_primitives --no-default-features --features std
+      - name: Test with only Sapling enabled
+        run: cargo test -p zcash_primitives --no-default-features --features std,sapling
+      - name: Test with only Orchard enabled
+        run: cargo test -p zcash_primitives --no-default-features --features std,orchard
+
   required-checks:
     name: Required status checks have passed
     needs:
@@ -534,6 +555,7 @@ jobs:
       - fmt
       - protobuf
       - uuid
+      - prim-feature-flags
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -13,8 +13,27 @@ workspace.
 ### Added
 - `zcash_primitives::block::Block::from_parts` (behind the `test-dependencies`
   feature flag).
+- The `sapling` and `orchard` feature flags (both enabled by default), which gate
+  compilation of the `sapling` and `orchard` dependencies. When a feature is
+  disabled, transactions containing that protocol's bundle are still parsed,
+  re-serialized byte-identically, and have their txid and authorizing-data
+  commitments computed; only conversion to the typed domain bundle is omitted.
+- `zcash_primitives::transaction::TransactionData::{has_sapling, has_orchard}`,
+  available irrespective of the `sapling`/`orchard` feature flags.
+- `zcash_primitives::transaction::{SaplingBundle, OrchardBundle}` type aliases for
+  the per-protocol bundle type at a given authorization state.
 
 ### Changed
+- The `sapling` and `orchard` dependencies are now optional, behind features of
+  the same name that are part of the default feature set. To build without a
+  protocol, use `default-features = false` and select the features you need. The
+  `circuits` feature now implies both `sapling` and `orchard`.
+- `zcash_primitives::transaction::TransactionData::{sapling_bundle, orchard_bundle}`
+  are now only available when the corresponding feature is enabled; use the new
+  `has_sapling`/`has_orchard` methods for feature-independent presence checks.
+- `zcash_primitives::transaction::sighash::signature_hash` and the
+  `zcash_primitives::transaction::builder` module now require the `sapling`
+  feature (the builder, via `circuits`, requires both protocols).
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -34,6 +34,14 @@ workspace.
 - `zcash_primitives::transaction::sighash::signature_hash` and the
   `zcash_primitives::transaction::builder` module now require the `sapling`
   feature (the builder, via `circuits`, requires both protocols).
+- The `zcash_primitives::transaction::TransactionDigest::{digest_sapling,
+  digest_orchard}` methods now take `Option<&SaplingBundle<A>>` /
+  `Option<&OrchardBundle<A>>` instead of the concrete `sapling::Bundle` /
+  `orchard::Bundle` types. With the corresponding feature enabled the alias
+  resolves to the same typed bundle (so existing implementations that name the
+  concrete type still compile); with the feature disabled it resolves to the
+  opaque byte representation, so an external implementor that supports
+  feature-off builds must handle that case.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -40,8 +40,8 @@ memuse.workspace = true
 ff.workspace = true
 jubjub.workspace = true
 nonempty.workspace = true
-orchard.workspace = true
-sapling.workspace = true
+orchard = { workspace = true, optional = true }
+sapling = { workspace = true, optional = true }
 
 # - Note Commitment Trees
 incrementalmerkletree = { workspace = true, features = ["legacy-api"] }
@@ -93,21 +93,33 @@ zip32.workspace = true
 pprof = { version = "0.15", features = ["criterion", "flamegraph"] }
 
 [features]
-default = ["multicore", "std", "circuits"]
+default = ["multicore", "std", "circuits", "sapling", "orchard"]
 std = [
     "document-features",
     "redjubjub/std",
-    "sapling/std",
-    "orchard/std",
+    "sapling?/std",
+    "orchard?/std",
     "transparent/std",
 ]
 zip-233 = []
 
-## Enables creating proofs
-circuits = ["orchard/circuit", "sapling/circuit"]
+## Enables conversion of parsed Sapling transaction data into typed domain bundles, and the
+## Sapling parts of the transaction builder. When disabled, the `sapling` crate is not
+## compiled; transactions are still parsed and re-serialized over the same wire format, with
+## Sapling bundles retained in an opaque byte representation.
+sapling = ["dep:sapling"]
+
+## Enables conversion of parsed Orchard transaction data into typed domain bundles, and the
+## Orchard parts of the transaction builder. When disabled, the `orchard` crate is not
+## compiled; transactions are still parsed and re-serialized over the same wire format, with
+## Orchard bundles retained in an opaque byte representation.
+orchard = ["dep:orchard"]
+
+## Enables creating proofs. Requires both the `sapling` and `orchard` features.
+circuits = ["sapling", "orchard", "orchard/circuit", "sapling/circuit"]
 
 ## Enables multithreading support for creating proofs.
-multicore = ["orchard/multicore", "sapling/multicore"]
+multicore = ["sapling?/multicore", "orchard?/multicore"]
 
 ## Enables spending transparent notes with the transaction builder.
 transparent-inputs = [
@@ -123,8 +135,8 @@ temporary-zcashd = []
 test-dependencies = [
     "dep:proptest",
     "incrementalmerkletree/test-dependencies",
-    "orchard/test-dependencies",
-    "sapling/test-dependencies",
+    "orchard?/test-dependencies",
+    "sapling?/test-dependencies",
     "transparent/test-dependencies",
     "zcash_protocol/test-dependencies",
 ]

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -37,8 +37,8 @@ sha2.workspace = true
 memuse.workspace = true
 
 # - Shielded protocols
-ff.workspace = true
-jubjub.workspace = true
+ff = { workspace = true, optional = true }
+jubjub = { workspace = true, optional = true }
 nonempty.workspace = true
 orchard = { workspace = true, optional = true }
 sapling = { workspace = true, optional = true }
@@ -67,7 +67,7 @@ document-features = { workspace = true, optional = true }
 hex.workspace = true
 
 # - Shielded protocols
-redjubjub.workspace = true
+redjubjub = { workspace = true, optional = true }
 
 # No-std support
 corez.workspace = true
@@ -96,7 +96,7 @@ pprof = { version = "0.15", features = ["criterion", "flamegraph"] }
 default = ["multicore", "std", "circuits", "sapling", "orchard"]
 std = [
     "document-features",
-    "redjubjub/std",
+    "redjubjub?/std",
     "sapling?/std",
     "orchard?/std",
     "transparent/std",
@@ -107,7 +107,7 @@ zip-233 = []
 ## Sapling parts of the transaction builder. When disabled, the `sapling` crate is not
 ## compiled; transactions are still parsed and re-serialized over the same wire format, with
 ## Sapling bundles retained in an opaque byte representation.
-sapling = ["dep:sapling"]
+sapling = ["dep:sapling", "dep:ff", "dep:jubjub", "dep:redjubjub"]
 
 ## Enables conversion of parsed Orchard transaction data into typed domain bundles, and the
 ## Orchard parts of the transaction builder. When disabled, the `orchard` crate is not

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -115,8 +115,17 @@ sapling = ["dep:sapling", "dep:ff", "dep:jubjub", "dep:redjubjub"]
 ## Orchard bundles retained in an opaque byte representation.
 orchard = ["dep:orchard"]
 
-## Enables creating proofs. Requires both the `sapling` and `orchard` features.
-circuits = ["sapling", "orchard", "orchard/circuit", "sapling/circuit"]
+## Enables creating Sapling proofs (the Sapling part of the transaction builder). Implies the
+## `sapling` feature.
+sapling-circuit = ["sapling", "sapling/circuit"]
+
+## Enables creating Orchard proofs (the Orchard part of the transaction builder). Implies the
+## `orchard` feature.
+orchard-circuit = ["orchard", "orchard/circuit"]
+
+## Enables creating proofs for both shielded protocols; a convenience alias for
+## `sapling-circuit` + `orchard-circuit`.
+circuits = ["sapling-circuit", "orchard-circuit"]
 
 ## Enables multithreading support for creating proofs.
 multicore = ["sapling?/multicore", "orchard?/multicore"]

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -4,11 +4,14 @@ use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
 
 use crate::encoding::{ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "sapling")]
+use incrementalmerkletree::Hashable;
 use incrementalmerkletree::{
-    Address, Hashable, Level, MerklePath, Position,
+    Address, Level, MerklePath, Position,
     frontier::{CommitmentTree, Frontier, NonEmptyFrontier},
     witness::IncrementalWitness,
 };
+#[cfg(feature = "orchard")]
 use orchard::tree::MerkleHashOrchard;
 use zcash_encoding::{Optional, Vector};
 
@@ -23,6 +26,7 @@ pub trait HashSer {
     fn write<W: Write>(&self, writer: W) -> io::Result<()>;
 }
 
+#[cfg(feature = "sapling")]
 impl HashSer for sapling::Node {
     fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut repr = [0u8; 32];
@@ -40,6 +44,7 @@ impl HashSer for sapling::Node {
     }
 }
 
+#[cfg(feature = "orchard")]
 impl HashSer for MerkleHashOrchard {
     fn read<R: Read>(mut reader: R) -> io::Result<Self>
     where
@@ -105,6 +110,7 @@ pub fn read_address<R: Read>(mut reader: R) -> io::Result<Address> {
     Ok(Address::from_parts(level, index))
 }
 
+#[cfg(feature = "sapling")]
 pub fn read_frontier_v0<H: Hashable + HashSer + Clone, R: Read>(
     mut reader: R,
 ) -> io::Result<Frontier<H, { sapling::NOTE_COMMITMENT_TREE_DEPTH }>> {
@@ -331,7 +337,9 @@ pub mod testing {
     }
 }
 
-#[cfg(test)]
+// These tests build Sapling commitment trees and use the `read_frontier_v0` helper, both of
+// which require the `sapling` feature.
+#[cfg(all(test, feature = "sapling"))]
 mod tests {
     use alloc::string::{String, ToString};
     use alloc::vec::Vec;

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -1,6 +1,14 @@
 //! Structs representing the components within Zcash transactions.
+#[cfg(feature = "orchard")]
 pub mod orchard;
+/// Parsing and serialization of Orchard components when the `orchard` feature is disabled.
+#[cfg(not(feature = "orchard"))]
+pub mod orchard_raw;
+#[cfg(feature = "sapling")]
 pub mod sapling;
+/// Parsing and serialization of Sapling components when the `sapling` feature is disabled.
+#[cfg(not(feature = "sapling"))]
+pub mod sapling_raw;
 pub mod sprout;
 
 pub use self::sprout::JsDescription;

--- a/zcash_primitives/src/transaction/components/orchard_raw.rs
+++ b/zcash_primitives/src/transaction/components/orchard_raw.rs
@@ -1,0 +1,262 @@
+//! Parsing and serialization of the Orchard components of a transaction when the `orchard`
+//! feature is disabled.
+//!
+//! When the `orchard` feature is not enabled, the `orchard` crate (and its `pasta_curves`
+//! dependency) is not compiled, so a transaction's Orchard bundle cannot be converted into
+//! the typed [`orchard::Bundle`] domain representation. These functions parse the exact same
+//! binary wire format as the typed path, retaining the parsed bytes in [`RawOrchardBundle`]
+//! so that the transaction can be re-serialized byte-identically and its consensus txid /
+//! authorizing-data digests computed (see [`crate::transaction::txid`]).
+//!
+//! Parsing here is *lenient*: it validates field lengths, the Orchard flags bits, and (under
+//! [`ProofSizeEnforcement::Strict`]) the canonical proof size, but it does NOT validate
+//! Pallas point membership of `cv_net`/`nullifier`/`rk`/`cmx`/`anchor` (that requires
+//! `pasta_curves`, which is only compiled with the `orchard` feature). Point-membership
+//! validation is therefore deferred to the point at which the bytes would be converted into
+//! a typed bundle, which requires the `orchard` feature. This is sufficient to re-serialize
+//! byte-identically and to compute the correct consensus txid.
+
+use alloc::vec::Vec;
+use corez::io::{self, Read, Write};
+
+use zcash_encoding::{Array, CompactSize, Vector};
+use zcash_protocol::value::ZatBalance;
+
+use crate::transaction::Transaction;
+
+const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
+const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
+const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
+
+const ENC_CIPHERTEXT_SIZE: usize = 580;
+const OUT_CIPHERTEXT_SIZE: usize = 80;
+
+// The canonical byte length of an Orchard proof is a fixed base plus a fixed per-action
+// contribution; these constants mirror `orchard::Proof::expected_proof_size`. A proof of any
+// other length is non-canonical (e.g. padded; GHSA-2x4w-pxqw-58v9).
+const PROOF_BASE_SIZE: usize = 2720;
+const PROOF_PER_ACTION_SIZE: usize = 2272;
+
+fn expected_proof_size(num_actions: usize) -> usize {
+    PROOF_BASE_SIZE + PROOF_PER_ACTION_SIZE * num_actions
+}
+
+/// Whether to enforce the canonical Orchard proof size when parsing, mirroring
+/// `orchard::bundle::ProofSizeEnforcement`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProofSizeEnforcement {
+    /// Do not enforce the canonical proof size (pre-NU6.2 consensus rules).
+    Unenforced,
+    /// Reject proofs that are not the canonical size for the number of actions.
+    Strict,
+}
+
+/// A parsed-but-unconverted Orchard action.
+#[derive(Clone, Debug)]
+pub struct RawOrchardAction {
+    pub(crate) cv_net: [u8; 32],
+    pub(crate) nullifier: [u8; 32],
+    pub(crate) rk: [u8; 32],
+    pub(crate) cmx: [u8; 32],
+    pub(crate) epk_bytes: [u8; 32],
+    pub(crate) enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
+    pub(crate) out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
+    pub(crate) spend_auth_sig: [u8; 64],
+}
+
+/// A parsed-but-unconverted Orchard bundle.
+///
+/// This is the representation of a transaction's Orchard bundle used when the `orchard`
+/// feature is disabled. It retains exactly the data required to re-serialize the bundle
+/// byte-identically and to compute the ZIP 244 txid and authorizing-data digests.
+#[derive(Clone, Debug)]
+pub struct RawOrchardBundle {
+    actions: Vec<RawOrchardAction>,
+    flags: u8,
+    value_balance: ZatBalance,
+    anchor: [u8; 32],
+    proof: Vec<u8>,
+    binding_sig: [u8; 64],
+}
+
+impl RawOrchardBundle {
+    pub(crate) fn actions(&self) -> &[RawOrchardAction] {
+        &self.actions
+    }
+
+    pub(crate) fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    pub(crate) fn value_balance(&self) -> &ZatBalance {
+        &self.value_balance
+    }
+
+    pub(crate) fn anchor(&self) -> &[u8; 32] {
+        &self.anchor
+    }
+
+    pub(crate) fn proof(&self) -> &[u8] {
+        &self.proof
+    }
+
+    pub(crate) fn binding_sig(&self) -> &[u8; 64] {
+        &self.binding_sig
+    }
+}
+
+struct RawActionWithoutAuth {
+    cv_net: [u8; 32],
+    nullifier: [u8; 32],
+    rk: [u8; 32],
+    cmx: [u8; 32],
+    epk_bytes: [u8; 32],
+    enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
+    out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
+}
+
+impl RawActionWithoutAuth {
+    fn with_auth(self, spend_auth_sig: [u8; 64]) -> RawOrchardAction {
+        RawOrchardAction {
+            cv_net: self.cv_net,
+            nullifier: self.nullifier,
+            rk: self.rk,
+            cmx: self.cmx,
+            epk_bytes: self.epk_bytes,
+            enc_ciphertext: self.enc_ciphertext,
+            out_ciphertext: self.out_ciphertext,
+            spend_auth_sig,
+        }
+    }
+}
+
+fn read_array<const N: usize, R: Read>(mut reader: R) -> io::Result<[u8; N]> {
+    let mut bytes = [0u8; N];
+    reader.read_exact(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn read_flags<R: Read>(mut reader: R) -> io::Result<u8> {
+    let mut byte = [0u8; 1];
+    reader.read_exact(&mut byte)?;
+    if byte[0] & FLAGS_EXPECTED_UNSET != 0 {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid Orchard flags",
+        ))
+    } else {
+        Ok(byte[0])
+    }
+}
+
+fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<RawActionWithoutAuth> {
+    let cv_net = read_array(&mut reader)?;
+    let nullifier = read_array(&mut reader)?;
+    let rk = read_array(&mut reader)?;
+    let cmx = read_array(&mut reader)?;
+    let epk_bytes = read_array(&mut reader)?;
+    let enc_ciphertext = read_array(&mut reader)?;
+    let out_ciphertext = read_array(&mut reader)?;
+    Ok(RawActionWithoutAuth {
+        cv_net,
+        nullifier,
+        rk,
+        cmx,
+        epk_bytes,
+        enc_ciphertext,
+        out_ciphertext,
+    })
+}
+
+fn write_action_without_auth<W: Write>(mut writer: W, act: &RawOrchardAction) -> io::Result<()> {
+    writer.write_all(&act.cv_net)?;
+    writer.write_all(&act.nullifier)?;
+    writer.write_all(&act.rk)?;
+    writer.write_all(&act.cmx)?;
+    writer.write_all(&act.epk_bytes)?;
+    writer.write_all(&act.enc_ciphertext)?;
+    writer.write_all(&act.out_ciphertext)
+}
+
+/// Reads an Orchard bundle from a v5 transaction format.
+pub(crate) fn read_v5_bundle<R: Read>(
+    mut reader: R,
+    proof_size_enforcement: ProofSizeEnforcement,
+) -> io::Result<Option<RawOrchardBundle>> {
+    #[allow(clippy::redundant_closure)]
+    let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
+    if actions_without_auth.is_empty() {
+        Ok(None)
+    } else {
+        let flags = read_flags(&mut reader)?;
+        let value_balance = Transaction::read_amount(&mut reader)?;
+        let anchor = read_array(&mut reader)?;
+        let proof = Vector::read(&mut reader, |r| {
+            let mut b = [0u8; 1];
+            r.read_exact(&mut b)?;
+            Ok(b[0])
+        })?;
+        let actions = actions_without_auth
+            .into_iter()
+            .map(|awa| Ok(awa.with_auth(read_array::<64, _>(&mut reader)?)))
+            .collect::<io::Result<Vec<_>>>()?;
+        let binding_sig = read_array(&mut reader)?;
+
+        if proof_size_enforcement == ProofSizeEnforcement::Strict
+            && proof.len() != expected_proof_size(actions.len())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "non-canonical Orchard proof size",
+            ));
+        }
+
+        Ok(Some(RawOrchardBundle {
+            actions,
+            flags,
+            value_balance,
+            anchor,
+            proof,
+            binding_sig,
+        }))
+    }
+}
+
+#[cfg(zcash_unstable = "nu7")]
+pub(crate) fn read_v6_bundle<R: Read>(reader: R) -> io::Result<Option<RawOrchardBundle>> {
+    read_v5_bundle(reader, ProofSizeEnforcement::Strict)
+}
+
+/// Writes an Orchard bundle in the v5 transaction format.
+pub(crate) fn write_v5_bundle<W: Write>(
+    bundle: Option<&RawOrchardBundle>,
+    mut writer: W,
+) -> io::Result<()> {
+    if let Some(bundle) = &bundle {
+        Vector::write(&mut writer, &bundle.actions, |w, a| {
+            write_action_without_auth(w, a)
+        })?;
+        writer.write_all(&[bundle.flags])?;
+        writer.write_all(&bundle.value_balance.to_i64_le_bytes())?;
+        writer.write_all(&bundle.anchor)?;
+        Vector::write(&mut writer, &bundle.proof, |w, b| w.write_all(&[*b]))?;
+        Array::write(
+            &mut writer,
+            bundle.actions.iter().map(|a| &a.spend_auth_sig[..]),
+            |w, e| w.write_all(e),
+        )?;
+        writer.write_all(&bundle.binding_sig)?;
+    } else {
+        CompactSize::write(&mut writer, 0)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(zcash_unstable = "nu7")]
+pub(crate) fn write_v6_bundle<W: Write>(
+    bundle: Option<&RawOrchardBundle>,
+    writer: W,
+) -> io::Result<()> {
+    write_v5_bundle(bundle, writer)
+}

--- a/zcash_primitives/src/transaction/components/orchard_raw.rs
+++ b/zcash_primitives/src/transaction/components/orchard_raw.rs
@@ -260,3 +260,79 @@ pub(crate) fn write_v6_bundle<W: Write>(
 ) -> io::Result<()> {
     write_v5_bundle(bundle, writer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ProofSizeEnforcement, expected_proof_size, read_v5_bundle};
+    use alloc::{vec, vec::Vec};
+    use corez::io::Write;
+    use zcash_encoding::Vector;
+
+    // Anchors the hand-copied proof-size constants to the canonical values from the orchard
+    // crate (`orchard::Proof::expected_proof_size`, cross-checked there against the action
+    // circuit), so they cannot silently drift from the feature-on path.
+    #[test]
+    fn proof_size_matches_known_values() {
+        assert_eq!(expected_proof_size(0), 2720);
+        assert_eq!(expected_proof_size(1), 4992);
+        assert_eq!(expected_proof_size(2), 7264);
+        assert_eq!(expected_proof_size(2) - expected_proof_size(1), 2272);
+    }
+
+    /// Wire bytes for a single-action Orchard bundle with a proof of the given length. The
+    /// action is all-zero bytes; feature-off parsing does not validate Pallas point membership,
+    /// so arbitrary 32-byte values parse.
+    fn single_action_bundle_bytes(proof_len: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let action = [0u8; 32 * 5 + 580 + 80];
+        Vector::write(&mut buf, &[action], |w, a| w.write_all(a)).unwrap();
+        buf.push(0u8); // flags
+        buf.extend_from_slice(&0i64.to_le_bytes()); // value_balance
+        buf.extend_from_slice(&[0u8; 32]); // anchor
+        Vector::write(&mut buf, &vec![0u8; proof_len], |w, b| w.write_all(&[*b])).unwrap();
+        buf.extend_from_slice(&[0u8; 64]); // per-action spend_auth_sig
+        buf.extend_from_slice(&[0u8; 64]); // binding_sig
+        buf
+    }
+
+    #[test]
+    fn strict_enforcement_rejects_noncanonical_proof_size() {
+        let canonical = expected_proof_size(1);
+
+        // Strict enforcement accepts the canonical size and rejects any other length
+        // (GHSA-2x4w-pxqw-58v9).
+        assert!(
+            read_v5_bundle(
+                &single_action_bundle_bytes(canonical)[..],
+                ProofSizeEnforcement::Strict,
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert!(
+            read_v5_bundle(
+                &single_action_bundle_bytes(canonical + 1)[..],
+                ProofSizeEnforcement::Strict,
+            )
+            .is_err()
+        );
+        assert!(
+            read_v5_bundle(
+                &single_action_bundle_bytes(canonical - 1)[..],
+                ProofSizeEnforcement::Strict,
+            )
+            .is_err()
+        );
+
+        // Unenforced (pre-NU6.2) accepts a non-canonical size to preserve the ability to parse
+        // historical transactions.
+        assert!(
+            read_v5_bundle(
+                &single_action_bundle_bytes(canonical + 1)[..],
+                ProofSizeEnforcement::Unenforced,
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+}

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -348,6 +348,26 @@ pub(crate) fn read_v4_components<R: Read>(
     }
 }
 
+/// Assembles a v4 Sapling bundle from its parsed components and (separately-read) binding
+/// signature, returning `None` when there is no bundle.
+pub(crate) fn build_v4_bundle(
+    value_balance: ZatBalance,
+    shielded_spends: Vec<SpendDescription<Authorized>>,
+    shielded_outputs: Vec<OutputDescription<GrothProofBytes>>,
+    binding_sig: Option<[u8; 64]>,
+) -> Option<Bundle<Authorized, ZatBalance>> {
+    binding_sig.and_then(|binding_sig| {
+        Bundle::from_parts(
+            shielded_spends,
+            shielded_outputs,
+            value_balance,
+            Authorized {
+                binding_sig: redjubjub::Signature::from(binding_sig),
+            },
+        )
+    })
+}
+
 /// Writes the Sapling components of a v4 transaction.
 #[cfg(feature = "temporary-zcashd")]
 pub fn temporary_zcashd_write_v4_components<W: Write>(

--- a/zcash_primitives/src/transaction/components/sapling_raw.rs
+++ b/zcash_primitives/src/transaction/components/sapling_raw.rs
@@ -8,16 +8,18 @@
 //! can be re-serialized byte-identically and its consensus txid / authorizing-data digests
 //! computed (see [`crate::transaction::txid`]).
 //!
-//! Canonical field-element (`cmu`, `anchor`), value-commitment (`cv`, "not small order"),
-//! and verification-key (`rk`) encodings are validated here using `jubjub` and `redjubjub`,
-//! which are always compiled, so parse-rejection of malformed Sapling encodings matches the
-//! typed path exactly.
+//! Parsing here is *lenient*: it validates field lengths and structure, but it does NOT
+//! validate the curve encodings of `cv`/`anchor`/`cmu`/`rk` (the canonical field-element,
+//! value-commitment "not small order", and verification-key checks performed by the typed
+//! path). Those require `jubjub` and `redjubjub`, which are only compiled with the `sapling`
+//! feature; validation is therefore deferred to the point at which the bytes would be
+//! converted into a typed bundle, which requires that feature. This matches the byte-oriented
+//! Orchard path (see [`super::orchard_raw`]) and is sufficient to re-serialize
+//! byte-identically and to compute the correct consensus txid / authorizing-data digests.
 
 use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
-use ff::PrimeField;
 
-use redjubjub::SpendAuth;
 use zcash_encoding::{Array, CompactSize, Vector};
 use zcash_protocol::value::ZatBalance;
 
@@ -104,50 +106,6 @@ impl RawSaplingBundle {
     }
 }
 
-/// Reads a value commitment, enforcing canonical encoding and rejecting small-order points
-/// (matching `sapling::value::ValueCommitment::from_bytes_not_small_order`).
-fn read_cv<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
-    let mut bytes = [0u8; 32];
-    reader.read_exact(&mut bytes)?;
-    // Matches `sapling::value::ValueCommitment::from_bytes_not_small_order`, which decodes the
-    // canonical Jubjub point encoding and rejects small-order points.
-    let affine = jubjub::AffinePoint::from_bytes(bytes);
-    if affine.is_none().into() {
-        return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid cv"));
-    }
-    let cv = jubjub::ExtendedPoint::from(affine.unwrap());
-    if bool::from(cv.is_small_order()) {
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid cv"))
-    } else {
-        Ok(bytes)
-    }
-}
-
-/// Reads a base field element (`cmu` or `anchor`), enforcing canonical encoding (matching
-/// `jubjub::Base::from_repr`, as used by `ExtractedNoteCommitment::from_bytes`).
-fn read_base<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
-    let mut f = [0u8; 32];
-    reader.read_exact(&mut f)?;
-    if Option::<jubjub::Base>::from(jubjub::Base::from_repr(f)).is_none() {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "base value not a valid field element",
-        ))
-    } else {
-        Ok(f)
-    }
-}
-
-/// Reads a randomized verification key, enforcing canonical encoding (matching
-/// `redjubjub::VerificationKey::<SpendAuth>::try_from`).
-fn read_rk<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
-    let mut bytes = [0u8; 32];
-    reader.read_exact(&mut bytes)?;
-    redjubjub::VerificationKey::<SpendAuth>::try_from(bytes)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "verification key is invalid"))?;
-    Ok(bytes)
-}
-
 fn read_zkproof<R: Read>(mut reader: R) -> io::Result<[u8; GROTH_PROOF_SIZE]> {
     let mut zkproof = [0u8; GROTH_PROOF_SIZE];
     reader.read_exact(&mut zkproof)?;
@@ -161,10 +119,10 @@ fn read_array<const N: usize, R: Read>(mut reader: R) -> io::Result<[u8; N]> {
 }
 
 fn read_spend_v4<R: Read>(mut reader: R) -> io::Result<RawSaplingSpend> {
-    let cv = read_cv(&mut reader)?;
-    let anchor = read_base(&mut reader)?;
+    let cv = read_array(&mut reader)?;
+    let anchor = read_array(&mut reader)?;
     let nullifier = read_array(&mut reader)?;
-    let rk = read_rk(&mut reader)?;
+    let rk = read_array(&mut reader)?;
     let zkproof = read_zkproof(&mut reader)?;
     let spend_auth_sig = read_array(&mut reader)?;
     Ok(RawSaplingSpend {
@@ -187,8 +145,8 @@ fn write_spend_v4<W: Write>(mut writer: W, spend: &RawSaplingSpend) -> io::Resul
 }
 
 fn read_output_v4<R: Read>(mut reader: R) -> io::Result<RawSaplingOutput> {
-    let cv = read_cv(&mut reader)?;
-    let cmu = read_base(&mut reader)?;
+    let cv = read_array(&mut reader)?;
+    let cmu = read_array(&mut reader)?;
     let ephemeral_key = read_array(&mut reader)?;
     let enc_ciphertext = read_array(&mut reader)?;
     let out_ciphertext = read_array(&mut reader)?;
@@ -278,14 +236,14 @@ pub(crate) fn write_v4_components<W: Write>(
 /// Reads a Sapling bundle from a v5 transaction format.
 pub(crate) fn read_v5_bundle<R: Read>(mut reader: R) -> io::Result<Option<RawSaplingBundle>> {
     let sd_v5s: Vec<([u8; 32], [u8; 32], [u8; 32])> = Vector::read(&mut reader, |r| {
-        let cv = read_cv(&mut *r)?;
+        let cv = read_array(&mut *r)?;
         let nullifier = read_array(&mut *r)?;
-        let rk = read_rk(&mut *r)?;
+        let rk = read_array(&mut *r)?;
         Ok((cv, nullifier, rk))
     })?;
     let od_v5s: Vec<RawSaplingOutput> = Vector::read(&mut reader, |r| {
-        let cv = read_cv(&mut *r)?;
-        let cmu = read_base(&mut *r)?;
+        let cv = read_array(&mut *r)?;
+        let cmu = read_array(&mut *r)?;
         let ephemeral_key = read_array(&mut *r)?;
         let enc_ciphertext = read_array(&mut *r)?;
         let out_ciphertext = read_array(&mut *r)?;
@@ -308,7 +266,7 @@ pub(crate) fn read_v5_bundle<R: Read>(mut reader: R) -> io::Result<Option<RawSap
     };
 
     let anchor = if n_spends > 0 {
-        Some(read_base(&mut reader)?)
+        Some(read_array(&mut reader)?)
     } else {
         None
     };

--- a/zcash_primitives/src/transaction/components/sapling_raw.rs
+++ b/zcash_primitives/src/transaction/components/sapling_raw.rs
@@ -1,0 +1,409 @@
+//! Parsing and serialization of the Sapling components of a transaction when the `sapling`
+//! feature is disabled.
+//!
+//! When the `sapling` feature is not enabled, the `sapling` crate is not compiled, so a
+//! transaction's Sapling bundle cannot be converted into the typed [`sapling::Bundle`]
+//! domain representation. These functions parse the exact same binary wire format as the
+//! typed path, retaining the parsed bytes in [`RawSaplingBundle`] so that the transaction
+//! can be re-serialized byte-identically and its consensus txid / authorizing-data digests
+//! computed (see [`crate::transaction::txid`]).
+//!
+//! Canonical field-element (`cmu`, `anchor`), value-commitment (`cv`, "not small order"),
+//! and verification-key (`rk`) encodings are validated here using `jubjub` and `redjubjub`,
+//! which are always compiled, so parse-rejection of malformed Sapling encodings matches the
+//! typed path exactly.
+
+use alloc::vec::Vec;
+use corez::io::{self, Read, Write};
+use ff::PrimeField;
+
+use redjubjub::SpendAuth;
+use zcash_encoding::{Array, CompactSize, Vector};
+use zcash_protocol::value::ZatBalance;
+
+use super::GROTH_PROOF_SIZE;
+use crate::transaction::Transaction;
+
+const ENC_CIPHERTEXT_SIZE: usize = 580;
+const OUT_CIPHERTEXT_SIZE: usize = 80;
+
+/// A parsed-but-unconverted Sapling spend description.
+///
+/// Holds the raw wire bytes of a v4 or v5 Sapling spend description. The `anchor` is stored
+/// per-spend (as in the v4 format); for v5 transactions, which encode a single shared
+/// anchor, that anchor is replicated into each spend.
+#[derive(Clone, Debug)]
+pub struct RawSaplingSpend {
+    pub(crate) cv: [u8; 32],
+    pub(crate) anchor: [u8; 32],
+    pub(crate) nullifier: [u8; 32],
+    pub(crate) rk: [u8; 32],
+    pub(crate) zkproof: [u8; GROTH_PROOF_SIZE],
+    pub(crate) spend_auth_sig: [u8; 64],
+}
+
+/// A parsed-but-unconverted Sapling output description.
+#[derive(Clone, Debug)]
+pub struct RawSaplingOutput {
+    pub(crate) cv: [u8; 32],
+    pub(crate) cmu: [u8; 32],
+    pub(crate) ephemeral_key: [u8; 32],
+    pub(crate) enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
+    pub(crate) out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
+    pub(crate) zkproof: [u8; GROTH_PROOF_SIZE],
+}
+
+/// A parsed-but-unconverted Sapling bundle.
+///
+/// This is the representation of a transaction's Sapling bundle used when the `sapling`
+/// feature is disabled. It retains exactly the data required to re-serialize the bundle
+/// byte-identically and to compute the ZIP 244 txid and authorizing-data digests.
+#[derive(Clone, Debug)]
+pub struct RawSaplingBundle {
+    spends: Vec<RawSaplingSpend>,
+    outputs: Vec<RawSaplingOutput>,
+    value_balance: ZatBalance,
+    binding_sig: [u8; 64],
+}
+
+impl RawSaplingBundle {
+    /// Constructs a bundle from its constituent parts, returning `None` if it would contain
+    /// neither spends nor outputs (matching `sapling::Bundle::from_parts`).
+    fn from_parts(
+        spends: Vec<RawSaplingSpend>,
+        outputs: Vec<RawSaplingOutput>,
+        value_balance: ZatBalance,
+        binding_sig: [u8; 64],
+    ) -> Option<Self> {
+        if spends.is_empty() && outputs.is_empty() {
+            None
+        } else {
+            Some(RawSaplingBundle {
+                spends,
+                outputs,
+                value_balance,
+                binding_sig,
+            })
+        }
+    }
+
+    pub(crate) fn shielded_spends(&self) -> &[RawSaplingSpend] {
+        &self.spends
+    }
+
+    pub(crate) fn shielded_outputs(&self) -> &[RawSaplingOutput] {
+        &self.outputs
+    }
+
+    pub(crate) fn value_balance(&self) -> &ZatBalance {
+        &self.value_balance
+    }
+
+    pub(crate) fn binding_sig(&self) -> &[u8; 64] {
+        &self.binding_sig
+    }
+}
+
+/// Reads a value commitment, enforcing canonical encoding and rejecting small-order points
+/// (matching `sapling::value::ValueCommitment::from_bytes_not_small_order`).
+fn read_cv<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
+    let mut bytes = [0u8; 32];
+    reader.read_exact(&mut bytes)?;
+    // Matches `sapling::value::ValueCommitment::from_bytes_not_small_order`, which decodes the
+    // canonical Jubjub point encoding and rejects small-order points.
+    let affine = jubjub::AffinePoint::from_bytes(bytes);
+    if affine.is_none().into() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid cv"));
+    }
+    let cv = jubjub::ExtendedPoint::from(affine.unwrap());
+    if bool::from(cv.is_small_order()) {
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid cv"))
+    } else {
+        Ok(bytes)
+    }
+}
+
+/// Reads a base field element (`cmu` or `anchor`), enforcing canonical encoding (matching
+/// `jubjub::Base::from_repr`, as used by `ExtractedNoteCommitment::from_bytes`).
+fn read_base<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
+    let mut f = [0u8; 32];
+    reader.read_exact(&mut f)?;
+    if Option::<jubjub::Base>::from(jubjub::Base::from_repr(f)).is_none() {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "base value not a valid field element",
+        ))
+    } else {
+        Ok(f)
+    }
+}
+
+/// Reads a randomized verification key, enforcing canonical encoding (matching
+/// `redjubjub::VerificationKey::<SpendAuth>::try_from`).
+fn read_rk<R: Read>(mut reader: R) -> io::Result<[u8; 32]> {
+    let mut bytes = [0u8; 32];
+    reader.read_exact(&mut bytes)?;
+    redjubjub::VerificationKey::<SpendAuth>::try_from(bytes)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "verification key is invalid"))?;
+    Ok(bytes)
+}
+
+fn read_zkproof<R: Read>(mut reader: R) -> io::Result<[u8; GROTH_PROOF_SIZE]> {
+    let mut zkproof = [0u8; GROTH_PROOF_SIZE];
+    reader.read_exact(&mut zkproof)?;
+    Ok(zkproof)
+}
+
+fn read_array<const N: usize, R: Read>(mut reader: R) -> io::Result<[u8; N]> {
+    let mut bytes = [0u8; N];
+    reader.read_exact(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn read_spend_v4<R: Read>(mut reader: R) -> io::Result<RawSaplingSpend> {
+    let cv = read_cv(&mut reader)?;
+    let anchor = read_base(&mut reader)?;
+    let nullifier = read_array(&mut reader)?;
+    let rk = read_rk(&mut reader)?;
+    let zkproof = read_zkproof(&mut reader)?;
+    let spend_auth_sig = read_array(&mut reader)?;
+    Ok(RawSaplingSpend {
+        cv,
+        anchor,
+        nullifier,
+        rk,
+        zkproof,
+        spend_auth_sig,
+    })
+}
+
+fn write_spend_v4<W: Write>(mut writer: W, spend: &RawSaplingSpend) -> io::Result<()> {
+    writer.write_all(&spend.cv)?;
+    writer.write_all(&spend.anchor)?;
+    writer.write_all(&spend.nullifier)?;
+    writer.write_all(&spend.rk)?;
+    writer.write_all(&spend.zkproof)?;
+    writer.write_all(&spend.spend_auth_sig)
+}
+
+fn read_output_v4<R: Read>(mut reader: R) -> io::Result<RawSaplingOutput> {
+    let cv = read_cv(&mut reader)?;
+    let cmu = read_base(&mut reader)?;
+    let ephemeral_key = read_array(&mut reader)?;
+    let enc_ciphertext = read_array(&mut reader)?;
+    let out_ciphertext = read_array(&mut reader)?;
+    let zkproof = read_zkproof(&mut reader)?;
+    Ok(RawSaplingOutput {
+        cv,
+        cmu,
+        ephemeral_key,
+        enc_ciphertext,
+        out_ciphertext,
+        zkproof,
+    })
+}
+
+fn write_output_v4<W: Write>(mut writer: W, output: &RawSaplingOutput) -> io::Result<()> {
+    writer.write_all(&output.cv)?;
+    writer.write_all(&output.cmu)?;
+    writer.write_all(&output.ephemeral_key)?;
+    writer.write_all(&output.enc_ciphertext)?;
+    writer.write_all(&output.out_ciphertext)?;
+    writer.write_all(&output.zkproof)
+}
+
+/// Reads the Sapling components of a v4 transaction.
+#[allow(clippy::type_complexity)]
+pub(crate) fn read_v4_components<R: Read>(
+    mut reader: R,
+    tx_has_sapling: bool,
+) -> io::Result<(ZatBalance, Vec<RawSaplingSpend>, Vec<RawSaplingOutput>)> {
+    if tx_has_sapling {
+        let vb = Transaction::read_amount(&mut reader)?;
+        #[allow(clippy::redundant_closure)]
+        let ss = Vector::read(&mut reader, |r| read_spend_v4(r))?;
+        #[allow(clippy::redundant_closure)]
+        let so = Vector::read(&mut reader, |r| read_output_v4(r))?;
+        Ok((vb, ss, so))
+    } else {
+        Ok((ZatBalance::zero(), vec![], vec![]))
+    }
+}
+
+/// Assembles a v4 Sapling bundle from its parsed components and (separately-read) binding
+/// signature, returning `None` when there is no bundle.
+pub(crate) fn build_v4_bundle(
+    value_balance: ZatBalance,
+    spends: Vec<RawSaplingSpend>,
+    outputs: Vec<RawSaplingOutput>,
+    binding_sig: Option<[u8; 64]>,
+) -> Option<RawSaplingBundle> {
+    binding_sig.and_then(|binding_sig| {
+        RawSaplingBundle::from_parts(spends, outputs, value_balance, binding_sig)
+    })
+}
+
+/// Writes the Sapling components of a v4 transaction.
+pub(crate) fn write_v4_components<W: Write>(
+    mut writer: W,
+    bundle: Option<&RawSaplingBundle>,
+    tx_has_sapling: bool,
+) -> io::Result<()> {
+    if tx_has_sapling {
+        writer.write_all(
+            &bundle
+                .map_or(ZatBalance::zero(), |b| b.value_balance)
+                .to_i64_le_bytes(),
+        )?;
+        Vector::write(
+            &mut writer,
+            bundle.map_or(&[][..], |b| &b.spends),
+            |w, e| write_spend_v4(w, e),
+        )?;
+        Vector::write(
+            &mut writer,
+            bundle.map_or(&[][..], |b| &b.outputs),
+            |w, e| write_output_v4(w, e),
+        )?;
+    } else if bundle.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Sapling components may not be present if Sapling is not active.",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Reads a Sapling bundle from a v5 transaction format.
+pub(crate) fn read_v5_bundle<R: Read>(mut reader: R) -> io::Result<Option<RawSaplingBundle>> {
+    let sd_v5s: Vec<([u8; 32], [u8; 32], [u8; 32])> = Vector::read(&mut reader, |r| {
+        let cv = read_cv(&mut *r)?;
+        let nullifier = read_array(&mut *r)?;
+        let rk = read_rk(&mut *r)?;
+        Ok((cv, nullifier, rk))
+    })?;
+    let od_v5s: Vec<RawSaplingOutput> = Vector::read(&mut reader, |r| {
+        let cv = read_cv(&mut *r)?;
+        let cmu = read_base(&mut *r)?;
+        let ephemeral_key = read_array(&mut *r)?;
+        let enc_ciphertext = read_array(&mut *r)?;
+        let out_ciphertext = read_array(&mut *r)?;
+        Ok(RawSaplingOutput {
+            cv,
+            cmu,
+            ephemeral_key,
+            enc_ciphertext,
+            out_ciphertext,
+            // Filled in from the separately-encoded output proofs below.
+            zkproof: [0u8; GROTH_PROOF_SIZE],
+        })
+    })?;
+    let n_spends = sd_v5s.len();
+    let n_outputs = od_v5s.len();
+    let value_balance = if n_spends > 0 || n_outputs > 0 {
+        Transaction::read_amount(&mut reader)?
+    } else {
+        ZatBalance::zero()
+    };
+
+    let anchor = if n_spends > 0 {
+        Some(read_base(&mut reader)?)
+    } else {
+        None
+    };
+
+    #[allow(clippy::redundant_closure)]
+    let v_spend_proofs = Array::read(&mut reader, n_spends, |r| read_zkproof(r))?;
+    let v_spend_auth_sigs = Array::read(&mut reader, n_spends, |r| read_array::<64, _>(r))?;
+    #[allow(clippy::redundant_closure)]
+    let v_output_proofs = Array::read(&mut reader, n_outputs, |r| read_zkproof(r))?;
+
+    let binding_sig = if n_spends > 0 || n_outputs > 0 {
+        let mut sig = [0u8; 64];
+        reader.read_exact(&mut sig)?;
+        Some(sig)
+    } else {
+        None
+    };
+
+    let spends = sd_v5s
+        .into_iter()
+        .zip(v_spend_proofs.into_iter().zip(v_spend_auth_sigs))
+        .map(
+            |((cv, nullifier, rk), (zkproof, spend_auth_sig))| RawSaplingSpend {
+                cv,
+                // the following `unwrap` is safe because we know n_spends > 0.
+                anchor: anchor.unwrap(),
+                nullifier,
+                rk,
+                zkproof,
+                spend_auth_sig,
+            },
+        )
+        .collect();
+
+    let outputs = od_v5s
+        .into_iter()
+        .zip(v_output_proofs)
+        .map(|(output, zkproof)| RawSaplingOutput { zkproof, ..output })
+        .collect();
+
+    Ok(binding_sig.and_then(|binding_sig| {
+        RawSaplingBundle::from_parts(spends, outputs, value_balance, binding_sig)
+    }))
+}
+
+/// Writes a Sapling bundle in the v5 transaction format.
+pub(crate) fn write_v5_bundle<W: Write>(
+    mut writer: W,
+    bundle: Option<&RawSaplingBundle>,
+) -> io::Result<()> {
+    if let Some(bundle) = bundle {
+        Vector::write(&mut writer, &bundle.spends, |w, s| {
+            w.write_all(&s.cv)?;
+            w.write_all(&s.nullifier)?;
+            w.write_all(&s.rk)
+        })?;
+
+        Vector::write(&mut writer, &bundle.outputs, |w, o| {
+            w.write_all(&o.cv)?;
+            w.write_all(&o.cmu)?;
+            w.write_all(&o.ephemeral_key)?;
+            w.write_all(&o.enc_ciphertext)?;
+            w.write_all(&o.out_ciphertext)
+        })?;
+
+        if !(bundle.spends.is_empty() && bundle.outputs.is_empty()) {
+            writer.write_all(&bundle.value_balance.to_i64_le_bytes())?;
+        }
+        if !bundle.spends.is_empty() {
+            writer.write_all(&bundle.spends[0].anchor)?;
+        }
+
+        Array::write(
+            &mut writer,
+            bundle.spends.iter().map(|s| &s.zkproof[..]),
+            |w, e| w.write_all(e),
+        )?;
+        Array::write(
+            &mut writer,
+            bundle.spends.iter().map(|s| &s.spend_auth_sig[..]),
+            |w, e| w.write_all(e),
+        )?;
+        Array::write(
+            &mut writer,
+            bundle.outputs.iter().map(|s| &s.zkproof[..]),
+            |w, e| w.write_all(e),
+        )?;
+
+        if !(bundle.spends.is_empty() && bundle.outputs.is_empty()) {
+            writer.write_all(&bundle.binding_sig)?;
+        }
+    } else {
+        CompactSize::write(&mut writer, 0)?;
+        CompactSize::write(&mut writer, 0)?;
+    }
+
+    Ok(())
+}

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -1,8 +1,14 @@
 //! Structs and methods for handling Zcash transactions.
+// The transaction builder constructs typed Sapling and Orchard bundles, and so requires both
+// protocol features. (A feature-off build can parse and re-serialize transactions, but not
+// build them.)
+#[cfg(all(feature = "sapling", feature = "orchard"))]
 pub mod builder;
 pub mod components;
 pub mod fees;
 pub mod sighash;
+// The v4 signature hash reads the typed Sapling bundle directly (v4 predates Orchard).
+#[cfg(feature = "sapling")]
 pub mod sighash_v4;
 pub mod sighash_v5;
 #[cfg(zcash_unstable = "nu7")]
@@ -21,7 +27,6 @@ use core::ops::Deref;
 use corez::io::{self, Read, Write};
 
 use ::transparent::bundle::{self as transparent, OutPoint, TxIn, TxOut};
-use orchard::bundle::ProofSizeEnforcement;
 use zcash_encoding::{CompactSize, Vector};
 use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
@@ -29,13 +34,25 @@ use zcash_protocol::{
 };
 
 use self::{
-    components::{
-        orchard as orchard_serialization, sapling as sapling_serialization,
-        sprout::{self, JsDescription},
-    },
+    components::sprout::{self, JsDescription},
     txid::{BlockTxCommitmentDigester, TxIdDigester, to_txid},
 };
 use ::transparent::util::sha256d::{HashReader, HashWriter};
+
+#[cfg(feature = "sapling")]
+use self::components::sapling as sapling_serialization;
+#[cfg(not(feature = "sapling"))]
+use self::components::sapling_raw as sapling_serialization;
+
+#[cfg(feature = "orchard")]
+use self::components::orchard as orchard_serialization;
+#[cfg(not(feature = "orchard"))]
+use self::components::orchard_raw as orchard_serialization;
+
+#[cfg(not(feature = "orchard"))]
+use self::components::orchard_raw::ProofSizeEnforcement;
+#[cfg(feature = "orchard")]
+use orchard::bundle::ProofSizeEnforcement;
 
 #[cfg(feature = "circuits")]
 use ::sapling::builder as sapling_builder;
@@ -241,7 +258,9 @@ impl TxVersion {
 /// Authorization state for a bundle of transaction data.
 pub trait Authorization {
     type TransparentAuth: transparent::Authorization;
+    #[cfg(feature = "sapling")]
     type SaplingAuth: sapling::bundle::Authorization;
+    #[cfg(feature = "orchard")]
     type OrchardAuth: orchard::bundle::Authorization;
 }
 
@@ -251,7 +270,9 @@ pub struct Authorized;
 
 impl Authorization for Authorized {
     type TransparentAuth = transparent::Authorized;
+    #[cfg(feature = "sapling")]
     type SaplingAuth = sapling::bundle::Authorized;
+    #[cfg(feature = "orchard")]
     type OrchardAuth = orchard::bundle::Authorized;
 }
 
@@ -281,6 +302,58 @@ impl Authorization for Coinbase {
         sapling_builder::InProgress<sapling_builder::Proven, sapling_builder::Unsigned>;
     type OrchardAuth =
         orchard::builder::InProgress<orchard::builder::Unproven, orchard::builder::Unauthorized>;
+}
+
+/// The type of a transaction's Sapling bundle for a given authorization state.
+///
+/// When the `sapling` feature is enabled this is the typed [`sapling::Bundle`] domain
+/// representation; when it is disabled, parsed Sapling bundles are retained as an opaque
+/// byte representation that supports re-serialization and digest computation but not access
+/// to the typed components.
+#[cfg(feature = "sapling")]
+pub type SaplingBundle<A> = sapling::Bundle<<A as Authorization>::SaplingAuth, ZatBalance>;
+/// The type of a transaction's Sapling bundle (opaque byte representation; the `sapling`
+/// feature is disabled).
+#[cfg(not(feature = "sapling"))]
+pub type SaplingBundle<A> = <A as RawSaplingBundleFor>::Bundle;
+
+/// Helper trait used only when the `sapling` feature is disabled, so that the public
+/// [`SaplingBundle`] alias can refer to its type parameter (avoiding an unused-parameter
+/// error) while resolving to the opaque raw bundle type regardless of `A`.
+#[cfg(not(feature = "sapling"))]
+#[doc(hidden)]
+pub trait RawSaplingBundleFor {
+    type Bundle;
+}
+#[cfg(not(feature = "sapling"))]
+impl<A> RawSaplingBundleFor for A {
+    type Bundle = sapling_serialization::RawSaplingBundle;
+}
+
+/// The type of a transaction's Orchard bundle for a given authorization state.
+///
+/// When the `orchard` feature is enabled this is the typed [`orchard::Bundle`] domain
+/// representation; when it is disabled, parsed Orchard bundles are retained as an opaque
+/// byte representation that supports re-serialization and digest computation but not access
+/// to the typed components.
+#[cfg(feature = "orchard")]
+pub type OrchardBundle<A> = orchard::bundle::Bundle<<A as Authorization>::OrchardAuth, ZatBalance>;
+/// The type of a transaction's Orchard bundle (opaque byte representation; the `orchard`
+/// feature is disabled).
+#[cfg(not(feature = "orchard"))]
+pub type OrchardBundle<A> = <A as RawOrchardBundleFor>::Bundle;
+
+/// Helper trait used only when the `orchard` feature is disabled, so that the public
+/// [`OrchardBundle`] alias can refer to its type parameter (avoiding an unused-parameter
+/// error) while resolving to the opaque raw bundle type regardless of `A`.
+#[cfg(not(feature = "orchard"))]
+#[doc(hidden)]
+pub trait RawOrchardBundleFor {
+    type Bundle;
+}
+#[cfg(not(feature = "orchard"))]
+impl<A> RawOrchardBundleFor for A {
+    type Bundle = orchard_serialization::RawOrchardBundle;
 }
 
 /// A Zcash transaction.
@@ -315,8 +388,8 @@ pub struct TransactionData<A: Authorization> {
     zip233_amount: Zatoshis,
     transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
     sprout_bundle: Option<sprout::Bundle>,
-    sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-    orchard_bundle: Option<orchard::bundle::Bundle<A::OrchardAuth, ZatBalance>>,
+    sapling_bundle: Option<SaplingBundle<A>>,
+    orchard_bundle: Option<OrchardBundle<A>>,
 }
 
 impl Clone for TransactionData<Authorized> {
@@ -359,8 +432,8 @@ impl<A: Authorization> TransactionData<A> {
         #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))] zip233_amount: Zatoshis,
         transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
         sprout_bundle: Option<sprout::Bundle>,
-        sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-        orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, ZatBalance>>,
+        sapling_bundle: Option<SaplingBundle<A>>,
+        orchard_bundle: Option<OrchardBundle<A>>,
     ) -> Self {
         TransactionData {
             version,
@@ -402,12 +475,28 @@ impl<A: Authorization> TransactionData<A> {
         self.sprout_bundle.as_ref()
     }
 
+    #[cfg(feature = "sapling")]
     pub fn sapling_bundle(&self) -> Option<&sapling::Bundle<A::SaplingAuth, ZatBalance>> {
         self.sapling_bundle.as_ref()
     }
 
+    #[cfg(feature = "orchard")]
     pub fn orchard_bundle(&self) -> Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>> {
         self.orchard_bundle.as_ref()
+    }
+
+    /// Returns whether this transaction contains a Sapling bundle.
+    ///
+    /// This method is available irrespective of whether the `sapling` feature is enabled.
+    pub fn has_sapling(&self) -> bool {
+        self.sapling_bundle.is_some()
+    }
+
+    /// Returns whether this transaction contains an Orchard bundle.
+    ///
+    /// This method is available irrespective of whether the `orchard` feature is enabled.
+    pub fn has_orchard(&self) -> bool {
+        self.orchard_bundle.is_some()
     }
 
     #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
@@ -498,12 +587,8 @@ impl<A: Authorization> TransactionData<A> {
         f_transparent: impl FnOnce(
             Option<transparent::Bundle<A::TransparentAuth>>,
         ) -> Option<transparent::Bundle<B::TransparentAuth>>,
-        f_sapling: impl FnOnce(
-            Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-        ) -> Option<sapling::Bundle<B::SaplingAuth, ZatBalance>>,
-        f_orchard: impl FnOnce(
-            Option<orchard::bundle::Bundle<A::OrchardAuth, ZatBalance>>,
-        ) -> Option<orchard::bundle::Bundle<B::OrchardAuth, ZatBalance>>,
+        f_sapling: impl FnOnce(Option<SaplingBundle<A>>) -> Option<SaplingBundle<B>>,
+        f_orchard: impl FnOnce(Option<OrchardBundle<A>>) -> Option<OrchardBundle<B>>,
     ) -> TransactionData<B> {
         TransactionData {
             version: self.version,
@@ -529,14 +614,8 @@ impl<A: Authorization> TransactionData<A> {
             Option<transparent::Bundle<A::TransparentAuth>>,
         )
             -> Result<Option<transparent::Bundle<B::TransparentAuth>>, E>,
-        f_sapling: impl FnOnce(
-            Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-        )
-            -> Result<Option<sapling::Bundle<B::SaplingAuth, ZatBalance>>, E>,
-        f_orchard: impl FnOnce(
-            Option<orchard::bundle::Bundle<A::OrchardAuth, ZatBalance>>,
-        )
-            -> Result<Option<orchard::bundle::Bundle<B::OrchardAuth, ZatBalance>>, E>,
+        f_sapling: impl FnOnce(Option<SaplingBundle<A>>) -> Result<Option<SaplingBundle<B>>, E>,
+        f_orchard: impl FnOnce(Option<OrchardBundle<A>>) -> Result<Option<OrchardBundle<B>>, E>,
     ) -> Result<TransactionData<B>, E> {
         Ok(TransactionData {
             version: self.version,
@@ -555,8 +634,14 @@ impl<A: Authorization> TransactionData<A> {
     pub fn map_authorization<B: Authorization>(
         self,
         f_transparent: impl transparent::MapAuth<A::TransparentAuth, B::TransparentAuth>,
-        mut f_sapling: impl sapling_serialization::MapAuth<A::SaplingAuth, B::SaplingAuth>,
-        mut f_orchard: impl orchard_serialization::MapAuth<A::OrchardAuth, B::OrchardAuth>,
+        #[cfg(feature = "sapling")] mut f_sapling: impl sapling_serialization::MapAuth<
+            A::SaplingAuth,
+            B::SaplingAuth,
+        >,
+        #[cfg(feature = "orchard")] mut f_orchard: impl orchard_serialization::MapAuth<
+            A::OrchardAuth,
+            B::OrchardAuth,
+        >,
     ) -> TransactionData<B> {
         TransactionData {
             version: self.version,
@@ -569,6 +654,9 @@ impl<A: Authorization> TransactionData<A> {
                 .transparent_bundle
                 .map(|b| b.map_authorization(f_transparent)),
             sprout_bundle: self.sprout_bundle,
+            // When the `sapling` feature is disabled the Sapling bundle is an opaque byte
+            // representation with no authorization to map, so it passes through unchanged.
+            #[cfg(feature = "sapling")]
             sapling_bundle: self.sapling_bundle.map(|b| {
                 b.map_authorization(
                     &mut f_sapling,
@@ -578,6 +666,11 @@ impl<A: Authorization> TransactionData<A> {
                     |f, a| f.map_authorization(a),
                 )
             }),
+            #[cfg(not(feature = "sapling"))]
+            sapling_bundle: self.sapling_bundle,
+            // When the `orchard` feature is disabled the Orchard bundle is an opaque byte
+            // representation with no authorization to map, so it passes through unchanged.
+            #[cfg(feature = "orchard")]
             orchard_bundle: self.orchard_bundle.map(|b| {
                 b.map_authorization(
                     &mut f_orchard,
@@ -585,6 +678,8 @@ impl<A: Authorization> TransactionData<A> {
                     |f, a| f.map_authorization(a),
                 )
             }),
+            #[cfg(not(feature = "orchard"))]
+            orchard_bundle: self.orchard_bundle,
         }
     }
 }
@@ -718,9 +813,9 @@ impl Transaction {
         let binding_sig = if version.has_sapling()
             && !(shielded_spends.is_empty() && shielded_outputs.is_empty())
         {
-            let mut sig = [0; 64];
+            let mut sig = [0u8; 64];
             reader.read_exact(&mut sig)?;
-            Some(redjubjub::Signature::from(sig))
+            Some(sig)
         } else {
             None
         };
@@ -740,14 +835,12 @@ impl Transaction {
                 zip233_amount: Zatoshis::ZERO,
                 transparent_bundle,
                 sprout_bundle,
-                sapling_bundle: binding_sig.and_then(|binding_sig| {
-                    sapling::Bundle::from_parts(
-                        shielded_spends,
-                        shielded_outputs,
-                        value_balance,
-                        sapling::bundle::Authorized { binding_sig },
-                    )
-                }),
+                sapling_bundle: sapling_serialization::build_v4_bundle(
+                    value_balance,
+                    shielded_spends,
+                    shielded_outputs,
+                    binding_sig,
+                ),
                 orchard_bundle: None,
             },
         })
@@ -878,7 +971,7 @@ impl Transaction {
         })
     }
 
-    #[cfg(feature = "temporary-zcashd")]
+    #[cfg(all(feature = "temporary-zcashd", feature = "sapling"))]
     pub fn temporary_zcashd_read_v5_sapling<R: Read>(
         reader: R,
     ) -> io::Result<Option<sapling::Bundle<sapling::bundle::Authorized, ZatBalance>>> {
@@ -934,7 +1027,10 @@ impl Transaction {
 
         if self.version.has_sapling() {
             if let Some(bundle) = self.sapling_bundle.as_ref() {
+                #[cfg(feature = "sapling")]
                 writer.write_all(&<[u8; 64]>::from(bundle.authorization().binding_sig))?;
+                #[cfg(not(feature = "sapling"))]
+                writer.write_all(bundle.binding_sig())?;
             }
         }
 
@@ -1005,7 +1101,7 @@ impl Transaction {
         Ok(())
     }
 
-    #[cfg(feature = "temporary-zcashd")]
+    #[cfg(all(feature = "temporary-zcashd", feature = "sapling"))]
     pub fn temporary_zcashd_write_v5_sapling<W: Write>(
         sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, ZatBalance>>,
         writer: W,
@@ -1060,15 +1156,9 @@ pub trait TransactionDigest<A: Authorization> {
         transparent_bundle: Option<&transparent::Bundle<A::TransparentAuth>>,
     ) -> Self::TransparentDigest;
 
-    fn digest_sapling(
-        &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-    ) -> Self::SaplingDigest;
+    fn digest_sapling(&self, sapling_bundle: Option<&SaplingBundle<A>>) -> Self::SaplingDigest;
 
-    fn digest_orchard(
-        &self,
-        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
-    ) -> Self::OrchardDigest;
+    fn digest_orchard(&self, orchard_bundle: Option<&OrchardBundle<A>>) -> Self::OrchardDigest;
 
     fn combine(
         &self,
@@ -1083,7 +1173,14 @@ pub enum DigestError {
     NotSigned,
 }
 
-#[cfg(any(test, feature = "test-dependencies"))]
+// The proptest strategies in this module build typed Sapling and Orchard bundles, and so
+// require both protocol features. Feature-off builds exercise transaction parsing via the
+// static ZIP 244 / ZIP 143 / ZIP 243 test vectors instead.
+#[cfg(all(
+    any(test, feature = "test-dependencies"),
+    feature = "sapling",
+    feature = "orchard"
+))]
 pub mod testing {
     use proptest::prelude::*;
 

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -1,12 +1,13 @@
 use blake2b_simd::Hash as Blake2bHash;
 
-use super::{
-    Authorization, TransactionData, TxDigests, TxVersion, sighash_v4::v4_signature_hash,
-    sighash_v5::v5_signature_hash,
-};
+#[cfg(feature = "sapling")]
+use super::{Authorization, TransactionData, TxDigests};
+#[cfg(feature = "sapling")]
+use super::{TxVersion, sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash};
+#[cfg(feature = "sapling")]
 use ::sapling::bundle::GrothProofBytes;
 
-#[cfg(zcash_unstable = "nu7")]
+#[cfg(all(feature = "sapling", zcash_unstable = "nu7"))]
 use super::sighash_v6::v6_signature_hash;
 
 pub enum SignableInput<'a> {
@@ -35,6 +36,13 @@ impl AsRef<[u8; 32]> for SignatureHash {
 /// the full data of the transaction, the input being signed, and the
 /// set of precomputed hashes produced in the construction of the
 /// transaction ID.
+///
+/// This requires the `sapling` feature, as it dispatches to the v4 signature hash which reads
+/// the typed Sapling bundle. For v5+ transactions, [`v5_signature_hash`] can be called
+/// directly without the `sapling` feature.
+///
+/// [`v5_signature_hash`]: crate::transaction::sighash_v5::v5_signature_hash
+#[cfg(feature = "sapling")]
 pub fn signature_hash<
     TA: ::transparent::sighash::TransparentAuthorizingContext,
     SA: sapling::bundle::Authorization<SpendProof = GrothProofBytes, OutputProof = GrothProofBytes>,

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1,23 +1,34 @@
 use proptest::prelude::*;
 
+// Imports used by the feature-independent consensus tests (parsing, txid, round-trip).
 #[cfg(test)]
+use {crate::transaction::Transaction, alloc::vec::Vec, zcash_protocol::consensus::BranchId};
+
+// Imports used by the tests that build typed Sapling/Orchard bundles and compute signature
+// hashes, which require both protocol features.
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 use {
     crate::transaction::{
-        Authorization, Transaction, TransactionData, TxDigests, TxIn, sighash::SignableInput,
+        Authorization, TransactionData, TxDigests, TxIn, sighash::SignableInput,
         sighash_v4::v4_signature_hash, sighash_v5::v5_signature_hash, testing::arb_tx, transparent,
         txid::TxIdDigester,
     },
     ::transparent::{
         address::Script, sighash::SighashType, sighash::TransparentAuthorizingContext,
     },
-    alloc::vec::Vec,
     blake2b_simd::Hash as Blake2bHash,
     core::ops::Deref,
-    zcash_protocol::{consensus::BranchId, value::Zatoshis},
+    zcash_protocol::value::Zatoshis,
     zcash_script::script,
 };
 
-#[cfg(all(test, zcash_unstable = "nu7", feature = "zip-233"))]
+#[cfg(all(
+    test,
+    zcash_unstable = "nu7",
+    feature = "zip-233",
+    feature = "sapling",
+    feature = "orchard"
+))]
 use super::sighash_v6::v6_signature_hash;
 
 #[cfg(any(test, feature = "test-dependencies"))]
@@ -37,7 +48,25 @@ fn tx_read_write() {
     assert_eq!(&data[..], &encoded[..]);
 }
 
-#[cfg(test)]
+/// Consensus oracle that runs irrespective of the `sapling`/`orchard` features: every ZIP 244
+/// test vector must parse, produce the expected consensus txid and authorizing-data digest,
+/// and re-serialize byte-identically. When the protocol features are disabled this exercises
+/// the opaque-byte-representation parse/serialize/digest paths.
+#[test]
+fn zip_0244_txid_auth_and_roundtrip() {
+    for tv in self::data::zip_0244::make_test_vectors() {
+        let tx = Transaction::read(&tv.tx[..], BranchId::Nu5).unwrap();
+
+        assert_eq!(tx.txid().as_ref(), &tv.txid);
+        assert_eq!(tx.auth_commitment().as_ref(), &tv.auth_digest);
+
+        let mut encoded = Vec::with_capacity(tv.tx.len());
+        tx.write(&mut encoded).unwrap();
+        assert_eq!(&tv.tx[..], &encoded[..]);
+    }
+}
+
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 fn check_roundtrip(tx: Transaction) -> Result<(), TestCaseError> {
     let mut txn_bytes = vec![];
     tx.write(&mut txn_bytes).unwrap();
@@ -63,7 +92,12 @@ fn check_roundtrip(tx: Transaction) -> Result<(), TestCaseError> {
 
 proptest! {
     #[test]
-    #[cfg(all(feature = "expensive-tests", not(feature = "no-expensive-tests")))]
+    #[cfg(all(
+        feature = "expensive-tests",
+        not(feature = "no-expensive-tests"),
+        feature = "sapling",
+        feature = "orchard"
+    ))]
     fn tx_serialization_roundtrip_sprout(tx in arb_tx(BranchId::Sprout)) {
         check_roundtrip(tx)?;
     }
@@ -71,7 +105,12 @@ proptest! {
 
 proptest! {
     #[test]
-    #[cfg(all(feature = "expensive-tests", not(feature = "no-expensive-tests")))]
+    #[cfg(all(
+        feature = "expensive-tests",
+        not(feature = "no-expensive-tests"),
+        feature = "sapling",
+        feature = "orchard"
+    ))]
     fn tx_serialization_roundtrip_overwinter(tx in arb_tx(BranchId::Overwinter)) {
         check_roundtrip(tx)?;
     }
@@ -79,7 +118,12 @@ proptest! {
 
 proptest! {
     #[test]
-    #[cfg(all(feature = "expensive-tests", not(feature = "no-expensive-tests")))]
+    #[cfg(all(
+        feature = "expensive-tests",
+        not(feature = "no-expensive-tests"),
+        feature = "sapling",
+        feature = "orchard"
+    ))]
     fn tx_serialization_roundtrip_sapling(tx in arb_tx(BranchId::Sapling)) {
         check_roundtrip(tx)?;
     }
@@ -87,7 +131,12 @@ proptest! {
 
 proptest! {
     #[test]
-    #[cfg(all(feature = "expensive-tests", not(feature = "no-expensive-tests")))]
+    #[cfg(all(
+        feature = "expensive-tests",
+        not(feature = "no-expensive-tests"),
+        feature = "sapling",
+        feature = "orchard"
+    ))]
     fn tx_serialization_roundtrip_blossom(tx in arb_tx(BranchId::Blossom)) {
         check_roundtrip(tx)?;
     }
@@ -95,7 +144,12 @@ proptest! {
 
 proptest! {
     #[test]
-    #[cfg(all(feature = "expensive-tests", not(feature = "no-expensive-tests")))]
+    #[cfg(all(
+        feature = "expensive-tests",
+        not(feature = "no-expensive-tests"),
+        feature = "sapling",
+        feature = "orchard"
+    ))]
     fn tx_serialization_roundtrip_heartwood(tx in arb_tx(BranchId::Heartwood)) {
         check_roundtrip(tx)?;
     }
@@ -104,6 +158,7 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
+    #[cfg(all(feature = "sapling", feature = "orchard"))]
     fn tx_serialization_roundtrip_canopy(tx in arb_tx(BranchId::Canopy)) {
         check_roundtrip(tx)?;
     }
@@ -112,6 +167,7 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
+    #[cfg(all(feature = "sapling", feature = "orchard"))]
     fn tx_serialization_roundtrip_nu5(tx in arb_tx(BranchId::Nu5)) {
         check_roundtrip(tx)?;
     }
@@ -121,11 +177,13 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
+    #[cfg(all(feature = "sapling", feature = "orchard"))]
     fn tx_serialization_roundtrip_nu7(tx in arb_tx(BranchId::Nu7)) {
         check_roundtrip(tx)?;
     }
 }
 
+#[cfg(all(feature = "sapling", feature = "orchard"))]
 #[test]
 fn zip_0143() {
     for tv in self::data::zip_0143::make_test_vectors() {
@@ -152,6 +210,7 @@ fn zip_0143() {
     }
 }
 
+#[cfg(all(feature = "sapling", feature = "orchard"))]
 #[test]
 fn zip_0243() {
     for tv in self::data::zip_0243::make_test_vectors() {
@@ -178,19 +237,19 @@ fn zip_0243() {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 #[derive(Debug)]
 struct TestTransparentAuth {
     input_amounts: Vec<Zatoshis>,
     input_scriptpubkeys: Vec<Script>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 impl transparent::Authorization for TestTransparentAuth {
     type ScriptSig = Script;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 impl TransparentAuthorizingContext for TestTransparentAuth {
     fn input_amounts(&self) -> Vec<Zatoshis> {
         self.input_amounts.clone()
@@ -201,16 +260,17 @@ impl TransparentAuthorizingContext for TestTransparentAuth {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 struct TestUnauthorized;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sapling", feature = "orchard"))]
 impl Authorization for TestUnauthorized {
     type TransparentAuth = TestTransparentAuth;
     type SaplingAuth = sapling::bundle::Authorized;
     type OrchardAuth = orchard::bundle::Authorized;
 }
 
+#[cfg(all(feature = "sapling", feature = "orchard"))]
 #[test]
 fn zip_0244() {
     fn to_test_txdata(
@@ -362,7 +422,12 @@ fn zip_0244() {
     }
 }
 
-#[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+#[cfg(all(
+    zcash_unstable = "nu7",
+    feature = "zip-233",
+    feature = "sapling",
+    feature = "orchard"
+))]
 #[test]
 fn zip_0233() {
     fn to_test_txdata(

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -66,6 +66,33 @@ fn zip_0244_txid_auth_and_roundtrip() {
     }
 }
 
+/// Feature-independent v3/v4 transaction round-trip oracle, covering the v4 Sapling
+/// parse/serialize path that the (v5-only) ZIP 244 oracle does not. The ZIP 243 vectors carry
+/// v4 Sapling spends and outputs, so with the `sapling` feature disabled this exercises the
+/// opaque-byte representation of a v4 Sapling bundle. A v4 txid is the double-SHA256 of the
+/// re-serialized transaction, so byte-identical round-tripping is the consensus property under
+/// test.
+#[test]
+fn zip_0143_zip_0243_roundtrip() {
+    fn check(tx_bytes: &[u8], branch_id: BranchId) {
+        let tx = Transaction::read(tx_bytes, branch_id).unwrap();
+        let mut encoded = Vec::with_capacity(tx_bytes.len());
+        tx.write(&mut encoded).unwrap();
+        assert_eq!(tx_bytes, &encoded[..]);
+    }
+
+    let mut count = 0;
+    for tv in self::data::zip_0143::make_test_vectors() {
+        check(&tv.tx[..], tv.consensus_branch_id);
+        count += 1;
+    }
+    for tv in self::data::zip_0243::make_test_vectors() {
+        check(&tv.tx[..], tv.consensus_branch_id);
+        count += 1;
+    }
+    assert!(count > 0);
+}
+
 #[cfg(all(test, feature = "sapling", feature = "orchard"))]
 fn check_roundtrip(tx: Transaction) -> Result<(), TestCaseError> {
     let mut txn_bytes = vec![];

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -98,28 +98,41 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
     h.finalize()
 }
 
+/// The byte encodings of the Sapling spend-description fields that are committed to by the
+/// [ZIP 244 spends digest](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest).
+///
+/// Both the typed (`sapling` feature enabled) and byte-oriented (feature disabled) paths
+/// extract these fields and feed them to [`hash_sapling_spends_inner`], so the two
+/// implementations cannot drift.
+struct SaplingSpendDigestFields {
+    cv: [u8; 32],
+    anchor: [u8; 32],
+    nullifier: [u8; 32],
+    rk: [u8; 32],
+}
+
 /// Implements [ZIP 244 section T.3a](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest)
 ///
 /// Write disjoint parts of each Sapling shielded spend to a pair of hashes:
 /// * \[nullifier*\] - personalized with ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION
-/// * \[(cv, anchor, rk, zkproof)*\] - personalized with ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION
+/// * \[(cv, anchor, rk)*\] - personalized with ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION
 ///
 /// Then, hash these together personalized by ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION
-#[cfg(feature = "sapling")]
-pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
-    shielded_spends: &[SpendDescription<A>],
+fn hash_sapling_spends_inner(
+    shielded_spends: impl Iterator<Item = SaplingSpendDigestFields>,
 ) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION);
-    if !shielded_spends.is_empty() {
+    let mut shielded_spends = shielded_spends.peekable();
+    if shielded_spends.peek().is_some() {
         let mut ch = hasher(ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION);
         let mut nh = hasher(ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION);
         for s_spend in shielded_spends {
             // we build the hash of nullifiers separately for compact blocks.
-            ch.write_all(s_spend.nullifier().as_ref()).unwrap();
+            ch.write_all(&s_spend.nullifier).unwrap();
 
-            nh.write_all(&s_spend.cv().to_bytes()).unwrap();
-            nh.write_all(&s_spend.anchor().to_repr()).unwrap();
-            nh.write_all(&<[u8; 32]>::from(*s_spend.rk())).unwrap();
+            nh.write_all(&s_spend.cv).unwrap();
+            nh.write_all(&s_spend.anchor).unwrap();
+            nh.write_all(&s_spend.rk).unwrap();
         }
 
         let compact_digest = ch.finalize();
@@ -130,26 +143,53 @@ pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
     h.finalize()
 }
 
-/// Equivalent of [`hash_sapling_spends`] operating on the opaque byte representation of a
-/// Sapling bundle used when the `sapling` feature is disabled.
+/// Computes the [ZIP 244 spends digest](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest)
+/// from the typed representation of a Sapling bundle's spend descriptions.
+#[cfg(feature = "sapling")]
+pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
+    shielded_spends: &[SpendDescription<A>],
+) -> Blake2bHash {
+    hash_sapling_spends_inner(
+        shielded_spends
+            .iter()
+            .map(|s_spend| SaplingSpendDigestFields {
+                cv: s_spend.cv().to_bytes(),
+                anchor: s_spend.anchor().to_repr(),
+                nullifier: s_spend.nullifier().0,
+                rk: (*s_spend.rk()).into(),
+            }),
+    )
+}
+
+/// Computes the [ZIP 244 spends digest](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest)
+/// from the byte representation of a Sapling bundle's spend descriptions, used when the
+/// `sapling` feature is disabled.
 #[cfg(not(feature = "sapling"))]
 fn hash_sapling_spends_raw(shielded_spends: &[RawSaplingSpend]) -> Blake2bHash {
-    let mut h = hasher(ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION);
-    if !shielded_spends.is_empty() {
-        let mut ch = hasher(ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION);
-        let mut nh = hasher(ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION);
-        for s_spend in shielded_spends {
-            ch.write_all(&s_spend.nullifier).unwrap();
+    hash_sapling_spends_inner(
+        shielded_spends
+            .iter()
+            .map(|s_spend| SaplingSpendDigestFields {
+                cv: s_spend.cv,
+                anchor: s_spend.anchor,
+                nullifier: s_spend.nullifier,
+                rk: s_spend.rk,
+            }),
+    )
+}
 
-            nh.write_all(&s_spend.cv).unwrap();
-            nh.write_all(&s_spend.anchor).unwrap();
-            nh.write_all(&s_spend.rk).unwrap();
-        }
-
-        h.write_all(ch.finalize().as_bytes()).unwrap();
-        h.write_all(nh.finalize().as_bytes()).unwrap();
-    }
-    h.finalize()
+/// The byte encodings of the Sapling output-description fields that are committed to by the
+/// [ZIP 244 outputs digest](https://zips.z.cash/zip-0244#t-3b-sapling-outputs-digest).
+///
+/// Both the typed (`sapling` feature enabled) and byte-oriented (feature disabled) paths
+/// extract these fields and feed them to [`hash_sapling_outputs_inner`], so the two
+/// implementations cannot drift.
+struct SaplingOutputDigestFields<'a> {
+    cv: [u8; 32],
+    cmu: [u8; 32],
+    ephemeral_key: &'a [u8],
+    enc_ciphertext: &'a [u8],
+    out_ciphertext: &'a [u8],
 }
 
 /// Implements [ZIP 244 section T.3b](https://zips.z.cash/zip-0244#t-3b-sapling-outputs-digest)
@@ -157,26 +197,28 @@ fn hash_sapling_spends_raw(shielded_spends: &[RawSaplingSpend]) -> Blake2bHash {
 /// Write disjoint parts of each Sapling shielded output as 3 separate hashes:
 /// * \[(cmu, epk, enc_ciphertext\[..52\])*\] personalized with ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION
 /// * \[enc_ciphertext\[52..564\]*\] (memo ciphertexts) personalized with ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION
-/// * \[(cv, enc_ciphertext\[564..\], out_ciphertext, zkproof)*\] personalized with ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION
+/// * \[(cv, enc_ciphertext\[564..\], out_ciphertext)*\] personalized with ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION
 ///
 /// Then, hash these together personalized with ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION
-#[cfg(feature = "sapling")]
-pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>]) -> Blake2bHash {
+fn hash_sapling_outputs_inner<'a>(
+    shielded_outputs: impl Iterator<Item = SaplingOutputDigestFields<'a>>,
+) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION);
-    if !shielded_outputs.is_empty() {
+    let mut shielded_outputs = shielded_outputs.peekable();
+    if shielded_outputs.peek().is_some() {
         let mut ch = hasher(ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION);
         let mut mh = hasher(ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION);
         let mut nh = hasher(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION);
         for s_out in shielded_outputs {
-            ch.write_all(s_out.cmu().to_bytes().as_ref()).unwrap();
-            ch.write_all(s_out.ephemeral_key().as_ref()).unwrap();
-            ch.write_all(&s_out.enc_ciphertext()[..52]).unwrap();
+            ch.write_all(&s_out.cmu).unwrap();
+            ch.write_all(s_out.ephemeral_key).unwrap();
+            ch.write_all(&s_out.enc_ciphertext[..52]).unwrap();
 
-            mh.write_all(&s_out.enc_ciphertext()[52..564]).unwrap();
+            mh.write_all(&s_out.enc_ciphertext[52..564]).unwrap();
 
-            nh.write_all(&s_out.cv().to_bytes()).unwrap();
-            nh.write_all(&s_out.enc_ciphertext()[564..]).unwrap();
-            nh.write_all(&s_out.out_ciphertext()[..]).unwrap();
+            nh.write_all(&s_out.cv).unwrap();
+            nh.write_all(&s_out.enc_ciphertext[564..]).unwrap();
+            nh.write_all(s_out.out_ciphertext).unwrap();
         }
 
         h.write_all(ch.finalize().as_bytes()).unwrap();
@@ -186,32 +228,39 @@ pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>])
     h.finalize()
 }
 
-/// Equivalent of [`hash_sapling_outputs`] operating on the opaque byte representation of a
-/// Sapling bundle used when the `sapling` feature is disabled.
+/// Computes the [ZIP 244 outputs digest](https://zips.z.cash/zip-0244#t-3b-sapling-outputs-digest)
+/// from the typed representation of a Sapling bundle's output descriptions.
+#[cfg(feature = "sapling")]
+pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>]) -> Blake2bHash {
+    hash_sapling_outputs_inner(
+        shielded_outputs
+            .iter()
+            .map(|s_out| SaplingOutputDigestFields {
+                cv: s_out.cv().to_bytes(),
+                cmu: s_out.cmu().to_bytes(),
+                ephemeral_key: s_out.ephemeral_key().as_ref(),
+                enc_ciphertext: s_out.enc_ciphertext(),
+                out_ciphertext: s_out.out_ciphertext(),
+            }),
+    )
+}
+
+/// Computes the [ZIP 244 outputs digest](https://zips.z.cash/zip-0244#t-3b-sapling-outputs-digest)
+/// from the byte representation of a Sapling bundle's output descriptions, used when the
+/// `sapling` feature is disabled.
 #[cfg(not(feature = "sapling"))]
 fn hash_sapling_outputs_raw(shielded_outputs: &[RawSaplingOutput]) -> Blake2bHash {
-    let mut h = hasher(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION);
-    if !shielded_outputs.is_empty() {
-        let mut ch = hasher(ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION);
-        let mut mh = hasher(ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION);
-        let mut nh = hasher(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION);
-        for s_out in shielded_outputs {
-            ch.write_all(&s_out.cmu).unwrap();
-            ch.write_all(&s_out.ephemeral_key).unwrap();
-            ch.write_all(&s_out.enc_ciphertext[..52]).unwrap();
-
-            mh.write_all(&s_out.enc_ciphertext[52..564]).unwrap();
-
-            nh.write_all(&s_out.cv).unwrap();
-            nh.write_all(&s_out.enc_ciphertext[564..]).unwrap();
-            nh.write_all(&s_out.out_ciphertext[..]).unwrap();
-        }
-
-        h.write_all(ch.finalize().as_bytes()).unwrap();
-        h.write_all(mh.finalize().as_bytes()).unwrap();
-        h.write_all(nh.finalize().as_bytes()).unwrap();
-    }
-    h.finalize()
+    hash_sapling_outputs_inner(
+        shielded_outputs
+            .iter()
+            .map(|s_out| SaplingOutputDigestFields {
+                cv: s_out.cv,
+                cmu: s_out.cmu,
+                ephemeral_key: &s_out.ephemeral_key,
+                enc_ciphertext: &s_out.enc_ciphertext,
+                out_ciphertext: &s_out.out_ciphertext,
+            }),
+    )
 }
 
 /// The txid commits to the hash of all transparent outputs. The

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -4,18 +4,26 @@ use core::convert::TryFrom;
 use corez::io::Write;
 
 use blake2b_simd::{Hash as Blake2bHash, Params};
+#[cfg(feature = "sapling")]
 use ff::PrimeField;
 
+#[cfg(feature = "orchard")]
 use ::orchard::bundle::{self as orchard};
+#[cfg(feature = "sapling")]
 use ::sapling::bundle::{OutputDescription, SpendDescription};
 use ::transparent::bundle::{self as transparent, TxIn, TxOut};
-use zcash_protocol::{
-    consensus::{BlockHeight, BranchId},
-    value::ZatBalance,
-};
+use zcash_protocol::consensus::{BlockHeight, BranchId};
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+use zcash_protocol::value::ZatBalance;
+
+#[cfg(not(feature = "orchard"))]
+use super::components::orchard_raw::RawOrchardBundle;
+#[cfg(not(feature = "sapling"))]
+use super::components::sapling_raw::{RawSaplingBundle, RawSaplingOutput, RawSaplingSpend};
 
 use super::{
-    Authorization, Authorized, TransactionDigest, TransparentDigests, TxDigests, TxId, TxVersion,
+    Authorization, Authorized, OrchardBundle, SaplingBundle, TransactionDigest, TransparentDigests,
+    TxDigests, TxId, TxVersion,
 };
 
 #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
@@ -97,6 +105,7 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
 /// * \[(cv, anchor, rk, zkproof)*\] - personalized with ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION
 ///
 /// Then, hash these together personalized by ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION
+#[cfg(feature = "sapling")]
 pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
     shielded_spends: &[SpendDescription<A>],
 ) -> Blake2bHash {
@@ -121,6 +130,28 @@ pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
     h.finalize()
 }
 
+/// Equivalent of [`hash_sapling_spends`] operating on the opaque byte representation of a
+/// Sapling bundle used when the `sapling` feature is disabled.
+#[cfg(not(feature = "sapling"))]
+fn hash_sapling_spends_raw(shielded_spends: &[RawSaplingSpend]) -> Blake2bHash {
+    let mut h = hasher(ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION);
+    if !shielded_spends.is_empty() {
+        let mut ch = hasher(ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION);
+        let mut nh = hasher(ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION);
+        for s_spend in shielded_spends {
+            ch.write_all(&s_spend.nullifier).unwrap();
+
+            nh.write_all(&s_spend.cv).unwrap();
+            nh.write_all(&s_spend.anchor).unwrap();
+            nh.write_all(&s_spend.rk).unwrap();
+        }
+
+        h.write_all(ch.finalize().as_bytes()).unwrap();
+        h.write_all(nh.finalize().as_bytes()).unwrap();
+    }
+    h.finalize()
+}
+
 /// Implements [ZIP 244 section T.3b](https://zips.z.cash/zip-0244#t-3b-sapling-outputs-digest)
 ///
 /// Write disjoint parts of each Sapling shielded output as 3 separate hashes:
@@ -129,6 +160,7 @@ pub(crate) fn hash_sapling_spends<A: sapling::bundle::Authorization>(
 /// * \[(cv, enc_ciphertext\[564..\], out_ciphertext, zkproof)*\] personalized with ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION
 ///
 /// Then, hash these together personalized with ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION
+#[cfg(feature = "sapling")]
 pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>]) -> Blake2bHash {
     let mut h = hasher(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION);
     if !shielded_outputs.is_empty() {
@@ -145,6 +177,34 @@ pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>])
             nh.write_all(&s_out.cv().to_bytes()).unwrap();
             nh.write_all(&s_out.enc_ciphertext()[564..]).unwrap();
             nh.write_all(&s_out.out_ciphertext()[..]).unwrap();
+        }
+
+        h.write_all(ch.finalize().as_bytes()).unwrap();
+        h.write_all(mh.finalize().as_bytes()).unwrap();
+        h.write_all(nh.finalize().as_bytes()).unwrap();
+    }
+    h.finalize()
+}
+
+/// Equivalent of [`hash_sapling_outputs`] operating on the opaque byte representation of a
+/// Sapling bundle used when the `sapling` feature is disabled.
+#[cfg(not(feature = "sapling"))]
+fn hash_sapling_outputs_raw(shielded_outputs: &[RawSaplingOutput]) -> Blake2bHash {
+    let mut h = hasher(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION);
+    if !shielded_outputs.is_empty() {
+        let mut ch = hasher(ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION);
+        let mut mh = hasher(ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION);
+        let mut nh = hasher(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION);
+        for s_out in shielded_outputs {
+            ch.write_all(&s_out.cmu).unwrap();
+            ch.write_all(&s_out.ephemeral_key).unwrap();
+            ch.write_all(&s_out.enc_ciphertext[..52]).unwrap();
+
+            mh.write_all(&s_out.enc_ciphertext[52..564]).unwrap();
+
+            nh.write_all(&s_out.cv).unwrap();
+            nh.write_all(&s_out.enc_ciphertext[564..]).unwrap();
+            nh.write_all(&s_out.out_ciphertext[..]).unwrap();
         }
 
         h.write_all(ch.finalize().as_bytes()).unwrap();
@@ -206,6 +266,7 @@ pub(crate) fn hash_transparent_txid_data(
 }
 
 /// Implements [ZIP 244 section T.3](https://zips.z.cash/zip-0244#t-3-sapling-digest)
+#[cfg(feature = "sapling")]
 fn hash_sapling_txid_data<A: sapling::bundle::Authorization>(
     bundle: &sapling::Bundle<A, ZatBalance>,
 ) -> Blake2bHash {
@@ -223,8 +284,157 @@ fn hash_sapling_txid_data<A: sapling::bundle::Authorization>(
     h.finalize()
 }
 
+/// Equivalent of [`hash_sapling_txid_data`] operating on the opaque byte representation of a
+/// Sapling bundle used when the `sapling` feature is disabled.
+#[cfg(not(feature = "sapling"))]
+fn hash_sapling_txid_data(bundle: &RawSaplingBundle) -> Blake2bHash {
+    let mut h = hasher(ZCASH_SAPLING_HASH_PERSONALIZATION);
+    if !(bundle.shielded_spends().is_empty() && bundle.shielded_outputs().is_empty()) {
+        h.write_all(hash_sapling_spends_raw(bundle.shielded_spends()).as_bytes())
+            .unwrap();
+
+        h.write_all(hash_sapling_outputs_raw(bundle.shielded_outputs()).as_bytes())
+            .unwrap();
+
+        h.write_all(&bundle.value_balance().to_i64_le_bytes())
+            .unwrap();
+    }
+    h.finalize()
+}
+
 fn hash_sapling_txid_empty() -> Blake2bHash {
     hasher(ZCASH_SAPLING_HASH_PERSONALIZATION).finalize()
+}
+
+// Personalizations for the Orchard ZIP 244 digests. When the `orchard` feature is enabled
+// these computations are performed by the `orchard` crate; when it is disabled they are
+// reimplemented here over the opaque byte representation of a parsed Orchard bundle.
+#[cfg(not(feature = "orchard"))]
+const ZCASH_ORCHARD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardHash";
+#[cfg(not(feature = "orchard"))]
+const ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActCHash";
+#[cfg(not(feature = "orchard"))]
+const ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActMHash";
+#[cfg(not(feature = "orchard"))]
+const ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActNHash";
+#[cfg(not(feature = "orchard"))]
+const ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaHash";
+
+/// Implements [ZIP 244 section T.5](https://zips.z.cash/zip-0244#t-5-orchard-digest).
+///
+/// When the `orchard` feature is enabled this delegates to the `orchard` crate; otherwise it
+/// reimplements the same computation over the opaque byte representation of a parsed bundle.
+#[cfg(feature = "orchard")]
+fn hash_orchard_txid_data<A: orchard::Authorization>(
+    bundle: &orchard::Bundle<A, ZatBalance>,
+) -> Blake2bHash {
+    bundle.commitment().0
+}
+
+#[cfg(not(feature = "orchard"))]
+fn hash_orchard_txid_data(bundle: &RawOrchardBundle) -> Blake2bHash {
+    let mut h = hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION);
+    let mut ch = hasher(ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION);
+    let mut mh = hasher(ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION);
+    let mut nh = hasher(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION);
+
+    for action in bundle.actions() {
+        ch.write_all(&action.nullifier).unwrap();
+        ch.write_all(&action.cmx).unwrap();
+        ch.write_all(&action.epk_bytes).unwrap();
+        ch.write_all(&action.enc_ciphertext[..52]).unwrap();
+
+        mh.write_all(&action.enc_ciphertext[52..564]).unwrap();
+
+        nh.write_all(&action.cv_net).unwrap();
+        nh.write_all(&action.rk).unwrap();
+        nh.write_all(&action.enc_ciphertext[564..]).unwrap();
+        nh.write_all(&action.out_ciphertext).unwrap();
+    }
+
+    h.write_all(ch.finalize().as_bytes()).unwrap();
+    h.write_all(mh.finalize().as_bytes()).unwrap();
+    h.write_all(nh.finalize().as_bytes()).unwrap();
+    h.write_all(&[bundle.flags()]).unwrap();
+    h.write_all(&bundle.value_balance().to_i64_le_bytes())
+        .unwrap();
+    h.write_all(bundle.anchor()).unwrap();
+    h.finalize()
+}
+
+#[cfg(feature = "orchard")]
+fn hash_orchard_txid_empty() -> Blake2bHash {
+    orchard::commitments::hash_bundle_txid_empty()
+}
+
+#[cfg(not(feature = "orchard"))]
+fn hash_orchard_txid_empty() -> Blake2bHash {
+    hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION).finalize()
+}
+
+/// Implements the Sapling authorizing-data digest (ZIP 244 section S.2-equivalent for the
+/// authorizing-data commitment), used by [`BlockTxCommitmentDigester`].
+#[cfg(feature = "sapling")]
+fn hash_sapling_auth_data(
+    sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, ZatBalance>>,
+) -> Blake2bHash {
+    let mut h = hasher(ZCASH_SAPLING_SIGS_HASH_PERSONALIZATION);
+    if let Some(bundle) = sapling_bundle {
+        for spend in bundle.shielded_spends() {
+            h.write_all(spend.zkproof()).unwrap();
+        }
+        for spend in bundle.shielded_spends() {
+            h.write_all(&<[u8; 64]>::from(*spend.spend_auth_sig()))
+                .unwrap();
+        }
+        for output in bundle.shielded_outputs() {
+            h.write_all(output.zkproof()).unwrap();
+        }
+        h.write_all(&<[u8; 64]>::from(bundle.authorization().binding_sig))
+            .unwrap();
+    }
+    h.finalize()
+}
+
+#[cfg(not(feature = "sapling"))]
+fn hash_sapling_auth_data(sapling_bundle: Option<&RawSaplingBundle>) -> Blake2bHash {
+    let mut h = hasher(ZCASH_SAPLING_SIGS_HASH_PERSONALIZATION);
+    if let Some(bundle) = sapling_bundle {
+        for spend in bundle.shielded_spends() {
+            h.write_all(&spend.zkproof).unwrap();
+        }
+        for spend in bundle.shielded_spends() {
+            h.write_all(&spend.spend_auth_sig).unwrap();
+        }
+        for output in bundle.shielded_outputs() {
+            h.write_all(&output.zkproof).unwrap();
+        }
+        h.write_all(bundle.binding_sig()).unwrap();
+    }
+    h.finalize()
+}
+
+/// Implements the Orchard authorizing-data digest, used by [`BlockTxCommitmentDigester`].
+#[cfg(feature = "orchard")]
+fn hash_orchard_auth_data(
+    orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
+) -> Blake2bHash {
+    orchard_bundle.map_or_else(orchard::commitments::hash_bundle_auth_empty, |b| {
+        b.authorizing_commitment().0
+    })
+}
+
+#[cfg(not(feature = "orchard"))]
+fn hash_orchard_auth_data(orchard_bundle: Option<&RawOrchardBundle>) -> Blake2bHash {
+    let mut h = hasher(ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION);
+    if let Some(bundle) = orchard_bundle {
+        h.write_all(bundle.proof()).unwrap();
+        for action in bundle.actions() {
+            h.write_all(&action.spend_auth_sig).unwrap();
+        }
+        h.write_all(bundle.binding_sig()).unwrap();
+    }
+    h.finalize()
 }
 
 /// A TransactionDigest implementation that commits to all of the effecting
@@ -269,18 +479,12 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         transparent_bundle.map(transparent_digests)
     }
 
-    fn digest_sapling(
-        &self,
-        sapling_bundle: Option<&sapling::Bundle<A::SaplingAuth, ZatBalance>>,
-    ) -> Self::SaplingDigest {
+    fn digest_sapling(&self, sapling_bundle: Option<&SaplingBundle<A>>) -> Self::SaplingDigest {
         sapling_bundle.map(hash_sapling_txid_data)
     }
 
-    fn digest_orchard(
-        &self,
-        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
-    ) -> Self::OrchardDigest {
-        orchard_bundle.map(|b| b.commitment().0)
+    fn digest_orchard(&self, orchard_bundle: Option<&OrchardBundle<A>>) -> Self::OrchardDigest {
+        orchard_bundle.map(hash_orchard_txid_data)
     }
 
     fn combine(
@@ -324,7 +528,7 @@ pub(crate) fn to_hash(
     .unwrap();
     h.write_all(
         orchard_digest
-            .unwrap_or_else(orchard::commitments::hash_bundle_txid_empty)
+            .unwrap_or_else(hash_orchard_txid_empty)
             .as_bytes(),
     )
     .unwrap();
@@ -389,38 +593,15 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         h.finalize()
     }
 
-    fn digest_sapling(
-        &self,
-        sapling_bundle: Option<&sapling::Bundle<sapling::bundle::Authorized, ZatBalance>>,
-    ) -> Blake2bHash {
-        let mut h = hasher(ZCASH_SAPLING_SIGS_HASH_PERSONALIZATION);
-        if let Some(bundle) = sapling_bundle {
-            for spend in bundle.shielded_spends() {
-                h.write_all(spend.zkproof()).unwrap();
-            }
-
-            for spend in bundle.shielded_spends() {
-                h.write_all(&<[u8; 64]>::from(*spend.spend_auth_sig()))
-                    .unwrap();
-            }
-
-            for output in bundle.shielded_outputs() {
-                h.write_all(output.zkproof()).unwrap();
-            }
-
-            h.write_all(&<[u8; 64]>::from(bundle.authorization().binding_sig))
-                .unwrap();
-        }
-        h.finalize()
+    fn digest_sapling(&self, sapling_bundle: Option<&SaplingBundle<Authorized>>) -> Blake2bHash {
+        hash_sapling_auth_data(sapling_bundle)
     }
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
+        orchard_bundle: Option<&OrchardBundle<Authorized>>,
     ) -> Self::OrchardDigest {
-        orchard_bundle.map_or_else(orchard::commitments::hash_bundle_auth_empty, |b| {
-            b.authorizing_commitment().0
-        })
+        hash_orchard_auth_data(orchard_bundle)
     }
 
     fn combine(


### PR DESCRIPTION
This is a simpler alternative to #1388

Closes #1162, which asked for these flags so that a consumer can depend on `zcash_primitives` without pulling in `sapling-crypto`. Today both `orchard` and `sapling` are unconditional `workspace = true` dependencies, and the existing `circuits` / `multicore` / `std` features only forward to their features rather than making the crates optional.
