### PR TITLE
Add PCZT Ironwood role support

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -49,6 +49,8 @@ workspace.
   bundles for v2 serialization).
 - The logical `pczt::Pczt` type now includes an Ironwood bundle behind
   `zcash_unstable = "nu6.3"` and `zcash_unstable = "nu7"`.
+- Ironwood PCZT role support behind `zcash_unstable = "nu6.3"` and
+  `zcash_unstable = "nu7"`.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -27,6 +27,11 @@ use getset::Getters;
 
 #[cfg(all(
     any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"),
+    any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"),
+))]
+use zcash_protocol::constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID};
+#[cfg(all(
+    any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"),
     zcash_unstable = "nu7",
     feature = "zip-233",
 ))]
@@ -35,10 +40,17 @@ use zcash_protocol::value::Zatoshis;
 use {
     common::{Global, determine_lock_time},
     zcash_primitives::transaction::{Authorization, TransactionData, TxVersion},
-    zcash_protocol::consensus::BranchId,
-    zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID},
+    zcash_protocol::{
+        consensus::BranchId,
+        constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID},
+    },
 };
 
+#[cfg(all(
+    any(feature = "io-finalizer", feature = "signer"),
+    any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"),
+))]
+use zcash_primitives::transaction::sighash_v6::v6_signature_hash;
 #[cfg(any(feature = "io-finalizer", feature = "signer"))]
 use {
     blake2b_simd::Hash as Blake2bHash,
@@ -387,6 +399,13 @@ impl Pczt {
             Option<::orchard::Bundle<A::OrchardAuth, zcash_protocol::value::ZatBalance>>,
             E,
         >,
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        extract_ironwood: impl FnOnce(
+            &::orchard::pczt::Bundle,
+        ) -> Result<
+            Option<::orchard::Bundle<A::OrchardAuth, zcash_protocol::value::ZatBalance>>,
+            E,
+        >,
     ) -> Result<ParsedPczt<A>, E>
     where
         A: Authorization,
@@ -405,10 +424,18 @@ impl Pczt {
             .into_parsed()
             .map_err(ExtractError::TransparentParse)?;
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
-        let orchard = orchard.into_parsed().map_err(ExtractError::OrchardParse)?;
+        let orchard = orchard
+            .into_orchard_parsed()
+            .map_err(ExtractError::OrchardParse)?;
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let ironwood = ironwood
+            .into_ironwood_parsed()
+            .map_err(ExtractError::IronwoodParse)?;
 
         let version = match (global.tx_version, global.version_group_id) {
             (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::V5),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            (V6_TX_VERSION, V6_VERSION_GROUP_ID) => Ok(TxVersion::V6),
             (version, version_group_id) => Err(ExtractError::UnsupportedTxVersion {
                 version,
                 version_group_id,
@@ -424,14 +451,41 @@ impl Pczt {
         let transparent_bundle = extract_transparent(&transparent)?;
         let sapling_bundle = extract_sapling(&sapling)?;
         let orchard_bundle = extract_orchard(&orchard)?;
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let ironwood_bundle = extract_ironwood(&ironwood)?;
 
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let tx_data = match version {
+            TxVersion::V6 => TransactionData::from_parts_v6(
+                consensus_branch_id,
+                lock_time,
+                global.expiry_height.into(),
+                #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+                Zatoshis::ZERO,
+                transparent_bundle,
+                sapling_bundle,
+                orchard_bundle,
+                ironwood_bundle,
+            ),
+            _ => TransactionData::from_parts(
+                version,
+                consensus_branch_id,
+                lock_time,
+                global.expiry_height.into(),
+                #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+                Zatoshis::ZERO,
+                transparent_bundle,
+                None,
+                sapling_bundle,
+                orchard_bundle,
+            ),
+        };
+        #[cfg(not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")))]
         let tx_data = TransactionData::from_parts(
             version,
             consensus_branch_id,
             lock_time,
             global.expiry_height.into(),
-            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
-            Zatoshis::ZERO,
             transparent_bundle,
             None,
             sapling_bundle,
@@ -459,6 +513,8 @@ impl Pczt {
             },
             |s| s.extract_effects().map_err(ExtractError::SaplingExtract),
             |o| o.extract_effects().map_err(ExtractError::OrchardExtract),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            |i| i.extract_effects().map_err(ExtractError::IronwoodExtract),
         )
         .map(|parsed| parsed.tx_data)
     }
@@ -476,7 +532,7 @@ pub(crate) struct ParsedPczt<A: Authorization> {
     pub(crate) sapling: ::sapling::pczt::Bundle,
     pub(crate) orchard: ::orchard::pczt::Bundle,
     #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-    pub(crate) ironwood: orchard::Bundle,
+    pub(crate) ironwood: ::orchard::pczt::Bundle,
     pub(crate) tx_data: TransactionData<A>,
 }
 
@@ -491,22 +547,21 @@ impl Authorization for EffectsOnly {
 }
 
 /// Helper to produce the correct sighash for a PCZT.
-///
-/// At present, only V5 transaction signature hashes are supported, and a
-/// version check *MUST* be performed prior to invoking this function. It is
-/// intended for use exclusively for use in the context of a callback to the
-/// `extract_tx_data` function, which performs this check.
 #[cfg(any(feature = "io-finalizer", feature = "signer"))]
 pub(crate) fn sighash(
     tx_data: &TransactionData<EffectsOnly>,
     signable_input: &SignableInput,
     txid_parts: &TxDigests<Blake2bHash>,
 ) -> [u8; 32] {
-    // TODO: Pick sighash based on tx version
-    v5_signature_hash(tx_data, signable_input, txid_parts)
-        .as_ref()
-        .try_into()
-        .expect("correct length")
+    match tx_data.version() {
+        TxVersion::V5 => v5_signature_hash(tx_data, signable_input, txid_parts),
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        TxVersion::V6 => v6_signature_hash(tx_data, signable_input, txid_parts),
+        _ => unreachable!("PCZT only supports v5 and v6 transaction data"),
+    }
+    .as_ref()
+    .try_into()
+    .expect("correct length")
 }
 
 /// Errors that can occur while parsing PCZT bundles and extracting transaction data.
@@ -516,6 +571,12 @@ pub(crate) fn sighash(
 pub enum ExtractError {
     /// The PCZT's transparent inputs have incompatible lock time requirements.
     IncompatibleLockTimes,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    /// An error occurred extracting the Ironwood protocol bundle from the Ironwood PCZT bundle.
+    IronwoodExtract(::orchard::pczt::TxExtractorError),
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    /// An error occurred parsing the Ironwood PCZT bundle from the PCZT data.
+    IronwoodParse(::orchard::pczt::ParseError),
     /// An error occurred extracting the Orchard protocol bundle from the Orchard PCZT bundle.
     OrchardExtract(::orchard::pczt::TxExtractorError),
     /// An error occurred parsing the Orchard PCZT bundle from the PCZT data.

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -751,7 +751,23 @@ impl Bundle {
 
 #[cfg(feature = "orchard")]
 impl Bundle {
-    pub(crate) fn into_parsed(self) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+    pub(crate) fn into_orchard_parsed(
+        self,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        self.into_parsed_with_version(BundleVersion::orchard_v2())
+    }
+
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub(crate) fn into_ironwood_parsed(
+        self,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        self.into_parsed_with_version(BundleVersion::ironwood_v3())
+    }
+
+    fn into_parsed_with_version(
+        self,
+        bundle_version: BundleVersion,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
         let note_version = self.note_version;
         let actions = self
             .actions
@@ -815,8 +831,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            // PCZT v1 only carries pre-NU6.3 Orchard bundles (V2 note plaintexts, bit 2 reserved).
-            BundleVersion::orchard_v2(),
+            bundle_version,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -825,11 +840,7 @@ impl Bundle {
     }
 
     pub(crate) fn serialize_from(bundle: orchard::pczt::Bundle) -> Self {
-        let note_version = bundle
-            .actions()
-            .first()
-            .map(|action| *action.spend().note_version())
-            .unwrap_or(NoteVersion::V2);
+        let note_version = bundle.bundle_version().note_version();
 
         assert!(
             bundle.actions().iter().all(|action| {

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -29,10 +29,15 @@ impl IoFinalizer {
     pub fn finalize_io(self) -> Result<Pczt, Error> {
         let Self { pczt } = self;
 
+        let has_orchard_actions = !pczt.orchard.actions.is_empty();
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let has_ironwood_actions = !pczt.ironwood.actions.is_empty();
+        #[cfg(not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")))]
+        let has_ironwood_actions = false;
         let has_shielded_spends =
-            !(pczt.sapling.spends.is_empty() && pczt.orchard.actions.is_empty());
+            !(pczt.sapling.spends.is_empty() && !has_orchard_actions && !has_ironwood_actions);
         let has_shielded_outputs =
-            !(pczt.sapling.outputs.is_empty() && pczt.orchard.actions.is_empty());
+            !(pczt.sapling.outputs.is_empty() && !has_orchard_actions && !has_ironwood_actions);
 
         // We can't build a transaction that has no spends or outputs.
         // However, we don't attempt to reject an entirely dummy transaction.
@@ -49,7 +54,7 @@ impl IoFinalizer {
             mut sapling,
             mut orchard,
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            ironwood,
+            mut ironwood,
             tx_data,
         } = pczt.extract_tx_data(
             |t| {
@@ -58,6 +63,8 @@ impl IoFinalizer {
             },
             |s| s.extract_effects().map_err(ExtractError::SaplingExtract),
             |o| o.extract_effects().map_err(ExtractError::OrchardExtract),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            |i| i.extract_effects().map_err(ExtractError::IronwoodExtract),
         )?;
 
         // After shielded IO finalization, the transaction effects cannot be modified
@@ -76,6 +83,10 @@ impl IoFinalizer {
         orchard
             .finalize_io(shielded_sighash, OsRng)
             .map_err(Error::OrchardFinalize)?;
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        ironwood
+            .finalize_io(shielded_sighash, OsRng)
+            .map_err(Error::IronwoodFinalize)?;
 
         Ok(Pczt {
             global,
@@ -83,7 +94,7 @@ impl IoFinalizer {
             sapling: crate::sapling::Bundle::serialize_from(sapling),
             orchard: crate::orchard::Bundle::serialize_from(orchard),
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            ironwood,
+            ironwood: crate::orchard::Bundle::serialize_from(ironwood),
         })
     }
 }
@@ -94,6 +105,8 @@ pub enum Error {
     Extract(crate::ExtractError),
     NoOutputs,
     NoSpends,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    IronwoodFinalize(orchard::pczt::IoFinalizerError),
     OrchardFinalize(orchard::pczt::IoFinalizerError),
     SaplingFinalize(sapling::pczt::IoFinalizerError),
 }

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -12,6 +12,29 @@ impl Signer {
         Self { pczt }
     }
 
+    #[cfg(all(
+        feature = "orchard",
+        any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")
+    ))]
+    pub fn sign_ironwood_with<E, F>(self, f: F) -> Result<Self, E>
+    where
+        E: From<orchard::pczt::ParseError>,
+        F: FnOnce(&Pczt, &mut orchard::pczt::Bundle, &mut u8) -> Result<(), E>,
+    {
+        let mut pczt = self.pczt;
+
+        let mut tx_modifiable = pczt.global.tx_modifiable;
+
+        let mut bundle = pczt.ironwood.clone().into_ironwood_parsed()?;
+
+        f(&pczt, &mut bundle, &mut tx_modifiable)?;
+
+        pczt.global.tx_modifiable = tx_modifiable;
+        pczt.ironwood = crate::orchard::Bundle::serialize_from(bundle);
+
+        Ok(Self { pczt })
+    }
+
     /// Exposes the capability to sign the Orchard spends.
     #[cfg(feature = "orchard")]
     pub fn sign_orchard_with<E, F>(self, f: F) -> Result<Self, E>
@@ -23,7 +46,7 @@ impl Signer {
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
 
-        let mut bundle = pczt.orchard.clone().into_parsed()?;
+        let mut bundle = pczt.orchard.clone().into_orchard_parsed()?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
 

--- a/pczt/src/roles/prover/mod.rs
+++ b/pczt/src/roles/prover/mod.rs
@@ -41,6 +41,12 @@ impl Prover {
         !self.pczt.orchard().actions().is_empty() && self.pczt.orchard().zkproof.is_none()
     }
 
+    /// Returns `true` if this PCZT contains Ironwood Actions but no Ironwood proof.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn requires_ironwood_proof(&self) -> bool {
+        !self.pczt.ironwood().actions().is_empty() && self.pczt.ironwood().zkproof.is_none()
+    }
+
     /// Finishes the Prover role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -14,7 +14,9 @@ impl super::Prover {
             ironwood,
         } = self.pczt;
 
-        let mut bundle = orchard.into_parsed().map_err(OrchardError::Parser)?;
+        let mut bundle = orchard
+            .into_orchard_parsed()
+            .map_err(OrchardError::Parser)?;
 
         bundle
             .create_proof(pk, OsRng)
@@ -31,11 +33,48 @@ impl super::Prover {
             },
         })
     }
+
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn create_ironwood_proof(self, pk: &ProvingKey) -> Result<Self, IronwoodError> {
+        let Pczt {
+            global,
+            transparent,
+            sapling,
+            orchard,
+            ironwood,
+        } = self.pczt;
+
+        let mut bundle = ironwood
+            .into_ironwood_parsed()
+            .map_err(IronwoodError::Parser)?;
+
+        bundle
+            .create_proof(pk, OsRng)
+            .map_err(IronwoodError::Prover)?;
+
+        Ok(Self {
+            pczt: Pczt {
+                global,
+                transparent,
+                sapling,
+                orchard,
+                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+            },
+        })
+    }
 }
 
 /// Errors that can occur while creating Orchard proofs for a PCZT.
 #[derive(Debug)]
 pub enum OrchardError {
+    Parser(orchard::pczt::ParseError),
+    Prover(orchard::pczt::ProverError),
+}
+
+/// Errors that can occur while creating Ironwood proofs for a PCZT.
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+#[derive(Debug)]
+pub enum IronwoodError {
     Parser(orchard::pczt::ParseError),
     Prover(orchard::pczt::ProverError),
 }

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -9,6 +9,15 @@ impl super::Redactor {
         f(OrchardRedactor(&mut self.pczt.orchard));
         self
     }
+
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn redact_ironwood_with<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(OrchardRedactor<'_>),
+    {
+        f(OrchardRedactor(&mut self.pczt.ironwood));
+        self
+    }
 }
 
 /// A Redactor for the Orchard bundle.

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -30,9 +30,6 @@ use crate::{
     },
 };
 
-#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-use crate::orchard::Bundle as PcztOrchardBundle;
-
 pub use crate::EffectsOnly;
 use crate::sighash;
 
@@ -42,7 +39,9 @@ pub struct Signer {
     sapling: sapling::pczt::Bundle,
     orchard: orchard::pczt::Bundle,
     #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-    ironwood: PcztOrchardBundle,
+    ironwood: orchard::pczt::Bundle,
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    empty_ironwood: Option<crate::orchard::Bundle>,
     /// Cached across multiple signatures.
     tx_data: TransactionData<EffectsOnly>,
     txid_parts: TxDigests<Blake2bHash>,
@@ -53,6 +52,13 @@ pub struct Signer {
 impl Signer {
     /// Instantiates the Signer role with the given PCZT.
     pub fn new(pczt: Pczt) -> Result<Self, Error> {
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        let empty_ironwood = pczt
+            .ironwood
+            .actions
+            .is_empty()
+            .then(|| pczt.ironwood.clone());
+
         let ParsedPczt {
             global,
             transparent,
@@ -68,6 +74,8 @@ impl Signer {
             },
             |s| s.extract_effects().map_err(ExtractError::SaplingExtract),
             |o| o.extract_effects().map_err(ExtractError::OrchardExtract),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            |i| i.extract_effects().map_err(ExtractError::IronwoodExtract),
         )?;
         let txid_parts = tx_data.digest(TxIdDigester);
         let shielded_sighash = sighash(&tx_data, &SignableInput::Shielded, &txid_parts);
@@ -79,6 +87,8 @@ impl Signer {
             orchard,
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
             ironwood,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            empty_ironwood,
             tx_data,
             txid_parts,
             shielded_sighash,
@@ -341,13 +351,29 @@ impl Signer {
 
     /// Finishes the Signer role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
-        Pczt {
-            global: self.global,
-            transparent: crate::transparent::Bundle::serialize_from(self.transparent),
-            sapling: crate::sapling::Bundle::serialize_from(self.sapling),
-            orchard: crate::orchard::Bundle::serialize_from(self.orchard),
+        let Self {
+            global,
+            transparent,
+            sapling,
+            orchard,
             #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-            ironwood: self.ironwood,
+            ironwood,
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            empty_ironwood,
+            tx_data: _,
+            txid_parts: _,
+            shielded_sighash: _,
+            secp: _,
+        } = self;
+
+        Pczt {
+            global,
+            transparent: crate::transparent::Bundle::serialize_from(transparent),
+            sapling: crate::sapling::Bundle::serialize_from(sapling),
+            orchard: crate::orchard::Bundle::serialize_from(orchard),
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            ironwood: empty_ironwood
+                .unwrap_or_else(|| crate::orchard::Bundle::serialize_from(ironwood)),
         }
     }
 }

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -15,6 +15,8 @@ use crate::Pczt;
 
 mod orchard;
 pub use self::orchard::OrchardError;
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+pub type IronwoodError = OrchardError;
 
 mod sapling;
 pub use self::sapling::SaplingError;
@@ -89,6 +91,11 @@ impl<'a> TransactionExtractor<'a> {
                 o.extract()
                     .map_err(|e| Error::Orchard(OrchardError::Extract(e)))
             },
+            #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+            |i| {
+                i.extract()
+                    .map_err(|e| Error::Ironwood(IronwoodError::Extract(e)))
+            },
         )?;
 
         // The commitment being signed is shared across all shielded inputs.
@@ -114,7 +121,7 @@ impl<'a> TransactionExtractor<'a> {
             },
         )?;
 
-        let tx = tx_data.freeze().expect("v5 tx can't fail here");
+        let tx = tx_data.freeze().expect("txid construction can't fail here");
 
         // Now that we have a supposedly fully-authorized transaction, verify it.
         if let Some(bundle) = tx.sapling_bundle() {
@@ -126,6 +133,11 @@ impl<'a> TransactionExtractor<'a> {
         if let Some(bundle) = tx.orchard_bundle() {
             orchard::verify_bundle(bundle, orchard_vk, *shielded_sighash.as_ref())
                 .map_err(Error::Orchard)?;
+        }
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        if let Some(bundle) = tx.ironwood_bundle() {
+            orchard::verify_ironwood_bundle(bundle, orchard_vk, *shielded_sighash.as_ref())
+                .map_err(Error::Ironwood)?;
         }
 
         Ok(tx)
@@ -149,6 +161,8 @@ pub enum Error {
     SaplingRequired,
     SighashMismatch,
     Transparent(TransparentError),
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    Ironwood(IronwoodError),
 }
 
 impl From<crate::ExtractError> for Error {

--- a/pczt/src/roles/tx_extractor/orchard.rs
+++ b/pczt/src/roles/tx_extractor/orchard.rs
@@ -14,8 +14,23 @@ pub(super) fn verify_bundle(
     if let Some(vk) = orchard_vk {
         verify_bundle_with_key(bundle, vk, sighash)
     } else {
-        // PCZT extraction produces new transactions, which use the NU6.2 (fixed) circuit.
+        // PCZT extraction produces new Orchard bundles using the NU6.2 fixed
+        // circuit.
         let vk = VerifyingKey::build(OrchardCircuitVersion::FixedPostNu6_2);
+        verify_bundle_with_key(bundle, &vk, sighash)
+    }
+}
+
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+pub(super) fn verify_ironwood_bundle(
+    bundle: &Bundle<Authorized, ZatBalance>,
+    orchard_vk: Option<&VerifyingKey>,
+    sighash: [u8; 32],
+) -> Result<(), OrchardError> {
+    if let Some(vk) = orchard_vk {
+        verify_bundle_with_key(bundle, vk, sighash)
+    } else {
+        let vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
         verify_bundle_with_key(bundle, &vk, sighash)
     }
 }

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -17,7 +17,9 @@ impl super::Updater {
             ironwood,
         } = self.pczt;
 
-        let mut bundle = orchard.into_parsed().map_err(OrchardError::Parser)?;
+        let mut bundle = orchard
+            .into_orchard_parsed()
+            .map_err(OrchardError::Parser)?;
 
         bundle.update_with(f).map_err(OrchardError::Updater)?;
 

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -15,7 +15,7 @@ impl super::Verifier {
             ironwood,
         } = self.pczt;
 
-        let bundle = orchard.into_parsed().map_err(OrchardError::Parse)?;
+        let bundle = orchard.into_orchard_parsed().map_err(OrchardError::Parse)?;
 
         f(&bundle)?;
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -48,6 +48,9 @@ workspace.
   number of Ironwood actions; pass `0` for transactions without an Ironwood
   bundle. Under ZIP 317 each Ironwood action is charged one marginal fee, the
   same as an Orchard action.
+- `TransactionData::from_parts_v6` is now also available behind
+  `zcash_unstable = "nu7"`, and includes the ZIP 233 amount argument when the
+  `zip-233` feature is enabled.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -409,12 +409,13 @@ impl<A: Authorization> TransactionData<A> {
     /// the wrong field is invalid and can be rejected by later serialization or
     /// commitment construction because the bundle flags and domains are protocol
     /// specific.
-    #[cfg(zcash_unstable = "nu6.3")]
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts_v6(
         consensus_branch_id: BranchId,
         lock_time: u32,
         expiry_height: BlockHeight,
+        #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))] zip233_amount: Zatoshis,
         transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
         sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
         orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, ZatBalance>>,
@@ -425,6 +426,8 @@ impl<A: Authorization> TransactionData<A> {
             consensus_branch_id,
             lock_time,
             expiry_height,
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            zip233_amount,
             transparent_bundle,
             sprout_bundle: None,
             sapling_bundle,


### PR DESCRIPTION
## Summary
- parse and serialize Ironwood PCZT bundles with the V6 Orchard bundle format
- integrate Ironwood into extraction, IO finalization, proving, low-level signing, redaction, and verification
- dispatch PCZT sighashes between V5 and V6
- make TransactionData::from_parts_v6 available under nu7 with ZIP 233 amount support

## Stack
1. #2490
2. #2491
3. This PR

## Testing
- cargo fmt --all
- cargo check -p pczt --all-features
- RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo check -p pczt --all-features
- RUSTFLAGS='--cfg zcash_unstable="nu6.3"' cargo check -p pczt --all-features
- RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test -p pczt --all-features empty_bundles_encode_as_none_and_decode_as_empty