### PR TITLE
zcash_primitives: Charge ZIP 317 marginal fees for Ironwood actions

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -89,6 +89,11 @@ workspace.
   addition to `propose_shielding`.
 - `zcash_client_backend::wallet::WalletTx::new` now takes a `transparent_outputs`
   argument.
+- `zcash_client_backend::fees::StandardFeeRule` tracks the new
+  `ironwood_action_count: usize` argument added to
+  `zcash_primitives::transaction::fees::FeeRule::fee_required`. Code that calls
+  `fee_required` directly or implements the trait must thread through the number
+  of Ironwood actions, passing `0` for transactions without an Ironwood bundle.
 
 ### Removed
 - `zcash_client_backend::data_api::WalletUtxo` (use `WalletTransparentOutput`

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -890,6 +890,10 @@ where
     #[cfg(feature = "orchard")]
     let use_orchard = orchard_action_count > 0;
 
+    // The wallet does not yet construct Ironwood bundles, so they contribute no
+    // actions to the fee.
+    let ironwood_action_count: usize = 0;
+
     let recipient_address: Address = recipient
         .clone()
         .convert_if_network(params.network_type())?;
@@ -904,6 +908,7 @@ where
                 spendable_notes.sapling().len(),
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             )
             .map(|fee| (fee, None)),
         Address::Transparent(_) => fee_rule
@@ -915,6 +920,7 @@ where
                 spendable_notes.sapling().len(),
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             )
             .map(|fee| (fee, None)),
         Address::Unified(addr) => fee_rule
@@ -930,6 +936,7 @@ where
                 spendable_notes.sapling().len(),
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             )
             .map(|fee| (fee, None)),
         Address::Tex(_) => fee_rule
@@ -941,6 +948,7 @@ where
                 spendable_notes.sapling().len(),
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             )
             .and_then(|tr0_fee| {
                 let tr1_fee = fee_rule.fee_required(
@@ -948,6 +956,7 @@ where
                     BlockHeight::from(target_height),
                     [InputSize::Known(P2PKH_STANDARD_INPUT_SIZE)],
                     [P2PKH_STANDARD_OUTPUT_SIZE],
+                    0,
                     0,
                     0,
                     0,
@@ -1294,6 +1303,10 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             }
         };
 
+        // The wallet does not yet construct Ironwood bundles, so they contribute
+        // no actions to the fee.
+        let ironwood_action_count = 0;
+
         let fee = fee_rule
             .fee_required(
                 params,
@@ -1305,6 +1318,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 0,
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             )
             // The `InputSelectorError::Change` variant is the only existing
             // carrier capable of holding an arbitrary fee-rule error

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -46,6 +46,7 @@ impl FeeRule for StandardFeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
+        ironwood_action_count: usize,
     ) -> Result<Zatoshis, Self::Error> {
         #[allow(deprecated)]
         match self {
@@ -57,6 +58,7 @@ impl FeeRule for StandardFeeRule {
                 sapling_input_count,
                 sapling_output_count,
                 orchard_action_count,
+                ironwood_action_count,
             ),
         }
     }

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -330,6 +330,10 @@ where
         }
     };
 
+    // Ironwood bundles are not yet constructed by the wallet, so they contribute
+    // no actions to the fee.
+    let ironwood_action_count = 0;
+
     let transparent_input_sizes = transparent_inputs
         .iter()
         .map(|i| i.serialized_size())
@@ -377,6 +381,7 @@ where
             sapling_input_count,
             sapling_output_count(0)?,
             orchard_action_count(0)?,
+            ironwood_action_count,
         )
         .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?;
 
@@ -409,6 +414,7 @@ where
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
                         orchard_action_count(target_change_counts.orchard())?,
+                        ironwood_action_count,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?,
             );
@@ -448,6 +454,7 @@ where
                         } else {
                             0
                         })?,
+                        ironwood_action_count,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?
             } else {

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -42,6 +42,12 @@ workspace.
   `zcash_primitives::transaction::components::orchard::{read_v5_bundle,
   read_v6_bundle, read_flags}` now take a `BundleVersion` argument, while
   `write_v6_bundle` derives the version from the bundle.
+- `zcash_primitives::transaction::fees::FeeRule::fee_required` now takes an
+  additional `ironwood_action_count: usize` argument following
+  `orchard_action_count`. Implementors and callers must thread through the
+  number of Ironwood actions; pass `0` for transactions without an Ironwood
+  bundle. Under ZIP 317 each Ironwood action is charged one marginal fee, the
+  same as an Orchard action.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -778,6 +778,9 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                         )
                     })
                     .map_err(FeeError::Bundle)?,
+                // The builder does not yet construct Ironwood bundles, so they
+                // contribute no actions to the fee.
+                0,
             )
             .map_err(FeeError::FeeRule)
     }

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -31,5 +31,6 @@ pub trait FeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
+        ironwood_action_count: usize,
     ) -> Result<Zatoshis, Self::Error>;
 }

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -36,6 +36,7 @@ impl super::FeeRule for FeeRule {
         _sapling_input_count: usize,
         _sapling_output_count: usize,
         _orchard_action_count: usize,
+        _ironwood_action_count: usize,
     ) -> Result<Zatoshis, Self::Error> {
         Ok(self.fixed_fee)
     }

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -41,8 +41,8 @@ pub const MINIMUM_FEE: Zatoshis = Zatoshis::const_from_u64(10_000);
 
 /// A [`FeeRule`] implementation that implements the [ZIP 317] fee rule.
 ///
-/// This fee rule supports Orchard, Sapling, and (P2PKH only) transparent inputs.
-/// Returns an error if a coin containing a non-P2PKH script is provided as an input.
+/// This fee rule supports Ironwood, Orchard, Sapling, and (P2PKH only) transparent
+/// inputs. Returns an error if a coin containing a non-P2PKH script is provided as an input.
 ///
 /// This fee rule may slightly overestimate fees in case where the user is attempting
 /// to spend a large number of transparent inputs. This is intentional and is relied
@@ -163,6 +163,7 @@ impl super::FeeRule for FeeRule {
         sapling_input_count: usize,
         sapling_output_count: usize,
         orchard_action_count: usize,
+        ironwood_action_count: usize,
     ) -> Result<Zatoshis, Self::Error> {
         let mut t_in_total_size: usize = 0;
         let mut unknown_p2sh_outpoints = vec![];
@@ -189,9 +190,48 @@ impl super::FeeRule for FeeRule {
             ceildiv(t_in_total_size, self.p2pkh_standard_input_size),
             ceildiv(t_out_total_size, self.p2pkh_standard_output_size),
         ) + max(sapling_input_count, sapling_output_count)
-            + orchard_action_count;
+            + orchard_action_count
+            + ironwood_action_count;
 
         (self.marginal_fee * max(self.grace_actions, logical_actions))
             .ok_or_else(|| BalanceError::Overflow.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::iter;
+
+    use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+
+    use super::{FeeRule, MARGINAL_FEE};
+    use crate::transaction::fees::{FeeRule as _, transparent::InputSize};
+
+    fn fee_for(orchard_action_count: usize, ironwood_action_count: usize) -> Zatoshis {
+        FeeRule::standard()
+            .fee_required(
+                &zcash_protocol::consensus::MAIN_NETWORK,
+                BlockHeight::from_u32(1_000_000),
+                iter::empty::<InputSize>(),
+                iter::empty::<usize>(),
+                0,
+                0,
+                orchard_action_count,
+                ironwood_action_count,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn ironwood_actions_charged_marginal_fee() {
+        // Five Ironwood actions exceed the grace allowance, so each is charged the
+        // marginal fee.
+        assert_eq!(fee_for(0, 5), (MARGINAL_FEE * 5usize).unwrap());
+    }
+
+    #[test]
+    fn ironwood_actions_combine_with_orchard() {
+        // Orchard and Ironwood actions are summed into the logical action count.
+        assert_eq!(fee_for(2, 3), (MARGINAL_FEE * 5usize).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

Updates the ZIP 317 fee computation in `zcash_primitives` to account for Ironwood actions, mirroring the existing Orchard handling. Ironwood is the shielded pool carried by the NU6.3 V6 transaction format.

- Adds an `ironwood_action_count: usize` argument to `FeeRule::fee_required`, folded into the ZIP 317 logical action count so that each Ironwood action is charged one marginal fee — the same treatment as an Orchard action.
- As with Orchard, the minimum-of-two-actions floor for a non-empty bundle is applied at the action-counting layer (the bundle type's `num_actions`), not in the fee rule itself; the fee rule simply adds the already-padded count.
- The transaction builder and `zcash_client_backend` callers thread through a count of zero, since neither constructs Ironwood bundles yet.

The fee-rule change is unconditional (fee computation is not feature-gated); the surrounding Ironwood/V6 support lives behind the `zcash_unstable = "nu6.3"` cfg.

## Follow-up

When Ironwood bundle construction is added to the builder, it will need an `ironwood_action_count` helper (paralleling the existing `orchard_action_count`) that applies the same `MIN_ACTIONS` padding, so that non-empty Ironwood bundles count as at least two actions.

## Testing

- New unit tests in `zip317.rs` covering Ironwood actions being charged the marginal fee, and combining additively with Orchard actions.
- `cargo check --workspace --all-features --tests` passes under `--cfg zcash_unstable="nu6.3"`.

Closes #2461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
