### PR TITLE
zcash_client_backend: Batch transparent input gathering when shielding

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -20,6 +20,12 @@ workspace.
     which records that a transparent outpoint was confirmed unspent as of a given
     height.
 - `zcash_client_backend::data_api::error::RewindError`
+- `zcash_client_backend::data_api::InputSource::get_spendable_transparent_outputs_for_addresses`,
+  a batched equivalent of `get_spendable_transparent_outputs` that returns the spendable
+  transparent outputs for a set of addresses. It has a default implementation that queries each
+  address individually, so existing implementors are unaffected; data stores may override it to
+  satisfy the request with a single query. Shielding now uses this method, avoiding a per-address
+  database round-trip when gathering inputs from wallets with many transparent addresses.
 - `zcash_client_backend::data_api::ll::wallet::PutBlocksError::ShardTreeForBlockRange`,
   a new variant that wraps a `shardtree` insertion error together with the
   shielded pool whose note commitment tree was being updated and the range of

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1550,6 +1550,39 @@ pub trait InputSource {
             "InputSource::get_spendable_transparent_outputs must be overridden for wallets to use the `transparent-inputs` feature"
         )
     }
+
+    /// Returns the list of spendable transparent outputs received by this wallet at any of the
+    /// given `addresses`, subject to the same spendability conditions as
+    /// [`InputSource::get_spendable_transparent_outputs`].
+    ///
+    /// This is the batched equivalent of calling
+    /// [`InputSource::get_spendable_transparent_outputs`] once per address. It exists so that data
+    /// stores can satisfy a multi-address request with a single query rather than one query per
+    /// address, which is prohibitively expensive for wallets that hold large numbers of transparent
+    /// addresses (as occurs when shielding). The default implementation simply iterates over
+    /// `addresses`; data stores should override it with a batched query where possible.
+    ///
+    /// Each returned output identifies its receiving address via
+    /// [`WalletTransparentOutput::recipient_address`].
+    #[cfg(feature = "transparent-inputs")]
+    fn get_spendable_transparent_outputs_for_addresses(
+        &self,
+        addresses: &[TransparentAddress],
+        target_height: TargetHeight,
+        confirmations_policy: ConfirmationsPolicy,
+        output_filter: TransparentOutputFilter,
+    ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+        let mut outputs = Vec::new();
+        for address in addresses {
+            outputs.extend(self.get_spendable_transparent_outputs(
+                address,
+                target_height,
+                confirmations_policy,
+                output_filter,
+            )?);
+        }
+        Ok(outputs)
+    }
 }
 
 /// Read-only operations required for light wallet functions.

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -455,6 +455,124 @@ where
     );
 }
 
+/// Verifies that `InputSource::get_spendable_transparent_outputs_for_addresses` returns the
+/// spendable outputs for a *set* of addresses in a single call, equivalent to the union of
+/// per-address queries, and honours subset and empty requests.
+pub fn get_spendable_transparent_outputs_for_addresses<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let birthday = st.test_account().unwrap().birthday().height();
+
+    let height_1 = birthday + 12345;
+    st.wallet_mut().update_chain_tip(height_1).unwrap();
+
+    // Obtain three distinct transparent receivers for the account.
+    let mut taddrs = Vec::new();
+    while taddrs.len() < 3 {
+        let (ua, _) = st
+            .wallet_mut()
+            .get_next_available_address(account_id, UnifiedAddressRequest::AllAvailableKeys)
+            .unwrap()
+            .expect("an address should be available within the gap limit");
+        if let Some(taddr) = ua.transparent() {
+            taddrs.push(*taddr);
+        }
+    }
+
+    // Place one distinct UTXO at each address.
+    let value = Zatoshis::const_from_u64(100_000);
+    for (i, taddr) in taddrs.iter().enumerate() {
+        let mut hash = [0u8; 32];
+        hash[..4].copy_from_slice(&(i as u32).to_le_bytes());
+        let utxo = WalletTransparentOutput::from_parts(
+            OutPoint::new(hash, 0),
+            TxOut::new(value, taddr.script().into()),
+            Some(height_1),
+            Some(account_id),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .unwrap();
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .unwrap();
+    }
+
+    let target_height = TargetHeight::from(height_1 + 1);
+    let sorted = |mut v: Vec<TransparentAddress>| {
+        v.sort();
+        v
+    };
+
+    // The batched query over all three addresses returns one output per address.
+    let all = st
+        .wallet()
+        .get_spendable_transparent_outputs_for_addresses(
+            &taddrs,
+            target_height,
+            ConfirmationsPolicy::MIN,
+            TransparentOutputFilter::All,
+        )
+        .unwrap();
+    assert_eq!(all.len(), 3);
+    assert_eq!(
+        sorted(all.iter().map(|u| *u.recipient_address()).collect()),
+        sorted(taddrs.clone()),
+    );
+
+    // It is equivalent to the union of per-address queries.
+    let mut per_address = Vec::new();
+    for taddr in &taddrs {
+        per_address.extend(
+            st.wallet()
+                .get_spendable_transparent_outputs(
+                    taddr,
+                    target_height,
+                    ConfirmationsPolicy::MIN,
+                    TransparentOutputFilter::All,
+                )
+                .unwrap(),
+        );
+    }
+    assert_eq!(
+        sorted(all.iter().map(|u| *u.recipient_address()).collect()),
+        sorted(per_address.iter().map(|u| *u.recipient_address()).collect()),
+    );
+
+    // A subset request returns only the requested address's output.
+    let subset = st
+        .wallet()
+        .get_spendable_transparent_outputs_for_addresses(
+            &taddrs[..1],
+            target_height,
+            ConfirmationsPolicy::MIN,
+            TransparentOutputFilter::All,
+        )
+        .unwrap();
+    assert_eq!(subset.len(), 1);
+    assert_eq!(subset[0].recipient_address(), &taddrs[0]);
+
+    // An empty request returns no outputs.
+    assert!(
+        st.wallet()
+            .get_spendable_transparent_outputs_for_addresses(
+                &[],
+                target_height,
+                ConfirmationsPolicy::MIN,
+                TransparentOutputFilter::All,
+            )
+            .unwrap()
+            .is_empty()
+    );
+}
+
 /// This test attempts to verify that transparent funds spendability is
 /// accounted for properly given the different minimum confirmations values
 /// that can be set when querying for balances.

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1374,49 +1374,48 @@ fn gather_shielding_inputs<DbT, ChangeErrT>(
 where
     DbT: InputSource,
 {
-    let (transparent_inputs, _, _) = source_addrs.iter().try_fold(
-        (
-            vec![],
-            BTreeSet::<TransparentAddress>::new(),
-            BTreeSet::<TransparentAddress>::new(),
-        ),
-        |(mut inputs, mut ephemeral_addrs, mut input_addrs), taddr| {
-            use transparent::keys::TransparentKeyScope;
+    use transparent::keys::TransparentKeyScope;
 
-            let utxos = wallet_db
-                .get_spendable_transparent_outputs(
-                    taddr,
-                    target_height,
-                    confirmations_policy,
-                    output_filter,
-                )
-                .map_err(InputSelectorError::DataSource)?;
+    // Gather the spendable UTXOs for every source address in a single query. This avoids issuing
+    // one query per address (including for the many addresses that have no spendable outputs),
+    // which is prohibitively expensive for wallets that hold large numbers of transparent
+    // addresses.
+    let utxos = wallet_db
+        .get_spendable_transparent_outputs_for_addresses(
+            source_addrs,
+            target_height,
+            confirmations_policy,
+            output_filter,
+        )
+        .map_err(InputSelectorError::DataSource)?;
 
-            // `InputSource::get_spendable_transparent_outputs` is required to return
-            // outputs received by `taddr`, so these `.extend()` calls are guaranteed
-            // to add at most a single new address to each set. But it's more
-            // convenient this way as we can reuse `utxo.recipient_key_scope()`
-            // instead of needing to query the wallet twice for each address to
-            // determine their scopes.
-            ephemeral_addrs.extend(utxos.iter().filter_map(|utxo| {
-                (utxo.recipient_key_scope() == Some(TransparentKeyScope::EPHEMERAL))
-                    .then_some(utxo.recipient_address())
-            }));
-            input_addrs.extend(utxos.iter().map(|utxo| utxo.recipient_address()));
-            inputs.extend(utxos.into_iter().map(|utxo| utxo.redact_account_data()));
+    // We use `recipient_key_scope()` and `recipient_address()` from the returned outputs to
+    // determine the set of input addresses and which of them are ephemeral, rather than querying
+    // the wallet again per address.
+    let ephemeral_addrs = utxos
+        .iter()
+        .filter_map(|utxo| {
+            (utxo.recipient_key_scope() == Some(TransparentKeyScope::EPHEMERAL))
+                .then_some(utxo.recipient_address())
+        })
+        .collect::<BTreeSet<_>>();
+    let input_addrs = utxos
+        .iter()
+        .map(|utxo| utxo.recipient_address())
+        .collect::<BTreeSet<_>>();
 
-            // Funds may be spent from at most one ephemeral address at a time. If there are no
-            // ephemeral addresses, we allow shielding from multiple transparent addresses.
-            if !ephemeral_addrs.is_empty() && input_addrs.len() > 1 {
-                Err(InputSelectorError::Proposal(
-                    ProposalError::EphemeralAddressLinkability,
-                ))
-            } else {
-                Ok((inputs, ephemeral_addrs, input_addrs))
-            }
-        },
-    )?;
-    Ok(transparent_inputs)
+    // Funds may be spent from at most one ephemeral address at a time. If there are no
+    // ephemeral addresses, we allow shielding from multiple transparent addresses.
+    if !ephemeral_addrs.is_empty() && input_addrs.len() > 1 {
+        return Err(InputSelectorError::Proposal(
+            ProposalError::EphemeralAddressLinkability,
+        ));
+    }
+
+    Ok(utxos
+        .into_iter()
+        .map(|utxo| utxo.redact_account_data())
+        .collect())
 }
 
 /// Resolves a [`ZcashAddress`] destination for a shielding proposal to the

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -609,6 +609,24 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         )
     }
 
+    #[cfg(feature = "transparent-inputs")]
+    fn get_spendable_transparent_outputs_for_addresses(
+        &self,
+        addresses: &[TransparentAddress],
+        target_height: TargetHeight,
+        confirmations_policy: ConfirmationsPolicy,
+        output_filter: TransparentOutputFilter,
+    ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+        wallet::transparent::get_spendable_transparent_outputs_for_addresses(
+            self.conn.borrow(),
+            &self.params,
+            addresses,
+            target_height,
+            confirmations_policy,
+            output_filter,
+        )
+    }
+
     /// Returns metadata for the spendable notes in the wallet.
     fn get_account_metadata(
         &self,

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1328,6 +1328,107 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     Ok(utxos)
 }
 
+/// Returns the list of spendable transparent outputs received by this wallet at any of the
+/// given `addresses`, under the same spendability conditions as
+/// [`get_spendable_transparent_outputs`].
+///
+/// This is the batched equivalent of [`get_spendable_transparent_outputs`]: it issues a single
+/// query over the entire set of provided addresses rather than one query per address, which avoids
+/// a per-address database round-trip (and, for each empty address, a wasted query) when shielding
+/// from a wallet that holds large numbers of transparent addresses. Each returned output
+/// identifies its receiving address, so a caller that needs to group results by address can do so
+/// from the returned values.
+///
+/// The query body mirrors that of [`get_spendable_transparent_outputs`], differing only in that
+/// the receiving address is matched against a set via `rarray` rather than a single value.
+pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Parameters>(
+    conn: &rusqlite::Connection,
+    params: &P,
+    addresses: &[TransparentAddress],
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    output_filter: TransparentOutputFilter,
+) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
+    if addresses.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let coinbase_only = match output_filter {
+        TransparentOutputFilter::All => 0i32,
+        TransparentOutputFilter::CoinbaseOnly => 1i32,
+    };
+
+    let mut stmt_utxos = conn.prepare_cached(&format!(
+        "SELECT t.txid, u.output_index, u.script,
+                u.value_zat, addresses.key_scope,
+                accounts.uuid AS account_uuid,
+                u.transaction_id AS creating_tx_id,
+                addresses.imported_transparent_receiver_script,
+                t.mined_height AS received_height
+         FROM transparent_received_outputs u
+         JOIN transactions t ON t.id_tx = u.transaction_id
+         JOIN accounts ON accounts.id = u.account_id
+         JOIN addresses ON addresses.id = u.address_id
+         WHERE addresses.cached_transparent_receiver_address IN rarray(:addresses)
+         AND u.value_zat > :min_value
+         AND ({}) -- the transaction is mined or unexpired with minconf 0
+         AND u.id NOT IN ({}) -- and the output is unspent
+         AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
+         AND ({}) -- exclude immature coinbase outputs
+         AND (:coinbase_only == 0 OR IFNULL(t.tx_index, 1) == 0) -- coinbase filter: unknown tx_index defaults to 1 (non-coinbase) to avoid false positives
+         ORDER BY addresses.cached_transparent_receiver_address, u.output_index",
+        tx_unexpired_condition_minconf_0("t"),
+        spent_utxos_clause(),
+        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        excluding_immature_coinbase_outputs("t"),
+    ))?;
+
+    // We treat all transparent UTXOs as untrusted; however, if zero-conf shielding
+    // is enabled, we set the minimum number of confirmations to zero.
+    let min_confirmations = if confirmations_policy.allow_zero_conf_shielding() {
+        0u32
+    } else {
+        u32::from(confirmations_policy.untrusted())
+    };
+
+    let address_values: Vec<Value> = addresses
+        .iter()
+        .map(|addr| Value::Text(addr.encode(params)))
+        .collect();
+    let addresses_ptr = Rc::new(address_values);
+
+    let mut rows = stmt_utxos.query(named_params![
+        ":addresses": &addresses_ptr,
+        ":target_height": u32::from(target_height),
+        ":min_confirmations": min_confirmations,
+        ":min_value": u64::from(zip317::MARGINAL_FEE),
+        ":coinbase_only": coinbase_only,
+    ])?;
+
+    let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
+    while let Some(row) = rows.next()? {
+        let mut output = to_unspent_transparent_output(conn, row)?;
+
+        // If the address has a redeem script, compute the known input size for fee
+        // estimation so that the ZIP 317 fee calculator can handle P2SH inputs.
+        let imported_transparent_receiver_script_bytes: Option<Vec<u8>> =
+            row.get("imported_transparent_receiver_script")?;
+        if let Some(rs_bytes) = imported_transparent_receiver_script_bytes {
+            if let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes)) {
+                if let Some(input_size) =
+                    transparent::builder::p2sh_input_serialized_len(&from_chain)
+                {
+                    output = output.with_known_input_size(input_size);
+                }
+            }
+        }
+
+        utxos.push(output);
+    }
+
+    Ok(utxos)
+}
+
 /// Returns a mapping from each transparent receiver associated with the specified account
 /// to its not-yet-shielded UTXO balance, including only the effects of transactions mined
 /// at a block height less than or equal to `summary_height`.
@@ -2502,6 +2603,13 @@ mod tests {
         zcash_client_backend::data_api::testing::transparent::shielding_many_transparent_utxos(
             TestDbFactory::default(),
             BlockCache::new(),
+        );
+    }
+
+    #[test]
+    fn get_spendable_transparent_outputs_for_addresses() {
+        zcash_client_backend::data_api::testing::transparent::get_spendable_transparent_outputs_for_addresses(
+            TestDbFactory::default(),
         );
     }
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1251,81 +1251,20 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     confirmations_policy: ConfirmationsPolicy,
     output_filter: TransparentOutputFilter,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
-    let coinbase_only = match output_filter {
-        TransparentOutputFilter::All => 0i32,
-        TransparentOutputFilter::CoinbaseOnly => 1i32,
-    };
-
-    // This statement is re-run once per source address when shielding, so it is prepared via
-    // `prepare_cached` to avoid recompiling it on each call. The address is matched against
-    // `addresses.cached_transparent_receiver_address` (rather than the denormalized
-    // `transparent_received_outputs.address`) so that the lookup is served by an index on the
-    // `addresses` table and joined to the outputs via `idx_transparent_received_outputs_address`,
-    // instead of scanning the full `transparent_received_outputs` table.
-    let mut stmt_utxos = conn.prepare_cached(&format!(
-        "SELECT t.txid, u.output_index, u.script,
-                u.value_zat, addresses.key_scope,
-                accounts.uuid AS account_uuid,
-                u.transaction_id AS creating_tx_id,
-                addresses.imported_transparent_receiver_script,
-                t.mined_height AS received_height
-         FROM transparent_received_outputs u
-         JOIN transactions t ON t.id_tx = u.transaction_id
-         JOIN accounts ON accounts.id = u.account_id
-         JOIN addresses ON addresses.id = u.address_id
-         WHERE addresses.cached_transparent_receiver_address = :address
-         AND u.value_zat > :min_value
-         AND ({}) -- the transaction is mined or unexpired with minconf 0
-         AND u.id NOT IN ({}) -- and the output is unspent
-         AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-         AND ({}) -- exclude immature coinbase outputs
-         AND (:coinbase_only == 0 OR IFNULL(t.tx_index, 1) == 0) -- coinbase filter: unknown tx_index defaults to 1 (non-coinbase) to avoid false positives",
-        tx_unexpired_condition_minconf_0("t"),
-        spent_utxos_clause(),
-        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
-        excluding_immature_coinbase_outputs("t"),
-    ))?;
-
-    let addr_str = address.encode(params);
-
-    // We treat all transparent UTXOs as untrusted; however, if zero-conf shielding
-    // is enabled, we set the minimum number of confirmations to zero.
-    let min_confirmations = if confirmations_policy.allow_zero_conf_shielding() {
-        0u32
-    } else {
-        u32::from(confirmations_policy.untrusted())
-    };
-
-    let mut rows = stmt_utxos.query(named_params![
-        ":address": addr_str,
-        ":target_height": u32::from(target_height),
-        ":min_confirmations": min_confirmations,
-        ":min_value": u64::from(zip317::MARGINAL_FEE),
-        ":coinbase_only": coinbase_only,
-    ])?;
-
-    let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
-    while let Some(row) = rows.next()? {
-        let mut output = to_unspent_transparent_output(conn, row)?;
-
-        // If the address has a redeem script, compute the known input size for fee
-        // estimation so that the ZIP 317 fee calculator can handle P2SH inputs.
-        let imported_transparent_receiver_script_bytes: Option<Vec<u8>> =
-            row.get("imported_transparent_receiver_script")?;
-        if let Some(rs_bytes) = imported_transparent_receiver_script_bytes {
-            if let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes)) {
-                if let Some(input_size) =
-                    transparent::builder::p2sh_input_serialized_len(&from_chain)
-                {
-                    output = output.with_known_input_size(input_size);
-                }
-            }
-        }
-
-        utxos.push(output);
-    }
-
-    Ok(utxos)
+    // Defer to the batched query with a singleton address set, so that there is a single query
+    // body to maintain. `transparent_received_outputs.address` is always equal to the
+    // `cached_transparent_receiver_address` of the joined `addresses` row (both are written from
+    // the same recipient address on insert, and the gap-limit migration backfilled this invariant
+    // for pre-existing rows), so matching on the latter for a single address selects the same
+    // outputs as the former.
+    get_spendable_transparent_outputs_for_addresses(
+        conn,
+        params,
+        core::slice::from_ref(address),
+        target_height,
+        confirmations_policy,
+        output_filter,
+    )
 }
 
 /// Returns the list of spendable transparent outputs received by this wallet at any of the


### PR DESCRIPTION
Part of the transparent-wallet-at-scale performance target #2470. This is the first of a stacked pair for #2472; a follow-up PR adds the per-transaction input cap.

`gather_shielding_inputs` called `InputSource::get_spendable_transparent_outputs` once per source address, issuing one database query per address — including for the many addresses that have no spendable outputs. For wallets that hold large numbers of transparent addresses (e.g. exchange/custodial wallets, or wallets recovered from a `zcashd` import), shielding therefore performed up to hundreds of thousands of queries.

This adds `InputSource::get_spendable_transparent_outputs_for_addresses`, a batched equivalent that returns the spendable outputs for a set of addresses. It has a default implementation that queries each address individually, so existing implementors are unaffected; the `zcash_client_sqlite` implementation overrides it with a single query that matches the receiving address against the set via `rarray`, ordered deterministically. `gather_shielding_inputs` now issues one query and applies the single-ephemeral linkability guard once over the full result, so the set of selected outputs (and hence the resulting proposal) is unchanged.

Includes a multi-address regression test (the prior shielding tests all used a single source address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
