### PR TITLE
Add spend-index feature for per-outpoint transparent spend queries

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,14 @@ workspace.
 ## [0.24.0] - PLANNED
 
 ### Added
+- A new `spend-index` feature flag, for consumers whose chain-data source can
+  resolve the spend of an individual transparent output (e.g. a full node with a
+  spent-outpoint index). It gates:
+  - `zcash_client_backend::data_api::TransactionDataRequest::GetSpendingTx`,
+    a per-outpoint request to detect the spend of a specific transparent output.
+  - `zcash_client_backend::data_api::WalletWrite::notify_output_verified_unspent`,
+    which records that a transparent outpoint was confirmed unspent as of a given
+    height.
 - `zcash_client_backend::data_api::error::RewindError`
 - `zcash_client_backend::data_api::ll::wallet::PutBlocksError::ShardTreeForBlockRange`,
   a new variant that wraps a `shardtree` insertion error together with the

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -194,6 +194,14 @@ transparent-inputs = [
 # from which it permits spending.
 transparent-key-import = ["transparent-inputs"]
 
+## Enables per-outpoint transparent spend queries, for consumers that have access
+## to a spent-outpoint index (e.g. a full node's spend index). Adds the
+## `TransactionDataRequest::SpendsOfTransparentOutput` request variant and the
+## `WalletWrite::notify_outpoint_unspent_checked` method, and is what a wallet
+## targeting such a data source enables instead of relying on address-based
+## `TransactionsInvolvingAddress` requests for transparent spend detection.
+spend-index = ["transparent-inputs"]
+
 ## Enables receiving and spending Orchard funds.
 orchard = ["dep:orchard", "dep:pasta_curves", "zcash_keys/orchard"]
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1106,10 +1106,14 @@ pub enum TransactionDataRequest {
     /// transparent address is requested.
     ///
     /// Fully transparent transactions, and transactions that do not contain either shielded inputs
-    /// or shielded outputs belonging to the wallet, may not be discovered by the process of chain
-    /// scanning; as a consequence, the wallet must actively query to find transactions that spend
-    /// such funds. Ideally we'd be able to query by [`OutPoint`] but this is not currently
-    /// functionality that is supported by the light wallet server.
+    /// or shielded outputs belonging to the wallet, may not be discovered by the process of
+    /// out-of-order chain scanning due to race conditions related to advancing the transparent
+    /// address gap limit; as a consequence, the wallet must actively query to find transactions
+    /// that spend such funds. Ideally we'd be able to query by [`OutPoint`] but this is not
+    /// currently functionality that is supported by the light wallet server; for full-node wallets
+    /// or other arrangements that allow privacy-preserving retrieval of individually identifying
+    /// information such as backends that support private information retrieval (PIR) consider
+    /// enabling the `spend-index` feature.
     ///
     /// The caller evaluating this request on behalf of the wallet backend should respond to this
     /// request by detecting transactions involving the specified address within the provided block
@@ -1120,6 +1124,29 @@ pub enum TransactionDataRequest {
     /// `block_end_height - 1` as the `as_of_height` argument.
     #[cfg(feature = "transparent-inputs")]
     TransactionsInvolvingAddress(TransactionsInvolvingAddress),
+    /// The main-chain transaction that spends of a specific transparent output, or confirmation
+    /// that the output remains unspent, is requested.
+    ///
+    /// When the `spend-index` feature is enabled, `GetSpendingTx` requests will be emitted by the
+    /// backend instead of [`TransactionDataRequest::TransactionsInvolvingAddress`], in
+    /// circumstances when spentness determination is needed. This feature should only be enabled
+    /// for wallets whose chain-data source can resolve the spend of an individual outpoint
+    /// directly — for example a full node that maintains a spent-outpoint index. It avoids needing
+    /// to retrieve potentially large amounts of transaction history (in the cas of a
+    /// heavily-reused address) just to discover whether one output was spent.
+    ///
+    /// The caller evaluating this request on behalf of the wallet backend should determine whether
+    /// `outpoint` has been spent on the main chain. Spentness should be taken from an
+    /// authoritative source (e.g. the node's UTXO set); the spend index is used only to identify
+    /// the spending transaction. If the output is spent, the caller should provide the spending
+    /// transaction to [`wallet::decrypt_and_store_transaction`]. If the output is confirmed
+    /// unspent as of some height, the caller should invoke
+    /// [`WalletWrite::notify_output_verified_unspent`] with that height. If the output is known to
+    /// be spent but the spending transaction cannot yet be resolved (e.g. an index is still being
+    /// built — see ZcashFoundation/zebra#10806), the caller should do nothing, so that the request
+    /// is re-issued and retried later.
+    #[cfg(feature = "spend-index")]
+    GetSpendingTx(OutPoint),
 }
 
 impl TransactionDataRequest {
@@ -3304,6 +3331,25 @@ pub trait WalletWrite: WalletRead {
     ) -> Result<(), Self::Error> {
         unimplemented!(
             "WalletWrite::notify_address_checked must be overridden for wallets to use the `transparent-inputs` feature"
+        )
+    }
+
+    /// Notifies the wallet backend that a specific transparent output was confirmed unspent as of
+    /// the given height, in response to a [`TransactionDataRequest::GetSpendingTx`]
+    /// request.
+    ///
+    /// # Arguments
+    /// - `outpoint`: the transparent outpoint whose spend status was checked.
+    /// - `as_of_height`: the maximum height among blocks that were inspected, and through which
+    ///   the outpoint is confirmed to remain unspent.
+    #[cfg(feature = "spend-index")]
+    fn notify_output_verified_unspent(
+        &mut self,
+        _outpoint: OutPoint,
+        _as_of_height: BlockHeight,
+    ) -> Result<(), Self::Error> {
+        unimplemented!(
+            "WalletWrite::notify_output_verified_unspent must be overridden for wallets to use the `spend-index` feature"
         )
     }
 }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -25,6 +25,13 @@ workspace.
   `truncate_to_chain_state`). Previously such errors surfaced as the generic
   `CommitmentTree` variant without the affected pool or target height.
 
+### Changed
+- (behind the new `spend-index` feature) `WalletRead::transaction_data_requests`
+  emits `TransactionDataRequest::GetSpendingTx` for transparent spend
+  detection instead of `TransactionDataRequest::TransactionsInvolvingAddress`.
+  `TransactionsInvolvingAddress` is still emitted for ephemeral-address discovery,
+  and for spend detection when `spend-index` is disabled.
+
 ## [0.21.1] - 2026-06-19
 
 ### Fixed

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -139,6 +139,14 @@ transparent-inputs = [
   "zcash_client_backend/transparent-inputs"
 ]
 
+## Emits per-outpoint `TransactionDataRequest::SpendsOfTransparentOutput` requests
+## (instead of address-based `TransactionsInvolvingAddress`) for transparent spend
+## detection, for wallets whose chain-data source has a spent-outpoint index.
+spend-index = [
+  "transparent-inputs",
+  "zcash_client_backend/spend-index",
+]
+
 # Enables operations that permit arbitrary transparent pubkeys to be associated
 # with an account in the wallet. Applications that rely on this feature mut
 # maintain spending keys corresponding to all imported pubkeys for any account

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1399,6 +1399,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
     ) -> Result<(), Self::Error> {
         self.transactionally(|wdb| wdb.notify_address_checked(request, as_of_height))
     }
+
+    #[cfg(feature = "spend-index")]
+    fn notify_output_verified_unspent(
+        &mut self,
+        outpoint: OutPoint,
+        as_of_height: BlockHeight,
+    ) -> Result<(), Self::Error> {
+        self.transactionally(|wdb| wdb.notify_output_verified_unspent(outpoint, as_of_height))
+    }
 }
 
 /// This impl block is only usable when you already have an [`SqlTransaction`], meaning
@@ -1796,6 +1805,19 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
             self.conn.0,
             &self.params,
             request.address(),
+            as_of_height,
+        )
+    }
+
+    #[cfg(feature = "spend-index")]
+    fn notify_output_verified_unspent(
+        &mut self,
+        outpoint: OutPoint,
+        as_of_height: BlockHeight,
+    ) -> Result<(), Self::Error> {
+        wallet::transparent::update_observed_unspent_height_for_outpoint(
+            self.conn.0,
+            &outpoint,
             as_of_height,
         )
     }

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -40,7 +40,9 @@ use zcash_keys::{
         transparent::gap_limits::{GapLimits, generate_address_list},
     },
 };
-use zcash_primitives::transaction::{builder::DEFAULT_TX_EXPIRY_DELTA, fees::zip317};
+#[cfg(not(feature = "spend-index"))]
+use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+use zcash_primitives::transaction::fees::zip317;
 use zcash_protocol::{
     TxId,
     consensus::{self, BlockHeight, COINBASE_MATURITY_BLOCKS},
@@ -1648,6 +1650,47 @@ pub(crate) fn update_observed_unspent_heights<P: consensus::Parameters>(
     Ok(())
 }
 
+/// Sets the max observed unspent height for the unspent transparent output identified by the given
+/// outpoint to at least the given height (will not cause the height to decrease). Used to record
+/// the result of a [`TransactionDataRequest::GetSpendingTx`] check that found the
+/// output unspent.
+///
+/// [`TransactionDataRequest::GetSpendingTx`]: zcash_client_backend::data_api::TransactionDataRequest::GetSpendingTx
+#[cfg(feature = "spend-index")]
+pub(crate) fn update_observed_unspent_height_for_outpoint(
+    conn: &rusqlite::Transaction,
+    outpoint: &OutPoint,
+    checked_at: BlockHeight,
+) -> Result<(), SqliteClientError> {
+    let chain_tip_height = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
+    let checked_at = std::cmp::min(checked_at, chain_tip_height);
+
+    let mut stmt = conn.prepare(
+        "UPDATE transparent_received_outputs AS tro
+         SET max_observed_unspent_height = CASE
+            WHEN max_observed_unspent_height IS NULL THEN :checked_at
+            WHEN max_observed_unspent_height < :checked_at THEN :checked_at
+            ELSE max_observed_unspent_height
+         END
+         FROM transactions t
+         WHERE tro.transaction_id = t.id_tx
+         AND t.txid = :txid
+         AND tro.output_index = :output_index
+         AND tro.id NOT IN (
+             SELECT transparent_received_output_id
+             FROM transparent_received_output_spends
+         )",
+    )?;
+
+    stmt.execute(named_params![
+        ":txid": outpoint.hash(),
+        ":output_index": outpoint.n(),
+        ":checked_at": u32::from(checked_at)
+    ])?;
+
+    Ok(())
+}
+
 /// Adds the given received UTXO to the datastore.
 pub(crate) fn put_received_transparent_utxo<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
@@ -1820,58 +1863,101 @@ pub(crate) fn transaction_data_requests<P: consensus::Parameters>(
         chain_tip_height
     );
 
-    // Create transaction data requests that can find spends of our received UTXOs. Ideally (at
-    // least so long as address-based transaction data requests are required at all) these requests
-    // would not be served by address-based lookups, but instead by querying for the spends of the
-    // associated outpoints directly.
-    let mut spend_requests_stmt = conn.prepare_cached(
-        "SELECT
-            ssq.address,
-            COALESCE(tro.max_observed_unspent_height + 1, t.mined_height) AS block_range_start
-         FROM transparent_spend_search_queue ssq
-         JOIN transactions t ON t.id_tx = ssq.transaction_id
-         JOIN transparent_received_outputs tro ON tro.transaction_id = t.id_tx
-         JOIN addresses ON addresses.id = tro.address_id
-         LEFT OUTER JOIN transparent_received_output_spends tros
-            ON tros.transparent_received_output_id = tro.id
-         WHERE tros.transaction_id IS NULL
-         AND addresses.key_scope != :ephemeral_key_scope
-         AND (
-             tro.max_observed_unspent_height IS NULL
-             OR tro.max_observed_unspent_height < :chain_tip_height
-         )
-         AND (
-             block_range_start IS NOT NULL
-             OR t.expiry_height > :chain_tip_height
-         )",
-    )?;
+    // Create transaction data requests that can find spends of our received UTXOs.
+    //
+    // With the `spend-index` feature, the chain-data source can resolve the spend of an
+    // individual outpoint directly, so we request spends per-outpoint. Otherwise we fall back to
+    // address-based requests (which, so long as address-based transaction data requests are
+    // required at all, are served by address-based lookups rather than by querying the spends of
+    // the associated outpoints directly).
+    #[cfg(feature = "spend-index")]
+    let spend_search_requests = {
+        // Per-outpoint spend resolution is privacy-preserving (it does not correlate the
+        // wallet's addresses to an untrusted server), so unlike the address-based path below
+        // there is no need to exclude ephemeral-address outpoints here.
+        let mut spend_requests_stmt = conn.prepare_cached(
+            "SELECT t.txid, ssq.output_index
+             FROM transparent_spend_search_queue ssq
+             JOIN transactions t ON t.id_tx = ssq.transaction_id
+             JOIN transparent_received_outputs tro
+                ON tro.transaction_id = ssq.transaction_id AND tro.output_index = ssq.output_index
+             LEFT OUTER JOIN transparent_received_output_spends tros
+                ON tros.transparent_received_output_id = tro.id
+             WHERE tros.transaction_id IS NULL
+             AND (
+                 tro.max_observed_unspent_height IS NULL
+                 OR tro.max_observed_unspent_height < :chain_tip_height
+             )",
+        )?;
 
-    let spend_search_rows = spend_requests_stmt.query_and_then(
-        named_params! {
-            ":ephemeral_key_scope": KeyScope::Ephemeral.encode(),
-            ":chain_tip_height": u32::from(chain_tip_height)
-        },
-        |row| {
-            let address = TransparentAddress::decode(params, &row.get::<_, String>(0)?)?;
-            // If the transaction that creates this UTXO is unmined, then this must be a mempool
-            // transaction so we default to the chain tip for block_range_start
-            let block_range_start = row
-                .get::<_, Option<u32>>(1)?
-                .map(BlockHeight::from)
-                .unwrap_or(chain_tip_height);
-            let max_end_height = block_range_start + DEFAULT_TX_EXPIRY_DELTA + 1;
-            Ok::<TransactionDataRequest, SqliteClientError>(
-                TransactionDataRequest::transactions_involving_address(
-                    address,
-                    block_range_start,
-                    Some(std::cmp::min(chain_tip_height + 1, max_end_height)),
-                    None,
-                    TransactionStatusFilter::Mined,
-                    OutputStatusFilter::All,
-                ),
-            )
-        },
-    )?;
+        spend_requests_stmt
+            .query_and_then(
+                named_params! {
+                    ":chain_tip_height": u32::from(chain_tip_height)
+                },
+                |row| {
+                    let outpoint = OutPoint::new(row.get::<_, [u8; 32]>(0)?, row.get::<_, u32>(1)?);
+                    Ok::<TransactionDataRequest, SqliteClientError>(
+                        TransactionDataRequest::GetSpendingTx(outpoint),
+                    )
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    #[cfg(not(feature = "spend-index"))]
+    let spend_search_requests = {
+        let mut spend_requests_stmt = conn.prepare_cached(
+            "SELECT
+                ssq.address,
+                COALESCE(tro.max_observed_unspent_height + 1, t.mined_height) AS block_range_start
+             FROM transparent_spend_search_queue ssq
+             JOIN transactions t ON t.id_tx = ssq.transaction_id
+             JOIN transparent_received_outputs tro ON tro.transaction_id = t.id_tx
+             JOIN addresses ON addresses.id = tro.address_id
+             LEFT OUTER JOIN transparent_received_output_spends tros
+                ON tros.transparent_received_output_id = tro.id
+             WHERE tros.transaction_id IS NULL
+             AND addresses.key_scope != :ephemeral_key_scope
+             AND (
+                 tro.max_observed_unspent_height IS NULL
+                 OR tro.max_observed_unspent_height < :chain_tip_height
+             )
+             AND (
+                 block_range_start IS NOT NULL
+                 OR t.expiry_height > :chain_tip_height
+             )",
+        )?;
+
+        spend_requests_stmt
+            .query_and_then(
+                named_params! {
+                    ":ephemeral_key_scope": KeyScope::Ephemeral.encode(),
+                    ":chain_tip_height": u32::from(chain_tip_height)
+                },
+                |row| {
+                    let address = TransparentAddress::decode(params, &row.get::<_, String>(0)?)?;
+                    // If the transaction that creates this UTXO is unmined, then this must be a
+                    // mempool transaction so we default to the chain tip for block_range_start
+                    let block_range_start = row
+                        .get::<_, Option<u32>>(1)?
+                        .map(BlockHeight::from)
+                        .unwrap_or(chain_tip_height);
+                    let max_end_height = block_range_start + DEFAULT_TX_EXPIRY_DELTA + 1;
+                    Ok::<TransactionDataRequest, SqliteClientError>(
+                        TransactionDataRequest::transactions_involving_address(
+                            address,
+                            block_range_start,
+                            Some(std::cmp::min(chain_tip_height + 1, max_end_height)),
+                            None,
+                            TransactionStatusFilter::Mined,
+                            OutputStatusFilter::All,
+                        ),
+                    )
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
     // Query for transactions that "return" funds to an ephemeral address. By including a block
     // range start equal to the mined height of the transaction, we make it harder to distinguish
@@ -1930,9 +2016,11 @@ pub(crate) fn transaction_data_requests<P: consensus::Parameters>(
         },
     )?;
 
-    spend_search_rows
-        .chain(ephemeral_check_rows)
-        .collect::<Result<Vec<_>, _>>()
+    let mut requests = spend_search_requests;
+    for request in ephemeral_check_rows {
+        requests.push(request?);
+    }
+    Ok(requests)
 }
 
 pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
@@ -2426,6 +2514,39 @@ mod tests {
             BlockCache::new(),
             GapLimits::default(),
         );
+    }
+
+    /// Smoke test that the `spend-index` feature's SQL is valid: `transaction_data_requests`
+    /// runs its per-outpoint spend-search query, and `update_observed_unspent_height_for_outpoint`
+    /// runs its `UPDATE ... FROM`. Exercised on a minimal wallet so the queries execute (failing
+    /// the test on any SQL error) without needing a populated spend-search queue.
+    #[test]
+    #[cfg(feature = "spend-index")]
+    fn spend_index_queries_are_valid_sql() {
+        use transparent::bundle::OutPoint;
+        use zcash_client_backend::data_api::WalletRead;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let chain_tip = st.test_account().unwrap().birthday().height() + 100;
+        st.wallet_mut().update_chain_tip(chain_tip).unwrap();
+
+        // Exercises the `spend-index` SELECT in `transaction_data_requests`.
+        st.wallet().transaction_data_requests().unwrap();
+
+        // Exercises the `spend-index` `UPDATE ... FROM` in
+        // `update_observed_unspent_height_for_outpoint` (the outpoint matches no rows).
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        super::update_observed_unspent_height_for_outpoint(
+            &tx,
+            &OutPoint::new([1u8; 32], 0),
+            chain_tip,
+        )
+        .unwrap();
+        tx.commit().unwrap();
     }
 
     #[test]

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `transparent::bundle::OutPoint` now implements `std::hash::Hash`.
+
 ## [0.8.0] - 2026-06-02
 
 ### Changed

--- a/zcash_transparent/src/bundle.rs
+++ b/zcash_transparent/src/bundle.rs
@@ -148,7 +148,7 @@ impl<A: Authorization> Bundle<A> {
 }
 
 /// A pointer to a transparent Zcash transaction output.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OutPoint {
     /// The txid of the transaction containing the output being pointed to.
     pub(crate) hash: TxId,


### PR DESCRIPTION
Adds a `spend-index` cargo feature (in zcash_client_backend and zcash_client_sqlite) for wallets whose chain-data source can resolve the spend of an individual transparent outpoint directly (e.g. a full node with a spent-outpoint index), as an alternative to address-based `TransactionsInvolvingAddress` requests.

- zcash_client_backend: gated `TransactionDataRequest::SpendsOfTransparentOutput(OutPoint)` request variant and `WalletWrite::notify_outpoint_unspent_checked`. The servicing contract documents that spentness should be taken from an authoritative source and the spend index used only to resolve the spender, with "spent but spender not yet resolvable" treated as retryable (see ZcashFoundation/zebra#10806).
- zcash_client_sqlite: when `spend-index` is enabled, `transaction_data_requests` emits the per-outpoint variant for spend detection instead of `TransactionsInvolvingAddress` (retained for ephemeral-address discovery and when the feature is disabled); implements `notify_outpoint_unspent_checked` by advancing the per-outpoint `max_observed_unspent_height` watermark.
- zcash_transparent: derive `Hash` for `OutPoint` (required for the `TransactionDataRequest` `Hash` derive; also a natural map/set key).

A unit test for the new emission/notify path is left as a TODO (noted in transparent.rs): populating the spend-search queue requires the low-level/block-scan store path.