### PR TITLE
Disable the stale zip_0233 test on release/nu6.3_testnet_support

### DIFF
--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -1122,6 +1122,10 @@ fn zip_0244() {
 
 #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
 #[test]
+// TODO: the ZIP 233 test vectors are stale relative to the NU6.3 v6 sighash/txid changes
+// in this release, so this fails on the "Test NU7" CI steps. Regenerate the vectors, or
+// re-enable, when the v7 transaction format and its ZIP 233 changes are settled.
+#[ignore = "stale ZIP 233 test vectors after NU6.3 v6 sighash/txid changes"]
 fn zip_0233() {
     fn to_test_txdata(
         tv: &self::data::zip_0233::TestVector,


### PR DESCRIPTION
`transaction::tests::zip_0233` fails on the **Test NU7** CI steps on this branch: the NU6.3 v6 sighash/txid changes moved the computed v6 digest, but the (unchanged) ZIP 233 test vectors still expect the old values.

This marks the test `#[ignore]` with a TODO to regenerate the vectors (or re-enable) when the v7 transaction format and its ZIP 233 changes are settled. Test-only — it still compiles (the `v6_signature_hash` signature and the vector file are unchanged), so `#[ignore]` is the right lever.

🤖 Prepared with Claude Opus 4.8