### PR TITLE
Add PCZT v2 serialization

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -43,6 +43,10 @@ workspace.
   `pczt::v1::Pczt`.
 - PCZT version 2 serialization, which encodes the Orchard note plaintext
   version at the Orchard bundle level.
+- `PartialEq` is now derived for the logical `pczt::transparent::{Bundle, Input,
+  Output}`, `pczt::sapling::{Bundle, Spend, Output}`, and
+  `pczt::orchard::{Bundle, Action, Spend, Output}` types (used to detect empty
+  bundles for v2 serialization).
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -23,6 +23,8 @@ workspace.
   `pczt::Pczt` type.
 - The Orchard PCZT logical model now tracks the Orchard bundle's note plaintext
   version separately from the version 1 serialization format.
+- PCZT version 2 serialization now omits empty Transparent, Sapling, and
+  Orchard bundles.
 - Direct `serde` serialization implementations have been removed from the
   logical `pczt::orchard::{Bundle, Action, Spend, Output}` types.
 - `pczt::Pczt::serialize` now consumes `self` and returns
@@ -39,6 +41,8 @@ workspace.
   encoding.
 - `pczt::v1`, a module providing the version 1 PCZT serialization format via
   `pczt::v1::Pczt`.
+- PCZT version 2 serialization, which encodes the Orchard note plaintext
+  version at the Orchard bundle level.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -47,6 +47,8 @@ workspace.
   Output}`, `pczt::sapling::{Bundle, Spend, Output}`, and
   `pczt::orchard::{Bundle, Action, Spend, Output}` types (used to detect empty
   bundles for v2 serialization).
+- The logical `pczt::Pczt` type now includes an Ironwood bundle behind
+  `zcash_unstable = "nu6.3"` and `zcash_unstable = "nu7"`.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -257,8 +257,9 @@ pub mod v2 {
         fn empty_bundles_encode_as_none_and_decode_as_empty() {
             // Zero anchors: the shielded bundles carry no anchor and no
             // spends/actions, so they are fully empty and omitted.
-            let pczt =
-                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
+            let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+                .unwrap()
+                .build();
 
             let encoded = Pczt::try_from(pczt).unwrap();
 
@@ -288,8 +289,9 @@ pub mod v2 {
             // A Sapling/Orchard bundle with a non-empty anchor differs from its
             // empty form, so it must not be omitted even with no spends/actions,
             // and the anchor must survive the v2 round-trip.
-            let pczt =
-                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32]).build();
+            let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32])
+                .unwrap()
+                .build();
 
             let encoded = Pczt::try_from(pczt).unwrap();
 
@@ -305,8 +307,9 @@ pub mod v2 {
 
         #[test]
         fn orchard_flags_and_note_version_do_not_prevent_omission() {
-            let mut pczt =
-                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
+            let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+                .unwrap()
+                .build();
             pczt.orchard.flags = 0;
             pczt.orchard.note_version = NoteVersion::V3;
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -111,7 +111,7 @@ pub mod v1 {
         }
     }
 
-    /// An encoder from the in-memory Pczt type to the type
+    /// Encodes the in-memory [`super::Pczt`] into the v1 serialization type [`Pczt`].
     impl TryFrom<super::Pczt> for Pczt {
         type Error = super::EncodingError;
 
@@ -144,41 +144,33 @@ pub mod v2 {
 
     use crate::{common, orchard, sapling, transparent};
 
-    fn empty_transparent() -> transparent::Bundle {
-        transparent::Bundle {
-            inputs: vec![],
-            outputs: vec![],
-        }
-    }
+    const EMPTY_TRANSPARENT: transparent::Bundle = transparent::Bundle {
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+    };
 
-    fn empty_sapling() -> sapling::Bundle {
-        sapling::Bundle {
-            spends: vec![],
-            outputs: vec![],
-            value_sum: 0,
-            anchor: [0; 32],
-            bsk: None,
-        }
-    }
-
-    fn empty_orchard() -> orchard::Bundle {
-        orchard::Bundle {
-            actions: vec![],
-            flags: 0,
-            value_sum: (0, true),
-            anchor: [0; 32],
-            note_version: orchard::NoteVersion::V2,
-            zkproof: None,
-            bsk: None,
-        }
-    }
+    const EMPTY_SAPLING: sapling::Bundle = sapling::Bundle {
+        spends: Vec::new(),
+        outputs: Vec::new(),
+        value_sum: 0,
+        anchor: [0; 32],
+        bsk: None,
+    };
 
     /// The in-memory type used for derived serialization of the v2 Pczt encoding.
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct Pczt {
         global: common::Global,
+        // This value is set to `None` if the transparent bundle is empty,
+        // meaning inputs and outputs are empty.
         transparent: Option<transparent::Bundle>,
+        // This value is set to `None` if the Sapling bundle is empty,
+        // meaning every field has its empty/default value.
         sapling: Option<sapling::Bundle>,
+        // This value is set to `None` if the Orchard bundle is empty,
+        // meaning actions, value sum, anchor, zkproof, and bsk are all
+        // empty. Flags and note version are not checked, as values can be
+        // defaulted there.
         orchard: Option<orchard::v2::Bundle>,
     }
 
@@ -191,21 +183,17 @@ pub mod v2 {
         }
     }
 
-    /// An encoder from the in-memory Pczt type to the type
+    /// Encodes the in-memory [`super::Pczt`] into the v2 serialization type [`Pczt`],
+    /// omitting empty Transparent, Sapling, and Orchard bundles.
     impl TryFrom<super::Pczt> for Pczt {
         type Error = super::EncodingError;
 
         fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
             Ok(Self {
                 global: pczt.global,
-                transparent: (!pczt.transparent.inputs.is_empty()
-                    || !pczt.transparent.outputs.is_empty())
-                .then_some(pczt.transparent),
-                sapling: (!pczt.sapling.spends.is_empty() || !pczt.sapling.outputs.is_empty())
-                    .then_some(pczt.sapling),
-                orchard: (!pczt.orchard.actions.is_empty())
-                    .then(|| orchard::v2::Bundle::try_from(pczt.orchard))
-                    .transpose()?,
+                transparent: (pczt.transparent != EMPTY_TRANSPARENT).then_some(pczt.transparent),
+                sapling: (pczt.sapling != EMPTY_SAPLING).then_some(pczt.sapling),
+                orchard: pczt.orchard.try_into()?,
             })
         }
     }
@@ -214,12 +202,12 @@ pub mod v2 {
         fn from(pczt: Pczt) -> Self {
             Self {
                 global: pczt.global,
-                transparent: pczt.transparent.unwrap_or_else(empty_transparent),
-                sapling: pczt.sapling.unwrap_or_else(empty_sapling),
+                transparent: pczt.transparent.unwrap_or(EMPTY_TRANSPARENT),
+                sapling: pczt.sapling.unwrap_or(EMPTY_SAPLING),
                 orchard: pczt
                     .orchard
                     .map(orchard::Bundle::from)
-                    .unwrap_or_else(empty_orchard),
+                    .unwrap_or(orchard::v2::EMPTY_BUNDLE),
             }
         }
     }
@@ -233,8 +221,10 @@ pub mod v2 {
 
         #[test]
         fn empty_bundles_encode_as_none_and_decode_as_empty() {
+            // Zero anchors: the shielded bundles carry no anchor and no
+            // spends/actions, so they are fully empty and omitted.
             let pczt =
-                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32]).build();
+                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
 
             let encoded = Pczt::try_from(pczt).unwrap();
 
@@ -250,6 +240,38 @@ pub mod v2 {
             assert!(decoded.sapling.outputs.is_empty());
             assert!(decoded.orchard.actions.is_empty());
             assert_eq!(decoded.orchard.note_version, NoteVersion::V2);
+        }
+
+        #[test]
+        fn anchored_bundles_are_preserved() {
+            // A Sapling/Orchard bundle with a non-empty anchor differs from its
+            // empty form, so it must not be omitted even with no spends/actions,
+            // and the anchor must survive the v2 round-trip.
+            let pczt =
+                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32]).build();
+
+            let encoded = Pczt::try_from(pczt).unwrap();
+
+            assert!(encoded.transparent.is_none());
+            assert!(encoded.sapling.is_some());
+            assert!(encoded.orchard.is_some());
+
+            let decoded = crate::parse(&encoded.serialize()).unwrap();
+
+            assert_eq!(decoded.sapling.anchor, [1; 32]);
+            assert_eq!(decoded.orchard.anchor, [2; 32]);
+        }
+
+        #[test]
+        fn orchard_flags_and_note_version_do_not_prevent_omission() {
+            let mut pczt =
+                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
+            pczt.orchard.flags = 0;
+            pczt.orchard.note_version = NoteVersion::V3;
+
+            let encoded = Pczt::try_from(pczt).unwrap();
+
+            assert!(encoded.orchard.is_none());
         }
     }
 }
@@ -286,10 +308,9 @@ impl Pczt {
 
     /// Serializes this PCZT as the latest PCZT version.
     ///
-    /// If you want a specific PCZT version, e.g. v1, use `v1::Pczt::serialize`
-    ///
+    /// To serialize a specific PCZT version, e.g. v1, use [`v1::Pczt::serialize`].
     pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
-        Ok(v2::Pczt::try_from(self.clone())?.serialize())
+        Ok(v2::Pczt::try_from(self)?.serialize())
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -56,6 +56,7 @@ pub mod transparent;
 
 pub(crate) const MAGIC_BYTES: &[u8] = b"PCZT";
 pub(crate) const PCZT_VERSION_1: u32 = 1;
+pub(crate) const PCZT_VERSION_2: u32 = 2;
 
 /// Parses a PCZT from its encoding.
 pub fn parse(bytes: &[u8]) -> Result<Pczt, ParseError> {
@@ -136,6 +137,123 @@ pub mod v1 {
     }
 }
 
+/// Types and operations for the v2 Pczt encoding.
+pub mod v2 {
+    use alloc::vec::Vec;
+    use serde::{Deserialize, Serialize};
+
+    use crate::{common, orchard, sapling, transparent};
+
+    fn empty_transparent() -> transparent::Bundle {
+        transparent::Bundle {
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+
+    fn empty_sapling() -> sapling::Bundle {
+        sapling::Bundle {
+            spends: vec![],
+            outputs: vec![],
+            value_sum: 0,
+            anchor: [0; 32],
+            bsk: None,
+        }
+    }
+
+    fn empty_orchard() -> orchard::Bundle {
+        orchard::Bundle {
+            actions: vec![],
+            flags: 0,
+            value_sum: (0, true),
+            anchor: [0; 32],
+            note_version: orchard::NoteVersion::V2,
+            zkproof: None,
+            bsk: None,
+        }
+    }
+
+    /// The in-memory type used for derived serialization of the v2 Pczt encoding.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Pczt {
+        global: common::Global,
+        transparent: Option<transparent::Bundle>,
+        sapling: Option<sapling::Bundle>,
+        orchard: Option<orchard::v2::Bundle>,
+    }
+
+    impl Pczt {
+        pub fn serialize(&self) -> Vec<u8> {
+            let mut bytes = vec![];
+            bytes.extend_from_slice(crate::MAGIC_BYTES);
+            bytes.extend_from_slice(&crate::PCZT_VERSION_2.to_le_bytes());
+            postcard::to_extend(&self, bytes).expect("can serialize into memory")
+        }
+    }
+
+    /// An encoder from the in-memory Pczt type to the type
+    impl TryFrom<super::Pczt> for Pczt {
+        type Error = super::EncodingError;
+
+        fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
+            Ok(Self {
+                global: pczt.global,
+                transparent: (!pczt.transparent.inputs.is_empty()
+                    || !pczt.transparent.outputs.is_empty())
+                .then_some(pczt.transparent),
+                sapling: (!pczt.sapling.spends.is_empty() || !pczt.sapling.outputs.is_empty())
+                    .then_some(pczt.sapling),
+                orchard: (!pczt.orchard.actions.is_empty())
+                    .then(|| orchard::v2::Bundle::try_from(pczt.orchard))
+                    .transpose()?,
+            })
+        }
+    }
+
+    impl From<Pczt> for super::Pczt {
+        fn from(pczt: Pczt) -> Self {
+            Self {
+                global: pczt.global,
+                transparent: pczt.transparent.unwrap_or_else(empty_transparent),
+                sapling: pczt.sapling.unwrap_or_else(empty_sapling),
+                orchard: pczt
+                    .orchard
+                    .map(orchard::Bundle::from)
+                    .unwrap_or_else(empty_orchard),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use zcash_protocol::consensus::BranchId;
+
+        use super::Pczt;
+        use crate::{orchard::NoteVersion, roles::creator::Creator};
+
+        #[test]
+        fn empty_bundles_encode_as_none_and_decode_as_empty() {
+            let pczt =
+                Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32]).build();
+
+            let encoded = Pczt::try_from(pczt).unwrap();
+
+            assert!(encoded.transparent.is_none());
+            assert!(encoded.sapling.is_none());
+            assert!(encoded.orchard.is_none());
+
+            let decoded = crate::parse(&encoded.serialize()).unwrap();
+
+            assert!(decoded.transparent.inputs.is_empty());
+            assert!(decoded.transparent.outputs.is_empty());
+            assert!(decoded.sapling.spends.is_empty());
+            assert!(decoded.sapling.outputs.is_empty());
+            assert!(decoded.orchard.actions.is_empty());
+            assert_eq!(decoded.orchard.note_version, NoteVersion::V2);
+        }
+    }
+}
+
 /// Errors that can occur while serializing a PCZT.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -159,13 +277,19 @@ impl Pczt {
             PCZT_VERSION_1 => postcard::from_bytes::<v1::Pczt>(&bytes[8..])
                 .map(Pczt::from)
                 .map_err(ParseError::Invalid),
+            PCZT_VERSION_2 => postcard::from_bytes::<v2::Pczt>(&bytes[8..])
+                .map(Pczt::from)
+                .map_err(ParseError::Invalid),
             _ => Err(ParseError::UnknownVersion(version)),
         }
     }
 
-    /// Serializes this PCZT.
+    /// Serializes this PCZT as the latest PCZT version.
+    ///
+    /// If you want a specific PCZT version, e.g. v1, use `v1::Pczt::serialize`
+    ///
     pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
-        Ok(v1::Pczt::try_from(self.clone())?.serialize())
+        Ok(v2::Pczt::try_from(self.clone())?.serialize())
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -84,6 +84,9 @@ pub struct Pczt {
     pub(crate) sapling: sapling::Bundle,
     #[getset(get = "pub")]
     pub(crate) orchard: orchard::Bundle,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    #[getset(get = "pub")]
+    pub(crate) ironwood: orchard::Bundle,
 }
 
 /// Types and operations for the v1 Pczt encoding.
@@ -116,6 +119,11 @@ pub mod v1 {
         type Error = super::EncodingError;
 
         fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            if !pczt.ironwood.actions.is_empty() {
+                return Err(super::EncodingError::UnsupportedTxVersion);
+            }
+
             Ok(Self {
                 global: pczt.global,
                 transparent: pczt.transparent,
@@ -132,6 +140,16 @@ pub mod v1 {
                 transparent: pczt.transparent,
                 sapling: pczt.sapling,
                 orchard: pczt.orchard.into(),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood: orchard::Bundle {
+                    actions: vec![],
+                    flags: 0,
+                    value_sum: (0, true),
+                    anchor: [0; 32],
+                    note_version: orchard::NoteVersion::V3,
+                    zkproof: None,
+                    bsk: None,
+                },
             }
         }
     }
@@ -172,6 +190,8 @@ pub mod v2 {
         // empty. Flags and note version are not checked, as values can be
         // defaulted there.
         orchard: Option<orchard::v2::Bundle>,
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        ironwood: Option<orchard::v2::Bundle>,
     }
 
     impl Pczt {
@@ -194,6 +214,8 @@ pub mod v2 {
                 transparent: (pczt.transparent != EMPTY_TRANSPARENT).then_some(pczt.transparent),
                 sapling: (pczt.sapling != EMPTY_SAPLING).then_some(pczt.sapling),
                 orchard: pczt.orchard.try_into()?,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood: pczt.ironwood.try_into()?,
             })
         }
     }
@@ -208,6 +230,18 @@ pub mod v2 {
                     .orchard
                     .map(orchard::Bundle::from)
                     .unwrap_or(orchard::v2::EMPTY_BUNDLE),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood: pczt.ironwood.map(orchard::Bundle::from).unwrap_or_else(|| {
+                    orchard::Bundle {
+                        actions: Vec::new(),
+                        flags: orchard::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+                        value_sum: (0, true),
+                        anchor: [0; 32],
+                        note_version: orchard::NoteVersion::V3,
+                        zkproof: None,
+                        bsk: None,
+                    }
+                }),
             }
         }
     }
@@ -231,6 +265,8 @@ pub mod v2 {
             assert!(encoded.transparent.is_none());
             assert!(encoded.sapling.is_none());
             assert!(encoded.orchard.is_none());
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            assert!(encoded.ironwood.is_none());
 
             let decoded = crate::parse(&encoded.serialize()).unwrap();
 
@@ -240,6 +276,11 @@ pub mod v2 {
             assert!(decoded.sapling.outputs.is_empty());
             assert!(decoded.orchard.actions.is_empty());
             assert_eq!(decoded.orchard.note_version, NoteVersion::V2);
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            {
+                assert!(decoded.ironwood.actions.is_empty());
+                assert_eq!(decoded.ironwood.note_version, NoteVersion::V3);
+            }
         }
 
         #[test]
@@ -280,6 +321,9 @@ pub mod v2 {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum EncodingError {
+    /// The requested transaction version cannot be represented in this PCZT
+    /// encoding.
+    UnsupportedTxVersion,
     /// The v1 PCZT encoding does not support this Orchard note plaintext version.
     UnsupportedOrchardNoteVersion,
 }
@@ -350,6 +394,8 @@ impl Pczt {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self;
 
         let transparent = transparent
@@ -394,6 +440,8 @@ impl Pczt {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
             tx_data,
         })
     }
@@ -424,6 +472,8 @@ pub(crate) struct ParsedPczt<A: Authorization> {
     pub(crate) transparent: ::transparent::pczt::Bundle,
     pub(crate) sapling: ::sapling::pczt::Bundle,
     pub(crate) orchard: ::orchard::pczt::Bundle,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub(crate) ironwood: orchard::Bundle,
     pub(crate) tx_data: TransactionData<A>,
 }
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -518,17 +518,13 @@ pub(crate) mod v2 {
     /// PCZT fields that are specific to producing the transaction's Orchard bundle.
     #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
     pub struct Bundle {
-        #[getset(get = "pub")]
-        pub(crate) actions: Vec<v1::Action>,
-        #[getset(get = "pub")]
-        pub(crate) flags: u8,
-        #[getset(get = "pub")]
-        pub(crate) value_sum: (u64, bool),
-        #[getset(get = "pub")]
-        pub(crate) anchor: [u8; 32],
+        actions: Vec<v1::Action>,
+        flags: u8,
+        value_sum: (u64, bool),
+        anchor: [u8; 32],
         note_version: SerializedNoteVersion,
-        pub(crate) zkproof: Option<Vec<u8>>,
-        pub(crate) bsk: Option<[u8; 32]>,
+        zkproof: Option<Vec<u8>>,
+        bsk: Option<[u8; 32]>,
     }
 
     impl TryFrom<super::Bundle> for Bundle {

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 
 #[cfg(not(feature = "orchard"))]
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NoteVersion {
     V2,
@@ -27,7 +26,7 @@ pub(crate) enum NoteVersion {
 }
 
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
-#[derive(Clone, Debug, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Bundle {
     /// The Orchard actions in this bundle.
     ///
@@ -77,8 +76,13 @@ pub struct Bundle {
     pub(crate) bsk: Option<[u8; 32]>,
 }
 
+/// The default Orchard bundle flags: both spends and outputs enabled (bits 0 and
+/// 1). This is the value the Creator sets on a new bundle, and the flag value of
+/// an empty bundle for serialization purposes.
+pub(crate) const ORCHARD_SPENDS_AND_OUTPUTS_ENABLED: u8 = 0b0000_0011;
+
 /// Information about an Orchard action within a transaction.
-#[derive(Clone, Debug, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Action {
     //
     // Action effecting data.
@@ -106,7 +110,7 @@ pub struct Action {
 }
 
 /// Information about the spend part of an Orchard action.
-#[derive(Clone, Debug, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Spend {
     //
     // Spend-specific Action effecting data.
@@ -192,7 +196,7 @@ pub struct Spend {
 }
 
 /// Information about the output part of an Orchard action.
-#[derive(Clone, Debug, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Output {
     //
     // Output-specific Action effecting data.
@@ -562,6 +566,45 @@ pub(crate) mod v2 {
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
             }
+        }
+    }
+
+    /// The canonical empty Orchard bundle reconstructed for omitted v2 bundles.
+    pub(crate) const EMPTY_BUNDLE: super::Bundle = super::Bundle {
+        actions: Vec::new(),
+        flags: super::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+        value_sum: (0, true),
+        anchor: [0; 32],
+        note_version: NoteVersion::V2,
+        zkproof: None,
+        bsk: None,
+    };
+
+    /// Whether `bundle` can be omitted from the v2 encoding.
+    ///
+    /// We check that actions, value sum, anchor, zkproof, and bsk are all
+    /// equal to the empty bundle. We do not check note version or flags, as
+    /// values can be defaulted there.
+    fn is_empty(bundle: &super::Bundle) -> bool {
+        bundle.actions == EMPTY_BUNDLE.actions
+            && bundle.value_sum == EMPTY_BUNDLE.value_sum
+            && bundle.anchor == EMPTY_BUNDLE.anchor
+            && bundle.zkproof == EMPTY_BUNDLE.zkproof
+            && bundle.bsk == EMPTY_BUNDLE.bsk
+    }
+
+    /// Encodes a logical Orchard bundle for the v2 PCZT format, owning the
+    /// decision of whether the bundle can be omitted. An [empty](is_empty) bundle
+    /// serializes to `None` and is dropped from the encoding; any other bundle is
+    /// converted via the [`Bundle`]-producing [`TryFrom`] impl. The reverse
+    /// direction is [`From<Bundle>`] plus [`EMPTY_BUNDLE`] for the omitted case.
+    impl TryFrom<super::Bundle> for Option<Bundle> {
+        type Error = crate::EncodingError;
+
+        fn try_from(bundle: super::Bundle) -> Result<Self, Self::Error> {
+            (!is_empty(&bundle))
+                .then(|| Bundle::try_from(bundle))
+                .transpose()
         }
     }
 }

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -19,9 +19,11 @@ use crate::{
 };
 
 #[cfg(not(feature = "orchard"))]
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NoteVersion {
     V2,
+    V3,
 }
 
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
@@ -292,7 +294,7 @@ pub mod v1 {
 
     /// Information about an Orchard action within a transaction.
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    struct Action {
+    pub(crate) struct Action {
         cv_net: [u8; 32],
         spend: Spend,
         output: Output,
@@ -302,7 +304,7 @@ pub mod v1 {
     /// Information about the spend part of an Orchard action.
     #[serde_as]
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    struct Spend {
+    pub(crate) struct Spend {
         nullifier: [u8; 32],
         rk: [u8; 32],
         #[serde_as(as = "Option<[_; 64]>")]
@@ -324,7 +326,7 @@ pub mod v1 {
     /// Information about the output part of an Orchard action.
     #[serde_as]
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    struct Output {
+    pub(crate) struct Output {
         cmx: [u8; 32],
         ephemeral_key: [u8; 32],
         enc_ciphertext: Vec<u8>,
@@ -470,6 +472,95 @@ pub mod v1 {
                 zip32_derivation: output.zip32_derivation,
                 user_address: output.user_address,
                 proprietary: output.proprietary,
+            }
+        }
+    }
+}
+
+/// Types for the v2 Orchard PCZT encoding.
+pub(crate) mod v2 {
+    use alloc::vec::Vec;
+
+    use getset::Getters;
+    use serde::{Deserialize, Serialize};
+
+    use super::{NoteVersion, v1};
+
+    /// A serializable representation of Orchard note plaintext versions.
+    #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+    enum SerializedNoteVersion {
+        V2,
+        V3,
+    }
+
+    impl From<NoteVersion> for SerializedNoteVersion {
+        fn from(note_version: NoteVersion) -> Self {
+            match note_version {
+                NoteVersion::V2 => Self::V2,
+                NoteVersion::V3 => Self::V3,
+            }
+        }
+    }
+
+    impl From<SerializedNoteVersion> for NoteVersion {
+        fn from(note_version: SerializedNoteVersion) -> Self {
+            match note_version {
+                SerializedNoteVersion::V2 => Self::V2,
+                SerializedNoteVersion::V3 => Self::V3,
+            }
+        }
+    }
+
+    /// PCZT fields that are specific to producing the transaction's Orchard bundle.
+    #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+    pub struct Bundle {
+        #[getset(get = "pub")]
+        pub(crate) actions: Vec<v1::Action>,
+        #[getset(get = "pub")]
+        pub(crate) flags: u8,
+        #[getset(get = "pub")]
+        pub(crate) value_sum: (u64, bool),
+        #[getset(get = "pub")]
+        pub(crate) anchor: [u8; 32],
+        note_version: SerializedNoteVersion,
+        pub(crate) zkproof: Option<Vec<u8>>,
+        pub(crate) bsk: Option<[u8; 32]>,
+    }
+
+    impl TryFrom<super::Bundle> for Bundle {
+        type Error = crate::EncodingError;
+
+        fn try_from(bundle: super::Bundle) -> Result<Self, Self::Error> {
+            Ok(Self {
+                actions: bundle
+                    .actions
+                    .into_iter()
+                    .map(v1::Action::from)
+                    .collect::<Vec<_>>(),
+                flags: bundle.flags,
+                value_sum: bundle.value_sum,
+                anchor: bundle.anchor,
+                note_version: bundle.note_version.into(),
+                zkproof: bundle.zkproof,
+                bsk: bundle.bsk,
+            })
+        }
+    }
+
+    impl From<Bundle> for super::Bundle {
+        fn from(bundle: Bundle) -> Self {
+            Self {
+                actions: bundle
+                    .actions
+                    .into_iter()
+                    .map(super::Action::from)
+                    .collect(),
+                flags: bundle.flags,
+                value_sum: bundle.value_sum,
+                anchor: bundle.anchor,
+                note_version: bundle.note_version.into(),
+                zkproof: bundle.zkproof,
+                bsk: bundle.bsk,
             }
         }
     }

--- a/pczt/src/roles/combiner/mod.rs
+++ b/pczt/src/roles/combiner/mod.rs
@@ -45,6 +45,11 @@ fn merge(lhs: Pczt, rhs: Pczt) -> Result<Pczt, Error> {
         .orchard
         .merge(rhs.orchard, &lhs.global, &rhs.global)
         .ok_or(Error::DataMismatch)?;
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    let ironwood = lhs
+        .ironwood
+        .merge(rhs.ironwood, &lhs.global, &rhs.global)
+        .ok_or(Error::DataMismatch)?;
 
     // Now that the per-protocol bundles are merged, merge the globals.
     let global = lhs.global.merge(rhs.global).ok_or(Error::DataMismatch)?;
@@ -54,6 +59,8 @@ fn merge(lhs: Pczt, rhs: Pczt) -> Result<Pczt, Error> {
         transparent,
         sapling,
         orchard,
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        ironwood,
     })
 }
 

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         FLAG_SHIELDED_MODIFIABLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
         FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
     },
-    orchard::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+    orchard::{Bundle as OrchardBundle, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED},
 };
 
 use zcash_protocol::consensus::BranchId;
@@ -167,7 +167,7 @@ impl Creator {
                 anchor: self.sapling_anchor,
                 bsk: None,
             },
-            orchard: crate::orchard::Bundle {
+            orchard: OrchardBundle {
                 actions: vec![],
                 flags: self.orchard_flags,
                 value_sum: (0, true),
@@ -177,6 +177,16 @@ impl Creator {
                 note_version: self.orchard_bundle_version.note_version(),
                 #[cfg(not(feature = "orchard"))]
                 note_version: crate::orchard::NoteVersion::V2,
+                zkproof: None,
+                bsk: None,
+            },
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood: OrchardBundle {
+                actions: vec![],
+                flags: self.orchard_flags,
+                value_sum: (0, true),
+                anchor: self.orchard_anchor,
+                note_version: NoteVersion::V3,
                 zkproof: None,
                 bsk: None,
             },
@@ -250,16 +260,26 @@ impl Creator {
                 }),
             orchard: parts
                 .orchard
-                .map(crate::orchard::Bundle::serialize_from)
-                .unwrap_or_else(|| crate::orchard::Bundle {
+                .map(OrchardBundle::serialize_from)
+                .unwrap_or_else(|| OrchardBundle {
                     actions: vec![],
                     flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
                     value_sum: (0, true),
                     anchor: orchard::Anchor::empty_tree().to_bytes(),
-                    note_version: crate::orchard::NoteVersion::V2,
+                    note_version: NoteVersion::V2,
                     zkproof: None,
                     bsk: None,
                 }),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood: OrchardBundle {
+                actions: vec![],
+                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+                value_sum: (0, true),
+                anchor: orchard::Anchor::empty_tree().to_bytes(),
+                note_version: NoteVersion::V3,
+                zkproof: None,
+                bsk: None,
+            },
         })
     }
 }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         FLAG_SHIELDED_MODIFIABLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
         FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
     },
+    orchard::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
 };
 
 use zcash_protocol::consensus::BranchId;
@@ -19,8 +20,6 @@ use zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID};
 const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
     | FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE
     | FLAG_SHIELDED_MODIFIABLE;
-
-const ORCHARD_SPENDS_AND_OUTPUTS_ENABLED: u8 = 0b0000_0011;
 
 /// Errors that can occur when creating a PCZT.
 #[derive(Debug)]
@@ -67,7 +66,6 @@ fn orchard_bundle_version_for_branch(branch_id: BranchId) -> orchard::bundle::Bu
         _ => BundleVersion::orchard_insecure_v1(),
     }
 }
-
 pub struct Creator {
     tx_version: u32,
     version_group_id: u32,

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -48,6 +48,8 @@ impl IoFinalizer {
             transparent,
             mut sapling,
             mut orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
             tx_data,
         } = pczt.extract_tx_data(
             |t| {
@@ -80,6 +82,8 @@ impl IoFinalizer {
             transparent: crate::transparent::Bundle::serialize_from(transparent),
             sapling: crate::sapling::Bundle::serialize_from(sapling),
             orchard: crate::orchard::Bundle::serialize_from(orchard),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         })
     }
 }

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -10,6 +10,8 @@ impl super::Prover {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut bundle = orchard.into_parsed().map_err(OrchardError::Parser)?;
@@ -24,6 +26,8 @@ impl super::Prover {
                 transparent,
                 sapling,
                 orchard: crate::orchard::Bundle::serialize_from(bundle),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/prover/sapling.rs
+++ b/pczt/src/roles/prover/sapling.rs
@@ -18,6 +18,8 @@ impl super::Prover {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
@@ -32,6 +34,8 @@ impl super::Prover {
                 transparent,
                 sapling: crate::sapling::Bundle::serialize_from(bundle),
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -30,6 +30,9 @@ use crate::{
     },
 };
 
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+use crate::orchard::Bundle as PcztOrchardBundle;
+
 pub use crate::EffectsOnly;
 use crate::sighash;
 
@@ -38,6 +41,8 @@ pub struct Signer {
     transparent: transparent::pczt::Bundle,
     sapling: sapling::pczt::Bundle,
     orchard: orchard::pczt::Bundle,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    ironwood: PcztOrchardBundle,
     /// Cached across multiple signatures.
     tx_data: TransactionData<EffectsOnly>,
     txid_parts: TxDigests<Blake2bHash>,
@@ -53,6 +58,8 @@ impl Signer {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
             tx_data,
         } = pczt.extract_tx_data(
             |t| {
@@ -70,6 +77,8 @@ impl Signer {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
             tx_data,
             txid_parts,
             shielded_sighash,
@@ -337,6 +346,8 @@ impl Signer {
             transparent: crate::transparent::Bundle::serialize_from(self.transparent),
             sapling: crate::sapling::Bundle::serialize_from(self.sapling),
             orchard: crate::orchard::Bundle::serialize_from(self.orchard),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood: self.ironwood,
         }
     }
 }

--- a/pczt/src/roles/spend_finalizer/mod.rs
+++ b/pczt/src/roles/spend_finalizer/mod.rs
@@ -21,6 +21,8 @@ impl SpendFinalizer {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut transparent = transparent.into_parsed().map_err(Error::TransparentParse)?;
@@ -34,6 +36,8 @@ impl SpendFinalizer {
             transparent: crate::transparent::Bundle::serialize_from(transparent),
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         })
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -43,6 +43,8 @@ impl Updater {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         f(GlobalUpdater(&mut global));
@@ -53,6 +55,8 @@ impl Updater {
                 transparent,
                 sapling,
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         }
     }

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -13,6 +13,8 @@ impl super::Updater {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut bundle = orchard.into_parsed().map_err(OrchardError::Parser)?;
@@ -25,6 +27,8 @@ impl super::Updater {
                 transparent,
                 sapling,
                 orchard: crate::orchard::Bundle::serialize_from(bundle),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/updater/sapling.rs
+++ b/pczt/src/roles/updater/sapling.rs
@@ -13,6 +13,8 @@ impl super::Updater {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
@@ -25,6 +27,8 @@ impl super::Updater {
                 transparent,
                 sapling: crate::sapling::Bundle::serialize_from(bundle),
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/updater/transparent.rs
+++ b/pczt/src/roles/updater/transparent.rs
@@ -13,6 +13,8 @@ impl super::Updater {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let mut bundle = transparent
@@ -27,6 +29,8 @@ impl super::Updater {
                 transparent: crate::transparent::Bundle::serialize_from(bundle),
                 sapling,
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -11,6 +11,8 @@ impl super::Verifier {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let bundle = orchard.into_parsed().map_err(OrchardError::Parse)?;
@@ -23,6 +25,8 @@ impl super::Verifier {
                 transparent,
                 sapling,
                 orchard: crate::orchard::Bundle::serialize_from(bundle),
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/verifier/sapling.rs
+++ b/pczt/src/roles/verifier/sapling.rs
@@ -11,6 +11,8 @@ impl super::Verifier {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
@@ -23,6 +25,8 @@ impl super::Verifier {
                 transparent,
                 sapling: crate::sapling::Bundle::serialize_from(bundle),
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/roles/verifier/transparent.rs
+++ b/pczt/src/roles/verifier/transparent.rs
@@ -11,6 +11,8 @@ impl super::Verifier {
             transparent,
             sapling,
             orchard,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood,
         } = self.pczt;
 
         let bundle = transparent
@@ -25,6 +27,8 @@ impl super::Verifier {
                 transparent: crate::transparent::Bundle::serialize_from(bundle),
                 sapling,
                 orchard,
+                #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+                ironwood,
             },
         })
     }

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -17,7 +17,7 @@ use crate::{
 const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;
 
 /// PCZT fields that are specific to producing the transaction's Sapling bundle (if any).
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Bundle {
     #[getset(get = "pub")]
     pub(crate) spends: Vec<Spend>,
@@ -47,7 +47,7 @@ pub struct Bundle {
 
 /// Information about a Sapling spend within a transaction.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Spend {
     //
     // SpendDescription effecting data.
@@ -160,7 +160,7 @@ pub struct Spend {
 
 /// Information about a Sapling output within a transaction.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Output {
     //
     // OutputDescription effecting data.

--- a/pczt/src/transparent.rs
+++ b/pczt/src/transparent.rs
@@ -19,7 +19,7 @@ use zcash_script::script::Evaluable;
 
 /// PCZT fields that are specific to producing the transaction's transparent bundle (if
 /// any).
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Bundle {
     #[getset(get = "pub")]
     pub(crate) inputs: Vec<Input>,
@@ -29,7 +29,7 @@ pub struct Bundle {
 
 /// Information about a transparent input within a transaction.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Input {
     //
     // Transparent effecting data.
@@ -140,7 +140,7 @@ pub struct Input {
 
 /// Information about a transparent output within a transaction.
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]
 pub struct Output {
     //
     // Transparent effecting data.

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -15,7 +15,7 @@ use pczt::{
         signer::Signer, spend_finalizer::SpendFinalizer, tx_extractor::TransactionExtractor,
         updater::Updater,
     },
-    v1,
+    v1, v2,
 };
 use rand_core::OsRng;
 use shardtree::{ShardTree, store::memory::MemoryShardStore};
@@ -44,13 +44,18 @@ fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
 }
 
 fn check_round_trip(pczt: &Pczt) {
-    // The default encoding is the v1 encoding.
-    let v1_encoded = v1::Pczt::try_from(pczt.clone())
+    // The v1 encoding remains available explicitly.
+    v1::Pczt::try_from(pczt.clone())
         .expect("v1 encoding succeeds")
         .serialize();
 
+    // The default encoding is the latest (v2) encoding.
+    let v2_encoded = v2::Pczt::try_from(pczt.clone())
+        .expect("v2 encoding succeeds")
+        .serialize();
+
     let encoded = pczt.clone().serialize().expect("serialization succeeds");
-    assert_eq!(encoded, v1_encoded);
+    assert_eq!(encoded, v2_encoded);
 
     let reencoded = Pczt::parse(&encoded)
         .expect("can parse encoded PCZT")


### PR DESCRIPTION
## Summary
- add PCZT version 2 serialization
- add Orchard v2 bundle serialization with bundle-level note version
- omit empty Transparent, Sapling, and Orchard bundles from v2 encodings

For Orchard v2 bundles, there isn't a "blank value struct" that covers all cases, because of "NoteVersion" and "Flags". So we detect whether to omit for serialization by running orchard::v2::is_empty, which counts as empty if everything but flags and note version are empty. Notably, we don't mark as empty if just Anchor is set even though we could in v6 txs due to it not being signed over. This is kept for v5 compatability.

## Stack
1. This PR
2. Add logical Ironwood PCZT bundle
3. Add PCZT Ironwood role support

## Testing
- cargo fmt --all
- cargo check -p pczt --all-features
- cargo test -p pczt --all-features empty_bundles_encode_as_none_and_decode_as_empty