### PR TITLE
zcash_client_backend: Account for the Ironwood bundle in fee and change calculation

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -98,11 +98,13 @@ workspace.
   heights at or beyond NU6.3 activation now count one action per Orchard spend
   or output, matching the post-NU6.3 transaction builder.
 - `zcash_client_backend::fees::ChangeStrategy::compute_balance` now takes an
-  additional `ironwood` bundle view (behind the `orchard` feature flag),
-  alongside the existing `orchard` view. A V6 transaction carries a separate
-  Ironwood bundle that is charged its own actions, so the built-in change
-  strategies populate this view from the same routing decision the transaction
-  builder uses. Pass an empty view when nothing targets the Ironwood pool.
+  additional `ironwood` bundle view and an `orchard_change_to_ironwood` flag
+  (behind the `orchard` feature flag), alongside the existing `orchard` view. A
+  V6 transaction carries a separate Ironwood bundle that is charged its own
+  actions, so the built-in change strategies populate the view — and route the
+  Orchard-pool change output into the Ironwood bundle when the builder will —
+  from the same routing decision the transaction builder uses. Pass an empty
+  view and `false` when nothing targets the Ironwood pool.
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
   routes Orchard-recipient spends and outputs through the Ironwood transaction
   builder when Ironwood is active, unless an explicit legacy V5 transaction is

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -97,6 +97,12 @@ workspace.
   of unconditionally using the legacy (pre-NU6.3) policy. Proposals targeting
   heights at or beyond NU6.3 activation now count one action per Orchard spend
   or output, matching the post-NU6.3 transaction builder.
+- `zcash_client_backend::fees::ChangeStrategy::compute_balance` now takes an
+  additional `ironwood` bundle view (behind the `orchard` feature flag),
+  alongside the existing `orchard` view. A V6 transaction carries a separate
+  Ironwood bundle that is charged its own actions, so the built-in change
+  strategies populate this view from the same routing decision the transaction
+  builder uses. Pass an empty view when nothing targets the Ironwood pool.
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
   routes Orchard-recipient spends and outputs through the Ironwood transaction
   builder when Ironwood is active, unless an explicit legacy V5 transaction is

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -704,6 +704,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             &orchard_fees::EmptyBundleView,
                             #[cfg(feature = "orchard")]
                             &orchard_fees::EmptyBundleView,
+                            #[cfg(feature = "orchard")]
+                            false,
                             Some(EphemeralBalance::Input(Zatoshis::ZERO)),
                             &wallet_meta,
                         ) {
@@ -727,6 +729,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         &orchard_fees::EmptyBundleView,
                         #[cfg(feature = "orchard")]
                         &orchard_fees::EmptyBundleView,
+                        #[cfg(feature = "orchard")]
+                        false,
                         Some(EphemeralBalance::Input(tr1_required_input_value)),
                         &wallet_meta,
                     )?;
@@ -763,6 +767,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // so `&orchard_inputs[..0]` is an empty slice of the correct type.
             #[cfg(feature = "orchard")]
             let orchard_view = (
+                // TODO: thread the target-height-selected Orchard `BundleVersion`
+                // here rather than this placeholder, which only approximates the
+                // Orchard action count for paths that restrict cross-address
+                // transfers.
                 crate::ANY_ORCHARD_BUNDLE_VERSION,
                 &orchard_inputs[..],
                 if orchard_outputs_are_ironwood {
@@ -798,6 +806,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 &orchard_view,
                 #[cfg(feature = "orchard")]
                 &ironwood_view,
+                #[cfg(feature = "orchard")]
+                orchard_outputs_are_ironwood,
                 ephemeral_output_value.map(EphemeralBalance::Output),
                 &wallet_meta,
             );
@@ -1675,6 +1685,8 @@ where
         &orchard_fees::EmptyBundleView,
         #[cfg(feature = "orchard")]
         &orchard_fees::EmptyBundleView,
+        #[cfg(feature = "orchard")]
+        false,
         None,
         wallet_meta,
     )

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -745,21 +745,13 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // action counts (and hence the fee) match the transaction that gets
             // built. We reuse the builder's own routing predicate so the proposal
             // and build paths cannot drift.
-            #[cfg(all(
-                feature = "orchard",
-                any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")
-            ))]
+            #[cfg(feature = "orchard")]
             let orchard_outputs_are_ironwood = super::orchard_outputs_to_ironwood(
                 params,
                 target_height,
                 #[cfg(feature = "unstable")]
                 proposed_version,
             );
-            #[cfg(all(
-                feature = "orchard",
-                not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))
-            ))]
-            let orchard_outputs_are_ironwood = false;
 
             // The Orchard bundle keeps the Orchard spends; its outputs move to the
             // Ironwood bundle when routing is active. Ironwood has no spends yet
@@ -767,11 +759,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // so `&orchard_inputs[..0]` is an empty slice of the correct type.
             #[cfg(feature = "orchard")]
             let orchard_view = (
-                // TODO: thread the target-height-selected Orchard `BundleVersion`
-                // here rather than this placeholder, which only approximates the
-                // Orchard action count for paths that restrict cross-address
-                // transfers.
-                crate::ANY_ORCHARD_BUNDLE_VERSION,
+                orchard_bundle_version_for_height(params, target_height),
                 &orchard_inputs[..],
                 if orchard_outputs_are_ironwood {
                     &orchard_outputs[..0]

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -702,6 +702,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             &sapling::EmptyBundleView,
                             #[cfg(feature = "orchard")]
                             &orchard_fees::EmptyBundleView,
+                            #[cfg(feature = "orchard")]
+                            &orchard_fees::EmptyBundleView,
                             Some(EphemeralBalance::Input(Zatoshis::ZERO)),
                             &wallet_meta,
                         ) {
@@ -721,6 +723,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         &[] as &[WalletTransparentOutput<<DbT as InputSource>::AccountId>],
                         &tr1_transparent_outputs,
                         &sapling::EmptyBundleView,
+                        #[cfg(feature = "orchard")]
+                        &orchard_fees::EmptyBundleView,
                         #[cfg(feature = "orchard")]
                         &orchard_fees::EmptyBundleView,
                         Some(EphemeralBalance::Input(tr1_required_input_value)),
@@ -750,6 +754,11 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
+                // TODO: when the wallet selects Ironwood notes or routes outputs
+                // to the Ironwood pool, pass them here so the Ironwood bundle's
+                // action count is included in the fee. Empty for now.
+                #[cfg(feature = "orchard")]
+                &orchard_fees::EmptyBundleView,
                 ephemeral_output_value.map(EphemeralBalance::Output),
                 &wallet_meta,
             );
@@ -1623,6 +1632,8 @@ where
         transparent_inputs,
         &[] as &[TxOut],
         &sapling::EmptyBundleView,
+        #[cfg(feature = "orchard")]
+        &orchard_fees::EmptyBundleView,
         #[cfg(feature = "orchard")]
         &orchard_fees::EmptyBundleView,
         None,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -736,6 +736,52 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 }
             };
 
+            // When the builder will route Orchard-pool outputs into a separate
+            // Ironwood bundle, mirror that split here so the proposal's per-bundle
+            // action counts (and hence the fee) match the transaction that gets
+            // built. We reuse the builder's own routing predicate so the proposal
+            // and build paths cannot drift.
+            #[cfg(all(
+                feature = "orchard",
+                any(zcash_unstable = "nu6.3", zcash_unstable = "nu7")
+            ))]
+            let orchard_outputs_are_ironwood = super::orchard_outputs_to_ironwood(
+                params,
+                target_height,
+                #[cfg(feature = "unstable")]
+                proposed_version,
+            );
+            #[cfg(all(
+                feature = "orchard",
+                not(any(zcash_unstable = "nu6.3", zcash_unstable = "nu7"))
+            ))]
+            let orchard_outputs_are_ironwood = false;
+
+            // The Orchard bundle keeps the Orchard spends; its outputs move to the
+            // Ironwood bundle when routing is active. Ironwood has no spends yet
+            // (the wallet does not select Ironwood notes until note detection lands),
+            // so `&orchard_inputs[..0]` is an empty slice of the correct type.
+            #[cfg(feature = "orchard")]
+            let orchard_view = (
+                crate::ANY_ORCHARD_BUNDLE_VERSION,
+                &orchard_inputs[..],
+                if orchard_outputs_are_ironwood {
+                    &orchard_outputs[..0]
+                } else {
+                    &orchard_outputs[..]
+                },
+            );
+            #[cfg(feature = "orchard")]
+            let ironwood_view = (
+                ::orchard::bundle::BundleVersion::ironwood_v3(),
+                &orchard_inputs[..0],
+                if orchard_outputs_are_ironwood {
+                    &orchard_outputs[..]
+                } else {
+                    &orchard_outputs[..0]
+                },
+            );
+
             // In the ZIP 320 case, this is the balance for transaction 0, taking into account
             // the ephemeral output.
             let tr0_balance = change_strategy.compute_balance(
@@ -749,16 +795,9 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     &sapling_outputs[..],
                 ),
                 #[cfg(feature = "orchard")]
-                &(
-                    orchard_bundle_version_for_height(params, target_height),
-                    &orchard_inputs[..],
-                    &orchard_outputs[..],
-                ),
-                // TODO: when the wallet selects Ironwood notes or routes outputs
-                // to the Ironwood pool, pass them here so the Ironwood bundle's
-                // action count is included in the fee. Empty for now.
+                &orchard_view,
                 #[cfg(feature = "orchard")]
-                &orchard_fees::EmptyBundleView,
+                &ironwood_view,
                 ephemeral_output_value.map(EphemeralBalance::Output),
                 &wallet_meta,
             );

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -564,7 +564,10 @@ pub trait ChangeStrategy {
     ///   Ironwood pool.
     /// - `orchard_change_to_ironwood`: whether Orchard-pool change should be counted
     ///   in the Ironwood bundle, mirroring how the builder routes Orchard-pool
-    ///   outputs into a separate Ironwood bundle when Ironwood is active.
+    ///   outputs into a separate Ironwood bundle when Ironwood is active. This is a
+    ///   single boolean rather than a richer type because it simply carries the
+    ///   builder's already-computed routing decision, so the proposal and the built
+    ///   transaction stay in lock-step.
     /// - `ephemeral_balance`: if the transaction is to be constructed with either an
     ///   ephemeral transparent input or an ephemeral transparent output this argument
     ///   may be used to provide the value of that input or output. The value of this

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -558,6 +558,13 @@ pub trait ChangeStrategy {
     /// inputs from most to least preferred to spend within each pool, so that the most
     /// preferred ones are less likely to be indicated to remove.
     ///
+    /// - `ironwood`: the Ironwood bundle view (behind the `orchard` feature). A V6
+    ///   transaction carries a separate Ironwood bundle, distinct from `orchard`,
+    ///   with its own action count; pass an empty view when nothing targets the
+    ///   Ironwood pool.
+    /// - `orchard_change_to_ironwood`: whether Orchard-pool change should be counted
+    ///   in the Ironwood bundle, mirroring how the builder routes Orchard-pool
+    ///   outputs into a separate Ironwood bundle when Ironwood is active.
     /// - `ephemeral_balance`: if the transaction is to be constructed with either an
     ///   ephemeral transparent input or an ephemeral transparent output this argument
     ///   may be used to provide the value of that input or output. The value of this
@@ -565,7 +572,7 @@ pub trait ChangeStrategy {
     /// - `wallet_meta`: Additional wallet metadata that the change strategy may use
     ///   in determining how to construct change outputs. This wallet metadata value
     ///   should be computed excluding the inputs provided in the `transparent_inputs`,
-    ///   `sapling`, and `orchard` arguments.
+    ///   `sapling`, `orchard`, and `ironwood` arguments.
     ///
     /// [ZIP 320]: https://zips.z.cash/zip-0320
     #[allow(clippy::too_many_arguments)]
@@ -577,10 +584,8 @@ pub trait ChangeStrategy {
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard::BundleView<NoteRefT>,
-        // The Ironwood bundle view. V6 transactions carry a separate Ironwood
-        // bundle (distinct from `orchard`), with its own action count; pass an
-        // empty view when nothing targets the Ironwood pool.
         #[cfg(feature = "orchard")] ironwood: &impl orchard::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>>;

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -577,6 +577,10 @@ pub trait ChangeStrategy {
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard::BundleView<NoteRefT>,
+        // The Ironwood bundle view. V6 transactions carry a separate Ironwood
+        // bundle (distinct from `orchard`), with its own action count; pass an
+        // empty view when nothing targets the Ironwood pool.
+        #[cfg(feature = "orchard")] ironwood: &impl orchard::BundleView<NoteRefT>,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>>;

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -28,21 +28,31 @@ pub(crate) struct NetFlows {
     sapling_out: Zatoshis,
     orchard_in: Zatoshis,
     orchard_out: Zatoshis,
+    // The Ironwood pool is accounted separately from Orchard because V6
+    // transactions carry separate Orchard and Ironwood bundles, each with its
+    // own action count. The value flow is identical whether output value lands
+    // in the Orchard or Ironwood bundle, so these only affect the action count.
+    ironwood_in: Zatoshis,
+    ironwood_out: Zatoshis,
 }
 
 impl NetFlows {
     fn total_in(&self) -> Result<Zatoshis, BalanceError> {
-        (self.t_in + self.sapling_in + self.orchard_in).ok_or(BalanceError::Overflow)
+        (self.t_in + self.sapling_in + self.orchard_in + self.ironwood_in)
+            .ok_or(BalanceError::Overflow)
     }
     fn total_out(&self) -> Result<Zatoshis, BalanceError> {
-        (self.t_out + self.sapling_out + self.orchard_out).ok_or(BalanceError::Overflow)
+        (self.t_out + self.sapling_out + self.orchard_out + self.ironwood_out)
+            .ok_or(BalanceError::Overflow)
     }
     /// Returns true iff the flows excluding change are fully transparent.
     fn is_transparent(&self) -> bool {
         !(self.sapling_in.is_positive()
             || self.sapling_out.is_positive()
             || self.orchard_in.is_positive()
-            || self.orchard_out.is_positive())
+            || self.orchard_out.is_positive()
+            || self.ironwood_in.is_positive()
+            || self.ironwood_out.is_positive())
     }
 }
 
@@ -52,6 +62,7 @@ pub(crate) fn calculate_net_flows<NoteRefT: Clone, F: FeeRule, E>(
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+    #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<NetFlows, ChangeError<E, NoteRefT>>
 where
@@ -104,6 +115,26 @@ where
     #[cfg(not(feature = "orchard"))]
     let orchard_out = Zatoshis::ZERO;
 
+    #[cfg(feature = "orchard")]
+    let ironwood_in = ironwood
+        .inputs()
+        .iter()
+        .map(orchard_fees::InputView::<NoteRefT>::value)
+        .sum::<Option<_>>()
+        .ok_or_else(overflow)?;
+    #[cfg(not(feature = "orchard"))]
+    let ironwood_in = Zatoshis::ZERO;
+
+    #[cfg(feature = "orchard")]
+    let ironwood_out = ironwood
+        .outputs()
+        .iter()
+        .map(orchard_fees::OutputView::value)
+        .sum::<Option<_>>()
+        .ok_or_else(overflow)?;
+    #[cfg(not(feature = "orchard"))]
+    let ironwood_out = Zatoshis::ZERO;
+
     Ok(NetFlows {
         t_in,
         t_out,
@@ -111,6 +142,8 @@ where
         sapling_out,
         orchard_in,
         orchard_out,
+        ironwood_in,
+        ironwood_out,
     })
 }
 
@@ -209,6 +242,7 @@ pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clo
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+    #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
     change_memo: Option<&MemoBytes>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<TransactionBalance, ChangeError<E, NoteRefT>>
@@ -229,6 +263,8 @@ where
         sapling,
         #[cfg(feature = "orchard")]
         orchard,
+        #[cfg(feature = "orchard")]
+        ironwood,
         ephemeral_balance,
     )?;
 
@@ -330,9 +366,30 @@ where
         }
     };
 
-    // Ironwood bundles are not yet constructed by the wallet, so they contribute
-    // no actions to the fee.
-    let ironwood_action_count = 0;
+    // The Ironwood bundle is accounted separately from Orchard: a V6 transaction
+    // carries distinct Orchard and Ironwood bundles, each padded to its own
+    // action floor. Callers route Ironwood inputs/outputs into the `ironwood`
+    // view; it is empty (contributing no actions) when nothing targets the
+    // Ironwood pool.
+    #[cfg(feature = "orchard")]
+    let ironwood_action_count = |change_count| {
+        orchard_fees::transactional_action_count(
+            ironwood.bundle_version(),
+            ironwood.inputs().len(),
+            ironwood.outputs().len() + change_count,
+        )
+        .map_err(ChangeError::BundleError)
+    };
+    #[cfg(not(feature = "orchard"))]
+    let ironwood_action_count = |change_count: usize| -> Result<usize, ChangeError<E, NoteRefT>> {
+        if change_count != 0 {
+            Err(ChangeError::BundleError(
+                "Nonzero Ironwood change requested but the `orchard` feature is not enabled.",
+            ))
+        } else {
+            Ok(0)
+        }
+    };
 
     let transparent_input_sizes = transparent_inputs
         .iter()
@@ -381,7 +438,7 @@ where
             sapling_input_count,
             sapling_output_count(0)?,
             orchard_action_count(0)?,
-            ironwood_action_count,
+            ironwood_action_count(0)?,
         )
         .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?;
 
@@ -414,7 +471,7 @@ where
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
                         orchard_action_count(target_change_counts.orchard())?,
-                        ironwood_action_count,
+                        ironwood_action_count(0)?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?,
             );
@@ -454,7 +511,7 @@ where
                         } else {
                             0
                         })?,
-                        ironwood_action_count,
+                        ironwood_action_count(0)?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?
             } else {

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -28,10 +28,11 @@ pub(crate) struct NetFlows {
     sapling_out: Zatoshis,
     orchard_in: Zatoshis,
     orchard_out: Zatoshis,
-    // The Ironwood pool is accounted separately from Orchard because V6
-    // transactions carry separate Orchard and Ironwood bundles, each with its
-    // own action count. The value flow is identical whether output value lands
-    // in the Orchard or Ironwood bundle, so these only affect the action count.
+    // Value flowing through the Ironwood bundle, accounted separately from
+    // Orchard because V6 transactions carry distinct Orchard and Ironwood
+    // bundles. Splitting output value between the Orchard and Ironwood views
+    // leaves `total_in`/`total_out` unchanged; the separate fields exist so each
+    // bundle's action count can be derived from its own inputs and outputs.
     ironwood_in: Zatoshis,
     ironwood_out: Zatoshis,
 }
@@ -243,6 +244,11 @@ pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clo
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
+    // Whether Orchard-pool change is routed into the Ironwood bundle (the builder
+    // does this when Ironwood is active). Orchard-pool payment outputs are already
+    // routed into the `ironwood` view by the caller; this carries the same decision
+    // for the change output, which is computed here.
+    #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
     change_memo: Option<&MemoBytes>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<TransactionBalance, ChangeError<E, NoteRefT>>
@@ -391,6 +397,15 @@ where
         }
     };
 
+    // When Ironwood is active, the builder routes Orchard-pool change into the
+    // Ironwood bundle (Orchard-pool payment outputs are already routed into the
+    // `ironwood` view by the caller). Mirror that here so the change output is
+    // counted in the same bundle the builder will place it in.
+    #[cfg(feature = "orchard")]
+    let route_change_to_ironwood = orchard_change_to_ironwood;
+    #[cfg(not(feature = "orchard"))]
+    let route_change_to_ironwood = false;
+
     let transparent_input_sizes = transparent_inputs
         .iter()
         .map(|i| i.serialized_size())
@@ -470,8 +485,16 @@ where
                         transparent_output_sizes.clone(),
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
-                        orchard_action_count(target_change_counts.orchard())?,
-                        ironwood_action_count(0)?,
+                        orchard_action_count(if route_change_to_ironwood {
+                            0
+                        } else {
+                            target_change_counts.orchard()
+                        })?,
+                        ironwood_action_count(if route_change_to_ironwood {
+                            target_change_counts.orchard()
+                        } else {
+                            0
+                        })?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?,
             );
@@ -506,12 +529,20 @@ where
                         } else {
                             0
                         })?,
-                        orchard_action_count(if change_pool == ShieldedPool::Orchard {
-                            split_count
-                        } else {
-                            0
-                        })?,
-                        ironwood_action_count(0)?,
+                        orchard_action_count(
+                            if change_pool == ShieldedPool::Orchard && !route_change_to_ironwood {
+                                split_count
+                            } else {
+                                0
+                            },
+                        )?,
+                        ironwood_action_count(
+                            if change_pool == ShieldedPool::Orchard && route_change_to_ironwood {
+                                split_count
+                            } else {
+                                0
+                            },
+                        )?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?
             } else {

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -84,6 +84,7 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -110,6 +111,8 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
+            #[cfg(feature = "orchard")]
+            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -171,6 +174,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -221,6 +226,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -83,6 +83,7 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -107,6 +108,8 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -166,6 +169,8 @@ mod tests {
             ),
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -212,6 +217,8 @@ mod tests {
                 ][..],
                 &[SaplingPayment::new(Zatoshis::const_from_u64(40000))][..],
             ),
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
             None,

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -653,6 +653,7 @@ mod tests {
                 }][..],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -662,6 +663,80 @@ mod tests {
             Ok(balance) if
                 balance.proposed_change() == [ChangeValue::orchard(Zatoshis::const_from_u64(35000), None)] &&
                 balance.fee_required() == Zatoshis::const_from_u64(15000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn ironwood_outputs_are_charged_actions() {
+        // V6 transactions carry a separate Ironwood bundle, so a populated
+        // Ironwood view must contribute its own actions to the fee rather than
+        // being treated as zero. Compare two otherwise-identical balances that
+        // differ only by the presence of an Ironwood output.
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+        );
+
+        let height = Network::TestNetwork
+            .activation_height(NetworkUpgrade::Nu5)
+            .unwrap()
+            .into();
+        let sapling_inputs = [TestSaplingInput {
+            note_id: 0,
+            value: Zatoshis::const_from_u64(100000),
+        }];
+        let orchard_outputs = [OrchardPayment::new(Zatoshis::const_from_u64(30000))];
+        let sapling_view = (
+            sapling::builder::BundleType::DEFAULT,
+            &sapling_inputs[..],
+            &[] as &[Infallible],
+        );
+        let orchard_view = (
+            crate::ANY_ORCHARD_BUNDLE_VERSION,
+            &[] as &[Infallible],
+            &orchard_outputs[..],
+        );
+
+        let without_ironwood = change_strategy
+            .compute_balance(
+                &Network::TestNetwork,
+                height,
+                &[] as &[TestTransparentInput],
+                &[] as &[TxOut],
+                &sapling_view,
+                &orchard_view,
+                &orchard_fees::EmptyBundleView,
+                None,
+                &(),
+            )
+            .unwrap();
+
+        let with_ironwood = change_strategy
+            .compute_balance(
+                &Network::TestNetwork,
+                height,
+                &[] as &[TestTransparentInput],
+                &[] as &[TxOut],
+                &sapling_view,
+                &orchard_view,
+                &(
+                    ::orchard::bundle::BundleVersion::ironwood_v3(),
+                    &[] as &[Infallible],
+                    &orchard_outputs[..],
+                ),
+                None,
+                &(),
+            )
+            .unwrap();
+
+        assert!(
+            with_ironwood.fee_required() > without_ironwood.fee_required(),
+            "Ironwood bundle outputs must add to the fee: {:?} vs {:?}",
+            with_ironwood.fee_required(),
+            without_ironwood.fee_required(),
         );
     }
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -673,6 +673,7 @@ mod tests {
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
             &orchard_fees::EmptyBundleView,
+            false,
             None,
             &(),
         );
@@ -714,7 +715,7 @@ mod tests {
             &[] as &[Infallible],
         );
         let orchard_view = (
-            crate::ANY_ORCHARD_BUNDLE_VERSION,
+            ::orchard::bundle::BundleVersion::orchard_v2(),
             &[] as &[Infallible],
             &orchard_outputs[..],
         );
@@ -781,7 +782,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
         );
 
@@ -804,7 +805,7 @@ mod tests {
             &[] as &[Infallible],
         );
         let orchard_view = (
-            crate::ANY_ORCHARD_BUNDLE_VERSION,
+            ::orchard::bundle::BundleVersion::orchard_v2(),
             &[] as &[Infallible],
             &orchard_outputs[..],
         );

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -125,6 +125,7 @@ where
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -149,6 +150,8 @@ where
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -235,6 +238,7 @@ where
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -258,6 +262,8 @@ where
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -322,6 +328,8 @@ mod tests {
             ),
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -366,6 +374,8 @@ mod tests {
                         }][..],
                         &[SaplingPayment::new(Zatoshis::const_from_u64(100_0000))][..],
                     ),
+                    #[cfg(feature = "orchard")]
+                    &orchard_fees::EmptyBundleView,
                     #[cfg(feature = "orchard")]
                     &orchard_fees::EmptyBundleView,
                     None,
@@ -419,6 +429,8 @@ mod tests {
                 ),
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                &orchard_fees::EmptyBundleView,
                 None,
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
@@ -460,6 +472,8 @@ mod tests {
                 ),
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                &orchard_fees::EmptyBundleView,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
@@ -494,6 +508,8 @@ mod tests {
                     }][..],
                     &[SaplingPayment::new(Zatoshis::const_from_u64(40001))][..],
                 ),
+                #[cfg(feature = "orchard")]
+                &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
                 None,
@@ -538,6 +554,8 @@ mod tests {
                         SaplingPayment::new(Zatoshis::const_from_u64(10000)),
                     ][..],
                 ),
+                #[cfg(feature = "orchard")]
+                &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
                 None,
@@ -589,6 +607,7 @@ mod tests {
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -689,6 +708,8 @@ mod tests {
             ),
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -735,6 +756,8 @@ mod tests {
             &sapling_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -779,6 +802,8 @@ mod tests {
                 Script::default(),
             )],
             &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
             None,
@@ -831,6 +856,8 @@ mod tests {
                 Script::default(),
             )],
             &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
             None,
@@ -894,6 +921,8 @@ mod tests {
             ),
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             None,
             &(),
         );
@@ -943,6 +972,8 @@ mod tests {
                 ][..],
                 &[SaplingPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
             None,

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -126,6 +126,7 @@ where
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -152,6 +153,8 @@ where
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
+            #[cfg(feature = "orchard")]
+            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -239,6 +242,7 @@ where
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
+        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -264,6 +268,8 @@ where
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
+            #[cfg(feature = "orchard")]
+            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -330,6 +336,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -378,6 +386,8 @@ mod tests {
                     &orchard_fees::EmptyBundleView,
                     #[cfg(feature = "orchard")]
                     &orchard_fees::EmptyBundleView,
+                    #[cfg(feature = "orchard")]
+                    false,
                     None,
                     &AccountMeta::new(Some(PoolMeta::new(existing_notes, total)), None),
                 )
@@ -431,6 +441,8 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                false,
                 None,
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
@@ -474,6 +486,8 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
@@ -512,6 +526,8 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
@@ -558,6 +574,8 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
+                #[cfg(feature = "orchard")]
+                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
@@ -608,6 +626,7 @@ mod tests {
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
             &orchard_fees::EmptyBundleView,
+            false,
             None,
             &(),
         );
@@ -709,6 +728,7 @@ mod tests {
                 &sapling_view,
                 &orchard_view,
                 &orchard_fees::EmptyBundleView,
+                false,
                 None,
                 &(),
             )
@@ -727,6 +747,7 @@ mod tests {
                     &[] as &[Infallible],
                     &orchard_outputs[..],
                 ),
+                false,
                 None,
                 &(),
             )
@@ -737,6 +758,80 @@ mod tests {
             "Ironwood bundle outputs must add to the fee: {:?} vs {:?}",
             with_ironwood.fee_required(),
             without_ironwood.fee_required(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn orchard_change_routes_to_ironwood_bundle() {
+        // With `orchard_change_to_ironwood` set (the builder routes Orchard-pool
+        // outputs into a separate Ironwood bundle when Ironwood is active), the
+        // Orchard-pool change output must be counted in the Ironwood bundle, not the
+        // Orchard bundle — matching where the builder places it. This exercises the
+        // change-routing path directly: an Orchard payment forces the change to the
+        // Orchard pool, and two Ironwood payments make the Ironwood bundle large
+        // enough that moving the change into it raises its action count, so routing
+        // the change has an observable effect on the fee.
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedProtocol::Orchard,
+            DustOutputPolicy::default(),
+        );
+
+        let height = Network::TestNetwork
+            .activation_height(NetworkUpgrade::Nu5)
+            .unwrap()
+            .into();
+        let sapling_inputs = [TestSaplingInput {
+            note_id: 0,
+            value: Zatoshis::const_from_u64(100000),
+        }];
+        let orchard_outputs = [OrchardPayment::new(Zatoshis::const_from_u64(10000))];
+        let ironwood_outputs = [
+            OrchardPayment::new(Zatoshis::const_from_u64(10000)),
+            OrchardPayment::new(Zatoshis::const_from_u64(10000)),
+        ];
+        let sapling_view = (
+            sapling::builder::BundleType::DEFAULT,
+            &sapling_inputs[..],
+            &[] as &[Infallible],
+        );
+        let orchard_view = (
+            crate::ANY_ORCHARD_BUNDLE_VERSION,
+            &[] as &[Infallible],
+            &orchard_outputs[..],
+        );
+        let ironwood_view = (
+            ::orchard::bundle::BundleVersion::ironwood_v3(),
+            &[] as &[Infallible],
+            &ironwood_outputs[..],
+        );
+
+        let fee_for = |orchard_change_to_ironwood: bool| {
+            change_strategy
+                .compute_balance(
+                    &Network::TestNetwork,
+                    height,
+                    &[] as &[TestTransparentInput],
+                    &[] as &[TxOut],
+                    &sapling_view,
+                    &orchard_view,
+                    &ironwood_view,
+                    orchard_change_to_ironwood,
+                    None,
+                    &(),
+                )
+                .unwrap()
+                .fee_required()
+        };
+
+        let change_in_orchard = fee_for(false);
+        let change_in_ironwood = fee_for(true);
+        assert!(
+            change_in_ironwood > change_in_orchard,
+            "routing Orchard-pool change into the Ironwood bundle should change the \
+             fee: {change_in_ironwood:?} (ironwood) vs {change_in_orchard:?} (orchard)",
         );
     }
 
@@ -785,6 +880,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -833,6 +930,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -881,6 +980,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -935,6 +1036,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -998,6 +1101,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );
@@ -1051,6 +1156,8 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            false,
             None,
             &(),
         );

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -753,11 +753,17 @@ mod tests {
             )
             .unwrap();
 
-        assert!(
-            with_ironwood.fee_required() > without_ironwood.fee_required(),
-            "Ironwood bundle outputs must add to the fee: {:?} vs {:?}",
-            with_ironwood.fee_required(),
+        // ZIP 317 floors each shielded bundle that is used at 2 actions. Without
+        // an Ironwood bundle: sapling (2) + orchard (2 outputs) = 4 actions; with
+        // an Ironwood output: + ironwood (2) = 6 actions. At 5000 zat/action that
+        // is 20000 vs 30000.
+        assert_eq!(
             without_ironwood.fee_required(),
+            Zatoshis::const_from_u64(20000)
+        );
+        assert_eq!(
+            with_ironwood.fee_required(),
+            Zatoshis::const_from_u64(30000)
         );
     }
 
@@ -826,13 +832,14 @@ mod tests {
                 .fee_required()
         };
 
+        // Change in Orchard: sapling (2) + orchard (1 payment + 1 change = 2) +
+        // ironwood (2 payments = 2) = 6 actions = 30000. Routing the change into
+        // Ironwood: orchard (1 payment = 2) + ironwood (2 payments + 1 change = 3)
+        // = 7 actions = 35000.
         let change_in_orchard = fee_for(false);
         let change_in_ironwood = fee_for(true);
-        assert!(
-            change_in_ironwood > change_in_orchard,
-            "routing Orchard-pool change into the Ironwood bundle should change the \
-             fee: {change_in_ironwood:?} (ironwood) vs {change_in_orchard:?} (orchard)",
-        );
+        assert_eq!(change_in_orchard, Zatoshis::const_from_u64(30000));
+        assert_eq!(change_in_ironwood, Zatoshis::const_from_u64(35000));
     }
 
     #[test]


### PR DESCRIPTION
V6 transactions carry separate Orchard and Ironwood bundles, each padded to its own action floor, and `FeeRule::fee_required` already takes a separate `ironwood_action_count` — but the wallet's change/fee calculation stubbed it to `0`.

This threads a dedicated Ironwood `BundleView` through `ChangeStrategy::compute_balance` (behind the `orchard` feature, mirroring the existing `orchard` view) and computes `ironwood_action_count` from it. At input selection, Orchard-pool outputs are routed into the Ironwood view when the builder will route them there, reusing the builder's own `orchard_outputs_to_ironwood` predicate (and the same `proposed_version`) so the proposal and build paths cannot drift. The Orchard bundle keeps the Orchard spends; Ironwood has no spends yet, since the wallet does not select Ironwood notes until note detection lands.

Includes a zip317 unit test asserting that a populated Ironwood view raises the required fee. A proposal-to-build integration test under Ironwood activation will follow.

Stacked on the Ironwood wallet-wiring branch; rebase onto `feat/ironwood` once that merges.