### PR TITLE
Add OP_RETURN support to proposal-based tx construction - swaps

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,23 @@ workspace.
 ## [0.24.0] - PLANNED
 
 ### Added
+- `zcash_client_backend::proposal::Step::op_return_data` getter, returning the
+  optional `OP_RETURN` payload attached to the step.
+- `zcash_client_backend::proposal::Step::with_op_return_data`, a builder method
+  to attach `OP_RETURN` data to a step. The data is validated at transaction
+  build time against the 80-byte standard relay limit.
+- `zcash_client_backend::proposal::Proposal::with_op_return_data`, a convenience
+  builder that attaches `OP_RETURN` data to the final step of a proposal.
+- Support for `OP_RETURN` transparent null-data outputs in
+  `zcash_client_backend::data_api::wallet::create_proposed_transactions`,
+  driven by the new `op_return_data` field on `Step`. Enables wallet integrations
+  with cross-chain swap protocols (THORChain, MAYAChain) that require a swap
+  memo embedded in the transaction's null-data output. The underlying primitive
+  `add_transparent_null_data_output` was introduced in #1786 for direct-builder
+  use cases; this change exposes the same capability through the high-level
+  `Proposal`-based API.
+- `op_return_data` field added to the `ProposalStep` protobuf message (optional
+  bytes, field 7), preserving backwards compatibility.
 - `zcash_client_backend::data_api::error::RewindError`
 - `zcash_client_backend::wallet::WalletTransparentOutput`:
   - `recipient_account`

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -40,6 +40,12 @@ message ProposalStep {
     // A flag indicating whether the step is for a shielding transaction,
     // used for determining which OVK to select for wallet-internal outputs.
     bool isShielding = 6;
+    // Optional `OP_RETURN` data to be included as a transparent null-data output in
+    // the constructed transaction (max 80 bytes per Bitcoin/Zcash standard relay rules).
+    // Used for cross-chain swap integrations (e.g., THORChain/MAYAChain) that require
+    // a memo embedded in the transaction's null-data output. When absent, no
+    // `OP_RETURN` output is added.
+    optional bytes opReturnData = 7;
 }
 
 enum ValuePool {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1744,6 +1744,13 @@ where
         }
     }
 
+    // If the proposal step requests an `OP_RETURN` output, append it. Length limits (max 80 bytes)
+    // are enforced by `TransparentBuilder::add_null_data_output`. This is used by cross-chain
+    // swap integrations (e.g., THORChain/MAYAChain) that require a memo embedded as null-data.
+    if let Some(op_return_data) = proposal_step.op_return_data() {
+        builder.add_transparent_null_data_output(op_return_data)?;
+    }
+
     Ok(BuildState {
         #[cfg(feature = "transparent-inputs")]
         step_index,

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -354,6 +354,34 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     pub fn steps(&self) -> &NonEmpty<Step<NoteRef>> {
         &self.steps
     }
+
+    /// Returns a copy of this proposal with the given `OP_RETURN` data attached to its final step.
+    ///
+    /// The final step is the one that produces the externally-visible transaction (in single-step
+    /// proposals this is the only step; in multi-step proposals such as TEX flows, it is the last
+    /// step). This is the appropriate target for swap memos (e.g., THORChain/MAYAChain) and other
+    /// cross-chain integrations where the memo must be embedded as an `OP_RETURN` output of the
+    /// outermost send.
+    ///
+    /// The data is not validated here; length limits are enforced at transaction build time by
+    /// `zcash_transparent::builder::TransparentBuilder::add_null_data_output` (max 80 bytes per
+    /// Bitcoin/Zcash standard relay rules).
+    pub fn with_op_return_data(self, data: Vec<u8>) -> Self {
+        let Self {
+            fee_rule,
+            min_target_height,
+            steps,
+        } = self;
+        // Move the steps into a Vec so we can replace the last entry without cloning the rest.
+        let mut vec: Vec<Step<NoteRef>> = steps.into_iter().collect();
+        let last = vec.pop().expect("NonEmpty guarantees at least one step");
+        vec.push(last.with_op_return_data(data));
+        Self {
+            fee_rule,
+            min_target_height,
+            steps: NonEmpty::from_vec(vec).expect("at least one step preserved"),
+        }
+    }
 }
 
 impl<FeeRuleT: Debug, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
@@ -411,6 +439,13 @@ pub struct Step<NoteRef> {
     prior_step_inputs: Vec<StepOutput>,
     balance: TransactionBalance,
     is_shielding: bool,
+    /// Optional data to be included as an `OP_RETURN` transparent output in the constructed
+    /// transaction. Limited to 80 bytes by Bitcoin/Zcash standard relay rules.
+    ///
+    /// This is intended for cross-chain swap integrations (e.g., THORChain/MAYAChain) that
+    /// require a memo embedded in the transaction's null-data output. When `None`, no
+    /// `OP_RETURN` output is added.
+    op_return_data: Option<Vec<u8>>,
 }
 
 impl<NoteRef> Step<NoteRef> {
@@ -527,6 +562,7 @@ impl<NoteRef> Step<NoteRef> {
                 prior_step_inputs,
                 balance,
                 is_shielding,
+                op_return_data: None,
             })
         } else {
             Err(ProposalError::BalanceError {
@@ -567,6 +603,28 @@ impl<NoteRef> Step<NoteRef> {
     /// recipients).
     pub fn is_shielding(&self) -> bool {
         self.is_shielding
+    }
+
+    /// Returns the `OP_RETURN` payload to include in the transaction, if any.
+    ///
+    /// This is the data that will be encoded into a transparent `OP_RETURN` (null-data) output
+    /// when the transaction is built. Used for cross-chain swap integrations
+    /// (THORChain/MAYAChain memos). Returns `None` if no such output should be added.
+    pub fn op_return_data(&self) -> Option<&[u8]> {
+        self.op_return_data.as_deref()
+    }
+
+    /// Returns a copy of this step with the given `OP_RETURN` data attached.
+    ///
+    /// When the transaction is built from a proposal containing this step, an additional
+    /// transparent `OP_RETURN` output will be appended carrying the supplied data.
+    ///
+    /// The data is not validated here; length limits are enforced at transaction build time
+    /// by `zcash_transparent::builder::TransparentBuilder::add_null_data_output` (max 80 bytes
+    /// per Bitcoin/Zcash standard relay rules).
+    pub fn with_op_return_data(mut self, data: Vec<u8>) -> Self {
+        self.op_return_data = Some(data);
+        self
     }
 
     /// Returns whether or not this proposal requires interaction with the specified pool.

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -689,6 +689,7 @@ impl proposal::Proposal {
                     inputs,
                     balance,
                     is_shielding: step.is_shielding(),
+                    op_return_data: step.op_return_data().map(|d| d.to_vec()),
                 }
             })
             .collect();
@@ -888,7 +889,7 @@ impl proposal::Proposal {
                     )
                     .map_err(|_| ProposalDecodingError::BalanceInvalid)?;
 
-                    let step = Step::from_parts(
+                    let built_step = Step::from_parts(
                         &steps,
                         transaction_request,
                         payment_pools,
@@ -900,7 +901,12 @@ impl proposal::Proposal {
                     )
                     .map_err(ProposalDecodingError::ProposalInvalid)?;
 
-                    steps.push(step);
+                    let built_step = match &step.op_return_data {
+                        Some(data) => built_step.with_op_return_data(data.clone()),
+                        None => built_step,
+                    };
+
+                    steps.push(built_step);
                 }
 
                 Proposal::multi_step(

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -45,6 +45,13 @@ pub struct ProposalStep {
     /// used for determining which OVK to select for wallet-internal outputs.
     #[prost(bool, tag = "6")]
     pub is_shielding: bool,
+    /// Optional `OP_RETURN` data to be included as a transparent null-data output in
+    /// the constructed transaction (max 80 bytes per Bitcoin/Zcash standard relay rules).
+    /// Used for cross-chain swap integrations (e.g., THORChain/MAYAChain) that require
+    /// a memo embedded in the transaction's null-data output. When absent, no
+    /// `OP_RETURN` output is added.
+    #[prost(bytes = "vec", optional, tag = "7")]
+    pub op_return_data: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// A mapping from ZIP 321 payment index to the output pool that has been chosen
 /// for that payment, based upon the payment address and the selected inputs to


### PR DESCRIPTION
zcash_client_backend: Add OP_RETURN support to Proposal-based transaction construction

Follow-up to #1786 (cc @zlyzol). Exposes the OP_RETURN primitive
(`add_transparent_null_data_output`) added for MAYAChain node integration
through the high-level `Proposal` API, enabling wallets to natively initiate
cross-chain swaps (THORChain/MAYAChain) via `create_proposed_transactions`.

Changes are purely additive:
- New `Step::op_return_data` field, getter, and `with_op_return_data` builder.
- New `Proposal::with_op_return_data` convenience method targeting the final step.
- `create_proposed_transactions` appends an OP_RETURN output when present.
- Protobuf: optional `opReturnData` field (field 7) on `ProposalStep`.

No existing API surfaces are changed; `Step::from_parts` signature is unchanged
and existing callers continue to work with `op_return_data: None` by default.
