### PR TITLE
pczt: Complete branch-aware v6/Ironwood support

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -84,6 +84,10 @@ workspace.
 - `pczt::ExtractError::UnsupportedConsensusBranchId`
 - `pczt::ExtractError::IronwoodNotSupported`
 - `pczt::roles::creator::Creator::{with_ironwood_anchor, with_ironwood_flags}`
+- `pczt::roles::signer::Signer::{sign_ironwood, apply_ironwood_signature}`
+- `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
+- `pczt::roles::verifier::Verifier::with_ironwood`
+- `pczt::roles::updater::Updater::update_ironwood_with`
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,6 +13,20 @@ workspace.
 ### Changed
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_transparent 0.9.0-pre.0`,
   `zcash_primitives 0.29.0-pre.0`, `zcash_proofs 0.29.0-pre.0`.
+- The empty states of the transparent, Sapling, Orchard, and Ironwood bundles
+  now have a single canonical representation, produced consistently by the
+  Creator, `Creator::build_from_parts`, the serialization formats, and the IO
+  Finalizer, so that copies of a PCZT that take different serialization paths
+  continue to merge successfully:
+  - `Creator::build_from_parts` now uses an all-zeroes anchor (rather than the
+    empty-tree root) for absent Sapling and Orchard bundles.
+  - The Creator now initializes empty bundle value sums as non-negative zero.
+  - The IO Finalizer no longer sets `bsk` on an empty Orchard-protocol bundle.
+  - An Orchard-protocol bundle whose fields differ from the canonical empty
+    representation is no longer omitted from (and then lossily restored by)
+    the v2 serialization format, and the v1 serialization format refuses to
+    encode a PCZT whose Ironwood bundle is not canonically empty, rather than
+    silently dropping its non-default fields.
 - Every PCZT role that parses the Orchard-pool bundle derives its bundle
   version from the PCZT's consensus branch ID, and returns an
   `UnsupportedConsensusBranchId` error when that branch ID is unrecognized or

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -31,6 +31,14 @@ workspace.
   version from the PCZT's consensus branch ID, and returns an
   `UnsupportedConsensusBranchId` error when that branch ID is unrecognized or
   predates NU5.
+- `pczt::roles::creator::Creator::new` now selects the v6 transaction format
+  (and its version group ID) for consensus branch IDs at NU6.3 or later;
+  previously the v5 format was always used.
+- Transaction extraction now rejects v6 PCZTs whose consensus branch ID
+  predates NU6.3, and non-v6 PCZTs that carry non-canonical Ironwood bundle
+  data.
+- The v1 serialization format refuses to encode v6 PCZTs, which a v1 parser
+  could decode but never extract a transaction from.
 - `pczt::roles::low_level_signer::Signer::sign_orchard_with` now bounds its
   error parameter by `From<pczt::roles::low_level_signer::OrchardParseError>`
   instead of `From<orchard::pczt::ParseError>` (as does the new
@@ -74,6 +82,9 @@ workspace.
 - The logical `pczt::Pczt` type now includes an Ironwood bundle.
 - Ironwood PCZT role support.
 - `pczt::ExtractError::UnsupportedConsensusBranchId`
+- `pczt::ExtractError::IronwoodNotSupported`
+- `pczt::roles::creator::Creator::{with_ironwood_anchor, with_ironwood_flags}`
+- `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,
   `pczt::roles::verifier::OrchardError`, and `pczt::roles::prover::OrchardError`.

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -38,7 +38,7 @@ use {
     common::{Global, determine_lock_time},
     zcash_primitives::transaction::{Authorization, TransactionData, TxVersion},
     zcash_protocol::{
-        consensus::BranchId,
+        consensus::{BranchId, OrchardProtocolRevision},
         constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID},
     },
 };
@@ -124,6 +124,12 @@ pub mod v1 {
         type Error = super::EncodingError;
 
         fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
+            // The v1 format predates the v6 transaction format; a parser of the v1
+            // encoding could parse a v6 PCZT but never extract a transaction from it.
+            if pczt.global.tx_version == zcash_protocol::constants::V6_TX_VERSION {
+                return Err(super::EncodingError::UnsupportedTxVersion);
+            }
+
             // The v1 format cannot represent an Ironwood bundle in any state other
             // than the canonical empty one; a parser of the v1 encoding will
             // reconstruct exactly that value.
@@ -149,6 +155,37 @@ pub mod v1 {
                 orchard: pczt.orchard.into(),
                 ironwood: orchard::EMPTY_IRONWOOD,
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use zcash_protocol::consensus::BranchId;
+
+        use crate::roles::creator::Creator;
+
+        #[test]
+        fn v1_refuses_v6_pczts_and_non_canonical_ironwood_bundles() {
+            // A v6 PCZT cannot be encoded as v1, even when its Ironwood bundle is
+            // canonically empty.
+            let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
+                .unwrap()
+                .build();
+            assert!(matches!(
+                super::Pczt::try_from(pczt),
+                Err(crate::EncodingError::UnsupportedTxVersion)
+            ));
+
+            // A v5 PCZT carrying non-canonical Ironwood bundle data cannot be encoded
+            // as v1, because the data would be dropped.
+            let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+                .unwrap()
+                .build();
+            pczt.ironwood.bsk = Some([1; 32]);
+            assert!(matches!(
+                super::Pczt::try_from(pczt),
+                Err(crate::EncodingError::UnsupportedTxVersion)
+            ));
         }
     }
 }
@@ -388,23 +425,11 @@ impl Pczt {
 
         let consensus_branch_id = BranchId::try_from(global.consensus_branch_id)
             .map_err(|_| ExtractError::UnknownConsensusBranchId)?;
-        let orchard_bundle_version = consensus_branch_id
+        let orchard_protocol_revision = consensus_branch_id
             .orchard_protocol_revision()
-            .map(crate::orchard::orchard_bundle_version_for_revision)
             // The v5 and v6 transaction formats do not exist prior to NU5, so no
             // transaction could be extracted under such a branch in any case.
             .ok_or(ExtractError::UnsupportedConsensusBranchId)?;
-
-        let transparent = transparent
-            .into_parsed()
-            .map_err(ExtractError::TransparentParse)?;
-        let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
-        let orchard = orchard
-            .into_parsed_with_version(orchard_bundle_version)
-            .map_err(ExtractError::OrchardParse)?;
-        let ironwood = ironwood
-            .into_ironwood_parsed()
-            .map_err(ExtractError::IronwoodParse)?;
 
         let version = match (global.tx_version, global.version_group_id) {
             (V5_TX_VERSION, V5_VERSION_GROUP_ID) => Ok(TxVersion::V5),
@@ -414,6 +439,32 @@ impl Pczt {
                 version_group_id,
             }),
         }?;
+
+        // The v6 transaction format does not exist prior to NU6.3 (the first upgrade
+        // under which the Orchard protocol is at revision V3).
+        if matches!(version, TxVersion::V6)
+            && orchard_protocol_revision < OrchardProtocolRevision::V3
+        {
+            return Err(ExtractError::UnsupportedConsensusBranchId.into());
+        }
+
+        // Only the v6 transaction format carries an Ironwood bundle.
+        if !matches!(version, TxVersion::V6) && ironwood != crate::orchard::EMPTY_IRONWOOD {
+            return Err(ExtractError::IronwoodNotSupported.into());
+        }
+
+        let transparent = transparent
+            .into_parsed()
+            .map_err(ExtractError::TransparentParse)?;
+        let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
+        let orchard = orchard
+            .into_parsed_with_version(crate::orchard::orchard_bundle_version_for_revision(
+                orchard_protocol_revision,
+            ))
+            .map_err(ExtractError::OrchardParse)?;
+        let ironwood = ironwood
+            .into_ironwood_parsed()
+            .map_err(ExtractError::IronwoodParse)?;
 
         let lock_time = determine_lock_time(&global, transparent.inputs())
             .ok_or(ExtractError::IncompatibleLockTimes)?;
@@ -526,6 +577,9 @@ pub enum ExtractError {
     IncompatibleLockTimes,
     /// An error occurred extracting the Ironwood protocol bundle from the Ironwood PCZT bundle.
     IronwoodExtract(::orchard::pczt::TxExtractorError),
+    /// The PCZT carries Ironwood bundle data, but its transaction version does not
+    /// support an Ironwood bundle.
+    IronwoodNotSupported,
     /// An error occurred parsing the Ironwood PCZT bundle from the PCZT data.
     IronwoodParse(::orchard::pczt::ParseError),
     /// An error occurred extracting the Orchard protocol bundle from the Orchard PCZT bundle.
@@ -562,4 +616,35 @@ pub enum ParseError {
     TooShort,
     /// The PCZT has an unknown version.
     UnknownVersion(u32),
+}
+
+#[cfg(all(test, any(feature = "io-finalizer", feature = "signer")))]
+mod extraction_tests {
+    use zcash_protocol::consensus::BranchId;
+
+    use crate::{ExtractError, roles::creator::Creator};
+
+    #[test]
+    fn v5_pczt_with_ironwood_data_does_not_extract() {
+        let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
+        pczt.ironwood.bsk = Some([1; 32]);
+        assert!(matches!(
+            pczt.into_effects(),
+            Err(ExtractError::IronwoodNotSupported)
+        ));
+    }
+
+    #[test]
+    fn v6_pczt_with_pre_nu6_3_branch_does_not_extract() {
+        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
+        pczt.global.consensus_branch_id = BranchId::Nu6_2.into();
+        assert!(matches!(
+            pczt.into_effects(),
+            Err(ExtractError::UnsupportedConsensusBranchId)
+        ));
+    }
 }

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -124,7 +124,10 @@ pub mod v1 {
         type Error = super::EncodingError;
 
         fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
-            if !pczt.ironwood.actions.is_empty() {
+            // The v1 format cannot represent an Ironwood bundle in any state other
+            // than the canonical empty one; a parser of the v1 encoding will
+            // reconstruct exactly that value.
+            if pczt.ironwood != orchard::EMPTY_IRONWOOD {
                 return Err(super::EncodingError::UnsupportedTxVersion);
             }
 
@@ -144,15 +147,7 @@ pub mod v1 {
                 transparent: pczt.transparent,
                 sapling: pczt.sapling,
                 orchard: pczt.orchard.into(),
-                ironwood: orchard::Bundle {
-                    actions: vec![],
-                    flags: 0,
-                    value_sum: (0, true),
-                    anchor: [0; 32],
-                    note_version: orchard::NoteVersion::V3,
-                    zkproof: None,
-                    bsk: None,
-                },
+                ironwood: orchard::EMPTY_IRONWOOD,
             }
         }
     }
@@ -164,19 +159,6 @@ pub mod v2 {
     use serde::{Deserialize, Serialize};
 
     use crate::{common, orchard, sapling, transparent};
-
-    const EMPTY_TRANSPARENT: transparent::Bundle = transparent::Bundle {
-        inputs: Vec::new(),
-        outputs: Vec::new(),
-    };
-
-    const EMPTY_SAPLING: sapling::Bundle = sapling::Bundle {
-        spends: Vec::new(),
-        outputs: Vec::new(),
-        value_sum: 0,
-        anchor: [0; 32],
-        bsk: None,
-    };
 
     /// The in-memory type used for derived serialization of the v2 Pczt encoding.
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -213,10 +195,11 @@ pub mod v2 {
         fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
             Ok(Self {
                 global: pczt.global,
-                transparent: (pczt.transparent != EMPTY_TRANSPARENT).then_some(pczt.transparent),
-                sapling: (pczt.sapling != EMPTY_SAPLING).then_some(pczt.sapling),
-                orchard: pczt.orchard.try_into()?,
-                ironwood: pczt.ironwood.try_into()?,
+                transparent: (pczt.transparent != transparent::EMPTY_BUNDLE)
+                    .then_some(pczt.transparent),
+                sapling: (pczt.sapling != sapling::EMPTY_BUNDLE).then_some(pczt.sapling),
+                orchard: orchard::v2::encode(pczt.orchard, &orchard::EMPTY_ORCHARD)?,
+                ironwood: orchard::v2::encode(pczt.ironwood, &orchard::EMPTY_IRONWOOD)?,
             })
         }
     }
@@ -225,23 +208,16 @@ pub mod v2 {
         fn from(pczt: Pczt) -> Self {
             Self {
                 global: pczt.global,
-                transparent: pczt.transparent.unwrap_or(EMPTY_TRANSPARENT),
-                sapling: pczt.sapling.unwrap_or(EMPTY_SAPLING),
+                transparent: pczt.transparent.unwrap_or(transparent::EMPTY_BUNDLE),
+                sapling: pczt.sapling.unwrap_or(sapling::EMPTY_BUNDLE),
                 orchard: pczt
                     .orchard
                     .map(orchard::Bundle::from)
-                    .unwrap_or(orchard::v2::EMPTY_BUNDLE),
-                ironwood: pczt.ironwood.map(orchard::Bundle::from).unwrap_or_else(|| {
-                    orchard::Bundle {
-                        actions: Vec::new(),
-                        flags: orchard::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-                        value_sum: (0, true),
-                        anchor: [0; 32],
-                        note_version: orchard::NoteVersion::V3,
-                        zkproof: None,
-                        bsk: None,
-                    }
-                }),
+                    .unwrap_or(orchard::EMPTY_ORCHARD),
+                ironwood: pczt
+                    .ironwood
+                    .map(orchard::Bundle::from)
+                    .unwrap_or(orchard::EMPTY_IRONWOOD),
             }
         }
     }
@@ -304,16 +280,22 @@ pub mod v2 {
         }
 
         #[test]
-        fn orchard_flags_and_note_version_do_not_prevent_omission() {
+        fn non_canonical_orchard_flags_and_note_version_prevent_omission() {
             let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
                 .unwrap()
                 .build();
             pczt.orchard.flags = 0;
             pczt.orchard.note_version = NoteVersion::V3;
 
-            let encoded = Pczt::try_from(pczt).unwrap();
+            // A bundle whose flags or note version differ from the canonical empty
+            // bundle is not omitted, so that those fields round-trip losslessly.
+            let encoded = Pczt::try_from(pczt.clone()).unwrap();
+            assert!(encoded.orchard.is_some());
 
-            assert!(encoded.orchard.is_none());
+            let decoded = crate::Pczt::from(encoded);
+            assert_eq!(decoded.orchard, pczt.orchard);
+            assert_eq!(decoded.orchard.flags, 0);
+            assert_eq!(decoded.orchard.note_version, NoteVersion::V3);
         }
     }
 }

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -166,7 +166,7 @@ pub mod v1 {
 
         #[test]
         fn v1_refuses_v6_pczts_and_non_canonical_ironwood_bundles() {
-            // A v6 PCZT cannot be encoded as v1, even when its Ironwood bundle is
+            // A v6 tx cannot be encoded as a v1 PCZT, even when its Ironwood bundle is
             // canonically empty.
             let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
                 .unwrap()
@@ -176,8 +176,8 @@ pub mod v1 {
                 Err(crate::EncodingError::UnsupportedTxVersion)
             ));
 
-            // A v5 PCZT carrying non-canonical Ironwood bundle data cannot be encoded
-            // as v1, because the data would be dropped.
+            // A v5 tx carrying non-canonical Ironwood bundle data cannot be encoded
+            // as a v1 PCZT, because the data would be dropped.
             let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
                 .unwrap()
                 .build();
@@ -440,17 +440,20 @@ impl Pczt {
             }),
         }?;
 
-        // The v6 transaction format does not exist prior to NU6.3 (the first upgrade
-        // under which the Orchard protocol is at revision V3).
-        if matches!(version, TxVersion::V6)
-            && orchard_protocol_revision < OrchardProtocolRevision::V3
-        {
-            return Err(ExtractError::UnsupportedConsensusBranchId.into());
-        }
-
-        // Only the v6 transaction format carries an Ironwood bundle.
-        if !matches!(version, TxVersion::V6) && ironwood != crate::orchard::EMPTY_IRONWOOD {
-            return Err(ExtractError::IronwoodNotSupported.into());
+        match version {
+            // Only the v6 transaction format carries an Ironwood bundle.
+            TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => {
+                if ironwood != crate::orchard::EMPTY_IRONWOOD {
+                    return Err(ExtractError::IronwoodNotSupported.into());
+                }
+            }
+            // The v6 transaction format does not exist prior to NU6.3 (the first
+            // upgrade under which the Orchard protocol is at revision V3).
+            TxVersion::V6 => {
+                if orchard_protocol_revision < OrchardProtocolRevision::V3 {
+                    return Err(ExtractError::UnsupportedConsensusBranchId.into());
+                }
+            }
         }
 
         let transparent = transparent
@@ -458,9 +461,13 @@ impl Pczt {
             .map_err(ExtractError::TransparentParse)?;
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
         let orchard = orchard
-            .into_parsed_with_version(crate::orchard::orchard_bundle_version_for_revision(
-                orchard_protocol_revision,
-            ))
+            .into_parsed_with_version(
+                crate::orchard::bundle_version_for_revision(
+                    orchard_protocol_revision,
+                    ::orchard::ValuePool::Orchard,
+                )
+                .expect("the Orchard pool is supported under every protocol revision"),
+            )
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
             .into_ironwood_parsed()

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -81,6 +81,36 @@ pub struct Bundle {
 /// an empty bundle for serialization purposes.
 pub(crate) const ORCHARD_SPENDS_AND_OUTPUTS_ENABLED: u8 = 0b0000_0011;
 
+/// The default Ironwood bundle flags: spends, outputs, and cross-address transfers
+/// enabled (bits 0, 1, and 2). This is the value the Creator sets on a new bundle,
+/// and the flag value of an empty bundle for serialization purposes.
+pub(crate) const IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED: u8 = 0b0000_0111;
+
+/// The canonical empty Orchard-pool bundle: the form the Orchard slot of a PCZT takes
+/// when it carries no Orchard-protocol data. The Creator, the v1 decoder, and the v2
+/// decoder all produce exactly this value for an absent bundle, so that copies of a
+/// PCZT that take different serialization paths continue to merge successfully.
+pub(crate) const EMPTY_ORCHARD: Bundle = Bundle {
+    actions: Vec::new(),
+    flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+    value_sum: (0, false),
+    anchor: [0; 32],
+    note_version: NoteVersion::V2,
+    zkproof: None,
+    bsk: None,
+};
+
+/// The canonical empty Ironwood bundle; see [`EMPTY_ORCHARD`].
+pub(crate) const EMPTY_IRONWOOD: Bundle = Bundle {
+    actions: Vec::new(),
+    flags: IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
+    value_sum: (0, false),
+    anchor: [0; 32],
+    note_version: NoteVersion::V3,
+    zkproof: None,
+    bsk: None,
+};
+
 /// Information about an Orchard action within a transaction.
 #[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Action {
@@ -565,43 +595,20 @@ pub(crate) mod v2 {
         }
     }
 
-    /// The canonical empty Orchard bundle reconstructed for omitted v2 bundles.
-    pub(crate) const EMPTY_BUNDLE: super::Bundle = super::Bundle {
-        actions: Vec::new(),
-        flags: super::ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-        value_sum: (0, true),
-        anchor: [0; 32],
-        note_version: NoteVersion::V2,
-        zkproof: None,
-        bsk: None,
-    };
-
-    /// Whether `bundle` can be omitted from the v2 encoding.
-    ///
-    /// We check that actions, value sum, anchor, zkproof, and bsk are all
-    /// equal to the empty bundle. We do not check note version or flags, as
-    /// values can be defaulted there.
-    fn is_empty(bundle: &super::Bundle) -> bool {
-        bundle.actions == EMPTY_BUNDLE.actions
-            && bundle.value_sum == EMPTY_BUNDLE.value_sum
-            && bundle.anchor == EMPTY_BUNDLE.anchor
-            && bundle.zkproof == EMPTY_BUNDLE.zkproof
-            && bundle.bsk == EMPTY_BUNDLE.bsk
-    }
-
-    /// Encodes a logical Orchard bundle for the v2 PCZT format, owning the
-    /// decision of whether the bundle can be omitted. An [empty](is_empty) bundle
-    /// serializes to `None` and is dropped from the encoding; any other bundle is
-    /// converted via the [`Bundle`]-producing [`TryFrom`] impl. The reverse
-    /// direction is [`From<Bundle>`] plus [`EMPTY_BUNDLE`] for the omitted case.
-    impl TryFrom<super::Bundle> for Option<Bundle> {
-        type Error = crate::EncodingError;
-
-        fn try_from(bundle: super::Bundle) -> Result<Self, Self::Error> {
-            (!is_empty(&bundle))
-                .then(|| Bundle::try_from(bundle))
-                .transpose()
-        }
+    /// Encodes a logical Orchard-protocol bundle for the v2 PCZT format, owning the
+    /// decision of whether the bundle can be omitted. A bundle that is exactly equal
+    /// to `empty` (the canonical empty bundle for its slot, [`super::EMPTY_ORCHARD`]
+    /// or [`super::EMPTY_IRONWOOD`]) serializes to `None` and is dropped from the
+    /// encoding; any other bundle is converted via the [`Bundle`]-producing
+    /// [`TryFrom`] impl. The reverse direction is [`From<Bundle>`] plus the canonical
+    /// empty bundle for the omitted case.
+    pub(crate) fn encode(
+        bundle: super::Bundle,
+        empty: &super::Bundle,
+    ) -> Result<Option<Bundle>, crate::EncodingError> {
+        (bundle != *empty)
+            .then(|| Bundle::try_from(bundle))
+            .transpose()
     }
 }
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -756,18 +756,27 @@ impl Bundle {
     }
 }
 
-/// Returns the Orchard-pool [`BundleVersion`] corresponding to the given Orchard
-/// protocol revision.
+/// Returns the [`BundleVersion`] in effect for the given Orchard-protocol value pool
+/// under the given Orchard protocol revision, or `None` if the pool is not supported
+/// under that revision (the Ironwood pool exists only from revision V3).
 #[cfg(feature = "orchard")]
-pub(crate) fn orchard_bundle_version_for_revision(
+pub(crate) fn bundle_version_for_revision(
     revision: zcash_protocol::consensus::OrchardProtocolRevision,
-) -> BundleVersion {
+    pool: orchard::ValuePool,
+) -> Option<BundleVersion> {
+    use orchard::ValuePool;
     use zcash_protocol::consensus::OrchardProtocolRevision;
 
-    match revision {
-        OrchardProtocolRevision::InsecureV1 => BundleVersion::orchard_insecure_v1(),
-        OrchardProtocolRevision::V2 => BundleVersion::orchard_v2(),
-        OrchardProtocolRevision::V3 => BundleVersion::orchard_v3(),
+    match pool {
+        ValuePool::Orchard => Some(match revision {
+            OrchardProtocolRevision::InsecureV1 => BundleVersion::orchard_insecure_v1(),
+            OrchardProtocolRevision::V2 => BundleVersion::orchard_v2(),
+            OrchardProtocolRevision::V3 => BundleVersion::orchard_v3(),
+        }),
+        ValuePool::Ironwood => match revision {
+            OrchardProtocolRevision::InsecureV1 | OrchardProtocolRevision::V2 => None,
+            OrchardProtocolRevision::V3 => Some(BundleVersion::ironwood_v3()),
+        },
     }
 }
 
@@ -781,7 +790,7 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
     BranchId::try_from(global.consensus_branch_id)
         .ok()?
         .orchard_protocol_revision()
-        .map(orchard_bundle_version_for_revision)
+        .and_then(|revision| bundle_version_for_revision(revision, orchard::ValuePool::Orchard))
 }
 
 #[cfg(feature = "orchard")]

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 use zcash_protocol::consensus::BranchId;
-use zcash_protocol::constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID};
+use zcash_protocol::constants::{
+    V5_TX_VERSION, V5_VERSION_GROUP_ID, V6_TX_VERSION, V6_VERSION_GROUP_ID,
+};
 
 /// Initial flags allowing any modification.
 const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
@@ -24,6 +26,9 @@ const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
 /// Errors that can occur when creating a PCZT.
 #[derive(Debug)]
 pub enum Error {
+    /// The transaction version implied by the consensus branch ID does not carry an
+    /// Ironwood bundle.
+    IronwoodNotSupported,
     /// The consensus branch ID does not correspond to any known network upgrade.
     UnknownConsensusBranchId,
     /// The network upgrade for the consensus branch ID predates the v5
@@ -62,12 +67,17 @@ pub struct Creator {
     orchard_flags: u8,
     #[cfg(feature = "orchard")]
     orchard_bundle_version: orchard::bundle::BundleVersion,
+    ironwood_flags: u8,
     sapling_anchor: [u8; 32],
     orchard_anchor: [u8; 32],
+    ironwood_anchor: [u8; 32],
 }
 
 impl Creator {
     /// Creates a new PCZT for the given consensus branch ID.
+    ///
+    /// The transaction version is implied by the consensus branch ID: the v6
+    /// transaction format from NU6.3 onward, and the v5 format for earlier upgrades.
     ///
     /// # Errors
     ///
@@ -81,8 +91,25 @@ impl Creator {
         sapling_anchor: [u8; 32],
         orchard_anchor: [u8; 32],
     ) -> Result<Self, Error> {
-        #[cfg_attr(not(feature = "orchard"), allow(unused_variables))]
         let branch_id = consensus_branch_id_for_pczt(consensus_branch_id)?;
+
+        let (tx_version, version_group_id) = match branch_id {
+            // Pre-NU5 branches are rejected by `consensus_branch_id_for_pczt`; NU5
+            // through NU6.2 use the v5 transaction format.
+            BranchId::Sprout
+            | BranchId::Overwinter
+            | BranchId::Sapling
+            | BranchId::Blossom
+            | BranchId::Heartwood
+            | BranchId::Canopy
+            | BranchId::Nu5
+            | BranchId::Nu6
+            | BranchId::Nu6_1
+            | BranchId::Nu6_2 => (V5_TX_VERSION, V5_VERSION_GROUP_ID),
+            BranchId::Nu6_3 => (V6_TX_VERSION, V6_VERSION_GROUP_ID),
+            #[cfg(zcash_unstable = "nu7")]
+            BranchId::Nu7 => (V6_TX_VERSION, V6_VERSION_GROUP_ID),
+        };
 
         #[cfg(feature = "orchard")]
         let orchard_bundle_version = branch_id
@@ -91,9 +118,8 @@ impl Creator {
             .expect("`consensus_branch_id_for_pczt` rejects branches that predate NU5");
 
         Ok(Self {
-            // Default to v5 transaction format.
-            tx_version: V5_TX_VERSION,
-            version_group_id: V5_VERSION_GROUP_ID,
+            tx_version,
+            version_group_id,
             consensus_branch_id,
             fallback_lock_time: None,
             expiry_height,
@@ -101,8 +127,10 @@ impl Creator {
             orchard_flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
             #[cfg(feature = "orchard")]
             orchard_bundle_version,
+            ironwood_flags: crate::orchard::IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
             sapling_anchor,
             orchard_anchor,
+            ironwood_anchor: [0; 32],
         })
     }
 
@@ -130,6 +158,43 @@ impl Creator {
     ) -> Result<Self, Error> {
         self.orchard_flags = orchard_flags
             .to_byte(self.orchard_bundle_version)
+            .ok_or(Error::UnrepresentableOrchardFlags)?;
+        Ok(self)
+    }
+
+    /// Sets the Ironwood anchor for the PCZT.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IronwoodNotSupported`] if the transaction version implied by
+    /// the consensus branch ID passed to [`Creator::new`] does not carry an Ironwood
+    /// bundle.
+    pub fn with_ironwood_anchor(mut self, ironwood_anchor: [u8; 32]) -> Result<Self, Error> {
+        if self.tx_version != V6_TX_VERSION {
+            return Err(Error::IronwoodNotSupported);
+        }
+        self.ironwood_anchor = ironwood_anchor;
+        Ok(self)
+    }
+
+    /// Sets the Ironwood flags for the PCZT.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IronwoodNotSupported`] if the transaction version implied by
+    /// the consensus branch ID passed to [`Creator::new`] does not carry an Ironwood
+    /// bundle, or [`Error::UnrepresentableOrchardFlags`] if `flags` cannot be encoded
+    /// under the Ironwood bundle version.
+    #[cfg(feature = "orchard")]
+    pub fn with_ironwood_flags(
+        mut self,
+        ironwood_flags: orchard::bundle::Flags,
+    ) -> Result<Self, Error> {
+        if self.tx_version != V6_TX_VERSION {
+            return Err(Error::IronwoodNotSupported);
+        }
+        self.ironwood_flags = ironwood_flags
+            .to_byte(orchard::bundle::BundleVersion::ironwood_v3())
             .ok_or(Error::UnrepresentableOrchardFlags)?;
         Ok(self)
     }
@@ -170,7 +235,11 @@ impl Creator {
                 zkproof: None,
                 bsk: None,
             },
-            ironwood: crate::orchard::EMPTY_IRONWOOD,
+            ironwood: OrchardBundle {
+                flags: self.ironwood_flags,
+                anchor: self.ironwood_anchor,
+                ..crate::orchard::EMPTY_IRONWOOD
+            },
         }
     }
 
@@ -187,8 +256,6 @@ impl Creator {
         use zcash_protocol::{consensus::NetworkConstants, constants::V4_TX_VERSION};
 
         use crate::common::FLAG_HAS_SIGHASH_SINGLE;
-
-        use zcash_protocol::constants::V6_TX_VERSION;
 
         let tx_version = match parts.version {
             zcash_primitives::transaction::TxVersion::Sprout(_)
@@ -237,5 +304,47 @@ impl Creator {
                 .map(OrchardBundle::serialize_from)
                 .unwrap_or(crate::orchard::EMPTY_IRONWOOD),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::consensus::BranchId;
+    use zcash_protocol::constants::{
+        V5_TX_VERSION, V5_VERSION_GROUP_ID, V6_TX_VERSION, V6_VERSION_GROUP_ID,
+    };
+
+    use super::{Creator, Error};
+
+    #[test]
+    fn tx_version_follows_branch() {
+        let pczt = Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
+        assert_eq!(pczt.global.tx_version, V5_TX_VERSION);
+        assert_eq!(pczt.global.version_group_id, V5_VERSION_GROUP_ID);
+
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .build();
+        assert_eq!(pczt.global.tx_version, V6_TX_VERSION);
+        assert_eq!(pczt.global.version_group_id, V6_VERSION_GROUP_ID);
+    }
+
+    #[test]
+    fn ironwood_anchor_requires_v6() {
+        assert!(matches!(
+            Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, [0; 32], [0; 32])
+                .unwrap()
+                .with_ironwood_anchor([1; 32]),
+            Err(Error::IronwoodNotSupported)
+        ));
+
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
+            .unwrap()
+            .with_ironwood_anchor([1; 32])
+            .unwrap()
+            .build();
+        assert_eq!(pczt.ironwood.anchor, [1; 32]);
     }
 }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         FLAG_SHIELDED_MODIFIABLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
         FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
     },
-    orchard::{Bundle as OrchardBundle, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED},
+    orchard::{Bundle as OrchardBundle, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED},
 };
 
 use zcash_protocol::consensus::BranchId;
@@ -160,7 +160,7 @@ impl Creator {
             orchard: OrchardBundle {
                 actions: vec![],
                 flags: self.orchard_flags,
-                value_sum: (0, true),
+                value_sum: (0, false),
                 anchor: self.orchard_anchor,
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
@@ -170,15 +170,7 @@ impl Creator {
                 zkproof: None,
                 bsk: None,
             },
-            ironwood: OrchardBundle {
-                actions: vec![],
-                flags: self.orchard_flags,
-                value_sum: (0, true),
-                anchor: self.orchard_anchor,
-                note_version: NoteVersion::V3,
-                zkproof: None,
-                bsk: None,
-            },
+            ironwood: crate::orchard::EMPTY_IRONWOOD,
         }
     }
 
@@ -231,41 +223,19 @@ impl Creator {
             transparent: parts
                 .transparent
                 .map(crate::transparent::Bundle::serialize_from)
-                .unwrap_or_else(|| crate::transparent::Bundle {
-                    inputs: vec![],
-                    outputs: vec![],
-                }),
+                .unwrap_or(crate::transparent::EMPTY_BUNDLE),
             sapling: parts
                 .sapling
                 .map(crate::sapling::Bundle::serialize_from)
-                .unwrap_or_else(|| crate::sapling::Bundle {
-                    spends: vec![],
-                    outputs: vec![],
-                    value_sum: 0,
-                    anchor: sapling::Anchor::empty_tree().to_bytes(),
-                    bsk: None,
-                }),
+                .unwrap_or(crate::sapling::EMPTY_BUNDLE),
             orchard: parts
                 .orchard
                 .map(OrchardBundle::serialize_from)
-                .unwrap_or_else(|| OrchardBundle {
-                    actions: vec![],
-                    flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-                    value_sum: (0, true),
-                    anchor: orchard::Anchor::empty_tree().to_bytes(),
-                    note_version: NoteVersion::V2,
-                    zkproof: None,
-                    bsk: None,
-                }),
-            ironwood: OrchardBundle {
-                actions: vec![],
-                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-                value_sum: (0, true),
-                anchor: orchard::Anchor::empty_tree().to_bytes(),
-                note_version: NoteVersion::V3,
-                zkproof: None,
-                bsk: None,
-            },
+                .unwrap_or(crate::orchard::EMPTY_ORCHARD),
+            ironwood: parts
+                .ironwood
+                .map(OrchardBundle::serialize_from)
+                .unwrap_or(crate::orchard::EMPTY_IRONWOOD),
         })
     }
 }

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[cfg(feature = "orchard")]
-use crate::orchard::orchard_bundle_version_for_revision;
+use crate::orchard::bundle_version_for_revision;
 
 use zcash_protocol::consensus::BranchId;
 use zcash_protocol::constants::{
@@ -124,14 +124,14 @@ impl Creator {
         })
     }
 
-    /// Returns the Orchard-pool bundle version implied by this Creator's consensus
-    /// branch ID.
+    /// Returns the bundle version in effect for the given Orchard-protocol value pool
+    /// under this Creator's consensus branch ID, or `None` if the pool is not
+    /// supported under that branch.
     #[cfg(feature = "orchard")]
-    fn orchard_bundle_version(&self) -> orchard::bundle::BundleVersion {
+    fn bundle_version(&self, pool: orchard::ValuePool) -> Option<orchard::bundle::BundleVersion> {
         self.consensus_branch_id
             .orchard_protocol_revision()
-            .map(orchard_bundle_version_for_revision)
-            .expect("`Creator::new` rejects branches that predate NU5")
+            .and_then(|revision| bundle_version_for_revision(revision, pool))
     }
 
     pub fn with_fallback_lock_time(mut self, fallback: u32) -> Self {
@@ -157,7 +157,10 @@ impl Creator {
         orchard_flags: orchard::bundle::Flags,
     ) -> Result<Self, Error> {
         self.orchard_flags = orchard_flags
-            .to_byte(self.orchard_bundle_version())
+            .to_byte(
+                self.bundle_version(orchard::ValuePool::Orchard)
+                    .expect("`Creator::new` rejects branches that predate NU5"),
+            )
             .ok_or(Error::UnrepresentableOrchardFlags)?;
         Ok(self)
     }
@@ -190,11 +193,11 @@ impl Creator {
         mut self,
         ironwood_flags: orchard::bundle::Flags,
     ) -> Result<Self, Error> {
-        if self.tx_version != V6_TX_VERSION {
-            return Err(Error::IronwoodNotSupported);
-        }
         self.ironwood_flags = ironwood_flags
-            .to_byte(orchard::bundle::BundleVersion::ironwood_v3())
+            .to_byte(
+                self.bundle_version(orchard::ValuePool::Ironwood)
+                    .ok_or(Error::IronwoodNotSupported)?,
+            )
             .ok_or(Error::UnrepresentableOrchardFlags)?;
         Ok(self)
     }
@@ -229,7 +232,10 @@ impl Creator {
                 anchor: self.orchard_anchor,
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
-                note_version: self.orchard_bundle_version().note_version(),
+                note_version: self
+                    .bundle_version(orchard::ValuePool::Orchard)
+                    .expect("`Creator::new` rejects branches that predate NU5")
+                    .note_version(),
                 #[cfg(not(feature = "orchard"))]
                 note_version: crate::orchard::NoteVersion::V2,
                 zkproof: None,

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -13,6 +13,9 @@ use crate::{
     orchard::{Bundle as OrchardBundle, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED},
 };
 
+#[cfg(feature = "orchard")]
+use crate::orchard::orchard_bundle_version_for_revision;
+
 use zcash_protocol::consensus::BranchId;
 use zcash_protocol::constants::{
     V5_TX_VERSION, V5_VERSION_GROUP_ID, V6_TX_VERSION, V6_VERSION_GROUP_ID,
@@ -54,19 +57,14 @@ fn consensus_branch_id_for_pczt(consensus_branch_id: u32) -> Result<BranchId, Er
     }
 }
 
-#[cfg(feature = "orchard")]
-use crate::orchard::orchard_bundle_version_for_revision;
-
 pub struct Creator {
     tx_version: u32,
     version_group_id: u32,
-    consensus_branch_id: u32,
+    consensus_branch_id: BranchId,
     fallback_lock_time: Option<u32>,
     expiry_height: u32,
     coin_type: u32,
     orchard_flags: u8,
-    #[cfg(feature = "orchard")]
-    orchard_bundle_version: orchard::bundle::BundleVersion,
     ironwood_flags: u8,
     sapling_anchor: [u8; 32],
     orchard_anchor: [u8; 32],
@@ -111,27 +109,29 @@ impl Creator {
             BranchId::Nu7 => (V6_TX_VERSION, V6_VERSION_GROUP_ID),
         };
 
-        #[cfg(feature = "orchard")]
-        let orchard_bundle_version = branch_id
-            .orchard_protocol_revision()
-            .map(orchard_bundle_version_for_revision)
-            .expect("`consensus_branch_id_for_pczt` rejects branches that predate NU5");
-
         Ok(Self {
             tx_version,
             version_group_id,
-            consensus_branch_id,
+            consensus_branch_id: branch_id,
             fallback_lock_time: None,
             expiry_height,
             coin_type,
             orchard_flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-            #[cfg(feature = "orchard")]
-            orchard_bundle_version,
             ironwood_flags: crate::orchard::IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
             sapling_anchor,
             orchard_anchor,
             ironwood_anchor: [0; 32],
         })
+    }
+
+    /// Returns the Orchard-pool bundle version implied by this Creator's consensus
+    /// branch ID.
+    #[cfg(feature = "orchard")]
+    fn orchard_bundle_version(&self) -> orchard::bundle::BundleVersion {
+        self.consensus_branch_id
+            .orchard_protocol_revision()
+            .map(orchard_bundle_version_for_revision)
+            .expect("`Creator::new` rejects branches that predate NU5")
     }
 
     pub fn with_fallback_lock_time(mut self, fallback: u32) -> Self {
@@ -157,7 +157,7 @@ impl Creator {
         orchard_flags: orchard::bundle::Flags,
     ) -> Result<Self, Error> {
         self.orchard_flags = orchard_flags
-            .to_byte(self.orchard_bundle_version)
+            .to_byte(self.orchard_bundle_version())
             .ok_or(Error::UnrepresentableOrchardFlags)?;
         Ok(self)
     }
@@ -204,7 +204,7 @@ impl Creator {
             global: crate::common::Global {
                 tx_version: self.tx_version,
                 version_group_id: self.version_group_id,
-                consensus_branch_id: self.consensus_branch_id,
+                consensus_branch_id: self.consensus_branch_id.into(),
                 fallback_lock_time: self.fallback_lock_time,
                 expiry_height: self.expiry_height,
                 coin_type: self.coin_type,
@@ -229,7 +229,7 @@ impl Creator {
                 anchor: self.orchard_anchor,
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
-                note_version: self.orchard_bundle_version.note_version(),
+                note_version: self.orchard_bundle_version().note_version(),
                 #[cfg(not(feature = "orchard"))]
                 note_version: crate::orchard::NoteVersion::V2,
                 zkproof: None,

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -72,15 +72,26 @@ impl IoFinalizer {
         let txid_parts = tx_data.digest(TxIdDigester);
         let shielded_sighash = sighash(&tx_data, &SignableInput::Shielded, &txid_parts);
 
+        // The Sapling bundle is always finalized: unlike the Orchard-protocol
+        // Transaction Extractor, the Sapling one requires `bsk` to be set even when
+        // the bundle is empty.
         sapling
             .finalize_io(shielded_sighash, OsRng)
             .map_err(Error::SaplingFinalize)?;
-        orchard
-            .finalize_io(shielded_sighash, OsRng)
-            .map_err(Error::OrchardFinalize)?;
-        ironwood
-            .finalize_io(shielded_sighash, OsRng)
-            .map_err(Error::IronwoodFinalize)?;
+        // An empty Orchard-protocol bundle carries no value commitment information
+        // and contributes nothing to the transaction; leave its `bsk` unset so that
+        // it stays in its canonical empty form (and so remains omissible by, or
+        // representable in, the serialization formats).
+        if has_orchard_actions {
+            orchard
+                .finalize_io(shielded_sighash, OsRng)
+                .map_err(Error::OrchardFinalize)?;
+        }
+        if has_ironwood_actions {
+            ironwood
+                .finalize_io(shielded_sighash, OsRng)
+                .map_err(Error::IronwoodFinalize)?;
+        }
 
         Ok(Pczt {
             global,

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -342,6 +342,72 @@ impl Signer {
         Ok(())
     }
 
+    /// Signs the Ironwood spend at the given index with the given spend authorizing key.
+    ///
+    /// Requires the spend's `fvk` field to be set (because the API does not take an FVK).
+    ///
+    /// It is the caller's responsibility to perform any semantic validity checks on the
+    /// PCZT (for example, comfirming that the change amounts are correct) before calling
+    /// this method.
+    pub fn sign_ironwood(
+        &mut self,
+        index: usize,
+        ask: &orchard::keys::SpendAuthorizingKey,
+    ) -> Result<(), Error> {
+        self.generate_or_apply_ironwood_signature(index, |spend, shielded_sighash| {
+            spend.sign(shielded_sighash, ask, OsRng)
+        })
+    }
+
+    /// Applies the given signature to the Ironwood spend.
+    ///
+    /// It is the caller's responsibility to perform any semantic validity checks on the
+    /// PCZT (for example, comfirming that the change amounts are correct) before calling
+    /// this method.
+    pub fn apply_ironwood_signature(
+        &mut self,
+        index: usize,
+        signature: redpallas::Signature<redpallas::SpendAuth>,
+    ) -> Result<(), Error> {
+        self.generate_or_apply_ironwood_signature(index, |action, shielded_sighash| {
+            action.apply_signature(shielded_sighash, signature)
+        })
+    }
+
+    fn generate_or_apply_ironwood_signature<F>(&mut self, index: usize, f: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut orchard::pczt::Action, [u8; 32]) -> Result<(), orchard::pczt::SignerError>,
+    {
+        let action = self
+            .ironwood
+            .actions_mut()
+            .get_mut(index)
+            .ok_or(Error::InvalidIndex)?;
+
+        // Check consistency of the input being signed if we have its note components.
+        match action.spend().verify_nullifier(None) {
+            Err(
+                orchard::pczt::VerifyError::MissingRecipient
+                | orchard::pczt::VerifyError::MissingValue
+                | orchard::pczt::VerifyError::MissingRho
+                | orchard::pczt::VerifyError::MissingRandomSeed,
+            ) => Ok(()),
+            r => r,
+        }
+        .map_err(Error::IronwoodVerify)?;
+
+        // Generate or apply the signature.
+        f(action, self.shielded_sighash).map_err(Error::IronwoodSign)?;
+
+        // Update transaction modifiability: all transaction effects have been committed
+        // to by the signature.
+        self.global.tx_modifiable &= !(FLAG_TRANSPARENT_INPUTS_MODIFIABLE
+            | FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE
+            | FLAG_SHIELDED_MODIFIABLE);
+
+        Ok(())
+    }
+
     /// Finishes the Signer role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         let Self {
@@ -373,6 +439,8 @@ impl Signer {
 pub enum Error {
     Extract(crate::ExtractError),
     InvalidIndex,
+    IronwoodSign(orchard::pczt::SignerError),
+    IronwoodVerify(orchard::pczt::VerifyError),
     OrchardSign(orchard::pczt::SignerError),
     OrchardVerify(orchard::pczt::VerifyError),
     SaplingSign(sapling::pczt::SignerError),

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -35,6 +35,36 @@ impl super::Updater {
             },
         })
     }
+
+    /// Updates the Ironwood bundle with information in the given closure.
+    pub fn update_ironwood_with<F>(self, f: F) -> Result<Self, OrchardError>
+    where
+        F: FnOnce(Updater<'_>) -> Result<(), UpdaterError>,
+    {
+        let Pczt {
+            global,
+            transparent,
+            sapling,
+            orchard,
+            ironwood,
+        } = self.pczt;
+
+        let mut bundle = ironwood
+            .into_ironwood_parsed()
+            .map_err(OrchardError::Parser)?;
+
+        bundle.update_with(f).map_err(OrchardError::Updater)?;
+
+        Ok(Self {
+            pczt: Pczt {
+                global,
+                transparent,
+                sapling,
+                orchard,
+                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+            },
+        })
+    }
 }
 
 /// Errors that can occur while updating the Orchard bundle of a PCZT.

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -33,6 +33,36 @@ impl super::Verifier {
             },
         })
     }
+
+    /// Parses the Ironwood bundle and then verifies it in the given closure.
+    pub fn with_ironwood<E, F>(self, f: F) -> Result<Self, OrchardError<E>>
+    where
+        F: FnOnce(&orchard::pczt::Bundle) -> Result<(), OrchardError<E>>,
+    {
+        let Pczt {
+            global,
+            transparent,
+            sapling,
+            orchard,
+            ironwood,
+        } = self.pczt;
+
+        let bundle = ironwood
+            .into_ironwood_parsed()
+            .map_err(OrchardError::Parse)?;
+
+        f(&bundle)?;
+
+        Ok(Self {
+            pczt: Pczt {
+                global,
+                transparent,
+                sapling,
+                orchard,
+                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+            },
+        })
+    }
 }
 
 /// Errors that can occur while verifying the Orchard bundle of a PCZT.

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -45,6 +45,16 @@ pub struct Bundle {
     pub(crate) bsk: Option<[u8; 32]>,
 }
 
+/// The canonical empty Sapling bundle: the form the Sapling bundle of a PCZT takes
+/// when it carries no Sapling data.
+pub(crate) const EMPTY_BUNDLE: Bundle = Bundle {
+    spends: Vec::new(),
+    outputs: Vec::new(),
+    value_sum: 0,
+    anchor: [0; 32],
+    bsk: None,
+};
+
 /// Information about a Sapling spend within a transaction.
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]

--- a/pczt/src/transparent.rs
+++ b/pczt/src/transparent.rs
@@ -27,6 +27,13 @@ pub struct Bundle {
     pub(crate) outputs: Vec<Output>,
 }
 
+/// The canonical empty transparent bundle: the form the transparent bundle of a PCZT
+/// takes when it carries no transparent data.
+pub(crate) const EMPTY_BUNDLE: Bundle = Bundle {
+    inputs: Vec::new(),
+    outputs: Vec::new(),
+};
+
 /// Information about a transparent input within a transaction.
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Getters)]


### PR DESCRIPTION
Stacked on #2516; resolves the remainder of the pczt gaps identified in the #2509
review. Closes #2519.

## Canonical empty bundle states

The Creator, `Creator::build_from_parts`, the v1/v2 serialization formats, and the IO
Finalizer previously produced four different representations of an "empty" Ironwood
bundle (and inconsistent empty Sapling/Orchard bundles), breaking `Bundle::merge` for
Combiner workflows that mix serialization-round-tripped and in-memory copies of a PCZT.
Each bundle type now has a single canonical empty representation used everywhere:

- The Creator's Ironwood placeholder no longer mirrors the Orchard bundle's flags and
  anchor (its flags are now the Ironwood defaults, with cross-address transfers enabled).
- `build_from_parts` uses the canonical empties (all-zeroes anchors rather than the
  empty-tree root) for absent bundles, and maps `parts.ironwood` through instead of
  discarding it — fixing the builder→PCZT path silently losing Ironwood spends/outputs.
- Empty bundle value sums are non-negative zero, matching re-serialized parsed bundles.
- The IO Finalizer no longer sets `bsk` on an empty Orchard-protocol bundle. (Sapling is
  still always finalized: its Transaction Extractor requires `bsk` even when empty.)
- The v2 omission decision is exact equality with the slot's canonical empty bundle, so
  non-default flags/note-version round-trip losslessly instead of being restored to
  defaults; v1 refuses to encode a PCZT whose Ironwood bundle is not canonically empty.

## Creator v6 support and extraction validation

- `Creator::new` derives the transaction version/version group ID from the consensus
  branch ID (v6 from NU6.3 onward); new `with_ironwood_anchor`/`with_ironwood_flags`
  configure the Ironwood bundle, rejecting use with non-v6 versions.
- Transaction extraction rejects v6 PCZTs whose branch ID predates NU6.3, and non-v6
  PCZTs carrying non-canonical Ironwood data, instead of silently dropping it or
  extracting a consensus-invalid transaction.
- The v1 format refuses to encode v6 PCZTs (parseable by 0.7.0 peers but never
  extractable).

## High-level Ironwood role methods

- `Signer::{sign_ironwood, apply_ironwood_signature}`, `Verifier::with_ironwood`, and
  `Updater::update_ironwood_with` — mechanical mirrors of the Orchard-pool methods, so
  hardware-wallet-style signers no longer need the low-level Signer to authorize
  Ironwood actions.

One deliberate leftover: the Signer's `empty_ironwood` passthrough is likely removable
now that empty-bundle parse/serialize round-trips are canonical, but that simplification
is left for a follow-up rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

