### PR TITLE
zcash_primitives: Add Ironwood wiring to the transaction builder

### DIFF
--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -104,6 +104,8 @@ fn transparent_to_orchard() {
         BuildConfig::Standard {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         },
     );
     builder
@@ -268,6 +270,8 @@ fn transparent_p2sh_multisig_to_orchard() {
         BuildConfig::Standard {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         },
     );
     builder
@@ -476,6 +480,8 @@ fn sapling_to_orchard() {
         BuildConfig::Standard {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         },
     );
     builder
@@ -638,6 +644,8 @@ fn orchard_to_orchard() {
         BuildConfig::Standard {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         },
     );
     builder

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1330,6 +1330,8 @@ where
         BuildConfig::Standard {
             sapling_anchor,
             orchard_anchor,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         },
     );
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -362,6 +362,8 @@ mod tests {
             BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: None,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             },
         );
         let mut transparent_signing_set = TransparentSigningSet::new();

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -23,6 +23,8 @@ workspace.
   - `TxDigests::ironwood_digest`, for carrying the Ironwood bundle digest.
   - `TransactionDigest::{IronwoodDigest, digest_ironwood}`, for digest
     implementations that commit to Ironwood bundles.
+- `zcash_primitives::transaction::builder::Builder::add_orchard_change_output`,
+  for constructing wallet-controlled Orchard change outputs.
 - `zcash_primitives::transaction::builder` Ironwood support (behind the
   `--cfg zcash_unstable="nu6.3"` or `--cfg zcash_unstable="nu7"` flag):
   - `BuildConfig::Standard::ironwood_anchor`, the anchor used to construct the

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -29,9 +29,9 @@ workspace.
   `--cfg zcash_unstable="nu6.3"` or `--cfg zcash_unstable="nu7"` flag):
   - `BuildConfig::Standard::ironwood_anchor`, the anchor used to construct the
     Ironwood bundle.
-  - `Builder::{add_ironwood_spend, add_ironwood_output,
-    add_ironwood_change_output}`, which build the Ironwood bundle alongside the
-    Orchard bundle and require `orchard::note::NoteVersion::V3` notes.
+  - `Builder::{add_ironwood_spend, add_ironwood_output}`, which build the
+    Ironwood bundle alongside the Orchard bundle and require
+    `orchard::note::NoteVersion::V3` notes.
   - `BuildResult::ironwood_meta` and `PcztParts::ironwood`/`PcztResult::ironwood_meta`,
     exposing the Ironwood bundle and its build metadata.
   - `Error::{IronwoodBuild, IronwoodSpend, IronwoodSpendUnsupportedNoteVersion,

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -23,6 +23,17 @@ workspace.
   - `TxDigests::ironwood_digest`, for carrying the Ironwood bundle digest.
   - `TransactionDigest::{IronwoodDigest, digest_ironwood}`, for digest
     implementations that commit to Ironwood bundles.
+- `zcash_primitives::transaction::builder` Ironwood support (behind the
+  `--cfg zcash_unstable="nu6.3"` or `--cfg zcash_unstable="nu7"` flag):
+  - `BuildConfig::Standard::ironwood_anchor`, the anchor used to construct the
+    Ironwood bundle.
+  - `Builder::{add_ironwood_spend, add_ironwood_output,
+    add_ironwood_change_output}`, which build the Ironwood bundle alongside the
+    Orchard bundle and require `orchard::note::NoteVersion::V3` notes.
+  - `BuildResult::ironwood_meta` and `PcztParts::ironwood`/`PcztResult::ironwood_meta`,
+    exposing the Ironwood bundle and its build metadata.
+  - `Error::{IronwoodBuild, IronwoodSpend, IronwoodSpendUnsupportedNoteVersion,
+    IronwoodRecipient, IronwoodBuilderNotAvailable}`.
 
 ### Changed
 - `zcash_primitives::transaction::builder`:

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1260,12 +1260,32 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             .transpose()
             .map_err(Error::SaplingBuild)?;
 
+        // Orchard and Ironwood actions share the post-NU6.3 circuit, so a single
+        // proving key serves both proofs when a V6 transaction carries both
+        // bundles. Build it once, from whichever bundle is present; their circuit
+        // versions agree whenever both are present.
+        let orchard_proving_key = {
+            let circuit_version = unauthed_tx
+                .orchard_bundle
+                .as_ref()
+                .map(|b| b.circuit_version());
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            let circuit_version = circuit_version.or_else(|| {
+                unauthed_tx
+                    .ironwood_bundle
+                    .as_ref()
+                    .map(|b| b.circuit_version())
+            });
+            circuit_version.map(orchard::circuit::ProvingKey::build)
+        };
+
         let orchard_bundle = unauthed_tx
             .orchard_bundle
             .map(|b| {
-                let circuit_version = b.circuit_version();
                 b.create_proof(
-                    &orchard::circuit::ProvingKey::build(circuit_version),
+                    orchard_proving_key
+                        .as_ref()
+                        .expect("proving key is built when an Orchard bundle is present"),
                     &mut rng,
                 )
                 .and_then(|b| {
@@ -1279,9 +1299,10 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
         let ironwood_bundle = unauthed_tx
             .ironwood_bundle
             .map(|b| {
-                let circuit_version = b.circuit_version();
                 b.create_proof(
-                    &orchard::circuit::ProvingKey::build(circuit_version),
+                    orchard_proving_key
+                        .as_ref()
+                        .expect("proving key is built when an Ironwood bundle is present"),
                     &mut rng,
                 )
                 .and_then(|b| {

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -87,16 +87,32 @@ pub enum Error<FE> {
     SaplingBuild(sapling::builder::Error),
     /// An error occurred in constructing the Orchard parts of a transaction.
     OrchardBuild(orchard::builder::BuildError),
+    /// An error occurred in constructing the Ironwood parts of a transaction.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodBuild(orchard::builder::BuildError),
     /// An error occurred in adding an Orchard Spend to a transaction.
     OrchardSpend(orchard::builder::SpendError),
     /// An error occurred in adding an Orchard Output to a transaction.
     OrchardRecipient(orchard::builder::OutputError),
+    /// An error occurred in adding an Ironwood Spend to a transaction.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodSpend(orchard::builder::SpendError),
+    /// An Ironwood spend note used an unsupported note plaintext version.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodSpendUnsupportedNoteVersion(orchard::NoteVersion),
+    /// An error occurred in adding an Ironwood Output to a transaction.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodRecipient(orchard::builder::OutputError),
     /// The builder was constructed without support for the Sapling pool, but a Sapling
     /// spend or output was added.
     SaplingBuilderNotAvailable,
     /// The builder was constructed with a target height before NU5 activation, but an Orchard
     /// spend or output was added.
     OrchardBuilderNotAvailable,
+    /// The builder was constructed with a target height before NU6.3 activation,
+    /// or without an Ironwood anchor, but an Ironwood spend or output was added.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodBuilderNotAvailable,
     /// An error occurred in constructing a coinbase transaction.
     Coinbase(coinbase::Error),
     /// The proposed transaction version or the consensus branch id for the target height does not
@@ -121,8 +137,21 @@ impl<FE: fmt::Display> fmt::Display for Error<FE> {
             Error::TransparentBuild(err) => err.fmt(f),
             Error::SaplingBuild(err) => err.fmt(f),
             Error::OrchardBuild(err) => write!(f, "{err:?}"),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            Error::IronwoodBuild(err) => write!(f, "{err:?}"),
             Error::OrchardSpend(err) => write!(f, "Could not add Orchard spend: {err}"),
             Error::OrchardRecipient(err) => write!(f, "Could not add Orchard recipient: {err}"),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            Error::IronwoodSpend(err) => write!(f, "Could not add Ironwood spend: {err}"),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            Error::IronwoodSpendUnsupportedNoteVersion(version) => write!(
+                f,
+                "Could not add Ironwood spend: note version {version:?} is unsupported"
+            ),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            Error::IronwoodRecipient(err) => {
+                write!(f, "Could not add Ironwood recipient: {err}")
+            }
             Error::SaplingBuilderNotAvailable => write!(
                 f,
                 "Cannot create Sapling transactions without a Sapling anchor"
@@ -130,6 +159,11 @@ impl<FE: fmt::Display> fmt::Display for Error<FE> {
             Error::OrchardBuilderNotAvailable => write!(
                 f,
                 "Cannot create Orchard transactions without an Orchard anchor, or before NU5 activation"
+            ),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            Error::IronwoodBuilderNotAvailable => write!(
+                f,
+                "Cannot create Ironwood transactions without an Ironwood anchor, or before NU6.3 activation"
             ),
             Error::Coinbase(err) => write!(
                 f,
@@ -222,6 +256,8 @@ pub enum BuildConfig {
     Standard {
         sapling_anchor: Option<sapling::Anchor>,
         orchard_anchor: Option<orchard::Anchor>,
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        ironwood_anchor: Option<orchard::Anchor>,
     },
     Coinbase {
         miner_data: Option<PushValue>,
@@ -275,6 +311,34 @@ impl BuildConfig {
                     orchard::Anchor::empty_tree(),
                 )
                 .expect("spends-disabled flags are valid for a non-Orchard coinbase bundle"),
+            ),
+        }
+    }
+
+    /// Returns the Ironwood builder for this configuration.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    fn ironwood_builder(&self) -> Option<orchard::builder::Builder> {
+        let bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        match self {
+            BuildConfig::Standard {
+                ironwood_anchor, ..
+            } => ironwood_anchor.as_ref().map(|a| {
+                orchard::builder::Builder::new(
+                    orchard::builder::BundleType::DEFAULT,
+                    bundle_version,
+                    bundle_version.default_flags(),
+                    *a,
+                )
+                .expect("the default flags are always representable for an Ironwood bundle")
+            }),
+            BuildConfig::Coinbase { .. } => Some(
+                orchard::builder::Builder::new(
+                    orchard::builder::BundleType::Coinbase,
+                    bundle_version,
+                    orchard::bundle::Flags::SPENDS_DISABLED,
+                    orchard::Anchor::empty_tree(),
+                )
+                .expect("spends-disabled flags are valid for an Ironwood coinbase bundle"),
             ),
         }
     }
@@ -336,6 +400,8 @@ pub struct BuildResult {
     transaction: Transaction,
     sapling_meta: SaplingMetadata,
     orchard_meta: orchard::builder::BundleMetadata,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    ironwood_meta: orchard::builder::BundleMetadata,
 }
 
 impl BuildResult {
@@ -355,6 +421,14 @@ impl BuildResult {
     pub fn orchard_meta(&self) -> &orchard::builder::BundleMetadata {
         &self.orchard_meta
     }
+
+    /// Returns the mapping from Ironwood inputs and outputs to the randomized
+    /// positions of the Actions that contain them in the Ironwood bundle in
+    /// the newly constructed transaction.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn ironwood_meta(&self) -> &orchard::builder::BundleMetadata {
+        &self.ironwood_meta
+    }
 }
 
 /// The result of [`Builder::build_for_pczt`].
@@ -366,6 +440,8 @@ pub struct PcztResult<P: Parameters> {
     pub pczt_parts: PcztParts<P>,
     pub sapling_meta: SaplingMetadata,
     pub orchard_meta: orchard::builder::BundleMetadata,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub ironwood_meta: orchard::builder::BundleMetadata,
 }
 
 /// The components of a PCZT.
@@ -379,6 +455,8 @@ pub struct PcztParts<P: Parameters> {
     pub transparent: Option<transparent::pczt::Bundle>,
     pub sapling: Option<sapling::pczt::Bundle>,
     pub orchard: Option<orchard::pczt::Bundle>,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub ironwood: Option<orchard::pczt::Bundle>,
 }
 
 /// Generates a [`Transaction`] from its inputs and outputs.
@@ -395,6 +473,8 @@ pub struct Builder<P, U> {
     sapling_builder: Option<sapling::builder::Builder>,
     orchard_builder: Option<orchard::builder::Builder>,
     orchard_bundle_version: Option<orchard::bundle::BundleVersion>,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    ironwood_builder: Option<orchard::builder::Builder>,
     _progress_notifier: U,
 }
 
@@ -438,6 +518,15 @@ impl<P, U> Builder<P, U> {
             .map_or_else(|| &[][..], |b| b.outputs())
     }
 
+    /// Returns `true` if any Ironwood spend, output, or change output has been
+    /// added to this builder (i.e. the transaction will carry an Ironwood bundle).
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    fn ironwood_in_use(&self) -> bool {
+        self.ironwood_builder.as_ref().is_some_and(|b| {
+            !b.spends().is_empty() || !b.outputs().is_empty() || !b.changes().is_empty()
+        })
+    }
+
     /// Checks that the given version supports all features required by the inputs and
     /// outputs already added to the builder.
     fn check_version_compatibility<FE>(&self, version: TxVersion) -> Result<(), Error<FE>> {
@@ -473,6 +562,28 @@ impl<P, U> Builder<P, U> {
                 Some(PoolType::ORCHARD),
             ));
         }
+
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        {
+            // Ironwood is available only when the target version carries an Ironwood bundle
+            // (V6) and the consensus branch is one in which Ironwood is active.
+            let ironwood_branch = match self.consensus_branch_id {
+                #[cfg(zcash_unstable = "nu6.3")]
+                BranchId::Nu6_3 => true,
+                #[cfg(zcash_unstable = "nu7")]
+                BranchId::Nu7 => true,
+                _ => false,
+            };
+            let ironwood_available = version.has_ironwood() && ironwood_branch;
+            if !ironwood_available && self.ironwood_in_use() {
+                return Err(Error::TargetIncompatible(
+                    self.consensus_branch_id,
+                    version,
+                    None,
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -502,6 +613,8 @@ impl<P: consensus::Parameters> Builder<P, ()> {
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
         let bundle_version = orchard_bundle_version_for_branch(consensus_branch_id);
+        // Default transaction version for the branch (V6 from NU6.3 onward).
+        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
 
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
             build_config.orchard_builder(bundle_version)
@@ -509,6 +622,15 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             None
         };
         let orchard_bundle_version = orchard_builder.as_ref().map(|_| bundle_version);
+
+        // The Ironwood builder exists exactly when the branch's transaction version
+        // carries an Ironwood bundle (V6, i.e. NU6.3 onward).
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let ironwood_builder = if tx_version.has_ironwood() {
+            build_config.ironwood_builder()
+        } else {
+            None
+        };
 
         let sapling_builder = build_config
             .sapling_builder_config()
@@ -535,9 +657,6 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             target_height + DEFAULT_TX_EXPIRY_DELTA
         };
 
-        // Determine the default transaction version for the consensus branch
-        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
-
         Builder {
             params,
             tx_version,
@@ -551,6 +670,8 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             sapling_builder,
             orchard_builder,
             orchard_bundle_version,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_builder,
             _progress_notifier: (),
         }
     }
@@ -579,6 +700,8 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             sapling_builder: self.sapling_builder,
             orchard_builder: self.orchard_builder,
             orchard_bundle_version: self.orchard_bundle_version,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_builder: self.ironwood_builder,
             _progress_notifier,
         }
     }
@@ -621,6 +744,85 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                 memo.into_bytes(),
             )
             .map_err(Error::OrchardRecipient)
+    }
+
+    /// Adds an Ironwood note to be spent in this bundle.
+    ///
+    /// The note must use [`orchard::note::NoteVersion::V3`], the Ironwood
+    /// note plaintext format.
+    ///
+    /// Returns an error if the given note has an unsupported version, or if
+    /// the given Merkle path does not have the required Ironwood anchor for the
+    /// note.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn add_ironwood_spend<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        note: orchard::Note,
+        merkle_path: orchard::tree::MerklePath,
+    ) -> Result<(), Error<FE>> {
+        let builder = self
+            .ironwood_builder
+            .as_mut()
+            .ok_or(Error::IronwoodBuilderNotAvailable)?;
+
+        if note.version() != orchard::note::NoteVersion::V3 {
+            return Err(Error::IronwoodSpendUnsupportedNoteVersion(note.version()));
+        }
+
+        builder
+            .add_spend(fvk, note, merkle_path)
+            .map_err(Error::IronwoodSpend)?;
+        Ok(())
+    }
+
+    /// Adds an Ironwood recipient to the transaction.
+    ///
+    /// This uses [`orchard::note::NoteVersion::V3`], the Ironwood note
+    /// plaintext format.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn add_ironwood_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.ironwood_builder
+            .as_mut()
+            .ok_or(Error::IronwoodBuilderNotAvailable)?
+            .add_output(
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::IronwoodRecipient)
+    }
+
+    /// Adds a wallet-controlled Ironwood change output to the transaction.
+    ///
+    /// This uses [`orchard::note::NoteVersion::V3`].
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn add_ironwood_change_output<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.ironwood_builder
+            .as_mut()
+            .ok_or(Error::IronwoodBuilderNotAvailable)?
+            .add_change_output(
+                fvk,
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::IronwoodRecipient)
     }
 
     /// Adds a Sapling note to be spent in this transaction.
@@ -723,6 +925,15 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                         .map_err(|_| BalanceError::Overflow)
                 },
             )?,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            self.ironwood_builder.as_ref().map_or_else(
+                || Ok(ZatBalance::zero()),
+                |builder| {
+                    builder
+                        .value_balance::<ZatBalance>()
+                        .map_err(|_| BalanceError::Overflow)
+                },
+            )?,
             #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
             -ZatBalance::from(self.zip233_amount),
         ];
@@ -748,6 +959,24 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             .sapling_builder
             .as_ref()
             .map_or(0, |builder| builder.inputs().len());
+
+        let is_coinbase = self.build_config.is_coinbase();
+
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let ironwood_actions = self
+            .ironwood_builder
+            .as_ref()
+            .map_or(Ok(0), |builder| {
+                orchard_action_count(
+                    builder,
+                    is_coinbase,
+                    orchard::bundle::BundleVersion::ironwood_v3(),
+                )
+            })
+            .map_err(FeeError::Bundle)?;
+
+        #[cfg(not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")))]
+        let ironwood_actions = 0;
 
         fee_rule
             .fee_required(
@@ -778,9 +1007,7 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                         )
                     })
                     .map_err(FeeError::Bundle)?,
-                // The builder does not yet construct Ironwood bundles, so they
-                // contribute no actions to the fee.
-                0,
+                ironwood_actions,
             )
             .map_err(FeeError::FeeRule)
     }
@@ -966,6 +1193,21 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             None => (None, orchard::builder::BundleMetadata::empty()),
         };
 
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let (ironwood_bundle, ironwood_meta) = match self
+            .ironwood_builder
+            .and_then(|builder| {
+                builder
+                    .build(&mut rng)
+                    .map_err(Error::IronwoodBuild)
+                    .transpose()
+            })
+            .transpose()?
+        {
+            Some((bundle, meta)) => (Some(bundle), meta),
+            None => (None, orchard::builder::BundleMetadata::empty()),
+        };
+
         let unauthed_tx: TransactionData<A> = TransactionData {
             version: self.tx_version,
             consensus_branch_id: self.consensus_branch_id,
@@ -987,7 +1229,7 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             sapling_bundle,
             orchard_bundle,
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            ironwood_bundle: None,
+            ironwood_bundle,
         };
 
         //
@@ -1033,6 +1275,22 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             .transpose()
             .map_err(Error::OrchardBuild)?;
 
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let ironwood_bundle = unauthed_tx
+            .ironwood_bundle
+            .map(|b| {
+                let circuit_version = b.circuit_version();
+                b.create_proof(
+                    &orchard::circuit::ProvingKey::build(circuit_version),
+                    &mut rng,
+                )
+                .and_then(|b| {
+                    b.apply_signatures(&mut rng, *shielded_sig_commitment.as_ref(), orchard_saks)
+                })
+            })
+            .transpose()
+            .map_err(Error::IronwoodBuild)?;
+
         let authorized_tx = TransactionData {
             version: unauthed_tx.version,
             consensus_branch_id: unauthed_tx.consensus_branch_id,
@@ -1045,7 +1303,7 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             sapling_bundle,
             orchard_bundle,
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            ironwood_bundle: None,
+            ironwood_bundle,
         };
 
         // The unwrap() here is safe because the txid hashing
@@ -1054,6 +1312,8 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             transaction: authorized_tx.freeze().unwrap(),
             sapling_meta,
             orchard_meta,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_meta,
         })
     }
 }
@@ -1117,6 +1377,27 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             None => (None, orchard::builder::BundleMetadata::empty()),
         };
 
+        // The Ironwood bundle is only carried by V6 transactions; for any other version it is
+        // left empty (and `check_version_compatibility` above rejects an in-use Ironwood
+        // builder paired with a non-V6 version).
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let (ironwood_bundle, ironwood_meta) = if self.tx_version.has_ironwood() {
+            match self
+                .ironwood_builder
+                .map(|builder| {
+                    builder
+                        .build_for_pczt(&mut rng)
+                        .map_err(Error::IronwoodBuild)
+                })
+                .transpose()?
+            {
+                Some((bundle, meta)) => (Some(bundle), meta),
+                None => (None, orchard::builder::BundleMetadata::empty()),
+            }
+        } else {
+            (None, orchard::builder::BundleMetadata::empty())
+        };
+
         Ok(PcztResult {
             pczt_parts: PcztParts {
                 params: self.params,
@@ -1127,9 +1408,13 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                 transparent: transparent_bundle,
                 sapling: sapling_bundle,
                 orchard: orchard_bundle,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood: ironwood_bundle,
             },
             sapling_meta,
             orchard_meta,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_meta,
         })
     }
 }
@@ -1233,6 +1518,15 @@ mod tests {
         zip32::AccountId,
     };
 
+    // The Ironwood tests below reference `TxVersion`/`BranchId` directly; without the
+    // `transparent-inputs` feature these are not otherwise in scope.
+    #[cfg(all(
+        feature = "circuits",
+        zcash_unstable = "nu6.3",
+        not(feature = "transparent-inputs")
+    ))]
+    use {crate::transaction::TxVersion, zcash_protocol::consensus::BranchId};
+
     #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
     fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
         use zcash_protocol::consensus::BlockHeight;
@@ -1282,6 +1576,8 @@ mod tests {
             BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             },
         );
 
@@ -1301,6 +1597,8 @@ mod tests {
             BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             },
         );
 
@@ -1336,6 +1634,286 @@ mod tests {
         );
 
         assert!(builder.orchard_builder.is_none());
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn nu6_3_coinbase_builder_uses_ironwood_not_orchard() {
+        let builder = Builder::new(
+            nu6_3_test_network(),
+            zcash_protocol::consensus::BlockHeight::from_u32(10),
+            BuildConfig::Coinbase { miner_data: None },
+        );
+
+        assert!(builder.orchard_builder.is_none());
+        assert_eq!(
+            builder
+                .ironwood_builder
+                .as_ref()
+                .map(|_| orchard::bundle::BundleVersion::ironwood_v3()),
+            Some(orchard::bundle::BundleVersion::ironwood_v3())
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn nu6_3_coinbase_builder_has_ironwood_output_option() {
+        let recipient = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        )
+        .address_at(0u32, orchard::keys::Scope::External);
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Coinbase { miner_data: None },
+        );
+
+        assert_matches!(
+            builder.add_orchard_output::<Infallible>(
+                None,
+                recipient,
+                Zatoshis::const_from_u64(10_000),
+                MemoBytes::empty(),
+            ),
+            Err(Error::OrchardBuilderNotAvailable)
+        );
+
+        builder
+            .add_ironwood_output::<Infallible>(
+                None,
+                recipient,
+                Zatoshis::const_from_u64(10_000),
+                MemoBytes::empty(),
+            )
+            .unwrap();
+        assert_eq!(
+            builder.ironwood_builder.as_ref().map(|b| b.outputs().len()),
+            Some(1)
+        );
+        assert_eq!(
+            super::orchard_action_count(
+                builder.ironwood_builder.as_ref().unwrap(),
+                true,
+                orchard::bundle::BundleVersion::ironwood_v3()
+            )
+            .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    #[cfg(all(
+        feature = "circuits",
+        feature = "transparent-inputs",
+        zcash_unstable = "nu6.3"
+    ))]
+    fn build_for_pczt_preserves_explicit_v6_without_ironwood() {
+        use ::transparent::keys::NonHardenedChildIndex;
+
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: None,
+                ironwood_anchor: None,
+            },
+        );
+        builder
+            .propose_version::<Infallible>(TxVersion::V6)
+            .unwrap();
+
+        let mut transparent_signing_set = TransparentSigningSet::new();
+        let tsk = AccountPrivKey::from_seed(&TEST_NETWORK, &[0u8; 32], AccountId::ZERO).unwrap();
+        let sk = tsk
+            .derive_external_secret_key(NonHardenedChildIndex::ZERO)
+            .unwrap();
+        let pubkey = transparent_signing_set.add_key(sk);
+        let prev_coin = TxOut::new(
+            Zatoshis::const_from_u64(50000),
+            tsk.to_account_pubkey()
+                .derive_external_ivk()
+                .unwrap()
+                .derive_address(NonHardenedChildIndex::ZERO)
+                .unwrap()
+                .script()
+                .into(),
+        );
+
+        builder
+            .add_transparent_p2pkh_input(pubkey, OutPoint::fake(), prev_coin)
+            .unwrap();
+        builder
+            .add_transparent_output(
+                &TransparentAddress::PublicKeyHash([0; 20]),
+                Zatoshis::const_from_u64(40000),
+            )
+            .unwrap();
+
+        let res = builder
+            .build_for_pczt(
+                OsRng,
+                &crate::transaction::fees::zip317::FeeRule::standard(),
+            )
+            .unwrap();
+        assert_eq!(res.pczt_parts.version, TxVersion::V6);
+        assert_eq!(
+            res.pczt_parts.consensus_branch_id,
+            zcash_protocol::consensus::BranchId::Nu6_3
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn ironwood_change_marks_ironwood_in_use() {
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: None,
+                ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            },
+        );
+        let fvk = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        );
+        let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
+        builder
+            .add_ironwood_change_output::<crate::transaction::fees::zip317::FeeRule>(
+                fvk,
+                None,
+                recipient,
+                Zatoshis::const_from_u64(10_000),
+                MemoBytes::empty(),
+            )
+            .unwrap();
+
+        assert!(builder.ironwood_in_use());
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn build_for_pczt_accepts_v6_when_ironwood_is_used() {
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: None,
+                ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            },
+        );
+        let recipient = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        )
+        .address_at(0u32, orchard::keys::Scope::External);
+        builder
+            .add_ironwood_output::<crate::transaction::fees::zip317::FeeRule>(
+                None,
+                recipient,
+                Zatoshis::const_from_u64(10_000),
+                MemoBytes::empty(),
+            )
+            .unwrap();
+
+        assert_matches!(
+            builder.build_for_pczt(
+                OsRng,
+                &crate::transaction::fees::zip317::FeeRule::standard(),
+            ),
+            Err(Error::InsufficientFunds(_))
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn build_for_pczt_rejects_explicit_v5_when_ironwood_is_used() {
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: None,
+                ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            },
+        );
+        builder
+            .propose_version::<Infallible>(TxVersion::V5)
+            .unwrap();
+
+        let recipient = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        )
+        .address_at(0u32, orchard::keys::Scope::External);
+        builder
+            .add_ironwood_output::<crate::transaction::fees::zip317::FeeRule>(
+                None,
+                recipient,
+                Zatoshis::const_from_u64(10_000),
+                MemoBytes::empty(),
+            )
+            .unwrap();
+
+        assert_matches!(
+            builder.build_for_pczt(
+                OsRng,
+                &crate::transaction::fees::zip317::FeeRule::standard(),
+            ),
+            Err(Error::TargetIncompatible(
+                BranchId::Nu6_3,
+                TxVersion::V5,
+                None
+            ))
+        );
+    }
+
+    /// Test helper: returns a full viewing key, an Orchard note carrying the given
+    /// note plaintext `version`, and a dummy Merkle path, for exercising the
+    /// Ironwood builder's note-version handling.
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn ironwood_note_with_version(
+        version: orchard::note::NoteVersion,
+    ) -> (
+        orchard::keys::FullViewingKey,
+        orchard::Note,
+        orchard::tree::MerklePath,
+    ) {
+        let sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
+        let fvk = orchard::keys::FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, orchard::keys::Scope::External);
+        let value = orchard::value::NoteValue::from_raw(99);
+        let rho = orchard::note::Rho::from_bytes(&[1; 32]).unwrap();
+        let rseed = (0u8..=255)
+            .find_map(|b| orchard::note::RandomSeed::from_bytes([b; 32], &rho).into_option())
+            .expect("at least one test rseed is valid");
+        let note = orchard::Note::from_parts(recipient, value, rho, rseed, version).unwrap();
+        let zero = orchard::tree::MerkleHashOrchard::from_bytes(&[0; 32]).unwrap();
+        let merkle_path = orchard::tree::MerklePath::from_parts(0, [zero; 32]);
+
+        (fvk, note, merkle_path)
+    }
+
+    #[test]
+    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
+    fn add_ironwood_spend_rejects_v2_note_version() {
+        let mut builder = Builder::new(
+            nu6_3_test_network(),
+            10u32.into(),
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: None,
+                ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            },
+        );
+        let (fvk, note, merkle_path) = ironwood_note_with_version(orchard::note::NoteVersion::V2);
+
+        assert_matches!(
+            builder.add_ironwood_spend::<Infallible>(fvk, note, merkle_path),
+            Err(Error::IronwoodSpendUnsupportedNoteVersion(
+                orchard::note::NoteVersion::V2
+            ))
+        );
     }
 
     #[test]
@@ -1399,6 +1977,8 @@ mod tests {
             build_config: BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             },
             target_height: sapling_activation_height,
             expiry_height: sapling_activation_height + DEFAULT_TX_EXPIRY_DELTA,
@@ -1408,6 +1988,8 @@ mod tests {
             sapling_builder: None,
             orchard_builder: None,
             orchard_bundle_version: None,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_builder: None,
             _progress_notifier: (),
         };
 
@@ -1471,6 +2053,8 @@ mod tests {
         let build_config = BuildConfig::Standard {
             sapling_anchor: Some(witness1.root().into()),
             orchard_anchor: None,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood_anchor: None,
         };
         let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
 
@@ -1512,6 +2096,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: None,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             assert_matches!(
@@ -1532,6 +2118,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -1555,6 +2143,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -1577,6 +2167,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder.set_zip233_amount(Zatoshis::const_from_u64(50000));
@@ -1603,6 +2195,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -1639,6 +2233,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -1684,6 +2280,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -1732,6 +2330,8 @@ mod tests {
             let build_config = BuildConfig::Standard {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -827,31 +827,6 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             .map_err(Error::IronwoodRecipient)
     }
 
-    /// Adds a wallet-controlled Ironwood change output to the transaction.
-    ///
-    /// This uses [`orchard::note::NoteVersion::V3`].
-    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-    pub fn add_ironwood_change_output<FE>(
-        &mut self,
-        fvk: orchard::keys::FullViewingKey,
-        ovk: Option<orchard::keys::OutgoingViewingKey>,
-        recipient: orchard::Address,
-        value: Zatoshis,
-        memo: MemoBytes,
-    ) -> Result<(), Error<FE>> {
-        self.ironwood_builder
-            .as_mut()
-            .ok_or(Error::IronwoodBuilderNotAvailable)?
-            .add_change_output(
-                fvk,
-                ovk,
-                recipient,
-                orchard::value::NoteValue::from_raw(value.into()),
-                memo.into_bytes(),
-            )
-            .map_err(Error::IronwoodRecipient)
-    }
-
     /// Adds a Sapling note to be spent in this transaction.
     ///
     /// Returns an error if the given Merkle path does not have the same anchor as the
@@ -1791,35 +1766,6 @@ mod tests {
             res.pczt_parts.consensus_branch_id,
             zcash_protocol::consensus::BranchId::Nu6_3
         );
-    }
-
-    #[test]
-    #[cfg(all(feature = "circuits", zcash_unstable = "nu6.3"))]
-    fn ironwood_change_marks_ironwood_in_use() {
-        let mut builder = Builder::new(
-            nu6_3_test_network(),
-            10u32.into(),
-            BuildConfig::Standard {
-                sapling_anchor: None,
-                orchard_anchor: None,
-                ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-            },
-        );
-        let fvk = orchard::keys::FullViewingKey::from(
-            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
-        );
-        let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
-        builder
-            .add_ironwood_change_output::<crate::transaction::fees::zip317::FeeRule>(
-                fvk,
-                None,
-                recipient,
-                Zatoshis::const_from_u64(10_000),
-                MemoBytes::empty(),
-            )
-            .unwrap();
-
-        assert!(builder.ironwood_in_use());
     }
 
     #[test]

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1285,6 +1285,11 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
                     &mut rng,
                 )
                 .and_then(|b| {
+                    // Ironwood actions use the Orchard bundle type and the same
+                    // Orchard spend authority. The `IronwoodNu6_3Onward` pool
+                    // restrictions select the Ironwood circuit and flag rules;
+                    // `apply_signatures` only signs actions whose `ak` matches
+                    // a supplied spend authorizing key.
                     b.apply_signatures(&mut rng, *shielded_sig_commitment.as_ref(), orchard_saks)
                 })
             })

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1260,23 +1260,20 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             .transpose()
             .map_err(Error::SaplingBuild)?;
 
-        // Orchard and Ironwood actions share the post-NU6.3 circuit, so a single
-        // proving key serves both proofs when a V6 transaction carries both
-        // bundles. Build it once, from whichever bundle is present; their circuit
-        // versions agree whenever both are present.
+        // The Orchard and Ironwood circuit version is fixed by the transaction's
+        // consensus branch (both pools share the post-NU6.3 circuit), so derive it
+        // once from the branch rather than from a bundle. Only build the key when
+        // an Orchard or Ironwood bundle is actually present.
         let orchard_proving_key = {
-            let circuit_version = unauthed_tx
-                .orchard_bundle
-                .as_ref()
-                .map(|b| b.circuit_version());
+            let build_proving_key = unauthed_tx.orchard_bundle.is_some();
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            let circuit_version = circuit_version.or_else(|| {
-                unauthed_tx
-                    .ironwood_bundle
-                    .as_ref()
-                    .map(|b| b.circuit_version())
-            });
-            circuit_version.map(orchard::circuit::ProvingKey::build)
+            let build_proving_key = build_proving_key || unauthed_tx.ironwood_bundle.is_some();
+            build_proving_key.then(|| {
+                orchard::circuit::ProvingKey::build(
+                    orchard_bundle_version_for_branch(unauthed_tx.consensus_branch_id)
+                        .circuit_version(),
+                )
+            })
         };
 
         let orchard_bundle = unauthed_tx

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -746,6 +746,33 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             .map_err(Error::OrchardRecipient)
     }
 
+    /// Adds a wallet-controlled Orchard change output to the transaction.
+    ///
+    /// Returns [`Error::OrchardBuilderNotAvailable`] if this builder is not
+    /// configured with an Orchard bundle builder. Returns
+    /// [`Error::OrchardRecipient`] if the Orchard builder rejects the recipient
+    /// or cannot construct the output.
+    pub fn add_orchard_change_output<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder
+            .as_mut()
+            .ok_or(Error::OrchardBuilderNotAvailable)?
+            .add_change_output(
+                fvk,
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::OrchardRecipient)
+    }
+
     /// Adds an Ironwood note to be spent in this bundle.
     ///
     /// The note must use [`orchard::note::NoteVersion::V3`], the Ironwood
@@ -960,8 +987,6 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             .as_ref()
             .map_or(0, |builder| builder.inputs().len());
 
-        let is_coinbase = self.build_config.is_coinbase();
-
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
         let ironwood_actions = self
             .ironwood_builder
@@ -969,7 +994,7 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
             .map_or(Ok(0), |builder| {
                 orchard_action_count(
                     builder,
-                    is_coinbase,
+                    self.build_config.is_coinbase(),
                     orchard::bundle::BundleVersion::ironwood_v3(),
                 )
             })
@@ -1926,29 +1951,57 @@ mod tests {
         feature = "circuits",
         any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")
     ))]
-    fn orchard_action_count_includes_change_outputs() {
-        let fvk = orchard::keys::FullViewingKey::from(
-            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
-        );
-        let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
+    fn orchard_action_count_uses_cross_address_disabled_count() {
+        let spend_sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
+        let spend_fvk = orchard::keys::FullViewingKey::from(&spend_sk);
+        let spend_recipient = spend_fvk.address_at(0u32, orchard::keys::Scope::External);
+        let rho = orchard::note::Rho::from_bytes(&[1; 32]).unwrap();
+        let rseed = (0u8..=255)
+            .find_map(|b| orchard::note::RandomSeed::from_bytes([b; 32], &rho).into_option())
+            .expect("at least one test rseed is valid");
+        let note = orchard::Note::from_parts(
+            spend_recipient,
+            orchard::value::NoteValue::from_raw(10_000),
+            rho,
+            rseed,
+            orchard::note::NoteVersion::V2,
+        )
+        .unwrap();
+        let leaf = orchard::tree::MerkleHashOrchard::from_cmx(&note.commitment().into());
+        let mut tree = CommitmentTree::<orchard::tree::MerkleHashOrchard, 32>::empty();
+        tree.append(leaf).unwrap();
+        let witness = IncrementalWitness::from_tree(tree).unwrap();
+        let anchor = witness.root().into();
+        let merkle_path = witness.path().unwrap().into();
+
         let mut builder = orchard::builder::Builder::new(
             orchard::builder::BundleType::DEFAULT,
             orchard::bundle::BundleVersion::orchard_v3(),
             orchard::bundle::BundleVersion::orchard_v3().default_flags(),
-            orchard::Anchor::empty_tree(),
+            anchor,
         )
         .unwrap();
 
-        builder
-            .add_change_output(
-                fvk,
-                None,
-                recipient,
-                orchard::value::NoteValue::from_raw(5_000),
-                [0u8; 512],
-            )
-            .unwrap();
+        builder.add_spend(spend_fvk, note, merkle_path).unwrap();
 
+        for seed in [[8u8; 32], [9u8; 32]] {
+            let change_fvk = orchard::keys::FullViewingKey::from(
+                &orchard::keys::SpendingKey::from_bytes(seed).unwrap(),
+            );
+            let recipient = change_fvk.address_at(0u32, orchard::keys::Scope::Internal);
+            builder
+                .add_change_output(
+                    change_fvk,
+                    None,
+                    recipient,
+                    orchard::value::NoteValue::from_raw(1_000),
+                    [0u8; 512],
+                )
+                .unwrap();
+        }
+
+        assert_eq!(builder.spends().len(), 1);
+        assert_eq!(builder.changes().len(), 2);
         assert_eq!(
             super::orchard_action_count(
                 &builder,
@@ -1956,7 +2009,42 @@ mod tests {
                 orchard::bundle::BundleVersion::orchard_v3(),
             )
             .unwrap(),
-            2
+            3
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn add_orchard_change_output_records_change() {
+        let target_height = TEST_NETWORK.activation_height(NetworkUpgrade::Nu5).unwrap();
+        let mut builder = Builder::new(
+            TEST_NETWORK,
+            target_height,
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: Some(orchard::Anchor::empty_tree()),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood_anchor: None,
+            },
+        );
+        let fvk = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        );
+        let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
+
+        builder
+            .add_orchard_change_output::<Infallible>(
+                fvk,
+                None,
+                recipient,
+                Zatoshis::const_from_u64(5_000),
+                MemoBytes::empty(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            builder.orchard_builder.as_ref().map(|b| b.changes().len()),
+            Some(1)
         );
     }
 


### PR DESCRIPTION
Adds builder support for constructing Ironwood bundles in v6 transactions, in parallel to the existing Orchard path.

Stacked on `adam/bump-orchard-30c4ea2` (the Ironwood builder uses `BundlePoolRestrictions::IronwoodNu6_3Onward` and the pool-parameterized orchard builder from there); retarget to `feat/ironwood` once that merges.

- Five Ironwood `Error` variants plus `IronwoodBuilderNotAvailable`.
- `BuildConfig::ironwood_anchor` and `ironwood_builder()` (pins `IronwoodNu6_3Onward`).
- `Builder`: `add_ironwood_spend` (enforces `NoteVersion::V3`), `add_ironwood_output`, `add_ironwood_change_output`, and the `build()`/`build_for_pczt()` wiring (construct, prove, sign, fee/action count, metadata). The Ironwood builder is created exactly when the branch's default transaction version is V6 (NU6.3 onward).

The `ironwood_anchor` field is cfg-gated on `nu6.3`/`nu7`, so the existing `BuildConfig::Standard` constructors in `pczt`, a `zcash_client_sqlite` migration, and the `zcash_client_backend` build path gain `ironwood_anchor: None` (wallet-side Ironwood building is a later split).
