### PR TITLE
Update Orchard to the published 0.15.0-pre.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2989,8 +2989,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/orchard?rev=2f322a220d2750c3fa752132f51594b8358f653f#2f322a220d2750c3fa752132f51594b8358f653f"
+version = "0.15.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e277dd4b46f5d06deae3ffb8af1a951e8622368f028c2a4d6fe59339566403"
 dependencies = [
  "aes",
  "bitvec",
@@ -4032,7 +4033,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ redjubjub = { version = "0.8", default-features = false }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 
 # - Orchard
-orchard = { version = "0.15.0-pre.0", default-features = false }
+orchard = { version = "0.15.0-pre.1", default-features = false }
 pasta_curves = "0.5"
 
 # - Transparent
@@ -184,9 +184,6 @@ zip32 = { version = "0.2", default-features = false }
 
 # Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
 time-core = "=0.1.2"
-
-[patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1922,7 +1922,7 @@ end = "2027-06-05"
 
 [[trusted.halo2_gadgets]]
 criteria = ["safe-to-deploy", "crypto-reviewed"]
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2022-05-10"
 end = "2025-04-22"
 
@@ -1946,13 +1946,13 @@ end = "2026-12-05"
 
 [[trusted.halo2_proofs]]
 criteria = ["safe-to-deploy", "crypto-reviewed"]
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2022-05-10"
 end = "2025-04-22"
 
 [[trusted.incrementalmerkletree]]
 criteria = "safe-to-deploy"
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2021-06-24"
 end = "2025-04-22"
 
@@ -1982,6 +1982,12 @@ end = "2025-12-16"
 
 [[trusted.orchard]]
 criteria = "safe-to-deploy"
+user-id = 1244 # Sean Bowe (ebfull)
+start = "2022-10-19"
+end = "2027-06-30"
+
+[[trusted.orchard]]
+criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)
 start = "2021-01-07"
 end = "2026-12-05"
@@ -1994,7 +2000,7 @@ end = "2027-04-17"
 
 [[trusted.orchard]]
 criteria = ["safe-to-deploy", "crypto-reviewed", "license-reviewed"]
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2022-10-19"
 end = "2025-04-22"
 
@@ -2204,7 +2210,7 @@ end = "2025-07-19"
 
 [[trusted.zcash_address]]
 criteria = "safe-to-deploy"
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2022-10-19"
 end = "2025-04-22"
 
@@ -2246,7 +2252,7 @@ end = "2027-06-05"
 
 [[trusted.zcash_encoding]]
 criteria = "safe-to-deploy"
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2022-10-19"
 end = "2025-04-22"
 
@@ -2264,7 +2270,7 @@ end = "2027-04-24"
 
 [[trusted.zcash_history]]
 criteria = "safe-to-deploy"
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2020-03-04"
 end = "2025-04-22"
 
@@ -2306,7 +2312,7 @@ end = "2026-10-24"
 
 [[trusted.zcash_primitives]]
 criteria = ["safe-to-deploy", "crypto-reviewed", "license-reviewed"]
-user-id = 1244
+user-id = 1244 # Sean Bowe (ebfull)
 start = "2019-10-08"
 end = "2025-04-22"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -86,11 +86,11 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.orchard]]
-version = "0.14.0"
-when = "2026-06-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
+version = "0.15.0-pre.1"
+when = "2026-06-30"
+user-id = 1244
+user-login = "ebfull"
+user-name = "Sean Bowe"
 
 [[publisher.pczt]]
 version = "0.7.0"


### PR DESCRIPTION
`feat/ironwood` pins orchard to git rev `2f322a22` (0.15.0-pre.0) via `[patch.crates-io]`. That revision already carries the `BundleVersion` API, which the published `0.15.0-pre.1` ships unchanged, so the patch is dropped in favour of the released crate. Dependency-only — no source edits.

Verified under `--cfg zcash_unstable="nu6.3"`: `cargo check --workspace --all-features` is clean (0 warnings), and `cargo test -p zcash_primitives --all-features` passes including `zip_0244` and the v6/Ironwood txid + authorizing-commitment vectors (txid and sighash unchanged). `cargo vet --locked` passes locally on cargo-vet 0.10.2.

cargo-vet note: `0.15.0-pre.1` was published by ebfull, whose orchard trust had lapsed (2025-04-22), so this adds a `safe-to-deploy` `trusted.orchard` entry for him (the tool's recommended `cargo vet trust orchard ebfull`). Recording that publisher in `imports.lock` lets cargo-vet resolve user-id 1244, so `cargo vet fmt` also annotates ebfull's existing `trusted.*` entries with his name which is the handful of one-line comment changes on otherwise-unrelated crates.
