### PR TITLE
Adapt to upstream Orchard API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.14.0"
-source = "git+https://github.com/zcash/orchard?rev=e81bccc6ab0e3235f01f10a75337c6f588e850f9#e81bccc6ab0e3235f01f10a75337c6f588e850f9"
+source = "git+https://github.com/zcash/orchard?rev=b2af0a11abe00f59c51258d349c2105fe7a16215#b2af0a11abe00f59c51258d349c2105fe7a16215"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,8 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+source = "git+https://github.com/zcash/orchard?rev=e81bccc6ab0e3235f01f10a75337c6f588e850f9#e81bccc6ab0e3235f01f10a75337c6f588e850f9"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215", default-features = false }
+orchard = { version = "0.14", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent
@@ -186,6 +186,9 @@ zip32 = { version = "0.2", default-features = false }
 
 # Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
 time-core = "=0.1.2"
+
+[patch.crates-io]
+orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { git = "https://github.com/zcash/orchard", rev = "e81bccc6ab0e3235f01f10a75337c6f588e850f9", default-features = false }
+orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { version = "0.14", default-features = false }
+orchard = { git = "https://github.com/zcash/orchard", rev = "e81bccc6ab0e3235f01f10a75337c6f588e850f9", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -8,6 +8,8 @@ use core::cmp::Ordering;
 #[cfg(feature = "orchard")]
 use ff::PrimeField;
 use getset::Getters;
+#[cfg(feature = "orchard")]
+use orchard::{bundle::BundleFormat, note::NoteVersion};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -419,6 +421,7 @@ impl Bundle {
                     action.spend.value,
                     action.spend.rho,
                     action.spend.rseed,
+                    NoteVersion::V2,
                     action.spend.fvk,
                     action.spend.witness,
                     action.spend.alpha,
@@ -445,6 +448,7 @@ impl Bundle {
                     action.output.recipient,
                     action.output.value,
                     action.output.rseed,
+                    NoteVersion::V2,
                     action.output.ock,
                     action
                         .output
@@ -467,6 +471,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
+            BundleFormat::PreNu6_3,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -563,7 +568,10 @@ impl Bundle {
 
         Self {
             actions,
-            flags: bundle.flags().to_byte(),
+            flags: bundle
+                .flags()
+                .to_byte(BundleFormat::PreNu6_3)
+                .expect("Orchard flags must be representable in the v5 transaction format"),
             value_sum,
             anchor: bundle.anchor().to_bytes(),
             zkproof: bundle

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -62,7 +62,9 @@ impl Creator {
 
     #[cfg(feature = "orchard")]
     pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
-        self.orchard_flags = orchard_flags.to_byte();
+        self.orchard_flags = orchard_flags
+            .to_byte(orchard::bundle::BundleFormat::PreNu6_3)
+            .expect("Orchard flags must be representable in the v5 transaction format");
         self
     }
 

--- a/pczt/src/roles/tx_extractor/orchard.rs
+++ b/pczt/src/roles/tx_extractor/orchard.rs
@@ -1,4 +1,8 @@
-use orchard::{Bundle, bundle::Authorized, circuit::VerifyingKey};
+use orchard::{
+    Bundle,
+    bundle::Authorized,
+    circuit::{OrchardCircuitVersion, VerifyingKey},
+};
 use rand_core::OsRng;
 use zcash_protocol::value::ZatBalance;
 
@@ -7,25 +11,29 @@ pub(super) fn verify_bundle(
     orchard_vk: Option<&VerifyingKey>,
     sighash: [u8; 32],
 ) -> Result<(), OrchardError> {
-    let mut validator = orchard::bundle::BatchValidator::new();
-    let rng = OsRng;
-
-    validator.add_bundle(bundle, sighash);
-
     if let Some(vk) = orchard_vk {
-        if validator.validate(vk, rng) {
-            Ok(())
-        } else {
-            Err(OrchardError::InvalidProof)
-        }
+        verify_bundle_with_key(bundle, vk, sighash)
     } else {
         // PCZT extraction produces new transactions, which use the NU6.2 (fixed) circuit.
-        let vk = VerifyingKey::build();
-        if validator.validate(&vk, rng) {
-            Ok(())
-        } else {
-            Err(OrchardError::InvalidProof)
-        }
+        let vk = VerifyingKey::build(OrchardCircuitVersion::FixedPostNu6_2);
+        verify_bundle_with_key(bundle, &vk, sighash)
+    }
+}
+
+fn verify_bundle_with_key(
+    bundle: &Bundle<Authorized, ZatBalance>,
+    vk: &VerifyingKey,
+    sighash: [u8; 32],
+) -> Result<(), OrchardError> {
+    let mut validator = orchard::bundle::BatchValidator::new(vk);
+    validator
+        .add_bundle(bundle, sighash)
+        .map_err(|_| OrchardError::InvalidProof)?;
+
+    if validator.validate(OsRng) {
+        Ok(())
+    } else {
+        Err(OrchardError::InvalidProof)
     }
 }
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -589,8 +589,8 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::BundleKind::Transaction,
             orchard::BundleProtocol::OrchardPreNu6_3,
+            orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );
         orchard_builder

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -38,7 +38,9 @@ use zcash_script::script::{self, Evaluable};
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
-    ORCHARD_PROVING_KEY.get_or_init(orchard::circuit::ProvingKey::build)
+    ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
 }
 
 fn check_round_trip(pczt: &Pczt) {
@@ -587,7 +589,8 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::builder::BundleType::DEFAULT,
+            orchard::BundleKind::Transaction,
+            orchard::BundleProtocol::OrchardPreNu6_3,
             orchard::Anchor::empty_tree(),
         );
         orchard_builder

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6097,7 +6097,9 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
 
     // Create proofs.
     let sapling_prover = LocalTxProver::bundled();
-    let orchard_pk = ::orchard::circuit::ProvingKey::build();
+    let orchard_pk = ::orchard::circuit::ProvingKey::build(
+        ::orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+    );
     let pczt_proven = Prover::new(pczt_updated)
         .create_orchard_proof(&orchard_pk)
         .unwrap()

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2334,7 +2334,14 @@ where
                     orchard::note::RandomSeed::from_bytes(*rseed, &rho).into_option()
                 })?;
 
-                orchard::Note::from_parts(recipient, value, rho, rseed).into_option()
+                orchard::Note::from_parts(
+                    recipient,
+                    value,
+                    rho,
+                    rseed,
+                    orchard::note::NoteVersion::V2,
+                )
+                .into_option()
             };
 
             let external_address = act

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -871,7 +871,7 @@ where
         };
         orchard::builder::BundleType::DEFAULT
             .num_actions(spendable_notes.orchard.len(), requested_orchard_actions)
-            .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?
+            .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s.as_static_str())))?
     };
     #[cfg(not(feature = "orchard"))]
     let orchard_action_count: usize = 0;

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -870,8 +870,12 @@ where
             0
         };
         orchard::builder::BundleType::DEFAULT
-            .num_actions(spendable_notes.orchard.len(), requested_orchard_actions)
-            .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s.as_static_str())))?
+            .num_actions(
+                spendable_notes.orchard.len(),
+                requested_orchard_actions,
+                ::orchard::BundleProtocol::OrchardPreNu6_3,
+            )
+            .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?
     };
     #[cfg(not(feature = "orchard"))]
     let orchard_action_count: usize = 0;
@@ -1264,7 +1268,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard::builder::BundleType::DEFAULT
-                    .num_actions(0, 1)
+                    .num_actions(0, 1, ::orchard::BundleProtocol::OrchardPreNu6_3)
                     .expect("orchard DEFAULT bundle type permits any (spends, outputs) count");
                 (0usize, count)
             }

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -317,8 +317,9 @@ where
             .num_actions(
                 orchard.inputs().len(),
                 orchard.outputs().len() + change_count,
+                ::orchard::BundleProtocol::OrchardPreNu6_3,
             )
-            .map_err(|e| ChangeError::BundleError(e.as_static_str()))
+            .map_err(ChangeError::BundleError)
     };
     #[cfg(not(feature = "orchard"))]
     let orchard_action_count = |change_count: usize| -> Result<usize, ChangeError<E, NoteRefT>> {
@@ -694,8 +695,12 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             #[cfg(feature = "orchard")]
             let o_action_count = orchard
                 .bundle_type()
-                .num_actions(o_req_inputs + _o_extra, o_outputs_len + change.orchard)
-                .map_err(|e| ChangeError::BundleError(e.as_static_str()))?;
+                .num_actions(
+                    o_req_inputs + _o_extra,
+                    o_outputs_len + change.orchard,
+                    ::orchard::BundleProtocol::OrchardPreNu6_3,
+                )
+                .map_err(ChangeError::BundleError)?;
             #[cfg(not(feature = "orchard"))]
             let o_action_count = 0;
 

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -318,7 +318,7 @@ where
                 orchard.inputs().len(),
                 orchard.outputs().len() + change_count,
             )
-            .map_err(ChangeError::BundleError)
+            .map_err(|e| ChangeError::BundleError(e.as_static_str()))
     };
     #[cfg(not(feature = "orchard"))]
     let orchard_action_count = |change_count: usize| -> Result<usize, ChangeError<E, NoteRefT>> {
@@ -695,7 +695,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             let o_action_count = orchard
                 .bundle_type()
                 .num_actions(o_req_inputs + _o_extra, o_outputs_len + change.orchard)
-                .map_err(ChangeError::BundleError)?;
+                .map_err(|e| ChangeError::BundleError(e.as_static_str()))?;
             #[cfg(not(feature = "orchard"))]
             let o_action_count = 0;
 

--- a/zcash_client_memory/src/types/notes/mod.rs
+++ b/zcash_client_memory/src/types/notes/mod.rs
@@ -125,7 +125,16 @@ mod serialization {
                         &rho,
                     )
                     .unwrap();
-                    Self::Orchard(orchard::Note::from_parts(recipient, value, rho, rseed).unwrap())
+                    Self::Orchard(
+                        orchard::Note::from_parts(
+                            recipient,
+                            value,
+                            rho,
+                            rseed,
+                            orchard::note::NoteVersion::V2,
+                        )
+                        .unwrap(),
+                    )
                 }
                 #[cfg(not(feature = "orchard"))]
                 _ => panic!("invalid protocol"),

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -110,6 +110,7 @@ pub(crate) fn to_received_note<P: consensus::Parameters>(
                 orchard::value::NoteValue::from_raw(note_value),
                 rho,
                 rseed,
+                orchard::note::NoteVersion::V2,
             ))
             .ok_or_else(|| SqliteClientError::CorruptedData("Invalid Orchard note.".to_string()))?;
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -282,13 +282,6 @@ impl BuildConfig {
     }
 }
 
-fn orchard_bundle_kind(bundle_type: orchard::builder::BundleType) -> orchard::BundleKind {
-    match bundle_type {
-        orchard::builder::BundleType::Transactional { .. } => orchard::BundleKind::Transaction,
-        orchard::builder::BundleType::Coinbase => orchard::BundleKind::Coinbase,
-    }
-}
-
 /// The result of a transaction build operation, which includes the resulting transaction along
 /// with metadata describing how spends and outputs were shuffled in creating the transaction's
 /// shielded bundles.
@@ -472,8 +465,8 @@ impl<'a, P: consensus::Parameters> Builder<'a, P, ()> {
                 .orchard_builder_config()
                 .map(|(bundle_type, anchor)| {
                     orchard::builder::Builder::new(
-                        orchard_bundle_kind(bundle_type),
                         orchard::BundleProtocol::OrchardPreNu6_3,
+                        bundle_type,
                         anchor,
                     )
                 })
@@ -758,8 +751,12 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
                     .zip(self.build_config.orchard_builder_config())
                     .map_or(Ok(0), |(builder, (bundle_type, _))| {
                         bundle_type
-                            .num_actions(builder.spends().len(), builder.outputs().len())
-                            .map_err(|e| FeeError::Bundle(e.as_static_str()))
+                            .num_actions(
+                                builder.spends().len(),
+                                builder.outputs().len(),
+                                builder.protocol(),
+                            )
+                            .map_err(FeeError::Bundle)
                     })?,
             )
             .map_err(FeeError::FeeRule)
@@ -804,8 +801,12 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
                     .zip(self.build_config.orchard_builder_config())
                     .map_or(Ok(0), |(builder, (bundle_type, _))| {
                         bundle_type
-                            .num_actions(builder.spends().len(), builder.outputs().len())
-                            .map_err(|e| FeeError::Bundle(e.as_static_str()))
+                            .num_actions(
+                                builder.spends().len(),
+                                builder.outputs().len(),
+                                builder.protocol(),
+                            )
+                            .map_err(FeeError::Bundle)
                     })?,
                 self.tze_builder.inputs(),
                 self.tze_builder.outputs(),

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -282,6 +282,13 @@ impl BuildConfig {
     }
 }
 
+fn orchard_bundle_kind(bundle_type: orchard::builder::BundleType) -> orchard::BundleKind {
+    match bundle_type {
+        orchard::builder::BundleType::Transactional { .. } => orchard::BundleKind::Transaction,
+        orchard::builder::BundleType::Coinbase => orchard::BundleKind::Coinbase,
+    }
+}
+
 /// The result of a transaction build operation, which includes the resulting transaction along
 /// with metadata describing how spends and outputs were shuffled in creating the transaction's
 /// shielded bundles.
@@ -463,7 +470,13 @@ impl<'a, P: consensus::Parameters> Builder<'a, P, ()> {
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
             build_config
                 .orchard_builder_config()
-                .map(|(bundle_type, anchor)| orchard::builder::Builder::new(bundle_type, anchor))
+                .map(|(bundle_type, anchor)| {
+                    orchard::builder::Builder::new(
+                        orchard_bundle_kind(bundle_type),
+                        orchard::BundleProtocol::OrchardPreNu6_3,
+                        anchor,
+                    )
+                })
         } else {
             None
         };
@@ -746,7 +759,7 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
                     .map_or(Ok(0), |(builder, (bundle_type, _))| {
                         bundle_type
                             .num_actions(builder.spends().len(), builder.outputs().len())
-                            .map_err(FeeError::Bundle)
+                            .map_err(|e| FeeError::Bundle(e.as_static_str()))
                     })?,
             )
             .map_err(FeeError::FeeRule)
@@ -792,7 +805,7 @@ impl<P: consensus::Parameters, U> Builder<'_, P, U> {
                     .map_or(Ok(0), |(builder, (bundle_type, _))| {
                         bundle_type
                             .num_actions(builder.spends().len(), builder.outputs().len())
-                            .map_err(FeeError::Bundle)
+                            .map_err(|e| FeeError::Bundle(e.as_static_str()))
                     })?,
                 self.tze_builder.inputs(),
                 self.tze_builder.outputs(),
@@ -1149,14 +1162,14 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'_, 
         let orchard_bundle = unauthed_tx
             .orchard_bundle
             .map(|b| {
-                b.create_proof(&orchard::circuit::ProvingKey::build(), &mut rng)
-                    .and_then(|b| {
-                        b.apply_signatures(
-                            &mut rng,
-                            *shielded_sig_commitment.as_ref(),
-                            orchard_saks,
-                        )
-                    })
+                let circuit_version = b.circuit_version();
+                b.create_proof(
+                    &orchard::circuit::ProvingKey::build(circuit_version),
+                    &mut rng,
+                )
+                .and_then(|b| {
+                    b.apply_signatures(&mut rng, *shielded_sig_commitment.as_ref(), orchard_saks)
+                })
             })
             .transpose()
             .map_err(Error::OrchardBuild)?;

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -9,7 +9,7 @@ use nonempty::NonEmpty;
 
 use orchard::{
     Action, Anchor,
-    bundle::{Authorization, Authorized, Flags, ProofSizeEnforcement},
+    bundle::{Authorization, Authorized, BundleFormat, Flags, ProofSizeEnforcement},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
     value::ValueCommitment,
@@ -173,7 +173,7 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
 pub fn read_flags<R: Read>(mut reader: R) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0])
+    Flags::from_byte(byte[0], BundleFormat::PreNu6_3)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -200,7 +200,16 @@ pub fn write_v5_bundle<W: Write>(
             write_action_without_auth(w, a)
         })?;
 
-        writer.write_all(&[bundle.flags().to_byte()])?;
+        let flags = bundle
+            .flags()
+            .to_byte(BundleFormat::PreNu6_3)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Orchard flags cannot be encoded in the v5 transaction format",
+                )
+            })?;
+        writer.write_all(&[flags])?;
         writer.write_all(&bundle.value_balance().to_i64_le_bytes())?;
         writer.write_all(&bundle.anchor().to_bytes())?;
         Vector::write(

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -365,7 +365,11 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         &self,
         orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::OrchardDigest {
-        orchard_bundle.map(|b| b.commitment().0)
+        orchard_bundle.map(|b| {
+            b.commitment(orchard::BundleFormat::PreNu6_3)
+                .expect("Orchard bundle flags must be representable in the v5 transaction format")
+                .0
+        })
     }
 
     #[cfg(zcash_unstable = "zfuture")]


### PR DESCRIPTION
Updates the Orchard dependency to upstream commit e81bccc6ab0e3235f01f10a75337c6f588e850f9 and adjusts the existing v5 Orchard and PCZT call sites for the new API shape.

Design notes:

- This PR is intentionally limited to updating `zcash_primitives` for the upstream Orchard API.
- Where the new API requires a bundle protocol, the existing behavior is preserved by inferring `PreNU6_3`.
- Where the new API requires `note_version`, the existing behavior is preserved by inferring `v2`.
- Follow up integration work will thread the protocol and note version from the correct sources. This first step keeps the old behavior while making `zcash_primitives` compile against the new Orchard interface.