### PR TITLE
zcash_client_backend: Add per-pool input/output counts to proposal Step

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,14 @@ workspace.
 ## [0.24.0] - PLANNED
 
 ### Added
+- `zcash_client_backend::proposal::Step` methods for counting the inputs and
+  outputs of a proposal step by pool, paralleling the existing
+  `input_in_pool`/`output_in_pool`/`change_in_pool` predicates:
+  - `input_count_in_pool`
+  - `output_count_in_pool`
+  - `change_count_in_pool`
+  - `orchard_action_count`, the number of Orchard actions a step requires
+    (the greater of its Orchard spends and its Orchard outputs plus change).
 - A new `spend-index` feature flag, for consumers whose chain-data source can
   resolve the spend of an individual transparent output (e.g. a full node with a
   spent-outpoint index). It gates:

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -602,6 +602,59 @@ impl<NoteRef> Step<NoteRef> {
             .iter()
             .any(|c| c.output_pool() == pool_type)
     }
+
+    /// Returns the number of inputs to this step that belong to the given pool.
+    ///
+    /// For a shielded pool this is the number of spent notes of that protocol; for
+    /// [`PoolType::Transparent`] it is the number of transparent inputs.
+    pub fn input_count_in_pool(&self, pool_type: PoolType) -> usize {
+        match pool_type {
+            PoolType::Transparent => self.transparent_inputs().len(),
+            PoolType::SAPLING => self
+                .shielded_inputs()
+                .iter()
+                .flat_map(|s_in| s_in.notes())
+                .filter(|note| note.note().protocol() == ShieldedProtocol::Sapling)
+                .count(),
+            PoolType::ORCHARD => self
+                .shielded_inputs()
+                .iter()
+                .flat_map(|s_in| s_in.notes())
+                .filter(|note| note.note().protocol() == ShieldedProtocol::Orchard)
+                .count(),
+        }
+    }
+
+    /// Returns the number of payment outputs of this step that are directed to the given pool.
+    ///
+    /// This does not include change outputs; use [`Step::change_count_in_pool`] for those.
+    pub fn output_count_in_pool(&self, pool_type: PoolType) -> usize {
+        self.payment_pools()
+            .values()
+            .filter(|pool| **pool == pool_type)
+            .count()
+    }
+
+    /// Returns the number of change outputs of this step that are directed to the given pool.
+    pub fn change_count_in_pool(&self, pool_type: PoolType) -> usize {
+        self.balance()
+            .proposed_change()
+            .iter()
+            .filter(|c| c.output_pool() == pool_type)
+            .count()
+    }
+
+    /// Returns the number of Orchard actions required by this step.
+    ///
+    /// Each Orchard action can carry both a spend and an output, so the number of actions is
+    /// the greater of the number of Orchard note spends and the number of Orchard outputs
+    /// (payments plus change) in this step.
+    pub fn orchard_action_count(&self) -> usize {
+        let spends = self.input_count_in_pool(PoolType::ORCHARD);
+        let outputs = self.output_count_in_pool(PoolType::ORCHARD)
+            + self.change_count_in_pool(PoolType::ORCHARD);
+        spends.max(outputs)
+    }
 }
 
 impl<NoteRef> Debug for Step<NoteRef> {

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -576,6 +576,11 @@ impl<NoteRef> Step<NoteRef> {
             || self.change_in_pool(pool_type)
     }
 
+    /// Returns whether or not this step spends any inputs from the given pool.
+    ///
+    /// For a shielded pool this is true when a note of that protocol is spent; for
+    /// [`PoolType::Transparent`] it is true when the step is a shielding step or has any
+    /// transparent inputs.
     pub fn input_in_pool(&self, pool_type: PoolType) -> bool {
         match pool_type {
             PoolType::Transparent => self.is_shielding() || !self.transparent_inputs().is_empty(),
@@ -592,10 +597,14 @@ impl<NoteRef> Step<NoteRef> {
         }
     }
 
+    /// Returns whether or not this step directs any payment output to the given pool.
+    ///
+    /// This does not consider change outputs; use [`Step::change_in_pool`] for those.
     pub fn output_in_pool(&self, pool_type: PoolType) -> bool {
         self.payment_pools().values().any(|pool| *pool == pool_type)
     }
 
+    /// Returns whether or not this step directs any change output to the given pool.
     pub fn change_in_pool(&self, pool_type: PoolType) -> bool {
         self.balance()
             .proposed_change()


### PR DESCRIPTION
This code is extracted from https://github.com/zcash/zallet/blob/main/zallet/src/components/json_rpc/methods/z_send_many.rs#L299-L340. It will be reused there later.
This was initially an idea from the work on https://github.com/zcash/zallet/pull/531.

------

Add counting methods on `Step` that parallel the existing `input_in_pool`/`output_in_pool`/`change_in_pool` predicates: `input_count_in_pool`, `output_count_in_pool`, `change_count_in_pool`, and `orchard_action_count`. The latter returns the number of Orchard actions a step requires (the greater of its Orchard spends and its Orchard outputs plus change), so consumers such as zallet can enforce an Orchard action limit without reimplementing the traversal.j