### PR TITLE
Update Orchard to the BundleVersion API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/orchard?rev=cbb6ed1d5cc1d7ec941ffe90763114757636539a#cbb6ed1d5cc1d7ec941ffe90763114757636539a"
+source = "git+https://github.com/zcash/orchard?rev=2f322a220d2750c3fa752132f51594b8358f653f#2f322a220d2750c3fa752132f51594b8358f653f"
 dependencies = [
  "aes",
  "bitvec",
@@ -4032,7 +4032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2989,8 +2989,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
-source = "git+https://github.com/zcash/orchard?rev=30c4ea2788375c542bfaa4704a3a772308729321#30c4ea2788375c542bfaa4704a3a772308729321"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/orchard?rev=a9b5403cc6bf26b31ff957e1b7368b1216cc30e5#a9b5403cc6bf26b31ff957e1b7368b1216cc30e5"
 dependencies = [
  "aes",
  "bitvec",
@@ -4032,7 +4032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/orchard?rev=a9b5403cc6bf26b31ff957e1b7368b1216cc30e5#a9b5403cc6bf26b31ff957e1b7368b1216cc30e5"
+source = "git+https://github.com/zcash/orchard?rev=cbb6ed1d5cc1d7ec941ffe90763114757636539a#cbb6ed1d5cc1d7ec941ffe90763114757636539a"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.14.0"
-source = "git+https://github.com/zcash/orchard?rev=b2af0a11abe00f59c51258d349c2105fe7a16215#b2af0a11abe00f59c51258d349c2105fe7a16215"
+source = "git+https://github.com/zcash/orchard?rev=30c4ea2788375c542bfaa4704a3a772308729321#30c4ea2788375c542bfaa4704a3a772308729321"
 dependencies = [
  "aes",
  "bitvec",
@@ -4032,7 +4032,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ zip32 = { version = "0.2", default-features = false }
 time-core = "=0.1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "30c4ea2788375c542bfaa4704a3a772308729321" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { version = "0.14", default-features = false }
+orchard = { version = "0.15.0-pre.0", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent
@@ -186,7 +186,7 @@ zip32 = { version = "0.2", default-features = false }
 time-core = "=0.1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "30c4ea2788375c542bfaa4704a3a772308729321" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "a9b5403cc6bf26b31ff957e1b7368b1216cc30e5" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ zip32 = { version = "0.2", default-features = false }
 time-core = "=0.1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "a9b5403cc6bf26b31ff957e1b7368b1216cc30e5" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "cbb6ed1d5cc1d7ec941ffe90763114757636539a" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ zip32 = { version = "0.2", default-features = false }
 time-core = "=0.1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "cbb6ed1d5cc1d7ec941ffe90763114757636539a" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,6 +11,14 @@ workspace.
 ## [0.8.0] - PLANNED
 
 ### Changed
+- `pczt::roles::creator::Creator::new` is now fallible, returning
+  `Result<Self, pczt::roles::creator::Error>`; it rejects unrecognized consensus
+  branch IDs and upgrades that predate the v5 transaction format.
+- `pczt::roles::creator::Creator::with_orchard_flags` is now fallible, returning
+  `Result<Self, pczt::roles::creator::Error>`. The Orchard bundle version (and
+  hence the note-plaintext version and flag-byte encoding) is now derived from the
+  consensus branch ID passed to `Creator::new` rather than supplied by the caller,
+  and the flags are validated against it.
 - PCZT version 1 is now treated as a serialization format for the logical
   `pczt::Pczt` type.
 - The Orchard PCZT logical model now tracks the Orchard bundle's note plaintext
@@ -22,6 +30,8 @@ workspace.
   returning `Vec<u8>`.
 
 ### Added
+- `pczt::roles::creator::Error`, the error type returned by the now-fallible
+  `Creator` methods.
 - `pczt::parse`, a free function for parsing PCZT encodings.
 - `pczt::EncodingError`, for errors that can occur during PCZT encoding.
 - `pczt::EncodingError::UnsupportedOrchardNoteVersion`, returned when an

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -9,7 +9,7 @@ use core::cmp::Ordering;
 use ff::PrimeField;
 use getset::Getters;
 #[cfg(feature = "orchard")]
-use orchard::bundle::BundlePoolRestrictions;
+use orchard::bundle::BundleVersion;
 #[cfg(feature = "orchard")]
 pub(crate) use orchard::note::NoteVersion;
 
@@ -23,16 +23,6 @@ use crate::{
 pub(crate) enum NoteVersion {
     V2,
 }
-
-/// Orchard pool restriction for PCZT operations whose result only depends on
-/// using an Orchard-equivalent flag format.
-///
-/// PCZT v1 serializes Orchard flags with bits 2..=7 reserved and only supports
-/// V2 Orchard note plaintexts. The selected `BundlePoolRestrictions` value names
-/// that flag format; it is not an NU6.2 network-height assumption.
-#[cfg(feature = "orchard")]
-pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: BundlePoolRestrictions =
-    BundlePoolRestrictions::OrchardNu6_2Only;
 
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
 #[derive(Clone, Debug, Getters)]
@@ -695,7 +685,8 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            ANY_ORCHARD_POOL_RESTRICTIONS,
+            // PCZT v1 only carries pre-NU6.3 Orchard bundles (V2 note plaintexts, bit 2 reserved).
+            BundleVersion::orchard_v1(),
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -806,10 +797,7 @@ impl Bundle {
 
         Self {
             actions,
-            flags: bundle
-                .flags()
-                .to_byte(ANY_ORCHARD_POOL_RESTRICTIONS)
-                .expect("Orchard flags must be representable in the v5 transaction format"),
+            flags: bundle.flag_byte(),
             value_sum,
             anchor: bundle.anchor().to_bytes(),
             note_version,

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -686,7 +686,7 @@ impl Bundle {
             actions,
             self.flags,
             // PCZT v1 only carries pre-NU6.3 Orchard bundles (V2 note plaintexts, bit 2 reserved).
-            BundleVersion::orchard_v1(),
+            BundleVersion::orchard_v2(),
             self.value_sum,
             self.anchor,
             self.zkproof,

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -9,7 +9,7 @@ use core::cmp::Ordering;
 use ff::PrimeField;
 use getset::Getters;
 #[cfg(feature = "orchard")]
-use orchard::bundle::BundleFormat;
+use orchard::bundle::BundlePoolRestrictions;
 #[cfg(feature = "orchard")]
 pub(crate) use orchard::note::NoteVersion;
 
@@ -635,7 +635,6 @@ impl Bundle {
                     action.spend.value,
                     action.spend.rho,
                     action.spend.rseed,
-                    note_version,
                     action.spend.fvk,
                     action.spend.witness,
                     action.spend.alpha,
@@ -650,6 +649,7 @@ impl Bundle {
                         })
                         .transpose()?,
                     action.spend.dummy_sk,
+                    note_version,
                     action.spend.proprietary,
                 )?;
 
@@ -662,7 +662,6 @@ impl Bundle {
                     action.output.recipient,
                     action.output.value,
                     action.output.rseed,
-                    note_version,
                     action.output.ock,
                     action
                         .output
@@ -675,6 +674,7 @@ impl Bundle {
                         })
                         .transpose()?,
                     action.output.user_address,
+                    note_version,
                     action.output.proprietary,
                 )?;
 
@@ -685,7 +685,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            BundleFormat::PreNu6_3,
+            BundlePoolRestrictions::OrchardNu6_2Only,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -798,7 +798,7 @@ impl Bundle {
             actions,
             flags: bundle
                 .flags()
-                .to_byte(BundleFormat::PreNu6_3)
+                .to_byte(BundlePoolRestrictions::OrchardNu6_2Only)
                 .expect("Orchard flags must be representable in the v5 transaction format"),
             value_sum,
             anchor: bundle.anchor().to_bytes(),

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -24,6 +24,16 @@ pub(crate) enum NoteVersion {
     V2,
 }
 
+/// Orchard pool restriction for PCZT operations whose result only depends on
+/// using an Orchard-equivalent flag format.
+///
+/// PCZT v1 serializes Orchard flags with bits 2..=7 reserved and only supports
+/// V2 Orchard note plaintexts. The selected `BundlePoolRestrictions` value names
+/// that flag format; it is not an NU6.2 network-height assumption.
+#[cfg(feature = "orchard")]
+pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: BundlePoolRestrictions =
+    BundlePoolRestrictions::OrchardNu6_2Only;
+
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
 #[derive(Clone, Debug, Getters)]
 pub struct Bundle {
@@ -685,7 +695,7 @@ impl Bundle {
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
-            BundlePoolRestrictions::OrchardNu6_2Only,
+            ANY_ORCHARD_POOL_RESTRICTIONS,
             self.value_sum,
             self.anchor,
             self.zkproof,
@@ -798,7 +808,7 @@ impl Bundle {
             actions,
             flags: bundle
                 .flags()
-                .to_byte(BundlePoolRestrictions::OrchardNu6_2Only)
+                .to_byte(ANY_ORCHARD_POOL_RESTRICTIONS)
                 .expect("Orchard flags must be representable in the v5 transaction format"),
             value_sum,
             anchor: bundle.anchor().to_bytes(),

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -47,7 +47,9 @@ mod tests {
             tx_extractor::{self, TransactionExtractor},
         };
 
-        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
+        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
 
         // Extraction fails because we haven't run the IO Finalizer.
         // Extraction fails in Sapling because we happen to extract it before Orchard.
@@ -69,7 +71,9 @@ mod tests {
             io_finalizer::{self, IoFinalizer},
         };
 
-        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32]).build();
+        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
 
         // IO finalization fails on spends because we happen to check them first.
         assert!(matches!(

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -63,7 +63,7 @@ impl Creator {
     #[cfg(feature = "orchard")]
     pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
         self.orchard_flags = orchard_flags
-            .to_byte(orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only)
+            .to_byte(crate::orchard::ANY_ORCHARD_POOL_RESTRICTIONS)
             .expect("Orchard flags must be representable in the v5 transaction format");
         self
     }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -29,6 +29,7 @@ pub struct Creator {
     expiry_height: u32,
     coin_type: u32,
     orchard_flags: u8,
+    orchard_note_version: crate::orchard::NoteVersion,
     sapling_anchor: [u8; 32],
     orchard_anchor: [u8; 32],
 }
@@ -50,6 +51,7 @@ impl Creator {
             expiry_height,
             coin_type,
             orchard_flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+            orchard_note_version: crate::orchard::NoteVersion::V2,
             sapling_anchor,
             orchard_anchor,
         }
@@ -60,12 +62,27 @@ impl Creator {
         self
     }
 
+    /// Selects the Orchard bundle version and flags for the PCZT.
+    ///
+    /// The version fixes both the note-plaintext version and the flag-byte format, and the flags
+    /// are encoded under it immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`orchard::bundle::BundleError::UnrepresentableFlags`] if `flags` cannot be encoded
+    /// under `bundle_version` (e.g. cross-address-enabled flags under a post-NU6.3 Orchard
+    /// version).
     #[cfg(feature = "orchard")]
-    pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
-        self.orchard_flags = orchard_flags
-            .to_byte(crate::orchard::ANY_ORCHARD_POOL_RESTRICTIONS)
-            .expect("Orchard flags must be representable in the v5 transaction format");
-        self
+    pub fn with_orchard_bundle_version(
+        mut self,
+        bundle_version: orchard::bundle::BundleVersion,
+        flags: orchard::bundle::Flags,
+    ) -> Result<Self, orchard::bundle::BundleError> {
+        self.orchard_flags = flags
+            .to_byte(bundle_version)
+            .ok_or(orchard::bundle::BundleError::UnrepresentableFlags)?;
+        self.orchard_note_version = bundle_version.note_version();
+        Ok(self)
     }
 
     pub fn build(self) -> Pczt {
@@ -96,7 +113,7 @@ impl Creator {
                 flags: self.orchard_flags,
                 value_sum: (0, true),
                 anchor: self.orchard_anchor,
-                note_version: crate::orchard::NoteVersion::V2,
+                note_version: self.orchard_note_version,
                 zkproof: None,
                 bsk: None,
             },

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -63,7 +63,7 @@ impl Creator {
     #[cfg(feature = "orchard")]
     pub fn with_orchard_flags(mut self, orchard_flags: orchard::bundle::Flags) -> Self {
         self.orchard_flags = orchard_flags
-            .to_byte(orchard::bundle::BundleFormat::PreNu6_3)
+            .to_byte(orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only)
             .expect("Orchard flags must be representable in the v5 transaction format");
         self
     }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     },
 };
 
+use zcash_protocol::consensus::BranchId;
 use zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID};
 
 /// Initial flags allowing any modification.
@@ -21,6 +22,52 @@ const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
 
 const ORCHARD_SPENDS_AND_OUTPUTS_ENABLED: u8 = 0b0000_0011;
 
+/// Errors that can occur when creating a PCZT.
+#[derive(Debug)]
+pub enum Error {
+    /// The consensus branch ID does not correspond to any known network upgrade.
+    UnknownConsensusBranchId,
+    /// The network upgrade for the consensus branch ID predates the v5
+    /// transaction format, so it cannot be used to create a PCZT.
+    UnsupportedConsensusBranchId,
+    /// The requested Orchard flags cannot be represented under the Orchard bundle
+    /// version implied by the consensus branch ID.
+    #[cfg(feature = "orchard")]
+    UnrepresentableOrchardFlags,
+}
+
+/// Returns the network upgrade for `consensus_branch_id`, rejecting unrecognized
+/// branch IDs and any upgrade that predates the v5 transaction format.
+fn consensus_branch_id_for_pczt(consensus_branch_id: u32) -> Result<BranchId, Error> {
+    match BranchId::try_from(consensus_branch_id).map_err(|_| Error::UnknownConsensusBranchId)? {
+        BranchId::Sprout
+        | BranchId::Overwinter
+        | BranchId::Sapling
+        | BranchId::Blossom
+        | BranchId::Heartwood
+        | BranchId::Canopy => Err(Error::UnsupportedConsensusBranchId),
+        branch_id => Ok(branch_id),
+    }
+}
+
+/// Returns the Orchard bundle version used by the Orchard pool of the given
+/// (v5-or-later) network upgrade.
+#[cfg(feature = "orchard")]
+fn orchard_bundle_version_for_branch(branch_id: BranchId) -> orchard::bundle::BundleVersion {
+    use orchard::bundle::BundleVersion;
+
+    match branch_id {
+        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
+        #[cfg(zcash_unstable = "nu6.3")]
+        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
+        #[cfg(zcash_unstable = "nu7")]
+        BranchId::Nu7 => BundleVersion::orchard_v3(),
+        // NU5, NU6, and NU6.1 use the original (pre-NU6.2) Orchard pool; pre-NU5
+        // branches are rejected before reaching here.
+        _ => BundleVersion::orchard_insecure_v1(),
+    }
+}
+
 pub struct Creator {
     tx_version: u32,
     version_group_id: u32,
@@ -29,20 +76,34 @@ pub struct Creator {
     expiry_height: u32,
     coin_type: u32,
     orchard_flags: u8,
-    orchard_note_version: crate::orchard::NoteVersion,
+    #[cfg(feature = "orchard")]
+    orchard_bundle_version: orchard::bundle::BundleVersion,
     sapling_anchor: [u8; 32],
     orchard_anchor: [u8; 32],
 }
 
 impl Creator {
+    /// Creates a new PCZT for the given consensus branch ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnknownConsensusBranchId`] if `consensus_branch_id` is not
+    /// a recognized branch ID, or [`Error::UnsupportedConsensusBranchId`] if it
+    /// predates the v5 transaction format.
     pub fn new(
         consensus_branch_id: u32,
         expiry_height: u32,
         coin_type: u32,
         sapling_anchor: [u8; 32],
         orchard_anchor: [u8; 32],
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        #[cfg_attr(not(feature = "orchard"), allow(unused_variables))]
+        let branch_id = consensus_branch_id_for_pczt(consensus_branch_id)?;
+
+        #[cfg(feature = "orchard")]
+        let orchard_bundle_version = orchard_bundle_version_for_branch(branch_id);
+
+        Ok(Self {
             // Default to v5 transaction format.
             tx_version: V5_TX_VERSION,
             version_group_id: V5_VERSION_GROUP_ID,
@@ -51,10 +112,11 @@ impl Creator {
             expiry_height,
             coin_type,
             orchard_flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-            orchard_note_version: crate::orchard::NoteVersion::V2,
+            #[cfg(feature = "orchard")]
+            orchard_bundle_version,
             sapling_anchor,
             orchard_anchor,
-        }
+        })
     }
 
     pub fn with_fallback_lock_time(mut self, fallback: u32) -> Self {
@@ -62,26 +124,25 @@ impl Creator {
         self
     }
 
-    /// Selects the Orchard bundle version and flags for the PCZT.
+    /// Sets the Orchard flags for the PCZT.
     ///
-    /// The version fixes both the note-plaintext version and the flag-byte format, and the flags
-    /// are encoded under it immediately.
+    /// The flags are validated against, and encoded under, the Orchard bundle
+    /// version implied by the consensus branch ID passed to [`Creator::new`]
+    /// (which also fixes the note-plaintext version).
     ///
     /// # Errors
     ///
-    /// Returns [`orchard::bundle::BundleError::UnrepresentableFlags`] if `flags` cannot be encoded
-    /// under `bundle_version` (e.g. cross-address-enabled flags under a post-NU6.3 Orchard
-    /// version).
+    /// Returns [`Error::UnrepresentableOrchardFlags`] if `flags` cannot be encoded
+    /// under that bundle version (e.g. cross-address-enabled flags under a
+    /// post-NU6.3 Orchard version).
     #[cfg(feature = "orchard")]
-    pub fn with_orchard_bundle_version(
+    pub fn with_orchard_flags(
         mut self,
-        bundle_version: orchard::bundle::BundleVersion,
-        flags: orchard::bundle::Flags,
-    ) -> Result<Self, orchard::bundle::BundleError> {
-        self.orchard_flags = flags
-            .to_byte(bundle_version)
-            .ok_or(orchard::bundle::BundleError::UnrepresentableFlags)?;
-        self.orchard_note_version = bundle_version.note_version();
+        orchard_flags: orchard::bundle::Flags,
+    ) -> Result<Self, Error> {
+        self.orchard_flags = orchard_flags
+            .to_byte(self.orchard_bundle_version)
+            .ok_or(Error::UnrepresentableOrchardFlags)?;
         Ok(self)
     }
 
@@ -113,7 +174,11 @@ impl Creator {
                 flags: self.orchard_flags,
                 value_sum: (0, true),
                 anchor: self.orchard_anchor,
-                note_version: self.orchard_note_version,
+                // The note-plaintext version is determined by the Orchard bundle version.
+                #[cfg(feature = "orchard")]
+                note_version: self.orchard_bundle_version.note_version(),
+                #[cfg(not(feature = "orchard"))]
+                note_version: crate::orchard::NoteVersion::V2,
                 zkproof: None,
                 bsk: None,
             },

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -589,7 +589,7 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::BundleProtocol::OrchardPreNu6_3,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -589,10 +589,12 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::bundle::BundleVersion::orchard_v1(),
             orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v1(),
+            orchard::bundle::BundleVersion::orchard_v1().default_flags(),
             orchard::Anchor::empty_tree(),
-        );
+        )
+        .unwrap();
         orchard_builder
             .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
             .unwrap();

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -590,8 +590,8 @@ fn orchard_to_orchard() {
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
             orchard::builder::BundleType::DEFAULT,
-            orchard::bundle::BundleVersion::orchard_v1(),
-            orchard::bundle::BundleVersion::orchard_v1().default_flags(),
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
             orchard::Anchor::empty_tree(),
         )
         .unwrap();

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -589,7 +589,7 @@ fn orchard_to_orchard() {
     let value = orchard::value::NoteValue::from_raw(1_000_000);
     let note = {
         let mut orchard_builder = orchard::builder::Builder::new(
-            orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+            orchard::bundle::BundleVersion::orchard_v1(),
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,9 @@ workspace.
 ## [0.24.0] - PLANNED
 
 ### Added
+- `zcash_client_backend::fees::orchard::BundleView::bundle_version`, replacing
+  the `bundle_type` accessor; it returns the `orchard::bundle::BundleVersion`
+  used to compute the Orchard action count.
 - `zcash_client_backend::data_api::error::RewindError`
 - `zcash_client_backend::data_api::ll::wallet::PutBlocksError::ShardTreeForBlockRange`,
   a new variant that wraps a `shardtree` insertion error together with the

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2291,8 +2291,17 @@ fn compact_orchard_action<R: RngCore + CryptoRng>(
         CompactOrchardAction {
             nullifier: compact_action.nullifier().to_bytes().to_vec(),
             cmx: compact_action.cmx().to_bytes().to_vec(),
-            ephemeral_key: compact_action.ephemeral_key().0.to_vec(),
-            ciphertext: compact_action.enc_ciphertext()[..52].to_vec(),
+            ephemeral_key:
+                ShieldedOutput::<::orchard::note_encryption::OrchardDomain, 52>::ephemeral_key(
+                    &compact_action,
+                )
+                .0
+                .to_vec(),
+            ciphertext:
+                ShieldedOutput::<::orchard::note_encryption::OrchardDomain, 52>::enc_ciphertext(
+                    &compact_action,
+                )[..52]
+                    .to_vec(),
         },
         note,
     )

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1868,14 +1868,8 @@ where
                     .transaction()
                     .orchard_bundle()
                     .and_then(|bundle| {
-                        // This is an Orchard bundle, so every Orchard pool
-                        // restriction selects the same V2 note plaintext domain.
                         bundle
-                            .decrypt_output_with_key(
-                                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
-                                output_index,
-                                &orchard_internal_ivk,
-                            )
+                            .decrypt_output_with_key(output_index, &orchard_internal_ivk)
                             .map(|(note, _, _)| Note::Orchard(note))
                     })
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK")

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1869,7 +1869,11 @@ where
                     .orchard_bundle()
                     .and_then(|bundle| {
                         bundle
-                            .decrypt_output_with_key(output_index, &orchard_internal_ivk)
+                            .decrypt_output_with_key(
+                                ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+                                output_index,
+                                &orchard_internal_ivk,
+                            )
                             .map(|(note, _, _)| Note::Orchard(note))
                     })
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK")

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1868,6 +1868,8 @@ where
                     .transaction()
                     .orchard_bundle()
                     .and_then(|bundle| {
+                        // This is an Orchard bundle, so every Orchard pool
+                        // restriction selects the same V2 note plaintext domain.
                         bundle
                             .decrypt_output_with_key(
                                 crate::ANY_ORCHARD_POOL_RESTRICTIONS,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1870,7 +1870,7 @@ where
                     .and_then(|bundle| {
                         bundle
                             .decrypt_output_with_key(
-                                ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+                                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                                 output_index,
                                 &orchard_internal_ivk,
                             )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -713,8 +713,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // Preserve the legacy Orchard action-count estimate here.
                     // If this path targets restrictions that disable
                     // cross-address transfers, thread the target-height-selected
-                    // `BundlePoolRestrictions` through this call.
-                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
+                    // `BundleVersion` through this call.
+                    crate::ANY_ORCHARD_BUNDLE_VERSION,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -876,9 +876,9 @@ where
         orchard_fees::transactional_action_count(
             // Preserve the legacy Orchard action-count estimate here. If this
             // path targets restrictions that disable cross-address transfers,
-            // thread the target-height-selected `BundlePoolRestrictions`
+            // thread the target-height-selected `BundleVersion`
             // through this call.
-            crate::ANY_ORCHARD_POOL_RESTRICTIONS,
+            crate::ANY_ORCHARD_BUNDLE_VERSION,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1278,7 +1278,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                     // With no Orchard spends and one requested output, the
                     // padded action count is independent of the Orchard pool
                     // restriction.
-                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
+                    crate::ANY_ORCHARD_BUNDLE_VERSION,
                     0,
                     1,
                 )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,6 +710,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
+                    // Preserve the legacy Orchard action-count estimate here.
+                    // If this path targets restrictions that disable
+                    // cross-address transfers, thread the target-height-selected
+                    // `BundlePoolRestrictions` through this call.
                     crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
@@ -870,6 +874,10 @@ where
             0
         };
         orchard_fees::transactional_action_count(
+            // Preserve the legacy Orchard action-count estimate here. If this
+            // path targets restrictions that disable cross-address transfers,
+            // thread the target-height-selected `BundlePoolRestrictions`
+            // through this call.
             crate::ANY_ORCHARD_POOL_RESTRICTIONS,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
@@ -1267,6 +1275,9 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
+                    // With no Orchard spends and one requested output, the
+                    // padded action count is independent of the Orchard pool
+                    // restriction.
                     crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     0,
                     1,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,7 +710,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
-                    ::orchard::BundleProtocol::OrchardPreNu6_3,
+                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -870,7 +870,7 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            ::orchard::BundleProtocol::OrchardPreNu6_3,
+            ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1267,7 +1267,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    ::orchard::BundleProtocol::OrchardPreNu6_3,
+                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                     0,
                     1,
                 )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -710,7 +710,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
-                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -870,7 +870,7 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+            crate::ANY_ORCHARD_POOL_RESTRICTIONS,
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1267,7 +1267,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                    crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                     0,
                     1,
                 )

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -313,7 +313,7 @@ where
     #[cfg(feature = "orchard")]
     let orchard_action_count = |change_count| {
         orchard_fees::transactional_action_count(
-            orchard.bundle_pool_restrictions(),
+            orchard.bundle_version(),
             orchard.inputs().len(),
             orchard.outputs().len() + change_count,
         )
@@ -692,7 +692,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
 
             #[cfg(feature = "orchard")]
             let o_action_count = orchard_fees::transactional_action_count(
-                orchard.bundle_pool_restrictions(),
+                orchard.bundle_version(),
                 o_req_inputs + _o_extra,
                 o_outputs_len + change.orchard,
             )

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -313,7 +313,7 @@ where
     #[cfg(feature = "orchard")]
     let orchard_action_count = |change_count| {
         orchard_fees::transactional_action_count(
-            orchard.bundle_protocol(),
+            orchard.bundle_pool_restrictions(),
             orchard.inputs().len(),
             orchard.outputs().len() + change_count,
         )
@@ -692,7 +692,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
 
             #[cfg(feature = "orchard")]
             let o_action_count = orchard_fees::transactional_action_count(
-                orchard.bundle_protocol(),
+                orchard.bundle_pool_restrictions(),
                 o_req_inputs + _o_extra,
                 o_outputs_len + change.orchard,
             )

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -3,15 +3,15 @@
 
 use std::convert::Infallible;
 
-use orchard::{BundleProtocol, builder::BundleType};
+use orchard::{builder::BundleType, bundle::BundlePoolRestrictions};
 use zcash_protocol::value::Zatoshis;
 
 pub(crate) fn transactional_action_count(
-    protocol: BundleProtocol,
+    pool_restrictions: BundlePoolRestrictions,
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    BundleType::DEFAULT.num_actions(num_spends, num_outputs, protocol)
+    BundleType::DEFAULT.num_actions(num_spends, num_outputs, pool_restrictions)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration
@@ -22,8 +22,8 @@ pub trait BundleView<NoteRef> {
     /// The type of inputs of the bundle.
     type Out: OutputView;
 
-    /// Returns the protocol rules for the bundle.
-    fn bundle_protocol(&self) -> BundleProtocol;
+    /// Returns the pool restrictions for the bundle.
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions;
     /// Returns the inputs to the bundle.
     fn inputs(&self) -> &[Self::In];
     /// Returns the outputs of the bundle.
@@ -31,12 +31,12 @@ pub trait BundleView<NoteRef> {
 }
 
 impl<'a, NoteRef, In: InputView<NoteRef>, Out: OutputView> BundleView<NoteRef>
-    for (BundleProtocol, &'a [In], &'a [Out])
+    for (BundlePoolRestrictions, &'a [In], &'a [Out])
 {
     type In = In;
     type Out = Out;
 
-    fn bundle_protocol(&self) -> BundleProtocol {
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
         self.0
     }
 
@@ -56,8 +56,8 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type In = Infallible;
     type Out = Infallible;
 
-    fn bundle_protocol(&self) -> BundleProtocol {
-        BundleProtocol::OrchardPreNu6_3
+    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
+        BundlePoolRestrictions::OrchardNu6_2Only
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -3,15 +3,15 @@
 
 use std::convert::Infallible;
 
-use orchard::{builder::BundleType, bundle::BundlePoolRestrictions};
+use orchard::{builder::BundleType, bundle::BundleVersion};
 use zcash_protocol::value::Zatoshis;
 
 pub(crate) fn transactional_action_count(
-    pool_restrictions: BundlePoolRestrictions,
+    bundle_version: BundleVersion,
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    BundleType::DEFAULT.num_actions(num_spends, num_outputs, pool_restrictions)
+    BundleType::DEFAULT.num_actions(num_spends, num_outputs, bundle_version)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration
@@ -22,8 +22,8 @@ pub trait BundleView<NoteRef> {
     /// The type of inputs of the bundle.
     type Out: OutputView;
 
-    /// Returns the pool restrictions for the bundle.
-    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions;
+    /// Returns the bundle version for the bundle.
+    fn bundle_version(&self) -> BundleVersion;
     /// Returns the inputs to the bundle.
     fn inputs(&self) -> &[Self::In];
     /// Returns the outputs of the bundle.
@@ -31,12 +31,12 @@ pub trait BundleView<NoteRef> {
 }
 
 impl<'a, NoteRef, In: InputView<NoteRef>, Out: OutputView> BundleView<NoteRef>
-    for (BundlePoolRestrictions, &'a [In], &'a [Out])
+    for (BundleVersion, &'a [In], &'a [Out])
 {
     type In = In;
     type Out = Out;
 
-    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
+    fn bundle_version(&self) -> BundleVersion {
         self.0
     }
 
@@ -56,8 +56,8 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type In = Infallible;
     type Out = Infallible;
 
-    fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
-        crate::ANY_ORCHARD_POOL_RESTRICTIONS
+    fn bundle_version(&self) -> BundleVersion {
+        crate::ANY_ORCHARD_BUNDLE_VERSION
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -57,7 +57,7 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type Out = Infallible;
 
     fn bundle_pool_restrictions(&self) -> BundlePoolRestrictions {
-        BundlePoolRestrictions::OrchardNu6_2Only
+        crate::ANY_ORCHARD_POOL_RESTRICTIONS
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -11,7 +11,7 @@ pub(crate) fn transactional_action_count(
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    BundleType::DEFAULT.num_actions(num_spends, num_outputs, bundle_version)
+    BundleType::DEFAULT.num_actions(bundle_version.default_flags(), num_spends, num_outputs)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
+                crate::ANY_ORCHARD_BUNDLE_VERSION,
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+                crate::ANY_ORCHARD_POOL_RESTRICTIONS,
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                orchard::BundleProtocol::OrchardPreNu6_3,
+                orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,16 +82,14 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
-/// Orchard pool restriction for call sites that should not select a concrete
-/// Orchard or Ironwood branch-specific policy.
+/// Orchard bundle version for fee and change call sites that should not select a concrete
+/// branch-specific policy.
 ///
-/// For note decryption, every Orchard pool restriction selects the same V2 note
-/// plaintext domain. For the fee call sites that use this constant, the chosen
-/// value preserves the legacy Orchard action-count policy those paths used before
-/// `BundlePoolRestrictions` replaced `BundleProtocol`.
+/// These paths only need a bundle version to drive the Orchard action-count policy; the chosen
+/// value preserves the legacy pre-NU6.3 Orchard behavior those paths used historically.
 #[cfg(feature = "orchard")]
-pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: ::orchard::bundle::BundlePoolRestrictions =
-    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only;
+pub(crate) const ANY_ORCHARD_BUNDLE_VERSION: ::orchard::bundle::BundleVersion =
+    ::orchard::bundle::BundleVersion::orchard_v1();
 
 #[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
 pub mod address {

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,11 +82,13 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
-/// Orchard pool restriction for operations whose result is invariant to it:
-/// note decryption and fee/action-count estimation. Every Orchard pool
-/// restriction yields the same result for these, so this names the otherwise
-/// arbitrary value rather than scattering `BundlePoolRestrictions` literals that
-/// read as load-bearing.
+/// Orchard pool restriction for call sites that should not select a concrete
+/// Orchard or Ironwood branch-specific policy.
+///
+/// For note decryption, every Orchard pool restriction selects the same V2 note
+/// plaintext domain. For the fee call sites that use this constant, the chosen
+/// value preserves the legacy Orchard action-count policy those paths used before
+/// `BundlePoolRestrictions` replaced `BundleProtocol`.
 #[cfg(feature = "orchard")]
 pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: ::orchard::bundle::BundlePoolRestrictions =
     ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only;

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,6 +82,15 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
+/// Orchard pool restriction for operations whose result is invariant to it:
+/// note decryption and fee/action-count estimation. Every Orchard pool
+/// restriction yields the same result for these, so this names the otherwise
+/// arbitrary value rather than scattering `BundlePoolRestrictions` literals that
+/// read as load-bearing.
+#[cfg(feature = "orchard")]
+pub(crate) const ANY_ORCHARD_POOL_RESTRICTIONS: ::orchard::bundle::BundlePoolRestrictions =
+    ::orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only;
+
 #[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
 pub mod address {
     pub use zcash_keys::address::*;

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -89,7 +89,7 @@ pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 /// value preserves the legacy pre-NU6.3 Orchard behavior those paths used historically.
 #[cfg(feature = "orchard")]
 pub(crate) const ANY_ORCHARD_BUNDLE_VERSION: ::orchard::bundle::BundleVersion =
-    ::orchard::bundle::BundleVersion::orchard_v1();
+    ::orchard::bundle::BundleVersion::orchard_v2();
 
 #[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
 pub mod address {

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -26,13 +26,19 @@ workspace.
 
 ### Changed
 - `zcash_primitives::transaction::builder`:
-  - NU6.3 standard builders use the NU6.3 Orchard bundle protocol when
+  - NU6.3 standard builders use the NU6.3 Orchard pool restrictions when
     constructing V6 transactions.
   - NU6.3 coinbase builders no longer expose Orchard outputs.
 - `TransactionDigest::digest_orchard` now receives `TxVersion`, so digest
   implementations can distinguish Orchard commitments by transaction format.
 - `TransactionDigest::digest_sapling` now receives `TxVersion`, so digest
   implementations can distinguish Sapling commitments by transaction format.
+- Updated the `orchard` dependency to the `feat/ironwood` revision `30c4ea2`,
+  which restricts cross-address transfers to the Ironwood pool (an Orchard v6
+  bundle can no longer set the cross-address flag) and renames the pool selector
+  to `BundlePoolRestrictions`. The v6 bundle (de)serialization helpers
+  `zcash_primitives::transaction::components::orchard::{read_v6_bundle,
+  write_v6_bundle, read_flags}` now take a `BundlePoolRestrictions` argument.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -33,12 +33,15 @@ workspace.
   implementations can distinguish Orchard commitments by transaction format.
 - `TransactionDigest::digest_sapling` now receives `TxVersion`, so digest
   implementations can distinguish Sapling commitments by transaction format.
-- Updated the `orchard` dependency to the `feat/ironwood` revision `30c4ea2`,
-  which restricts cross-address transfers to the Ironwood pool (an Orchard v6
-  bundle can no longer set the cross-address flag) and renames the pool selector
-  to `BundlePoolRestrictions`. The v6 bundle (de)serialization helpers
-  `zcash_primitives::transaction::components::orchard::{read_v6_bundle,
-  write_v6_bundle, read_flags}` now take a `BundlePoolRestrictions` argument.
+- Updated the `orchard` dependency to the `feat/ironwood` revision `cbb6ed1`,
+  which gives every `Bundle` an explicit `BundleVersion` (distinguishing value
+  pool, protocol version, and bundle version) and lifts `Flags` out of
+  `BundleType`. Cross-address transfers are restricted to the Ironwood pool (an
+  Orchard v6 bundle can no longer set the cross-address flag). The bundle
+  (de)serialization helpers
+  `zcash_primitives::transaction::components::orchard::{read_v5_bundle,
+  read_v6_bundle, read_flags}` now take a `BundleVersion` argument, while
+  `write_v6_bundle` derives the version from the bundle.
 
 ### Removed
 - All support for Transparent Zcash Extensions (TZEs), which was only ever

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -247,19 +247,26 @@ impl BuildConfig {
     /// Returns the Orchard builder for this configuration.
     fn orchard_builder(
         &self,
-        protocol: orchard::BundleProtocol,
+        pool_restrictions: orchard::bundle::BundlePoolRestrictions,
     ) -> Option<orchard::builder::Builder> {
         match self {
             BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
-                orchard::builder::Builder::new(protocol, orchard::builder::BundleType::DEFAULT, *a)
+                orchard::builder::Builder::new(
+                    pool_restrictions,
+                    orchard::builder::BundleType::DEFAULT,
+                    *a,
+                )
             }),
             BuildConfig::Coinbase { .. }
-                if matches!(protocol, orchard::BundleProtocol::OrchardPostNu6_3) =>
+                if matches!(
+                    pool_restrictions,
+                    orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward
+                ) =>
             {
                 None
             }
             BuildConfig::Coinbase { .. } => Some(orchard::builder::Builder::new(
-                protocol,
+                pool_restrictions,
                 orchard::builder::BundleType::Coinbase,
                 orchard::Anchor::empty_tree(),
             )),
@@ -275,6 +282,7 @@ impl BuildConfig {
 fn orchard_action_count(
     builder: &orchard::builder::Builder,
     is_coinbase: bool,
+    pool_restrictions: orchard::bundle::BundlePoolRestrictions,
 ) -> Result<usize, &'static str> {
     let num_spends = builder.spends().len();
     let num_outputs = builder
@@ -289,17 +297,19 @@ fn orchard_action_count(
         orchard::builder::BundleType::DEFAULT
     };
 
-    bundle_type.num_actions(num_spends, num_outputs, builder.protocol())
+    bundle_type.num_actions(num_spends, num_outputs, pool_restrictions)
 }
 
-fn orchard_protocol_for_branch(consensus_branch_id: BranchId) -> orchard::BundleProtocol {
+fn orchard_pool_restrictions_for_branch(
+    consensus_branch_id: BranchId,
+) -> orchard::bundle::BundlePoolRestrictions {
     match consensus_branch_id {
         #[cfg(zcash_unstable = "nu6.3")]
-        BranchId::Nu6_3 => orchard::BundleProtocol::OrchardPostNu6_3,
+        BranchId::Nu6_3 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
         #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => orchard::BundleProtocol::OrchardPostNu6_3,
-        BranchId::Nu6_2 => orchard::BundleProtocol::OrchardPreNu6_3,
-        _ => orchard::BundleProtocol::OrchardPreNu6_2,
+        BranchId::Nu7 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        BranchId::Nu6_2 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
+        _ => orchard::bundle::BundlePoolRestrictions::OrchardPreNu6_2,
     }
 }
 
@@ -369,6 +379,7 @@ pub struct Builder<P, U> {
     transparent_builder: TransparentBuilder,
     sapling_builder: Option<sapling::builder::Builder>,
     orchard_builder: Option<orchard::builder::Builder>,
+    orchard_pool_restrictions: Option<orchard::bundle::BundlePoolRestrictions>,
     _progress_notifier: U,
 }
 
@@ -475,13 +486,14 @@ impl<P: consensus::Parameters> Builder<P, ()> {
     /// expiry delta (20 blocks).
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
-        let orchard_protocol = orchard_protocol_for_branch(consensus_branch_id);
+        let pool_restrictions = orchard_pool_restrictions_for_branch(consensus_branch_id);
 
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
-            build_config.orchard_builder(orchard_protocol)
+            build_config.orchard_builder(pool_restrictions)
         } else {
             None
         };
+        let orchard_pool_restrictions = orchard_builder.as_ref().map(|_| pool_restrictions);
 
         let sapling_builder = build_config
             .sapling_builder_config()
@@ -523,6 +535,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder,
             orchard_builder,
+            orchard_pool_restrictions,
             _progress_notifier: (),
         }
     }
@@ -550,6 +563,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: self.transparent_builder,
             sapling_builder: self.sapling_builder,
             orchard_builder: self.orchard_builder,
+            orchard_pool_restrictions: self.orchard_pool_restrictions,
             _progress_notifier,
         }
     }
@@ -741,7 +755,12 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                 self.orchard_builder
                     .as_ref()
                     .map_or(Ok(0), |builder| {
-                        orchard_action_count(builder, self.build_config.is_coinbase())
+                        orchard_action_count(
+                            builder,
+                            self.build_config.is_coinbase(),
+                            self.orchard_pool_restrictions
+                                .expect("orchard builder present implies pool restrictions"),
+                        )
                     })
                     .map_err(FeeError::Bundle)?,
             )
@@ -1250,8 +1269,8 @@ mod tests {
 
         assert_eq!(builder.tx_version, crate::transaction::TxVersion::V6);
         assert_eq!(
-            builder.orchard_builder.as_ref().map(|b| b.protocol()),
-            Some(orchard::BundleProtocol::OrchardPostNu6_3)
+            builder.orchard_pool_restrictions,
+            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
         );
     }
 
@@ -1272,8 +1291,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            builder.orchard_builder.as_ref().map(|b| b.protocol()),
-            Some(orchard::BundleProtocol::OrchardPostNu6_3)
+            builder.orchard_pool_restrictions,
+            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
         );
     }
 
@@ -1312,7 +1331,7 @@ mod tests {
         );
         let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
         let mut builder = orchard::builder::Builder::new(
-            orchard::BundleProtocol::OrchardPostNu6_3,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );
@@ -1327,7 +1346,15 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(super::orchard_action_count(&builder, false).unwrap(), 2);
+        assert_eq!(
+            super::orchard_action_count(
+                &builder,
+                false,
+                orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+            )
+            .unwrap(),
+            2
+        );
     }
 
     // This test only works with the transparent_inputs feature because we have to
@@ -1360,6 +1387,7 @@ mod tests {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder: None,
             orchard_builder: None,
+            orchard_pool_restrictions: None,
             _progress_notifier: (),
         };
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -252,21 +252,30 @@ impl BuildConfig {
         match self {
             BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    bundle_version,
                     orchard::builder::BundleType::DEFAULT,
+                    bundle_version,
+                    bundle_version.default_flags(),
                     *a,
                 )
+                .expect("the default flags are always representable for a transactional bundle")
             }),
             BuildConfig::Coinbase { .. }
                 if bundle_version == orchard::bundle::BundleVersion::orchard_v2() =>
             {
                 None
             }
-            BuildConfig::Coinbase { .. } => Some(orchard::builder::Builder::new(
-                bundle_version,
-                orchard::builder::BundleType::Coinbase,
-                orchard::Anchor::empty_tree(),
-            )),
+            BuildConfig::Coinbase { .. } => Some(
+                orchard::builder::Builder::new(
+                    orchard::builder::BundleType::Coinbase,
+                    bundle_version,
+                    // Coinbase transactions have `enableSpends = 0`. Every pool for which a
+                    // coinbase Orchard bundle is built (Orchard pre-NU6.3 and Ironwood) permits
+                    // cross-address transfers, so the spends-disabled flag set is representable.
+                    orchard::bundle::Flags::SPENDS_DISABLED,
+                    orchard::Anchor::empty_tree(),
+                )
+                .expect("spends-disabled flags are valid for a non-Orchard coinbase bundle"),
+            ),
         }
     }
 
@@ -288,13 +297,22 @@ fn orchard_action_count(
         .checked_add(builder.changes().len())
         .ok_or("num_outputs + num_changes overflowed")?;
 
-    let bundle_type = if is_coinbase {
-        orchard::builder::BundleType::Coinbase
+    // The flags must match those the builder constructs for each configuration (see
+    // `orchard_builder`). For a `Coinbase` bundle `num_actions` ignores the flags, but supplying
+    // the matching set keeps the two paths consistent.
+    let (bundle_type, flags) = if is_coinbase {
+        (
+            orchard::builder::BundleType::Coinbase,
+            orchard::bundle::Flags::SPENDS_DISABLED,
+        )
     } else {
-        orchard::builder::BundleType::DEFAULT
+        (
+            orchard::builder::BundleType::DEFAULT,
+            bundle_version.default_flags(),
+        )
     };
 
-    bundle_type.num_actions(num_spends, num_outputs, bundle_version)
+    bundle_type.num_actions(flags, num_spends, num_outputs)
 }
 
 fn orchard_bundle_version_for_branch(
@@ -1328,10 +1346,12 @@ mod tests {
         );
         let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
         let mut builder = orchard::builder::Builder::new(
-            orchard::bundle::BundleVersion::orchard_v2(),
             orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
             orchard::Anchor::empty_tree(),
-        );
+        )
+        .unwrap();
 
         builder
             .add_change_output(

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -247,26 +247,23 @@ impl BuildConfig {
     /// Returns the Orchard builder for this configuration.
     fn orchard_builder(
         &self,
-        pool_restrictions: orchard::bundle::BundlePoolRestrictions,
+        bundle_version: orchard::bundle::BundleVersion,
     ) -> Option<orchard::builder::Builder> {
         match self {
             BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    pool_restrictions,
+                    bundle_version,
                     orchard::builder::BundleType::DEFAULT,
                     *a,
                 )
             }),
             BuildConfig::Coinbase { .. }
-                if matches!(
-                    pool_restrictions,
-                    orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward
-                ) =>
+                if bundle_version == orchard::bundle::BundleVersion::orchard_v2() =>
             {
                 None
             }
             BuildConfig::Coinbase { .. } => Some(orchard::builder::Builder::new(
-                pool_restrictions,
+                bundle_version,
                 orchard::builder::BundleType::Coinbase,
                 orchard::Anchor::empty_tree(),
             )),
@@ -282,7 +279,7 @@ impl BuildConfig {
 fn orchard_action_count(
     builder: &orchard::builder::Builder,
     is_coinbase: bool,
-    pool_restrictions: orchard::bundle::BundlePoolRestrictions,
+    bundle_version: orchard::bundle::BundleVersion,
 ) -> Result<usize, &'static str> {
     let num_spends = builder.spends().len();
     let num_outputs = builder
@@ -297,19 +294,19 @@ fn orchard_action_count(
         orchard::builder::BundleType::DEFAULT
     };
 
-    bundle_type.num_actions(num_spends, num_outputs, pool_restrictions)
+    bundle_type.num_actions(num_spends, num_outputs, bundle_version)
 }
 
-fn orchard_pool_restrictions_for_branch(
+fn orchard_bundle_version_for_branch(
     consensus_branch_id: BranchId,
-) -> orchard::bundle::BundlePoolRestrictions {
+) -> orchard::bundle::BundleVersion {
     match consensus_branch_id {
         #[cfg(zcash_unstable = "nu6.3")]
-        BranchId::Nu6_3 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        BranchId::Nu6_3 => orchard::bundle::BundleVersion::orchard_v2(),
         #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
-        BranchId::Nu6_2 => orchard::bundle::BundlePoolRestrictions::OrchardNu6_2Only,
-        _ => orchard::bundle::BundlePoolRestrictions::OrchardPreNu6_2,
+        BranchId::Nu7 => orchard::bundle::BundleVersion::orchard_v2(),
+        BranchId::Nu6_2 => orchard::bundle::BundleVersion::orchard_v1(),
+        _ => orchard::bundle::BundleVersion::orchard_insecure_v0(),
     }
 }
 
@@ -379,7 +376,7 @@ pub struct Builder<P, U> {
     transparent_builder: TransparentBuilder,
     sapling_builder: Option<sapling::builder::Builder>,
     orchard_builder: Option<orchard::builder::Builder>,
-    orchard_pool_restrictions: Option<orchard::bundle::BundlePoolRestrictions>,
+    orchard_bundle_version: Option<orchard::bundle::BundleVersion>,
     _progress_notifier: U,
 }
 
@@ -486,14 +483,14 @@ impl<P: consensus::Parameters> Builder<P, ()> {
     /// expiry delta (20 blocks).
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
-        let pool_restrictions = orchard_pool_restrictions_for_branch(consensus_branch_id);
+        let bundle_version = orchard_bundle_version_for_branch(consensus_branch_id);
 
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
-            build_config.orchard_builder(pool_restrictions)
+            build_config.orchard_builder(bundle_version)
         } else {
             None
         };
-        let orchard_pool_restrictions = orchard_builder.as_ref().map(|_| pool_restrictions);
+        let orchard_bundle_version = orchard_builder.as_ref().map(|_| bundle_version);
 
         let sapling_builder = build_config
             .sapling_builder_config()
@@ -535,7 +532,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder,
             orchard_builder,
-            orchard_pool_restrictions,
+            orchard_bundle_version,
             _progress_notifier: (),
         }
     }
@@ -563,7 +560,7 @@ impl<P: consensus::Parameters> Builder<P, ()> {
             transparent_builder: self.transparent_builder,
             sapling_builder: self.sapling_builder,
             orchard_builder: self.orchard_builder,
-            orchard_pool_restrictions: self.orchard_pool_restrictions,
+            orchard_bundle_version: self.orchard_bundle_version,
             _progress_notifier,
         }
     }
@@ -758,8 +755,8 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
                         orchard_action_count(
                             builder,
                             self.build_config.is_coinbase(),
-                            self.orchard_pool_restrictions
-                                .expect("orchard builder present implies pool restrictions"),
+                            self.orchard_bundle_version
+                                .expect("orchard builder present implies bundle version"),
                         )
                     })
                     .map_err(FeeError::Bundle)?,
@@ -1269,8 +1266,8 @@ mod tests {
 
         assert_eq!(builder.tx_version, crate::transaction::TxVersion::V6);
         assert_eq!(
-            builder.orchard_pool_restrictions,
-            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
+            builder.orchard_bundle_version,
+            Some(orchard::bundle::BundleVersion::orchard_v2())
         );
     }
 
@@ -1291,8 +1288,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            builder.orchard_pool_restrictions,
-            Some(orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward)
+            builder.orchard_bundle_version,
+            Some(orchard::bundle::BundleVersion::orchard_v2())
         );
     }
 
@@ -1331,7 +1328,7 @@ mod tests {
         );
         let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
         let mut builder = orchard::builder::Builder::new(
-            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+            orchard::bundle::BundleVersion::orchard_v2(),
             orchard::builder::BundleType::DEFAULT,
             orchard::Anchor::empty_tree(),
         );
@@ -1350,7 +1347,7 @@ mod tests {
             super::orchard_action_count(
                 &builder,
                 false,
-                orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+                orchard::bundle::BundleVersion::orchard_v2(),
             )
             .unwrap(),
             2
@@ -1387,7 +1384,7 @@ mod tests {
             transparent_builder: TransparentBuilder::empty(),
             sapling_builder: None,
             orchard_builder: None,
-            orchard_pool_restrictions: None,
+            orchard_bundle_version: None,
             _progress_notifier: (),
         };
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -260,7 +260,7 @@ impl BuildConfig {
                 .expect("the default flags are always representable for a transactional bundle")
             }),
             BuildConfig::Coinbase { .. }
-                if bundle_version == orchard::bundle::BundleVersion::orchard_v2() =>
+                if bundle_version == orchard::bundle::BundleVersion::orchard_v3() =>
             {
                 None
             }
@@ -320,11 +320,11 @@ fn orchard_bundle_version_for_branch(
 ) -> orchard::bundle::BundleVersion {
     match consensus_branch_id {
         #[cfg(zcash_unstable = "nu6.3")]
-        BranchId::Nu6_3 => orchard::bundle::BundleVersion::orchard_v2(),
+        BranchId::Nu6_3 => orchard::bundle::BundleVersion::orchard_v3(),
         #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => orchard::bundle::BundleVersion::orchard_v2(),
-        BranchId::Nu6_2 => orchard::bundle::BundleVersion::orchard_v1(),
-        _ => orchard::bundle::BundleVersion::orchard_insecure_v0(),
+        BranchId::Nu7 => orchard::bundle::BundleVersion::orchard_v3(),
+        BranchId::Nu6_2 => orchard::bundle::BundleVersion::orchard_v2(),
+        _ => orchard::bundle::BundleVersion::orchard_insecure_v1(),
     }
 }
 
@@ -1285,7 +1285,7 @@ mod tests {
         assert_eq!(builder.tx_version, crate::transaction::TxVersion::V6);
         assert_eq!(
             builder.orchard_bundle_version,
-            Some(orchard::bundle::BundleVersion::orchard_v2())
+            Some(orchard::bundle::BundleVersion::orchard_v3())
         );
     }
 
@@ -1307,7 +1307,7 @@ mod tests {
 
         assert_eq!(
             builder.orchard_bundle_version,
-            Some(orchard::bundle::BundleVersion::orchard_v2())
+            Some(orchard::bundle::BundleVersion::orchard_v3())
         );
     }
 
@@ -1347,8 +1347,8 @@ mod tests {
         let recipient = fvk.address_at(0u32, orchard::keys::Scope::Internal);
         let mut builder = orchard::builder::Builder::new(
             orchard::builder::BundleType::DEFAULT,
-            orchard::bundle::BundleVersion::orchard_v2(),
-            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            orchard::bundle::BundleVersion::orchard_v3(),
+            orchard::bundle::BundleVersion::orchard_v3().default_flags(),
             orchard::Anchor::empty_tree(),
         )
         .unwrap();
@@ -1367,7 +1367,7 @@ mod tests {
             super::orchard_action_count(
                 &builder,
                 false,
-                orchard::bundle::BundleVersion::orchard_v2(),
+                orchard::bundle::BundleVersion::orchard_v3(),
             )
             .unwrap(),
             2

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -9,7 +9,7 @@ use nonempty::NonEmpty;
 
 use orchard::{
     Action, Anchor,
-    bundle::{Authorization, Authorized, BundleFormat, Flags, ProofSizeEnforcement},
+    bundle::{Authorization, Authorized, BundlePoolRestrictions, Flags, ProofSizeEnforcement},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
     value::ValueCommitment,
@@ -50,14 +50,14 @@ impl MapAuth<Authorized, Authorized> for () {
 fn read_bundle<R: Read>(
     mut reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
-    bundle_format: BundleFormat,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
-        let flags = read_flags(&mut reader, bundle_format)?;
+        let flags = read_flags(&mut reader, pool_restrictions)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
         let proof_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
@@ -99,20 +99,47 @@ fn read_bundle<R: Read>(
 /// height; only the bundle commitment domain varies across upgrades, and that
 /// affects the txid/sighash digests rather than deserialization. Since this is
 /// public API, keeping the signature unchanged also avoids an unnecessary
-/// breaking change. (By contrast, `read_v6_bundle` is reused across the
-/// Ironwood and Orchard v6 bundles, so its format is selected by the caller.)
+/// breaking change. (By contrast, `read_v6_bundle` takes a `pool_restrictions`
+/// argument so the caller selects the Orchard or Ironwood v6 pool.)
 pub fn read_v5_bundle<R: Read>(
     reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, proof_size_enforcement, BundleFormat::PreNu6_3)
+    read_bundle(
+        reader,
+        proof_size_enforcement,
+        BundlePoolRestrictions::OrchardNu6_2Only,
+    )
 }
 
+/// Rejects pool restrictions that are not valid for the v6 transaction format,
+/// which has exactly two Orchard-bundle slots: the Orchard slot
+/// (`OrchardNu6_3Onward`) and the Ironwood slot (`IronwoodNu6_3Onward`). A pre-v6
+/// restriction would (de)serialize the flag byte with the wrong cross-address
+/// (bit 2) semantics.
+#[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+fn check_v6_pool_restrictions(pool_restrictions: BundlePoolRestrictions) -> io::Result<()> {
+    match pool_restrictions {
+        BundlePoolRestrictions::OrchardNu6_3Onward
+        | BundlePoolRestrictions::IronwoodNu6_3Onward => Ok(()),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "v6 Orchard bundles require OrchardNu6_3Onward or IronwoodNu6_3Onward",
+        )),
+    }
+}
+
+/// Reads an [`orchard::Bundle`] from a v6 transaction format. `pool_restrictions`
+/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
+/// `IronwoodNu6_3Onward` for the Ironwood bundle (whose flag-byte encoding permits
+/// the cross-address bit, unlike the Orchard v6 pool).
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn read_v6_bundle<R: Read>(
     reader: R,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, ProofSizeEnforcement::Strict, BundleFormat::Nu6_3)
+    check_v6_pool_restrictions(pool_restrictions)?;
+    read_bundle(reader, ProofSizeEnforcement::Strict, pool_restrictions)
 }
 
 pub fn read_value_commitment<R: Read>(mut reader: R) -> io::Result<ValueCommitment> {
@@ -188,10 +215,13 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
-pub fn read_flags<R: Read>(mut reader: R, bundle_format: BundleFormat) -> io::Result<Flags> {
+pub fn read_flags<R: Read>(
+    mut reader: R,
+    pool_restrictions: BundlePoolRestrictions,
+) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0], bundle_format)
+    Flags::from_byte(byte[0], pool_restrictions)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -211,14 +241,14 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 fn write_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     mut writer: W,
-    bundle_format: BundleFormat,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
         Vector::write_nonempty(&mut writer, bundle.actions(), |w, a| {
             write_action_without_auth(w, a)
         })?;
 
-        let flags = bundle.flags().to_byte(bundle_format).ok_or_else(|| {
+        let flags = bundle.flags().to_byte(pool_restrictions).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Orchard flags cannot be encoded in this transaction format",
@@ -252,15 +282,20 @@ pub fn write_v5_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundleFormat::PreNu6_3)
+    write_bundle(bundle, writer, BundlePoolRestrictions::OrchardNu6_2Only)
 }
 
+/// Writes an [`orchard::Bundle`] in the v6 transaction format. `pool_restrictions`
+/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
+/// `IronwoodNu6_3Onward` for the Ironwood bundle.
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn write_v6_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
+    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundleFormat::Nu6_3)
+    check_v6_pool_restrictions(pool_restrictions)?;
+    write_bundle(bundle, writer, pool_restrictions)
 }
 
 pub fn write_value_commitment<W: Write>(mut writer: W, cv: &ValueCommitment) -> io::Result<()> {
@@ -330,9 +365,77 @@ pub mod testing {
         v: TxVersion,
     ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
         if v.has_orchard() {
-            Strategy::boxed((1usize..100).prop_flat_map(|n| prop::option::of(arb_bundle(n))))
+            // In a v6 transaction the Orchard pool is encoded as
+            // `OrchardNu6_3Onward`, which forbids cross-address transfers, so a
+            // valid Orchard bundle must have the cross-address flag disabled.
+            // (The Ironwood slot uses `arb_ironwood_bundle_for_version`, whose
+            // `IronwoodNu6_3Onward` pool permits cross-address transfers.)
+            let force_cross_address_disabled = orchard_pool_forbids_cross_address(v);
+            (1usize..100)
+                .prop_flat_map(move |n| {
+                    prop::option::of(arb_bundle(n).prop_map(move |bundle| {
+                        if force_cross_address_disabled && bundle.flags().cross_address_enabled() {
+                            with_cross_address_disabled(bundle)
+                        } else {
+                            bundle
+                        }
+                    }))
+                })
+                .boxed()
         } else {
-            Strategy::boxed(Just(None))
+            Just(None).boxed()
         }
+    }
+
+    /// Generates Ironwood bundles for the v6 transaction format. Unlike the
+    /// Orchard v6 pool, the Ironwood pool (`IronwoodNu6_3Onward`) permits
+    /// cross-address transfers, so the cross-address flag is left as generated;
+    /// this exercises the Ironwood serialization path the Orchard generator
+    /// cannot.
+    #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+    pub fn arb_ironwood_bundle_for_version(
+        v: TxVersion,
+    ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
+        if v.has_ironwood() {
+            (1usize..100)
+                .prop_flat_map(|n| prop::option::of(arb_bundle(n)))
+                .boxed()
+        } else {
+            Just(None).boxed()
+        }
+    }
+
+    /// Mirrors `txid::orchard_commitment_domain`: v6 Orchard bundles use
+    /// `OrchardNu6_3Onward`, which forbids cross-address transfers; v5 uses
+    /// `OrchardNu6_2Only`, which permits them.
+    fn orchard_pool_forbids_cross_address(v: TxVersion) -> bool {
+        #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
+        if matches!(v, TxVersion::V6) {
+            return true;
+        }
+        let _ = v;
+        false
+    }
+
+    /// Rebuilds an Orchard bundle with the cross-address flag cleared (preserving
+    /// its spends/outputs flags) so it is valid under the Orchard v6 pool
+    /// restriction `OrchardNu6_3Onward`.
+    fn with_cross_address_disabled(
+        bundle: Bundle<Authorized, ZatBalance>,
+    ) -> Bundle<Authorized, ZatBalance> {
+        use ::orchard::bundle::{BundlePoolRestrictions, Flags, ProofSizeEnforcement};
+        let byte = u8::from(bundle.flags().spends_enabled())
+            | (u8::from(bundle.flags().outputs_enabled()) << 1);
+        let flags = Flags::from_byte(byte, BundlePoolRestrictions::OrchardNu6_3Onward)
+            .expect("spends/outputs-only flags encode under OrchardNu6_3Onward");
+        ::orchard::Bundle::try_from_parts(
+            bundle.actions().clone(),
+            flags,
+            *bundle.value_balance(),
+            *bundle.anchor(),
+            bundle.authorization().clone(),
+            ProofSizeEnforcement::Strict,
+        )
+        .expect("clearing cross-address yields a representable Orchard bundle")
     }
 }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -77,7 +77,7 @@ fn read_bundle<R: Read>(
         // `try_from_parts` rejects a proof whose length is not the canonical size for the number
         // of actions, preventing a proof padded with arbitrary data (GHSA-2x4w-pxqw-58v9). Proof
         // size is enforced for every version except the historical pre-NU6.2 Orchard pool
-        // ([`BundleVersion::orchard_insecure_v0`]); see the `bundle_version` chosen by the caller.
+        // ([`BundleVersion::orchard_insecure_v1`]); see the `bundle_version` chosen by the caller.
         orchard::Bundle::try_from_parts(
             actions,
             flags,
@@ -103,8 +103,8 @@ fn read_bundle<R: Read>(
 /// the caller selects the Orchard or Ironwood v6 slot.
 ///
 /// `bundle_version` must be an Orchard-pool version whose flag byte uses the v5 grammar (bit 2
-/// reserved): [`BundleVersion::orchard_insecure_v0`] before NU6.2, [`BundleVersion::orchard_v1`]
-/// at NU6.2, or [`BundleVersion::orchard_v2`] from NU6.3 (a v5 transaction stays valid under
+/// reserved): [`BundleVersion::orchard_insecure_v1`] before NU6.2, [`BundleVersion::orchard_v2`]
+/// at NU6.2, or [`BundleVersion::orchard_v3`] from NU6.3 (a v5 transaction stays valid under
 /// NU6.3+). All three share that grammar, and the version's protocol generation selects whether
 /// the canonical proof size is enforced.
 pub fn read_v5_bundle<R: Read>(
@@ -115,26 +115,26 @@ pub fn read_v5_bundle<R: Read>(
 }
 
 /// Rejects bundle versions that are not valid for the v6 transaction format, which has exactly
-/// two Orchard-bundle slots: the Orchard slot ([`BundleVersion::orchard_v2`]) and the Ironwood
-/// slot ([`BundleVersion::ironwood_v2`]). A pre-NU6.3 version would (de)serialize the flag byte
+/// two Orchard-bundle slots: the Orchard slot ([`BundleVersion::orchard_v3`]) and the Ironwood
+/// slot ([`BundleVersion::ironwood_v3`]). A pre-NU6.3 version would (de)serialize the flag byte
 /// with the wrong cross-address (bit 2) semantics.
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 fn check_v6_bundle_version(bundle_version: BundleVersion) -> io::Result<()> {
-    if bundle_version == BundleVersion::orchard_v2()
-        || bundle_version == BundleVersion::ironwood_v2()
+    if bundle_version == BundleVersion::orchard_v3()
+        || bundle_version == BundleVersion::ironwood_v3()
     {
         Ok(())
     } else {
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "v6 Orchard bundles require orchard_v2 or ironwood_v2",
+            "v6 Orchard bundles require orchard_v3 or ironwood_v3",
         ))
     }
 }
 
 /// Reads an [`orchard::Bundle`] from a v6 transaction format. `bundle_version`
-/// selects the pool: [`BundleVersion::orchard_v2`] for the Orchard v6 bundle, or
-/// [`BundleVersion::ironwood_v2`] for the Ironwood bundle (whose flag-byte encoding permits
+/// selects the pool: [`BundleVersion::orchard_v3`] for the Orchard v6 bundle, or
+/// [`BundleVersion::ironwood_v3`] for the Ironwood bundle (whose flag-byte encoding permits
 /// the cross-address bit, unlike the Orchard v6 pool).
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn read_v6_bundle<R: Read>(
@@ -285,7 +285,7 @@ pub fn write_v5_bundle<W: Write>(
 
 /// Writes an [`orchard::Bundle`] in the v6 transaction format. The bundle's own
 /// [`BundleVersion`] selects the pool (and hence the flag-byte grammar): the Orchard slot uses
-/// [`BundleVersion::orchard_v2`], the Ironwood slot [`BundleVersion::ironwood_v2`].
+/// [`BundleVersion::orchard_v3`], the Ironwood slot [`BundleVersion::ironwood_v3`].
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn write_v6_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
@@ -364,8 +364,8 @@ pub mod testing {
         v: TxVersion,
     ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
         if v.has_orchard() {
-            // The Orchard slot uses `orchard_v2()` in a v6 transaction (cross-address forbidden)
-            // and `orchard_v1()` in a v5 transaction; the Ironwood slot is generated separately by
+            // The Orchard slot uses `orchard_v3()` in a v6 transaction (cross-address forbidden)
+            // and `orchard_v2()` in a v5 transaction; the Ironwood slot is generated separately by
             // `arb_ironwood_bundle_for_version`.
             let bundle_version = orchard_bundle_version(v);
             (1usize..100)
@@ -381,7 +381,7 @@ pub mod testing {
     }
 
     /// Generates Ironwood bundles for the v6 transaction format. Unlike the Orchard v6 pool, the
-    /// Ironwood pool ([`BundleVersion::ironwood_v2`]) permits cross-address transfers, so this
+    /// Ironwood pool ([`BundleVersion::ironwood_v3`]) permits cross-address transfers, so this
     /// exercises the Ironwood serialization path the Orchard generator cannot.
     #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
     pub fn arb_ironwood_bundle_for_version(
@@ -392,7 +392,7 @@ pub mod testing {
                 .prop_flat_map(|n| {
                     prop::option::of(
                         arb_bundle(n)
-                            .prop_map(|b| rebuild_with_version(b, BundleVersion::ironwood_v2())),
+                            .prop_map(|b| rebuild_with_version(b, BundleVersion::ironwood_v3())),
                     )
                 })
                 .boxed()
@@ -401,15 +401,15 @@ pub mod testing {
         }
     }
 
-    /// The Orchard-slot [`BundleVersion`] for a transaction version: `orchard_v2()` in v6 (where
-    /// the Orchard pool forbids cross-address transfers), `orchard_v1()` otherwise.
+    /// The Orchard-slot [`BundleVersion`] for a transaction version: `orchard_v3()` in v6 (where
+    /// the Orchard pool forbids cross-address transfers), `orchard_v2()` otherwise.
     fn orchard_bundle_version(v: TxVersion) -> BundleVersion {
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
         if matches!(v, TxVersion::V6) {
-            return BundleVersion::orchard_v2();
+            return BundleVersion::orchard_v3();
         }
         let _ = v;
-        BundleVersion::orchard_v1()
+        BundleVersion::orchard_v2()
     }
 
     /// Rebuilds an arbitrary bundle under `bundle_version`, choosing a cross-address flag value
@@ -424,7 +424,7 @@ pub mod testing {
     ) -> Bundle<Authorized, ZatBalance> {
         let mut byte = u8::from(bundle.flags().spends_enabled())
             | (u8::from(bundle.flags().outputs_enabled()) << 1);
-        if bundle_version == BundleVersion::ironwood_v2() {
+        if bundle_version == BundleVersion::ironwood_v3() {
             byte |= 0b100;
         }
         let flags = Flags::from_byte(byte, bundle_version)

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -9,7 +9,7 @@ use nonempty::NonEmpty;
 
 use orchard::{
     Action, Anchor,
-    bundle::{Authorization, Authorized, BundlePoolRestrictions, Flags, ProofSizeEnforcement},
+    bundle::{Authorization, Authorized, BundleVersion, Flags},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
     value::ValueCommitment,
@@ -22,13 +22,6 @@ use crate::transaction::Transaction;
 pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
-
-/// The Orchard flag-byte grammar used by v5 transaction serialization.
-///
-/// This names the `BundlePoolRestrictions` value that makes Orchard's flag
-/// parser treat bit 2 as reserved. It is a serialization-format selector, not an
-/// assertion that the transaction is being read or written in the NU6.2 epoch.
-const ORCHARD_V5_FLAG_FORMAT: BundlePoolRestrictions = BundlePoolRestrictions::OrchardNu6_2Only;
 
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
@@ -56,15 +49,14 @@ impl MapAuth<Authorized, Authorized> for () {
 
 fn read_bundle<R: Read>(
     mut reader: R,
-    proof_size_enforcement: ProofSizeEnforcement,
-    flag_format: BundlePoolRestrictions,
+    bundle_version: BundleVersion,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
-        let flags = read_flags(&mut reader, flag_format)?;
+        let flags = read_flags(&mut reader, bundle_version)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
         let proof_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
@@ -82,15 +74,17 @@ fn read_bundle<R: Read>(
             binding_signature,
         );
 
-        // `try_from_parts` rejects a proof whose length is not the canonical size for the
-        // number of actions, preventing a proof padded with arbitrary data (GHSA-2x4w-pxqw-58v9).
+        // `try_from_parts` rejects a proof whose length is not the canonical size for the number
+        // of actions, preventing a proof padded with arbitrary data (GHSA-2x4w-pxqw-58v9). Proof
+        // size is enforced for every version except the historical pre-NU6.2 Orchard pool
+        // ([`BundleVersion::orchard_insecure_v0`]); see the `bundle_version` chosen by the caller.
         orchard::Bundle::try_from_parts(
             actions,
             flags,
             value_balance,
             anchor,
             authorization,
-            proof_size_enforcement,
+            bundle_version,
         )
         .map(Some)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
@@ -105,46 +99,50 @@ fn read_bundle<R: Read>(
 /// upgrade, so a v5 bundle deserializes the same way regardless of activation
 /// height; only the bundle commitment domain varies across upgrades, and that
 /// affects the txid/sighash digests rather than deserialization. Since this is
-/// public API, keeping the signature unchanged also avoids an unnecessary
-/// breaking change. A v5 transaction always uses `ORCHARD_V5_FLAG_FORMAT` for
-/// the Orchard flag byte. By contrast, `read_v6_bundle` takes a
-/// `pool_restrictions` argument so the caller selects the Orchard or Ironwood v6
-/// slot.
+/// public API. By contrast, `read_v6_bundle` takes a `bundle_version` argument so
+/// the caller selects the Orchard or Ironwood v6 slot.
+///
+/// `bundle_version` must be an Orchard-pool version whose flag byte uses the v5 grammar (bit 2
+/// reserved): [`BundleVersion::orchard_insecure_v0`] before NU6.2, [`BundleVersion::orchard_v1`]
+/// at NU6.2, or [`BundleVersion::orchard_v2`] from NU6.3 (a v5 transaction stays valid under
+/// NU6.3+). All three share that grammar, and the version's protocol generation selects whether
+/// the canonical proof size is enforced.
 pub fn read_v5_bundle<R: Read>(
     reader: R,
-    proof_size_enforcement: ProofSizeEnforcement,
+    bundle_version: BundleVersion,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, proof_size_enforcement, ORCHARD_V5_FLAG_FORMAT)
+    read_bundle(reader, bundle_version)
 }
 
-/// Rejects pool restrictions that are not valid for the v6 transaction format,
-/// which has exactly two Orchard-bundle slots: the Orchard slot
-/// (`OrchardNu6_3Onward`) and the Ironwood slot (`IronwoodNu6_3Onward`). A pre-v6
-/// restriction would (de)serialize the flag byte with the wrong cross-address
-/// (bit 2) semantics.
+/// Rejects bundle versions that are not valid for the v6 transaction format, which has exactly
+/// two Orchard-bundle slots: the Orchard slot ([`BundleVersion::orchard_v2`]) and the Ironwood
+/// slot ([`BundleVersion::ironwood_v2`]). A pre-NU6.3 version would (de)serialize the flag byte
+/// with the wrong cross-address (bit 2) semantics.
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-fn check_v6_pool_restrictions(pool_restrictions: BundlePoolRestrictions) -> io::Result<()> {
-    match pool_restrictions {
-        BundlePoolRestrictions::OrchardNu6_3Onward
-        | BundlePoolRestrictions::IronwoodNu6_3Onward => Ok(()),
-        _ => Err(io::Error::new(
+fn check_v6_bundle_version(bundle_version: BundleVersion) -> io::Result<()> {
+    if bundle_version == BundleVersion::orchard_v2()
+        || bundle_version == BundleVersion::ironwood_v2()
+    {
+        Ok(())
+    } else {
+        Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "v6 Orchard bundles require OrchardNu6_3Onward or IronwoodNu6_3Onward",
-        )),
+            "v6 Orchard bundles require orchard_v2 or ironwood_v2",
+        ))
     }
 }
 
-/// Reads an [`orchard::Bundle`] from a v6 transaction format. `pool_restrictions`
-/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
-/// `IronwoodNu6_3Onward` for the Ironwood bundle (whose flag-byte encoding permits
+/// Reads an [`orchard::Bundle`] from a v6 transaction format. `bundle_version`
+/// selects the pool: [`BundleVersion::orchard_v2`] for the Orchard v6 bundle, or
+/// [`BundleVersion::ironwood_v2`] for the Ironwood bundle (whose flag-byte encoding permits
 /// the cross-address bit, unlike the Orchard v6 pool).
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn read_v6_bundle<R: Read>(
     reader: R,
-    pool_restrictions: BundlePoolRestrictions,
+    bundle_version: BundleVersion,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    check_v6_pool_restrictions(pool_restrictions)?;
-    read_bundle(reader, ProofSizeEnforcement::Strict, pool_restrictions)
+    check_v6_bundle_version(bundle_version)?;
+    read_bundle(reader, bundle_version)
 }
 
 pub fn read_value_commitment<R: Read>(mut reader: R) -> io::Result<ValueCommitment> {
@@ -220,13 +218,10 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
-pub fn read_flags<R: Read>(
-    mut reader: R,
-    flag_format: BundlePoolRestrictions,
-) -> io::Result<Flags> {
+pub fn read_flags<R: Read>(mut reader: R, bundle_version: BundleVersion) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0], flag_format)
+    Flags::from_byte(byte[0], bundle_version)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -246,20 +241,15 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 fn write_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     mut writer: W,
-    flag_format: BundlePoolRestrictions,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
         Vector::write_nonempty(&mut writer, bundle.actions(), |w, a| {
             write_action_without_auth(w, a)
         })?;
 
-        let flags = bundle.flags().to_byte(flag_format).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Orchard flags cannot be encoded in this transaction format",
-            )
-        })?;
-        writer.write_all(&[flags])?;
+        // The flag byte is encoded under the bundle's own `BundleVersion`, which is infallible:
+        // a `Bundle` is only ever constructed with flags representable under its version.
+        writer.write_all(&[bundle.flag_byte()])?;
         writer.write_all(&bundle.value_balance().to_i64_le_bytes())?;
         writer.write_all(&bundle.anchor().to_bytes())?;
         Vector::write(
@@ -284,26 +274,27 @@ fn write_bundle<W: Write>(
 
 /// Writes an [`orchard::Bundle`] in the v5 transaction format.
 ///
-/// V5 serialization always uses `ORCHARD_V5_FLAG_FORMAT` for the Orchard flag
-/// byte, even when the v5 transaction appears after NU6.3 activation.
+/// The Orchard flag byte is encoded under the bundle's own [`BundleVersion`]; an Orchard bundle
+/// never sets the cross-address bit, so its byte is always valid for the v5 format.
 pub fn write_v5_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, ORCHARD_V5_FLAG_FORMAT)
+    write_bundle(bundle, writer)
 }
 
-/// Writes an [`orchard::Bundle`] in the v6 transaction format. `pool_restrictions`
-/// selects the pool: `OrchardNu6_3Onward` for the Orchard v6 bundle, or
-/// `IronwoodNu6_3Onward` for the Ironwood bundle.
+/// Writes an [`orchard::Bundle`] in the v6 transaction format. The bundle's own
+/// [`BundleVersion`] selects the pool (and hence the flag-byte grammar): the Orchard slot uses
+/// [`BundleVersion::orchard_v2`], the Ironwood slot [`BundleVersion::ironwood_v2`].
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
 pub fn write_v6_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
-    pool_restrictions: BundlePoolRestrictions,
 ) -> io::Result<()> {
-    check_v6_pool_restrictions(pool_restrictions)?;
-    write_bundle(bundle, writer, pool_restrictions)
+    if let Some(bundle) = bundle {
+        check_v6_bundle_version(bundle.bundle_version())?;
+    }
+    write_bundle(bundle, writer)
 }
 
 pub fn write_value_commitment<W: Write>(mut writer: W, cv: &ValueCommitment) -> io::Result<()> {
@@ -351,7 +342,7 @@ pub mod testing {
     use proptest::prelude::*;
 
     use orchard::bundle::{
-        Authorized, Bundle,
+        Authorized, Bundle, BundleVersion, Flags,
         testing::{self as t_orch},
     };
     use zcash_protocol::value::{ZatBalance, testing::arb_zat_balance};
@@ -373,21 +364,15 @@ pub mod testing {
         v: TxVersion,
     ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
         if v.has_orchard() {
-            // In a v6 transaction the Orchard pool is encoded as
-            // `OrchardNu6_3Onward`, which forbids cross-address transfers, so a
-            // valid Orchard bundle must have the cross-address flag disabled.
-            // (The Ironwood slot uses `arb_ironwood_bundle_for_version`, whose
-            // `IronwoodNu6_3Onward` pool permits cross-address transfers.)
-            let force_cross_address_disabled = orchard_pool_forbids_cross_address(v);
+            // The Orchard slot uses `orchard_v2()` in a v6 transaction (cross-address forbidden)
+            // and `orchard_v1()` in a v5 transaction; the Ironwood slot is generated separately by
+            // `arb_ironwood_bundle_for_version`.
+            let bundle_version = orchard_bundle_version(v);
             (1usize..100)
                 .prop_flat_map(move |n| {
-                    prop::option::of(arb_bundle(n).prop_map(move |bundle| {
-                        if force_cross_address_disabled && bundle.flags().cross_address_enabled() {
-                            with_cross_address_disabled(bundle)
-                        } else {
-                            bundle
-                        }
-                    }))
+                    prop::option::of(
+                        arb_bundle(n).prop_map(move |b| rebuild_with_version(b, bundle_version)),
+                    )
                 })
                 .boxed()
         } else {
@@ -395,55 +380,63 @@ pub mod testing {
         }
     }
 
-    /// Generates Ironwood bundles for the v6 transaction format. Unlike the
-    /// Orchard v6 pool, the Ironwood pool (`IronwoodNu6_3Onward`) permits
-    /// cross-address transfers, so the cross-address flag is left as generated;
-    /// this exercises the Ironwood serialization path the Orchard generator
-    /// cannot.
+    /// Generates Ironwood bundles for the v6 transaction format. Unlike the Orchard v6 pool, the
+    /// Ironwood pool ([`BundleVersion::ironwood_v2`]) permits cross-address transfers, so this
+    /// exercises the Ironwood serialization path the Orchard generator cannot.
     #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
     pub fn arb_ironwood_bundle_for_version(
         v: TxVersion,
     ) -> impl Strategy<Value = Option<Bundle<Authorized, ZatBalance>>> {
         if v.has_ironwood() {
             (1usize..100)
-                .prop_flat_map(|n| prop::option::of(arb_bundle(n)))
+                .prop_flat_map(|n| {
+                    prop::option::of(
+                        arb_bundle(n)
+                            .prop_map(|b| rebuild_with_version(b, BundleVersion::ironwood_v2())),
+                    )
+                })
                 .boxed()
         } else {
             Just(None).boxed()
         }
     }
 
-    /// Mirrors `txid::orchard_commitment_domain`: v6 Orchard bundles use
-    /// `OrchardNu6_3Onward`, which forbids cross-address transfers; v5 uses
-    /// `OrchardNu6_2Only`, which permits them.
-    fn orchard_pool_forbids_cross_address(v: TxVersion) -> bool {
+    /// The Orchard-slot [`BundleVersion`] for a transaction version: `orchard_v2()` in v6 (where
+    /// the Orchard pool forbids cross-address transfers), `orchard_v1()` otherwise.
+    fn orchard_bundle_version(v: TxVersion) -> BundleVersion {
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
         if matches!(v, TxVersion::V6) {
-            return true;
+            return BundleVersion::orchard_v2();
         }
         let _ = v;
-        false
+        BundleVersion::orchard_v1()
     }
 
-    /// Rebuilds an Orchard bundle with the cross-address flag cleared (preserving
-    /// its spends/outputs flags) so it is valid under the Orchard v6 pool
-    /// restriction `OrchardNu6_3Onward`.
-    fn with_cross_address_disabled(
+    /// Rebuilds an arbitrary bundle under `bundle_version`, choosing a cross-address flag value
+    /// that the version can represent while preserving the generated spend/output flags.
+    ///
+    /// Cross-address is only encodable in bit 2 for the Ironwood pool, so bit 2 is set there (to
+    /// exercise that serialization path) and left clear otherwise: pre-NU6.3 Orchard has
+    /// cross-address implicitly enabled, and post-NU6.3 Orchard forbids it.
+    pub(crate) fn rebuild_with_version(
         bundle: Bundle<Authorized, ZatBalance>,
+        bundle_version: BundleVersion,
     ) -> Bundle<Authorized, ZatBalance> {
-        use ::orchard::bundle::{BundlePoolRestrictions, Flags, ProofSizeEnforcement};
-        let byte = u8::from(bundle.flags().spends_enabled())
+        let mut byte = u8::from(bundle.flags().spends_enabled())
             | (u8::from(bundle.flags().outputs_enabled()) << 1);
-        let flags = Flags::from_byte(byte, BundlePoolRestrictions::OrchardNu6_3Onward)
-            .expect("spends/outputs-only flags encode under OrchardNu6_3Onward");
+        if bundle_version == BundleVersion::ironwood_v2() {
+            byte |= 0b100;
+        }
+        let flags = Flags::from_byte(byte, bundle_version)
+            .expect("constructed flag byte is representable under the target version");
         ::orchard::Bundle::try_from_parts(
             bundle.actions().clone(),
             flags,
             *bundle.value_balance(),
             *bundle.anchor(),
             bundle.authorization().clone(),
-            ProofSizeEnforcement::Strict,
+            bundle_version,
         )
-        .expect("clearing cross-address yields a representable Orchard bundle")
+        .expect("flags are representable under the target version")
     }
 }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -23,6 +23,13 @@ pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
 
+/// The Orchard flag-byte grammar used by v5 transaction serialization.
+///
+/// This names the `BundlePoolRestrictions` value that makes Orchard's flag
+/// parser treat bit 2 as reserved. It is a serialization-format selector, not an
+/// assertion that the transaction is being read or written in the NU6.2 epoch.
+const ORCHARD_V5_FLAG_FORMAT: BundlePoolRestrictions = BundlePoolRestrictions::OrchardNu6_2Only;
+
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
     fn map_authorization(&self, a: A) -> B;
@@ -50,14 +57,14 @@ impl MapAuth<Authorized, Authorized> for () {
 fn read_bundle<R: Read>(
     mut reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
-        let flags = read_flags(&mut reader, pool_restrictions)?;
+        let flags = read_flags(&mut reader, flag_format)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
         let proof_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
@@ -99,17 +106,15 @@ fn read_bundle<R: Read>(
 /// height; only the bundle commitment domain varies across upgrades, and that
 /// affects the txid/sighash digests rather than deserialization. Since this is
 /// public API, keeping the signature unchanged also avoids an unnecessary
-/// breaking change. (By contrast, `read_v6_bundle` takes a `pool_restrictions`
-/// argument so the caller selects the Orchard or Ironwood v6 pool.)
+/// breaking change. A v5 transaction always uses `ORCHARD_V5_FLAG_FORMAT` for
+/// the Orchard flag byte. By contrast, `read_v6_bundle` takes a
+/// `pool_restrictions` argument so the caller selects the Orchard or Ironwood v6
+/// slot.
 pub fn read_v5_bundle<R: Read>(
     reader: R,
     proof_size_enforcement: ProofSizeEnforcement,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(
-        reader,
-        proof_size_enforcement,
-        BundlePoolRestrictions::OrchardNu6_2Only,
-    )
+    read_bundle(reader, proof_size_enforcement, ORCHARD_V5_FLAG_FORMAT)
 }
 
 /// Rejects pool restrictions that are not valid for the v6 transaction format,
@@ -217,11 +222,11 @@ pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>
 
 pub fn read_flags<R: Read>(
     mut reader: R,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<Flags> {
     let mut byte = [0u8; 1];
     reader.read_exact(&mut byte)?;
-    Flags::from_byte(byte[0], pool_restrictions)
+    Flags::from_byte(byte[0], flag_format)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid Orchard flags"))
 }
 
@@ -241,14 +246,14 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 fn write_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     mut writer: W,
-    pool_restrictions: BundlePoolRestrictions,
+    flag_format: BundlePoolRestrictions,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
         Vector::write_nonempty(&mut writer, bundle.actions(), |w, a| {
             write_action_without_auth(w, a)
         })?;
 
-        let flags = bundle.flags().to_byte(pool_restrictions).ok_or_else(|| {
+        let flags = bundle.flags().to_byte(flag_format).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Orchard flags cannot be encoded in this transaction format",
@@ -278,11 +283,14 @@ fn write_bundle<W: Write>(
 }
 
 /// Writes an [`orchard::Bundle`] in the v5 transaction format.
+///
+/// V5 serialization always uses `ORCHARD_V5_FLAG_FORMAT` for the Orchard flag
+/// byte, even when the v5 transaction appears after NU6.3 activation.
 pub fn write_v5_bundle<W: Write>(
     bundle: Option<&orchard::Bundle<Authorized, ZatBalance>>,
     writer: W,
 ) -> io::Result<()> {
-    write_bundle(bundle, writer, BundlePoolRestrictions::OrchardNu6_2Only)
+    write_bundle(bundle, writer, ORCHARD_V5_FLAG_FORMAT)
 }
 
 /// Writes an [`orchard::Bundle`] in the v6 transaction format. `pool_restrictions`

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -403,9 +403,9 @@ impl<A: Authorization> TransactionData<A> {
     /// Both the Orchard and Ironwood bundle fields use [`orchard::Bundle`], but
     /// they are distinct V6 transaction fields with distinct bundle versions.
     /// The `orchard_bundle` argument must contain a bundle constructed for
-    /// [`orchard::bundle::BundleVersion::orchard_v2`], while `ironwood_bundle`
+    /// [`orchard::bundle::BundleVersion::orchard_v3`], while `ironwood_bundle`
     /// must contain a bundle constructed for
-    /// [`orchard::bundle::BundleVersion::ironwood_v2`]. Supplying a bundle for
+    /// [`orchard::bundle::BundleVersion::ironwood_v3`]. Supplying a bundle for
     /// the wrong field is invalid and can be rejected by later serialization or
     /// commitment construction because the bundle flags and domains are protocol
     /// specific.
@@ -899,12 +899,12 @@ impl Transaction {
                 | BranchId::Canopy
                 | BranchId::Nu5
                 | BranchId::Nu6
-                | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v0(),
-                BranchId::Nu6_2 => BundleVersion::orchard_v1(),
+                | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
+                BranchId::Nu6_2 => BundleVersion::orchard_v2(),
                 #[cfg(zcash_unstable = "nu6.3")]
-                BranchId::Nu6_3 => BundleVersion::orchard_v2(),
+                BranchId::Nu6_3 => BundleVersion::orchard_v3(),
                 #[cfg(zcash_unstable = "nu7")]
-                BranchId::Nu7 => BundleVersion::orchard_v2(),
+                BranchId::Nu7 => BundleVersion::orchard_v3(),
             },
         )?;
 
@@ -934,12 +934,12 @@ impl Transaction {
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
         let orchard_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v3(),
         )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
         let ironwood_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundleVersion::ironwood_v2(),
+            orchard::bundle::BundleVersion::ironwood_v3(),
         )?;
 
         let data = TransactionData {

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -401,11 +401,11 @@ impl<A: Authorization> TransactionData<A> {
     /// including the Ironwood bundle.
     ///
     /// Both the Orchard and Ironwood bundle fields use [`orchard::Bundle`], but
-    /// they are distinct V6 transaction fields with distinct bundle protocols.
+    /// they are distinct V6 transaction fields with distinct pool restrictions.
     /// The `orchard_bundle` argument must contain a bundle constructed for
-    /// [`orchard::BundleProtocol::OrchardPostNu6_3`], while `ironwood_bundle`
+    /// [`orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward`], while `ironwood_bundle`
     /// must contain a bundle constructed for
-    /// [`orchard::BundleProtocol::IronwoodPostNu6_3`]. Supplying a bundle for
+    /// [`orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward`]. Supplying a bundle for
     /// the wrong field is invalid and can be rejected by later serialization or
     /// commitment construction because the bundle flags and domains are protocol
     /// specific.
@@ -925,9 +925,15 @@ impl Transaction {
 
         let transparent_bundle = Self::read_transparent(&mut reader)?;
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
-        let orchard_bundle = orchard_serialization::read_v6_bundle(&mut reader)?;
+        let orchard_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        let ironwood_bundle = orchard_serialization::read_v6_bundle(&mut reader)?;
+        let ironwood_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
+        )?;
 
         let data = TransactionData {
             version,
@@ -1084,9 +1090,17 @@ impl Transaction {
 
         self.write_transparent(&mut writer)?;
         self.write_v5_sapling(&mut writer)?;
-        orchard_serialization::write_v6_bundle(self.orchard_bundle.as_ref(), &mut writer)?;
+        orchard_serialization::write_v6_bundle(
+            self.orchard_bundle.as_ref(),
+            &mut writer,
+            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+        )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        orchard_serialization::write_v6_bundle(self.ironwood_bundle.as_ref(), &mut writer)?;
+        orchard_serialization::write_v6_bundle(
+            self.ironwood_bundle.as_ref(),
+            &mut writer,
+            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
+        )?;
 
         Ok(())
     }
@@ -1293,7 +1307,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },
@@ -1325,7 +1339,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },
@@ -1357,7 +1371,7 @@ pub mod testing {
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
             ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_bundle_for_version(version).boxed()
+                orchard::arb_ironwood_bundle_for_version(version).boxed()
             } else {
                 Just(None).boxed()
             },

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -21,7 +21,7 @@ use core::ops::Deref;
 use corez::io::{self, Read, Write};
 
 use ::transparent::bundle::{self as transparent, OutPoint, TxIn, TxOut};
-use orchard::bundle::ProofSizeEnforcement;
+use orchard::bundle::BundleVersion;
 use zcash_encoding::{CompactSize, Vector};
 use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
@@ -401,11 +401,11 @@ impl<A: Authorization> TransactionData<A> {
     /// including the Ironwood bundle.
     ///
     /// Both the Orchard and Ironwood bundle fields use [`orchard::Bundle`], but
-    /// they are distinct V6 transaction fields with distinct pool restrictions.
+    /// they are distinct V6 transaction fields with distinct bundle versions.
     /// The `orchard_bundle` argument must contain a bundle constructed for
-    /// [`orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward`], while `ironwood_bundle`
+    /// [`orchard::bundle::BundleVersion::orchard_v2`], while `ironwood_bundle`
     /// must contain a bundle constructed for
-    /// [`orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward`]. Supplying a bundle for
+    /// [`orchard::bundle::BundleVersion::ironwood_v2`]. Supplying a bundle for
     /// the wrong field is invalid and can be rejected by later serialization or
     /// commitment construction because the bundle flags and domains are protocol
     /// specific.
@@ -883,6 +883,13 @@ impl Transaction {
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
         let orchard_bundle = orchard_serialization::read_v5_bundle(
             &mut reader,
+            // The v5 Orchard flag byte is the same in every epoch (bit 2 reserved), so the txid is
+            // unaffected by this choice, but the `BundleVersion` fixes the bundle's cross-address
+            // semantics and circuit generation, which do follow the consensus epoch:
+            //   * pre-NU6.2: historical insecure circuit, cross-address enabled, proof size not
+            //     enforced;
+            //   * NU6.2: fixed circuit, cross-address enabled;
+            //   * NU6.3 onward: post-NU6.3 circuit, cross-address disabled (consensus-mandated).
             match consensus_branch_id {
                 BranchId::Sprout
                 | BranchId::Overwinter
@@ -892,12 +899,12 @@ impl Transaction {
                 | BranchId::Canopy
                 | BranchId::Nu5
                 | BranchId::Nu6
-                | BranchId::Nu6_1 => ProofSizeEnforcement::Unenforced,
-                BranchId::Nu6_2 => ProofSizeEnforcement::Strict,
+                | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v0(),
+                BranchId::Nu6_2 => BundleVersion::orchard_v1(),
                 #[cfg(zcash_unstable = "nu6.3")]
-                BranchId::Nu6_3 => ProofSizeEnforcement::Strict,
+                BranchId::Nu6_3 => BundleVersion::orchard_v2(),
                 #[cfg(zcash_unstable = "nu7")]
-                BranchId::Nu7 => ProofSizeEnforcement::Strict,
+                BranchId::Nu7 => BundleVersion::orchard_v2(),
             },
         )?;
 
@@ -927,12 +934,12 @@ impl Transaction {
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
         let orchard_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+            orchard::bundle::BundleVersion::orchard_v2(),
         )?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
         let ironwood_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
+            orchard::bundle::BundleVersion::ironwood_v2(),
         )?;
 
         let data = TransactionData {
@@ -1090,17 +1097,9 @@ impl Transaction {
 
         self.write_transparent(&mut writer)?;
         self.write_v5_sapling(&mut writer)?;
-        orchard_serialization::write_v6_bundle(
-            self.orchard_bundle.as_ref(),
-            &mut writer,
-            orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
-        )?;
+        orchard_serialization::write_v6_bundle(self.orchard_bundle.as_ref(), &mut writer)?;
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        orchard_serialization::write_v6_bundle(
-            self.ironwood_bundle.as_ref(),
-            &mut writer,
-            orchard::bundle::BundlePoolRestrictions::IronwoodNu6_3Onward,
-        )?;
+        orchard_serialization::write_v6_bundle(self.ironwood_bundle.as_ref(), &mut writer)?;
 
         Ok(())
     }

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -170,13 +170,10 @@ fn v6_empty_orchard_txid_uses_v6_orchard_personalization() {
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 #[test]
 fn v6_branch_reconstruction_preserves_ironwood_bundle() {
-    use proptest::{strategy::ValueTree, test_runner::TestRunner};
+    use proptest::test_runner::TestRunner;
 
     let mut runner = TestRunner::default();
-    let ironwood_bundle = crate::transaction::components::orchard::testing::arb_bundle(1)
-        .new_tree(&mut runner)
-        .unwrap()
-        .current();
+    let ironwood_bundle = test_ironwood_bundle(&mut runner);
     let tx = TransactionData::from_parts_v6(
         BranchId::Nu6_3,
         0,
@@ -241,10 +238,30 @@ fn test_orchard_bundle(
 ) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
     use proptest::strategy::ValueTree;
 
-    crate::transaction::components::orchard::testing::arb_bundle(1)
+    let bundle = crate::transaction::components::orchard::testing::arb_bundle(1)
         .new_tree(runner)
         .unwrap()
-        .current()
+        .current();
+    crate::transaction::components::orchard::testing::rebuild_with_version(
+        bundle,
+        orchard::bundle::BundleVersion::orchard_v2(),
+    )
+}
+
+#[cfg(all(test, zcash_unstable = "nu6.3"))]
+fn test_ironwood_bundle(
+    runner: &mut proptest::test_runner::TestRunner,
+) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
+    use proptest::strategy::ValueTree;
+
+    let bundle = crate::transaction::components::orchard::testing::arb_bundle(1)
+        .new_tree(runner)
+        .unwrap()
+        .current();
+    crate::transaction::components::orchard::testing::rebuild_with_version(
+        bundle,
+        orchard::bundle::BundleVersion::ironwood_v2(),
+    )
 }
 
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
@@ -258,7 +275,7 @@ fn bundle_with_anchor(
         *bundle.value_balance(),
         anchor,
         bundle.authorization().clone(),
-        orchard::bundle::ProofSizeEnforcement::Strict,
+        bundle.bundle_version(),
     )
     .unwrap()
 }
@@ -413,26 +430,24 @@ fn v5_tx_data_with_sapling_bundle(
 }
 
 /// Clears the cross-address flag on an Orchard bundle (preserving spends/outputs)
-/// so it is representable in a v6 Orchard slot (`OrchardNu6_3Onward`, which
-/// forbids cross-address transfers; cross-address is Ironwood-only).
+/// so it is representable in a v6 Orchard slot ([`orchard::bundle::BundleVersion::orchard_v2`],
+/// which forbids cross-address transfers; cross-address is Ironwood-only).
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 fn disable_cross_address(
     bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
 ) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
     let byte = u8::from(bundle.flags().spends_enabled())
         | (u8::from(bundle.flags().outputs_enabled()) << 1);
-    let flags = orchard::bundle::Flags::from_byte(
-        byte,
-        orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
-    )
-    .unwrap();
+    let flags =
+        orchard::bundle::Flags::from_byte(byte, orchard::bundle::BundleVersion::orchard_v2())
+            .unwrap();
     orchard::Bundle::try_from_parts(
         bundle.actions().clone(),
         flags,
         *bundle.value_balance(),
         *bundle.anchor(),
         bundle.authorization().clone(),
-        orchard::bundle::ProofSizeEnforcement::Strict,
+        orchard::bundle::BundleVersion::orchard_v2(),
     )
     .unwrap()
 }
@@ -571,7 +586,7 @@ fn v6_orchard_anchor_changes_auth_commitment_not_txid_or_sighash() {
 #[test]
 fn v6_ironwood_anchor_changes_auth_commitment_not_txid_or_sighash() {
     let mut runner = proptest::test_runner::TestRunner::default();
-    let bundle = test_orchard_bundle(&mut runner);
+    let bundle = test_ironwood_bundle(&mut runner);
 
     let bundle_a = bundle_with_anchor(&bundle, test_anchor(1));
     let bundle_b = bundle_with_anchor(&bundle, test_anchor(2));

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -412,6 +412,31 @@ fn v5_tx_data_with_sapling_bundle(
     )
 }
 
+/// Clears the cross-address flag on an Orchard bundle (preserving spends/outputs)
+/// so it is representable in a v6 Orchard slot (`OrchardNu6_3Onward`, which
+/// forbids cross-address transfers; cross-address is Ironwood-only).
+#[cfg(all(test, zcash_unstable = "nu6.3"))]
+fn disable_cross_address(
+    bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
+) -> orchard::Bundle<orchard::bundle::Authorized, ZatBalance> {
+    let byte = u8::from(bundle.flags().spends_enabled())
+        | (u8::from(bundle.flags().outputs_enabled()) << 1);
+    let flags = orchard::bundle::Flags::from_byte(
+        byte,
+        orchard::bundle::BundlePoolRestrictions::OrchardNu6_3Onward,
+    )
+    .unwrap();
+    orchard::Bundle::try_from_parts(
+        bundle.actions().clone(),
+        flags,
+        *bundle.value_balance(),
+        *bundle.anchor(),
+        bundle.authorization().clone(),
+        orchard::bundle::ProofSizeEnforcement::Strict,
+    )
+    .unwrap()
+}
+
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 fn v6_tx_with_orchard_bundle(
     orchard_bundle: orchard::Bundle<orchard::bundle::Authorized, ZatBalance>,
@@ -422,7 +447,7 @@ fn v6_tx_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(orchard_bundle),
+        Some(disable_cross_address(orchard_bundle)),
         None,
     )
     .freeze()
@@ -471,7 +496,7 @@ fn v6_tx_data_with_orchard_bundle(
         1u32.into(),
         None,
         None,
-        Some(orchard_bundle),
+        Some(disable_cross_address(orchard_bundle)),
         None,
     )
 }

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -244,7 +244,7 @@ fn test_orchard_bundle(
         .current();
     crate::transaction::components::orchard::testing::rebuild_with_version(
         bundle,
-        orchard::bundle::BundleVersion::orchard_v2(),
+        orchard::bundle::BundleVersion::orchard_v3(),
     )
 }
 
@@ -260,7 +260,7 @@ fn test_ironwood_bundle(
         .current();
     crate::transaction::components::orchard::testing::rebuild_with_version(
         bundle,
-        orchard::bundle::BundleVersion::ironwood_v2(),
+        orchard::bundle::BundleVersion::ironwood_v3(),
     )
 }
 
@@ -430,7 +430,7 @@ fn v5_tx_data_with_sapling_bundle(
 }
 
 /// Clears the cross-address flag on an Orchard bundle (preserving spends/outputs)
-/// so it is representable in a v6 Orchard slot ([`orchard::bundle::BundleVersion::orchard_v2`],
+/// so it is representable in a v6 Orchard slot ([`orchard::bundle::BundleVersion::orchard_v3`],
 /// which forbids cross-address transfers; cross-address is Ironwood-only).
 #[cfg(all(test, zcash_unstable = "nu6.3"))]
 fn disable_cross_address(
@@ -439,7 +439,7 @@ fn disable_cross_address(
     let byte = u8::from(bundle.flags().spends_enabled())
         | (u8::from(bundle.flags().outputs_enabled()) << 1);
     let flags =
-        orchard::bundle::Flags::from_byte(byte, orchard::bundle::BundleVersion::orchard_v2())
+        orchard::bundle::Flags::from_byte(byte, orchard::bundle::BundleVersion::orchard_v3())
             .unwrap();
     orchard::Bundle::try_from_parts(
         bundle.actions().clone(),
@@ -447,7 +447,7 @@ fn disable_cross_address(
         *bundle.value_balance(),
         *bundle.anchor(),
         bundle.authorization().clone(),
-        orchard::bundle::BundleVersion::orchard_v2(),
+        orchard::bundle::BundleVersion::orchard_v3(),
     )
     .unwrap()
 }

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -84,7 +84,7 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
 /// pre-bump `BundleCommitmentDomain` for a given transaction version. The pool
 /// restriction here is only used for empty-bundle commitments (which hash no
 /// flags); present bundles derive their restriction from their own flags via
-/// [`orchard_pool_restrictions_for_flags`].
+/// [`orchard_flag_format_for_flags`].
 fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, OrchardTxVersion) {
     match version {
         TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => (
@@ -99,20 +99,19 @@ fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, Orc
     }
 }
 
-/// Selects the Orchard pool restriction used to compute a present bundle's txid
+/// Selects the Orchard flag-byte format used to compute a present bundle's txid
 /// and authorizing commitments from the bundle's own cross-address flag.
 ///
 /// The commitment *format* is chosen by the transaction version (see
-/// [`orchard_commitment_domain`]); the only Orchard pool restriction that affects
-/// the commitment is whether cross-address transfers are enabled. Deriving it from
-/// the bundle's flags keeps the flag byte encodable, so `Flags::to_byte` always
-/// returns `Some` and the `expect(..)` at the call sites is unreachable.
+/// [`orchard_commitment_domain`]). This helper only chooses a value that makes
+/// the bundle flags encodable for Orchard's `Flags::to_byte` API, so the
+/// `expect(..)` at the call sites is unreachable.
 ///
 /// A cross-address-enabled Orchard bundle is rejected by `read_v6_bundle`/
 /// `write_v6_bundle` under `OrchardNu6_3Onward`, so it can never appear in a
 /// serialized transaction; this restriction therefore only diverges from the slot
 /// restriction for in-memory bundles that no node can produce or relay.
-fn orchard_pool_restrictions_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
+fn orchard_flag_format_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
     if flags.cross_address_enabled() {
         BundlePoolRestrictions::OrchardNu6_2Only
     } else {
@@ -378,8 +377,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| {
             let (_, tx_version) = orchard_commitment_domain(version);
-            let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
-            b.commitment(pool_restrictions, tx_version)
+            let flag_format = orchard_flag_format_for_flags(b.flags());
+            b.commitment(flag_format, tx_version)
                 .expect("Orchard bundle flags must be representable in their transaction format")
                 .0
         })
@@ -632,8 +631,8 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
                     .expect("empty Orchard bundle auth commitment is valid for its tx format")
             },
             |b| {
-                let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
-                b.authorizing_commitment(pool_restrictions, tx_version)
+                let flag_format = orchard_flag_format_for_flags(b.flags());
+                b.authorizing_commitment(flag_format, tx_version)
                     .expect("Orchard bundle flags must be representable in their tx format")
                     .0
             },

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -6,7 +6,7 @@ use corez::io::Write;
 use blake2b_simd::{Hash as Blake2bHash, Params};
 use ff::PrimeField;
 
-use ::orchard::bundle::{self as orchard, commitments::BundleCommitmentDomain};
+use ::orchard::bundle::{self as orchard, BundlePoolRestrictions, TxVersion as OrchardTxVersion};
 use ::sapling::bundle::{OutputDescription, SpendDescription};
 use ::transparent::bundle::{self as transparent, TxIn, TxOut};
 use zcash_protocol::{
@@ -80,19 +80,52 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
     }
 }
 
-fn orchard_commitment_domain(version: TxVersion) -> BundleCommitmentDomain {
+/// Selects the `(pool restriction, orchard tx version)` pair that reproduces the
+/// pre-bump `BundleCommitmentDomain` for a given transaction version. The pool
+/// restriction here is only used for empty-bundle commitments (which hash no
+/// flags); present bundles derive their restriction from their own flags via
+/// [`orchard_pool_restrictions_for_flags`].
+fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, OrchardTxVersion) {
     match version {
-        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => {
-            BundleCommitmentDomain::ORCHARD_V5_PRE_NU6_3
-        }
+        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => (
+            BundlePoolRestrictions::OrchardNu6_2Only,
+            OrchardTxVersion::V5,
+        ),
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        TxVersion::V6 => BundleCommitmentDomain::ORCHARD_V6,
+        TxVersion::V6 => (
+            BundlePoolRestrictions::OrchardNu6_3Onward,
+            OrchardTxVersion::V6,
+        ),
+    }
+}
+
+/// Selects the Orchard pool restriction used to compute a present bundle's txid
+/// and authorizing commitments from the bundle's own cross-address flag.
+///
+/// The commitment *format* is chosen by the transaction version (see
+/// [`orchard_commitment_domain`]); the only Orchard pool restriction that affects
+/// the commitment is whether cross-address transfers are enabled. Deriving it from
+/// the bundle's flags keeps the flag byte encodable, so `Flags::to_byte` always
+/// returns `Some` and the `expect(..)` at the call sites is unreachable.
+///
+/// A cross-address-enabled Orchard bundle is rejected by `read_v6_bundle`/
+/// `write_v6_bundle` under `OrchardNu6_3Onward`, so it can never appear in a
+/// serialized transaction; this restriction therefore only diverges from the slot
+/// restriction for in-memory bundles that no node can produce or relay.
+fn orchard_pool_restrictions_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
+    if flags.cross_address_enabled() {
+        BundlePoolRestrictions::OrchardNu6_2Only
+    } else {
+        BundlePoolRestrictions::OrchardNu6_3Onward
     }
 }
 
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-fn ironwood_v6_domain() -> BundleCommitmentDomain {
-    BundleCommitmentDomain::IRONWOOD_V6
+fn ironwood_v6_domain() -> (BundlePoolRestrictions, OrchardTxVersion) {
+    (
+        BundlePoolRestrictions::IronwoodNu6_3Onward,
+        OrchardTxVersion::V6,
+    )
 }
 
 fn hasher(personal: &[u8; 16]) -> StateWrite {
@@ -344,7 +377,9 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| {
-            b.commitment_for_domain(orchard_commitment_domain(version))
+            let (_, tx_version) = orchard_commitment_domain(version);
+            let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
+            b.commitment(pool_restrictions, tx_version)
                 .expect("Orchard bundle flags must be representable in their transaction format")
                 .0
         })
@@ -356,7 +391,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         ironwood_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::IronwoodDigest {
         ironwood_bundle.map(|b| {
-            b.commitment_for_domain(ironwood_v6_domain())
+            let (pool_restrictions, tx_version) = ironwood_v6_domain();
+            b.commitment(pool_restrictions, tx_version)
                 .expect("Ironwood bundle flags must be representable")
                 .0
         })
@@ -408,9 +444,9 @@ pub(crate) fn to_hash(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(orchard_commitment_domain(
-                    _txversion,
-                ))
+                let (pool_restrictions, tx_version) = orchard_commitment_domain(_txversion);
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
     )
@@ -446,9 +482,9 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(orchard_commitment_domain(
-                    TxVersion::V6,
-                ))
+                let (pool_restrictions, tx_version) = orchard_commitment_domain(TxVersion::V6);
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
     )
@@ -456,7 +492,9 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         ironwood_digest
             .unwrap_or_else(|| {
-                orchard::commitments::hash_bundle_txid_empty_with_domain(ironwood_v6_domain())
+                let (pool_restrictions, tx_version) = ironwood_v6_domain();
+                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                    .expect("empty Ironwood bundle txid commitment is valid")
             })
             .as_bytes(),
     )
@@ -587,14 +625,16 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         version: TxVersion,
         orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::OrchardDigest {
+        let (pool_restrictions, tx_version) = orchard_commitment_domain(version);
         orchard_bundle.map_or_else(
             || {
-                orchard::commitments::hash_bundle_auth_empty_with_domain(orchard_commitment_domain(
-                    version,
-                ))
+                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                    .expect("empty Orchard bundle auth commitment is valid for its tx format")
             },
             |b| {
-                b.authorizing_commitment_for_domain(orchard_commitment_domain(version))
+                let pool_restrictions = orchard_pool_restrictions_for_flags(b.flags());
+                b.authorizing_commitment(pool_restrictions, tx_version)
+                    .expect("Orchard bundle flags must be representable in their tx format")
                     .0
             },
         )
@@ -605,9 +645,17 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         &self,
         ironwood_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::IronwoodDigest {
+        let (pool_restrictions, tx_version) = ironwood_v6_domain();
         ironwood_bundle.map_or_else(
-            || orchard::commitments::hash_bundle_auth_empty_with_domain(ironwood_v6_domain()),
-            |b| b.authorizing_commitment_for_domain(ironwood_v6_domain()).0,
+            || {
+                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                    .expect("empty Ironwood bundle auth commitment is valid")
+            },
+            |b| {
+                b.authorizing_commitment(pool_restrictions, tx_version)
+                    .expect("Ironwood bundle flags must be representable")
+                    .0
+            },
         )
     }
 

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -6,7 +6,10 @@ use corez::io::Write;
 use blake2b_simd::{Hash as Blake2bHash, Params};
 use ff::PrimeField;
 
-use ::orchard::bundle::{self as orchard, BundlePoolRestrictions, TxVersion as OrchardTxVersion};
+use ::orchard::{
+    ValuePool,
+    bundle::{self as orchard, TxVersion as OrchardTxVersion},
+};
 use ::sapling::bundle::{OutputDescription, SpendDescription};
 use ::transparent::bundle::{self as transparent, TxIn, TxOut};
 use zcash_protocol::{
@@ -80,51 +83,24 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
     }
 }
 
-/// Selects the `(pool restriction, orchard tx version)` pair that reproduces the
-/// pre-bump `BundleCommitmentDomain` for a given transaction version. The pool
-/// restriction here is only used for empty-bundle commitments (which hash no
-/// flags); present bundles derive their restriction from their own flags via
-/// [`orchard_flag_format_for_flags`].
-fn orchard_commitment_domain(version: TxVersion) -> (BundlePoolRestrictions, OrchardTxVersion) {
+/// Selects the `(value pool, orchard tx version)` pair that reproduces the
+/// pre-bump `BundleCommitmentDomain` for a given transaction version. The value
+/// pool here is only used for empty-bundle commitments (which hash no flags);
+/// present bundles compute their commitments from the `BundleVersion` each
+/// bundle carries.
+fn orchard_commitment_domain(version: TxVersion) -> (ValuePool, OrchardTxVersion) {
     match version {
-        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => (
-            BundlePoolRestrictions::OrchardNu6_2Only,
-            OrchardTxVersion::V5,
-        ),
+        TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => {
+            (ValuePool::Orchard, OrchardTxVersion::V5)
+        }
         #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-        TxVersion::V6 => (
-            BundlePoolRestrictions::OrchardNu6_3Onward,
-            OrchardTxVersion::V6,
-        ),
-    }
-}
-
-/// Selects the Orchard flag-byte format used to compute a present bundle's txid
-/// and authorizing commitments from the bundle's own cross-address flag.
-///
-/// The commitment *format* is chosen by the transaction version (see
-/// [`orchard_commitment_domain`]). This helper only chooses a value that makes
-/// the bundle flags encodable for Orchard's `Flags::to_byte` API, so the
-/// `expect(..)` at the call sites is unreachable.
-///
-/// A cross-address-enabled Orchard bundle is rejected by `read_v6_bundle`/
-/// `write_v6_bundle` under `OrchardNu6_3Onward`, so it can never appear in a
-/// serialized transaction; this restriction therefore only diverges from the slot
-/// restriction for in-memory bundles that no node can produce or relay.
-fn orchard_flag_format_for_flags(flags: &orchard::Flags) -> BundlePoolRestrictions {
-    if flags.cross_address_enabled() {
-        BundlePoolRestrictions::OrchardNu6_2Only
-    } else {
-        BundlePoolRestrictions::OrchardNu6_3Onward
+        TxVersion::V6 => (ValuePool::Orchard, OrchardTxVersion::V6),
     }
 }
 
 #[cfg(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))]
-fn ironwood_v6_domain() -> (BundlePoolRestrictions, OrchardTxVersion) {
-    (
-        BundlePoolRestrictions::IronwoodNu6_3Onward,
-        OrchardTxVersion::V6,
-    )
+fn ironwood_v6_domain() -> (ValuePool, OrchardTxVersion) {
+    (ValuePool::Ironwood, OrchardTxVersion::V6)
 }
 
 fn hasher(personal: &[u8; 16]) -> StateWrite {
@@ -377,8 +353,7 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| {
             let (_, tx_version) = orchard_commitment_domain(version);
-            let flag_format = orchard_flag_format_for_flags(b.flags());
-            b.commitment(flag_format, tx_version)
+            b.commitment(tx_version)
                 .expect("Orchard bundle flags must be representable in their transaction format")
                 .0
         })
@@ -390,8 +365,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         ironwood_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::IronwoodDigest {
         ironwood_bundle.map(|b| {
-            let (pool_restrictions, tx_version) = ironwood_v6_domain();
-            b.commitment(pool_restrictions, tx_version)
+            let (_, tx_version) = ironwood_v6_domain();
+            b.commitment(tx_version)
                 .expect("Ironwood bundle flags must be representable")
                 .0
         })
@@ -443,8 +418,8 @@ pub(crate) fn to_hash(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                let (pool_restrictions, tx_version) = orchard_commitment_domain(_txversion);
-                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                let (value_pool, tx_version) = orchard_commitment_domain(_txversion);
+                orchard::commitments::hash_bundle_txid_empty(value_pool, tx_version)
                     .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
@@ -481,8 +456,8 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         orchard_digest
             .unwrap_or_else(|| {
-                let (pool_restrictions, tx_version) = orchard_commitment_domain(TxVersion::V6);
-                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                let (value_pool, tx_version) = orchard_commitment_domain(TxVersion::V6);
+                orchard::commitments::hash_bundle_txid_empty(value_pool, tx_version)
                     .expect("empty Orchard bundle txid commitment is valid for its tx format")
             })
             .as_bytes(),
@@ -491,8 +466,8 @@ pub(crate) fn to_hash_v6(
     h.write_all(
         ironwood_digest
             .unwrap_or_else(|| {
-                let (pool_restrictions, tx_version) = ironwood_v6_domain();
-                orchard::commitments::hash_bundle_txid_empty(pool_restrictions, tx_version)
+                let (value_pool, tx_version) = ironwood_v6_domain();
+                orchard::commitments::hash_bundle_txid_empty(value_pool, tx_version)
                     .expect("empty Ironwood bundle txid commitment is valid")
             })
             .as_bytes(),
@@ -624,15 +599,14 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         version: TxVersion,
         orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::OrchardDigest {
-        let (pool_restrictions, tx_version) = orchard_commitment_domain(version);
+        let (value_pool, tx_version) = orchard_commitment_domain(version);
         orchard_bundle.map_or_else(
             || {
-                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                orchard::commitments::hash_bundle_auth_empty(value_pool, tx_version)
                     .expect("empty Orchard bundle auth commitment is valid for its tx format")
             },
             |b| {
-                let flag_format = orchard_flag_format_for_flags(b.flags());
-                b.authorizing_commitment(flag_format, tx_version)
+                b.authorizing_commitment(tx_version)
                     .expect("Orchard bundle flags must be representable in their tx format")
                     .0
             },
@@ -644,14 +618,14 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         &self,
         ironwood_bundle: Option<&orchard::Bundle<orchard::Authorized, ZatBalance>>,
     ) -> Self::IronwoodDigest {
-        let (pool_restrictions, tx_version) = ironwood_v6_domain();
+        let (value_pool, tx_version) = ironwood_v6_domain();
         ironwood_bundle.map_or_else(
             || {
-                orchard::commitments::hash_bundle_auth_empty(pool_restrictions, tx_version)
+                orchard::commitments::hash_bundle_auth_empty(value_pool, tx_version)
                     .expect("empty Ironwood bundle auth commitment is valid")
             },
             |b| {
-                b.authorizing_commitment(pool_restrictions, tx_version)
+                b.authorizing_commitment(tx_version)
                     .expect("Ironwood bundle flags must be representable")
                     .0
             },


### PR DESCRIPTION
Stacked on `adam/bump-orchard-30c4ea2`, and pairs with zcash/orchard#519.

Bumps the patched `orchard` dependency to the revision that replaces `BundlePoolRestrictions` with `BundleVersion` (each `Bundle` now carries its `(value pool, protocol version)`), and adapts the integration to the new API.

## Summary
- **Transaction (de)serialization** derives the `BundleVersion` for each Orchard/Ironwood slot from the consensus context and threads it into bundle construction. The v5 read maps the branch to the version (pre-NU6.2 → `orchard_insecure_v0`, NU6.2 → `orchard_v1`, NU6.3+ → `orchard_v2`), which also subsumes the former `ProofSizeEnforcement` choice.
- **txid / authorizing commitments** read the version from the bundle; `commitment`/`authorizing_commitment` drop their version argument, and serialization uses the new infallible `Bundle::flag_byte`. The empty-bundle commitment helpers now take a `ValuePool`.
- **PCZT Creator** takes `with_orchard_bundle_version(version, flags)`; the fee and decryption call sites drop their version arguments.

## Testing
Full workspace test suite passes under `--cfg zcash_unstable="nu6.3"` with `--all-features` (34/34 suites). Workspace also compiles clean under default and `nu7`. `cargo vet --locked` passes.

> [!NOTE]
> The `orchard` patch points at the `zcash/orchard` `chore/naming_nits` branch backing #519; it will need re-pointing as that PR merges/rebases into `feat/ironwood`.

---
Opened as a draft for review. Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
