### PR TITLE
Split Ironwood consensus cfg from NU7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - Orchard
           - all-pools
           - all-features
+          - NU6.3
           - NU7
 
         include:
@@ -45,6 +46,9 @@ jobs:
             all-pools: true
           - state: all-features
             all-features: true
+          - state: NU6.3
+            all-features: true
+            rustflags: '--cfg zcash_unstable="nu6.3"'
           - state: NU7
             all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
@@ -92,6 +96,7 @@ jobs:
           - Orchard
           - all-pools
           - all-features
+          - NU6.3
           - NU7
 
         include:
@@ -108,6 +113,9 @@ jobs:
             all-pools: true
           - state: all-features
             all-features: true
+          - state: NU6.3
+            all-features: true
+            rustflags: '--cfg zcash_unstable="nu6.3"'
           - state: NU7
             all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
@@ -115,6 +123,8 @@ jobs:
         exclude:
           - target: macOS
             state: all-features
+          - target: macOS
+            state: NU6.3
           - target: macOS
             state: NU7
 
@@ -159,6 +169,7 @@ jobs:
           - Sapling-only
           - Orchard
           - all-features
+          - NU6.3
           - NU7
 
         include:
@@ -171,6 +182,9 @@ jobs:
             orchard-pool: true
           - state: all-features
             all-features: true
+          - state: NU6.3
+            all-features: true
+            rustflags: '--cfg zcash_unstable="nu6.3"'
           - state: NU7
             all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,9 @@ cargo test --workspace --all-features --features expensive-tests
 
 # NU6.3 unstable network upgrade tests
 RUSTFLAGS='--cfg zcash_unstable="nu6.3"' cargo test --workspace --all-features
+
+# NU7 unstable network upgrade tests
+RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test --workspace --all-features
 ```
 
 ## Lint & Format
@@ -215,6 +218,7 @@ in-development functionality:
 
 - `zcash_unstable="zfuture"`
 - `zcash_unstable="nu6.3"`
+- `zcash_unstable="nu7"`
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,8 @@ cargo test --profile=dev -p <crate_name> <test_name>
 # Expensive/slow tests (CI runs these separately)
 cargo test --workspace --all-features --features expensive-tests
 
-# NU7 unstable network upgrade tests
-RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test --workspace --all-features
+# NU6.3 unstable network upgrade tests
+RUSTFLAGS='--cfg zcash_unstable="nu6.3"' cargo test --workspace --all-features
 ```
 
 ## Lint & Format
@@ -214,7 +214,7 @@ These are `cfg` flags (not Cargo feature flags) that enable unstable or
 in-development functionality:
 
 - `zcash_unstable="zfuture"`
-- `zcash_unstable="nu7"`
+- `zcash_unstable="nu6.3"`
 
 ## Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,6 @@ debug = true
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(tokio_unstable)',
-  'cfg(zcash_unstable, values("zfuture", "nu7"))',
+  'cfg(zcash_unstable, values("zfuture", "nu6.3", "nu7"))',
   'cfg(live_network_tests)',
 ] }

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,16 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID}` under
+  `zcash_unstable = "nu6.3"`. The v6 version group ID is provisional until the
+  Ironwood / NU6.3 value is chosen.
+- `zcash_protocol::consensus::{NetworkUpgrade::Nu6_3, BranchId::Nu6_3}` under
+  `zcash_unstable = "nu6.3"`. The NU6.3 consensus branch ID is provisional until
+  the Ironwood / NU6.3 value is chosen.
+- `zcash_protocol::local_consensus::LocalNetwork::nu6_3` under
+  `zcash_unstable = "nu6.3"`.
+
 ## [0.9.0] - 2026-06-02
 
 ### Changed

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -493,6 +493,8 @@ impl Parameters for MainNetwork {
             NetworkUpgrade::Nu6 => Some(BlockHeight(2_726_400)),
             NetworkUpgrade::Nu6_1 => Some(BlockHeight(3_146_400)),
             NetworkUpgrade::Nu6_2 => Some(BlockHeight(3_364_600)),
+            #[cfg(zcash_unstable = "nu6.3")]
+            NetworkUpgrade::Nu6_3 => None,
             #[cfg(zcash_unstable = "nu7")]
             NetworkUpgrade::Nu7 => None,
             #[cfg(zcash_unstable = "zfuture")]
@@ -527,6 +529,8 @@ impl Parameters for TestNetwork {
             NetworkUpgrade::Nu6 => Some(BlockHeight(2_976_000)),
             NetworkUpgrade::Nu6_1 => Some(BlockHeight(3_536_500)),
             NetworkUpgrade::Nu6_2 => Some(BlockHeight(4_052_000)),
+            #[cfg(zcash_unstable = "nu6.3")]
+            NetworkUpgrade::Nu6_3 => None,
             #[cfg(zcash_unstable = "nu7")]
             NetworkUpgrade::Nu7 => None,
             #[cfg(zcash_unstable = "zfuture")]
@@ -605,6 +609,9 @@ pub enum NetworkUpgrade {
     ///
     /// [Nu6.2]: https://z.cash/upgrade/nu6.2/
     Nu6_2,
+    /// The Ironwood / NU6.3 network upgrade.
+    #[cfg(zcash_unstable = "nu6.3")]
+    Nu6_3,
     /// The [Nu7 (proposed)] network upgrade.
     ///
     /// [Nu7 (proposed)]: https://z.cash/upgrade/nu7/
@@ -634,6 +641,8 @@ impl fmt::Display for NetworkUpgrade {
             NetworkUpgrade::Nu6 => write!(f, "Nu6"),
             NetworkUpgrade::Nu6_1 => write!(f, "Nu6.1"),
             NetworkUpgrade::Nu6_2 => write!(f, "Nu6.2"),
+            #[cfg(zcash_unstable = "nu6.3")]
+            NetworkUpgrade::Nu6_3 => write!(f, "Nu6.3"),
             #[cfg(zcash_unstable = "nu7")]
             NetworkUpgrade::Nu7 => write!(f, "Nu7"),
             #[cfg(zcash_unstable = "zfuture")]
@@ -654,6 +663,8 @@ impl NetworkUpgrade {
             NetworkUpgrade::Nu6 => BranchId::Nu6,
             NetworkUpgrade::Nu6_1 => BranchId::Nu6_1,
             NetworkUpgrade::Nu6_2 => BranchId::Nu6_2,
+            #[cfg(zcash_unstable = "nu6.3")]
+            NetworkUpgrade::Nu6_3 => BranchId::Nu6_3,
             #[cfg(zcash_unstable = "nu7")]
             NetworkUpgrade::Nu7 => BranchId::Nu7,
             #[cfg(zcash_unstable = "zfuture")]
@@ -676,6 +687,8 @@ const UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     NetworkUpgrade::Nu6,
     NetworkUpgrade::Nu6_1,
     NetworkUpgrade::Nu6_2,
+    #[cfg(zcash_unstable = "nu6.3")]
+    NetworkUpgrade::Nu6_3,
     #[cfg(zcash_unstable = "nu7")]
     NetworkUpgrade::Nu7,
 ];
@@ -729,6 +742,12 @@ pub enum BranchId {
     Nu6_1,
     /// The consensus rules deployed by [`NetworkUpgrade::Nu6_2`].
     Nu6_2,
+    /// The consensus rules to be deployed by [`NetworkUpgrade::Nu6_3`].
+    ///
+    /// This variant is gated by `zcash_unstable = "nu6.3"` and currently uses a
+    /// placeholder branch ID until the Ironwood / NU6.3 consensus branch ID is chosen.
+    #[cfg(zcash_unstable = "nu6.3")]
+    Nu6_3,
     /// The consensus rules to be deployed by [`NetworkUpgrade::Nu7`].
     #[cfg(zcash_unstable = "nu7")]
     Nu7,
@@ -756,6 +775,9 @@ impl TryFrom<u32> for BranchId {
             0xc8e7_1055 => Ok(BranchId::Nu6),
             0x4dec_4df0 => Ok(BranchId::Nu6_1),
             0x5437_f330 => Ok(BranchId::Nu6_2),
+            #[cfg(zcash_unstable = "nu6.3")]
+            // TODO: Replace this placeholder once the Ironwood / NU6.3 consensus branch ID is chosen.
+            0xffff_ffff => Ok(BranchId::Nu6_3),
             #[cfg(zcash_unstable = "nu7")]
             0xffff_ffff => Ok(BranchId::Nu7),
             #[cfg(zcash_unstable = "zfuture")]
@@ -778,6 +800,9 @@ impl From<BranchId> for u32 {
             BranchId::Nu6 => 0xc8e7_1055,
             BranchId::Nu6_1 => 0x4dec_4df0,
             BranchId::Nu6_2 => 0x5437_f330,
+            #[cfg(zcash_unstable = "nu6.3")]
+            // TODO: Replace this placeholder once the Ironwood / NU6.3 consensus branch ID is chosen.
+            BranchId::Nu6_3 => 0xffff_ffff,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => 0xffff_ffff,
             #[cfg(zcash_unstable = "zfuture")]
@@ -857,14 +882,27 @@ impl BranchId {
             BranchId::Nu6_2 => params
                 .activation_height(NetworkUpgrade::Nu6_2)
                 .map(|lower| {
-                    #[cfg(zcash_unstable = "nu7")]
+                    #[cfg(zcash_unstable = "nu6.3")]
+                    let upper = params.activation_height(NetworkUpgrade::Nu6_3);
+                    #[cfg(all(not(zcash_unstable = "nu6.3"), zcash_unstable = "nu7"))]
                     let upper = params.activation_height(NetworkUpgrade::Nu7);
-                    #[cfg(zcash_unstable = "zfuture")]
+                    #[cfg(all(
+                        not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")),
+                        zcash_unstable = "zfuture"
+                    ))]
                     let upper = params.activation_height(NetworkUpgrade::ZFuture);
-                    #[cfg(not(any(zcash_unstable = "nu7", zcash_unstable = "zfuture")))]
+                    #[cfg(not(any(
+                        zcash_unstable = "nu6.3",
+                        zcash_unstable = "nu7",
+                        zcash_unstable = "zfuture"
+                    )))]
                     let upper = None;
                     (lower, upper)
                 }),
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => params
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .map(|lower| (lower, None)),
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => params
                 .activation_height(NetworkUpgrade::Nu7)
@@ -886,6 +924,8 @@ impl BranchId {
         match self {
             Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1
             | Nu6_2 => true,
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => false,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => false,
             #[cfg(zcash_unstable = "zfuture")]
@@ -899,6 +939,8 @@ impl BranchId {
         match self {
             Sprout | Overwinter => false,
             Sapling | Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu6_2 => true,
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => true,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => true,
             #[cfg(zcash_unstable = "zfuture")]
@@ -912,6 +954,8 @@ impl BranchId {
         match self {
             Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy => false,
             Nu5 | Nu6 | Nu6_1 | Nu6_2 => true,
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => true,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => true,
             #[cfg(zcash_unstable = "zfuture")]
@@ -939,6 +983,8 @@ pub mod testing {
             BranchId::Nu6,
             BranchId::Nu6_1,
             BranchId::Nu6_2,
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7,
             #[cfg(zcash_unstable = "zfuture")]

--- a/components/zcash_protocol/src/constants.rs
+++ b/components/zcash_protocol/src/constants.rs
@@ -37,10 +37,13 @@ pub const V5_TX_VERSION: u32 = 5;
 pub const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
 
 /// Transaction version 6, specified in [ZIP 230](https://zips.z.cash/zip-0230).
-#[cfg(zcash_unstable = "nu7")]
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub const V6_TX_VERSION: u32 = 6;
 /// The version group ID for Zcash v6 transactions.
-#[cfg(zcash_unstable = "nu7")]
+///
+/// This value is gated by `zcash_unstable = "nu6.3"` or `zcash_unstable = "nu7"`
+/// and is a placeholder until the network upgrade version group ID is chosen.
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub const V6_VERSION_GROUP_ID: u32 = 0xFFFFFFFF;
 
 /// This version is used exclusively for in-development transaction

--- a/components/zcash_protocol/src/lib.rs
+++ b/components/zcash_protocol/src/lib.rs
@@ -14,6 +14,11 @@
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 
+#[cfg(all(zcash_unstable = "nu6.3", zcash_unstable = "zfuture"))]
+compile_error!(
+    "zcash_unstable=\"nu6.3\" and zcash_unstable=\"zfuture\" cannot be enabled together"
+);
+
 #[cfg_attr(any(test, feature = "test-dependencies"), macro_use)]
 extern crate alloc;
 

--- a/components/zcash_protocol/src/local_consensus.rs
+++ b/components/zcash_protocol/src/local_consensus.rs
@@ -30,6 +30,10 @@ use crate::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
 ///         nu6: Some(BlockHeight::from_u32(1)),
 ///         nu6_1: Some(BlockHeight::from_u32(1)),
 ///         nu6_2: Some(BlockHeight::from_u32(1)),
+///         #[cfg(zcash_unstable = "nu6.3")]
+///         nu6_3: Some(BlockHeight::from_u32(1)),
+///         #[cfg(zcash_unstable = "nu7")]
+///         nu7: Some(BlockHeight::from_u32(1)),
 ///     };
 ///     ```
 ///     
@@ -44,6 +48,8 @@ pub struct LocalNetwork {
     pub nu6: Option<BlockHeight>,
     pub nu6_1: Option<BlockHeight>,
     pub nu6_2: Option<BlockHeight>,
+    #[cfg(zcash_unstable = "nu6.3")]
+    pub nu6_3: Option<BlockHeight>,
     #[cfg(zcash_unstable = "nu7")]
     pub nu7: Option<BlockHeight>,
     #[cfg(zcash_unstable = "zfuture")]
@@ -67,6 +73,8 @@ impl Parameters for LocalNetwork {
             NetworkUpgrade::Nu6 => self.nu6,
             NetworkUpgrade::Nu6_1 => self.nu6_1,
             NetworkUpgrade::Nu6_2 => self.nu6_2,
+            #[cfg(zcash_unstable = "nu6.3")]
+            NetworkUpgrade::Nu6_3 => self.nu6_3,
             #[cfg(zcash_unstable = "nu7")]
             NetworkUpgrade::Nu7 => self.nu7,
             #[cfg(zcash_unstable = "zfuture")]
@@ -94,6 +102,8 @@ mod tests {
         let expected_nu6 = BlockHeight::from_u32(7);
         let expected_nu6_1 = BlockHeight::from_u32(8);
         let expected_nu6_2 = BlockHeight::from_u32(9);
+        #[cfg(zcash_unstable = "nu6.3")]
+        let expected_nu6_3 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
@@ -109,6 +119,8 @@ mod tests {
             nu6: Some(expected_nu6),
             nu6_1: Some(expected_nu6_1),
             nu6_2: Some(expected_nu6_2),
+            #[cfg(zcash_unstable = "nu6.3")]
+            nu6_3: Some(expected_nu6_3),
             #[cfg(zcash_unstable = "nu7")]
             nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]
@@ -124,6 +136,9 @@ mod tests {
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu6, expected_nu6));
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu6_1, expected_nu6_1));
         assert!(regtest.is_nu_active(NetworkUpgrade::Nu6_2, expected_nu6_2));
+        // nu6_3 must not be activated at or below the nu6_2 height
+        #[cfg(zcash_unstable = "nu6.3")]
+        assert!(!regtest.is_nu_active(NetworkUpgrade::Nu6_3, expected_nu6_2));
         // nu7 must not be activated at or below the nu6_2 height
         #[cfg(zcash_unstable = "nu7")]
         assert!(!regtest.is_nu_active(NetworkUpgrade::Nu7, expected_nu6_2));
@@ -143,6 +158,8 @@ mod tests {
         let expected_nu6 = BlockHeight::from_u32(7);
         let expected_nu6_1 = BlockHeight::from_u32(8);
         let expected_nu6_2 = BlockHeight::from_u32(9);
+        #[cfg(zcash_unstable = "nu6.3")]
+        let expected_nu6_3 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
@@ -158,6 +175,8 @@ mod tests {
             nu6: Some(expected_nu6),
             nu6_1: Some(expected_nu6_1),
             nu6_2: Some(expected_nu6_2),
+            #[cfg(zcash_unstable = "nu6.3")]
+            nu6_3: Some(expected_nu6_3),
             #[cfg(zcash_unstable = "nu7")]
             nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]
@@ -200,6 +219,11 @@ mod tests {
             regtest.activation_height(NetworkUpgrade::Nu6_2),
             Some(expected_nu6_2)
         );
+        #[cfg(zcash_unstable = "nu6.3")]
+        assert_eq!(
+            regtest.activation_height(NetworkUpgrade::Nu6_3),
+            Some(expected_nu6_3)
+        );
         #[cfg(zcash_unstable = "nu7")]
         assert_eq!(
             regtest.activation_height(NetworkUpgrade::Nu7),
@@ -223,6 +247,8 @@ mod tests {
         let expected_nu6 = BlockHeight::from_u32(7);
         let expected_nu6_1 = BlockHeight::from_u32(8);
         let expected_nu6_2 = BlockHeight::from_u32(9);
+        #[cfg(zcash_unstable = "nu6.3")]
+        let expected_nu6_3 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "nu7")]
         let expected_nu7 = BlockHeight::from_u32(10);
         #[cfg(zcash_unstable = "zfuture")]
@@ -238,6 +264,8 @@ mod tests {
             nu6: Some(expected_nu6),
             nu6_1: Some(expected_nu6_1),
             nu6_2: Some(expected_nu6_2),
+            #[cfg(zcash_unstable = "nu6.3")]
+            nu6_3: Some(expected_nu6_3),
             #[cfg(zcash_unstable = "nu7")]
             nu7: Some(expected_nu7),
             #[cfg(zcash_unstable = "zfuture")]

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1513,6 +1513,8 @@ impl TestBuilder<(), ()> {
         nu6: None,
         nu6_1: None,
         nu6_2: None,
+        #[cfg(zcash_unstable = "nu6.3")]
+        nu6_3: None,
         #[cfg(zcash_unstable = "nu7")]
         nu7: None,
         #[cfg(zcash_unstable = "zfuture")]

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -237,6 +237,8 @@ impl TxVersion {
             BranchId::Nu6 => TxVersion::V5,
             BranchId::Nu6_1 => TxVersion::V5,
             BranchId::Nu6_2 => TxVersion::V5,
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => TxVersion::V5,
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => TxVersion::V6,
             #[cfg(zcash_unstable = "zfuture")]
@@ -256,6 +258,8 @@ impl TxVersion {
             TxVersion::V4 => match consensus_branch_id {
                 Sprout | Overwinter => false,
                 Sapling | Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu6_2 => true,
+                #[cfg(zcash_unstable = "nu6.3")]
+                Nu6_3 => true,
                 #[cfg(zcash_unstable = "nu7")]
                 Nu7 => false, // ZIP 2003
                 #[cfg(zcash_unstable = "zfuture")]
@@ -264,6 +268,8 @@ impl TxVersion {
             TxVersion::V5 => match consensus_branch_id {
                 Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy => false,
                 Nu5 | Nu6 | Nu6_1 | Nu6_2 => true,
+                #[cfg(zcash_unstable = "nu6.3")]
+                Nu6_3 => true,
                 #[cfg(zcash_unstable = "nu7")]
                 Nu7 => true,
                 #[cfg(zcash_unstable = "zfuture")]
@@ -273,12 +279,16 @@ impl TxVersion {
             TxVersion::V6 => match consensus_branch_id {
                 Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5 | Nu6
                 | Nu6_1 | Nu6_2 => false,
+                #[cfg(zcash_unstable = "nu6.3")]
+                Nu6_3 => false,
                 Nu7 => true, // ZIP 230 or ZIP 248, whichever is chosen for activation
             },
             #[cfg(zcash_unstable = "zfuture")]
             TxVersion::ZFuture => match consensus_branch_id {
                 Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5 | Nu6
                 | Nu6_1 | Nu6_2 => false,
+                #[cfg(zcash_unstable = "nu6.3")]
+                Nu6_3 => false,
                 ZFuture => true,
             },
         }
@@ -961,6 +971,8 @@ impl Transaction {
                 | BranchId::Nu6
                 | BranchId::Nu6_1 => ProofSizeEnforcement::Unenforced,
                 BranchId::Nu6_2 => ProofSizeEnforcement::Strict,
+                #[cfg(zcash_unstable = "nu6.3")]
+                BranchId::Nu6_3 => ProofSizeEnforcement::Strict,
                 #[cfg(zcash_unstable = "nu7")]
                 BranchId::Nu7 => ProofSizeEnforcement::Strict,
                 #[cfg(zcash_unstable = "zfuture")]
@@ -1356,6 +1368,8 @@ pub mod testing {
             BranchId::Nu6 => Just(TxVersion::V5).boxed(),
             BranchId::Nu6_1 => Just(TxVersion::V5).boxed(),
             BranchId::Nu6_2 => Just(TxVersion::V5).boxed(),
+            #[cfg(zcash_unstable = "nu6.3")]
+            BranchId::Nu6_3 => Just(TxVersion::V5).boxed(),
             #[cfg(zcash_unstable = "nu7")]
             BranchId::Nu7 => Just(TxVersion::V6).boxed(),
             #[cfg(zcash_unstable = "zfuture")]


### PR DESCRIPTION
## Summary

This splits the Ironwood / NU6.3 consensus foundation out from the existing NU7 cfg path while keeping the scope limited to consensus and transaction plumbing.

(I took this out of #2429 / https://github.com/valargroup/librustzcash/pull/44 )

Changes included:
- Adds zcash_unstable = "nu6.3" support for NetworkUpgrade::Nu6_3 and BranchId::Nu6_3.
- Enables v6 transaction constants under NU6.3 as well as NU7.
- Updates transaction version selection for NU6.3 vs NU7.
- Updates local consensus test scaffolding for NU6.3.
- Updates CI so both NU6.3 and NU7 all-features configurations run.

Intentionally excluded:
- The zcash_history Ironwood V3 history tree changes from the source branch.

## Validation

- YAML parse for .github/workflows/ci.yml
- git diff --cached --check
- cargo check -p zcash_protocol -p zcash_primitives -p zcash_client_backend --all-features
- RUSTFLAGS='--cfg zcash_unstable="nu6.3"' cargo check -p zcash_protocol -p zcash_primitives -p zcash_client_backend -p pczt --all-features
- RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo check -p zcash_protocol -p zcash_primitives -p zcash_client_backend -p pczt --all-features