### PR TITLE
zcash_client_backend: recognize OP_RETURN outputs as data, not unsupported

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -51,6 +51,10 @@ workspace.
     Tokio-based batch decryption engine for full blocks and transactions.
 
 ### Changed
+- During scanning, transparent `OP_RETURN` (nulldata) outputs are now recognized as
+  unspendable data outputs and skipped silently, instead of being logged as
+  unsupported script kinds. Other unrecognized transparent script kinds continue to
+  be logged.
 - `zcash_client_backend::data_api`:
   - Changes to the `InputSource` trait:
     - The result types of `InputSource::get_unspent_transparent_output` and

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -18,6 +18,7 @@ use zcash_protocol::{
     consensus::{self, BlockHeight},
     value::{BalanceError, Zatoshis},
 };
+use zcash_script::solver::ScriptKind;
 
 use crate::{
     TransferType,
@@ -891,12 +892,17 @@ where
                 }
             }
         } else if let Some(script_kind) = script_kind {
-            warn!(
-                "Ignoring unsupported script kind '{}' for tx {} output {}",
-                script_kind.as_str(),
-                tx.txid(),
-                output_index
-            );
+            // `OP_RETURN` (nulldata) outputs are provably-unspendable data carriers with
+            // no recipient address; they are never wallet outputs, so skip them silently
+            // rather than reporting them as unsupported.
+            if !matches!(script_kind, ScriptKind::NullData { .. }) {
+                warn!(
+                    "Ignoring unsupported script kind '{}' for tx {} output {}",
+                    script_kind.as_str(),
+                    tx.txid(),
+                    output_index
+                );
+            }
         } else {
             warn!(
                 "Unable to determine recipient address for tx {} output {}",


### PR DESCRIPTION
`detect_wallet_transparent_outputs` logged a `warn!` for every transparent output whose script kind could not be converted to an address, including `OP_RETURN` (nulldata) outputs. nulldata outputs are provably-unspendable data carriers with no recipient address and are never wallet outputs, so this flagged them as "unsupported script kind" once per output during scanning -- very noisy on chains with frequent OP_RETURN usage.

Recognize `ScriptKind::NullData` explicitly and skip it silently, while still logging other unrecognized script kinds and the un-parseable case.