### PR TITLE
Bump orchard to 30c4ea2 (feat/ironwood)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.14.0"
-source = "git+https://github.com/zcash/orchard?rev=b2af0a11abe00f59c51258d349c2105fe7a16215#b2af0a11abe00f59c51258d349c2105fe7a16215"
+source = "git+https://github.com/zcash/orchard?rev=30c4ea2788375c542bfaa4704a3a772308729321#30c4ea2788375c542bfaa4704a3a772308729321"
 dependencies = [
  "aes",
  "bitvec",
@@ -4032,7 +4032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ zip32 = { version = "0.2", default-features = false }
 time-core = "=0.1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "30c4ea2788375c542bfaa4704a3a772308729321" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -28,8 +28,9 @@ pub(crate) enum NoteVersion {
 /// using an Orchard-equivalent flag format.
 ///
 /// PCZT v1 serializes Orchard flags with bits 2..=7 reserved and only supports
-/// V2 Orchard note plaintexts. The selected `BundlePoolRestrictions` value names
-/// that flag format; it is not an NU6.2 network-height assumption.
+/// Orchard note plaintexts (which always use lead byte 0x02). The selected
+/// `BundlePoolRestrictions` value names that flag format; it is not an NU6.2
+/// network-height assumption.
 #[cfg(feature = "orchard")]
 pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: BundlePoolRestrictions =
     BundlePoolRestrictions::OrchardNu6_2Only;

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -9,7 +9,7 @@ use core::cmp::Ordering;
 use ff::PrimeField;
 use getset::Getters;
 #[cfg(feature = "orchard")]
-use orchard::bundle::BundleFormat;
+use orchard::bundle::BundlePoolRestrictions;
 #[cfg(feature = "orchard")]
 pub(crate) use orchard::note::NoteVersion;
 
@@ -635,7 +635,6 @@ impl Bundle {
                     action.spend.value,
                     action.spend.rho,
                     action.spend.rseed,
-                    note_version,
                     action.spend.fvk,
                     action.spend.witness,
                     action.spend.alpha,
@@ -650,6 +649,7 @@ impl Bundle {
                         })
                         .transpose()?,
                     action.spend.dummy_sk,
+                    note_version,
                     action.spend.proprietary,
                 )?;
 
@@ -662,7 +662,6 @@ impl Bundle {
                     action.output.recipient,
                     action.output.value,
                     action.output.rseed,
-                    note_version,
                     action.output.ock,
                     action
                         .output
@@ -675,6 +674,7 @@ impl Bundle {
                         })
                         .transpose()?,
                     action.output.user_address,
+                    note_version,
                     action.output.proprietary,
                 )?;
 
@@ -685,7 +685,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            BundleFormat::PreNu6_3,
+            BundlePoolRestrictions::OrchardNu6_2Only,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -798,7 +798,7 @@ impl Bundle {
             actions,
             flags: bundle
                 .flags()
-                .to_byte(BundleFormat::PreNu6_3)
+                .to_byte(BundlePoolRestrictions::OrchardNu6_2Only)
                 .expect("Orchard flags must be representable in the v5 transaction format"),
             value_sum,
             anchor: bundle.anchor().to_bytes(),

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -24,6 +24,16 @@ pub(crate) enum NoteVersion {
     V2,
 }
 
+/// Orchard pool restriction for PCZT operations whose result only depends on
+/// using an Orchard-equivalent flag format.
+///
+/// PCZT v1 serializes Orchard flags with bits 2..=7 reserved and only supports
+/// V2 Orchard note plaintexts. The selected `BundlePoolRestrictions` value names
+/// that flag format; it is not an NU6.2 network-height assumption.
+#[cfg(feature = "orchard")]
+pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: BundlePoolRestrictions =
+    BundlePoolRestrictions::OrchardNu6_2Only;
+
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
 #[derive(Clone, Debug, Getters)]
 pub struct Bundle {
@@ -685,7 +695,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            BundlePoolRestrictions::OrchardNu6_2Only,
+            ANY_ORCHARD_POOL_RESTRICTIONS,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -798,7 +808,7 @@ impl Bundle {
             actions,
             flags: bundle
                 .flags()
-                .to_byte(BundlePoolRestrictions::OrchardNu6_2Only)
+                .to_byte(ANY_ORCHARD_POOL_RESTRICTIONS)
                 .expect("Orchard flags must be representable in the v5 transaction format"),
             value_sum,
             anchor: bundle.anchor().to_bytes(),

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -63,7 +63,7 @@ impl Creator {
     #[cfg(feature = "orchard")]
     pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
         self.orchard_flags = orchard_flags
-            .to_byte(orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only)
+            .to_byte(crate::orchard::ANY_ORCHARD_POOL_RESTRICTIONS)
             .expect("Orchard flags must be representable in the v5 transaction format");
         self
     }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -63,7 +63,7 @@ impl Creator {
     #[cfg(feature = "orchard")]
     pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
         self.orchard_flags = orchard_flags
-            .to_byte(orchard::bundle::BundleFormat::PreNu6_3)
+            .to_byte(orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only)
             .expect("Orchard flags must be representable in the v5 transaction format");
         self
     }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -589,7 +589,7 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::BundleProtocol::OrchardPreNu6_3,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2291,8 +2291,17 @@ fn compact_orchard_action<R: RngCore + CryptoRng>(
         CompactOrchardAction {
             nullifier: compact_action.nullifier().to_bytes().to_vec(),
             cmx: compact_action.cmx().to_bytes().to_vec(),
-            ephemeral_key: compact_action.ephemeral_key().0.to_vec(),
-            ciphertext: compact_action.enc_ciphertext()[..52].to_vec(),
+            ephemeral_key:
+                ShieldedOutput::<::orchard::note_encryption::OrchardDomain, 52>::ephemeral_key(
+                    &compact_action,
+                )
+                .0
+                .to_vec(),
+            ciphertext:
+                ShieldedOutput::<::orchard::note_encryption::OrchardDomain, 52>::enc_ciphertext(
+                    &compact_action,
+                )[..52]
+                    .to_vec(),
         },
         note,
     )

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1869,7 +1869,11 @@ where
                     .orchard_bundle()
                     .and_then(|bundle| {
                         bundle
-                            .decrypt_output_with_key(output_index, &orchard_internal_ivk)
+                            .decrypt_output_with_key(
+                                ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+                                output_index,
+                                &orchard_internal_ivk,
+                            )
                             .map(|(note, _, _)| Note::Orchard(note))
                     })
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK")

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1868,6 +1868,8 @@ where
                     .transaction()
                     .orchard_bundle()
                     .and_then(|bundle| {
+                        // This is an Orchard bundle, so every Orchard pool
+                        // restriction selects the same V2 note plaintext domain.
                         bundle
                             .decrypt_output_with_key(
                                 crate::ANY_ORCHARD_POOL_RESTRICTIONS,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1870,7 +1870,7 @@ where
                     .and_then(|bundle| {
                         bundle
                             .decrypt_output_with_key(
-                                ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+                                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                                 output_index,
                                 &orchard_internal_ivk,
                             )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -711,7 +711,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 #[cfg(feature = "orchard")]
                 &(
                     // Preserve the legacy Orchard action-count estimate here.
-                    // If this path targets restrictions that disable
+                    // FIXME: When this path targets restrictions that disable
                     // cross-address transfers, thread the target-height-selected
                     // `BundlePoolRestrictions` through this call.
                     crate::ANY_ORCHARD_POOL_RESTRICTIONS,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,6 +710,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
+                    // Preserve the legacy Orchard action-count estimate here.
+                    // If this path targets restrictions that disable
+                    // cross-address transfers, thread the target-height-selected
+                    // `BundlePoolRestrictions` through this call.
                     crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
@@ -870,6 +874,10 @@ where
             0
         };
         orchard_fees::transactional_action_count(
+            // Preserve the legacy Orchard action-count estimate here. If this
+            // path targets restrictions that disable cross-address transfers,
+            // thread the target-height-selected `BundlePoolRestrictions`
+            // through this call.
             crate::ANY_ORCHARD_POOL_RESTRICTIONS,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
@@ -1267,6 +1275,9 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
+                    // With no Orchard spends and one requested output, the
+                    // padded action count is independent of the Orchard pool
+                    // restriction.
                     crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     0,
                     1,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -874,10 +874,10 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            // Preserve the legacy Orchard action-count estimate here. If this
-            // path targets restrictions that disable cross-address transfers,
-            // thread the target-height-selected `BundlePoolRestrictions`
-            // through this call.
+            // Preserve the legacy Orchard action-count estimate here.
+            // FIXME: When this path needs to respect restrictions that disable
+            // cross-address transfers, thread the target-height-selected
+            // `BundlePoolRestrictions` through this call.
             crate::ANY_ORCHARD_POOL_RESTRICTIONS,
             spendable_notes.orchard.len(),
             requested_orchard_actions,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,7 +710,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
-                    ::orchard::BundleProtocol::OrchardPreNu6_3,
+                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -870,7 +870,7 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            ::orchard::BundleProtocol::OrchardPreNu6_3,
+            ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1267,7 +1267,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    ::orchard::BundleProtocol::OrchardPreNu6_3,
+                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                     0,
                     1,
                 )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,7 +710,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
-                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -870,7 +870,7 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+            crate::ANY_ORCHARD_POOL_RESTRICTIONS,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1267,7 +1267,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     0,
                     1,
                 )

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -313,7 +313,7 @@ where
     #[cfg(feature = "orchard")]
     let orchard_action_count = |change_count| {
         orchard_fees::transactional_action_count(
-            orchard.bundle_protocol(),
+            orchard.bundle_pool_restrictions(),
             orchard.inputs().len(),
             orchard.outputs().len() + change_count,
         )
@@ -692,7 +692,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
 
             #[cfg(feature = "orchard")]
             let o_action_count = orchard_fees::transactional_action_count(
-                orchard.bundle_protocol(),
+                orchard.bundle_pool_restrictions(),
                 o_req_inputs + _o_extra,
                 o_outputs_len + change.orchard,
             )

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -3,15 +3,15 @@
 
 use std::convert::Infallible;
 
-use orchard::{BundleProtocol, builder::BundleType};
+use orchard::{builder::BundleType, bundle::BundlePoolRestrictions};
 use zcash_protocol::value::Zatoshis;
 
 pub(crate) fn transactional_action_count(
-    protocol: BundleProtocol,
+    pool_restrictions: BundlePoolRestrictions,
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    BundleType::DEFAULT.num_actions(num_spends, num_outputs, protocol)
+    BundleType::DEFAULT.num_actions(num_spends, num_outputs, pool_restrictions)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration
@@ -22,8 +22,8 @@ pub trait BundleView<NoteRef> {
     /// The type of inputs of the bundle.
     type Out: OutputView;
 
-    /// Returns the protocol rules for the bundle.
-    fn bundle_protocol(&self) -> BundleProtocol;
+    /// Returns the pool restrictions for the bundle.
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions;
     /// Returns the inputs to the bundle.
     fn inputs(&self) -> &[Self::In];
     /// Returns the outputs of the bundle.
@@ -31,12 +31,12 @@ pub trait BundleView<NoteRef> {
 }
 
 impl<'a, NoteRef, In: InputView<NoteRef>, Out: OutputView> BundleView<NoteRef>
-    for (BundleProtocol, &'a [In], &'a [Out])
+    for (BundlePoolRestrictions, &'a [In], &'a [Out])
 {
     type In = In;
     type Out = Out;
 
-    fn bundle_protocol(&self) -> BundleProtocol {
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
         self.0
     }
 
@@ -56,8 +56,8 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type In = Infallible;
     type Out = Infallible;
 
-    fn bundle_protocol(&self) -> BundleProtocol {
-        BundleProtocol::OrchardPreNu6_3
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
+        BundlePoolRestrictions::OrchardNu6_2Only
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -57,7 +57,7 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type Out = Infallible;
 
     fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
-        BundlePoolRestrictions::OrchardNu6_2Only
+        crate::ANY_ORCHARD_POOL_RESTRICTIONS
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                orchard::BundleProtocol::OrchardPreNu6_3,
+                orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,11 +82,13 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
-/// Orchard pool restriction for operations whose result is invariant to it:
-/// note decryption and fee/action-count estimation. Every Orchard pool
-/// restriction yields the same result for these, so this names the otherwise
-/// arbitrary value rather than scattering `BundlePoolRestrictions` literals that
-/// read as load-bearing.
+/// Orchard pool restriction for call sites that should not select a concrete
+/// Orchard or Ironwood branch-specific policy.
+///
+/// For note decryption, every Orchard pool restriction selects the same V2 note
+/// plaintext domain. For the fee call sites that use this constant, the chosen
+/// value preserves the legacy Orchard action-count policy those paths used before
+/// `BundlePoolRestrictions` replaced `BundleProtocol`.
 #[cfg(feature = "orchard")]
 pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: ::orchard::bundle::BundlePoolRestrictions =
     ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only;

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,6 +82,15 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
+/// Orchard pool restriction for operations whose result is invariant to it:
+/// note decryption and fee/action-count estimation. Every Orchard pool
+/// restriction yields the same result for these, so this names the otherwise
+/// arbitrary value rather than scattering `BundlePoolRestrictions` literals that
+/// read as load-bearing.
+#[cfg(feature = "orchard")]
+pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: ::orchard::bundle::BundlePoolRestrictions =
+    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only;
+
 #[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
 pub mod address {
     pub use zcash_keys::address::*;

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -26,13 +26,19 @@ workspace.
 
 ### Changed
 - `zcash_primitives::transaction::builder`:
-  - NU6.3 standard builders use the NU6.3 Orchard bundle protocol when
+  - NU6.3 standard builders use the NU6.3 Orchard pool restrictions when
     constructing V6 transactions.
   - NU6.3 coinbase builders no longer expose Orchard outputs.
 - `TransactionDigest::digest_orchard` now receives `TxVersion`, so digest
   implementations can distinguish Orchard commitments by transaction format.
 - `TransactionDigest::digest_sapling` now receives `TxVersion`, so digest
   implementations can distinguish Sapling commitments by transaction format.
+- Updated the `orchard` dependency to the `feat/ironwood` revision `30c4ea2`,
+  which restricts cross-address transfers to the Ironwood pool (an Orchard v6
+  bundle can no longer set the cross-address flag) and renames the pool selector
+  to `BundlePoolRestrictions`. The v6 bundle (de)serialization helpers
+  `zcash_primitives::transaction::components::orchard::{read_v6_bundle,
+  write_v6_bundle, read_flags}` now take a `BundlePoolRestrictions` argument.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -247,19 +247,26 @@ impl BuildConfig {
     /// Returns the Orchard builder for this configuration.
     fn orchard_builder(
         &self,
-        protocol: orchard::BundleProtocol,
+        pool_restrictions: orchard::bundle::BundlePoolRestrictions,
     ) -> Option<orchard::builder::Builder> {
         match self {
             BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
-                orchard::builder::Builder::new(protocol, orchard::builder::BundleType::DEFAULT, *a)
+                orchard::builder::Builder::new(
+                    pool_restrictions,
+                    orchard::builder::BundleType::DEFAULT,
+                    *a,
+                )
             }),
             BuildConfig::Coinbase { .. }
-                if matches!(protocol, orchard::BundleProtocol::OrchardPostNu6_3) =>
+                if matches!(
+                    pool_restrictions,
+                    orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward
+                ) =>
             {
                 None
             }
             BuildConfig::Coinbase { .. } => Some(orchard::builder::Builder::new(
-                protocol,
+                pool_restrictions,
                 orchard::builder::BundleType::Coinbase,
                 orchard::Anchor::empty_tree(),
             )),
@@ -275,6 +282,7 @@ impl BuildConfig {
 fn orchard_action_count(
     builder: &orchard::builder::Builder,
     is_coinbase: bool,
+    pool_restrictions: orchard::bundle::BundlePoolRestrictions,
 ) -> Result<usize, &'static str> {
     let num_spends = builder.spends().len();
     let num_outputs = builder
@@ -289,17 +297,19 @@ fn orchard_action_count(
         orchard::builder::BundleType::DEFAULT
     };
 
-    bundle_type.num_actions(num_spends, num_outputs, builder.protocol())
+    bundle_type.num_actions(num_spends, num_outputs, pool_restrictions)
 }
 
-fn orchard_protocol_for_branch(consensus_branch_id: BranchId) -> orchard::BundleProtocol {
+fn orchard_pool_restrictions_for_branch(
+    consensus_branch_id: BranchId,
+) -> orchard::bundle::BundlePoolRestrictions {
     match consensus_branch_id {
         #[cfg(zcash_unstable = "nu6.3")]
-        BranchId::Nu6_3 => orchard::BundleProtocol::OrchardPostNu6_3,
+        BranchId::Nu6_3 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
         #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => orchard::BundleProtocol::OrchardPostNu6_3,
-        BranchId::Nu6_2 => orchard::BundleProtocol::OrchardPreNu6_3,
-        _ => orchard::BundleProtocol::OrchardPreNu6_2,
+        BranchId::Nu7 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        BranchId::Nu6_2 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+        _ => orchard::bundle::BundlePoolRestrictions::OrchardPreNu6_2,
     }
 }
 
@@ -369,6 +379,7 @@ pub struct Builder<P, U> {
     transparent_builder: TransparentBuilder,
     sapling_builder: Option<sapling::builder::Builder>,
     orchard_builder: Option<orchard::builder::Builder>,
+    orchard_pool_restrictions: Option<orchard::bundle::BundlePoolRestrictions>,
     _progress_notifier: U,
 }
 
@@ -475,13 +486,14 @@ impl<P: consensus::Parameters> Builder<P, ()> {
     /// expiry delta (20 blocks).
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
-        let orchard_protocol = orchard_protocol_for_branch(consensus_branch_id);
+        let pool_restrictions = orchard_pool_restrictions_for_branch(consensus_branch_id);
 
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
-            build_config.orchard_builder(orchard_protocol)
+            build_config.orchard_builder(pool_restrictions)
         } else {
             None
         };
+        let orchard_pool_restrictions = orchard_builder.as_ref().map(|_| pool_restrictions);
 
         let sapling_builder = build_config
             .sapling_builder_config()
@@ -523,6 +535,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder,
             orchard_builder,
+            orchard_pool_restrictions,
             _progress_notifier: (),
         }
     }
@@ -550,6 +563,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: self.transparent_builder,
             sapling_builder: self.sapling_builder,
             orchard_builder: self.orchard_builder,
+            orchard_pool_restrictions: self.orchard_pool_restrictions,
             _progress_notifier,
         }
     }
@@ -741,7 +755,12 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                 self.orchard_builder
                     .as_ref()
                     .map_or(Ok(0), |builder| {
-                        orchard_action_count(builder, self.build_config.is_coinbase())
+                        orchard_action_count(
+                            builder,
+                            self.build_config.is_coinbase(),
+                            self.orchard_pool_restrictions
+                                .expect("orchard builder present implies pool restrictions"),
+                        )
                     })
                     .map_err(FeeError::Bundle)?,
             )
@@ -1250,8 +1269,8 @@ mod tests {
 
         assert_eq!(builder.tx_version, crate::transaction::TxVersion::V6);
         assert_eq!(
-            builder.orchard_builder.as_ref().map(|b| b.protocol()),
-            Some(orchard::BundleProtocol::OrchardPostNu6_3)
+            builder.orchard_pool_restrictions,
+            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
         );
     }
 
@@ -1272,8 +1291,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            builder.orchard_builder.as_ref().map(|b| b.protocol()),
-            Some(orchard::BundleProtocol::OrchardPostNu6_3)
+            builder.orchard_pool_restrictions,
+            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
         );
     }
 
@@ -1312,7 +1331,7 @@ mod tests {
         );
         let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
         let mut builder = orchard::builder::Builder::new(
-            orchard::BundleProtocol::OrchardPostNu6_3,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );
@@ -1327,7 +1346,15 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(super::orchard_action_count(&builder, false).unwrap(), 2);
+        assert_eq!(
+            super::orchard_action_count(
+                &builder,
+                false,
+                orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+            )
+            .unwrap(),
+            2
+        );
     }
 
     // This test only works with the transparent_inputs feature because we have to
@@ -1360,6 +1387,7 @@ mod tests {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder: None,
             orchard_builder: None,
+            orchard_pool_restrictions: None,
             _progress_notifier: (),
         };
 

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -9,7 +9,7 @@ use nonempty::NonEmpty;
 
 use orchard::{
     Action, Anchor,
-    bundle::{Authorization, Authorized, BundleFormat, Flags, ProofSizeEnforcement},
+    bundle::{Authorization, Authorized, BundlePoolRestrictions, Flags, ProofSizeEnforcement},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
     value::ValueCommitment,
@@ -50,14 +50,14 @@ impl MapAuth<Authorized, Authorized> for () {
 fn read_bundle<R: Read>(
     mut reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
-    bundle_format: BundleFormat,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
-        let flags = read_flags(&mut reader, bundle_format)?;
+        let flags = read_flags(&mut reader, pool_restrictions)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
         let proof_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
@@ -99,20 +99,47 @@ fn read_bundle<R: Read>(
 /// height; only the bundle commitment domain varies across upgrades, and that
 /// affects the txid/sighash digests rather than deserialization. Since this is
 /// public API, keeping the signature unchanged also avoids an unnecessary
-/// breaking change. (By contrast, `read_v6_bundle` is reused across the
-/// Ironwood and Orchard v6 bundles, so its format is selected by the caller.)
+/// breaking change. (By contrast, `read_v6_bundle` takes a `pool_restrictions`
+/// argument so the caller selects the Orchard or Ironwood v6 pool.)
 pub fn read_v5_bundle<R: Read>(
     reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, proof_size_enforcement, BundleFormat::PreNu6_3)
+    read_bundle(
+        reader,
+        proof_size_enforcement,
+        BundlePoolRestrictions::OrchardNu6_2Only,
+    )
 }
 
+/// Rejects pool restrictions that are not valid for the v6 transaction format,
+/// which has exactly two Orchard-bundle slots: the Orchard slot
+/// (`OrchardNu6_3Onward`) and the Ironwood slot (`IronwoodNu6_3Onward`). A pre-v6
+/// restriction would (de)serialize the flag byte with the wrong cross-address
+/// (bit 2) semantics.
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+fn check_v6_pool_restrictions(pool_restrictions: BundlePoolRestrictions) -> io::Result<()> {
+    match pool_restrictions {
+        BundlePoolRestrictions::OrchardNu6_3Onward
+        | BundlePoolRestrictions::IronwoodNu6_3Onward => Ok(()),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "v6 Orchard bundles require OrchardNu6_3Onward or IronwoodNu6_3Onward",
+        )),
+    }
+}
+
+/// Reads an [`orchard::Bundle`] from a v6 transaction format. `pool_restrictions`
+/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
+/// `IronwoodNu6_3Onward` for the Ironwood bundle (whose flag-byte encoding permits
+/// the cross-address bit, unlike the Orchard v6 pool).
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn read_v6_bundle<R: Read>(
     reader: R,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, ProofSizeEnforcement::Strict, BundleFormat::Nu6_3)
+    check_v6_pool_restrictions(pool_restrictions)?;
+    read_bundle(reader, ProofSizeEnforcement::Strict, pool_restrictions)
 }
 
 pub fn read_value_commitment<R: Read>(mut reader: R) -> io::Result<ValueCommitment> {
@@ -188,10 +215,13 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
-pub fn read_flags<R: Read>(mut reader: R, bundle_format: BundleFormat) -> io::Result<Flags> {
+pub fn read_flags<R: Read>(
+    mut reader: R,
+    pool_restrictions: BundlePoolRestrictions,
+) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0], bundle_format)
+    Flags::from_byte(byte[0], pool_restrictions)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -211,14 +241,14 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 fn write_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     mut writer: W,
-    bundle_format: BundleFormat,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
         Vector::write_nonempty(&mut writer, bundle.actions(), |w, a| {
             write_action_without_auth(w, a)
         })?;
 
-        let flags = bundle.flags().to_byte(bundle_format).ok_or_else(|| {
+        let flags = bundle.flags().to_byte(pool_restrictions).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Orchard flags cannot be encoded in this transaction format",
@@ -252,15 +282,20 @@ pub fn write_v5_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundleFormat::PreNu6_3)
+    write_bundle(bundle, writer, BundlePoolRestrictions::OrchardNu6_2Only)
 }
 
+/// Writes an [`orchard::Bundle`] in the v6 transaction format. `pool_restrictions`
+/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
+/// `IronwoodNu6_3Onward` for the Ironwood bundle.
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn write_v6_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundleFormat::Nu6_3)
+    check_v6_pool_restrictions(pool_restrictions)?;
+    write_bundle(bundle, writer, pool_restrictions)
 }
 
 pub fn write_value_commitment<W: Write>(mut writer: W, cv: &ValueCommitment) -> io::Result<()> {
@@ -330,9 +365,77 @@ pub mod testing {
         v: TxVersion,
     ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
         if v.has_orchard() {
-            Strategy::boxed((1usize..100).prop_flat_map(|n| prop::option::of(arb_bundle(n))))
+            // In a v6 transaction the Orchard pool is encoded as
+            // `OrchardNu6_3Onward`, which forbids cross-address transfers, so a
+            // valid Orchard bundle must have the cross-address flag disabled.
+            // (The Ironwood slot uses `arb_ironwood_bundle_for_version`, whose
+            // `IronwoodNu6_3Onward` pool permits cross-address transfers.)
+            let force_cross_address_disabled = orchard_pool_forbids_cross_address(v);
+            (1usize..100)
+                .prop_flat_map(move |n| {
+                    prop::option::of(arb_bundle(n).prop_map(move |bundle| {
+                        if force_cross_address_disabled && bundle.flags().cross_address_enabled() {
+                            with_cross_address_disabled(bundle)
+                        } else {
+                            bundle
+                        }
+                    }))
+                })
+                .boxed()
         } else {
-            Strategy::boxed(Just(None))
+            Just(None).boxed()
         }
+    }
+
+    /// Generates Ironwood bundles for the v6 transaction format. Unlike the
+    /// Orchard v6 pool, the Ironwood pool (`IronwoodNu6_3Onward`) permits
+    /// cross-address transfers, so the cross-address flag is left as generated;
+    /// this exercises the Ironwood serialization path the Orchard generator
+    /// cannot.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn arb_ironwood_bundle_for_version(
+        v: TxVersion,
+    ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
+        if v.has_ironwood() {
+            (1usize..100)
+                .prop_flat_map(|n| prop::option::of(arb_bundle(n)))
+                .boxed()
+        } else {
+            Just(None).boxed()
+        }
+    }
+
+    /// Mirrors `txid::orchard_commitment_domain`: v6 Orchard bundles use
+    /// `OrchardNu6_3Onward`, which forbids cross-address transfers; v5 uses
+    /// `OrchardNu6_2Only`, which permits them.
+    fn orchard_pool_forbids_cross_address(v: TxVersion) -> bool {
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        if matches!(v, TxVersion::V6) {
+            return true;
+        }
+        let _ = v;
+        false
+    }
+
+    /// Rebuilds an Orchard bundle with the cross-address flag cleared (preserving
+    /// its spends/outputs flags) so it is valid under the Orchard v6 pool
+    /// restriction `OrchardNu6_3Onward`.
+    fn with_cross_address_disabled(
+        bundle: Bundle<Authorized, ZatBalance>,
+    ) -> Bundle<Authorized, ZatBalance> {
+        use ::orchard::bundle::{BundlePoolRestrictions, Flags, ProofSizeEnforcement};
+        let byte = u8::from(bundle.flags().spends_enabled())
+            | (u8::from(bundle.flags().outputs_enabled()) << 1);
+        let flags = Flags::from_byte(byte, BundlePoolRestrictions::OrchardNu6_3Onward)
+            .expect("spends/outputs-only flags encode under OrchardNu6_3Onward");
+        ::orchard::Bundle::try_from_parts(
+            bundle.actions().clone(),
+            flags,
+            *bundle.value_balance(),
+            *bundle.anchor(),
+            bundle.authorization().clone(),
+            ProofSizeEnforcement::Strict,
+        )
+        .expect("clearing cross-address yields a representable Orchard bundle")
     }
 }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -428,7 +428,7 @@ pub mod testing {
     /// Rebuilds an Orchard bundle with the cross-address flag cleared (preserving
     /// its spends/outputs flags) so it is valid under the Orchard v6 pool
     /// restriction `OrchardNu6_3Onward`.
-    fn with_cross_address_disabled(
+    pub(crate) fn with_cross_address_disabled(
         bundle: Bundle<Authorized, ZatBalance>,
     ) -> Bundle<Authorized, ZatBalance> {
         use ::orchard::bundle::{BundlePoolRestrictions, Flags, ProofSizeEnforcement};

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -23,6 +23,13 @@ pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
 
+/// The Orchard flag-byte grammar used by v5 transaction serialization.
+///
+/// This names the `BundlePoolRestrictions` value that makes Orchard's flag
+/// parser treat bit 2 as reserved. It is a serialization-format selector, not an
+/// assertion that the transaction is being read or written in the NU6.2 epoch.
+const ORCHARD_V5_FLAG_FORMAT: BundlePoolRestrictions = BundlePoolRestrictions::OrchardNu6_2Only;
+
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
     fn map_authorization(&self, a: A) -> B;
@@ -50,14 +57,14 @@ impl MapAuth<Authorized, Authorized> for () {
 fn read_bundle<R: Read>(
     mut reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
-        let flags = read_flags(&mut reader, pool_restrictions)?;
+        let flags = read_flags(&mut reader, flag_format)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
         let proof_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
@@ -99,17 +106,15 @@ fn read_bundle<R: Read>(
 /// height; only the bundle commitment domain varies across upgrades, and that
 /// affects the txid/sighash digests rather than deserialization. Since this is
 /// public API, keeping the signature unchanged also avoids an unnecessary
-/// breaking change. (By contrast, `read_v6_bundle` takes a `pool_restrictions`
-/// argument so the caller selects the Orchard or Ironwood v6 pool.)
+/// breaking change. A v5 transaction always uses `ORCHARD_V5_FLAG_FORMAT` for
+/// the Orchard flag byte. By contrast, `read_v6_bundle` takes a
+/// `pool_restrictions` argument so the caller selects the Orchard or Ironwood v6
+/// slot.
 pub fn read_v5_bundle<R: Read>(
     reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(
-        reader,
-        proof_size_enforcement,
-        BundlePoolRestrictions::OrchardNu6_2Only,
-    )
+    read_bundle(reader, proof_size_enforcement, ORCHARD_V5_FLAG_FORMAT)
 }
 
 /// Rejects pool restrictions that are not valid for the v6 transaction format,
@@ -217,11 +222,11 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
 
 pub fn read_flags<R: Read>(
     mut reader: R,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0], pool_restrictions)
+    Flags::from_byte(byte[0], flag_format)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -241,14 +246,14 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 fn write_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     mut writer: W,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
         Vector::write_nonempty(&mut writer, bundle.actions(), |w, a| {
             write_action_without_auth(w, a)
         })?;
 
-        let flags = bundle.flags().to_byte(pool_restrictions).ok_or_else(|| {
+        let flags = bundle.flags().to_byte(flag_format).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Orchard flags cannot be encoded in this transaction format",
@@ -278,11 +283,14 @@ fn write_bundle<W: Write>(
 }
 
 /// Writes an [`orchard::Bundle`] in the v5 transaction format.
+///
+/// V5 serialization always uses `ORCHARD_V5_FLAG_FORMAT` for the Orchard flag
+/// byte, even when the v5 transaction appears after NU6.3 activation.
 pub fn write_v5_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundlePoolRestrictions::OrchardNu6_2Only)
+    write_bundle(bundle, writer, ORCHARD_V5_FLAG_FORMAT)
 }
 
 /// Writes an [`orchard::Bundle`] in the v6 transaction format. `pool_restrictions`

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -401,11 +401,11 @@ impl<A: Authorization> TransactionData<A> {
     /// including the Ironwood bundle.
     ///
     /// Both the Orchard and Ironwood bundle fields use [`orchard::Bundle`], but
-    /// they are distinct V6 transaction fields with distinct bundle protocols.
+    /// they are distinct V6 transaction fields with distinct pool restrictions.
     /// The `orchard_bundle` argument must contain a bundle constructed for
-    /// [`orchard::BundleProtocol::OrchardPostNu6_3`], while `ironwood_bundle`
+    /// [`orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward`], while `ironwood_bundle`
     /// must contain a bundle constructed for
-    /// [`orchard::BundleProtocol::IronwoodPostNu6_3`]. Supplying a bundle for
+    /// [`orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward`]. Supplying a bundle for
     /// the wrong field is invalid and can be rejected by later serialization or
     /// commitment construction because the bundle flags and domains are protocol
     /// specific.
@@ -925,9 +925,15 @@ impl Transaction {
 
         let transparent_bundle = Self::read_transparent(&mut reader)?;
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
-        let orchard_bundle = orchard_serialization::read_v6_bundle(&mut reader)?;
+        let orchard_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        let ironwood_bundle = orchard_serialization::read_v6_bundle(&mut reader)?;
+        let ironwood_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
+        )?;
 
         let data = TransactionData {
             version,
@@ -1084,9 +1090,17 @@ impl Transaction {
 
         self.write_transparent(&mut writer)?;
         self.write_v5_sapling(&mut writer)?;
-        orchard_serialization::write_v6_bundle(self.orchard_bundle.as_ref(), &mut writer)?;
+        orchard_serialization::write_v6_bundle(
+            self.orchard_bundle.as_ref(),
+            &mut writer,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        orchard_serialization::write_v6_bundle(self.ironwood_bundle.as_ref(), &mut writer)?;
+        orchard_serialization::write_v6_bundle(
+            self.ironwood_bundle.as_ref(),
+            &mut writer,
+            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
+        )?;
 
         Ok(())
     }
@@ -1293,7 +1307,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },
@@ -1325,7 +1339,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },
@@ -1357,7 +1371,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -412,6 +412,31 @@ fn v5_tx_data_with_sapling_bundle(
     )
 }
 
+/// Clears the cross-address flag on an Orchard bundle (preserving spends/outputs)
+/// so it is representable in a v6 Orchard slot (`OrchardNu6_3Onward`, which
+/// forbids cross-address transfers; cross-address is Ironwood-only).
+#[cfg(all(test, zcash_unstable = "nu6.3"))]
+fn disable_cross_address(
+    bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
+) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
+    let byte = u8::from(bundle.flags().spends_enabled())
+        | (u8::from(bundle.flags().outputs_enabled()) << 1);
+    let flags = orchard::bundle::Flags::from_byte(
+        byte,
+        orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+    )
+    .unwrap();
+    orchard::Bundle::try_from_parts(
+        bundle.actions().clone(),
+        flags,
+        *bundle.value_balance(),
+        *bundle.anchor(),
+        bundle.authorization().clone(),
+        orchard::bundle::ProofSizeEnforcement::Strict,
+    )
+    .unwrap()
+}
+
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 fn v6_tx_with_orchard_bundle(
     orchard_bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
@@ -422,7 +447,7 @@ fn v6_tx_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(orchard_bundle),
+        Some(disable_cross_address(orchard_bundle)),
         None,
     )
     .freeze()
@@ -471,7 +496,7 @@ fn v6_tx_data_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(orchard_bundle),
+        Some(disable_cross_address(orchard_bundle)),
         None,
     )
 }

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -20,6 +20,7 @@ use {
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 use crate::transaction::{
     TransactionDigest,
+    components::orchard::testing::with_cross_address_disabled,
     txid::{BlockTxCommitmentDigester, hash_sapling_spends},
 };
 
@@ -412,31 +413,6 @@ fn v5_tx_data_with_sapling_bundle(
     )
 }
 
-/// Clears the cross-address flag on an Orchard bundle (preserving spends/outputs)
-/// so it is representable in a v6 Orchard slot (`OrchardNu6_3Onward`, which
-/// forbids cross-address transfers; cross-address is Ironwood-only).
-#[cfg(all(test, zcash_unstable = "nu6.3"))]
-fn disable_cross_address(
-    bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
-) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
-    let byte = u8::from(bundle.flags().spends_enabled())
-        | (u8::from(bundle.flags().outputs_enabled()) << 1);
-    let flags = orchard::bundle::Flags::from_byte(
-        byte,
-        orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
-    )
-    .unwrap();
-    orchard::Bundle::try_from_parts(
-        bundle.actions().clone(),
-        flags,
-        *bundle.value_balance(),
-        *bundle.anchor(),
-        bundle.authorization().clone(),
-        orchard::bundle::ProofSizeEnforcement::Strict,
-    )
-    .unwrap()
-}
-
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 fn v6_tx_with_orchard_bundle(
     orchard_bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
@@ -447,7 +423,7 @@ fn v6_tx_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(disable_cross_address(orchard_bundle)),
+        Some(with_cross_address_disabled(orchard_bundle)),
         None,
     )
     .freeze()
@@ -496,7 +472,7 @@ fn v6_tx_data_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(disable_cross_address(orchard_bundle)),
+        Some(with_cross_address_disabled(orchard_bundle)),
         None,
     )
 }

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -84,7 +84,7 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
 /// pre-bump `BundleCommitmentDomain` for a given transaction version. The pool
 /// restriction here is only used for empty-bundle commitments (which hash no
 /// flags); present bundles derive their restriction from their own flags via
-/// [`orchard_pool_restrictions_for_flags`].
+/// [`orchard_flag_format_for_flags`].
 fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, OrchardTxVersion) {
     match version {
         TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => (
@@ -99,20 +99,19 @@ fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, Orc
     }
 }
 
-/// Selects the Orchard pool restriction used to compute a present bundle's txid
+/// Selects the Orchard flag-byte format used to compute a present bundle's txid
 /// and authorizing commitments from the bundle's own cross-address flag.
 ///
 /// The commitment *format* is chosen by the transaction version (see
-/// [`orchard_commitment_domain`]); the only Orchard pool restriction that affects
-/// the commitment is whether cross-address transfers are enabled. Deriving it from
-/// the bundle's flags keeps the flag byte encodable, so `Flags::to_byte` always
-/// returns `Some` and the `expect(..)` at the call sites is unreachable.
+/// [`orchard_commitment_domain`]). This helper only chooses a value that makes
+/// the bundle flags encodable for Orchard's `Flags::to_byte` API, so the
+/// `expect(..)` at the call sites is unreachable.
 ///
 /// A cross-address-enabled Orchard bundle is rejected by `read_v6_bundle`/
 /// `write_v6_bundle` under `OrchardNu6_3Onward`, so it can never appear in a
 /// serialized transaction; this restriction therefore only diverges from the slot
 /// restriction for in-memory bundles that no node can produce or relay.
-fn orchard_pool_restrictions_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
+fn orchard_flag_format_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
     if flags.cross_address_enabled() {
         BundlePoolRestrictions::OrchardNu6_2Only
     } else {
@@ -378,8 +377,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| {
             let (_, tx_version) = orchard_commitment_domain(version);
-            let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
-            b.commitment(pool_restrictions, tx_version)
+            let flag_format = orchard_flag_format_for_flags(b.flags());
+            b.commitment(flag_format, tx_version)
                 .expect("Orchard bundle flags must be representable in their transaction format")
                 .0
         })
@@ -632,8 +631,8 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
                     .expect("empty Orchard bundle auth commitment is valid for its tx format")
             },
             |b| {
-                let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
-                b.authorizing_commitment(pool_restrictions, tx_version)
+                let flag_format = orchard_flag_format_for_flags(b.flags());
+                b.authorizing_commitment(flag_format, tx_version)
                     .expect("Orchard bundle flags must be representable in their tx format")
                     .0
             },

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -6,7 +6,7 @@ use corez::io::Write;
 use blake2b_simd::{Hash as Blake2bHash, Params};
 use ff::PrimeField;
 
-use ::orchard::bundle::{self as orchard, commitments::BundleCommitmentDomain};
+use ::orchard::bundle::{self as orchard, BundlePoolRestrictions, TxVersion as OrchardTxVersion};
 use ::sapling::bundle::{OutputDescription, SpendDescription};
 use ::transparent::bundle::{self as transparent, TxIn, TxOut};
 use zcash_protocol::{
@@ -80,19 +80,52 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
     }
 }
 
-fn orchard_commitment_domain(version: TxVersion) -> BundleCommitmentDomain {
+/// Selects the `(pool restriction, orchard tx version)` pair that reproduces the
+/// pre-bump `BundleCommitmentDomain` for a given transaction version. The pool
+/// restriction here is only used for empty-bundle commitments (which hash no
+/// flags); present bundles derive their restriction from their own flags via
+/// [`orchard_pool_restrictions_for_flags`].
+fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, OrchardTxVersion) {
     match version {
-        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => {
-            BundleCommitmentDomain::ORCHARD_V5_PRE_NU6_3
-        }
+        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => (
+            BundlePoolRestrictions::OrchardNu6_2Only,
+            OrchardTxVersion::V5,
+        ),
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        TxVersion::V6 => BundleCommitmentDomain::ORCHARD_V6,
+        TxVersion::V6 => (
+            BundlePoolRestrictions::OrchardNu6_3Onward,
+            OrchardTxVersion::V6,
+        ),
+    }
+}
+
+/// Selects the Orchard pool restriction used to compute a present bundle's txid
+/// and authorizing commitments from the bundle's own cross-address flag.
+///
+/// The commitment *format* is chosen by the transaction version (see
+/// [`orchard_commitment_domain`]); the only Orchard pool restriction that affects
+/// the commitment is whether cross-address transfers are enabled. Deriving it from
+/// the bundle's flags keeps the flag byte encodable, so `Flags::to_byte` always
+/// returns `Some` and the `expect(..)` at the call sites is unreachable.
+///
+/// A cross-address-enabled Orchard bundle is rejected by `read_v6_bundle`/
+/// `write_v6_bundle` under `OrchardNu6_3Onward`, so it can never appear in a
+/// serialized transaction; this restriction therefore only diverges from the slot
+/// restriction for in-memory bundles that no node can produce or relay.
+fn orchard_pool_restrictions_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
+    if flags.cross_address_enabled() {
+        BundlePoolRestrictions::OrchardNu6_2Only
+    } else {
+        BundlePoolRestrictions::OrchardNu6_3Onward
     }
 }
 
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-fn ironwood_v6_domain() -> BundleCommitmentDomain {
-    BundleCommitmentDomain::IRONWOOD_V6
+fn ironwood_v6_domain() -> (BundlePoolRestrictions, OrchardTxVersion) {
+    (
+        BundlePoolRestrictions::IronwoodNu6_3Onward,
+        OrchardTxVersion::V6,
+    )
 }
 
 fn hasher(personal: &[u8; 16]) -> StateWrite {
@@ -344,7 +377,9 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| {
-            b.commitment_for_domain(orchard_commitment_domain(version))
+            let (_, tx_version) = orchard_commitment_domain(version);
+            let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
+            b.commitment(pool_restrictions, tx_version)
                 .expect("Orchard bundle flags must be representable in their transaction format")
                 .0
         })
@@ -356,7 +391,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         ironwood_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::IronwoodDigest {
         ironwood_bundle.map(|b| {
-            b.commitment_for_domain(ironwood_v6_domain())
+            let (pool_restrictions, tx_version) = ironwood_v6_domain();
+            b.commitment(pool_restrictions, tx_version)
                 .expect("Ironwood bundle flags must be representable")
                 .0
         })
@@ -408,9 +444,9 @@ pub(crate) fn to_hash(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(orchard_commitment_domain(
-                    _txversion,
-                ))
+                let (pool_restrictions, tx_version) = orchard_commitment_domain(_txversion);
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
     )
@@ -446,9 +482,9 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(orchard_commitment_domain(
-                    TxVersion::V6,
-                ))
+                let (pool_restrictions, tx_version) = orchard_commitment_domain(TxVersion::V6);
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
     )
@@ -456,7 +492,9 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         ironwood_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(ironwood_v6_domain())
+                let (pool_restrictions, tx_version) = ironwood_v6_domain();
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Ironwood bundle txid commitment is valid")
             })
             .as_bytes(),
     )
@@ -587,14 +625,16 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         version: TxVersion,
         orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::OrchardDigest {
+        let (pool_restrictions, tx_version) = orchard_commitment_domain(version);
         orchard_bundle.map_or_else(
             || {
-                orchard::commitments::hash_bundle_auth_empty_with_domain(orchard_commitment_domain(
-                    version,
-                ))
+                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle auth commitment is valid for its tx format")
             },
             |b| {
-                b.authorizing_commitment_for_domain(orchard_commitment_domain(version))
+                let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
+                b.authorizing_commitment(pool_restrictions, tx_version)
+                    .expect("Orchard bundle flags must be representable in their tx format")
                     .0
             },
         )
@@ -605,9 +645,17 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         &self,
         ironwood_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::IronwoodDigest {
+        let (pool_restrictions, tx_version) = ironwood_v6_domain();
         ironwood_bundle.map_or_else(
-            || orchard::commitments::hash_bundle_auth_empty_with_domain(ironwood_v6_domain()),
-            |b| b.authorizing_commitment_for_domain(ironwood_v6_domain()).0,
+            || {
+                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                    .expect("empty Ironwood bundle auth commitment is valid")
+            },
+            |b| {
+                b.authorizing_commitment(pool_restrictions, tx_version)
+                    .expect("Ironwood bundle flags must be representable")
+                    .0
+            },
         )
     }
 


### PR DESCRIPTION
Bumps the `orchard` git pin from `b2af0a11` to `30c4ea2` (current `zcash/orchard` `feat/ironwood` tip), realigning `feat/ironwood` off its divergent side-branch pin onto canonical orchard.

This is an API + light semantics migration:

- `BundleProtocol` → `BundlePoolRestrictions` (`OrchardPreNu6_3` → `OrchardNu6_2Only`, `OrchardPostNu6_3` → `OrchardNu6_3Onward`, `IronwoodPostNu6_3` → `IronwoodNu6_3Onward`).
- Commitment-domain API → fallible `(pool_restrictions, tx_version)` in `txid.rs`. Present bundles derive the pool restriction from their own flags, empty bundles from the tx version; txid/auth digests are byte-preserved.
- `BundleFormat` removed; (de)serialization takes a `BundlePoolRestrictions`. `read_v6_bundle`/`write_v6_bundle` take the pool restriction as an argument so the caller selects the Orchard or Ironwood v6 pool (the Ironwood pool permits the cross-address flag, the Orchard v6 pool does not; the old single `BundleFormat::Nu6_3` covered both), and reject pre-v6 restrictions.
- `Builder` now carries the selected pool restriction.
- Adapt to the new orchard pczt parse signatures (the `note_version` argument moved) and to the note-encryption `Domain`, which is now generic over a `DomainPolicy` (pass `OrchardDomain` / an explicit pool restriction).
