### PR TITLE
zcash_client_sqlite: Extend scan ranges for Ironwood subtrees

### DIFF
--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -165,6 +165,13 @@ pub const SAPLING_SHARD_HEIGHT: u8 = sapling::NOTE_COMMITMENT_TREE_DEPTH / 2;
 #[cfg(feature = "orchard")]
 pub const ORCHARD_SHARD_HEIGHT: u8 = { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 } / 2;
 
+/// The height of subtree roots in the Ironwood note commitment tree.
+///
+/// This conforms to the structure of subtree data returned by
+/// `lightwalletd` when using the `GetSubtreeRoots` GRPC call.
+#[cfg(feature = "orchard")]
+pub const IRONWOOD_SHARD_HEIGHT: u8 = { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 } / 2;
+
 /// An enumeration of constraints that can be applied when querying for nullifiers for notes
 /// belonging to the wallet.
 pub enum NullifierQuery {

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Eq,
-    collections::{BTreeSet, HashSet},
+    collections::HashSet,
     convert::Infallible,
     hash::Hash,
     num::{NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize},
@@ -23,7 +23,7 @@ use zcash_primitives::{
 };
 use zcash_protocol::{
     ShieldedPool,
-    consensus::{self, BlockHeight, COINBASE_MATURITY_BLOCKS, NetworkUpgrade, Parameters},
+    consensus::{self, BlockHeight, NetworkUpgrade, Parameters},
     local_consensus::LocalNetwork,
     memo::{Memo, MemoBytes},
     value::Zatoshis,
@@ -6575,6 +6575,8 @@ where
     Dsf: DataStoreFactory,
     <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
 {
+    use std::collections::BTreeSet;
+
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
     let (t_addr, _) = st.get_account().usk().default_transparent_address();
     let account = st.get_account().id();
@@ -7072,6 +7074,8 @@ pub fn propose_and_build_shielding_coinbase_succeeds<T: ShieldedPoolTester, Dsf>
     Dsf: DataStoreFactory,
     <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
 {
+    use zcash_protocol::consensus::COINBASE_MATURITY_BLOCKS;
+
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
     let account = st.get_account();
     let (t_addr, _) = account.usk().default_transparent_address();

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -12,7 +12,7 @@ use zcash_address::{ConversionError, ZcashAddress};
 use zcash_keys::address::{Address, UnifiedAddress};
 use zcash_primitives::transaction::fees::{
     FeeRule,
-    transparent::{self as transparent_fees, InputSize},
+    transparent::InputSize,
     zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
 };
 use zcash_protocol::{
@@ -45,6 +45,7 @@ use {
     std::collections::BTreeSet,
     std::convert::Infallible,
     transparent::{address::TransparentAddress, bundle::OutPoint},
+    zcash_primitives::transaction::fees::transparent as transparent_fees,
     zip321::Payment,
 };
 
@@ -808,6 +809,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
 
         #[cfg(not(feature = "transparent-inputs"))]
         let transparent_inputs = vec![];
+        #[cfg(feature = "transparent-inputs")]
         let mut amount_at_transparent_gather = Zatoshis::ZERO;
         #[cfg(feature = "transparent-inputs")]
         let mut transparent_inputs = match spend_policy {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -32,6 +32,10 @@ workspace.
   The `WalletCommitmentTrees::with_ironwood_tree_mut` implementation now provides
   the persisted Ironwood tree (Ironwood note commitments are Orchard-shaped, so
   the tree reuses the Orchard shard store under a separate table prefix).
+- Block scan-range planning now extends suggested scan ranges to complete
+  Ironwood note commitment tree subtrees when Ironwood notes are detected,
+  mirroring the existing Sapling and Orchard behavior. The extension activates at
+  NU6.3.
 - `zcash_client_sqlite::error::SqliteClientError::PutBlocksCommitmentTree`, a
   new variant that records the shielded pool and the range of block heights
   being added to the wallet when a note commitment tree error occurs during a

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -102,8 +102,8 @@ use wallet::{
 
 #[cfg(feature = "orchard")]
 use {
-    zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT,
     zcash_client_backend::data_api::ll::ReceivedOrchardOutput,
+    zcash_client_backend::data_api::{IRONWOOD_SHARD_HEIGHT, ORCHARD_SHARD_HEIGHT},
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -2335,13 +2335,13 @@ where
 /// as a distinct alias to make Ironwood usage self-documenting at call sites.
 #[cfg(feature = "orchard")]
 pub(crate) type IronwoodShardStore<C> =
-    SqliteShardStore<C, orchard::tree::MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>;
+    SqliteShardStore<C, orchard::tree::MerkleHashOrchard, IRONWOOD_SHARD_HEIGHT>;
 
 #[cfg(feature = "orchard")]
 pub(crate) type IronwoodCommitmentTree<C> = ShardTree<
     IronwoodShardStore<C>,
     { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-    ORCHARD_SHARD_HEIGHT,
+    IRONWOOD_SHARD_HEIGHT,
 >;
 
 /// Returns a handle to the Ironwood note commitment tree.

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -26,7 +26,6 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
         *,
     },
-    fees::StandardFeeRule,
     wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput},
 };
 use zcash_keys::{
@@ -52,6 +51,7 @@ use {
     crate::TransparentAddressMetadata,
     ::transparent::{address::TransparentAddress, bundle::OutPoint, keys::NonHardenedChildIndex},
     core::ops::Range,
+    zcash_client_backend::fees::StandardFeeRule,
     zcash_keys::keys::transparent::gap_limits::GapLimits,
 };
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -29,7 +29,11 @@ use crate::{
 };
 
 #[cfg(feature = "orchard")]
-use {crate::ORCHARD_TABLES_PREFIX, zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT};
+use {
+    crate::IRONWOOD_TABLES_PREFIX, crate::ORCHARD_TABLES_PREFIX,
+    zcash_client_backend::data_api::IRONWOOD_SHARD_HEIGHT,
+    zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT,
+};
 
 pub(crate) struct TableConstants {
     pub(crate) table_prefix: &'static str,
@@ -56,6 +60,15 @@ const ORCHARD_TABLE_CONSTANTS: TableConstants = TableConstants {
     shard_height: ORCHARD_SHARD_HEIGHT,
 };
 
+#[cfg(feature = "orchard")]
+const IRONWOOD_TABLE_CONSTANTS: TableConstants = TableConstants {
+    table_prefix: IRONWOOD_TABLES_PREFIX,
+    output_index_col: "action_index",
+    output_count_col: "ironwood_action_count",
+    note_reconstruction_cols: "rho, rseed, note_version",
+    shard_height: IRONWOOD_SHARD_HEIGHT,
+};
+
 #[allow(dead_code)]
 pub(crate) trait ErrUnsupportedPool {
     fn unsupported_pool_type(pool_type: PoolType) -> Self;
@@ -70,7 +83,10 @@ pub(crate) fn table_constants<E: ErrUnsupportedPool>(
         ShieldedPool::Orchard => Ok(ORCHARD_TABLE_CONSTANTS),
         #[cfg(not(feature = "orchard"))]
         ShieldedPool::Orchard => Err(E::unsupported_pool_type(PoolType::ORCHARD)),
-        ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
+        #[cfg(feature = "orchard")]
+        ShieldedPool::Ironwood => Ok(IRONWOOD_TABLE_CONSTANTS),
+        #[cfg(not(feature = "orchard"))]
+        ShieldedPool::Ironwood => Err(E::unsupported_pool_type(PoolType::IRONWOOD)),
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -392,9 +392,12 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
+    ironwood_shardtree::MIGRATION_ID,
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
-    witness_stabilized_notes::MIGRATION_ID,
+    add_transparent_receiver_address_index::MIGRATION_ID,
+    add_transparent_value_index::MIGRATION_ID,
+    ironwood_received_notes::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
-use zcash_protocol::consensus;
+use zcash_protocol::{ShieldedPool, consensus};
 
 use super::account_delete_cascade;
 use crate::wallet::init::WalletMigrationError;
@@ -55,7 +55,18 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
         )?;
 
         // Backfill: Identify any notes which have stable witness data, and mark them as such.
-        mark_stabilized_notes(transaction, &self.params)?;
+        // Only the Sapling and Orchard received-note tables exist at this point in the migration
+        // DAG; the Ironwood table is introduced by a later migration (already stabilization-aware),
+        // so it is intentionally excluded from this backfill.
+        mark_stabilized_notes(
+            transaction,
+            &self.params,
+            &[
+                ShieldedPool::Sapling,
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Orchard,
+            ],
+        )?;
 
         Ok(())
     }
@@ -415,6 +426,7 @@ mod tests {
     #[test]
     fn gap_in_scanned_coverage_prevents_stabilization() {
         use zcash_client_backend::data_api::scanning::ScanPriority;
+        use zcash_protocol::ShieldedPool;
 
         use crate::wallet::scanning::{mark_stabilized_notes, priority_code};
 
@@ -597,7 +609,16 @@ mod tests {
         // First call: the non-Scanned gap lies inside shard 0's extent, so the note must
         // NOT stabilize.
         let tx = db_data.conn.transaction().unwrap();
-        mark_stabilized_notes(&tx, &network).unwrap();
+        mark_stabilized_notes(
+            &tx,
+            &network,
+            &[
+                ShieldedPool::Sapling,
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Orchard,
+            ],
+        )
+        .unwrap();
         tx.commit().unwrap();
 
         assert_eq!(
@@ -632,7 +653,16 @@ mod tests {
             .unwrap();
 
         let tx = db_data.conn.transaction().unwrap();
-        mark_stabilized_notes(&tx, &network).unwrap();
+        mark_stabilized_notes(
+            &tx,
+            &network,
+            &[
+                ShieldedPool::Sapling,
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Orchard,
+            ],
+        )
+        .unwrap();
         tx.commit().unwrap();
 
         assert_eq!(

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -28,6 +28,9 @@ use super::{block_max_scanned, wallet_birthday};
 #[cfg(feature = "orchard")]
 use zcash_client_backend::data_api::{IRONWOOD_SHARD_HEIGHT, ORCHARD_SHARD_HEIGHT};
 
+#[cfg(not(feature = "orchard"))]
+use zcash_protocol::PoolType;
+
 pub(crate) fn priority_code(priority: &ScanPriority) -> i64 {
     use ScanPriority::*;
     match priority {
@@ -674,7 +677,6 @@ pub(crate) mod tests {
     };
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{
-        ShieldedPool,
         consensus::{BlockHeight, NetworkUpgrade, Parameters},
         local_consensus::LocalNetwork,
         value::Zatoshis,
@@ -696,9 +698,9 @@ pub(crate) mod tests {
     #[cfg(feature = "orchard")]
     #[test]
     fn extend_range_uses_ironwood_tree_shards() {
-        use std::collections::BTreeSet;
-
         use rusqlite::Connection;
+        use std::collections::BTreeSet;
+        use zcash_protocol::ShieldedPool;
 
         let mut conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -26,10 +26,7 @@ use super::common::table_constants;
 use super::{block_max_scanned, wallet_birthday};
 
 #[cfg(feature = "orchard")]
-use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
-
-#[cfg(not(feature = "orchard"))]
-use zcash_protocol::PoolType;
+use zcash_client_backend::data_api::{IRONWOOD_SHARD_HEIGHT, ORCHARD_SHARD_HEIGHT};
 
 pub(crate) fn priority_code(priority: &ScanPriority) -> i64 {
     use ScanPriority::*;
@@ -225,11 +222,11 @@ fn extend_range(
     conn: &rusqlite::Transaction<'_>,
     range: &Range<BlockHeight>,
     required_subtree_indices: BTreeSet<u64>,
-    protocol: ShieldedPool,
+    pool: ShieldedPool,
     fallback_start_height: Option<BlockHeight>,
     birthday_height: Option<BlockHeight>,
 ) -> Result<Option<Range<BlockHeight>>, SqliteClientError> {
-    let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
+    let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(pool)?;
 
     // we'll either have both min and max bounds, or we'll have neither
     let subtree_index_bounds = required_subtree_indices
@@ -302,6 +299,10 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
         let mut required_sapling_subtrees = BTreeSet::new();
         #[cfg(feature = "orchard")]
         let mut required_orchard_subtrees = BTreeSet::new();
+        // Ironwood note commitments are Orchard-shaped and use the Orchard shard height, but are
+        // tracked in a separate commitment tree.
+        #[cfg(feature = "orchard")]
+        let mut required_ironwood_subtrees = BTreeSet::new();
         for (protocol, position) in wallet_note_positions {
             match protocol {
                 ShieldedPool::Sapling => {
@@ -321,7 +322,15 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
                     )));
                 }
                 ShieldedPool::Ironwood => {
-                    todo!("Ironwood pool support is not yet implemented")
+                    #[cfg(feature = "orchard")]
+                    required_ironwood_subtrees.insert(
+                        Address::above_position(IRONWOOD_SHARD_HEIGHT.into(), *position).index(),
+                    );
+
+                    #[cfg(not(feature = "orchard"))]
+                    return Err(SqliteClientError::UnsupportedPoolType(PoolType::Shielded(
+                        *protocol,
+                    )));
                 }
             }
         }
@@ -342,6 +351,18 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
             required_orchard_subtrees,
             ShieldedPool::Orchard,
             params.activation_height(NetworkUpgrade::Nu5),
+            wallet_birthday,
+        )?
+        .or(extended_range);
+
+        // Ironwood's commitment tree activates at NU6.3.
+        #[cfg(feature = "orchard")]
+        let extended_range = extend_range(
+            conn,
+            extended_range.as_ref().unwrap_or(&range),
+            required_ironwood_subtrees,
+            ShieldedPool::Ironwood,
+            params.activation_height(NetworkUpgrade::Nu6_3),
             wallet_birthday,
         )?
         .or(extended_range);
@@ -373,8 +394,18 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
 
     replace_queue_entries::<SqliteClientError>(conn, &query_range, replacement, false)?;
 
-    // Check for any newly stabilized notes, and mark them as stabilized
-    mark_stabilized_notes(conn, params)?;
+    // Check for any newly stabilized notes, and mark them as stabilized.
+    mark_stabilized_notes(
+        conn,
+        params,
+        &[
+            ShieldedPool::Sapling,
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Orchard,
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Ironwood,
+        ],
+    )?;
 
     Ok(())
 }
@@ -384,28 +415,38 @@ pub(crate) fn scan_complete<P: consensus::Parameters>(
 ///
 /// This means that a note within the chain-tip shard can not be marked as `witness_stabilized`,
 /// because the tip shard is by definition not complete or confirmed to the `PRUNING_DEPTH`.
+///
+/// Only the pools listed in `pools` are processed. Callers must restrict this to pools whose
+/// received-note tables exist in the schema at the point of the call; in particular the
+/// `witness_stabilized_notes` migration runs before the Ironwood received-note table is created,
+/// so it must not request the Ironwood pool.
 pub(crate) fn mark_stabilized_notes<P: consensus::Parameters>(
     conn: &rusqlite::Transaction<'_>,
     params: &P,
+    pools: &[ShieldedPool],
 ) -> Result<(), SqliteClientError> {
     fn mark_pool(
         conn: &rusqlite::Transaction<'_>,
-        pool: &str,
-        shard_height: u8,
+        pool: ShieldedPool,
         pruning_floor: u32,
     ) -> Result<(), SqliteClientError> {
+        let TableConstants {
+            table_prefix,
+            shard_height,
+            ..
+        } = table_constants::<SqliteClientError>(pool)?;
         let sql = format!(
-            "UPDATE {pool}_received_notes
+            "UPDATE {table_prefix}_received_notes
              SET witness_stabilized = 1
              WHERE witness_stabilized = 0
                AND commitment_tree_position IS NOT NULL
                AND EXISTS (
-                   SELECT 1 FROM {pool}_tree_shards shard
+                   SELECT 1 FROM {table_prefix}_tree_shards shard
                    WHERE shard.subtree_end_height IS NOT NULL
                      AND shard.subtree_end_height <= :pruning_floor
                      AND (commitment_tree_position >> :shard_height) = shard.shard_index
                      AND shard.shard_index NOT IN (
-                         SELECT shard_index FROM v_{pool}_shard_unscanned_ranges
+                         SELECT shard_index FROM v_{table_prefix}_shard_unscanned_ranges
                      )
                )",
         );
@@ -419,10 +460,10 @@ pub(crate) fn mark_stabilized_notes<P: consensus::Parameters>(
     if let Some(max_scanned_height) = block_max_scanned(conn, params)?.map(|m| m.block_height()) {
         let pruning_floor: u32 = u32::from(max_scanned_height).saturating_sub(PRUNING_DEPTH - 1);
 
-        // Mark stabilized notes in each pool
-        mark_pool(conn, "sapling", SAPLING_SHARD_HEIGHT, pruning_floor)?;
-        #[cfg(feature = "orchard")]
-        mark_pool(conn, "orchard", ORCHARD_SHARD_HEIGHT, pruning_floor)?;
+        // Mark stabilized notes in each requested pool.
+        for pool in pools {
+            mark_pool(conn, *pool, pruning_floor)?;
+        }
     }
 
     Ok(())
@@ -633,6 +674,7 @@ pub(crate) mod tests {
     };
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{
+        ShieldedPool,
         consensus::{BlockHeight, NetworkUpgrade, Parameters},
         local_consensus::LocalNetwork,
         value::Zatoshis,
@@ -647,6 +689,49 @@ pub(crate) mod tests {
         },
         wallet::scanning::{insert_queue_entries, replace_queue_entries, suggest_scan_ranges},
     };
+
+    /// `extend_range` for the Ironwood pool must query the `ironwood_tree_shards` table (rather
+    /// than the Orchard tree), extending the scan range to cover the subtrees containing the
+    /// discovered notes.
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn extend_range_uses_ironwood_tree_shards() {
+        use std::collections::BTreeSet;
+
+        use rusqlite::Connection;
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE ironwood_tree_shards (
+                shard_index INTEGER PRIMARY KEY,
+                subtree_end_height INTEGER
+            );
+            INSERT INTO ironwood_tree_shards (shard_index, subtree_end_height)
+            VALUES (0, 100), (1, 200);",
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        let range = BlockHeight::from_u32(50)..BlockHeight::from_u32(60);
+        let required = BTreeSet::from([1u64]);
+
+        let extended = super::extend_range(
+            &tx,
+            &range,
+            required,
+            ShieldedPool::Ironwood,
+            Some(BlockHeight::from_u32(10)),
+            Some(BlockHeight::from_u32(5)),
+        )
+        .unwrap();
+
+        // Subtree 1 spans from the end of subtree 0 (height 100) to its own end (height 200), so
+        // the scan range is extended to cover [50, 201).
+        assert_eq!(
+            extended,
+            Some(BlockHeight::from_u32(50)..BlockHeight::from_u32(201))
+        );
+    }
 
     #[cfg(feature = "orchard")]
     use {


### PR DESCRIPTION
Stacked on #2532 (base: `dw/ironwood-note-version-migrations`).

When Ironwood notes are detected during scanning, this extends the suggested
scan ranges to include the blocks needed to complete the Ironwood note
commitment tree subtrees containing those notes, mirroring the existing Sapling
and Orchard handling, and removes the corresponding `todo!` in
`update_completed_ranges`.

### Design note

~~Ironwood notes are stored alongside Orchard notes in `orchard_received_notes`,
but their commitment tree is tracked separately (in the `ironwood_*` tables). A
single `ShieldedPool` -> table-prefix mapping (`table_constants`) cannot serve
both the note table and the tree tables for Ironwood, so `extend_range` now
takes the tree table prefix directly instead of deriving it from a
`ShieldedPool`.~~ The Sapling, Orchard, and Ironwood callers pass their respective
prefixes, and the Ironwood extension is gated on NU6.3 activation.

### Tests

Adds `extend_range_uses_ironwood_tree_shards`, verifying that `extend_range`
queries the `ironwood_tree_shards` table and extends the scan range to cover the
subtrees containing the discovered notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)