### PR TITLE
zcash_client_backend: Cap shielding transparent inputs to a fraction of block space

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -26,6 +26,13 @@ workspace.
   address individually, so existing implementors are unaffected; data stores may override it to
   satisfy the request with a single query. Shielding now uses this method, avoiding a per-address
   database round-trip when gathering inputs from wallets with many transparent addresses.
+- `zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelector::with_shielding_block_space_percent`,
+  which configures the maximum fraction of a block's space (as an integer percentage, default 10)
+  that a single shielding transaction's transparent inputs may occupy. When shielding gathers more
+  spendable transparent outputs than fit within this bound, the highest-value outputs are selected
+  first and the remainder are left unspent, to be consolidated by a subsequent shielding
+  transaction. This bounds the size of the shielding transaction for wallets that hold very large
+  numbers of transparent UTXOs.
 - `zcash_client_backend::data_api::ll::wallet::PutBlocksError::ShardTreeForBlockRange`,
   a new variant that wraps a `shardtree` insertion error together with the
   shielded pool whose note commitment tree was being updated and the range of

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -573,6 +573,103 @@ where
     );
 }
 
+/// Verifies that a shielding proposal caps the number of transparent inputs in a single
+/// transaction to the selector's configured fraction of block space, selecting the highest-value
+/// UTXOs first and leaving the remainder unspent.
+pub fn shielding_transparent_input_cap<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    // At 1% of block space the cap is (2_000_000 * 1 / 100) / 150 = 133 inputs.
+    const BLOCK_SPACE_PERCENT: u32 = 1;
+    const CAP: usize = 133;
+    const NUM_UTXOS: usize = CAP + 7; // 140; the 7 smallest must be dropped.
+    const BASE: u64 = 100_000;
+    const STEP: u64 = 1_000;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account.id(), UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    // Initialize the wallet with chain data that has no shielded notes for us.
+    let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+    let not_our_value = Zatoshis::const_from_u64(10_000);
+    let (start_height, _, _) =
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    for _ in 1..10 {
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    }
+    st.scan_cached_blocks(start_height, 10);
+
+    // Add `NUM_UTXOS` distinct-value P2PKH UTXOs at the same transparent address, so that
+    // largest-first selection is unambiguous.
+    let height = st.wallet().chain_height().unwrap().unwrap();
+    for i in 0..NUM_UTXOS {
+        let value = Zatoshis::const_from_u64(BASE + (i as u64) * STEP);
+        let mut hash = [0u8; 32];
+        hash[..4].copy_from_slice(&(i as u32).to_le_bytes());
+        let utxo = WalletTransparentOutput::from_parts(
+            OutPoint::new(hash, 0),
+            TxOut::new(value, taddr.script().into()),
+            Some(height),
+            Some(account.id()),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .unwrap();
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .unwrap();
+    }
+
+    // Propose shielding with a 1%-of-block-space input cap.
+    let input_selector =
+        GreedyInputSelector::new().with_shielding_block_space_percent(BLOCK_SPACE_PERCENT);
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedProtocol::Sapling,
+        DustOutputPolicy::default(),
+    );
+    let proposal = st
+        .propose_shielding(
+            &input_selector,
+            &change_strategy,
+            Zatoshis::const_from_u64(BASE),
+            &[*taddr],
+            account.id(),
+            ConfirmationsPolicy::MIN,
+            TransparentOutputFilter::All,
+        )
+        .expect("shielding proposal should succeed");
+
+    let inputs = proposal.steps().first().transparent_inputs();
+    assert_eq!(
+        inputs.len(),
+        CAP,
+        "the number of transparent inputs should be capped",
+    );
+
+    // The selected inputs must be the `CAP` highest-value UTXOs: the `NUM_UTXOS - CAP` smallest
+    // are dropped, so the smallest selected value is `BASE + (NUM_UTXOS - CAP) * STEP`.
+    let min_selected = inputs.iter().map(|u| u.value()).min().unwrap();
+    assert_eq!(
+        min_selected,
+        Zatoshis::const_from_u64(BASE + ((NUM_UTXOS - CAP) as u64) * STEP),
+        "the lowest-value UTXOs should be the ones left unspent",
+    );
+}
+
 /// This test attempts to verify that transparent funds spendability is
 /// accounted for properly given the different minimum confirmations values
 /// that can be set when querying for balances.

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -414,12 +414,25 @@ impl orchard_fees::OutputView for OrchardPayment {
     }
 }
 
+/// The Zcash consensus maximum block size, in bytes.
+#[cfg(feature = "transparent-inputs")]
+const MAX_BLOCK_BYTES: usize = 2_000_000;
+
+/// The default maximum fraction of a block's space, as an integer percentage, that a single
+/// shielding transaction's transparent inputs may occupy.
+#[cfg(feature = "transparent-inputs")]
+const DEFAULT_SHIELDING_BLOCK_SPACE_PERCENT: u32 = 10;
+
 /// An [`InputSelector`] implementation that uses a greedy strategy to select between available
 /// notes.
 ///
 /// This implementation performs input selection using methods available via the
 /// [`InputSource`] interface.
 pub struct GreedyInputSelector<DbT> {
+    /// The maximum fraction of a block's space, as an integer percentage (0–100), that a single
+    /// shielding transaction's transparent inputs may occupy.
+    #[cfg(feature = "transparent-inputs")]
+    shielding_block_space_percent: u32,
     _ds_type: PhantomData<DbT>,
 }
 
@@ -435,9 +448,32 @@ impl<DbT> GreedyInputSelector<DbT> {
     /// [`EphemeralBalance::Output`]: crate::fees::EphemeralBalance::Output
     pub fn new() -> Self {
         GreedyInputSelector {
+            #[cfg(feature = "transparent-inputs")]
+            shielding_block_space_percent: DEFAULT_SHIELDING_BLOCK_SPACE_PERCENT,
             _ds_type: PhantomData,
         }
     }
+
+    /// Sets the maximum fraction of a block's space, as an integer percentage (0–100), that a
+    /// single shielding transaction's transparent inputs may occupy.
+    ///
+    /// When shielding gathers more spendable transparent outputs than will fit within this bound,
+    /// the highest-value outputs are selected first and the remainder are left unspent, to be
+    /// consolidated by a subsequent shielding transaction. Values above 100 are clamped to 100.
+    /// Defaults to 10.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_shielding_block_space_percent(mut self, percent: u32) -> Self {
+        self.shielding_block_space_percent = percent.min(100);
+        self
+    }
+}
+
+/// Returns the maximum number of transparent inputs that a single shielding transaction may
+/// select, given the configured fraction of a block's space (as an integer percentage) that its
+/// inputs may occupy.
+#[cfg(feature = "transparent-inputs")]
+fn shielding_max_inputs(block_space_percent: u32) -> usize {
+    (MAX_BLOCK_BYTES.saturating_mul(block_space_percent as usize) / 100) / P2PKH_STANDARD_INPUT_SIZE
 }
 
 impl<DbT> Default for GreedyInputSelector<DbT> {
@@ -1157,6 +1193,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             target_height,
             confirmations_policy,
             output_filter,
+            shielding_max_inputs(self.shielding_block_space_percent),
         )?;
 
         let wallet_meta = change_strategy
@@ -1216,7 +1253,11 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         // rather than a more general "shield to address" path; only coinbase
         // outputs are eligible because they have no prior transparent transaction
         // graph that could be exposed to the shielded recipient.
-        let mut transparent_inputs = gather_shielding_inputs::<DbT, FeeRuleT::Error>(
+        // The block-space cap and the caller-supplied `limit` (when present) both bound the number
+        // of transparent inputs; `gather_shielding_inputs` applies the more restrictive of the two,
+        // keeping the highest-value UTXOs first. When `limit` is `Some(0)` this empties the set, and
+        // the subsequent `InsufficientFunds` check fires; this is the documented behavior.
+        let transparent_inputs = gather_shielding_inputs::<DbT, FeeRuleT::Error>(
             wallet_db,
             source_addrs,
             target_height,
@@ -1224,20 +1265,10 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             // as coinbase txs require 100, which will be enforced by note selection.
             ConfirmationsPolicy::MIN,
             TransparentOutputFilter::CoinbaseOnly,
+            limit
+                .unwrap_or(usize::MAX)
+                .min(shielding_max_inputs(self.shielding_block_space_percent)),
         )?;
-
-        // Apply the optional cap on selected UTXOs, keeping the highest-value
-        // UTXOs first (stable tiebreaker by outpoint for determinism). When
-        // `limit` is `Some(0)` this empties the set, and the subsequent
-        // `InsufficientFunds` check fires; this is the documented behavior.
-        if let Some(n) = limit {
-            transparent_inputs.sort_by(|a, b| {
-                b.value()
-                    .cmp(&a.value())
-                    .then_with(|| a.outpoint().cmp(b.outpoint()))
-            });
-            transparent_inputs.truncate(n);
-        }
 
         let destination_pool =
             resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(&to_address, params)?;
@@ -1362,6 +1393,7 @@ fn gather_shielding_inputs<DbT, ChangeErrT>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: TransparentOutputFilter,
+    max_inputs: usize,
 ) -> Result<
     Vec<WalletTransparentOutput<()>>,
     InputSelectorError<
@@ -1380,7 +1412,7 @@ where
     // one query per address (including for the many addresses that have no spendable outputs),
     // which is prohibitively expensive for wallets that hold large numbers of transparent
     // addresses.
-    let utxos = wallet_db
+    let mut utxos = wallet_db
         .get_spendable_transparent_outputs_for_addresses(
             source_addrs,
             target_height,
@@ -1388,6 +1420,19 @@ where
             output_filter,
         )
         .map_err(InputSelectorError::DataSource)?;
+
+    // Cap the number of transparent inputs that a single shielding transaction may consume,
+    // keeping the highest-value UTXOs first (stable tiebreaker by outpoint for determinism). UTXOs
+    // beyond the cap are left unspent, to be consolidated by a subsequent shielding transaction.
+    // When `max_inputs` is 0 this empties the set, and the caller's `InsufficientFunds` check
+    // fires. The cap is applied before the linkability check below so that the check reflects the
+    // outputs that will actually be spent.
+    utxos.sort_by(|a, b| {
+        b.value()
+            .cmp(&a.value())
+            .then_with(|| a.outpoint().cmp(b.outpoint()))
+    });
+    utxos.truncate(max_inputs);
 
     // We use `recipient_key_scope()` and `recipient_address()` from the returned outputs to
     // determine the set of input addresses and which of them are ephemeral, rather than querying
@@ -1546,4 +1591,19 @@ where
         None,
         wallet_meta,
     )
+}
+
+#[cfg(all(test, feature = "transparent-inputs"))]
+mod tests {
+    use super::shielding_max_inputs;
+
+    #[test]
+    fn shielding_max_inputs_from_block_space_percent() {
+        // max_inputs = (MAX_BLOCK_BYTES * percent / 100) / P2PKH_STANDARD_INPUT_SIZE
+        //            = (2_000_000 * percent / 100) / 150
+        assert_eq!(shielding_max_inputs(0), 0);
+        assert_eq!(shielding_max_inputs(1), 133); // 20_000 / 150
+        assert_eq!(shielding_max_inputs(10), 1333); // 200_000 / 150
+        assert_eq!(shielding_max_inputs(100), 13333); // 2_000_000 / 150
+    }
 }

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2553,6 +2553,14 @@ mod tests {
     }
 
     #[test]
+    fn shielding_transparent_input_cap() {
+        zcash_client_backend::data_api::testing::transparent::shielding_transparent_input_cap(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
     fn transparent_balance_spendability() {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_spendability(
             TestDbFactory::default(),


### PR DESCRIPTION
Part of the transparent-wallet-at-scale performance target #2470. Stacked on #2488 (the batching half of #2472); the base will become `main` once #2488 merges.

Shielding gathered every spendable transparent UTXO into a single proposed transaction, which for wallets with very large UTXO sets produces a transaction that cannot be built or relayed. This caps the transparent inputs of a single shielding transaction to a configurable fraction of a block's space (default 10%), selecting the highest-value inputs first; the remainder is left unspent, to be consolidated by a subsequent (manually-initiated) shielding transaction.

The fraction is configured via `GreedyInputSelector::with_shielding_block_space_percent`. The cap (`(2_000_000 × percent / 100) / 150` inputs) is applied in `gather_shielding_inputs`, so both the standard and coinbase shielding paths share it, and the coinbase path's existing `limit` now composes with it (the more restrictive of the two applies).

Tests: a unit test of the cap math and an integration test asserting that, with a 1%-of-block-space cap and 140 distinct-value UTXOs, exactly the 133 highest-value UTXOs are selected.

Closes #2472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
