### PR TITLE
zcash_client_memory: document unsupported status

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ graph TB
   - light client protocol support
   - fee calculation
   - transaction proposals & high-level transaction construction APIs
+* `zcash_client_memory`: An in-memory wallet storage implementation that is
+  currently unsupported, undocumented, and not usable as a wallet backend
 * `zcash_client_sqlite`: SQLite-based implementation of `zcash_client_backend` storage APIs
 
 #### Utilities & Common Dependencies

--- a/zcash_client_memory/src/lib.rs
+++ b/zcash_client_memory/src/lib.rs
@@ -1,3 +1,10 @@
+//! In-memory wallet storage implementation.
+//!
+//! This crate is currently unsupported, undocumented, and not usable as a
+//! wallet storage backend. It is included as a work-in-progress alternative to
+//! `zcash_client_sqlite`, but it is not suitable for production use or security
+//! review unless that review is specifically scoped to this crate.
+
 mod block_source;
 mod error;
 mod input_source;


### PR DESCRIPTION
Documents the current unsupported status of `zcash_client_memory`.

This adds a warning to the crate-level docs and the repository README that
`zcash_client_memory` is currently unsupported, undocumented, and not usable as
a wallet storage backend.

Closes #2355.