### PR TITLE
zcash_primitives: Address post-merge review comments from PR #2509

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -8,6 +8,12 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [Unreleased]
+
+### Added
+- `zcash_protocol::consensus::OrchardProtocolRevision`
+- `zcash_protocol::consensus::BranchId::orchard_protocol_revision`
+
 ## [0.10.0-pre.0] - 2026-06-30
 
 This release sets the NU6.3 activation height to 4134000 on testnet.

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -900,6 +900,44 @@ impl BranchId {
             BranchId::Nu7 => true,
         }
     }
+
+    /// Returns the revision of the Orchard protocol in effect under this consensus
+    /// branch, or `None` for branches that predate NU5 (under which the Orchard
+    /// protocol is not supported).
+    pub fn orchard_protocol_revision(&self) -> Option<OrchardProtocolRevision> {
+        use BranchId::*;
+        match self {
+            Sprout | Overwinter | Sapling | Blossom | Heartwood | Canopy => None,
+            Nu5 | Nu6 | Nu6_1 => Some(OrchardProtocolRevision::InsecureV1),
+            Nu6_2 => Some(OrchardProtocolRevision::V2),
+            Nu6_3 => Some(OrchardProtocolRevision::V3),
+            #[cfg(zcash_unstable = "nu7")]
+            Nu7 => Some(OrchardProtocolRevision::V3),
+        }
+    }
+}
+
+/// The revision of the Orchard protocol deployed by a network upgrade.
+///
+/// The revisions correspond one-to-one to the `orchard` crate's `ProtocolVersion`;
+/// this type exists so that crates that do not depend on `orchard` can express which
+/// protocol revision a consensus branch selects. Use
+/// [`BranchId::orchard_protocol_revision`] to obtain the revision in effect under a
+/// given consensus branch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OrchardProtocolRevision {
+    /// The original revision of the Orchard protocol, deployed at NU5 and used prior
+    /// to NU6.2. Uses the historical unsound Orchard circuit; cross-address transfers
+    /// are permitted.
+    InsecureV1,
+    /// The revision of the Orchard protocol deployed at NU6.2. Uses the post-NU6.2
+    /// fixed circuit; cross-address transfers are permitted.
+    V2,
+    /// The revision of the Orchard protocol deployed at NU6.3, which introduces the
+    /// Ironwood value pool. Uses the post-NU6.3 circuit; cross-address transfers are
+    /// prohibited for the Orchard value pool and permitted for the Ironwood value
+    /// pool.
+    V3,
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]
@@ -985,6 +1023,34 @@ mod tests {
     fn branch_id_from_u32() {
         assert_eq!(BranchId::try_from(0), Ok(BranchId::Sprout));
         assert!(BranchId::try_from(1).is_err());
+    }
+
+    #[test]
+    fn orchard_protocol_revision() {
+        use super::OrchardProtocolRevision;
+
+        assert_eq!(BranchId::Canopy.orchard_protocol_revision(), None);
+        assert_eq!(
+            BranchId::Nu5.orchard_protocol_revision(),
+            Some(OrchardProtocolRevision::InsecureV1)
+        );
+        assert_eq!(
+            BranchId::Nu6_1.orchard_protocol_revision(),
+            Some(OrchardProtocolRevision::InsecureV1)
+        );
+        assert_eq!(
+            BranchId::Nu6_2.orchard_protocol_revision(),
+            Some(OrchardProtocolRevision::V2)
+        );
+        assert_eq!(
+            BranchId::Nu6_3.orchard_protocol_revision(),
+            Some(OrchardProtocolRevision::V3)
+        );
+        #[cfg(zcash_unstable = "nu7")]
+        assert_eq!(
+            BranchId::Nu7.orchard_protocol_revision(),
+            Some(OrchardProtocolRevision::V3)
+        );
     }
 
     #[test]

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,6 +13,14 @@ workspace.
 ### Changed
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_transparent 0.9.0-pre.0`,
   `zcash_primitives 0.29.0-pre.0`, `zcash_proofs 0.29.0-pre.0`.
+- Every PCZT role that parses the Orchard-pool bundle derives its bundle
+  version from the PCZT's consensus branch ID, and returns an
+  `UnsupportedConsensusBranchId` error when that branch ID is unrecognized or
+  predates NU5.
+- `pczt::roles::low_level_signer::Signer::sign_orchard_with` now bounds its
+  error parameter by `From<pczt::roles::low_level_signer::OrchardParseError>`
+  instead of `From<orchard::pczt::ParseError>` (as does the new
+  `sign_ironwood_with`).
 - `pczt::roles::creator::Creator::new` is now fallible, returning
   `Result<Self, pczt::roles::creator::Error>`; it rejects unrecognized consensus
   branch IDs and upgrades that predate the v5 transaction format.
@@ -51,6 +59,10 @@ workspace.
   bundles for v2 serialization).
 - The logical `pczt::Pczt` type now includes an Ironwood bundle.
 - Ironwood PCZT role support.
+- `pczt::ExtractError::UnsupportedConsensusBranchId`
+- `pczt::roles::low_level_signer::OrchardParseError`
+- `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,
+  `pczt::roles::verifier::OrchardError`, and `pczt::roles::prover::OrchardError`.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -406,15 +406,19 @@ impl Pczt {
 
         let consensus_branch_id = BranchId::try_from(global.consensus_branch_id)
             .map_err(|_| ExtractError::UnknownConsensusBranchId)?;
+        let orchard_bundle_version = consensus_branch_id
+            .orchard_protocol_revision()
+            .map(crate::orchard::orchard_bundle_version_for_revision)
+            // The v5 and v6 transaction formats do not exist prior to NU5, so no
+            // transaction could be extracted under such a branch in any case.
+            .ok_or(ExtractError::UnsupportedConsensusBranchId)?;
 
         let transparent = transparent
             .into_parsed()
             .map_err(ExtractError::TransparentParse)?;
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
         let orchard = orchard
-            .into_parsed_with_version(crate::orchard::orchard_bundle_version_for_branch(
-                consensus_branch_id,
-            ))
+            .into_parsed_with_version(orchard_bundle_version)
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
             .into_ironwood_parsed()
@@ -558,6 +562,9 @@ pub enum ExtractError {
     /// The consensus branch ID requested by the PCZT does not correspond to a
     /// known network upgrade.
     UnknownConsensusBranchId,
+    /// The network upgrade for the PCZT's consensus branch ID predates the v5
+    /// transaction format, so no transaction can be extracted from it.
+    UnsupportedConsensusBranchId,
     /// The PCZT specifies an unsupported transaction version.
     UnsupportedTxVersion { version: u32, version_group_id: u32 },
 }

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -404,12 +404,17 @@ impl Pczt {
             ironwood,
         } = self;
 
+        let consensus_branch_id = BranchId::try_from(global.consensus_branch_id)
+            .map_err(|_| ExtractError::UnknownConsensusBranchId)?;
+
         let transparent = transparent
             .into_parsed()
             .map_err(ExtractError::TransparentParse)?;
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
         let orchard = orchard
-            .into_orchard_parsed()
+            .into_parsed_with_version(crate::orchard::orchard_bundle_version_for_branch(
+                consensus_branch_id,
+            ))
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
             .into_ironwood_parsed()
@@ -423,9 +428,6 @@ impl Pczt {
                 version_group_id,
             }),
         }?;
-
-        let consensus_branch_id = BranchId::try_from(global.consensus_branch_id)
-            .map_err(|_| ExtractError::UnknownConsensusBranchId)?;
 
         let lock_time = determine_lock_time(&global, transparent.inputs())
             .ok_or(ExtractError::IncompatibleLockTimes)?;

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -749,49 +749,36 @@ impl Bundle {
     }
 }
 
-/// Returns the Orchard bundle version used by the Orchard pool of the given
-/// (v5-or-later) network upgrade.
+/// Returns the Orchard-pool [`BundleVersion`] corresponding to the given Orchard
+/// protocol revision.
 #[cfg(feature = "orchard")]
-pub(crate) fn orchard_bundle_version_for_branch(
-    branch_id: zcash_protocol::consensus::BranchId,
+pub(crate) fn orchard_bundle_version_for_revision(
+    revision: zcash_protocol::consensus::OrchardProtocolRevision,
 ) -> BundleVersion {
+    use zcash_protocol::consensus::OrchardProtocolRevision;
+
+    match revision {
+        OrchardProtocolRevision::InsecureV1 => BundleVersion::orchard_insecure_v1(),
+        OrchardProtocolRevision::V2 => BundleVersion::orchard_v2(),
+        OrchardProtocolRevision::V3 => BundleVersion::orchard_v3(),
+    }
+}
+
+/// Returns the Orchard-pool [`BundleVersion`] implied by the given PCZT global data,
+/// or `None` if the PCZT's consensus branch ID is unrecognized or predates NU5 (under
+/// which the Orchard protocol is not supported).
+#[cfg(feature = "orchard")]
+pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<BundleVersion> {
     use zcash_protocol::consensus::BranchId;
 
-    match branch_id {
-        // NU5, NU6, and NU6.1 use the original (pre-NU6.2) Orchard pool; pre-NU5
-        // branches are rejected before reaching here.
-        BranchId::Sprout
-        | BranchId::Overwinter
-        | BranchId::Sapling
-        | BranchId::Blossom
-        | BranchId::Heartwood
-        | BranchId::Canopy
-        | BranchId::Nu5
-        | BranchId::Nu6
-        | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
-        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
-        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
-        #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => BundleVersion::orchard_v3(),
-    }
+    BranchId::try_from(global.consensus_branch_id)
+        .ok()?
+        .orchard_protocol_revision()
+        .map(orchard_bundle_version_for_revision)
 }
 
 #[cfg(feature = "orchard")]
 impl Bundle {
-    /// Parses the Orchard-pool bundle using the legacy (pre-NU6.3) Orchard bundle
-    /// version.
-    ///
-    /// TODO: this is incorrect for PCZTs whose consensus branch ID is NU6.3 or later
-    /// (under which the Orchard pool mandates the cross-address restriction); callers
-    /// should instead derive the bundle version from the PCZT's consensus branch ID via
-    /// [`orchard_bundle_version_for_branch`] and use [`Self::into_parsed_with_version`],
-    /// as `Pczt::extract_tx_data` does.
-    pub(crate) fn into_orchard_parsed(
-        self,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_with_version(BundleVersion::orchard_v2())
-    }
-
     pub(crate) fn into_ironwood_parsed(
         self,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -749,8 +749,43 @@ impl Bundle {
     }
 }
 
+/// Returns the Orchard bundle version used by the Orchard pool of the given
+/// (v5-or-later) network upgrade.
+#[cfg(feature = "orchard")]
+pub(crate) fn orchard_bundle_version_for_branch(
+    branch_id: zcash_protocol::consensus::BranchId,
+) -> BundleVersion {
+    use zcash_protocol::consensus::BranchId;
+
+    match branch_id {
+        // NU5, NU6, and NU6.1 use the original (pre-NU6.2) Orchard pool; pre-NU5
+        // branches are rejected before reaching here.
+        BranchId::Sprout
+        | BranchId::Overwinter
+        | BranchId::Sapling
+        | BranchId::Blossom
+        | BranchId::Heartwood
+        | BranchId::Canopy
+        | BranchId::Nu5
+        | BranchId::Nu6
+        | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
+        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
+        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
+        #[cfg(zcash_unstable = "nu7")]
+        BranchId::Nu7 => BundleVersion::orchard_v3(),
+    }
+}
+
 #[cfg(feature = "orchard")]
 impl Bundle {
+    /// Parses the Orchard-pool bundle using the legacy (pre-NU6.3) Orchard bundle
+    /// version.
+    ///
+    /// TODO: this is incorrect for PCZTs whose consensus branch ID is NU6.3 or later
+    /// (under which the Orchard pool mandates the cross-address restriction); callers
+    /// should instead derive the bundle version from the PCZT's consensus branch ID via
+    /// [`orchard_bundle_version_for_branch`] and use [`Self::into_parsed_with_version`],
+    /// as `Pczt::extract_tx_data` does.
     pub(crate) fn into_orchard_parsed(
         self,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
@@ -763,7 +798,7 @@ impl Bundle {
         self.into_parsed_with_version(BundleVersion::ironwood_v3())
     }
 
-    fn into_parsed_with_version(
+    pub(crate) fn into_parsed_with_version(
         self,
         bundle_version: BundleVersion,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -50,7 +50,7 @@ fn consensus_branch_id_for_pczt(consensus_branch_id: u32) -> Result<BranchId, Er
 }
 
 #[cfg(feature = "orchard")]
-use crate::orchard::orchard_bundle_version_for_branch;
+use crate::orchard::orchard_bundle_version_for_revision;
 
 pub struct Creator {
     tx_version: u32,
@@ -85,7 +85,10 @@ impl Creator {
         let branch_id = consensus_branch_id_for_pczt(consensus_branch_id)?;
 
         #[cfg(feature = "orchard")]
-        let orchard_bundle_version = orchard_bundle_version_for_branch(branch_id);
+        let orchard_bundle_version = branch_id
+            .orchard_protocol_revision()
+            .map(orchard_bundle_version_for_revision)
+            .expect("`consensus_branch_id_for_pczt` rejects branches that predate NU5");
 
         Ok(Self {
             // Default to v5 transaction format.

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -49,30 +49,9 @@ fn consensus_branch_id_for_pczt(consensus_branch_id: u32) -> Result<BranchId, Er
     }
 }
 
-/// Returns the Orchard bundle version used by the Orchard pool of the given
-/// (v5-or-later) network upgrade.
 #[cfg(feature = "orchard")]
-fn orchard_bundle_version_for_branch(branch_id: BranchId) -> orchard::bundle::BundleVersion {
-    use orchard::bundle::BundleVersion;
+use crate::orchard::orchard_bundle_version_for_branch;
 
-    match branch_id {
-        // NU5, NU6, and NU6.1 use the original (pre-NU6.2) Orchard pool; pre-NU5
-        // branches are rejected before reaching here.
-        BranchId::Sprout
-        | BranchId::Overwinter
-        | BranchId::Sapling
-        | BranchId::Blossom
-        | BranchId::Heartwood
-        | BranchId::Canopy
-        | BranchId::Nu5
-        | BranchId::Nu6
-        | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
-        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
-        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
-        #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => BundleVersion::orchard_v3(),
-    }
-}
 pub struct Creator {
     tx_version: u32,
     version_group_id: u32,

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -12,17 +12,22 @@ impl Signer {
         Self { pczt }
     }
 
+    /// Exposes the capability to sign the Ironwood spends.
     #[cfg(feature = "orchard")]
     pub fn sign_ironwood_with<E, F>(self, f: F) -> Result<Self, E>
     where
-        E: From<orchard::pczt::ParseError>,
+        E: From<OrchardParseError>,
         F: FnOnce(&Pczt, &mut orchard::pczt::Bundle, &mut u8) -> Result<(), E>,
     {
         let mut pczt = self.pczt;
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
 
-        let mut bundle = pczt.ironwood.clone().into_ironwood_parsed()?;
+        let mut bundle = pczt
+            .ironwood
+            .clone()
+            .into_ironwood_parsed()
+            .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
 
@@ -36,14 +41,20 @@ impl Signer {
     #[cfg(feature = "orchard")]
     pub fn sign_orchard_with<E, F>(self, f: F) -> Result<Self, E>
     where
-        E: From<orchard::pczt::ParseError>,
+        E: From<OrchardParseError>,
         F: FnOnce(&Pczt, &mut orchard::pczt::Bundle, &mut u8) -> Result<(), E>,
     {
         let mut pczt = self.pczt;
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
 
-        let mut bundle = pczt.orchard.clone().into_orchard_parsed()?;
+        let bundle_version = crate::orchard::orchard_bundle_version(&pczt.global)
+            .ok_or(OrchardParseError::UnsupportedConsensusBranchId)?;
+        let mut bundle = pczt
+            .orchard
+            .clone()
+            .into_parsed_with_version(bundle_version)
+            .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
 
@@ -98,5 +109,24 @@ impl Signer {
     /// Finishes the low-level Signer role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
+    }
+}
+
+/// Errors that can occur while parsing an Orchard-protocol bundle of a PCZT for
+/// signing.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum OrchardParseError {
+    /// The bundle data was structurally invalid.
+    Parse(orchard::pczt::ParseError),
+    /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
+    /// the Orchard protocol is not supported).
+    UnsupportedConsensusBranchId,
+}
+
+#[cfg(feature = "orchard")]
+impl From<orchard::pczt::ParseError> for OrchardParseError {
+    fn from(e: orchard::pczt::ParseError) -> Self {
+        OrchardParseError::Parse(e)
     }
 }

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -14,7 +14,10 @@ impl super::Prover {
         } = self.pczt;
 
         let mut bundle = orchard
-            .into_orchard_parsed()
+            .into_parsed_with_version(
+                crate::orchard::orchard_bundle_version(&global)
+                    .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+            )
             .map_err(OrchardError::Parser)?;
 
         bundle
@@ -66,6 +69,9 @@ impl super::Prover {
 pub enum OrchardError {
     Parser(orchard::pczt::ParseError),
     Prover(orchard::pczt::ProverError),
+    /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
+    /// the Orchard protocol is not supported).
+    UnsupportedConsensusBranchId,
 }
 
 /// Errors that can occur while creating Ironwood proofs for a PCZT.

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -133,7 +133,7 @@ impl<'a> TransactionExtractor<'a> {
                 .map_err(Error::Orchard)?;
         }
         if let Some(bundle) = tx.ironwood_bundle() {
-            orchard::verify_ironwood_bundle(bundle, orchard_vk, *shielded_sighash.as_ref())
+            orchard::verify_bundle(bundle, orchard_vk, *shielded_sighash.as_ref())
                 .map_err(Error::Ironwood)?;
         }
 

--- a/pczt/src/roles/tx_extractor/orchard.rs
+++ b/pczt/src/roles/tx_extractor/orchard.rs
@@ -1,8 +1,4 @@
-use orchard::{
-    Bundle,
-    bundle::Authorized,
-    circuit::{OrchardCircuitVersion, VerifyingKey},
-};
+use orchard::{Bundle, bundle::Authorized, circuit::VerifyingKey};
 use rand_core::OsRng;
 use zcash_protocol::value::ZatBalance;
 
@@ -11,26 +7,15 @@ pub(super) fn verify_bundle(
     orchard_vk: Option<&VerifyingKey>,
     sighash: [u8; 32],
 ) -> Result<(), OrchardError> {
-    if let Some(vk) = orchard_vk {
-        verify_bundle_with_key(bundle, vk, sighash)
-    } else {
-        // PCZT extraction produces new Orchard bundles using the NU6.2 fixed
-        // circuit.
-        let vk = VerifyingKey::build(OrchardCircuitVersion::FixedPostNu6_2);
-        verify_bundle_with_key(bundle, &vk, sighash)
-    }
-}
-
-pub(super) fn verify_ironwood_bundle(
-    bundle: &Bundle<Authorized, ZatBalance>,
-    orchard_vk: Option<&VerifyingKey>,
-    sighash: [u8; 32],
-) -> Result<(), OrchardError> {
-    if let Some(vk) = orchard_vk {
-        verify_bundle_with_key(bundle, vk, sighash)
-    } else {
-        let vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
-        verify_bundle_with_key(bundle, &vk, sighash)
+    match orchard_vk {
+        Some(vk) => verify_bundle_with_key(bundle, vk, sighash),
+        // The circuit version is fixed by the bundle's own `BundleVersion`, which
+        // `extract_tx_data` derives from the PCZT's consensus branch ID.
+        None => verify_bundle_with_key(
+            bundle,
+            &VerifyingKey::build(bundle.bundle_version().circuit_version()),
+            sighash,
+        ),
     }
 }
 

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -17,7 +17,10 @@ impl super::Updater {
         } = self.pczt;
 
         let mut bundle = orchard
-            .into_orchard_parsed()
+            .into_parsed_with_version(
+                crate::orchard::orchard_bundle_version(&global)
+                    .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+            )
             .map_err(OrchardError::Parser)?;
 
         bundle.update_with(f).map_err(OrchardError::Updater)?;
@@ -38,5 +41,8 @@ impl super::Updater {
 #[derive(Debug)]
 pub enum OrchardError {
     Parser(ParseError),
+    /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
+    /// the Orchard protocol is not supported).
+    UnsupportedConsensusBranchId,
     Updater(UpdaterError),
 }

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -14,7 +14,12 @@ impl super::Verifier {
             ironwood,
         } = self.pczt;
 
-        let bundle = orchard.into_orchard_parsed().map_err(OrchardError::Parse)?;
+        let bundle = orchard
+            .into_parsed_with_version(
+                crate::orchard::orchard_bundle_version(&global)
+                    .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+            )
+            .map_err(OrchardError::Parse)?;
 
         f(&bundle)?;
 
@@ -34,6 +39,9 @@ impl super::Verifier {
 #[derive(Debug)]
 pub enum OrchardError<E> {
     Parse(orchard::pczt::ParseError),
+    /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
+    /// the Orchard protocol is not supported).
+    UnsupportedConsensusBranchId,
     Verify(orchard::pczt::VerifyError),
     Custom(E),
 }

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -87,6 +87,11 @@ workspace.
   `zcash_address 0.13.0-pre.0`, `zcash_transparent 0.9.0-pre.0`,
   `zcash_keys 0.15.0-pre.0`, `zcash_primitives 0.29.0-pre.0`,
   `zcash_proofs 0.29.0-pre.0`.
+- Fee and change calculation now derive the Orchard bundle version — and hence
+  the Orchard action-count policy — from the proposal's target height, instead
+  of unconditionally using the legacy (pre-NU6.3) policy. Proposals targeting
+  heights at or beyond NU6.3 activation now count one action per Orchard spend
+  or output, matching the post-NU6.3 transaction builder.
 - `zcash_client_backend::data_api`:
   - Changes to the `InputSource` trait:
     - The result types of `InputSource::get_unspent_transparent_output` and

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6189,6 +6189,9 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     );
     assert_matches!(&create_proposed_result, Ok(_));
     let pczt_created = create_proposed_result.unwrap();
+    let pczt_branch_id =
+        consensus::BranchId::try_from(*pczt_created.global().consensus_branch_id())
+            .expect("the PCZT carries a valid consensus branch ID");
 
     // If we don't create proofs or signatures, we will fail to extract a transaction.
     assert_matches!(
@@ -6199,10 +6202,19 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     // Add proof generation keys to Sapling spends.
     let pczt_updated = P0::add_proof_generation_keys(pczt_created, account.usk()).unwrap();
 
-    // Create proofs.
+    // Create proofs, using the circuit that governs the Orchard pool under the
+    // consensus branch the PCZT was created for. (The test network's most recent
+    // upgrade is NU5, so this is currently the historical pre-NU6.2 circuit;
+    // modernizing the test network fixture is part of the broader Ironwood test
+    // coverage work.)
     let sapling_prover = LocalTxProver::bundled();
     let orchard_pk = ::orchard::circuit::ProvingKey::build(
-        ::orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+        zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+            pczt_branch_id,
+            ::orchard::ValuePool::Orchard,
+        )
+        .expect("the PCZT's consensus branch supports the Orchard pool")
+        .circuit_version(),
     );
     let pczt_proven = Prover::new(pczt_updated)
         .create_orchard_proof(&orchard_pk)

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -746,11 +746,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 ),
                 #[cfg(feature = "orchard")]
                 &(
-                    // Preserve the legacy Orchard action-count estimate here.
-                    // If this path targets restrictions that disable
-                    // cross-address transfers, thread the target-height-selected
-                    // `BundleVersion` through this call.
-                    crate::ANY_ORCHARD_BUNDLE_VERSION,
+                    orchard_bundle_version_for_height(params, target_height),
                     &orchard_inputs[..],
                     &orchard_outputs[..],
                 ),
@@ -843,6 +839,23 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
     }
 }
 
+/// Returns the Orchard bundle version whose action-count policy applies to
+/// transactions constructed for the given target height.
+#[cfg(feature = "orchard")]
+fn orchard_bundle_version_for_height<ParamsT: consensus::Parameters>(
+    params: &ParamsT,
+    target_height: TargetHeight,
+) -> ::orchard::bundle::BundleVersion {
+    zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+        consensus::BranchId::for_height(params, BlockHeight::from(target_height)),
+        ::orchard::ValuePool::Orchard,
+    )
+    // Orchard did not exist prior to NU5, so no Orchard bundle (and no Orchard
+    // action) can be produced for a pre-NU5 target height; every bundle version
+    // yields the correct action count (zero) for an empty bundle.
+    .unwrap_or(::orchard::bundle::BundleVersion::orchard_insecure_v1())
+}
+
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(crate) fn propose_send_max<ParamsT, InputSourceT, FeeRuleT>(
     params: &ParamsT,
@@ -910,11 +923,7 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            // Preserve the legacy Orchard action-count estimate here. If this
-            // path targets restrictions that disable cross-address transfers,
-            // thread the target-height-selected `BundleVersion`
-            // through this call.
-            crate::ANY_ORCHARD_BUNDLE_VERSION,
+            orchard_bundle_version_for_height(params, target_height),
             spendable_notes.orchard.len(),
             requested_orchard_actions,
         )
@@ -1315,14 +1324,11 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    // With no Orchard spends and one requested output, the
-                    // padded action count is independent of the Orchard pool
-                    // restriction.
-                    crate::ANY_ORCHARD_BUNDLE_VERSION,
+                    orchard_bundle_version_for_height(params, target_height),
                     0,
                     1,
                 )
-                .expect("legacy Orchard protocol permits any transactional spend and output count");
+                .expect("every Orchard bundle version permits spending and output creation");
                 (0usize, count)
             }
             // Unreachable: `resolve_shielded_destination` rejects transparent

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -618,4 +618,20 @@ pub(crate) mod tests {
             self.value
         }
     }
+
+    #[cfg(feature = "orchard")]
+    pub(crate) struct TestOrchardInput {
+        pub note_id: u32,
+        pub value: Zatoshis,
+    }
+
+    #[cfg(feature = "orchard")]
+    impl super::orchard::InputView<u32> for TestOrchardInput {
+        fn note_id(&self) -> &u32 {
+            &self.note_id
+        }
+        fn value(&self) -> Zatoshis {
+            self.value
+        }
+    }
 }

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -57,7 +57,10 @@ impl<NoteRef> BundleView<NoteRef> for EmptyBundleView {
     type Out = Infallible;
 
     fn bundle_version(&self) -> BundleVersion {
-        crate::ANY_ORCHARD_BUNDLE_VERSION
+        // An empty bundle contains no spends or outputs, and therefore produces
+        // zero actions under every bundle version's action-count policy, so the
+        // version returned here cannot affect fee calculation.
+        BundleVersion::orchard_v2()
     }
 
     fn inputs(&self) -> &[Self::In] {

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -585,7 +585,7 @@ mod tests {
                 &[] as &[Infallible],
             ),
             &(
-                crate::ANY_ORCHARD_BUNDLE_VERSION,
+                ::orchard::bundle::BundleVersion::orchard_v2(),
                 &[] as &[Infallible],
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -602,6 +602,51 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "orchard")]
+    fn orchard_v3_change_counts_spends_and_outputs_separately() {
+        use crate::fees::{sapling as sapling_fees, tests::TestOrchardInput};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedProtocol::Orchard,
+            DustOutputPolicy::default(),
+        );
+
+        // Under the post-NU6.3 Orchard pool restriction (cross-address transfers
+        // disabled), every spend and output occupies its own action: one spend plus a
+        // payment and a change output make three logical actions, where the legacy
+        // policy would count `max(1, 2) == 2`.
+        let result = change_strategy.compute_balance(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .unwrap()
+                .into(),
+            &[] as &[TestTransparentInput],
+            &[] as &[TxOut],
+            &sapling_fees::EmptyBundleView,
+            &(
+                ::orchard::bundle::BundleVersion::orchard_v3(),
+                &[TestOrchardInput {
+                    note_id: 0,
+                    value: Zatoshis::const_from_u64(80000),
+                }][..],
+                &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
+            ),
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::orchard(Zatoshis::const_from_u64(35000), None)] &&
+                balance.fee_required() == Zatoshis::const_from_u64(15000)
+        );
+    }
+
+    #[test]
     fn change_with_transparent_payments_implicitly_allowing_zero_change() {
         change_with_transparent_payments(DustOutputPolicy::default())
     }

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -82,15 +82,6 @@ pub mod tor;
 
 pub use decrypt::{DecryptedOutput, TransferType, decrypt_transaction};
 
-/// Orchard bundle version for fee and change call sites that should not select a concrete
-/// branch-specific policy.
-///
-/// These paths only need a bundle version to drive the Orchard action-count policy; the chosen
-/// value preserves the legacy pre-NU6.3 Orchard behavior those paths used historically.
-#[cfg(feature = "orchard")]
-pub(crate) const ANY_ORCHARD_BUNDLE_VERSION: ::orchard::bundle::BundleVersion =
-    ::orchard::bundle::BundleVersion::orchard_v2();
-
 #[deprecated(note = "This module is deprecated; use `::zcash_keys::address` instead.")]
 pub mod address {
     pub use zcash_keys::address::*;

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -8,6 +8,17 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
+## [Unreleased]
+
+### Added
+- `zcash_primitives::transaction::components::orchard::orchard_bundle_version_for_branch`
+
+### Changed
+- `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes
+  the consensus branch ID under which the transaction was constructed instead of
+  an `orchard::bundle::BundleVersion`; the Orchard bundle version is derived
+  from the branch ID via `orchard_bundle_version_for_branch`.
+
 ## [0.29.0-pre.0] - 2026-06-30
 
 ### Added

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -11,13 +11,22 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- `zcash_primitives::transaction::components::orchard::orchard_bundle_version_for_branch`
+- `zcash_primitives::transaction::components::orchard::bundle_version_for_branch`
 
 ### Changed
 - `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes
   the consensus branch ID under which the transaction was constructed instead of
   an `orchard::bundle::BundleVersion`; the Orchard bundle version is derived
-  from the branch ID via `orchard_bundle_version_for_branch`.
+  from the branch ID via `bundle_version_for_branch`. A transaction whose
+  consensus branch ID predates NU5 is now rejected as invalid data if it
+  contains a non-empty Orchard bundle.
+- `zcash_primitives::transaction::components::orchard::read_v6_bundle` now takes
+  the consensus branch ID and the `orchard::ValuePool` identifying the bundle
+  slot to read, instead of an `orchard::bundle::BundleVersion`; the slot's
+  bundle version is derived via `bundle_version_for_branch`. A non-empty bundle
+  in a slot whose value pool is not supported under the transaction's consensus
+  branch ID (the Orchard pool prior to NU5; the Ironwood pool prior to NU6.3)
+  is now rejected as invalid data.
 
 ## [0.29.0-pre.0] - 2026-06-30
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -19,6 +19,7 @@ use zcash_script::opcode::PushValue;
 
 use crate::transaction::{
     Transaction, TxVersion,
+    components::orchard::orchard_bundle_version_for_branch,
     fees::{
         FeeRule,
         transparent::{InputView, OutputView},
@@ -305,8 +306,8 @@ impl BuildConfig {
                 orchard::builder::Builder::new(
                     orchard::builder::BundleType::Coinbase,
                     bundle_version,
-                    // Coinbase transactions have `enableSpends = 0`. Every pool for which a
-                    // coinbase Orchard bundle is built (Orchard pre-NU6.3 and Ironwood) permits
+                    // Coinbase transactions have `enableSpends = 0`. Every protocol version
+                    // for which a coinbase Orchard-pool bundle can be built (pre-NU6.3) permits
                     // cross-address transfers, so the spends-disabled flag set is representable.
                     orchard::bundle::Flags::SPENDS_DISABLED,
                     orchard::Anchor::empty_tree(),
@@ -377,18 +378,6 @@ fn orchard_action_count(
     };
 
     bundle_type.num_actions(flags, num_spends, num_outputs)
-}
-
-fn orchard_bundle_version_for_branch(
-    consensus_branch_id: BranchId,
-) -> orchard::bundle::BundleVersion {
-    match consensus_branch_id {
-        BranchId::Nu6_3 => orchard::bundle::BundleVersion::orchard_v3(),
-        #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => orchard::bundle::BundleVersion::orchard_v3(),
-        BranchId::Nu6_2 => orchard::bundle::BundleVersion::orchard_v2(),
-        _ => orchard::bundle::BundleVersion::orchard_insecure_v1(),
-    }
 }
 
 /// The result of a transaction build operation, which includes the resulting transaction along
@@ -512,6 +501,14 @@ impl<P, U> Builder<P, U> {
             .map_or_else(|| &[][..], |b| b.outputs())
     }
 
+    /// Returns `true` if any Orchard spend, output, or change output has been
+    /// added to this builder (i.e. the transaction will carry an Orchard bundle).
+    fn orchard_in_use(&self) -> bool {
+        self.orchard_builder.as_ref().is_some_and(|b| {
+            !b.spends().is_empty() || !b.outputs().is_empty() || !b.changes().is_empty()
+        })
+    }
+
     /// Returns `true` if any Ironwood spend, output, or change output has been
     /// added to this builder (i.e. the transaction will carry an Ironwood bundle).
     fn ironwood_in_use(&self) -> bool {
@@ -543,11 +540,7 @@ impl<P, U> Builder<P, U> {
         }
 
         let orchard_available = version.has_orchard() && self.consensus_branch_id.has_orchard();
-        if !orchard_available
-            && self.orchard_builder.as_ref().is_some_and(|b| {
-                !b.spends().is_empty() || !b.outputs().is_empty() || !b.changes().is_empty()
-            })
-        {
+        if !orchard_available && self.orchard_in_use() {
             return Err(Error::TargetIncompatible(
                 self.consensus_branch_id,
                 version,
@@ -703,7 +696,7 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
     ///
     /// Disabling expiry by setting the height to `BlockHeight::from(0)` is not
     /// recommended: non-expiring transactions are not yet well tested
-    /// end-to-end and may surface edge cases elsewhere in the stack. Callers
+    /// end-to-end and are known to cause bugs elsewhere in the stack. Callers
     /// should avoid a zero expiry height unless they specifically need it.
     pub fn with_expiry_height(mut self, expiry_height: BlockHeight) -> Self {
         self.expiry_height = expiry_height;
@@ -1581,8 +1574,8 @@ mod tests {
             nu6: Some(BlockHeight::from_u32(7)),
             nu6_1: Some(BlockHeight::from_u32(8)),
             nu6_2: Some(BlockHeight::from_u32(9)),
-            nu6_3: None,
-            nu7: Some(BlockHeight::from_u32(10)),
+            nu6_3: Some(BlockHeight::from_u32(10)),
+            nu7: Some(BlockHeight::from_u32(11)),
         }
     }
 
@@ -1646,7 +1639,7 @@ mod tests {
     fn nu7_coinbase_builder_does_not_expose_orchard() {
         let builder = Builder::new(
             nu7_test_network(),
-            zcash_protocol::consensus::BlockHeight::from_u32(10),
+            zcash_protocol::consensus::BlockHeight::from_u32(11),
             BuildConfig::Coinbase { miner_data: None },
         );
 
@@ -1876,6 +1869,25 @@ mod tests {
         let merkle_path = orchard::tree::MerklePath::from_parts(0, [zero; 32]);
 
         (fvk, note, merkle_path)
+    }
+
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn note_commitment_and_nullifier_depend_on_note_version() {
+        let (fvk, v2_note, _) = ironwood_note_with_version(orchard::note::NoteVersion::V2);
+        let (_, v3_note, _) = ironwood_note_with_version(orchard::note::NoteVersion::V3);
+
+        // The notes share every field except the note plaintext version (lead byte
+        // 0x02 vs 0x03), which must domain-separate both the commitment and the
+        // nullifier.
+        assert_ne!(
+            orchard::note::ExtractedNoteCommitment::from(v2_note.commitment()).to_bytes(),
+            orchard::note::ExtractedNoteCommitment::from(v3_note.commitment()).to_bytes(),
+        );
+        assert_ne!(
+            v2_note.nullifier(&fvk).to_bytes(),
+            v3_note.nullifier(&fvk).to_bytes(),
+        );
     }
 
     #[test]

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -11,7 +11,7 @@ use ::transparent::{
 };
 use zcash_protocol::{
     PoolType,
-    consensus::{self, BlockHeight, BranchId, NetworkUpgrade, Parameters},
+    consensus::{self, BlockHeight, BranchId, Parameters},
     memo::MemoBytes,
     value::{BalanceError, ZatBalance, Zatoshis},
 };
@@ -19,7 +19,7 @@ use zcash_script::opcode::PushValue;
 
 use crate::transaction::{
     Transaction, TxVersion,
-    components::orchard::orchard_bundle_version_for_branch,
+    components::orchard::bundle_version_for_branch,
     fees::{
         FeeRule,
         transparent::{InputView, OutputView},
@@ -595,16 +595,16 @@ impl<P: consensus::Parameters> Builder<P, ()> {
     /// expiry delta (20 blocks).
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
-        let bundle_version = orchard_bundle_version_for_branch(consensus_branch_id);
+        // `bundle_version_for_branch` returns `Some` exactly for the branches in
+        // which the Orchard pool is supported (NU5 onward), so this also gates
+        // Orchard builder construction on NU5 activation.
+        let bundle_version =
+            bundle_version_for_branch(consensus_branch_id, orchard::ValuePool::Orchard);
         // Default transaction version for the branch (V6 from NU6.3 onward).
         let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
 
-        let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
-            build_config.orchard_builder(bundle_version)
-        } else {
-            None
-        };
-        let orchard_bundle_version = orchard_builder.as_ref().map(|_| bundle_version);
+        let orchard_builder = bundle_version.and_then(|v| build_config.orchard_builder(v));
+        let orchard_bundle_version = orchard_builder.as_ref().and(bundle_version);
 
         // The Ironwood builder exists exactly when the branch's transaction version
         // carries an Ironwood bundle (V6, i.e. NU6.3 onward).
@@ -1269,8 +1269,12 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             let build_proving_key = build_proving_key || unauthed_tx.ironwood_bundle.is_some();
             build_proving_key.then(|| {
                 orchard::circuit::ProvingKey::build(
-                    orchard_bundle_version_for_branch(unauthed_tx.consensus_branch_id)
-                        .circuit_version(),
+                    bundle_version_for_branch(
+                        unauthed_tx.consensus_branch_id,
+                        orchard::ValuePool::Orchard,
+                    )
+                    .expect("an Orchard or Ironwood bundle implies an NU5+ consensus branch")
+                    .circuit_version(),
                 )
             })
         };

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -8,7 +8,7 @@ use corez::io::{self, Read, Write};
 use nonempty::NonEmpty;
 
 use orchard::{
-    Action, Anchor,
+    Action, Anchor, ValuePool,
     bundle::{Authorization, Authorized, BundleVersion, Flags},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
@@ -49,13 +49,20 @@ impl MapAuth<Authorized, Authorized> for () {
 
 fn read_bundle<R: Read>(
     mut reader: R,
-    bundle_version: BundleVersion,
+    bundle_version: Option<BundleVersion>,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
         Ok(None)
     } else {
+        let bundle_version = bundle_version.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Orchard-protocol bundles may not be present in this transaction version \
+                 under the transaction's consensus branch ID",
+            )
+        })?;
         let flags = read_flags(&mut reader, bundle_version)?;
         let value_balance = Transaction::read_amount(&mut reader)?;
         let anchor = read_anchor(&mut reader)?;
@@ -91,30 +98,53 @@ fn read_bundle<R: Read>(
     }
 }
 
-/// Returns the Orchard-pool [`BundleVersion`] in effect for the given consensus branch.
+/// Returns the [`BundleVersion`] in effect for the given Orchard-protocol value pool
+/// under the given consensus branch, or `None` if the pool is not supported under that
+/// branch (the Orchard pool prior to NU5; the Ironwood pool prior to NU6.3).
 ///
-/// The v5 Orchard flag byte is the same in every epoch (bit 2 reserved), so serialization
-/// is unaffected by this choice, but the `BundleVersion` fixes the bundle's cross-address
-/// semantics and circuit generation, which do follow the consensus epoch:
-///   * pre-NU6.2: historical insecure circuit, cross-address enabled, proof size not
-///     enforced;
-///   * NU6.2: fixed circuit, cross-address enabled;
-///   * NU6.3 onward: post-NU6.3 circuit, cross-address disabled (consensus-mandated).
-pub fn orchard_bundle_version_for_branch(consensus_branch_id: BranchId) -> BundleVersion {
-    match consensus_branch_id {
-        BranchId::Sprout
-        | BranchId::Overwinter
-        | BranchId::Sapling
-        | BranchId::Blossom
-        | BranchId::Heartwood
-        | BranchId::Canopy
-        | BranchId::Nu5
-        | BranchId::Nu6
-        | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
-        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
-        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
-        #[cfg(zcash_unstable = "nu7")]
-        BranchId::Nu7 => BundleVersion::orchard_v3(),
+/// The `BundleVersion` fixes a bundle's flag-byte grammar, cross-address semantics, and
+/// circuit generation:
+///   * Orchard pool, NU5 through NU6.1: historical insecure circuit, cross-address
+///     enabled, proof size not enforced;
+///   * Orchard pool, NU6.2: fixed circuit, cross-address enabled;
+///   * Orchard pool, NU6.3 onward: post-NU6.3 circuit, cross-address disabled
+///     (consensus-mandated);
+///   * Ironwood pool, NU6.3 onward: post-NU6.3 circuit, cross-address enabled.
+pub fn bundle_version_for_branch(
+    consensus_branch_id: BranchId,
+    pool: ValuePool,
+) -> Option<BundleVersion> {
+    match pool {
+        ValuePool::Orchard => match consensus_branch_id {
+            BranchId::Sprout
+            | BranchId::Overwinter
+            | BranchId::Sapling
+            | BranchId::Blossom
+            | BranchId::Heartwood
+            | BranchId::Canopy => None,
+            BranchId::Nu5 | BranchId::Nu6 | BranchId::Nu6_1 => {
+                Some(BundleVersion::orchard_insecure_v1())
+            }
+            BranchId::Nu6_2 => Some(BundleVersion::orchard_v2()),
+            BranchId::Nu6_3 => Some(BundleVersion::orchard_v3()),
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => Some(BundleVersion::orchard_v3()),
+        },
+        ValuePool::Ironwood => match consensus_branch_id {
+            BranchId::Sprout
+            | BranchId::Overwinter
+            | BranchId::Sapling
+            | BranchId::Blossom
+            | BranchId::Heartwood
+            | BranchId::Canopy
+            | BranchId::Nu5
+            | BranchId::Nu6
+            | BranchId::Nu6_1
+            | BranchId::Nu6_2 => None,
+            BranchId::Nu6_3 => Some(BundleVersion::ironwood_v3()),
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => Some(BundleVersion::ironwood_v3()),
+        },
     }
 }
 
@@ -123,17 +153,16 @@ pub fn orchard_bundle_version_for_branch(consensus_branch_id: BranchId) -> Bundl
 /// The v5 Orchard wire serialization is identical in every epoch (flag bit 2 is
 /// reserved), but the returned bundle's [`BundleVersion`] — which fixes its
 /// cross-address semantics and circuit generation — follows the consensus epoch
-/// identified by `consensus_branch_id` (see
-/// [`orchard_bundle_version_for_branch`]). By contrast, `read_v6_bundle` takes a
-/// `bundle_version` argument so the caller selects the Orchard or Ironwood v6
-/// slot.
+/// identified by `consensus_branch_id` (see [`bundle_version_for_branch`]). A
+/// non-empty Orchard bundle under a consensus branch that predates NU5 is
+/// rejected as invalid data.
 pub fn read_v5_bundle<R: Read>(
     reader: R,
     consensus_branch_id: BranchId,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
     read_bundle(
         reader,
-        orchard_bundle_version_for_branch(consensus_branch_id),
+        bundle_version_for_branch(consensus_branch_id, ValuePool::Orchard),
     )
 }
 
@@ -154,16 +183,19 @@ fn check_v6_bundle_version(bundle_version: BundleVersion) -> io::Result<()> {
     }
 }
 
-/// Reads an [`orchard::Bundle`] from a v6 transaction format. `bundle_version`
-/// selects the pool: [`BundleVersion::orchard_v3`] for the Orchard v6 bundle, or
-/// [`BundleVersion::ironwood_v3`] for the Ironwood bundle (whose flag-byte encoding permits
-/// the cross-address bit, unlike the Orchard v6 pool).
+/// Reads an [`orchard::Bundle`] from a v6 transaction format. `pool` selects the bundle
+/// slot to read: the Orchard slot ([`ValuePool::Orchard`]) or the Ironwood slot
+/// ([`ValuePool::Ironwood`], whose flag-byte encoding permits the cross-address bit,
+/// unlike the Orchard v6 pool). The slot's [`BundleVersion`] is derived from
+/// `consensus_branch_id` (see [`bundle_version_for_branch`]); a non-empty bundle in a
+/// slot whose value pool is not supported under the transaction's consensus branch is
+/// rejected as invalid data.
 pub fn read_v6_bundle<R: Read>(
     reader: R,
-    bundle_version: BundleVersion,
+    consensus_branch_id: BranchId,
+    pool: ValuePool,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    check_v6_bundle_version(bundle_version)?;
-    read_bundle(reader, bundle_version)
+    read_bundle(reader, bundle_version_for_branch(consensus_branch_id, pool))
 }
 
 pub fn read_value_commitment<R: Read>(mut reader: R) -> io::Result<ValueCommitment> {

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -15,7 +15,10 @@ use orchard::{
     value::ValueCommitment,
 };
 use zcash_encoding::{Array, CompactSize, Vector};
-use zcash_protocol::{consensus::BranchId, value::ZatBalance};
+use zcash_protocol::{
+    consensus::{BranchId, OrchardProtocolRevision},
+    value::ZatBalance,
+};
 
 use crate::transaction::Transaction;
 
@@ -102,8 +105,9 @@ fn read_bundle<R: Read>(
 /// under the given consensus branch, or `None` if the pool is not supported under that
 /// branch (the Orchard pool prior to NU5; the Ironwood pool prior to NU6.3).
 ///
-/// The `BundleVersion` fixes a bundle's flag-byte grammar, cross-address semantics, and
-/// circuit generation:
+/// The protocol revision is determined by
+/// [`BranchId::orchard_protocol_revision`]. The `BundleVersion` fixes a bundle's
+/// flag-byte grammar, cross-address semantics, and circuit generation:
 ///   * Orchard pool, NU5 through NU6.1: historical insecure circuit, cross-address
 ///     enabled, proof size not enforced;
 ///   * Orchard pool, NU6.2: fixed circuit, cross-address enabled;
@@ -114,36 +118,16 @@ pub fn bundle_version_for_branch(
     consensus_branch_id: BranchId,
     pool: ValuePool,
 ) -> Option<BundleVersion> {
+    let revision = consensus_branch_id.orchard_protocol_revision()?;
     match pool {
-        ValuePool::Orchard => match consensus_branch_id {
-            BranchId::Sprout
-            | BranchId::Overwinter
-            | BranchId::Sapling
-            | BranchId::Blossom
-            | BranchId::Heartwood
-            | BranchId::Canopy => None,
-            BranchId::Nu5 | BranchId::Nu6 | BranchId::Nu6_1 => {
-                Some(BundleVersion::orchard_insecure_v1())
-            }
-            BranchId::Nu6_2 => Some(BundleVersion::orchard_v2()),
-            BranchId::Nu6_3 => Some(BundleVersion::orchard_v3()),
-            #[cfg(zcash_unstable = "nu7")]
-            BranchId::Nu7 => Some(BundleVersion::orchard_v3()),
-        },
-        ValuePool::Ironwood => match consensus_branch_id {
-            BranchId::Sprout
-            | BranchId::Overwinter
-            | BranchId::Sapling
-            | BranchId::Blossom
-            | BranchId::Heartwood
-            | BranchId::Canopy
-            | BranchId::Nu5
-            | BranchId::Nu6
-            | BranchId::Nu6_1
-            | BranchId::Nu6_2 => None,
-            BranchId::Nu6_3 => Some(BundleVersion::ironwood_v3()),
-            #[cfg(zcash_unstable = "nu7")]
-            BranchId::Nu7 => Some(BundleVersion::ironwood_v3()),
+        ValuePool::Orchard => Some(match revision {
+            OrchardProtocolRevision::InsecureV1 => BundleVersion::orchard_insecure_v1(),
+            OrchardProtocolRevision::V2 => BundleVersion::orchard_v2(),
+            OrchardProtocolRevision::V3 => BundleVersion::orchard_v3(),
+        }),
+        ValuePool::Ironwood => match revision {
+            OrchardProtocolRevision::InsecureV1 | OrchardProtocolRevision::V2 => None,
+            OrchardProtocolRevision::V3 => Some(BundleVersion::ironwood_v3()),
         },
     }
 }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -15,7 +15,7 @@ use orchard::{
     value::ValueCommitment,
 };
 use zcash_encoding::{Array, CompactSize, Vector};
-use zcash_protocol::value::ZatBalance;
+use zcash_protocol::{consensus::BranchId, value::ZatBalance};
 
 use crate::transaction::Transaction;
 
@@ -91,27 +91,50 @@ fn read_bundle<R: Read>(
     }
 }
 
+/// Returns the Orchard-pool [`BundleVersion`] in effect for the given consensus branch.
+///
+/// The v5 Orchard flag byte is the same in every epoch (bit 2 reserved), so serialization
+/// is unaffected by this choice, but the `BundleVersion` fixes the bundle's cross-address
+/// semantics and circuit generation, which do follow the consensus epoch:
+///   * pre-NU6.2: historical insecure circuit, cross-address enabled, proof size not
+///     enforced;
+///   * NU6.2: fixed circuit, cross-address enabled;
+///   * NU6.3 onward: post-NU6.3 circuit, cross-address disabled (consensus-mandated).
+pub fn orchard_bundle_version_for_branch(consensus_branch_id: BranchId) -> BundleVersion {
+    match consensus_branch_id {
+        BranchId::Sprout
+        | BranchId::Overwinter
+        | BranchId::Sapling
+        | BranchId::Blossom
+        | BranchId::Heartwood
+        | BranchId::Canopy
+        | BranchId::Nu5
+        | BranchId::Nu6
+        | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
+        BranchId::Nu6_2 => BundleVersion::orchard_v2(),
+        BranchId::Nu6_3 => BundleVersion::orchard_v3(),
+        #[cfg(zcash_unstable = "nu7")]
+        BranchId::Nu7 => BundleVersion::orchard_v3(),
+    }
+}
+
 /// Reads an [`orchard::Bundle`] from a v5 transaction format.
 ///
-/// This deliberately does not take the consensus branch ID to determine the
-/// format to read. Although NU6.3 does not disable v5 transactions, the Orchard
-/// action flags and wire serialization are identical before and after the
-/// upgrade, so a v5 bundle deserializes the same way regardless of activation
-/// height; only the bundle commitment domain varies across upgrades, and that
-/// affects the txid/sighash digests rather than deserialization. Since this is
-/// public API. By contrast, `read_v6_bundle` takes a `bundle_version` argument so
-/// the caller selects the Orchard or Ironwood v6 slot.
-///
-/// `bundle_version` must be an Orchard-pool version whose flag byte uses the v5 grammar (bit 2
-/// reserved): [`BundleVersion::orchard_insecure_v1`] before NU6.2, [`BundleVersion::orchard_v2`]
-/// at NU6.2, or [`BundleVersion::orchard_v3`] from NU6.3 (a v5 transaction stays valid under
-/// NU6.3+). All three share that grammar, and the version's protocol generation selects whether
-/// the canonical proof size is enforced.
+/// The v5 Orchard wire serialization is identical in every epoch (flag bit 2 is
+/// reserved), but the returned bundle's [`BundleVersion`] — which fixes its
+/// cross-address semantics and circuit generation — follows the consensus epoch
+/// identified by `consensus_branch_id` (see
+/// [`orchard_bundle_version_for_branch`]). By contrast, `read_v6_bundle` takes a
+/// `bundle_version` argument so the caller selects the Orchard or Ironwood v6
+/// slot.
 pub fn read_v5_bundle<R: Read>(
     reader: R,
-    bundle_version: BundleVersion,
+    consensus_branch_id: BranchId,
 ) -> io::Result<Option<orchard::Bundle<Authorized, ZatBalance>>> {
-    read_bundle(reader, bundle_version)
+    read_bundle(
+        reader,
+        orchard_bundle_version_for_branch(consensus_branch_id),
+    )
 }
 
 /// Rejects bundle versions that are not valid for the v6 transaction format, which has exactly

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -882,11 +882,13 @@ impl Transaction {
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
         let orchard_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundleVersion::orchard_v3(),
+            header_fragment.consensus_branch_id,
+            orchard::ValuePool::Orchard,
         )?;
         let ironwood_bundle = orchard_serialization::read_v6_bundle(
             &mut reader,
-            orchard::bundle::BundleVersion::ironwood_v3(),
+            header_fragment.consensus_branch_id,
+            orchard::ValuePool::Ironwood,
         )?;
 
         let data = TransactionData {

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -20,7 +20,6 @@ use core::ops::Deref;
 use corez::io::{self, Read, Write};
 
 use ::transparent::bundle::{self as transparent, OutPoint, TxIn, TxOut};
-use orchard::bundle::BundleVersion;
 use zcash_encoding::{CompactSize, Vector};
 use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
@@ -174,7 +173,10 @@ impl TxVersion {
 
     /// Returns `true` if this transaction version supports the Ironwood protocol.
     pub fn has_ironwood(&self) -> bool {
-        matches!(self, TxVersion::V6)
+        match self {
+            TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => false,
+            TxVersion::V6 => true,
+        }
     }
 
     #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
@@ -853,31 +855,8 @@ impl Transaction {
 
         let transparent_bundle = Self::read_transparent(&mut reader)?;
         let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
-        let orchard_bundle = orchard_serialization::read_v5_bundle(
-            &mut reader,
-            // The v5 Orchard flag byte is the same in every epoch (bit 2 reserved), so the txid is
-            // unaffected by this choice, but the `BundleVersion` fixes the bundle's cross-address
-            // semantics and circuit generation, which do follow the consensus epoch:
-            //   * pre-NU6.2: historical insecure circuit, cross-address enabled, proof size not
-            //     enforced;
-            //   * NU6.2: fixed circuit, cross-address enabled;
-            //   * NU6.3 onward: post-NU6.3 circuit, cross-address disabled (consensus-mandated).
-            match consensus_branch_id {
-                BranchId::Sprout
-                | BranchId::Overwinter
-                | BranchId::Sapling
-                | BranchId::Blossom
-                | BranchId::Heartwood
-                | BranchId::Canopy
-                | BranchId::Nu5
-                | BranchId::Nu6
-                | BranchId::Nu6_1 => BundleVersion::orchard_insecure_v1(),
-                BranchId::Nu6_2 => BundleVersion::orchard_v2(),
-                BranchId::Nu6_3 => BundleVersion::orchard_v3(),
-                #[cfg(zcash_unstable = "nu7")]
-                BranchId::Nu7 => BundleVersion::orchard_v3(),
-            },
-        )?;
+        let orchard_bundle =
+            orchard_serialization::read_v5_bundle(&mut reader, consensus_branch_id)?;
 
         let data = TransactionData {
             version,
@@ -1237,11 +1216,7 @@ pub mod testing {
             transparent_bundle in transparent::arb_bundle(),
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
-            ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_ironwood_bundle_for_version(version).boxed()
-            } else {
-                Just(None).boxed()
-            },
+            ironwood_bundle in orchard::arb_ironwood_bundle_for_version(version),
             version in Just(version),
         ) -> TransactionData<Authorized> {
             TransactionData {
@@ -1269,11 +1244,7 @@ pub mod testing {
             transparent_bundle in transparent::arb_bundle(),
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
-            ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_ironwood_bundle_for_version(version).boxed()
-            } else {
-                Just(None).boxed()
-            },
+            ironwood_bundle in orchard::arb_ironwood_bundle_for_version(version),
             version in Just(version),
         ) -> TransactionData<Authorized> {
             TransactionData {
@@ -1301,11 +1272,7 @@ pub mod testing {
             transparent_bundle in transparent::arb_bundle(),
             sapling_bundle in sapling::arb_bundle_for_version(version),
             orchard_bundle in orchard::arb_bundle_for_version(version),
-            ironwood_bundle in if version.has_ironwood() {
-                orchard::arb_ironwood_bundle_for_version(version).boxed()
-            } else {
-                Just(None).boxed()
-            },
+            ironwood_bundle in orchard::arb_ironwood_bundle_for_version(version),
             version in Just(version),
         ) -> TransactionData<Authorized> {
             TransactionData {

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -78,11 +78,11 @@ fn sapling_auth_includes_anchor(version: TxVersion) -> bool {
     }
 }
 
-/// Selects the `(value pool, orchard tx version)` pair that reproduces the
-/// pre-bump `BundleCommitmentDomain` for a given transaction version. The value
-/// pool here is only used for empty-bundle commitments (which hash no flags);
-/// present bundles compute their commitments from the `BundleVersion` each
-/// bundle carries.
+/// Selects the `(value pool, orchard tx version)` pair identifying the
+/// `BundleCommitmentDomain` used for Orchard-slot commitments in the given
+/// transaction version. The value pool here is only used for empty-bundle
+/// commitments (which hash no flags); present bundles compute their commitments
+/// from the `BundleVersion` each bundle carries.
 fn orchard_commitment_domain(version: TxVersion) -> (ValuePool, OrchardTxVersion) {
     match version {
         TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => {
@@ -142,7 +142,7 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
 ///
 /// Write disjoint parts of each Sapling shielded spend to a pair of hashes:
 /// * \[nullifier*\] - personalized with ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION
-/// * \[(cv, anchor, rk)*\] for pre-v6 transactions, personalized with
+/// * \[(cv, anchor, rk)*\] for v5 transactions (v4 is not handled here), personalized with
 ///   ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION
 /// * \[(cv, rk)*\] for v6 transactions, personalized with
 ///   ZCASH_SAPLING_SPENDS_V6_NONCOMPACT_HASH_PERSONALIZATION

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -138,7 +138,8 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
     h.finalize()
 }
 
-/// Implements [ZIP 244 section T.3a](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest)
+/// Implements [ZIP 244 section T.3a](https://zips.z.cash/zip-0244#t-3a-sapling-spends-digest);
+/// the v6 variant is specified in [ZIP 229](https://zips.z.cash/zip-0229).
 ///
 /// Write disjoint parts of each Sapling shielded spend to a pair of hashes:
 /// * \[nullifier*\] - personalized with ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION
@@ -263,7 +264,9 @@ pub(crate) fn hash_transparent_txid_data(
     h.finalize()
 }
 
-/// Implements [ZIP 244 section T.3](https://zips.z.cash/zip-0244#t-3-sapling-digest)
+/// Implements [ZIP 244 section T.3](https://zips.z.cash/zip-0244#t-3-sapling-digest);
+/// for v6 transactions the Sapling digest follows
+/// [ZIP 229](https://zips.z.cash/zip-0229).
 fn hash_sapling_txid_data<A: sapling::bundle::Authorization>(
     version: TxVersion,
     bundle: &sapling::Bundle<A, ZatBalance>,
@@ -504,8 +507,9 @@ pub fn to_txid(
 pub struct BlockTxCommitmentDigester;
 
 impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
-    /// We use the header digest to pass the transaction ID into
-    /// where it needs to be used for personalization string construction.
+    /// We use the header digest to pass the transaction version and consensus
+    /// branch ID into where they need to be used for personalization string
+    /// construction.
     type HeaderDigest = (TxVersion, BranchId);
     type TransparentDigest = Blake2bHash;
     type SaplingDigest = Blake2bHash;


### PR DESCRIPTION
Addresses @daira's post-merge review comments on #2509:

- `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes the
  consensus branch ID (as discussed in the `read_v5_bundle` rationale thread), deriving
  the Orchard bundle version via a new public helper `orchard_bundle_version_for_branch`.
  The helper is an exhaustive match, replacing both the wildcard-arm private helper in
  `builder.rs` and the inline mapping in `Transaction::read_v5`, and the incomplete
  "Since this is public API." sentence is gone.
- `TxVersion::has_ironwood` is now an exhaustive match.
- The three `arb_txdata` proptest strategies use `arb_ironwood_bundle_for_version`
  directly (it already yields `None` for versions without Ironwood support).
- Factored out `Builder::orchard_in_use`, mirroring `ironwood_in_use`.
- Applied the suggested comment/doc corrections (coinbase Orchard-builder flag comment,
  `with_expiry_height` warning, `txid.rs` "pre-bump" wording and Sapling spends digest
  doc).
- The nu7 builder test network now activates NU6.3 at height 10 and NU7 at height 11,
  per the suggestions.
- Added a unified `bundle_version_for_branch(branch_id, pool)`, returning the
  `BundleVersion` in effect for an Orchard-protocol value pool under a consensus
  branch, or `None` when the pool is unsupported under that branch (Orchard prior to
  NU5; Ironwood prior to NU6.3). `read_v5_bundle` now takes the consensus branch ID,
  and `read_v6_bundle` the branch ID plus the `orchard::ValuePool` selecting the slot,
  in place of caller-supplied `BundleVersion`s — callers can no longer select a
  wrong-slot bundle version, and a non-empty bundle belonging to an unsupported pool is
  rejected as invalid data. In `Builder::new` the `None` result subsumes the previous
  explicit NU5-activation check.
- Removed `zcash_client_backend::ANY_ORCHARD_BUNDLE_VERSION`: every fee/change call
  site has the proposal's target height available and now derives the Orchard bundle
  version from it, so proposals targeting post-NU6.3 heights count one action per
  Orchard spend or output, matching the transaction builder. (`EmptyBundleView` keeps
  a fixed version, which is sound because an empty bundle yields zero actions under
  every version's policy.) This also answers "does this need to be public?": yes —
  `zcash_client_backend` now consumes `bundle_version_for_branch`.
- Added `note_commitment_and_nullifier_depend_on_note_version`, checking that lead-byte
  0x02 and 0x03 notes with otherwise identical fields produce distinct commitments and
  nullifiers.

- **pczt**: fixed extraction and verification of post-NU6.3 Orchard-pool bundles
  (reported by @daira on #2509). `extract_tx_data` now parses the Orchard-pool bundle
  using the bundle version implied by the PCZT's consensus branch ID, and the
  Transaction Extractor verifies each Orchard-protocol bundle using the circuit
  version implied by the bundle's own version instead of hardcoding the NU6.2 fixed
  circuit; `verify_bundle`/`verify_ironwood_bundle` collapse into one function.
- The branch-to-Orchard-revision consensus knowledge now lives in one place:
  `zcash_protocol::consensus::BranchId::orchard_protocol_revision`, returning the new
  `OrchardProtocolRevision` enum. `zcash_primitives::…::bundle_version_for_branch` and
  `pczt` both derive `BundleVersion`s from it via trivial conversions (pczt cannot
  reuse the `zcash_primitives` helper directly because that dependency is optional).
  Building on this, **all** remaining PCZT roles (Updater, Verifier, Prover, low-level
  Signer) are now branch-aware — the Prover in particular now proves against the
  correct circuit for post-NU6.3 Orchard-pool bundles — and the legacy-pinned
  `into_orchard_parsed` is removed. This completes the first section of #2519.
- Applied the ZIP 244 / ZIP 229 attribution fixes to the Sapling digest documentation
  in `txid.rs`, and corrected the `BlockTxCommitmentDigester::HeaderDigest` doc.
- Added a ZIP 317 change-calculation test covering the post-NU6.3 Orchard
  action-count policy (partially addressing the `fees/zip317.rs` coverage comment;
  the broader Ironwood coverage gaps are tracked in #2518).

Comments deliberately not addressed here (all marked non-blocking):

- `add_ironwood_output` succeeding after `propose_version(V5)` ("arguably this call
  should fail") — add-time version validation is a behavioral design change, deferred.
- The `zip233Amount`-in-v6 characterization and NU7 tx-version boilerplate question —
  per the comment, not necessary to fix now.
- The type-safety suggestion for distinguishing Orchard-pool from Ironwood-pool bundle
  parameters — needs a design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






