### PR TITLE
Release zcash_client_sqlite version 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -23,6 +23,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.8.0] - 2026-04-23

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -1045,8 +1045,16 @@ mod tests {
             BranchId::Nu6_1,
         );
         assert_eq!(
-            BranchId::for_height(&MAIN_NETWORK, BlockHeight(5_000_000)),
+            BranchId::for_height(&MAIN_NETWORK, BlockHeight(3_364_599)),
             BranchId::Nu6_1,
+        );
+        assert_eq!(
+            BranchId::for_height(&MAIN_NETWORK, BlockHeight(3_364_600)),
+            BranchId::Nu6_2,
+        );
+        assert_eq!(
+            BranchId::for_height(&MAIN_NETWORK, BlockHeight(5_000_000)),
+            BranchId::Nu6_2,
         );
     }
 }

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -97,9 +97,7 @@ mod tests {
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_nu7 = BlockHeight::from_u32(10);
-        #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(11);
+        let expected_z_future = BlockHeight::from_u32(10);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),
@@ -148,9 +146,7 @@ mod tests {
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_nu7 = BlockHeight::from_u32(10);
-        #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(11);
+        let expected_z_future = BlockHeight::from_u32(10);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),
@@ -230,9 +226,7 @@ mod tests {
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
-        let expected_nu7 = BlockHeight::from_u32(10);
-        #[cfg(zcash_unstable = "zfuture")]
-        let expected_z_future = BlockHeight::from_u32(11);
+        let expected_z_future = BlockHeight::from_u32(10);
 
         let regtest = LocalNetwork {
             overwinter: Some(expected_overwinter),

--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -17,6 +17,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.7.0] - 2026-04-23

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -16,6 +16,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.6.0] - 2026-04-27

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -898,6 +898,10 @@ criteria = "safe-to-deploy"
 version = "0.12.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.pczt]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.petgraph]]
 version = "0.6.5"
 criteria = "safe-to-deploy"
@@ -1685,6 +1689,14 @@ criteria = "safe-to-deploy"
 [[exemptions.yansi]]
 version = "1.0.1"
 criteria = "safe-to-run"
+
+[[exemptions.zcash_client_backend]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zcash_client_sqlite]]
+version = "0.21.1"
+criteria = "safe-to-deploy"
 
 [[exemptions.zeroize]]
 version = "1.6.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -92,13 +92,6 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.pczt]]
-version = "0.6.0"
-when = "2026-04-28"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.sapling-crypto]]
 version = "0.7.0"
 when = "2026-04-21"
@@ -444,20 +437,6 @@ user-name = "Jack Grigg"
 [[publisher.zcash_address]]
 version = "0.12.0"
 when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_client_backend]]
-version = "0.22.0"
-when = "2026-04-28"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_client_sqlite]]
-version = "0.20.2"
-when = "2026-05-07"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/zcash/CHANGELOG.md
+++ b/zcash/CHANGELOG.md
@@ -13,6 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.1.0] - 2024-07-15

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -17,6 +17,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.22.0] - 2026-04-27

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3117,6 +3117,110 @@ where
     );
 }
 
+/// Regression test for a bug in which [`WalletWrite::delete_account`] failed with a
+/// `rusqlite::Error::InvalidParameterName(":address")` panic when the account being
+/// deleted was referenced by a `sent_notes` row via its `to_account_id` column.
+///
+/// The triggering state is reached when a transaction is sent from one account in the
+/// wallet to an address belonging to a second account in the same wallet, and the
+/// transaction is then decrypted via [`decrypt_and_store_transaction`] so that the
+/// cross-account transfer is recorded with a non-null `to_account_id` and a received
+/// output that has an associated address. Deleting the recipient account then exercises
+/// the `sent_notes` update path inside `delete_account`.
+///
+/// [`WalletWrite::delete_account`]: crate::data_api::WalletWrite::delete_account
+pub fn account_deletion_with_internal_transfer<T: ShieldedPoolTester, DSF>(
+    ds_factory: DSF,
+    cache: impl TestCache,
+) where
+    DSF: DataStoreFactory,
+    <DSF as DataStoreFactory>::DataStore: Reset,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .build();
+
+    // Add two accounts to the wallet, derived from the same seed.
+    let seed = Secret::new([0u8; 32].to_vec());
+    let birthday = AccountBirthday::from_sapling_activation(st.network(), BlockHash([0; 32]));
+    let (account1, usk1) = st
+        .wallet_mut()
+        .create_account("account1", &seed, &birthday, None)
+        .unwrap();
+    let dfvk1 = T::sk_to_fvk(T::usk_to_sk(&usk1));
+
+    let (account2, usk2) = st
+        .wallet_mut()
+        .create_account("account2", &seed, &birthday, None)
+        .unwrap();
+    let dfvk2 = T::sk_to_fvk(T::usk_to_sk(&usk2));
+
+    // Add funds to account 1 in a single note.
+    let value = Zatoshis::from_u64(100000).unwrap();
+    let (h, _, _) = st.generate_next_block(&dfvk1, AddressType::DefaultExternal, value);
+    st.scan_cached_blocks(h, 1);
+
+    assert_eq!(st.get_total_balance(account1), value);
+    assert_eq!(st.get_total_balance(account2), Zatoshis::ZERO);
+
+    // Send funds from account 1 to an address belonging to account 2.
+    let bal_2 = Zatoshis::from_u64(50000).unwrap();
+    let addr2 = T::fvk_default_address(&dfvk2);
+    let req = TransactionRequest::new(vec![Payment::without_memo(
+        addr2.to_zcash_address(st.network()),
+        bal_2,
+    )])
+    .unwrap();
+
+    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+
+    let txid = st
+        .spend(
+            &input_selector,
+            &change_strategy,
+            &usk1,
+            req,
+            OvkPolicy::Sender,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap()[0];
+
+    let (h, _) = st.generate_next_block_including(txid);
+    st.scan_cached_blocks(h, 1);
+
+    assert_eq!(st.get_total_balance(account2), bal_2);
+
+    // Decrypt and store the transaction. Because the wallet owns the funding inputs
+    // (account 1) and the output is received by account 2, this records the send as an
+    // internal cross-account transfer, setting `sent_notes.to_account_id` to account 2
+    // and associating the received output with account 2's address. This is the state
+    // that triggers the `delete_account` bug.
+    let tx = st.wallet().get_transaction(txid).unwrap().unwrap();
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), &tx, Some(h)).unwrap();
+
+    // Deleting account 2, the recipient of the internal transfer, must succeed. Prior to
+    // the fix this failed with `rusqlite::Error::InvalidParameterName(":address")` because
+    // the `sent_notes` update statement bound the wrong parameter name.
+    assert_matches!(st.wallet_mut().delete_account(account2), Ok(_));
+
+    // account 1 should still exist and retain its change balance.
+    let summary = st
+        .wallet()
+        .get_wallet_summary(ConfirmationsPolicy::MIN)
+        .unwrap()
+        .unwrap();
+    assert!(summary.account_balances().get(&account2).is_none());
+    assert!(summary.account_balances().contains_key(&account1));
+}
+
 pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedPoolTester, Dsf>(
     ds_factory: Dsf,
     cache: impl TestCache,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## Unreleased
 
+## [0.21.1] - 2026-06-19
+
 ### Fixed
 - Fixed a bug in `WalletDb::delete_account` that caused it to fail with
   `rusqlite::Error::InvalidParameterName(":address")` when the account being

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -15,6 +15,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.20.2] - 2026-05-07

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,6 +8,16 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## Unreleased
+
+### Fixed
+- Fixed a bug in `WalletDb::delete_account` that caused it to fail with
+  `rusqlite::Error::InvalidParameterName(":address")` when the account being
+  deleted was referenced by a `sent_notes` row via its `to_account_id` column
+  (for example, after an internal transfer to an address belonging to the
+  account being deleted). The `sent_notes` update statement bound a parameter
+  named `:address` while the SQL expected `:to_address`.
+
 ## [0.21.0] - 2026-06-02
 
 ### Changed

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.21.0"
+version = "0.21.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -198,6 +198,13 @@ pub(crate) fn account_deletion<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn account_deletion_with_internal_transfer<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::account_deletion_with_internal_transfer::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn external_address_change_spends_detected_in_restore_from_seed<
     T: ShieldedPoolTester,
 >() {

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -756,7 +756,7 @@ pub(crate) fn delete_account(
         if let Some(address) = row.get::<_, Option<String>>("to_address")? {
             update_sent_note.execute(named_params![
                 ":sent_note_id": row.get::<_, i64>("sent_note_id")?,
-                ":address": address
+                ":to_address": address
             ])?;
         }
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -602,6 +602,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn account_deletion_with_internal_transfer() {
+        testing::pool::account_deletion_with_internal_transfer::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn external_address_change_spends_detected_in_restore_from_seed() {
         testing::pool::external_address_change_spends_detected_in_restore_from_seed::<
             OrchardPoolTester,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -545,6 +545,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn account_deletion_with_internal_transfer() {
+        testing::pool::account_deletion_with_internal_transfer::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn external_address_change_spends_detected_in_restore_from_seed() {
         testing::pool::external_address_change_spends_detected_in_restore_from_seed::<
             SaplingPoolTester,

--- a/zcash_extensions/CHANGELOG.md
+++ b/zcash_extensions/CHANGELOG.md
@@ -13,6 +13,7 @@ and this library adheres to Rust's notion of
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.1.0] - 2024-07-15

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -14,6 +14,11 @@ workspace.
 ### Changed
 - Migrated to `zcash_protocol 0.9`, `zcash_address 0.12`, `zcash_transparent 0.8`, `orchard 0.14`
 
+### Fixed
+- Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
+  (GHSA-2x4w-pxqw-58v9).
+
 ## [0.13.0] - 2026-04-27
 
 ### Added

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -26,7 +26,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
-  (GHSA-2x4w-pxqw-58v9).
+  (GHSA-ww9q-8r59-xv46).
 
 ### Security
 - Deserialization of v5 Orchard bundles now rejects proofs whose length is not

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -17,6 +17,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.27.0] - 2026-04-27

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -17,6 +17,7 @@ workspace.
 
 ### Fixed
 - Updated to crate versions that fix an Orchard soundness vulnerability
+  (GHSA-ww9q-8r59-xv46) and Orchard non-canonical proof size issue
   (GHSA-2x4w-pxqw-58v9).
 
 ## [0.7.0] - 2026-04-23


### PR DESCRIPTION
Patch release of zcash_client_sqlite which backports several fixes from main

COR-1367