### PR TITLE
zcash_client_sqlite: Upgrade imported transparent addresses to their derived form on gap-limit derivation

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -42,8 +42,14 @@ workspace.
   them in place: within a single account it keeps a canonical record (preferring an HD-derived
   record over an imported one), repoints the affected received outputs to it, and deletes the
   redundant records, preserving the earliest recorded `exposed_at_height` among the merged
-  records. A receiver duplicated across more than one account cannot be safely merged
-  and causes the migration to abort.
+  records. A receiver duplicated across more than one account is resolved by derivation:
+  when exactly one of the records reproduces the receiver when derived from its own account's
+  viewing key at its recorded child index, that record is retained and the received outputs of
+  the others are reattributed to it (this can occur for wallets migrated from `zcashd`, where an
+  address may have been both imported standalone into one account and derived by another,
+  including under the ZIP 32 account index 0x7FFFFFFF used for the `zcashd` legacy account).
+  A cross-account duplicate for which no unique record can be verified by derivation causes
+  the migration to abort.
 
 ### Fixed
 - Deriving a transparent address that was previously imported as a standalone receiver now

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -54,8 +54,11 @@ workspace.
 ### Fixed
 - Deriving a transparent address that was previously imported as a standalone receiver now
   upgrades the existing address record in place to its derived form, instead of failing on the
-  transparent-receiver uniqueness invariant added in this release. Funds received at such an
-  address become spendable once the account derives it.
+  transparent-receiver uniqueness invariant added in this release. If the import was recorded
+  under a different account, the record's account attribution — and that of any outputs
+  received at the address — moves to the deriving account, since successful derivation
+  establishes that account's ownership of the address. Funds received at such an address
+  become spendable once the account derives it.
 
 ## [0.21.1] - 2026-06-19
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -41,8 +41,15 @@ workspace.
   duplicate cached transparent receiver addresses, the migration that adds the index resolves
   them in place: within a single account it keeps a canonical record (preferring an HD-derived
   record over an imported one), repoints the affected received outputs to it, and deletes the
-  redundant records. A receiver duplicated across more than one account cannot be safely merged
+  redundant records, preserving the earliest recorded `exposed_at_height` among the merged
+  records. A receiver duplicated across more than one account cannot be safely merged
   and causes the migration to abort.
+
+### Fixed
+- Deriving a transparent address that was previously imported as a standalone receiver now
+  upgrades the existing address record in place to its derived form, instead of failing on the
+  transparent-receiver uniqueness invariant added in this release. Funds received at such an
+  address become spendable once the account derives it.
 
 ## [0.21.1] - 2026-06-19
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -232,7 +232,9 @@ pub(super) fn all_migrations<
         Box::new(witness_stabilized_notes::Migration {
             params: params.clone(),
         }),
-        Box::new(add_transparent_receiver_address_index::Migration),
+        Box::new(add_transparent_receiver_address_index::Migration {
+            params: params.clone(),
+        }),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
@@ -104,6 +104,21 @@ impl RusqliteMigration for Migration {
                 )));
             }
 
+            // Carry the earliest observed exposure across the merged records onto the canonical
+            // one, so that upgrading an imported receiver to its derived form does not discard an
+            // earlier exposure height recorded against the imported record. Run this before
+            // deleting the redundant rows, while the whole group is still present.
+            transaction.execute(
+                "UPDATE addresses
+                 SET exposed_at_height = (
+                     SELECT MIN(exposed_at_height)
+                     FROM addresses
+                     WHERE cached_transparent_receiver_address = :addr
+                 )
+                 WHERE id = :canonical",
+                named_params! { ":addr": addr, ":canonical": canonical_id },
+            )?;
+
             for (dup_id, _) in group.iter().skip(1) {
                 for table in [
                     "transparent_received_outputs",
@@ -349,6 +364,67 @@ mod tests {
             )
             .unwrap();
         assert_eq!(imported_count, 0);
+    }
+
+    /// When repairing a duplicate, the surviving canonical record keeps the earliest
+    /// `exposed_at_height` observed across the merged records.
+    #[test]
+    fn repair_carries_min_exposed_at_height() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let account_id = insert_account(&db_data.conn, 0, [0xAA; 16]);
+
+        // Derived (canonical) record exposed at height 200.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+                 exposed_at_height)
+                 VALUES (?1, 0, X'00000000000000000000000000', 'addr_derived', 0, 't_exp', 5, 200)",
+                [account_id],
+            )
+            .unwrap();
+        let derived_id = db_data.conn.last_insert_rowid();
+
+        // Imported record exposed earlier, at height 100.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, imported_transparent_receiver_pubkey,
+                 receiver_flags, exposed_at_height)
+                 VALUES (?1, -1, 'addr_imported', 't_exp',
+                 X'020000000000000000000000000000000000000000000000000000000000000001', 5, 100)",
+                [account_id],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // The canonical (derived) record now carries the earliest exposure.
+        let exposed: Option<i64> = db_data
+            .conn
+            .query_row(
+                "SELECT exposed_at_height FROM addresses WHERE id = ?1",
+                [derived_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exposed, Some(100));
     }
 
     /// A transparent receiver duplicated across more than one account cannot be safely merged, so

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
@@ -12,15 +12,19 @@
 //! Any pre-existing duplicates (for example, the same address both HD-derived and standalone
 //! imported) are resolved by the migration: a single canonical record is retained, the
 //! received-output foreign keys of the others are repointed to it, and the redundant records are
-//! deleted. A receiver duplicated across more than one account cannot be safely merged and aborts
-//! the migration. `NULL` values do not participate in SQLite's `UNIQUE` semantics, so rows without
-//! a transparent receiver are unaffected.
+//! deleted. A receiver duplicated across more than one account is resolved by derivation: if
+//! exactly one of the records reproduces the receiver when its address is derived from its own
+//! account's viewing key at its recorded child index, that record is definitively correct and is
+//! retained (with the received outputs of the others reattributed to it); otherwise the conflict
+//! cannot be resolved automatically and the migration aborts. `NULL` values do not participate in
+//! SQLite's `UNIQUE` semantics, so rows without a transparent receiver are unaffected.
 
 use std::collections::HashSet;
 
 use rusqlite::named_params;
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
+use zcash_protocol::consensus;
 
 use super::standalone_p2sh;
 use crate::wallet::init::WalletMigrationError;
@@ -33,9 +37,121 @@ pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x3d4f12d6_3da9_4ace_ac65_
 // modifies the `addresses` table, so the index will not be dropped by a subsequent table rebuild.
 const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
 
-pub(super) struct Migration;
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
 
-impl schemerz::Migration<Uuid> for Migration {
+/// An address record participating in a duplicated-receiver group: its row id, its account's row
+/// id, its key scope code, its transparent child index, and its account's UFVK and UIVK
+/// encodings.
+type AddressRecord = (i64, i64, i64, Option<u32>, Option<String>, String);
+
+/// The error reported when a duplicated receiver cannot be resolved automatically.
+fn unresolvable_duplicate(addr: &str) -> WalletMigrationError {
+    WalletMigrationError::CorruptedData(format!(
+        "The transparent address {addr} is associated with address records in more \
+         than one account; this cannot be resolved automatically."
+    ))
+}
+
+/// Whether deriving a transparent address from the record's own account viewing key, at the
+/// record's key scope and child index, reproduces the duplicated receiver — which definitively
+/// establishes the record as the correct one for that receiver.
+#[cfg(feature = "transparent-inputs")]
+fn record_derives_receiver<P: consensus::Parameters>(
+    params: &P,
+    key_scope: i64,
+    child_index: Option<u32>,
+    ufvk: Option<&str>,
+    uivk: &str,
+    addr: &str,
+) -> bool {
+    use transparent::keys::{IncomingViewingKey as _, NonHardenedChildIndex};
+    use zcash_keys::{
+        encoding::AddressCodec as _,
+        keys::{UnifiedFullViewingKey, UnifiedIncomingViewingKey},
+    };
+
+    let Some(idx) = child_index.and_then(NonHardenedChildIndex::from_index) else {
+        return false;
+    };
+
+    let derived = match key_scope {
+        // External scope: prefer the UFVK's account pubkey, falling back to the UIVK's
+        // external IVK.
+        0 => ufvk
+            .and_then(|s| UnifiedFullViewingKey::decode(params, s).ok())
+            .and_then(|k| {
+                k.transparent()
+                    .and_then(|apk| apk.derive_external_ivk().ok())
+            })
+            .and_then(|ivk| ivk.derive_address(idx).ok())
+            .or_else(|| {
+                UnifiedIncomingViewingKey::decode(params, uivk)
+                    .ok()
+                    .and_then(|k| {
+                        k.transparent()
+                            .as_ref()
+                            .and_then(|ivk| ivk.derive_address(idx).ok())
+                    })
+            }),
+        // Internal scope: derivable only from the UFVK's account pubkey.
+        1 => ufvk
+            .and_then(|s| UnifiedFullViewingKey::decode(params, s).ok())
+            .and_then(|k| {
+                k.transparent()
+                    .and_then(|apk| apk.derive_internal_ivk().ok())
+            })
+            .and_then(|ivk| ivk.derive_address(idx).ok()),
+        // Foreign and ephemeral records cannot be verified by scope derivation.
+        _ => None,
+    };
+
+    derived.is_some_and(|d| d.encode(params) == addr)
+}
+
+/// Resolves a receiver duplicated across more than one account by derivation: the unique record
+/// (if any) whose address is reproduced by derivation from its own account's viewing key is
+/// definitively the correct one. Returns the winning record's `(id, account_id)`, or an error if
+/// no unique record can be verified.
+#[cfg(feature = "transparent-inputs")]
+fn resolve_cross_account_duplicate<P: consensus::Parameters>(
+    params: &P,
+    addr: &str,
+    group: &[AddressRecord],
+) -> Result<(i64, i64), WalletMigrationError> {
+    let verified = group
+        .iter()
+        .filter(|(_, _, key_scope, child_index, ufvk, uivk)| {
+            record_derives_receiver(
+                params,
+                *key_scope,
+                *child_index,
+                ufvk.as_deref(),
+                uivk,
+                addr,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    match verified[..] {
+        [(id, account_id, ..)] => Ok((*id, *account_id)),
+        _ => Err(unresolvable_duplicate(addr)),
+    }
+}
+
+/// Without `transparent-inputs`, the key APIs needed for derivation-based verification are
+/// unavailable, so a cross-account duplicate cannot be resolved automatically.
+#[cfg(not(feature = "transparent-inputs"))]
+fn resolve_cross_account_duplicate<P: consensus::Parameters>(
+    _params: &P,
+    addr: &str,
+    _group: &[AddressRecord],
+) -> Result<(i64, i64), WalletMigrationError> {
+    Err(unresolvable_duplicate(addr))
+}
+
+impl<P> schemerz::Migration<Uuid> for Migration<P> {
     fn id(&self) -> Uuid {
         MIGRATION_ID
     }
@@ -49,18 +165,19 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 }
 
-impl RusqliteMigration for Migration {
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
     type Error = WalletMigrationError;
 
     fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
         // Resolve any pre-existing violations of the uniqueness invariant before adding the
         // constraint, so that a database that already contains duplicate transparent receivers is
         // repaired in place rather than rendered permanently unopenable. For each transparent
-        // receiver associated with more than one address record, we keep a single canonical record
-        // (preferring an HD-derived record, which is recoverable from the seed, over an imported
-        // one, and breaking ties by lowest id), repoint every received-output foreign key to it,
-        // and delete the redundant records. A receiver associated with records in more than one
-        // account cannot be safely merged, so in that case we abort the migration.
+        // receiver associated with more than one address record within a single account, we keep
+        // a single canonical record (preferring an HD-derived record, which is recoverable from
+        // the seed, over an imported one, and breaking ties by lowest id). For a receiver
+        // duplicated across accounts, the canonical record is the unique one verified by
+        // derivation from its own account's viewing key; the received outputs of the redundant
+        // records follow the canonical record, including their account attribution.
         let mut duplicates_stmt = transaction.prepare(
             "SELECT cached_transparent_receiver_address
              FROM addresses
@@ -74,35 +191,42 @@ impl RusqliteMigration for Migration {
         drop(duplicates_stmt);
 
         for addr in duplicate_addrs {
-            // The address records sharing this receiver, ordered so that the canonical record
-            // (HD-derived before imported, then lowest id) comes first.
+            // The address records sharing this receiver, ordered so that the single-account
+            // canonical record (HD-derived before imported, then lowest id) comes first.
             let mut group_stmt = transaction.prepare(
-                "SELECT id, account_id
-                 FROM addresses
-                 WHERE cached_transparent_receiver_address = :addr
-                 ORDER BY (transparent_child_index IS NULL), id",
+                "SELECT a.id, a.account_id, a.key_scope, a.transparent_child_index,
+                        accounts.ufvk, accounts.uivk
+                 FROM addresses a
+                 JOIN accounts ON accounts.id = a.account_id
+                 WHERE a.cached_transparent_receiver_address = :addr
+                 ORDER BY (a.transparent_child_index IS NULL), a.id",
             )?;
-            let group = group_stmt
+            let group: Vec<AddressRecord> = group_stmt
                 .query_map(named_params! { ":addr": addr }, |row| {
-                    Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
                 })?
                 .collect::<Result<Vec<_>, _>>()?;
             drop(group_stmt);
 
-            let (canonical_id, canonical_account) = group[0];
-
-            // A receiver duplicated across accounts cannot be safely merged: the received outputs
-            // referencing each record carry their own `account_id`, which would no longer match
-            // the kept address record.
-            if group
+            let single_account = group
                 .iter()
-                .any(|(_, account_id)| *account_id != canonical_account)
-            {
-                return Err(WalletMigrationError::CorruptedData(format!(
-                    "The transparent address {addr} is associated with address records in more \
-                     than one account; this cannot be resolved automatically."
-                )));
-            }
+                .all(|(_, account_id, ..)| *account_id == group[0].1);
+
+            let (canonical_id, canonical_account) = if single_account {
+                (group[0].0, group[0].1)
+            } else {
+                // The received outputs referencing each record carry their own `account_id`, so a
+                // cross-account merge is only safe when derivation definitively establishes which
+                // record (and thus which account) the receiver belongs to.
+                resolve_cross_account_duplicate(&self.params, &addr, &group)?
+            };
 
             // Carry the earliest observed exposure across the merged records onto the canonical
             // one, so that upgrading an imported receiver to its derived form does not discard an
@@ -119,7 +243,7 @@ impl RusqliteMigration for Migration {
                 named_params! { ":addr": addr, ":canonical": canonical_id },
             )?;
 
-            for (dup_id, _) in group.iter().skip(1) {
+            for (dup_id, ..) in group.iter().filter(|(id, ..)| *id != canonical_id) {
                 for table in [
                     "transparent_received_outputs",
                     "sapling_received_notes",
@@ -127,9 +251,15 @@ impl RusqliteMigration for Migration {
                 ] {
                     transaction.execute(
                         &format!(
-                            "UPDATE {table} SET address_id = :canonical WHERE address_id = :dup"
+                            "UPDATE {table}
+                             SET address_id = :canonical, account_id = :canonical_account
+                             WHERE address_id = :dup"
                         ),
-                        named_params! { ":canonical": canonical_id, ":dup": dup_id },
+                        named_params! {
+                            ":canonical": canonical_id,
+                            ":canonical_account": canonical_account,
+                            ":dup": dup_id,
+                        },
                     )?;
                 }
                 transaction.execute(
@@ -199,6 +329,235 @@ mod tests {
         .unwrap();
 
         conn.last_insert_rowid()
+    }
+
+    /// The encoded transparent address actually derivable by the [`insert_account`] test account
+    /// at the given ZIP 32 account index, at external child index 0 — i.e. an address for which
+    /// derivation-based verification of an address record will succeed.
+    #[cfg(feature = "transparent-inputs")]
+    fn account_external_address(network: &Network, account_index: u32) -> String {
+        use transparent::keys::{IncomingViewingKey as _, NonHardenedChildIndex};
+        use zcash_keys::encoding::AddressCodec as _;
+
+        let usk = UnifiedSpendingKey::from_seed(
+            network,
+            &[0xab; 32][..],
+            zip32::AccountId::try_from(account_index).unwrap(),
+        )
+        .unwrap();
+        usk.to_unified_full_viewing_key()
+            .transparent()
+            .unwrap()
+            .derive_external_ivk()
+            .unwrap()
+            .derive_address(NonHardenedChildIndex::ZERO)
+            .unwrap()
+            .encode(network)
+    }
+
+    /// A receiver duplicated across two accounts is resolved when exactly one of the records is
+    /// verified by derivation: deriving from its own account's viewing key at its recorded child
+    /// index yields the duplicated receiver. The verified record wins; the other account's record
+    /// is deleted, its received outputs are repointed to the winner (including their account
+    /// attribution), and the earliest exposure height is preserved.
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn resolves_cross_account_duplicate_by_derivation() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let account_a = insert_account(&db_data.conn, 0, [0xAA; 16]);
+        let account_l = insert_account(&db_data.conn, 0x7FFF_FFFF, [0xBB; 16]);
+
+        // The receiver genuinely derivable by account A at external index 0.
+        let taddr = account_external_address(&network, 0);
+
+        // Account A's derived record for the receiver: verification will succeed.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+                 exposed_at_height)
+                 VALUES (?1, 0, X'00000000000000000000000000', ?2, 0, ?2, 5, 200)",
+                rusqlite::params![account_a, taddr],
+            )
+            .unwrap();
+        let derived_id = db_data.conn.last_insert_rowid();
+
+        // The same receiver imported standalone into the other account, with an earlier
+        // exposure height.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, imported_transparent_receiver_pubkey,
+                 receiver_flags, exposed_at_height)
+                 VALUES (?1, -1, ?2, ?2,
+                 X'020000000000000000000000000000000000000000000000000000000000000002', 5, 100)",
+                rusqlite::params![account_l, taddr],
+            )
+            .unwrap();
+        let imported_id = db_data.conn.last_insert_rowid();
+
+        // A received output attached to the imported record, attributed to the other account.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height) VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transparent_received_outputs
+                 (transaction_id, output_index, account_id, address, script, value_zat, address_id)
+                 VALUES (1, 0, ?1, ?2, X'00', 100000, ?3)",
+                rusqlite::params![account_l, taddr, imported_id],
+            )
+            .unwrap();
+
+        // The migration resolves the cross-account duplicate rather than failing.
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // Only the derivation-verified record remains, carrying the earliest exposure height.
+        let remaining: Vec<(i64, Option<u32>)> = db_data
+            .conn
+            .prepare(
+                "SELECT id, exposed_at_height FROM addresses
+                 WHERE cached_transparent_receiver_address = ?1",
+            )
+            .unwrap()
+            .query_map([&taddr], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(remaining, vec![(derived_id, Some(100))]);
+
+        // The received output was repointed to the winning record, and its account attribution
+        // moved with it.
+        let (address_id, account_id): (i64, i64) = db_data
+            .conn
+            .query_row(
+                "SELECT address_id, account_id FROM transparent_received_outputs
+                 WHERE transaction_id = 1 AND output_index = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((address_id, account_id), (derived_id, account_a));
+    }
+
+    /// Derivation-based verification is the sole criterion for resolving a cross-account
+    /// duplicate: an address genuinely derived under the ZIP 32 account index 0x7FFFFFFF (the
+    /// index used for the `zcashd` legacy account) wins over another account's imported record,
+    /// exactly as any other account's derived address would.
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn cross_account_winner_may_be_legacy_account() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let account_a = insert_account(&db_data.conn, 0, [0xAA; 16]);
+        let account_l = insert_account(&db_data.conn, 0x7FFF_FFFF, [0xBB; 16]);
+
+        // The receiver genuinely derivable by the 0x7FFFFFFF-indexed account.
+        let taddr = account_external_address(&network, 0x7FFF_FFFF);
+
+        // The 0x7FFFFFFF account's derived record: verification will succeed.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+                 exposed_at_height)
+                 VALUES (?1, 0, X'00000000000000000000000000', ?2, 0, ?2, 5, 200)",
+                rusqlite::params![account_l, taddr],
+            )
+            .unwrap();
+        let derived_id = db_data.conn.last_insert_rowid();
+
+        // The same receiver imported standalone into the other account.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, imported_transparent_receiver_pubkey,
+                 receiver_flags, exposed_at_height)
+                 VALUES (?1, -1, ?2, ?2,
+                 X'020000000000000000000000000000000000000000000000000000000000000003', 5, 100)",
+                rusqlite::params![account_a, taddr],
+            )
+            .unwrap();
+        let imported_id = db_data.conn.last_insert_rowid();
+
+        // A received output attached to the imported record.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, min_observed_height) VALUES (1, X'00', 1)",
+                [],
+            )
+            .unwrap();
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transparent_received_outputs
+                 (transaction_id, output_index, account_id, address, script, value_zat, address_id)
+                 VALUES (1, 0, ?1, ?2, X'00', 100000, ?3)",
+                rusqlite::params![account_a, taddr, imported_id],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // The 0x7FFFFFFF account's verified record wins, and the output's account attribution
+        // follows it.
+        let remaining: Vec<i64> = db_data
+            .conn
+            .prepare("SELECT id FROM addresses WHERE cached_transparent_receiver_address = ?1")
+            .unwrap()
+            .query_map([&taddr], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(remaining, vec![derived_id]);
+
+        let (address_id, account_id): (i64, i64) = db_data
+            .conn
+            .query_row(
+                "SELECT address_id, account_id FROM transparent_received_outputs
+                 WHERE transaction_id = 1 AND output_index = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((address_id, account_id), (derived_id, account_l));
     }
 
     /// After the migration, two derived addresses that share a transparent receiver must be

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 use zcash_protocol::consensus;
 
 use super::standalone_p2sh;
-use crate::wallet::init::WalletMigrationError;
+use crate::wallet::{encoding::KeyScope, init::WalletMigrationError};
 
 pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x3d4f12d6_3da9_4ace_ac65_a0dd0a7adc32);
 
@@ -41,10 +41,22 @@ pub(super) struct Migration<P> {
     pub(super) params: P,
 }
 
-/// An address record participating in a duplicated-receiver group: its row id, its account's row
-/// id, its key scope code, its transparent child index, and its account's UFVK and UIVK
-/// encodings.
-type AddressRecord = (i64, i64, i64, Option<u32>, Option<String>, String);
+/// An address record participating in a duplicated-receiver group.
+#[cfg_attr(not(feature = "transparent-inputs"), allow(dead_code))]
+struct AddressRecord {
+    /// The `addresses` row id of the record.
+    id: i64,
+    /// The row id of the account that holds the record.
+    account_id: i64,
+    /// The record's key scope.
+    key_scope: KeyScope,
+    /// The record's transparent child index, if any.
+    transparent_child_index: Option<u32>,
+    /// The encoded UFVK of the record's account, if known.
+    ufvk: Option<String>,
+    /// The encoded UIVK of the record's account.
+    uivk: String,
+}
 
 /// The error reported when a duplicated receiver cannot be resolved automatically.
 fn unresolvable_duplicate(addr: &str) -> WalletMigrationError {
@@ -60,10 +72,7 @@ fn unresolvable_duplicate(addr: &str) -> WalletMigrationError {
 #[cfg(feature = "transparent-inputs")]
 fn record_derives_receiver<P: consensus::Parameters>(
     params: &P,
-    key_scope: i64,
-    child_index: Option<u32>,
-    ufvk: Option<&str>,
-    uivk: &str,
+    record: &AddressRecord,
     addr: &str,
 ) -> bool {
     use transparent::keys::{IncomingViewingKey as _, NonHardenedChildIndex};
@@ -72,22 +81,30 @@ fn record_derives_receiver<P: consensus::Parameters>(
         keys::{UnifiedFullViewingKey, UnifiedIncomingViewingKey},
     };
 
-    let Some(idx) = child_index.and_then(NonHardenedChildIndex::from_index) else {
+    let Some(idx) = record
+        .transparent_child_index
+        .and_then(NonHardenedChildIndex::from_index)
+    else {
         return false;
     };
 
-    let derived = match key_scope {
+    let account_pubkey = |ufvk: &str| {
+        UnifiedFullViewingKey::decode(params, ufvk)
+            .ok()
+            .and_then(|k| k.transparent().cloned())
+    };
+
+    let derived = match record.key_scope {
         // External scope: prefer the UFVK's account pubkey, falling back to the UIVK's
         // external IVK.
-        0 => ufvk
-            .and_then(|s| UnifiedFullViewingKey::decode(params, s).ok())
-            .and_then(|k| {
-                k.transparent()
-                    .and_then(|apk| apk.derive_external_ivk().ok())
-            })
+        KeyScope::Zip32(zip32::Scope::External) => record
+            .ufvk
+            .as_deref()
+            .and_then(account_pubkey)
+            .and_then(|apk| apk.derive_external_ivk().ok())
             .and_then(|ivk| ivk.derive_address(idx).ok())
             .or_else(|| {
-                UnifiedIncomingViewingKey::decode(params, uivk)
+                UnifiedIncomingViewingKey::decode(params, &record.uivk)
                     .ok()
                     .and_then(|k| {
                         k.transparent()
@@ -96,15 +113,22 @@ fn record_derives_receiver<P: consensus::Parameters>(
                     })
             }),
         // Internal scope: derivable only from the UFVK's account pubkey.
-        1 => ufvk
-            .and_then(|s| UnifiedFullViewingKey::decode(params, s).ok())
-            .and_then(|k| {
-                k.transparent()
-                    .and_then(|apk| apk.derive_internal_ivk().ok())
-            })
+        KeyScope::Zip32(zip32::Scope::Internal) => record
+            .ufvk
+            .as_deref()
+            .and_then(account_pubkey)
+            .and_then(|apk| apk.derive_internal_ivk().ok())
             .and_then(|ivk| ivk.derive_address(idx).ok()),
-        // Foreign and ephemeral records cannot be verified by scope derivation.
-        _ => None,
+        // Ephemeral scope: derivable only from the UFVK's account pubkey.
+        KeyScope::Ephemeral => record
+            .ufvk
+            .as_deref()
+            .and_then(account_pubkey)
+            .and_then(|apk| apk.derive_ephemeral_ivk().ok())
+            .and_then(|ivk| ivk.derive_ephemeral_address(idx).ok()),
+        // A `Foreign` record has no derivation relationship to its account, so it cannot be
+        // verified.
+        KeyScope::Foreign => None,
     };
 
     derived.is_some_and(|d| d.encode(params) == addr)
@@ -122,20 +146,11 @@ fn resolve_cross_account_duplicate<P: consensus::Parameters>(
 ) -> Result<(i64, i64), WalletMigrationError> {
     let verified = group
         .iter()
-        .filter(|(_, _, key_scope, child_index, ufvk, uivk)| {
-            record_derives_receiver(
-                params,
-                *key_scope,
-                *child_index,
-                ufvk.as_deref(),
-                uivk,
-                addr,
-            )
-        })
+        .filter(|record| record_derives_receiver(params, record, addr))
         .collect::<Vec<_>>();
 
     match verified[..] {
-        [(id, account_id, ..)] => Ok((*id, *account_id)),
+        [record] => Ok((record.id, record.account_id)),
         _ => Err(unresolvable_duplicate(addr)),
     }
 }
@@ -206,21 +221,35 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                     Ok((
                         row.get(0)?,
                         row.get(1)?,
-                        row.get(2)?,
+                        row.get::<_, i64>(2)?,
                         row.get(3)?,
                         row.get(4)?,
                         row.get(5)?,
                     ))
                 })?
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .map(
+                    |(id, account_id, scope_code, transparent_child_index, ufvk, uivk)| {
+                        Ok::<_, WalletMigrationError>(AddressRecord {
+                            id,
+                            account_id,
+                            key_scope: KeyScope::decode(scope_code)?,
+                            transparent_child_index,
+                            ufvk,
+                            uivk,
+                        })
+                    },
+                )
                 .collect::<Result<Vec<_>, _>>()?;
             drop(group_stmt);
 
             let single_account = group
                 .iter()
-                .all(|(_, account_id, ..)| *account_id == group[0].1);
+                .all(|record| record.account_id == group[0].account_id);
 
             let (canonical_id, canonical_account) = if single_account {
-                (group[0].0, group[0].1)
+                (group[0].id, group[0].account_id)
             } else {
                 // The received outputs referencing each record carry their own `account_id`, so a
                 // cross-account merge is only safe when derivation definitively establishes which
@@ -243,7 +272,11 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 named_params! { ":addr": addr, ":canonical": canonical_id },
             )?;
 
-            for (dup_id, ..) in group.iter().filter(|(id, ..)| *id != canonical_id) {
+            for dup_id in group
+                .iter()
+                .map(|record| record.id)
+                .filter(|id| *id != canonical_id)
+            {
                 for table in [
                     "transparent_received_outputs",
                     "sapling_received_notes",
@@ -558,6 +591,96 @@ mod tests {
             )
             .unwrap();
         assert_eq!((address_id, account_id), (derived_id, account_l));
+    }
+
+    /// The encoded transparent address derivable by the [`insert_account`] test account at the
+    /// given ZIP 32 account index, at *ephemeral* child index 0.
+    #[cfg(feature = "transparent-inputs")]
+    fn account_ephemeral_address(network: &Network, account_index: u32) -> String {
+        use transparent::keys::NonHardenedChildIndex;
+        use zcash_keys::encoding::AddressCodec as _;
+
+        let usk = UnifiedSpendingKey::from_seed(
+            network,
+            &[0xab; 32][..],
+            zip32::AccountId::try_from(account_index).unwrap(),
+        )
+        .unwrap();
+        usk.to_unified_full_viewing_key()
+            .transparent()
+            .unwrap()
+            .derive_ephemeral_ivk()
+            .unwrap()
+            .derive_ephemeral_address(NonHardenedChildIndex::ZERO)
+            .unwrap()
+            .encode(network)
+    }
+
+    /// Ephemeral-scope records are derivation-verifiable: a cross-account duplicate in which one
+    /// record is an ephemeral address genuinely derived by its own account is resolved in favor
+    /// of that record.
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn resolves_cross_account_duplicate_by_ephemeral_derivation() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        let account_a = insert_account(&db_data.conn, 0, [0xAA; 16]);
+        let account_l = insert_account(&db_data.conn, 0x7FFF_FFFF, [0xBB; 16]);
+
+        // The receiver genuinely derivable by account A at ephemeral index 0.
+        let taddr = account_ephemeral_address(&network, 0);
+
+        // Account A's ephemeral-scope record for the receiver: verification will succeed.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+                 exposed_at_height)
+                 VALUES (?1, 2, X'00000000000000000000000000', ?2, 0, ?2, 5, 200)",
+                rusqlite::params![account_a, taddr],
+            )
+            .unwrap();
+        let ephemeral_id = db_data.conn.last_insert_rowid();
+
+        // The same receiver imported standalone into the other account.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, imported_transparent_receiver_pubkey,
+                 receiver_flags, exposed_at_height)
+                 VALUES (?1, -1, ?2, ?2,
+                 X'020000000000000000000000000000000000000000000000000000000000000005', 5, 100)",
+                rusqlite::params![account_l, taddr],
+            )
+            .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // The ephemeral record verified by derivation wins.
+        let remaining: Vec<i64> = db_data
+            .conn
+            .prepare("SELECT id FROM addresses WHERE cached_transparent_receiver_address = ?1")
+            .unwrap()
+            .query_map([&taddr], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(remaining, vec![ephemeral_id]);
     }
 
     /// After the migration, two derived addresses that share a transparent receiver must be

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -721,6 +721,25 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
     key_scope: TransparentKeyScope,
     address_list: Vec<(Address, TransparentAddress, NonHardenedChildIndex)>,
 ) -> Result<(), SqliteClientError> {
+    // If the address being derived was previously imported as a standalone (`Foreign`)
+    // receiver, upgrade that row in place to its derived form rather than inserting a second row
+    // for the same transparent receiver (which the UNIQUE index on
+    // `cached_transparent_receiver_address` forbids). The row `id` is preserved, so any UTXOs,
+    // exposure, and spend-search state already attached to the imported receiver carry over and
+    // become spendable.
+    //
+    // The lookup below reads only columns present at every schema version at which
+    // `store_address_range` runs, so it is safe when this function is called from a migration.
+    // The upgrade `UPDATE` clears the `imported_transparent_receiver_*` columns, so it is only
+    // ever prepared and executed when a `Foreign` row exists — which cannot occur before those
+    // columns have been added.
+    let mut stmt_lookup_foreign = conn.prepare_cached(
+        "SELECT id FROM addresses
+         WHERE account_id = :account_id
+           AND cached_transparent_receiver_address = :transparent_address
+           AND key_scope = :foreign_scope",
+    )?;
+
     // exposed_at_height is initially NULL
     let mut stmt_insert_address = conn.prepare_cached(
         "INSERT INTO addresses (
@@ -743,15 +762,55 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
             .convert::<ReceiverFlags>()
             .expect("address is valid");
 
-        stmt_insert_address.execute(named_params![
-            ":account_id": account_id.0,
-            ":diversifier_index_be": encode_diversifier_index_be(transparent_child_index.into()),
-            ":key_scope": KeyScope::try_from(key_scope)?.encode(),
-            ":address": zcash_address.encode(),
-            ":transparent_child_index": transparent_child_index.index(),
-            ":transparent_address": transparent_address.encode(params),
-            ":receiver_flags": receiver_flags.bits()
-        ])?;
+        let derived_scope = KeyScope::try_from(key_scope)?.encode();
+        let diversifier_index_be = encode_diversifier_index_be(transparent_child_index.into());
+        let transparent_address_enc = transparent_address.encode(params);
+        let address_enc = zcash_address.encode();
+        let child_index = transparent_child_index.index();
+        let flags = receiver_flags.bits();
+
+        let foreign_id: Option<i64> = stmt_lookup_foreign
+            .query_row(
+                named_params![
+                    ":account_id": account_id.0,
+                    ":transparent_address": transparent_address_enc,
+                    ":foreign_scope": KeyScope::Foreign.encode(),
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(foreign_id) = foreign_id {
+            conn.execute(
+                "UPDATE addresses
+                 SET key_scope = :key_scope,
+                     diversifier_index_be = :diversifier_index_be,
+                     address = :address,
+                     transparent_child_index = :transparent_child_index,
+                     receiver_flags = :receiver_flags,
+                     imported_transparent_receiver_pubkey = NULL,
+                     imported_transparent_receiver_script = NULL
+                 WHERE id = :id",
+                named_params![
+                    ":key_scope": derived_scope,
+                    ":diversifier_index_be": diversifier_index_be,
+                    ":address": address_enc,
+                    ":transparent_child_index": child_index,
+                    ":receiver_flags": flags,
+                    ":id": foreign_id,
+                ],
+            )?;
+        } else {
+            stmt_insert_address.execute(named_params![
+                ":account_id": account_id.0,
+                ":diversifier_index_be": diversifier_index_be,
+                ":key_scope": derived_scope,
+                ":address": address_enc,
+                ":transparent_child_index": child_index,
+                ":transparent_address": transparent_address_enc,
+                ":receiver_flags": flags,
+            ])?;
+        }
     }
     Ok(())
 }
@@ -2670,6 +2729,115 @@ mod tests {
             BlockCache::new(),
             GapLimits::default(),
         );
+    }
+
+    /// Deriving an address that already exists as a standalone (`Foreign`) import upgrades the
+    /// existing row in place — same `id`, derived scope, import columns cleared — rather than
+    /// inserting a duplicate row for the same transparent receiver, and any UTXO already
+    /// attached to the imported row carries over.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn store_address_range_upgrades_imported_receiver() {
+        use rusqlite::named_params;
+        use transparent::address::TransparentAddress;
+        use zcash_keys::{address::Address, encoding::AddressCodec};
+
+        use crate::wallet::encoding::KeyScope;
+
+        let st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_uuid = st.test_account().unwrap().id();
+        let network = *st.network();
+
+        // An address we pretend was imported standalone and is also derivable at child index 100
+        // (beyond the default external gap of 10, so no real derived row occupies that index).
+        let taddr = TransparentAddress::PublicKeyHash([0x11; 20]);
+        let taddr_enc = taddr.encode(&network);
+        let child_index = NonHardenedChildIndex::from_index(100).unwrap();
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let account_id = get_account_ref(&tx, account_uuid).unwrap();
+
+        // A standalone (`Foreign`) row for the receiver, exposed at height 55.
+        tx.execute(
+            "INSERT INTO addresses
+                 (account_id, key_scope, address, cached_transparent_receiver_address,
+                  imported_transparent_receiver_pubkey, receiver_flags, exposed_at_height)
+             VALUES (:account_id, :foreign, :address, :taddr,
+                  X'020000000000000000000000000000000000000000000000000000000000000001', 1, 55)",
+            named_params! {
+                ":account_id": account_id.0,
+                ":foreign": KeyScope::Foreign.encode(),
+                ":address": &taddr_enc,
+                ":taddr": &taddr_enc,
+            },
+        )
+        .unwrap();
+        let foreign_id = tx.last_insert_rowid();
+
+        // A UTXO attached to the imported row.
+        tx.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height) VALUES (1, X'00', 1)",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO transparent_received_outputs
+                 (transaction_id, output_index, account_id, address, script, value_zat, address_id)
+             VALUES (1, 0, :account_id, :taddr, X'00', 100000, :addr_id)",
+            named_params! { ":account_id": account_id.0, ":taddr": &taddr_enc, ":addr_id": foreign_id },
+        )
+        .unwrap();
+
+        // Derive the same address at child index 7 via the gap-generation storage entry point.
+        super::store_address_range(
+            &tx,
+            &network,
+            account_id,
+            TransparentKeyScope::EXTERNAL,
+            vec![(Address::from(taddr), taddr, child_index)],
+        )
+        .unwrap();
+
+        // Exactly one row remains for the receiver: the upgraded former-import row.
+        let mut stmt = tx
+            .prepare(
+                "SELECT id, key_scope, transparent_child_index,
+                        imported_transparent_receiver_pubkey IS NULL
+                 FROM addresses WHERE cached_transparent_receiver_address = :taddr",
+            )
+            .unwrap();
+        let rows: Vec<(i64, i64, Option<u32>, bool)> = stmt
+            .query_map(named_params! { ":taddr": &taddr_enc }, |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        drop(stmt);
+
+        assert_eq!(rows.len(), 1);
+        let (id, key_scope, child, pubkey_is_null) = rows[0];
+        assert_eq!(id, foreign_id, "upgraded in place, same id");
+        assert_eq!(key_scope, KeyScope::EXTERNAL.encode());
+        assert_eq!(child, Some(100));
+        assert!(pubkey_is_null, "standalone-import column cleared");
+
+        // The UTXO still references the (now-derived) row.
+        let utxo_addr_id: i64 = tx
+            .query_row(
+                "SELECT address_id FROM transparent_received_outputs
+                 WHERE transaction_id = 1 AND output_index = 0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(utxo_addr_id, foreign_id);
+
+        tx.commit().unwrap();
     }
 
     /// Smoke test that the `spend-index` feature's SQL is valid: `transaction_data_requests`

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2820,7 +2820,7 @@ mod tests {
         )
         .unwrap();
 
-        // Derive the same address at child index 7 via the gap-generation storage entry point.
+        // Derive the same address at child index 100 via the gap-generation storage entry point.
         super::store_address_range(
             &tx,
             &network,

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -728,15 +728,21 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
     // exposure, and spend-search state already attached to the imported receiver carry over and
     // become spendable.
     //
+    // The import may have been made under a *different* account: deriving the address is itself
+    // proof that the deriving account owns it, so in that case the row's account attribution
+    // (and that of any outputs received at the address) moves to the deriving account. The
+    // receiver-uniqueness index guarantees at most one row per receiver, and the deriving
+    // account cannot already hold a row at this (key scope, child index) — such a row would be
+    // this same receiver — so retargeting the row cannot violate the address-tuple constraint.
+    //
     // The lookup below reads only columns present at every schema version at which
     // `store_address_range` runs, so it is safe when this function is called from a migration.
     // The upgrade `UPDATE` clears the `imported_transparent_receiver_*` columns, so it is only
     // ever prepared and executed when a `Foreign` row exists — which cannot occur before those
     // columns have been added.
     let mut stmt_lookup_foreign = conn.prepare_cached(
-        "SELECT id FROM addresses
-         WHERE account_id = :account_id
-           AND cached_transparent_receiver_address = :transparent_address
+        "SELECT id, account_id FROM addresses
+         WHERE cached_transparent_receiver_address = :transparent_address
            AND key_scope = :foreign_scope",
     )?;
 
@@ -769,21 +775,21 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
         let child_index = transparent_child_index.index();
         let flags = receiver_flags.bits();
 
-        let foreign_id: Option<i64> = stmt_lookup_foreign
+        let foreign_row: Option<(i64, i64)> = stmt_lookup_foreign
             .query_row(
                 named_params![
-                    ":account_id": account_id.0,
                     ":transparent_address": transparent_address_enc,
                     ":foreign_scope": KeyScope::Foreign.encode(),
                 ],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()?;
 
-        if let Some(foreign_id) = foreign_id {
+        if let Some((foreign_id, foreign_account)) = foreign_row {
             conn.execute(
                 "UPDATE addresses
-                 SET key_scope = :key_scope,
+                 SET account_id = :account_id,
+                     key_scope = :key_scope,
                      diversifier_index_be = :diversifier_index_be,
                      address = :address,
                      transparent_child_index = :transparent_child_index,
@@ -792,6 +798,7 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
                      imported_transparent_receiver_script = NULL
                  WHERE id = :id",
                 named_params![
+                    ":account_id": account_id.0,
                     ":key_scope": derived_scope,
                     ":diversifier_index_be": diversifier_index_be,
                     ":address": address_enc,
@@ -800,6 +807,27 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
                     ":id": foreign_id,
                 ],
             )?;
+
+            // If the import was recorded under a different account, the outputs received at
+            // the address follow the (derivation-proven) attribution to this account.
+            if foreign_account != account_id.0 {
+                for table in [
+                    "transparent_received_outputs",
+                    "sapling_received_notes",
+                    "orchard_received_notes",
+                ] {
+                    conn.execute(
+                        &format!(
+                            "UPDATE {table} SET account_id = :account_id
+                             WHERE address_id = :address_id"
+                        ),
+                        named_params![
+                            ":account_id": account_id.0,
+                            ":address_id": foreign_id,
+                        ],
+                    )?;
+                }
+            }
         } else {
             stmt_insert_address.execute(named_params![
                 ":account_id": account_id.0,
@@ -2836,6 +2864,138 @@ mod tests {
             )
             .unwrap();
         assert_eq!(utxo_addr_id, foreign_id);
+
+        tx.commit().unwrap();
+    }
+
+    /// Deriving an address that was imported as a standalone (`Foreign`) receiver under a
+    /// *different* account also upgrades the existing row in place: deriving the address is
+    /// itself proof that the deriving account owns it, so the row's account attribution moves
+    /// to the deriving account, along with the account attribution of any outputs received at
+    /// the address. Without this, the derive would fail on the receiver-uniqueness index.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn store_address_range_upgrades_receiver_imported_under_other_account() {
+        use rusqlite::named_params;
+        use transparent::address::TransparentAddress;
+        use zcash_client_backend::data_api::{AccountBirthday, chain::ChainState};
+        use zcash_keys::{address::Address, encoding::AddressCodec};
+        use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+        use crate::wallet::encoding::KeyScope;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_a_uuid = st.test_account().unwrap().id();
+        let network = *st.network();
+
+        // A second account, under which the address will be imported.
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(
+                network.activation_height(NetworkUpgrade::Sapling).unwrap() - 1,
+                BlockHash([0; 32]),
+            ),
+            None,
+        );
+        let seed_b = Secret::new(vec![42u8; 32]);
+        let (account_b_uuid, _) = st
+            .wallet_mut()
+            .create_account("b", &seed_b, &birthday, None)
+            .unwrap();
+
+        // An address we pretend was imported standalone under account B, and is derivable by
+        // account A at child index 100 (beyond the default external gap of 10).
+        let taddr = TransparentAddress::PublicKeyHash([0x22; 20]);
+        let taddr_enc = taddr.encode(&network);
+        let child_index = NonHardenedChildIndex::from_index(100).unwrap();
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let account_a = get_account_ref(&tx, account_a_uuid).unwrap();
+        let account_b = get_account_ref(&tx, account_b_uuid).unwrap();
+
+        // The standalone (`Foreign`) row under account B.
+        tx.execute(
+            "INSERT INTO addresses
+                 (account_id, key_scope, address, cached_transparent_receiver_address,
+                  imported_transparent_receiver_pubkey, receiver_flags, exposed_at_height)
+             VALUES (:account_id, :foreign, :address, :taddr,
+                  X'020000000000000000000000000000000000000000000000000000000000000004', 1, 55)",
+            named_params! {
+                ":account_id": account_b.0,
+                ":foreign": KeyScope::Foreign.encode(),
+                ":address": &taddr_enc,
+                ":taddr": &taddr_enc,
+            },
+        )
+        .unwrap();
+        let foreign_id = tx.last_insert_rowid();
+
+        // A UTXO attached to the imported row, attributed to account B.
+        tx.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height) VALUES (1, X'00', 1)",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO transparent_received_outputs
+                 (transaction_id, output_index, account_id, address, script, value_zat, address_id)
+             VALUES (1, 0, :account_id, :taddr, X'00', 100000, :addr_id)",
+            named_params! { ":account_id": account_b.0, ":taddr": &taddr_enc, ":addr_id": foreign_id },
+        )
+        .unwrap();
+
+        // Account A derives the same address.
+        super::store_address_range(
+            &tx,
+            &network,
+            account_a,
+            TransparentKeyScope::EXTERNAL,
+            vec![(Address::from(taddr), taddr, child_index)],
+        )
+        .unwrap();
+
+        // Exactly one row remains for the receiver: the upgraded former-import row, now
+        // belonging to account A.
+        let mut stmt = tx
+            .prepare(
+                "SELECT id, account_id, key_scope, transparent_child_index,
+                        imported_transparent_receiver_pubkey IS NULL
+                 FROM addresses WHERE cached_transparent_receiver_address = :taddr",
+            )
+            .unwrap();
+        let rows: Vec<(i64, i64, i64, Option<u32>, bool)> = stmt
+            .query_map(named_params! { ":taddr": &taddr_enc }, |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        drop(stmt);
+
+        assert_eq!(rows.len(), 1);
+        let (id, account_id, key_scope, child, pubkey_is_null) = rows[0];
+        assert_eq!(id, foreign_id, "upgraded in place, same id");
+        assert_eq!(
+            account_id, account_a.0,
+            "attribution moved to the deriving account"
+        );
+        assert_eq!(key_scope, KeyScope::EXTERNAL.encode());
+        assert_eq!(child, Some(100));
+        assert!(pubkey_is_null, "standalone-import column cleared");
+
+        // The UTXO followed the row, and its account attribution moved with it.
+        let (utxo_addr_id, utxo_account_id): (i64, i64) = tx
+            .query_row(
+                "SELECT address_id, account_id FROM transparent_received_outputs
+                 WHERE transaction_id = 1 AND output_index = 0",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((utxo_addr_id, utxo_account_id), (foreign_id, account_a.0));
 
         tx.commit().unwrap();
     }


### PR DESCRIPTION
## Summary

A transparent address can exist in the `addresses` table both as a standalone (`Foreign`)
import — e.g. a watch-only pubkey/script imported into an account — and as an address the
account itself derives. When gap-limit generation derived such an address,
`store_address_range` inserted a *second* row for the same transparent receiver instead of
reconciling with the existing import. On databases carrying the new `UNIQUE` index on
`addresses.cached_transparent_receiver_address` (#2486) this makes the derive fail outright
with a constraint violation; without it, it silently produced a duplicate record for the
receiver, violating the intended one-record-per-receiver invariant.

This PR:

- **`store_address_range` upgrades in place.** When the address being derived already exists as
  a `Foreign`-scope row for the receiver in the same account, the existing row is upgraded to
  its derived form (`key_scope`, `transparent_child_index`, `diversifier_index_be`,
  `receiver_flags`; the `imported_transparent_receiver_*` columns cleared) instead of inserting
  a duplicate. The row `id` is preserved, so any UTXOs, exposure, and spend-search state already
  attached to the imported receiver carry over. The lookup that decides whether to upgrade reads
  only columns present at every schema version at which `store_address_range` runs, and the
  imported-column `UPDATE` is prepared only when a `Foreign` row actually exists — so this
  function remains usable from the `transparent_gap_limit_handling` migration, which runs before
  those columns are added.

- **Migration exposure carry-over.** The `add_transparent_receiver_address_index` migration
  (#2486) already collapses a pre-existing derived/imported duplicate onto a canonical record;
  it now also carries the earliest `exposed_at_height` among the merged records onto the
  survivor.

- **Cross-account duplicates are resolved by derivation** (review follow-up). Previously a
  receiver duplicated across more than one account was an unconditional migration abort. Now,
  if exactly one of the records reproduces the receiver when its address is derived from its
  own account's viewing key at its recorded child index, that record is definitively correct:
  it is retained, and the received outputs of the other records are repointed to it along with
  their account attribution (the reason cross-account merges were previously unsafe). No
  account is privileged in this determination — an address genuinely derived under the ZIP 32
  account index `0x7FFFFFFF` (used for the `zcashd` legacy account) wins over another account's
  imported record just as any other verified derivation would. Cross-account duplicates for
  which no unique record verifies still abort with `CorruptedData`.

CHANGELOG updated.

## Test plan

- New `store_address_range_upgrades_imported_receiver`: importing a standalone address that is
  subsequently derived upgrades the existing row in place (same `id`, derived scope, import
  columns cleared, no duplicate), and a UTXO attached to it carries over.
- New `repair_carries_min_exposed_at_height`: the migration keeps the earliest exposure height
  when merging a duplicate.
- New `resolves_cross_account_duplicate_by_derivation`: a receiver duplicated across two
  accounts, where one record is genuinely derivable from its account's viewing key, is resolved
  in favor of the verified record; the attached output's `account_id` moves with it.
- New `cross_account_winner_may_be_legacy_account`: the mirror case — the verified derivation
  is under account index `0x7FFFFFFF`, and that record wins over another account's import,
  demonstrating that resolution is not keyed on account identity.
- Pre-existing `rejects_cross_account_duplicates` still passes: a cross-account duplicate in
  which neither record verifies by derivation continues to abort.
- Full `zcash_client_sqlite` suite passes under `--features transparent-key-import,orchard`
  (268 passed, 0 failed); the crate also builds without the `transparent-inputs` feature
  (cross-account resolution requires the key APIs and remains fail-closed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
