### PR TITLE
Move PCZT v1 into versioned module

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,12 +13,15 @@ workspace.
 ### Changed
 - PCZT version 1 is now treated as a serialization format for the logical
   `pczt::Pczt` type.
+- `pczt::Pczt::serialize` now consumes `self` and returns
+  `Result<Vec<u8>, pczt::EncodingError>` rather than borrowing `self` and
+  returning `Vec<u8>`.
 
 ### Added
 - `pczt::parse`, a free function for parsing PCZT encodings.
-- `pczt::SerializeError`, for errors that can occur during PCZT serialization.
-- `pczt::Pczt::serialize_v1`, for explicitly serializing the logical PCZT type
-  with the version 1 encoding.
+- `pczt::EncodingError`, for errors that can occur during PCZT encoding.
+- `pczt::v1`, a module providing the version 1 PCZT serialization format via
+  `pczt::v1::Pczt`.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -16,6 +16,7 @@ workspace.
 
 ### Added
 - `pczt::parse`, a free function for parsing PCZT encodings.
+- `pczt::SerializeError`, for errors that can occur during PCZT serialization.
 - `pczt::Pczt::serialize_v1`, for explicitly serializing the logical PCZT type
   with the version 1 encoding.
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -8,6 +8,17 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [0.8.0] - PLANNED
+
+### Changed
+- PCZT version 1 is now treated as a serialization format for the logical
+  `pczt::Pczt` type.
+
+### Added
+- `pczt::parse`, a free function for parsing PCZT encodings.
+- `pczt::Pczt::serialize_v1`, for explicitly serializing the logical PCZT type
+  with the version 1 encoding.
+
 ## [0.7.0] - 2026-06-02
 
 ### Changed

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -139,7 +139,7 @@ impl Pczt {
         let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
         match version {
             PCZT_VERSION_1 => postcard::from_bytes::<v1::Pczt>(&bytes[8..])
-                .map(Into::into)
+                .map(Pczt::from)
                 .map_err(ParseError::Invalid),
             _ => Err(ParseError::UnknownVersion(version)),
         }

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -24,7 +24,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use getset::Getters;
-use serde::{Deserialize, Serialize};
 
 #[cfg(all(
     any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"),
@@ -55,15 +54,20 @@ pub mod orchard;
 pub mod sapling;
 pub mod transparent;
 
-const MAGIC_BYTES: &[u8] = b"PCZT";
-const PCZT_VERSION_1: u32 = 1;
+pub(crate) const MAGIC_BYTES: &[u8] = b"PCZT";
+pub(crate) const PCZT_VERSION_1: u32 = 1;
+
+/// Parses a PCZT from its encoding.
+pub fn parse(bytes: &[u8]) -> Result<Pczt, ParseError> {
+    Pczt::parse(bytes)
+}
 
 /// A partially-created Zcash transaction.
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, Getters)]
 pub struct Pczt {
     /// Global fields that are relevant to the transaction as a whole.
     #[getset(get = "pub")]
-    global: common::Global,
+    pub(crate) global: common::Global,
 
     //
     // Protocol-specific fields.
@@ -74,12 +78,53 @@ pub struct Pczt {
     // it has been determined whether there are protocol-specific inputs or outputs.
     //
     #[getset(get = "pub")]
-    transparent: transparent::Bundle,
+    pub(crate) transparent: transparent::Bundle,
     #[getset(get = "pub")]
-    sapling: sapling::Bundle,
+    pub(crate) sapling: sapling::Bundle,
     #[getset(get = "pub")]
-    orchard: orchard::Bundle,
+    pub(crate) orchard: orchard::Bundle,
 }
+
+mod v1 {
+    use serde::{Deserialize, Serialize};
+
+    use crate::{common, orchard, sapling, transparent};
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(super) struct Pczt {
+        pub(super) global: common::Global,
+        pub(super) transparent: transparent::Bundle,
+        pub(super) sapling: sapling::Bundle,
+        pub(super) orchard: orchard::Bundle,
+    }
+}
+
+impl From<v1::Pczt> for Pczt {
+    fn from(pczt: v1::Pczt) -> Self {
+        Self {
+            global: pczt.global,
+            transparent: pczt.transparent,
+            sapling: pczt.sapling,
+            orchard: pczt.orchard,
+        }
+    }
+}
+
+impl From<&Pczt> for v1::Pczt {
+    fn from(pczt: &Pczt) -> Self {
+        Self {
+            global: pczt.global.clone(),
+            transparent: pczt.transparent.clone(),
+            sapling: pczt.sapling.clone(),
+            orchard: pczt.orchard.clone(),
+        }
+    }
+}
+
+/// Errors that can occur while serializing a PCZT using the v1 encoding.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum V1SerializeError {}
 
 impl Pczt {
     /// Parses a PCZT from its encoding.
@@ -90,21 +135,28 @@ impl Pczt {
         if &bytes[..4] != MAGIC_BYTES {
             return Err(ParseError::NotPczt);
         }
-        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
-        if version != PCZT_VERSION_1 {
-            return Err(ParseError::UnknownVersion(version));
-        }
 
-        // This is a v1 PCZT.
-        postcard::from_bytes(&bytes[8..]).map_err(ParseError::Invalid)
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        match version {
+            PCZT_VERSION_1 => postcard::from_bytes::<v1::Pczt>(&bytes[8..])
+                .map(Into::into)
+                .map_err(ParseError::Invalid),
+            _ => Err(ParseError::UnknownVersion(version)),
+        }
     }
 
     /// Serializes this PCZT.
     pub fn serialize(&self) -> Vec<u8> {
+        self.serialize_v1()
+            .expect("v1 can encode the current logical PCZT")
+    }
+
+    /// Serializes this PCZT using the v1 encoding.
+    pub fn serialize_v1(&self) -> Result<Vec<u8>, V1SerializeError> {
         let mut bytes = vec![];
         bytes.extend_from_slice(MAGIC_BYTES);
         bytes.extend_from_slice(&PCZT_VERSION_1.to_le_bytes());
-        postcard::to_extend(self, bytes).expect("can serialize into memory")
+        Ok(postcard::to_extend(&v1::Pczt::from(self), bytes).expect("can serialize into memory"))
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided
@@ -238,9 +290,10 @@ impl Authorization for EffectsOnly {
 
 /// Helper to produce the correct sighash for a PCZT.
 ///
-/// At present, only V5 transaction signature hashes are supported, and a version check *MUST* be
-/// performed prior to invoking this function. It is intended for use exclusively for use in the
-/// context of a callback to the `extract_tx_data` function, which performs this check.
+/// At present, only V5 transaction signature hashes are supported, and a
+/// version check *MUST* be performed prior to invoking this function. It is
+/// intended for use exclusively for use in the context of a callback to the
+/// `extract_tx_data` function, which performs this check.
 #[cfg(any(feature = "io-finalizer", feature = "signer"))]
 pub(crate) fn sighash(
     tx_data: &TransactionData<EffectsOnly>,
@@ -269,11 +322,13 @@ pub enum ExtractError {
     SaplingExtract(::sapling::pczt::TxExtractorError),
     /// An error occurred parsing the Sapling PCZT bundle from the PCZT data.
     SaplingParse(::sapling::pczt::ParseError),
-    /// An error occurred extracting the transparent protocol bundle from the transparent PCZT bundle.
+    /// An error occurred extracting the transparent protocol bundle from the
+    /// transparent PCZT bundle.
     TransparentExtract(::transparent::pczt::TxExtractorError),
     /// An error occurred parsing the transparent PCZT bundle from the PCZT data.
     TransparentParse(::transparent::pczt::ParseError),
-    /// The consensus branch ID requested by the PCZT does not correspond to a known network upgrade.
+    /// The consensus branch ID requested by the PCZT does not correspond to a
+    /// known network upgrade.
     UnknownConsensusBranchId,
     /// The PCZT specifies an unsupported transaction version.
     UnsupportedTxVersion { version: u32, version_group_id: u32 },

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -121,10 +121,10 @@ impl From<&Pczt> for v1::Pczt {
     }
 }
 
-/// Errors that can occur while serializing a PCZT using the v1 encoding.
+/// Errors that can occur while serializing a PCZT.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum V1SerializeError {}
+pub enum SerializeError {}
 
 impl Pczt {
     /// Parses a PCZT from its encoding.
@@ -152,7 +152,7 @@ impl Pczt {
     }
 
     /// Serializes this PCZT using the v1 encoding.
-    pub fn serialize_v1(&self) -> Result<Vec<u8>, V1SerializeError> {
+    pub fn serialize_v1(&self) -> Result<Vec<u8>, SerializeError> {
         let mut bytes = vec![];
         bytes.extend_from_slice(MAGIC_BYTES);
         bytes.extend_from_slice(&PCZT_VERSION_1.to_le_bytes());

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -85,38 +85,53 @@ pub struct Pczt {
     pub(crate) orchard: orchard::Bundle,
 }
 
-mod v1 {
+/// Types and operations for the v1 Pczt encoding.
+pub mod v1 {
+    use alloc::vec::Vec;
     use serde::{Deserialize, Serialize};
 
     use crate::{common, orchard, sapling, transparent};
 
+    /// The in-memory type used for derived serialization of the v1 Pczt encoding.
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub(super) struct Pczt {
-        pub(super) global: common::Global,
-        pub(super) transparent: transparent::Bundle,
-        pub(super) sapling: sapling::Bundle,
-        pub(super) orchard: orchard::Bundle,
+    pub struct Pczt {
+        global: common::Global,
+        transparent: transparent::Bundle,
+        sapling: sapling::Bundle,
+        orchard: orchard::Bundle,
     }
-}
 
-impl From<v1::Pczt> for Pczt {
-    fn from(pczt: v1::Pczt) -> Self {
-        Self {
-            global: pczt.global,
-            transparent: pczt.transparent,
-            sapling: pczt.sapling,
-            orchard: pczt.orchard,
+    impl Pczt {
+        pub fn serialize(&self) -> Vec<u8> {
+            let mut bytes = vec![];
+            bytes.extend_from_slice(crate::MAGIC_BYTES);
+            bytes.extend_from_slice(&crate::PCZT_VERSION_1.to_le_bytes());
+            postcard::to_extend(&self, bytes).expect("can serialize into memory")
         }
     }
-}
 
-impl From<&Pczt> for v1::Pczt {
-    fn from(pczt: &Pczt) -> Self {
-        Self {
-            global: pczt.global.clone(),
-            transparent: pczt.transparent.clone(),
-            sapling: pczt.sapling.clone(),
-            orchard: pczt.orchard.clone(),
+    /// An encoder from the in-memory Pczt type to the type
+    impl TryFrom<super::Pczt> for Pczt {
+        type Error = super::EncodingError;
+
+        fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
+            Ok(Self {
+                global: pczt.global,
+                transparent: pczt.transparent,
+                sapling: pczt.sapling,
+                orchard: pczt.orchard,
+            })
+        }
+    }
+
+    impl From<Pczt> for super::Pczt {
+        fn from(pczt: Pczt) -> Self {
+            Self {
+                global: pczt.global,
+                transparent: pczt.transparent,
+                sapling: pczt.sapling,
+                orchard: pczt.orchard,
+            }
         }
     }
 }
@@ -124,7 +139,7 @@ impl From<&Pczt> for v1::Pczt {
 /// Errors that can occur while serializing a PCZT.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum SerializeError {}
+pub enum EncodingError {}
 
 impl Pczt {
     /// Parses a PCZT from its encoding.
@@ -146,17 +161,8 @@ impl Pczt {
     }
 
     /// Serializes this PCZT.
-    pub fn serialize(&self) -> Vec<u8> {
-        self.serialize_v1()
-            .expect("v1 can encode the current logical PCZT")
-    }
-
-    /// Serializes this PCZT using the v1 encoding.
-    pub fn serialize_v1(&self) -> Result<Vec<u8>, SerializeError> {
-        let mut bytes = vec![];
-        bytes.extend_from_slice(MAGIC_BYTES);
-        bytes.extend_from_slice(&PCZT_VERSION_1.to_le_bytes());
-        Ok(postcard::to_extend(&v1::Pczt::from(self), bytes).expect("can serialize into memory"))
+    pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
+        Ok(v1::Pczt::try_from(self.clone())?.serialize())
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -43,6 +43,8 @@ fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
 fn check_round_trip(pczt: &Pczt) {
     let encoded = pczt.serialize();
     assert_eq!(encoded, Pczt::parse(&encoded).unwrap().serialize());
+    assert_eq!(encoded, pczt::parse(&encoded).unwrap().serialize());
+    assert_eq!(encoded, pczt.serialize_v1().unwrap());
 }
 
 #[test]

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -15,6 +15,7 @@ use pczt::{
         signer::Signer, spend_finalizer::SpendFinalizer, tx_extractor::TransactionExtractor,
         updater::Updater,
     },
+    v1,
 };
 use rand_core::OsRng;
 use shardtree::{ShardTree, store::memory::MemoryShardStore};
@@ -41,10 +42,19 @@ fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
 }
 
 fn check_round_trip(pczt: &Pczt) {
-    let encoded = pczt.serialize();
-    assert_eq!(encoded, Pczt::parse(&encoded).unwrap().serialize());
-    assert_eq!(encoded, pczt::parse(&encoded).unwrap().serialize());
-    assert_eq!(encoded, pczt.serialize_v1().unwrap());
+    // The default encoding is the v1 encoding.
+    let v1_encoded = v1::Pczt::try_from(pczt.clone())
+        .expect("v1 encoding succeeds")
+        .serialize();
+
+    let encoded = pczt.clone().serialize().expect("serialization succeeds");
+    assert_eq!(encoded, v1_encoded);
+
+    let reencoded = Pczt::parse(&encoded)
+        .expect("can parse encoded PCZT")
+        .serialize()
+        .expect("serialization succeeds");
+    assert_eq!(encoded, reencoded);
 }
 
 #[test]
@@ -527,7 +537,7 @@ fn sapling_to_orchard() {
 
     // Pass the PCZT to be signed through a serialization cycle to ensure we don't lose
     // any information. This emulates passing it to another device.
-    let pczt = Pczt::parse(&pczt.serialize()).unwrap();
+    let pczt = Pczt::parse(&pczt.serialize().unwrap()).unwrap();
 
     // Apply signatures.
     let mut signer = Signer::new(pczt).unwrap();
@@ -539,7 +549,7 @@ fn sapling_to_orchard() {
 
     // Emulate passing the signed PCZT back to the first device.
     let pczt_with_sapling_signatures =
-        Pczt::parse(&pczt_with_sapling_signatures.serialize()).unwrap();
+        Pczt::parse(&pczt_with_sapling_signatures.serialize().unwrap()).unwrap();
 
     // Combine the three PCZTs into one.
     let pczt = Combiner::new(vec![


### PR DESCRIPTION
## Summary

- Move the existing PCZT v1 implementation into an inline `pczt::v1` module.
- Preserve existing top-level `pczt::Pczt`, `ParseError`, `ExtractError`, and `EffectsOnly` paths via re-exports.
- Add a planned changelog entry for the new public module.

## Validation

- `cargo fmt --all`
- `cargo check -p pczt --all-features`
- `cargo test -p pczt --all-features`

## API surface

- Adds public module `pczt::v1`.
- Adds public paths `pczt::v1::Pczt`, `pczt::v1::ParseError`, and feature-gated `pczt::v1::ExtractError` / `pczt::v1::EffectsOnly`.
- Changes `Pczt` fields `global`, `transparent`, `sapling`, and `orchard` from private-at-crate-root to `pub(crate)` inside `v1` so existing role modules can construct and destructure the type.