### PR TITLE
zcash_protocol: Rename `ShieldedProtocol` to `ShieldedPool` and add `ShieldedPool::Ironwood`

### DIFF
--- a/components/zcash_protocol/src/lib.rs
+++ b/components/zcash_protocol/src/lib.rs
@@ -32,14 +32,17 @@ pub mod value;
 mod txid;
 pub use txid::TxId;
 
-/// A Zcash shielded transfer protocol.
+/// A Zcash shielded pool.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ShieldedProtocol {
-    /// The Sapling protocol
+pub enum ShieldedPool {
+    /// The Sapling pool
     Sapling,
-    /// The Orchard protocol
+    /// The Orchard pool
     Orchard,
 }
+
+#[deprecated(note = "Use `ShieldedPool` instead.")]
+pub type ShieldedProtocol = ShieldedPool;
 
 /// A value pool in the Zcash protocol.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -47,21 +50,21 @@ pub enum PoolType {
     /// The transparent value pool
     Transparent,
     /// A shielded value pool.
-    Shielded(ShieldedProtocol),
+    Shielded(ShieldedPool),
 }
 
 impl PoolType {
     pub const TRANSPARENT: PoolType = PoolType::Transparent;
-    pub const SAPLING: PoolType = PoolType::Shielded(ShieldedProtocol::Sapling);
-    pub const ORCHARD: PoolType = PoolType::Shielded(ShieldedProtocol::Orchard);
+    pub const SAPLING: PoolType = PoolType::Shielded(ShieldedPool::Sapling);
+    pub const ORCHARD: PoolType = PoolType::Shielded(ShieldedPool::Orchard);
 }
 
 impl fmt::Display for PoolType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PoolType::Transparent => f.write_str("Transparent"),
-            PoolType::Shielded(ShieldedProtocol::Sapling) => f.write_str("Sapling"),
-            PoolType::Shielded(ShieldedProtocol::Orchard) => f.write_str("Orchard"),
+            PoolType::Shielded(ShieldedPool::Sapling) => f.write_str("Sapling"),
+            PoolType::Shielded(ShieldedPool::Orchard) => f.write_str("Orchard"),
         }
     }
 }
@@ -70,17 +73,14 @@ impl fmt::Display for PoolType {
 pub mod testing {
     use proptest::prelude::{Just, Strategy, prop_oneof};
 
-    use super::ShieldedProtocol;
+    use super::ShieldedPool;
 
-    /// A [`proptest`] strategy that yields a [`ShieldedProtocol`] variant uniformly at
+    /// A [`proptest`] strategy that yields a [`ShieldedPool`] variant uniformly at
     /// random.
     ///
     /// This is useful for properties that should hold for every shielded protocol, so that
     /// the protocol does not have to be hard-coded in each test.
-    pub fn arb_protocol() -> impl Strategy<Value = ShieldedProtocol> {
-        prop_oneof![
-            Just(ShieldedProtocol::Sapling),
-            Just(ShieldedProtocol::Orchard),
-        ]
+    pub fn arb_protocol() -> impl Strategy<Value = ShieldedPool> {
+        prop_oneof![Just(ShieldedPool::Sapling), Just(ShieldedPool::Orchard),]
     }
 }

--- a/components/zcash_protocol/src/lib.rs
+++ b/components/zcash_protocol/src/lib.rs
@@ -39,6 +39,8 @@ pub enum ShieldedPool {
     Sapling,
     /// The Orchard pool
     Orchard,
+    /// The Ironwood pool
+    Ironwood,
 }
 
 #[deprecated(note = "Use `ShieldedPool` instead.")]
@@ -57,6 +59,7 @@ impl PoolType {
     pub const TRANSPARENT: PoolType = PoolType::Transparent;
     pub const SAPLING: PoolType = PoolType::Shielded(ShieldedPool::Sapling);
     pub const ORCHARD: PoolType = PoolType::Shielded(ShieldedPool::Orchard);
+    pub const IRONWOOD: PoolType = PoolType::Shielded(ShieldedPool::Ironwood);
 }
 
 impl fmt::Display for PoolType {
@@ -65,6 +68,7 @@ impl fmt::Display for PoolType {
             PoolType::Transparent => f.write_str("Transparent"),
             PoolType::Shielded(ShieldedPool::Sapling) => f.write_str("Sapling"),
             PoolType::Shielded(ShieldedPool::Orchard) => f.write_str("Orchard"),
+            PoolType::Shielded(ShieldedPool::Ironwood) => f.write_str("Ironwood"),
         }
     }
 }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -83,7 +83,7 @@ use zcash_keys::{
 };
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
 use zcash_protocol::{
-    PoolType, ShieldedProtocol, TxId,
+    PoolType, ShieldedPool, TxId,
     consensus::{self, BlockHeight, TxIndex},
     memo::{Memo, MemoBytes},
     value::{BalanceError, Zatoshis},
@@ -1283,10 +1283,10 @@ impl AccountMeta {
     }
 
     /// Returns the number of unspent notes in the wallet for the given shielded protocol.
-    pub fn note_count(&self, protocol: ShieldedProtocol) -> Option<usize> {
+    pub fn note_count(&self, protocol: ShieldedPool) -> Option<usize> {
         match protocol {
-            ShieldedProtocol::Sapling => self.sapling_note_count(),
-            ShieldedProtocol::Orchard => self.orchard_note_count(),
+            ShieldedPool::Sapling => self.sapling_note_count(),
+            ShieldedPool::Orchard => self.orchard_note_count(),
         }
     }
 
@@ -1464,7 +1464,7 @@ pub trait InputSource {
     fn get_spendable_note(
         &self,
         txid: &TxId,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error>;
@@ -1476,7 +1476,7 @@ pub trait InputSource {
         &self,
         account: Self::AccountId,
         target_value: TargetValue,
-        sources: &[ShieldedProtocol],
+        sources: &[ShieldedPool],
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
@@ -1487,7 +1487,7 @@ pub trait InputSource {
     fn select_unspent_notes(
         &self,
         account: Self::AccountId,
-        sources: &[ShieldedProtocol],
+        sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
@@ -2016,7 +2016,7 @@ pub trait WalletTest: InputSource + WalletRead {
     fn get_sent_note_ids(
         &self,
         _txid: &TxId,
-        _protocol: ShieldedProtocol,
+        _protocol: ShieldedPool,
     ) -> Result<Vec<NoteId>, <Self as WalletRead>::Error>;
 
     /// Returns the outputs for a transaction sent by the wallet.
@@ -2029,7 +2029,7 @@ pub trait WalletTest: InputSource + WalletRead {
     #[allow(clippy::type_complexity)]
     fn get_checkpoint_history(
         &self,
-        protocol: &ShieldedProtocol,
+        protocol: &ShieldedPool,
     ) -> Result<
         Vec<(BlockHeight, Option<incrementalmerkletree::Position>)>,
         <Self as WalletRead>::Error,
@@ -2063,7 +2063,7 @@ pub trait WalletTest: InputSource + WalletRead {
     /// Returns all the notes that have been received by the wallet.
     fn get_notes(
         &self,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
     ) -> Result<Vec<ReceivedNote<Self::NoteRef, Note>>, <Self as InputSource>::Error>;
 
     /// Returns a vector of ephemeral transparent addresses associated with the given

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1287,6 +1287,7 @@ impl AccountMeta {
         match protocol {
             ShieldedPool::Sapling => self.sapling_note_count(),
             ShieldedPool::Orchard => self.orchard_note_count(),
+            ShieldedPool::Ironwood => todo!("Ironwood note counts are not yet tracked"),
         }
     }
 

--- a/zcash_client_backend/src/data_api/ll.rs
+++ b/zcash_client_backend/src/data_api/ll.rs
@@ -20,7 +20,7 @@ use zcash_primitives::{
     transaction::{Transaction, TransactionData},
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol, TxId,
+    PoolType, ShieldedPool, TxId,
     consensus::{BlockHeight, TxIndex},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -580,7 +580,7 @@ pub trait LowLevelWalletWrite: LowLevelWalletRead {
     fn notify_scan_complete(
         &mut self,
         range: Range<BlockHeight>,
-        wallet_note_positions: &[(ShieldedProtocol, Position)],
+        wallet_note_positions: &[(ShieldedPool, Position)],
     ) -> Result<(), Self::Error>;
 
     #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -14,7 +14,7 @@ use transparent::{address::TransparentAddress, bundle::OutPoint};
 use zcash_keys::{address::Receiver, encoding::AddressCodec as _};
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     value::{BalanceError, Zatoshis},
 };
@@ -137,7 +137,7 @@ pub enum PutBlocksError<SE, TE> {
     /// the wallet when the error occurred.
     ShardTreeForBlockRange {
         /// The shielded pool whose note commitment tree was being updated when the error occurred.
-        pool: ShieldedProtocol,
+        pool: ShieldedPool,
         /// The range of block heights that were being added to the wallet when the error
         /// occurred.
         block_range: Range<BlockHeight>,
@@ -374,19 +374,16 @@ where
             .map_err(PutBlocksError::Storage)?;
 
         note_positions.extend(block.transactions().iter().flat_map(|wtx| {
-            let iter = wtx.sapling_outputs().iter().map(|out| {
-                (
-                    ShieldedProtocol::Sapling,
-                    out.note_commitment_tree_position(),
-                )
-            });
+            let iter = wtx
+                .sapling_outputs()
+                .iter()
+                .map(|out| (ShieldedPool::Sapling, out.note_commitment_tree_position()));
             #[cfg(feature = "orchard")]
-            let iter = iter.chain(wtx.orchard_outputs().iter().map(|out| {
-                (
-                    ShieldedProtocol::Orchard,
-                    out.note_commitment_tree_position(),
-                )
-            }));
+            let iter = iter.chain(
+                wtx.orchard_outputs()
+                    .iter()
+                    .map(|out| (ShieldedPool::Orchard, out.note_commitment_tree_position())),
+            );
 
             iter
         }));
@@ -494,7 +491,7 @@ where
                     &mut missing_checkpoints,
                 )
                 .map_err(|error| PutBlocksError::ShardTreeForBlockRange {
-                    pool: ShieldedProtocol::Sapling,
+                    pool: ShieldedPool::Sapling,
                     block_range: from_state.block_height()..(last_scanned_height + 1),
                     error,
                 })
@@ -516,7 +513,7 @@ where
                     &mut missing_checkpoints,
                 )
                 .map_err(|error| PutBlocksError::ShardTreeForBlockRange {
-                    pool: ShieldedProtocol::Orchard,
+                    pool: ShieldedPool::Orchard,
                     block_range: from_state.block_height()..(last_scanned_height + 1),
                     error,
                 })

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -35,7 +35,7 @@ use zcash_primitives::{
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, Network, NetworkUpgrade, Parameters as _},
     local_consensus::LocalNetwork,
     memo::{Memo, MemoBytes},
@@ -945,9 +945,9 @@ where
         let input_selector = GreedyInputSelector::new();
 
         #[cfg(not(feature = "orchard"))]
-        let fallback_change_pool = ShieldedProtocol::Sapling;
+        let fallback_change_pool = ShieldedPool::Sapling;
         #[cfg(feature = "orchard")]
-        let fallback_change_pool = ShieldedProtocol::Orchard;
+        let fallback_change_pool = ShieldedPool::Orchard;
 
         let change_strategy = standard::SingleOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
@@ -1071,7 +1071,7 @@ where
             self.wallet_mut(),
             &network,
             spend_from_account,
-            &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+            &[ShieldedPool::Sapling, ShieldedPool::Orchard],
             fee_rule,
             to,
             memo,
@@ -1092,7 +1092,7 @@ where
         amount: Zatoshis,
         memo: Option<MemoBytes>,
         change_memo: Option<MemoBytes>,
-        fallback_change_pool: ShieldedProtocol,
+        fallback_change_pool: ShieldedPool,
     ) -> Result<
         Proposal<StandardFeeRule, <DbT as InputSource>::NoteRef>,
         super::wallet::ProposeTransferErrT<
@@ -1451,7 +1451,7 @@ impl<Cache, DbT: WalletRead + Reset> TestState<Cache, DbT, LocalNetwork> {
 pub fn single_output_change_strategy<DbT: InputSource>(
     fee_rule: StandardFeeRule,
     change_memo: Option<&str>,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
 ) -> standard::SingleOutputChangeStrategy<DbT> {
     let change_memo = change_memo.map(|m| MemoBytes::from(m.parse::<Memo>().unwrap()));
     standard::SingleOutputChangeStrategy::new(
@@ -2714,7 +2714,7 @@ impl InputSource for MockWalletDb {
     fn get_spendable_note(
         &self,
         _txid: &TxId,
-        _protocol: ShieldedProtocol,
+        _protocol: ShieldedPool,
         _index: u32,
         _target_height: TargetHeight,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
@@ -2725,7 +2725,7 @@ impl InputSource for MockWalletDb {
         &self,
         _account: Self::AccountId,
         _target_value: TargetValue,
-        _sources: &[ShieldedProtocol],
+        _sources: &[ShieldedPool],
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _exclude: &[Self::NoteRef],
@@ -2736,7 +2736,7 @@ impl InputSource for MockWalletDb {
     fn select_unspent_notes(
         &self,
         _account: Self::AccountId,
-        _sources: &[ShieldedProtocol],
+        _sources: &[ShieldedPool],
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -15,7 +15,7 @@ use zcash_keys::{
 use zcash_note_encryption::try_output_recovery_with_ovk;
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::Zatoshis,
@@ -35,7 +35,7 @@ use crate::{
 /// Type for running pool-agnostic tests on the Orchard pool.
 pub struct OrchardPoolTester;
 impl ShieldedPoolTester for OrchardPoolTester {
-    const SHIELDED_PROTOCOL: ShieldedProtocol = ShieldedProtocol::Orchard;
+    const SHIELDED_PROTOCOL: ShieldedPool = ShieldedPool::Orchard;
     // const MERKLE_TREE_DEPTH: u8 = {orchard::NOTE_COMMITMENT_TREE_DEPTH as u8};
 
     type Sk = SpendingKey;
@@ -134,7 +134,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
             .select_spendable_notes(
                 account,
                 target_value,
-                &[ShieldedProtocol::Orchard],
+                &[ShieldedPool::Orchard],
                 target_height,
                 confirmations_policy,
                 exclude,
@@ -149,12 +149,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
-            .select_unspent_notes(
-                account,
-                &[ShieldedProtocol::Orchard],
-                target_height,
-                exclude,
-            )
+            .select_unspent_notes(account, &[ShieldedPool::Orchard], target_height, exclude)
             .map(|n| n.take_orchard())
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -22,7 +22,7 @@ use zcash_primitives::{
     },
 };
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, COINBASE_MATURITY_BLOCKS, NetworkUpgrade, Parameters},
     local_consensus::LocalNetwork,
     memo::{Memo, MemoBytes},
@@ -108,7 +108,7 @@ use dsl::{TestDsl, TestNoteConfig};
     doc = "[`OrchardPoolTester`]: https://github.com/zcash/librustzcash/blob/0777cbc2def6ba6b99f96333eaf96c314c1f3a37/zcash_client_backend/src/data_api/testing/orchard.rs#L33"
 )]
 pub trait ShieldedPoolTester {
-    const SHIELDED_PROTOCOL: ShieldedProtocol;
+    const SHIELDED_PROTOCOL: ShieldedPool;
 
     type Sk;
     type Fvk: TestFvk;
@@ -3997,10 +3997,7 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     // Since this is a cross-pool transfer, change will be sent to the preferred pool.
     assert_eq!(
         change_output.output_pool(),
-        PoolType::Shielded(std::cmp::max(
-            ShieldedProtocol::Sapling,
-            ShieldedProtocol::Orchard
-        ))
+        PoolType::Shielded(std::cmp::max(ShieldedPool::Sapling, ShieldedPool::Orchard))
     );
     assert_eq!(change_output.value(), expected_change);
 

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -9,7 +9,7 @@ use shardtree::error::ShardTreeError;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::transaction::{Transaction, components::sapling::zip212_enforcement};
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::Zatoshis,
@@ -31,7 +31,7 @@ use super::{TestState, pool::ShieldedPoolTester};
 /// Type for running pool-agnostic tests on the Sapling pool.
 pub struct SaplingPoolTester;
 impl ShieldedPoolTester for SaplingPoolTester {
-    const SHIELDED_PROTOCOL: ShieldedProtocol = ShieldedProtocol::Sapling;
+    const SHIELDED_PROTOCOL: ShieldedPool = ShieldedPool::Sapling;
     // const MERKLE_TREE_DEPTH: u8 = sapling::NOTE_COMMITMENT_TREE_DEPTH;
 
     type Sk = ExtendedSpendingKey;
@@ -118,7 +118,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
             .select_spendable_notes(
                 account,
                 target_value,
-                &[ShieldedProtocol::Sapling],
+                &[ShieldedPool::Sapling],
                 target_height,
                 confirmations_policy,
                 exclude,
@@ -133,12 +133,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
-            .select_unspent_notes(
-                account,
-                &[ShieldedProtocol::Sapling],
-                target_height,
-                exclude,
-            )
+            .select_unspent_notes(account, &[ShieldedPool::Sapling], target_height, exclude)
             .map(|n| n.take_sapling())
     }
 

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -26,9 +26,7 @@ use crate::{
     data_api::{
         Account as _, Balance, InputSource as _, TransparentOutputFilter, WalletRead as _,
         WalletTest as _, WalletWrite,
-        testing::{
-            AddressType, DataStoreFactory, ShieldedProtocol, TestBuilder, TestCache, TestState,
-        },
+        testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
             input_selection::GreedyInputSelector,
@@ -286,7 +284,7 @@ where
     let change_strategy = standard::SingleOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         DustOutputPolicy::default(),
     );
     let txid = st
@@ -429,7 +427,7 @@ where
     let change_strategy = standard::SingleOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         DustOutputPolicy::default(),
     );
     let txids = st
@@ -638,7 +636,7 @@ where
     let change_strategy = standard::SingleOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         DustOutputPolicy::default(),
     );
     let proposal = st
@@ -1201,7 +1199,7 @@ where
     let change_strategy = standard::SingleOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         DustOutputPolicy::default(),
     );
 
@@ -1544,7 +1542,7 @@ where
     let change_strategy = standard::SingleOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         DustOutputPolicy::default(),
     );
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1625,6 +1625,9 @@ where
                     let to = *ua.transparent().expect("The mapping between payment pool and receiver is checked in step construction");
                     add_transparent_output(&mut builder, &mut transparent_output_meta, to)?;
                 }
+                PoolType::Shielded(ShieldedPool::Ironwood) => {
+                    todo!("Ironwood pool support is not yet implemented")
+                }
             },
             Address::Sapling(to) => {
                 add_sapling_output(&mut builder, &mut sapling_output_meta, to)?;
@@ -1699,6 +1702,9 @@ where
             PoolType::Transparent => {
                 #[cfg(not(feature = "transparent-inputs"))]
                 return Err(Error::UnsupportedChangeType(output_pool));
+            }
+            PoolType::Shielded(ShieldedPool::Ironwood) => {
+                todo!("Ironwood pool support is not yet implemented")
             }
         }
     }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -75,7 +75,7 @@ use zcash_primitives::transaction::{
     fees::FeeRule,
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -707,7 +707,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     amount: Zatoshis,
     memo: Option<MemoBytes>,
     change_memo: Option<MemoBytes>,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
     #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<StandardFeeRule, DbT::NoteRef>,
@@ -769,7 +769,7 @@ pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
     wallet_db: &mut DbT,
     params: &ParamsT,
     spend_from_account: <DbT as InputSource>::AccountId,
-    spend_pools: &[ShieldedProtocol],
+    spend_pools: &[ShieldedPool],
     fee_rule: &FeeRuleT,
     recipient: ZcashAddress,
     memo: Option<MemoBytes>,
@@ -1236,7 +1236,7 @@ where
     }
 
     let (sapling_anchor, sapling_inputs) = if proposal_step
-        .involves(PoolType::Shielded(ShieldedProtocol::Sapling))
+        .involves(PoolType::Shielded(ShieldedPool::Sapling))
     {
         proposal_step.shielded_inputs().map_or_else(
             || Ok((Some(sapling::Anchor::empty_tree()), vec![])),
@@ -1280,7 +1280,7 @@ where
 
     #[cfg(feature = "orchard")]
     let (orchard_anchor, orchard_inputs) = if proposal_step
-        .involves(PoolType::Shielded(ShieldedProtocol::Orchard))
+        .involves(PoolType::Shielded(ShieldedPool::Orchard))
     {
         proposal_step.shielded_inputs().map_or_else(
             || Ok((Some(orchard::Anchor::empty_tree()), vec![])),
@@ -1609,15 +1609,15 @@ where
         {
             Address::Unified(ua) => match output_pool {
                 #[cfg(not(feature = "orchard"))]
-                PoolType::Shielded(ShieldedProtocol::Orchard) => {
+                PoolType::Shielded(ShieldedPool::Orchard) => {
                     return Err(Error::ProposalNotSupported);
                 }
                 #[cfg(feature = "orchard")]
-                PoolType::Shielded(ShieldedProtocol::Orchard) => {
+                PoolType::Shielded(ShieldedPool::Orchard) => {
                     let to = *ua.orchard().expect("The mapping between payment pool and receiver is checked in step construction");
                     add_orchard_output(&mut builder, &mut orchard_output_meta, to)?;
                 }
-                PoolType::Shielded(ShieldedProtocol::Sapling) => {
+                PoolType::Shielded(ShieldedPool::Sapling) => {
                     let to = *ua.sapling().expect("The mapping between payment pool and receiver is checked in step construction");
                     add_sapling_output(&mut builder, &mut sapling_output_meta, to)?;
                 }
@@ -1653,7 +1653,7 @@ where
             .map_or_else(MemoBytes::empty, |m| m.clone());
         let output_pool = change_value.output_pool();
         match output_pool {
-            PoolType::Shielded(ShieldedProtocol::Sapling) => {
+            PoolType::Shielded(ShieldedPool::Sapling) => {
                 builder.add_sapling_output(
                     internal_ovk.map(|k| k.into()),
                     ufvk.sapling()
@@ -1672,7 +1672,7 @@ where
                     Some(memo),
                 ))
             }
-            PoolType::Shielded(ShieldedProtocol::Orchard) => {
+            PoolType::Shielded(ShieldedPool::Orchard) => {
                 #[cfg(not(feature = "orchard"))]
                 return Err(Error::UnsupportedChangeType(output_pool));
 
@@ -2479,7 +2479,7 @@ where
         domain: D,
         note: D::Note,
         output: &O,
-        output_pool: ShieldedProtocol,
+        output_pool: ShieldedPool,
         output_index: usize,
         pczt_recipient: PcztRecipient<AccountId>,
         external_address: Option<ZcashAddress>,
@@ -2540,7 +2540,7 @@ where
                             domain,
                             note,
                             action,
-                            ShieldedProtocol::Orchard,
+                            ShieldedPool::Orchard,
                             output_index,
                             pczt_recipient,
                             external_address,
@@ -2571,7 +2571,7 @@ where
                             domain,
                             note,
                             action,
-                            ShieldedProtocol::Sapling,
+                            ShieldedPool::Sapling,
                             output_index,
                             pczt_recipient,
                             external_address,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -16,7 +16,7 @@ use zcash_primitives::transaction::fees::{
     zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -803,11 +803,11 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
 
             let selectable_pools = {
                 if orchard_supported && sapling_supported {
-                    &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard][..]
+                    &[ShieldedPool::Sapling, ShieldedPool::Orchard][..]
                 } else if orchard_supported {
-                    &[ShieldedProtocol::Orchard][..]
+                    &[ShieldedPool::Orchard][..]
                 } else if sapling_supported {
-                    &[ShieldedProtocol::Sapling][..]
+                    &[ShieldedPool::Sapling][..]
                 } else {
                     &[]
                 }
@@ -862,7 +862,7 @@ pub(crate) fn propose_send_max<ParamsT, InputSourceT, FeeRuleT>(
     wallet_db: &InputSourceT,
     fee_rule: &FeeRuleT,
     source_account: InputSourceT::AccountId,
-    spend_pools: &[ShieldedProtocol],
+    spend_pools: &[ShieldedPool],
     target_height: TargetHeight,
     anchor_height: BlockHeight,
     mode: MaxSpendMode,

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -11,7 +11,7 @@ use zcash_primitives::transaction::fees::{
     zip317::{self as prim_zip317},
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -73,7 +73,7 @@ pub struct ChangeValue(ChangeValueInner);
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum ChangeValueInner {
     Shielded {
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         value: Zatoshis,
         memo: Option<MemoBytes>,
     },
@@ -89,7 +89,7 @@ impl ChangeValue {
     }
 
     /// Constructs a new change value that will be created as a shielded output.
-    pub fn shielded(protocol: ShieldedProtocol, value: Zatoshis, memo: Option<MemoBytes>) -> Self {
+    pub fn shielded(protocol: ShieldedPool, value: Zatoshis, memo: Option<MemoBytes>) -> Self {
         Self(ChangeValueInner::Shielded {
             protocol,
             value,
@@ -99,13 +99,13 @@ impl ChangeValue {
 
     /// Constructs a new change value that will be created as a Sapling output.
     pub fn sapling(value: Zatoshis, memo: Option<MemoBytes>) -> Self {
-        Self::shielded(ShieldedProtocol::Sapling, value, memo)
+        Self::shielded(ShieldedPool::Sapling, value, memo)
     }
 
     /// Constructs a new change value that will be created as an Orchard output.
     #[cfg(feature = "orchard")]
     pub fn orchard(value: Zatoshis, memo: Option<MemoBytes>) -> Self {
-        Self::shielded(ShieldedProtocol::Orchard, value, memo)
+        Self::shielded(ShieldedPool::Orchard, value, memo)
     }
 
     /// Returns the pool to which the change or ephemeral output should be sent.

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -5,7 +5,7 @@ use zcash_primitives::transaction::fees::{
     FeeRule, transparent, zip317::MINIMUM_FEE, zip317::P2PKH_STANDARD_OUTPUT_SIZE,
 };
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -117,24 +117,24 @@ where
 /// Decide which shielded pool change should go to if there is any.
 pub(crate) fn select_change_pool(
     _net_flows: &NetFlows,
-    _fallback_change_pool: ShieldedProtocol,
-) -> ShieldedProtocol {
+    _fallback_change_pool: ShieldedPool,
+) -> ShieldedPool {
     // TODO: implement a less naive strategy for selecting the pool to which change will be sent.
     #[cfg(feature = "orchard")]
     if _net_flows.orchard_in.is_positive() || _net_flows.orchard_out.is_positive() {
         // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
-        ShieldedProtocol::Orchard
+        ShieldedPool::Orchard
     } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
         // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
         // Sapling outputs, so that we avoid pool-crossing.
-        ShieldedProtocol::Sapling
+        ShieldedPool::Sapling
     } else {
         // The flows are transparent, so there may not be change. If there is, the caller
         // gets to decide where to shield it.
         _fallback_change_pool
     }
     #[cfg(not(feature = "orchard"))]
-    ShieldedProtocol::Sapling
+    ShieldedPool::Sapling
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -170,7 +170,7 @@ pub(crate) struct SinglePoolBalanceConfig<'a, P, F> {
     dust_output_policy: &'a DustOutputPolicy,
     default_dust_threshold: Zatoshis,
     split_policy: &'a SplitPolicy,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
     marginal_fee: Zatoshis,
     grace_actions: usize,
 }
@@ -183,7 +183,7 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
         dust_output_policy: &'a DustOutputPolicy,
         default_dust_threshold: Zatoshis,
         split_policy: &'a SplitPolicy,
-        fallback_change_pool: ShieldedProtocol,
+        fallback_change_pool: ShieldedPool,
         marginal_fee: Zatoshis,
         grace_actions: usize,
     ) -> Self {
@@ -241,12 +241,12 @@ where
     });
     let target_change_counts = OutputManifest {
         transparent: 0,
-        sapling: if change_pool == ShieldedProtocol::Sapling {
+        sapling: if change_pool == ShieldedPool::Sapling {
             target_change_count
         } else {
             0
         },
-        orchard: if change_pool == ShieldedProtocol::Orchard {
+        orchard: if change_pool == ShieldedPool::Orchard {
             target_change_count
         } else {
             0
@@ -444,12 +444,12 @@ where
                         transparent_input_sizes,
                         transparent_output_sizes,
                         sapling_input_count,
-                        sapling_output_count(if change_pool == ShieldedProtocol::Sapling {
+                        sapling_output_count(if change_pool == ShieldedPool::Sapling {
                             split_count
                         } else {
                             0
                         })?,
-                        orchard_action_count(if change_pool == ShieldedProtocol::Orchard {
+                        orchard_action_count(if change_pool == ShieldedPool::Orchard {
                             split_count
                         } else {
                             0

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 use zcash_primitives::transaction::fees::{fixed::FeeRule as FixedFeeRule, transparent};
 use zcash_protocol::{
-    ShieldedProtocol, consensus,
+    ShieldedPool, consensus,
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
 };
@@ -28,7 +28,7 @@ use super::orchard as orchard_fees;
 pub struct SingleOutputChangeStrategy<I> {
     fee_rule: FixedFeeRule,
     change_memo: Option<MemoBytes>,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
     meta_source: PhantomData<I>,
 }
@@ -42,7 +42,7 @@ impl<I> SingleOutputChangeStrategy<I> {
     pub fn new(
         fee_rule: FixedFeeRule,
         change_memo: Option<MemoBytes>,
-        fallback_change_pool: ShieldedProtocol,
+        fallback_change_pool: ShieldedPool,
         dust_output_policy: DustOutputPolicy,
     ) -> Self {
         Self {
@@ -120,7 +120,7 @@ mod tests {
         fixed::FeeRule as FixedFeeRule, zip317::MINIMUM_FEE,
     };
     use zcash_protocol::{
-        ShieldedProtocol,
+        ShieldedPool,
         consensus::{Network, NetworkUpgrade, Parameters},
         value::Zatoshis,
     };
@@ -143,7 +143,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<MockWalletDb>::new(
             fee_rule,
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 
@@ -184,7 +184,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<MockWalletDb>::new(
             fee_rule,
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 
 use zcash_primitives::transaction::fees::{FeeRule, transparent, zip317 as prim_zip317};
 use zcash_protocol::{
-    ShieldedProtocol, consensus,
+    ShieldedPool, consensus,
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
 };
@@ -65,7 +65,7 @@ impl Zip317FeeRule for StandardFeeRule {
 pub struct SingleOutputChangeStrategy<R, I> {
     fee_rule: R,
     change_memo: Option<MemoBytes>,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
     meta_source: PhantomData<I>,
 }
@@ -79,7 +79,7 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
     pub fn new(
         fee_rule: R,
         change_memo: Option<MemoBytes>,
-        fallback_change_pool: ShieldedProtocol,
+        fallback_change_pool: ShieldedPool,
         dust_output_policy: DustOutputPolicy,
     ) -> Self {
         Self {
@@ -160,7 +160,7 @@ where
 pub struct MultiOutputChangeStrategy<R, I> {
     fee_rule: R,
     change_memo: Option<MemoBytes>,
-    fallback_change_pool: ShieldedProtocol,
+    fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
     split_policy: SplitPolicy,
     meta_source: PhantomData<I>,
@@ -181,7 +181,7 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
     pub fn new(
         fee_rule: R,
         change_memo: Option<MemoBytes>,
-        fallback_change_pool: ShieldedProtocol,
+        fallback_change_pool: ShieldedPool,
         dust_output_policy: DustOutputPolicy,
         split_policy: SplitPolicy,
     ) -> Self {
@@ -271,7 +271,7 @@ mod tests {
     use ::transparent::{address::Script, bundle::TxOut};
     use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
     use zcash_protocol::{
-        ShieldedProtocol,
+        ShieldedPool,
         consensus::{Network, NetworkUpgrade, Parameters},
         value::Zatoshis,
     };
@@ -299,7 +299,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 
@@ -339,7 +339,7 @@ mod tests {
         let change_strategy = MultiOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(5).unwrap(),
@@ -563,7 +563,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
         );
 
@@ -609,7 +609,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
         );
 
@@ -663,7 +663,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             dust_output_policy,
         );
 
@@ -710,7 +710,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 
@@ -756,7 +756,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 
@@ -802,7 +802,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::new(
                 DustAction::AllowDustChange,
                 Some(Zatoshis::const_from_u64(1000)),
@@ -862,7 +862,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             dust_output_policy,
         );
 
@@ -911,7 +911,7 @@ mod tests {
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
             Zip317FeeRule::standard(),
             None,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             DustOutputPolicy::default(),
         );
 

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -96,8 +96,8 @@ pub mod keys {
 }
 #[deprecated(note = "use ::zcash_protocol::PoolType instead")]
 pub type PoolType = zcash_protocol::PoolType;
-#[deprecated(note = "use ::zcash_protocol::ShieldedProtocol instead")]
-pub type ShieldedProtocol = zcash_protocol::ShieldedProtocol;
+#[deprecated(note = "use ::zcash_protocol::ShieldedPool instead")]
+pub type ShieldedPool = zcash_protocol::ShieldedPool;
 #[deprecated(note = "This module is deprecated; use the `zip321` crate instead.")]
 pub mod zip321 {
     pub use zip321::*;

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -7,7 +7,7 @@ use std::{
 
 use nonempty::NonEmpty;
 use zcash_primitives::transaction::TxId;
-use zcash_protocol::{PoolType, ShieldedProtocol, consensus::BlockHeight, value::Zatoshis};
+use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 use zip321::{TransactionRequest, Zip321Error};
 
 use crate::{
@@ -587,12 +587,12 @@ impl<NoteRef> Step<NoteRef> {
             PoolType::SAPLING => self.shielded_inputs().iter().any(|s_in| {
                 s_in.notes()
                     .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedProtocol::Sapling))
+                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Sapling))
             }),
             PoolType::ORCHARD => self.shielded_inputs().iter().any(|s_in| {
                 s_in.notes()
                     .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedProtocol::Orchard))
+                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Orchard))
             }),
         }
     }
@@ -623,13 +623,13 @@ impl<NoteRef> Step<NoteRef> {
                 .shielded_inputs()
                 .iter()
                 .flat_map(|s_in| s_in.notes())
-                .filter(|note| note.note().protocol() == ShieldedProtocol::Sapling)
+                .filter(|note| note.note().protocol() == ShieldedPool::Sapling)
                 .count(),
             PoolType::ORCHARD => self
                 .shielded_inputs()
                 .iter()
                 .flat_map(|s_in| s_in.notes())
-                .filter(|note| note.note().protocol() == ShieldedProtocol::Orchard)
+                .filter(|note| note.note().protocol() == ShieldedPool::Orchard)
                 .count(),
         }
     }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -594,6 +594,7 @@ impl<NoteRef> Step<NoteRef> {
                     .iter()
                     .any(|note| matches!(note.note().protocol(), ShieldedPool::Orchard))
             }),
+            PoolType::IRONWOOD => todo!("Ironwood pool support is not yet implemented"),
         }
     }
 
@@ -631,6 +632,7 @@ impl<NoteRef> Step<NoteRef> {
                 .flat_map(|s_in| s_in.notes())
                 .filter(|note| note.note().protocol() == ShieldedPool::Orchard)
                 .count(),
+            PoolType::IRONWOOD => todo!("Ironwood pool support is not yet implemented"),
         }
     }
 

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -582,6 +582,11 @@ impl From<ShieldedPool> for proposal::ValuePool {
         match value {
             ShieldedPool::Sapling => proposal::ValuePool::Sapling,
             ShieldedPool::Orchard => proposal::ValuePool::Orchard,
+            ShieldedPool::Ironwood => {
+                todo!(
+                    "Ironwood value pool is not yet representable in the protobuf proposal format"
+                )
+            }
         }
     }
 }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -18,7 +18,7 @@ use zcash_primitives::{
     transaction::TxId,
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight, NetworkType},
     memo::{self, MemoBytes},
     value::Zatoshis,
@@ -462,7 +462,7 @@ pub enum ProposalDecodingError<DbError> {
     /// The proposal violated balance or structural constraints.
     ProposalInvalid(ProposalError),
     /// An inputs field for the given protocol was present, but contained no input note references.
-    EmptyShieldedInputs(ShieldedProtocol),
+    EmptyShieldedInputs(ShieldedPool),
     /// A memo field was provided for a transparent output.
     TransparentMemo,
     /// Change outputs to the specified pool are not supported.
@@ -577,11 +577,11 @@ impl From<PoolType> for proposal::ValuePool {
     }
 }
 
-impl From<ShieldedProtocol> for proposal::ValuePool {
-    fn from(value: ShieldedProtocol) -> Self {
+impl From<ShieldedPool> for proposal::ValuePool {
+    fn from(value: ShieldedPool) -> Self {
         match value {
-            ShieldedProtocol::Sapling => proposal::ValuePool::Sapling,
-            ShieldedProtocol::Orchard => proposal::ValuePool::Orchard,
+            ShieldedPool::Sapling => proposal::ValuePool::Sapling,
+            ShieldedPool::Orchard => proposal::ValuePool::Orchard,
         }
     }
 }
@@ -860,11 +860,11 @@ impl proposal::Proposal {
                                     })
                                     .transpose()?;
                                 match (cv.pool_type()?, cv.is_ephemeral) {
-                                    (PoolType::Shielded(ShieldedProtocol::Sapling), false) => {
+                                    (PoolType::Shielded(ShieldedPool::Sapling), false) => {
                                         Ok(ChangeValue::sapling(value, memo))
                                     }
                                     #[cfg(feature = "orchard")]
-                                    (PoolType::Shielded(ShieldedProtocol::Orchard), false) => {
+                                    (PoolType::Shielded(ShieldedPool::Orchard), false) => {
                                         Ok(ChangeValue::orchard(value, memo))
                                     }
                                     (PoolType::Transparent, _) if memo.is_some() => {

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -13,7 +13,7 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_note_encryption::{BatchDomain, Domain, ShieldedOutput};
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight},
 };
 use zip32::Scope;
@@ -472,7 +472,7 @@ pub enum ScanError {
     EncodingInvalid {
         at_height: BlockHeight,
         txid: TxId,
-        pool_type: ShieldedProtocol,
+        pool_type: ShieldedPool,
         index: usize,
     },
 
@@ -490,7 +490,7 @@ pub enum ScanError {
     /// The note commitment tree size for the given protocol at the proposed new block is not equal
     /// to the size at the previous block plus the count of this block's outputs.
     TreeSizeMismatch {
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         at_height: BlockHeight,
         given: u32,
         computed: u32,
@@ -500,7 +500,7 @@ pub enum ScanError {
     /// [`CompactBlock`] being scanned, making it impossible to construct the nullifier for a
     /// detected note.
     TreeSizeUnknown {
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         at_height: BlockHeight,
     },
 
@@ -508,14 +508,14 @@ pub enum ScanError {
     /// that is invalidated by the data in the block itself. This may be caused by the presence
     /// of default values in the chain metadata.
     TreeSizeInvalid {
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         at_height: BlockHeight,
     },
 
     /// The size of the note commitment tree for the given protocol would exceed the
     /// `u32` range as a result of applying the outputs in the block being scanned.
     TreeSizeOverflow {
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         at_height: BlockHeight,
     },
 }

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -10,7 +10,7 @@ use tracing::{debug, trace};
 use zcash_note_encryption::batch;
 use zcash_primitives::transaction::components::sapling::zip212_enforcement;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, NetworkUpgrade, TxIndex},
 };
 
@@ -140,7 +140,7 @@ where
                             ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,
-                                pool_type: ShieldedProtocol::Sapling,
+                                pool_type: ShieldedPool::Sapling,
                                 index: i,
                             }
                         })
@@ -160,7 +160,7 @@ where
                         CompactAction::try_from(action).map_err(|_| ScanError::EncodingInvalid {
                             at_height: block_height,
                             txid,
-                            pool_type: ShieldedProtocol::Orchard,
+                            pool_type: ShieldedPool::Orchard,
                             index: i,
                         })
                     })
@@ -296,7 +296,7 @@ where
                             ScanError::EncodingInvalid {
                                 at_height: cur_height,
                                 txid,
-                                pool_type: ShieldedProtocol::Sapling,
+                                pool_type: ShieldedPool::Sapling,
                                 index: i,
                             }
                         })?,
@@ -333,7 +333,7 @@ where
                         ScanError::EncodingInvalid {
                             at_height: cur_height,
                             txid,
-                            pool_type: ShieldedProtocol::Orchard,
+                            pool_type: ShieldedPool::Orchard,
                             index: i,
                         }
                     })?;
@@ -415,7 +415,7 @@ impl PositionTracker {
             params: &P,
             block: &CompactBlock,
             prior_block_metadata: Option<&BlockMetadata>,
-            protocol: ShieldedProtocol,
+            protocol: ShieldedPool,
             activation_nu: NetworkUpgrade,
             prior_tree_size: impl Fn(&BlockMetadata) -> Option<u32>,
             tx_output_count: impl Fn(&CompactTx) -> usize,
@@ -489,7 +489,7 @@ impl PositionTracker {
             params,
             block,
             prior_block_metadata,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             NetworkUpgrade::Sapling,
             |m| m.sapling_tree_size(),
             |tx| tx.outputs.len(),
@@ -501,7 +501,7 @@ impl PositionTracker {
             params,
             block,
             prior_block_metadata,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             NetworkUpgrade::Nu5,
             |m| m.orchard_tree_size(),
             |tx| tx.actions.len(),
@@ -556,7 +556,7 @@ impl PositionTracker {
         if let Some(chain_meta) = chain_metadata {
             if chain_meta.sapling_commitment_tree_size != self.sapling_tree_position {
                 return Err(ScanError::TreeSizeMismatch {
-                    protocol: ShieldedProtocol::Sapling,
+                    protocol: ShieldedPool::Sapling,
                     at_height,
                     given: chain_meta.sapling_commitment_tree_size,
                     computed: self.sapling_tree_position,
@@ -566,7 +566,7 @@ impl PositionTracker {
             #[cfg(feature = "orchard")]
             if chain_meta.orchard_commitment_tree_size != self.orchard_tree_position {
                 return Err(ScanError::TreeSizeMismatch {
-                    protocol: ShieldedProtocol::Orchard,
+                    protocol: ShieldedPool::Orchard,
                     at_height,
                     given: chain_meta.orchard_commitment_tree_size,
                     computed: self.orchard_tree_position,

--- a/zcash_client_backend/src/scanning/full.rs
+++ b/zcash_client_backend/src/scanning/full.rs
@@ -14,7 +14,7 @@ use zcash_primitives::{
     transaction::{Transaction, components::sapling::zip212_enforcement},
 };
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, NetworkUpgrade, TxIndex},
 };
 
@@ -597,7 +597,7 @@ fn tree_sizes_around(
     activation_height: Option<BlockHeight>,
     prior_tree_size: Option<u32>,
     mut output_counts: impl Iterator<Item = usize>,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
 ) -> Result<(u32, u32), ScanError> {
     let start_tree_size = match prior_tree_size {
         Some(size) => size,
@@ -670,7 +670,7 @@ impl PositionTracker {
                 b.tx.sapling_bundle()
                     .map_or(0, |bd| bd.shielded_outputs().len())
             }),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
         )?;
 
         #[cfg(feature = "orchard")]
@@ -680,7 +680,7 @@ impl PositionTracker {
             prior_block_metadata.and_then(|m| m.orchard_tree_size()),
             vtx.iter()
                 .map(|b| b.tx.orchard_bundle().map_or(0, |bd| bd.actions().len())),
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
         )?;
 
         Ok(Self {
@@ -762,7 +762,7 @@ mod tests {
 
     // The behaviour of `tree_sizes_around` is independent of the shielded protocol (the
     // protocol is only echoed back in errors), so these properties are checked for a
-    // `ShieldedProtocol` drawn uniformly at random via `arb_protocol`.
+    // `ShieldedPool` drawn uniformly at random via `arb_protocol`.
     proptest! {
         /// A known prior tree size is the starting point, and each transaction's outputs
         /// are summed onto it to reach the final size. An empty block (no transactions, or

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -14,7 +14,7 @@ use zcash_keys::{address::Receiver, keys::OutgoingViewingKey};
 use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_primitives::transaction::{TxId, fees::transparent as transparent_fees};
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{BlockHeight, TxIndex},
     value::{BalanceError, Zatoshis},
 };
@@ -34,13 +34,13 @@ use {::transparent::keys::NonHardenedChildIndex, std::time::SystemTime};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NoteId {
     txid: TxId,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     output_index: u16,
 }
 
 impl NoteId {
     /// Constructs a new `NoteId` from its parts.
-    pub fn new(txid: TxId, protocol: ShieldedProtocol, output_index: u16) -> Self {
+    pub fn new(txid: TxId, protocol: ShieldedPool, output_index: u16) -> Self {
         Self {
             txid,
             protocol,
@@ -54,7 +54,7 @@ impl NoteId {
     }
 
     /// Returns the shielded protocol used by this note.
-    pub fn protocol(&self) -> ShieldedProtocol {
+    pub fn protocol(&self) -> ShieldedPool {
         self.protocol
     }
 
@@ -575,11 +575,11 @@ impl Note {
     }
 
     /// Returns the shielded protocol used by this note.
-    pub fn protocol(&self) -> ShieldedProtocol {
+    pub fn protocol(&self) -> ShieldedPool {
         match self {
-            Note::Sapling(_) => ShieldedProtocol::Sapling,
+            Note::Sapling(_) => ShieldedPool::Sapling,
             #[cfg(feature = "orchard")]
-            Note::Orchard(_) => ShieldedProtocol::Orchard,
+            Note::Orchard(_) => ShieldedPool::Orchard,
         }
     }
 }

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -19,9 +19,7 @@ use zcash_client_backend::data_api::ll;
 use zcash_client_backend::data_api::ll::wallet::PutBlocksError;
 use zcash_keys::address::UnifiedAddress;
 use zcash_keys::keys::AddressGenerationError;
-use zcash_protocol::{
-    PoolType, ShieldedProtocol, TxId, consensus::BlockHeight, value::BalanceError,
-};
+use zcash_protocol::{PoolType, ShieldedPool, TxId, consensus::BlockHeight, value::BalanceError};
 use zip32::DiversifierIndex;
 
 use crate::{
@@ -130,7 +128,7 @@ pub enum SqliteClientError {
     /// added to the wallet when the error occurred.
     PutBlocksCommitmentTree {
         /// The shielded pool whose note commitment tree was being updated when the error occurred.
-        pool: ShieldedProtocol,
+        pool: ShieldedPool,
         /// The range of block heights that were being added to the wallet when the error
         /// occurred.
         block_range: Range<BlockHeight>,
@@ -144,7 +142,7 @@ pub enum SqliteClientError {
     /// truncated to when the error occurred.
     TruncateCommitmentTree {
         /// The shielded pool whose note commitment tree was being updated when the error occurred.
-        pool: ShieldedProtocol,
+        pool: ShieldedPool,
         /// The block height that the wallet was being truncated to when the error occurred.
         height: BlockHeight,
         /// The underlying note commitment tree error.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -82,7 +82,7 @@ use zcash_primitives::{
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, TxIndex},
     memo::Memo,
 };
@@ -241,7 +241,7 @@ impl ConditionallySelectable for AccountRef {
 
 /// An opaque type for received note identifiers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ReceivedNoteId(pub(crate) ShieldedProtocol, pub(crate) i64);
+pub struct ReceivedNoteId(pub(crate) ShieldedPool, pub(crate) i64);
 
 impl fmt::Display for ReceivedNoteId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -466,12 +466,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
     fn get_spendable_note(
         &self,
         txid: &TxId,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         match protocol {
-            ShieldedProtocol::Sapling => wallet::sapling::get_spendable_sapling_note(
+            ShieldedPool::Sapling => wallet::sapling::get_spendable_sapling_note(
                 self.conn.borrow(),
                 &self.params,
                 txid,
@@ -479,7 +479,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 target_height,
             )
             .map(|opt| opt.map(|n| n.map_note(Note::Sapling))),
-            ShieldedProtocol::Orchard => {
+            ShieldedPool::Orchard => {
                 #[cfg(feature = "orchard")]
                 return wallet::orchard::get_spendable_orchard_note(
                     self.conn.borrow(),
@@ -500,13 +500,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         account: Self::AccountId,
         target_value: TargetValue,
-        sources: &[ShieldedProtocol],
+        sources: &[ShieldedPool],
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
-            if sources.contains(&ShieldedProtocol::Sapling) {
+            if sources.contains(&ShieldedPool::Sapling) {
                 wallet::sapling::select_spendable_sapling_notes(
                     self.conn.borrow(),
                     &self.params,
@@ -520,7 +520,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 vec![]
             },
             #[cfg(feature = "orchard")]
-            if sources.contains(&ShieldedProtocol::Orchard) {
+            if sources.contains(&ShieldedPool::Orchard) {
                 wallet::orchard::select_spendable_orchard_notes(
                     self.conn.borrow(),
                     &self.params,
@@ -539,12 +539,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
     fn select_unspent_notes(
         &self,
         account: Self::AccountId,
-        sources: &[ShieldedProtocol],
+        sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
-            if sources.contains(&ShieldedProtocol::Sapling) {
+            if sources.contains(&ShieldedPool::Sapling) {
                 wallet::common::select_unspent_notes(
                     self.conn.borrow(),
                     &self.params,
@@ -552,7 +552,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     ConfirmationsPolicy::MIN,
                     exclude,
-                    ShieldedProtocol::Sapling,
+                    ShieldedPool::Sapling,
                     wallet::sapling::to_received_note,
                     wallet::common::NoteRequest::Unspent,
                 )?
@@ -560,7 +560,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 vec![]
             },
             #[cfg(feature = "orchard")]
-            if sources.contains(&ShieldedProtocol::Orchard) {
+            if sources.contains(&ShieldedPool::Orchard) {
                 wallet::common::select_unspent_notes(
                     self.conn.borrow(),
                     &self.params,
@@ -568,7 +568,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     ConfirmationsPolicy::MIN,
                     exclude,
-                    ShieldedProtocol::Orchard,
+                    ShieldedPool::Orchard,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
                 )?
@@ -637,7 +637,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
     ) -> Result<AccountMeta, Self::Error> {
         let sapling_pool_meta = unspent_notes_meta(
             self.conn.borrow(),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             target_height,
             account_id,
             selector,
@@ -647,7 +647,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         #[cfg(feature = "orchard")]
         let orchard_pool_meta = unspent_notes_meta(
             self.conn.borrow(),
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             target_height,
             account_id,
             selector,
@@ -1024,7 +1024,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
     fn get_sent_note_ids(
         &self,
         txid: &TxId,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
     ) -> Result<Vec<NoteId>, <Self as WalletRead>::Error> {
         use crate::wallet::encoding::pool_code;
 
@@ -1120,7 +1120,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
 
     fn get_checkpoint_history(
         &self,
-        protocol: &ShieldedProtocol,
+        protocol: &ShieldedPool,
     ) -> Result<
         Vec<(BlockHeight, Option<incrementalmerkletree::Position>)>,
         <Self as WalletRead>::Error,
@@ -1146,7 +1146,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
 
     fn get_notes(
         &self,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
     ) -> Result<Vec<ReceivedNote<Self::NoteRef, Note>>, <Self as InputSource>::Error> {
         let (target_height, _) = self
             .get_target_and_anchor_heights(NonZeroU32::MIN)?
@@ -1932,7 +1932,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         &self,
         nf: &::sapling::Nullifier,
     ) -> Result<Option<Self::TxRef>, Self::Error> {
-        wallet::query_nullifier_map(self.conn.borrow(), ShieldedProtocol::Sapling, nf)
+        wallet::query_nullifier_map(self.conn.borrow(), ShieldedPool::Sapling, nf)
     }
 
     #[cfg(feature = "orchard")]
@@ -1940,11 +1940,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         &self,
         nf: &::orchard::note::Nullifier,
     ) -> Result<Option<Self::TxRef>, Self::Error> {
-        wallet::query_nullifier_map(
-            self.conn.borrow(),
-            ShieldedProtocol::Orchard,
-            &nf.to_bytes(),
-        )
+        wallet::query_nullifier_map(self.conn.borrow(), ShieldedPool::Orchard, &nf.to_bytes())
     }
 
     #[cfg(feature = "transparent-inputs")]
@@ -2064,12 +2060,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         block_height: BlockHeight,
         nfs: &[(TxIndex, TxId, Vec<::sapling::Nullifier>)],
     ) -> Result<(), Self::Error> {
-        wallet::insert_nullifier_map(
-            self.conn.borrow(),
-            block_height,
-            ShieldedProtocol::Sapling,
-            nfs,
-        )
+        wallet::insert_nullifier_map(self.conn.borrow(), block_height, ShieldedPool::Sapling, nfs)
     }
 
     #[cfg(feature = "orchard")]
@@ -2110,7 +2101,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         wallet::insert_nullifier_map(
             self.conn.borrow(),
             block_height,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             &nfs.iter()
                 .map(|(idx, txid, nfs)| (*idx, *txid, nfs.iter().map(|n| n.to_bytes()).collect()))
                 .collect::<Vec<_>>(),
@@ -2236,7 +2227,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
     fn notify_scan_complete(
         &mut self,
         range: Range<BlockHeight>,
-        wallet_note_positions: &[(ShieldedProtocol, Position)],
+        wallet_note_positions: &[(ShieldedPool, Position)],
     ) -> Result<(), Self::Error> {
         wallet::scanning::scan_complete(
             self.conn.borrow(),

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -493,6 +493,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 #[cfg(not(feature = "orchard"))]
                 return Err(SqliteClientError::UnsupportedPoolType(PoolType::ORCHARD));
             }
+            ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
         }
     }
 

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -37,7 +37,7 @@ use zcash_primitives::{
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
-    ShieldedProtocol, consensus, consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo,
+    ShieldedPool, consensus, consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo,
 };
 use zip32::DiversifierIndex;
 

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -443,6 +443,7 @@ pub(crate) fn truncate_to_chain_state_commitment_tree_error<T: ShieldedPoolTeste
             captured.final_sapling_tree().clone(),
             foreign.final_orchard_tree().clone(),
         ),
+        ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
     };
     #[cfg(not(feature = "orchard"))]
     let bad_chain_state = ChainState::new(
@@ -564,6 +565,7 @@ pub(crate) fn put_blocks_commitment_tree_error<T: ShieldedPoolTester>() {
             captured.final_sapling_tree().clone(),
             foreign.final_orchard_tree().clone(),
         ),
+        ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
     };
     #[cfg(not(feature = "orchard"))]
     let bad_from_state = ChainState::new(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -356,7 +356,7 @@ pub(crate) fn truncate_to_chain_state_commitment_tree_error<T: ShieldedPoolTeste
         WalletWrite, chain::ChainState, testing::AddressType, testing::pool::dsl::TestDsl,
     };
     #[cfg(feature = "orchard")]
-    use zcash_protocol::ShieldedProtocol;
+    use zcash_protocol::ShieldedPool;
     use zcash_protocol::{
         consensus::{NetworkUpgrade, Parameters},
         value::Zatoshis,
@@ -431,13 +431,13 @@ pub(crate) fn truncate_to_chain_state_commitment_tree_error<T: ShieldedPoolTeste
     // Claim wallet A's captured height/hash, but substitute wallet B's frontier for pool `T`.
     #[cfg(feature = "orchard")]
     let bad_chain_state = match T::SHIELDED_PROTOCOL {
-        ShieldedProtocol::Sapling => ChainState::new(
+        ShieldedPool::Sapling => ChainState::new(
             capture_height,
             captured.block_hash(),
             foreign.final_sapling_tree().clone(),
             captured.final_orchard_tree().clone(),
         ),
-        ShieldedProtocol::Orchard => ChainState::new(
+        ShieldedPool::Orchard => ChainState::new(
             capture_height,
             captured.block_hash(),
             captured.final_sapling_tree().clone(),
@@ -480,7 +480,7 @@ pub(crate) fn put_blocks_commitment_tree_error<T: ShieldedPoolTester>() {
         testing::pool::dsl::TestDsl,
     };
     #[cfg(feature = "orchard")]
-    use zcash_protocol::ShieldedProtocol;
+    use zcash_protocol::ShieldedPool;
     use zcash_protocol::{
         consensus::{NetworkUpgrade, Parameters},
         value::Zatoshis,
@@ -552,13 +552,13 @@ pub(crate) fn put_blocks_commitment_tree_error<T: ShieldedPoolTester>() {
     // B's frontier for pool `T`.
     #[cfg(feature = "orchard")]
     let bad_from_state = match T::SHIELDED_PROTOCOL {
-        ShieldedProtocol::Sapling => ChainState::new(
+        ShieldedPool::Sapling => ChainState::new(
             from_height - 1,
             captured.block_hash(),
             foreign.final_sapling_tree().clone(),
             captured.final_orchard_tree().clone(),
         ),
-        ShieldedProtocol::Orchard => ChainState::new(
+        ShieldedPool::Orchard => ChainState::new(
             from_height - 1,
             captured.block_hash(),
             captured.final_sapling_tree().clone(),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1978,6 +1978,7 @@ fn estimate_tree_size<P: consensus::Parameters>(
             ShieldedPool::Orchard => last_scanned.orchard_tree_size(),
             #[cfg(not(feature = "orchard"))]
             ShieldedPool::Orchard => None,
+            ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
         }
         .map(|tree_size| (last_scanned.block_height(), u64::from(tree_size)))
     });
@@ -5008,6 +5009,7 @@ pub(crate) fn get_block_range(
     let prefix = match protocol {
         ShieldedPool::Sapling => "sapling",
         ShieldedPool::Orchard => "orchard",
+        ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
     };
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT MIN(height), MAX(height), MAX({prefix}_commitment_tree_size)

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -114,7 +114,7 @@ use zcash_primitives::{
     transaction::{Transaction, TransactionData, builder::DEFAULT_TX_EXPIRY_DELTA, fees::zip317},
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol, TxId,
+    PoolType, ShieldedPool, TxId,
     consensus::{self, BlockHeight, BranchId, NetworkUpgrade, Parameters, TxIndex},
     memo::{Memo, MemoBytes},
     value::{ZatBalance, Zatoshis},
@@ -1922,7 +1922,7 @@ pub(crate) struct SubtreeProgressEstimator;
 fn estimate_tree_size<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
-    shielded_protocol: ShieldedProtocol,
+    shielded_protocol: ShieldedPool,
     pool_activation_height: BlockHeight,
     chain_tip_height: BlockHeight,
 ) -> Result<Option<u64>, SqliteClientError> {
@@ -1973,11 +1973,11 @@ fn estimate_tree_size<P: consensus::Parameters>(
     // Get the tree size at the last scanned height, if known.
     let last_scanned = block_max_scanned(conn, params)?.and_then(|last_scanned| {
         match shielded_protocol {
-            ShieldedProtocol::Sapling => last_scanned.sapling_tree_size(),
+            ShieldedPool::Sapling => last_scanned.sapling_tree_size(),
             #[cfg(feature = "orchard")]
-            ShieldedProtocol::Orchard => last_scanned.orchard_tree_size(),
+            ShieldedPool::Orchard => last_scanned.orchard_tree_size(),
             #[cfg(not(feature = "orchard"))]
-            ShieldedProtocol::Orchard => None,
+            ShieldedPool::Orchard => None,
         }
         .map(|tree_size| (last_scanned.block_height(), u64::from(tree_size)))
     });
@@ -2097,7 +2097,7 @@ fn estimate_tree_size<P: consensus::Parameters>(
 fn subtree_scan_progress<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
     params: &P,
-    shielded_protocol: ShieldedProtocol,
+    shielded_protocol: ShieldedPool,
     pool_activation_height: BlockHeight,
     min_birthday_height: BlockHeight,
     recover_until_height: Option<BlockHeight>,
@@ -2364,7 +2364,7 @@ impl ProgressEstimator for SubtreeProgressEstimator {
         subtree_scan_progress(
             conn,
             params,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             sapling_activation_height,
             birthday_height,
             recover_until_height,
@@ -2390,7 +2390,7 @@ impl ProgressEstimator for SubtreeProgressEstimator {
         subtree_scan_progress(
             conn,
             params,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             nu5_activation_height,
             birthday_height,
             recover_until_height,
@@ -2492,7 +2492,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         anchor_height: Option<BlockHeight>,
         confirmations_policy: ConfirmationsPolicy,
         account_balances: &mut HashMap<AccountUuid, AccountBalance>,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
         with_pool_balance: F,
     ) -> Result<(), SqliteClientError>
     where
@@ -2676,7 +2676,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
             anchor_height,
             confirmations_policy,
             &mut account_balances,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             |balances,
              spendable_value,
              change_pending_confirmation,
@@ -2701,7 +2701,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         anchor_height,
         confirmations_policy,
         &mut account_balances,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         |balances,
          spendable_value,
          change_pending_confirmation,
@@ -3046,7 +3046,7 @@ pub(crate) fn get_anchor_height(
 ) -> Result<Option<BlockHeight>, SqliteClientError> {
     let sapling_anchor_height = get_max_checkpointed_height(
         conn,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         target_height,
         min_confirmations,
     )?;
@@ -3054,7 +3054,7 @@ pub(crate) fn get_anchor_height(
     #[cfg(feature = "orchard")]
     let orchard_anchor_height = get_max_checkpointed_height(
         conn,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         target_height,
         min_confirmations,
     )?;
@@ -3768,7 +3768,7 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         wdb.with_sapling_tree_mut(|tree| {
             tree.truncate_to_checkpoint(&truncation_height)
                 .map_err(|error| SqliteClientError::TruncateCommitmentTree {
-                    pool: ShieldedProtocol::Sapling,
+                    pool: ShieldedPool::Sapling,
                     height: truncation_height,
                     error,
                 })?;
@@ -3778,7 +3778,7 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
         wdb.with_orchard_tree_mut(|tree| {
             tree.truncate_to_checkpoint(&truncation_height)
                 .map_err(|error| SqliteClientError::TruncateCommitmentTree {
-                    pool: ShieldedProtocol::Orchard,
+                    pool: ShieldedPool::Orchard,
                     height: truncation_height,
                     error,
                 })?;
@@ -3906,7 +3906,7 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
                 },
             )
             .map_err(|error| SqliteClientError::TruncateCommitmentTree {
-                pool: ShieldedProtocol::Sapling,
+                pool: ShieldedPool::Sapling,
                 height: target_height,
                 error,
             })?;
@@ -3923,7 +3923,7 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
                 },
             )
             .map_err(|error| SqliteClientError::TruncateCommitmentTree {
-                pool: ShieldedProtocol::Orchard,
+                pool: ShieldedPool::Orchard,
                 height: target_height,
                 error,
             })?;
@@ -4736,9 +4736,9 @@ fn flag_previously_received_change(
         .map_err(SqliteClientError::from)
     };
 
-    flag_received_change(ShieldedProtocol::Sapling)?;
+    flag_received_change(ShieldedPool::Sapling)?;
     #[cfg(feature = "orchard")]
-    flag_received_change(ShieldedProtocol::Orchard)?;
+    flag_received_change(ShieldedPool::Orchard)?;
 
     Ok(())
 }
@@ -4843,7 +4843,7 @@ pub(crate) fn put_sent_output<P: consensus::Parameters>(
 pub(crate) fn insert_nullifier_map<N: AsRef<[u8]>>(
     conn: &rusqlite::Transaction<'_>,
     block_height: BlockHeight,
-    spend_pool: ShieldedProtocol,
+    spend_pool: ShieldedPool,
     new_entries: &[(TxIndex, TxId, Vec<N>)],
 ) -> Result<(), SqliteClientError> {
     let mut stmt_select_tx_locators = conn.prepare_cached(
@@ -4932,7 +4932,7 @@ pub(crate) fn insert_nullifier_map<N: AsRef<[u8]>>(
 /// this nullifier is revealed, if any.
 pub(crate) fn query_nullifier_map<N: AsRef<[u8]>>(
     conn: &rusqlite::Transaction<'_>,
-    spend_pool: ShieldedProtocol,
+    spend_pool: ShieldedPool,
     nf: &N,
 ) -> Result<Option<TxRef>, SqliteClientError> {
     let mut stmt_select_locator = conn.prepare_cached(
@@ -5002,12 +5002,12 @@ pub(crate) fn prune_nullifier_map(
 
 pub(crate) fn get_block_range(
     conn: &rusqlite::Connection,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     commitment_tree_address: incrementalmerkletree::Address,
 ) -> Result<Option<Range<BlockHeight>>, SqliteClientError> {
     let prefix = match protocol {
-        ShieldedProtocol::Sapling => "sapling",
-        ShieldedProtocol::Orchard => "orchard",
+        ShieldedPool::Sapling => "sapling",
+        ShieldedPool::Orchard => "orchard",
     };
     let mut stmt = conn.prepare_cached(&format!(
         "SELECT MIN(height), MAX(height), MAX({prefix}_commitment_tree_size)
@@ -5130,7 +5130,7 @@ pub mod testing {
     use zcash_client_backend::data_api::testing::TransactionSummary;
     use zcash_primitives::transaction::TxId;
     use zcash_protocol::{
-        ShieldedProtocol,
+        ShieldedPool,
         consensus::BlockHeight,
         value::{ZatBalance, Zatoshis},
     };
@@ -5181,7 +5181,7 @@ pub mod testing {
     #[allow(dead_code)] // used only for tests that are flagged off by default
     pub(crate) fn get_checkpoint_history(
         conn: &rusqlite::Connection,
-        protocol: ShieldedProtocol,
+        protocol: ShieldedPool,
     ) -> Result<Vec<(BlockHeight, Option<Position>)>, SqliteClientError> {
         let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
 
@@ -5389,7 +5389,7 @@ mod tests {
             testing::{InitialChainState, pool::ShieldedPoolTester, sapling::SaplingPoolTester},
         };
         use zcash_protocol::{
-            ShieldedProtocol,
+            ShieldedPool,
             consensus::{NetworkUpgrade, Parameters},
         };
 
@@ -5494,7 +5494,7 @@ mod tests {
         let progress = super::subtree_scan_progress(
             st.wallet().conn(),
             st.network(),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             sapling_activation_height,
             sapling_activation_height,
             Some(recover_until_height),
@@ -5535,7 +5535,7 @@ mod tests {
             testing::{InitialChainState, pool::ShieldedPoolTester, sapling::SaplingPoolTester},
         };
         use zcash_protocol::{
-            ShieldedProtocol,
+            ShieldedPool,
             consensus::{NetworkUpgrade, Parameters},
         };
 
@@ -5633,7 +5633,7 @@ mod tests {
         let progress = super::subtree_scan_progress(
             st.wallet().conn(),
             st.network(),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             sapling_activation_height,
             sapling_activation_height,
             Some(recover_until_height),
@@ -5697,7 +5697,7 @@ mod tests {
             testing::{InitialChainState, pool::ShieldedPoolTester, sapling::SaplingPoolTester},
         };
         use zcash_protocol::{
-            ShieldedProtocol,
+            ShieldedPool,
             consensus::{NetworkUpgrade, Parameters},
         };
 
@@ -5804,7 +5804,7 @@ mod tests {
         let progress = super::subtree_scan_progress(
             st.wallet().conn(),
             st.network(),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             sapling_activation_height,
             sapling_activation_height,
             Some(recover_until_height),

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -23,7 +23,7 @@ use zcash_client_backend::{
     serialization::shardtree::{read_shard, write_shard},
 };
 use zcash_primitives::merkle_tree::HashSer;
-use zcash_protocol::{ShieldedProtocol, consensus::BlockHeight};
+use zcash_protocol::{ShieldedPool, consensus::BlockHeight};
 
 use crate::{error::SqliteClientError, sapling_tree};
 
@@ -806,7 +806,7 @@ pub(crate) fn get_checkpoint(
 
 pub(crate) fn get_max_checkpointed_height(
     conn: &rusqlite::Connection,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     target_height: TargetHeight,
     min_confirmations: NonZeroU32,
 ) -> Result<Option<BlockHeight>, SqliteClientError> {
@@ -1146,7 +1146,7 @@ pub(crate) fn check_witnesses(
     }
 
     for addr in sapling_incomplete {
-        let range = super::get_block_range(conn, ShieldedProtocol::Sapling, addr)?;
+        let range = super::get_block_range(conn, ShieldedPool::Sapling, addr)?;
         scan_ranges.extend(range);
     }
 
@@ -1169,7 +1169,7 @@ pub(crate) fn check_witnesses(
         }
 
         for addr in orchard_incomplete {
-            let range = super::get_block_range(conn, ShieldedProtocol::Orchard, addr)?;
+            let range = super::get_block_range(conn, ShieldedPool::Orchard, addr)?;
             scan_ranges.extend(range);
         }
     }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -70,6 +70,7 @@ pub(crate) fn table_constants<E: ErrUnsupportedPool>(
         ShieldedPool::Orchard => Ok(ORCHARD_TABLE_CONSTANTS),
         #[cfg(not(feature = "orchard"))]
         ShieldedPool::Orchard => Err(E::unsupported_pool_type(PoolType::ORCHARD)),
+        ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -14,7 +14,7 @@ use zcash_client_backend::{
 };
 use zcash_primitives::transaction::{TxId, builder::DEFAULT_TX_EXPIRY_DELTA, fees::zip317};
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     value::{BalanceError, Zatoshis},
 };
@@ -62,14 +62,14 @@ pub(crate) trait ErrUnsupportedPool {
 }
 
 pub(crate) fn table_constants<E: ErrUnsupportedPool>(
-    shielded_protocol: ShieldedProtocol,
+    shielded_protocol: ShieldedPool,
 ) -> Result<TableConstants, E> {
     match shielded_protocol {
-        ShieldedProtocol::Sapling => Ok(SAPLING_TABLE_CONSTANTS),
+        ShieldedPool::Sapling => Ok(SAPLING_TABLE_CONSTANTS),
         #[cfg(feature = "orchard")]
-        ShieldedProtocol::Orchard => Ok(ORCHARD_TABLE_CONSTANTS),
+        ShieldedPool::Orchard => Ok(ORCHARD_TABLE_CONSTANTS),
         #[cfg(not(feature = "orchard"))]
-        ShieldedProtocol::Orchard => Err(E::unsupported_pool_type(PoolType::ORCHARD)),
+        ShieldedPool::Orchard => Err(E::unsupported_pool_type(PoolType::ORCHARD)),
     }
 }
 
@@ -154,7 +154,7 @@ fn unscanned_tip_exists(
 /// select a few too many nullifiers, it's not a big deal.
 pub(crate) fn get_nullifiers<N, F: Fn(&[u8]) -> Result<N, SqliteClientError>>(
     conn: &Connection,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     query: NullifierQuery,
     parse_nf: F,
 ) -> Result<Vec<(AccountUuid, N)>, SqliteClientError> {
@@ -205,7 +205,7 @@ pub(crate) fn get_spendable_note<P: consensus::Parameters, F, Note>(
     params: &P,
     txid: &TxId,
     index: u32,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     target_height: TargetHeight,
     to_spendable_note: F,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
@@ -304,7 +304,7 @@ pub(crate) fn select_spendable_notes<P: consensus::Parameters, F, Note>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     to_spendable_note: F,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
@@ -361,7 +361,7 @@ pub(crate) fn select_unspent_notes<P: consensus::Parameters, F, Note>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     to_received_note: F,
     note_request: NoteRequest,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
@@ -520,7 +520,7 @@ fn select_spendable_notes_matching_value<P: consensus::Parameters, F, Note>(
     anchor_height: BlockHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     to_spendable_note: F,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
@@ -726,7 +726,7 @@ impl UnspentNoteMeta {
 
 pub(crate) fn select_unspent_note_meta(
     conn: &rusqlite::Connection,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     wallet_birthday: BlockHeight,
     anchor_height: BlockHeight,
 ) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
@@ -788,7 +788,7 @@ pub(crate) fn select_unspent_note_meta(
 
 pub(crate) fn unspent_notes_meta(
     conn: &rusqlite::Connection,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     target_height: TargetHeight,
     account: AccountUuid,
     filter: &NoteFilter,
@@ -971,7 +971,7 @@ mod tests {
         AddressType, TestBuilder, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
     };
     use zcash_primitives::block::BlockHash;
-    use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
+    use zcash_protocol::{ShieldedPool, value::Zatoshis};
 
     use crate::testing::{BlockCache, db::TestDbFactory};
 
@@ -994,7 +994,7 @@ mod tests {
 
         let unspent_note_meta = super::select_unspent_note_meta(
             st.wallet().conn(),
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             birthday_height,
             h,
         )

--- a/zcash_client_sqlite/src/wallet/encoding.rs
+++ b/zcash_client_sqlite/src/wallet/encoding.rs
@@ -39,6 +39,9 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
         PoolType::Transparent => 0i64,
         PoolType::Shielded(ShieldedPool::Sapling) => 2i64,
         PoolType::Shielded(ShieldedPool::Orchard) => 3i64,
+        PoolType::Shielded(ShieldedPool::Ironwood) => {
+            todo!("Ironwood pool code is not yet assigned")
+        }
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/encoding.rs
+++ b/zcash_client_sqlite/src/wallet/encoding.rs
@@ -14,7 +14,7 @@ use zcash_keys::{
     address::{Address, UnifiedAddress},
     keys::{ReceiverRequirement, ReceiverRequirements},
 };
-use zcash_protocol::{PoolType, ShieldedProtocol, consensus::NetworkType, memo::MemoBytes};
+use zcash_protocol::{PoolType, ShieldedPool, consensus::NetworkType, memo::MemoBytes};
 use zip32::DiversifierIndex;
 
 use crate::error::SqliteClientError;
@@ -37,8 +37,8 @@ pub(crate) fn pool_code(pool_type: PoolType) -> i64 {
     // implementation detail.
     match pool_type {
         PoolType::Transparent => 0i64,
-        PoolType::Shielded(ShieldedProtocol::Sapling) => 2i64,
-        PoolType::Shielded(ShieldedProtocol::Orchard) => 3i64,
+        PoolType::Shielded(ShieldedPool::Sapling) => 2i64,
+        PoolType::Shielded(ShieldedPool::Orchard) => 3i64,
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -18,7 +18,7 @@ use zcash_client_backend::{
 use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight},
 };
 use zip32::Scope;
@@ -33,7 +33,7 @@ pub(crate) fn to_received_note<P: consensus::Parameters>(
     params: &P,
     row: &Row,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
-    let note_id = ReceivedNoteId(ShieldedProtocol::Orchard, row.get("id")?);
+    let note_id = ReceivedNoteId(ShieldedPool::Orchard, row.get("id")?);
     let txid = row.get::<_, [u8; 32]>("txid").map(TxId::from_bytes)?;
     let action_index = row.get("action_index")?;
     let diversifier = {
@@ -140,7 +140,7 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
         params,
         txid,
         index,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         target_height,
         to_received_note,
     )
@@ -163,7 +163,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         target_height,
         confirmations_policy,
         exclude,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         to_received_note,
     )
 }
@@ -284,7 +284,7 @@ pub(crate) fn select_unspent_note_meta(
 ) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
     super::common::select_unspent_note_meta(
         conn,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         wallet_birthday,
         anchor_height,
     )
@@ -387,7 +387,7 @@ pub(crate) fn get_orchard_nullifiers(
     conn: &Connection,
     query: NullifierQuery,
 ) -> Result<Vec<(AccountUuid, Nullifier)>, SqliteClientError> {
-    super::common::get_nullifiers(conn, ShieldedProtocol::Orchard, query, |nf_bytes| {
+    super::common::get_nullifiers(conn, ShieldedPool::Orchard, query, |nf_bytes| {
         Nullifier::from_bytes(<&[u8; 32]>::try_from(nf_bytes).map_err(|_| {
             SqliteClientError::CorruptedData(
                 "unable to parse Orchard nullifier: expected 32 bytes".to_string(),

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -17,7 +17,7 @@ use zcash_client_backend::{
 };
 use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::{
-    ShieldedProtocol, TxId,
+    ShieldedPool, TxId,
     consensus::{self, BlockHeight},
 };
 use zip32::Scope;
@@ -32,7 +32,7 @@ pub(crate) fn to_received_note<P: consensus::Parameters>(
     params: &P,
     row: &Row,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
-    let note_id = ReceivedNoteId(ShieldedProtocol::Sapling, row.get("id")?);
+    let note_id = ReceivedNoteId(ShieldedPool::Sapling, row.get("id")?);
     let txid = row.get::<_, [u8; 32]>("txid").map(TxId::from_bytes)?;
     let output_index = row.get("output_index")?;
     let diversifier = {
@@ -144,7 +144,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
         params,
         txid,
         index,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         target_height,
         to_received_note,
     )
@@ -172,7 +172,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         target_height,
         confirmations_policy,
         exclude,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         to_received_note,
     )
 }
@@ -184,7 +184,7 @@ pub(crate) fn select_unspent_note_meta(
 ) -> Result<Vec<UnspentNoteMeta>, SqliteClientError> {
     super::common::select_unspent_note_meta(
         conn,
-        ShieldedProtocol::Sapling,
+        ShieldedPool::Sapling,
         wallet_birthday,
         anchor_height,
     )
@@ -200,7 +200,7 @@ pub(crate) fn get_sapling_nullifiers(
     conn: &Connection,
     query: NullifierQuery,
 ) -> Result<Vec<(AccountUuid, Nullifier)>, SqliteClientError> {
-    super::common::get_nullifiers(conn, ShieldedProtocol::Sapling, query, |nf_bytes| {
+    super::common::get_nullifiers(conn, ShieldedPool::Sapling, query, |nf_bytes| {
         sapling::Nullifier::from_slice(nf_bytes).map_err(|_| {
             SqliteClientError::CorruptedData("unable to parse Sapling nullifier".to_string())
         })

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -320,6 +320,9 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
                         *protocol,
                     )));
                 }
+                ShieldedPool::Ironwood => {
+                    todo!("Ironwood pool support is not yet implemented")
+                }
             }
         }
 

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -11,7 +11,7 @@ use zcash_client_backend::data_api::{
     scanning::{ScanPriority, ScanRange, spanning_tree::SpanningTree},
 };
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{self, BlockHeight, NetworkUpgrade},
 };
 
@@ -225,7 +225,7 @@ fn extend_range(
     conn: &rusqlite::Transaction<'_>,
     range: &Range<BlockHeight>,
     required_subtree_indices: BTreeSet<u64>,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
     fallback_start_height: Option<BlockHeight>,
     birthday_height: Option<BlockHeight>,
 ) -> Result<Option<Range<BlockHeight>>, SqliteClientError> {
@@ -287,7 +287,7 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
     conn: &rusqlite::Transaction<'_>,
     params: &P,
     range: Range<BlockHeight>,
-    wallet_note_positions: &[(ShieldedProtocol, Position)],
+    wallet_note_positions: &[(ShieldedPool, Position)],
 ) -> Result<(), SqliteClientError> {
     // Read the wallet birthday (if known).
     // TODO: use per-pool birthdays?
@@ -304,12 +304,12 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         let mut required_orchard_subtrees = BTreeSet::new();
         for (protocol, position) in wallet_note_positions {
             match protocol {
-                ShieldedProtocol::Sapling => {
+                ShieldedPool::Sapling => {
                     required_sapling_subtrees.insert(
                         Address::above_position(SAPLING_SHARD_HEIGHT.into(), *position).index(),
                     );
                 }
-                ShieldedProtocol::Orchard => {
+                ShieldedPool::Orchard => {
                     #[cfg(feature = "orchard")]
                     required_orchard_subtrees.insert(
                         Address::above_position(ORCHARD_SHARD_HEIGHT.into(), *position).index(),
@@ -327,7 +327,7 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
             conn,
             &range,
             required_sapling_subtrees,
-            ShieldedProtocol::Sapling,
+            ShieldedPool::Sapling,
             params.activation_height(NetworkUpgrade::Sapling),
             wallet_birthday,
         )?;
@@ -337,7 +337,7 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
             conn,
             extended_range.as_ref().unwrap_or(&range),
             required_orchard_subtrees,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             params.activation_height(NetworkUpgrade::Nu5),
             wallet_birthday,
         )?
@@ -427,7 +427,7 @@ pub(crate) fn mark_stabilized_notes<P: consensus::Parameters>(
 
 fn tip_shard_end_height(
     conn: &rusqlite::Transaction<'_>,
-    protocol: ShieldedProtocol,
+    protocol: ShieldedPool,
 ) -> Result<Option<BlockHeight>, SqliteClientError> {
     let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
     conn.query_row(
@@ -478,9 +478,9 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
     // Read the maximum height from each of the shards tables. The minimum of the two
     // gives the start of a height range that covers the last incomplete shard of both the
     // Sapling and Orchard pools.
-    let sapling_shard_tip = tip_shard_end_height(conn, ShieldedProtocol::Sapling)?;
+    let sapling_shard_tip = tip_shard_end_height(conn, ShieldedPool::Sapling)?;
     #[cfg(feature = "orchard")]
-    let orchard_shard_tip = tip_shard_end_height(conn, ShieldedProtocol::Orchard)?;
+    let orchard_shard_tip = tip_shard_end_height(conn, ShieldedPool::Orchard)?;
 
     #[cfg(feature = "orchard")]
     let min_shard_tip = match (sapling_shard_tip, orchard_shard_tip) {

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -444,7 +444,10 @@ impl Address {
             Address::Unified(ua) => match pool_type {
                 PoolType::Transparent => ua.has_transparent(),
                 PoolType::Shielded(ShieldedPool::Sapling) => ua.has_sapling(),
-                PoolType::Shielded(ShieldedPool::Orchard) => ua.has_orchard(),
+                // Ironwood shares the Orchard receiver.
+                PoolType::Shielded(ShieldedPool::Orchard | ShieldedPool::Ironwood) => {
+                    ua.has_orchard()
+                }
             },
         }
     }

--- a/zcash_keys/src/address.rs
+++ b/zcash_keys/src/address.rs
@@ -12,7 +12,7 @@ use zcash_protocol::consensus::{self, NetworkType};
 
 #[cfg(feature = "sapling")]
 use sapling::PaymentAddress;
-use zcash_protocol::{PoolType, ShieldedProtocol};
+use zcash_protocol::{PoolType, ShieldedPool};
 
 /// A Unified Address.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -436,15 +436,15 @@ impl Address {
         match self {
             #[cfg(feature = "sapling")]
             Address::Sapling(_) => {
-                matches!(pool_type, PoolType::Shielded(ShieldedProtocol::Sapling))
+                matches!(pool_type, PoolType::Shielded(ShieldedPool::Sapling))
             }
             Address::Transparent(_) | Address::Tex(_) => {
                 matches!(pool_type, PoolType::Transparent)
             }
             Address::Unified(ua) => match pool_type {
                 PoolType::Transparent => ua.has_transparent(),
-                PoolType::Shielded(ShieldedProtocol::Sapling) => ua.has_sapling(),
-                PoolType::Shielded(ShieldedProtocol::Orchard) => ua.has_orchard(),
+                PoolType::Shielded(ShieldedPool::Sapling) => ua.has_sapling(),
+                PoolType::Shielded(ShieldedPool::Orchard) => ua.has_orchard(),
             },
         }
     }


### PR DESCRIPTION
It is no longer appropriate to refer to the Orchard "shielded protocol"
as there are three different variants of the Orchard shielded protocol.
`zcash_protocol::ShieldedProtocol` has historically been used as a pool
identifier; the rename here reifies this change.