### PR TITLE
pczt: preverified signing parse for the low-level Signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,8 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e277dd4b46f5d06deae3ffb8af1a951e8622368f028c2a4d6fe59339566403"
+source = "git+https://github.com/zcash/orchard?rev=20c10904ae84af19fe657bbbb7369c4dac4f142a#20c10904ae84af19fe657bbbb7369c4dac4f142a"
 dependencies = [
  "aes",
  "bitvec",
@@ -3181,6 +3180,7 @@ dependencies = [
  "orchard",
  "pasta_curves",
  "postcard",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "redjubjub",
  "ripemd 0.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.1"
-source = "git+https://github.com/zcash/orchard?rev=20c10904ae84af19fe657bbbb7369c4dac4f142a#20c10904ae84af19fe657bbbb7369c4dac4f142a"
+source = "git+https://github.com/zcash/orchard?rev=ab7c5fae83d3c197ba045b6485fa0206d68dc6f4#ab7c5fae83d3c197ba045b6485fa0206d68dc6f4"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,3 +227,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(zcash_unstable, values("nu7"))',
   'cfg(live_network_tests)',
 ] }
+
+[patch.crates-io]
+orchard = { git = "https://github.com/zcash/orchard", rev = "20c10904ae84af19fe657bbbb7369c4dac4f142a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,4 +229,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "20c10904ae84af19fe657bbbb7369c4dac4f142a" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "ab7c5fae83d3c197ba045b6485fa0206d68dc6f4" }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -62,6 +62,15 @@ workspace.
 - `pczt::Pczt::serialize` now consumes `self` and returns
   `Result<Vec<u8>, pczt::EncodingError>` rather than borrowing `self` and
   returning `Vec<u8>`.
+- The low-level Signer's `sign_orchard_with` and `sign_ironwood_with` now parse
+  the bundle with a preverified signing parse that skips deriving each spend's
+  full viewing key, driven by a bounded loop that keeps parsing stack usage flat
+  on constrained devices. These methods no longer validate the wire `fvk` bytes
+  (callers must first run the full Verifier checks over the identical PCZT bytes)
+  but preserve them unchanged in the returned PCZT. The signing closure must not
+  add, remove, or reorder actions; doing so now returns the new
+  `pczt::roles::low_level_signer::OrchardParseError::SigningClosureModifiedActions`
+  error and leaves the PCZT unmodified.
 
 ### Added
 - `pczt::roles::creator::Error`, the error type returned by the now-fallible

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -55,6 +55,7 @@ document-features = { workspace = true, optional = true }
 
 [dev-dependencies]
 incrementalmerkletree.workspace = true
+rand_chacha.workspace = true
 ripemd.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 sha2.workspace = true
@@ -64,6 +65,7 @@ zcash_primitives = { workspace = true, features = [
     "transparent-inputs",
 ] }
 zcash_proofs = { workspace = true, features = ["bundled-prover"] }
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
 zip32.workspace = true
 
 [features]

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -846,12 +846,11 @@ impl Bundle {
         bundle_version: BundleVersion,
         preverified: bool,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        // Parse each action through an `#[inline(never)]` helper driven by a plain
-        // loop, not `.map(..).collect()`: the latter compiles to a single combined
-        // stack frame (the per-action closure inlined into `try_fold`) tens of KB
-        // deep, overflowing the fixed task stacks of embedded signers. The loop keeps
-        // one bounded helper frame live at a time, and is behaviorally identical
-        // (same order, same first error).
+        // We parse actions through a helper that is specifically `#[inline(never)]`.
+        // This is because if this gets inlined in a loop (e.g. `.map(..).collect()`),
+        // it could compile into a stack frame that is tens of KB deep.
+        // This can overflow stacks of embedded signers for high action count
+        // transactions.
         #[inline(never)]
         fn parse_action_inner(
             action: Action,

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -924,16 +924,7 @@ impl Bundle {
                 action.output.proprietary,
             )?;
 
-            if preverified {
-                orchard::pczt::Action::parse_preverified_for_signing(
-                    action.cv_net,
-                    spend,
-                    output,
-                    action.rcv,
-                )
-            } else {
-                orchard::pczt::Action::parse(action.cv_net, spend, output, action.rcv)
-            }
+            orchard::pczt::Action::parse(action.cv_net, spend, output, action.rcv)
         }
 
         let note_version = self.note_version;
@@ -942,27 +933,15 @@ impl Bundle {
             actions.push(parse_action_inner(action, note_version, preverified)?);
         }
 
-        if preverified {
-            orchard::pczt::Bundle::parse_preverified_for_signing(
-                actions,
-                self.flags,
-                bundle_version,
-                self.value_sum,
-                self.anchor,
-                self.zkproof,
-                self.bsk,
-            )
-        } else {
-            orchard::pczt::Bundle::parse(
-                actions,
-                self.flags,
-                bundle_version,
-                self.value_sum,
-                self.anchor,
-                self.zkproof,
-                self.bsk,
-            )
-        }
+        orchard::pczt::Bundle::parse(
+            actions,
+            self.flags,
+            bundle_version,
+            self.value_sum,
+            self.anchor,
+            self.zkproof,
+            self.bsk,
+        )
     }
 
     pub(crate) fn serialize_from(bundle: orchard::pczt::Bundle) -> Self {

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -795,22 +795,79 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
 
 #[cfg(feature = "orchard")]
 impl Bundle {
+    /// Parses this bundle as an Ironwood-pool bundle, deriving each spend's
+    /// `FullViewingKey` from its wire `fvk` bytes.
     pub(crate) fn into_ironwood_parsed(
         self,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
         self.into_parsed_with_version(BundleVersion::ironwood_v3())
     }
 
+    /// Parses this bundle as an Ironwood-pool bundle for a preverified signing pass,
+    /// skipping each spend's `FullViewingKey` derivation. See
+    /// [`Bundle::into_parsed_with_version_preverified_for_signing`] for the invariant
+    /// callers must uphold.
+    pub(crate) fn into_ironwood_parsed_preverified_for_signing(
+        self,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        self.into_parsed_with_version_preverified_for_signing(BundleVersion::ironwood_v3())
+    }
+
+    /// Parses this bundle with the given bundle version, deriving each spend's
+    /// `FullViewingKey` from its wire `fvk` bytes.
     pub(crate) fn into_parsed_with_version(
         self,
         bundle_version: BundleVersion,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        let note_version = self.note_version;
-        let actions = self
-            .actions
-            .into_iter()
-            .map(|action| {
-                let spend = orchard::pczt::Spend::parse(
+        self.into_parsed_inner(bundle_version, false)
+    }
+
+    /// Parses this bundle with the given bundle version for a preverified signing
+    /// pass, skipping each spend's `FullViewingKey` derivation (an expensive step the
+    /// spend authorization signature does not depend on).
+    ///
+    /// Callers MUST have already run the full Verifier checks over the identical PCZT
+    /// bytes: the wire `fvk` bytes are neither validated nor retained here (each spend
+    /// has `fvk: None`), so the result must not go to the Verifier check path or the
+    /// Prover, and re-serializing it drops the wire `fvk`s (the low-level Signer
+    /// restores them from a pre-parse snapshot).
+    pub(crate) fn into_parsed_with_version_preverified_for_signing(
+        self,
+        bundle_version: BundleVersion,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        self.into_parsed_inner(bundle_version, true)
+    }
+
+    /// The shared body of [`Bundle::into_parsed_with_version`] and
+    /// [`Bundle::into_parsed_with_version_preverified_for_signing`]: `preverified`
+    /// selects between the full parse and the preverified signing parse.
+    fn into_parsed_inner(
+        self,
+        bundle_version: BundleVersion,
+        preverified: bool,
+    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        // Parse each action through an `#[inline(never)]` helper driven by a plain
+        // loop, not `.map(..).collect()`: the latter compiles to a single combined
+        // stack frame (the per-action closure inlined into `try_fold`) tens of KB
+        // deep, overflowing the fixed task stacks of embedded signers. The loop keeps
+        // one bounded helper frame live at a time, and is behaviorally identical
+        // (same order, same first error).
+        #[inline(never)]
+        fn parse_action_inner(
+            action: Action,
+            note_version: NoteVersion,
+            preverified: bool,
+        ) -> Result<orchard::pczt::Action, orchard::pczt::ParseError> {
+            let spend_zip32_derivation = action
+                .spend
+                .zip32_derivation
+                .map(|z| {
+                    orchard::pczt::Zip32Derivation::parse(z.seed_fingerprint, z.derivation_path)
+                })
+                .transpose()?;
+
+            let spend = if preverified {
+                orchard::pczt::Spend::parse_preverified_for_signing(
                     action.spend.nullifier,
                     action.spend.rk,
                     action.spend.spend_auth_sig,
@@ -821,59 +878,91 @@ impl Bundle {
                     action.spend.fvk,
                     action.spend.witness,
                     action.spend.alpha,
-                    action
-                        .spend
-                        .zip32_derivation
-                        .map(|z| {
-                            orchard::pczt::Zip32Derivation::parse(
-                                z.seed_fingerprint,
-                                z.derivation_path,
-                            )
-                        })
-                        .transpose()?,
+                    spend_zip32_derivation,
                     action.spend.dummy_sk,
                     note_version,
                     action.spend.proprietary,
-                )?;
-
-                let output = orchard::pczt::Output::parse(
-                    *spend.nullifier(),
-                    action.output.cmx,
-                    action.output.ephemeral_key,
-                    action.output.enc_ciphertext,
-                    action.output.out_ciphertext,
-                    action.output.recipient,
-                    action.output.value,
-                    action.output.rseed,
-                    action.output.ock,
-                    action
-                        .output
-                        .zip32_derivation
-                        .map(|z| {
-                            orchard::pczt::Zip32Derivation::parse(
-                                z.seed_fingerprint,
-                                z.derivation_path,
-                            )
-                        })
-                        .transpose()?,
-                    action.output.user_address,
+                )
+            } else {
+                orchard::pczt::Spend::parse(
+                    action.spend.nullifier,
+                    action.spend.rk,
+                    action.spend.spend_auth_sig,
+                    action.spend.recipient,
+                    action.spend.value,
+                    action.spend.rho,
+                    action.spend.rseed,
+                    action.spend.fvk,
+                    action.spend.witness,
+                    action.spend.alpha,
+                    spend_zip32_derivation,
+                    action.spend.dummy_sk,
                     note_version,
-                    action.output.proprietary,
-                )?;
+                    action.spend.proprietary,
+                )
+            }?;
 
+            let output = orchard::pczt::Output::parse(
+                *spend.nullifier(),
+                action.output.cmx,
+                action.output.ephemeral_key,
+                action.output.enc_ciphertext,
+                action.output.out_ciphertext,
+                action.output.recipient,
+                action.output.value,
+                action.output.rseed,
+                action.output.ock,
+                action
+                    .output
+                    .zip32_derivation
+                    .map(|z| {
+                        orchard::pczt::Zip32Derivation::parse(z.seed_fingerprint, z.derivation_path)
+                    })
+                    .transpose()?,
+                action.output.user_address,
+                note_version,
+                action.output.proprietary,
+            )?;
+
+            if preverified {
+                orchard::pczt::Action::parse_preverified_for_signing(
+                    action.cv_net,
+                    spend,
+                    output,
+                    action.rcv,
+                )
+            } else {
                 orchard::pczt::Action::parse(action.cv_net, spend, output, action.rcv)
-            })
-            .collect::<Result<_, _>>()?;
+            }
+        }
 
-        orchard::pczt::Bundle::parse(
-            actions,
-            self.flags,
-            bundle_version,
-            self.value_sum,
-            self.anchor,
-            self.zkproof,
-            self.bsk,
-        )
+        let note_version = self.note_version;
+        let mut actions = Vec::with_capacity(self.actions.len());
+        for action in self.actions {
+            actions.push(parse_action_inner(action, note_version, preverified)?);
+        }
+
+        if preverified {
+            orchard::pczt::Bundle::parse_preverified_for_signing(
+                actions,
+                self.flags,
+                bundle_version,
+                self.value_sum,
+                self.anchor,
+                self.zkproof,
+                self.bsk,
+            )
+        } else {
+            orchard::pczt::Bundle::parse(
+                actions,
+                self.flags,
+                bundle_version,
+                self.value_sum,
+                self.anchor,
+                self.zkproof,
+                self.bsk,
+            )
+        }
     }
 
     pub(crate) fn serialize_from(bundle: orchard::pczt::Bundle) -> Self {

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -13,6 +13,17 @@ impl Signer {
     }
 
     /// Exposes the capability to sign the Ironwood spends.
+    ///
+    /// The bundle is parsed with a preverified signing parse that skips deriving each
+    /// spend's `FullViewingKey` (an expensive step the spend authorization signature
+    /// does not depend on). Callers that rely on the wire `fvk` bytes MUST have
+    /// already run the full Verifier checks over the identical PCZT bytes: they are
+    /// not validated here, and the signing closure sees each spend's `fvk` as `None`.
+    ///
+    /// The signing closure must not add, remove, or reorder actions. A well-behaved
+    /// closure leaves the returned PCZT's wire `fvk` bytes unchanged; a violating one
+    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`],
+    /// leaving the PCZT unmodified.
     #[cfg(feature = "orchard")]
     pub fn sign_ironwood_with<E, F>(self, f: F) -> Result<Self, E>
     where
@@ -23,21 +34,34 @@ impl Signer {
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
 
+        let fvk_snapshot = snapshot_spend_fvks(&pczt.ironwood);
         let mut bundle = pczt
             .ironwood
             .clone()
-            .into_ironwood_parsed()
+            .into_ironwood_parsed_preverified_for_signing()
             .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
 
         pczt.global.tx_modifiable = tx_modifiable;
         pczt.ironwood = crate::orchard::Bundle::serialize_from(bundle);
+        restore_spend_fvks(&mut pczt.ironwood, &fvk_snapshot).map_err(E::from)?;
 
         Ok(Self { pczt })
     }
 
     /// Exposes the capability to sign the Orchard spends.
+    ///
+    /// The bundle is parsed with a preverified signing parse that skips deriving each
+    /// spend's `FullViewingKey` (an expensive step the spend authorization signature
+    /// does not depend on). Callers that rely on the wire `fvk` bytes MUST have
+    /// already run the full Verifier checks over the identical PCZT bytes: they are
+    /// not validated here, and the signing closure sees each spend's `fvk` as `None`.
+    ///
+    /// The signing closure must not add, remove, or reorder actions. A well-behaved
+    /// closure leaves the returned PCZT's wire `fvk` bytes unchanged; a violating one
+    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`],
+    /// leaving the PCZT unmodified.
     #[cfg(feature = "orchard")]
     pub fn sign_orchard_with<E, F>(self, f: F) -> Result<Self, E>
     where
@@ -50,16 +74,18 @@ impl Signer {
 
         let bundle_version = crate::orchard::orchard_bundle_version(&pczt.global)
             .ok_or(OrchardParseError::UnsupportedConsensusBranchId)?;
+        let fvk_snapshot = snapshot_spend_fvks(&pczt.orchard);
         let mut bundle = pczt
             .orchard
             .clone()
-            .into_parsed_with_version(bundle_version)
+            .into_parsed_with_version_preverified_for_signing(bundle_version)
             .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
 
         pczt.global.tx_modifiable = tx_modifiable;
         pczt.orchard = crate::orchard::Bundle::serialize_from(bundle);
+        restore_spend_fvks(&mut pczt.orchard, &fvk_snapshot).map_err(E::from)?;
 
         Ok(Self { pczt })
     }
@@ -112,6 +138,53 @@ impl Signer {
     }
 }
 
+/// A by-position snapshot of each spend's wire `(rk, fvk)` bytes: the `fvk` that the
+/// preverified signing parse drops and must restore, paired with the `rk` used as a
+/// per-position tamper check. See [`restore_spend_fvks`].
+#[cfg(feature = "orchard")]
+type SpendFvkSnapshot = alloc::vec::Vec<([u8; 32], Option<[u8; 96]>)>;
+
+/// Snapshots each action's spend `(rk, fvk)` wire bytes, by position, for
+/// [`restore_spend_fvks`] to restore after serialization.
+#[cfg(feature = "orchard")]
+fn snapshot_spend_fvks(bundle: &crate::orchard::Bundle) -> SpendFvkSnapshot {
+    bundle
+        .actions()
+        .iter()
+        .map(|action| (action.spend.rk, action.spend.fvk))
+        .collect()
+}
+
+/// Restores the wire `fvk` bytes from [`snapshot_spend_fvks`] into each spend by
+/// position, after proving the signing closure did not resize or reorder the action
+/// list.
+///
+/// Positional restore is only sound if each position still holds its original action,
+/// so this checks the action count and each position's wire `rk` — the one
+/// always-present spend field that pins an action's identity, since a nullifier can
+/// be shared — against the snapshot before writing any `fvk`. On a mismatch it writes
+/// nothing and returns [`OrchardParseError::SigningClosureModifiedActions`].
+#[cfg(feature = "orchard")]
+fn restore_spend_fvks(
+    bundle: &mut crate::orchard::Bundle,
+    snapshot: &SpendFvkSnapshot,
+) -> Result<(), OrchardParseError> {
+    // Reject a resized or reordered list before writing: a count change misaligns
+    // every later `fvk`, and a reorder moves `rk`s off their snapshotted positions.
+    if bundle.actions.len() != snapshot.len() {
+        return Err(OrchardParseError::SigningClosureModifiedActions);
+    }
+    for (action, (rk, _)) in bundle.actions.iter().zip(snapshot) {
+        if action.spend.rk != *rk {
+            return Err(OrchardParseError::SigningClosureModifiedActions);
+        }
+    }
+    for (action, (_, fvk)) in bundle.actions.iter_mut().zip(snapshot) {
+        action.spend.fvk = *fvk;
+    }
+    Ok(())
+}
+
 /// Errors that can occur while parsing an Orchard-protocol bundle of a PCZT for
 /// signing.
 #[cfg(feature = "orchard")]
@@ -122,11 +195,114 @@ pub enum OrchardParseError {
     /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
     /// the Orchard protocol is not supported).
     UnsupportedConsensusBranchId,
+    /// A signing closure passed to [`Signer::sign_orchard_with`] or
+    /// [`Signer::sign_ironwood_with`] added, removed, or reordered actions, which
+    /// those methods forbid. The PCZT is left unmodified.
+    SigningClosureModifiedActions,
 }
 
 #[cfg(feature = "orchard")]
 impl From<orchard::pczt::ParseError> for OrchardParseError {
     fn from(e: orchard::pczt::ParseError) -> Self {
         OrchardParseError::Parse(e)
+    }
+}
+
+#[cfg(all(test, feature = "orchard"))]
+mod tests {
+    use alloc::collections::BTreeMap;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use crate::orchard::{Action, Bundle, NoteVersion, Output, Spend};
+
+    use super::{OrchardParseError, restore_spend_fvks, snapshot_spend_fvks};
+
+    #[test]
+    fn restore_spend_fvks_preserves_duplicate_nullifiers_by_position() {
+        let first_fvk = Some([7u8; 96]);
+        let second_fvk = Some([9u8; 96]);
+        // Shared nullifier, distinct `rk`s: proves the restore keys on position, not
+        // the (here ambiguous) nullifier.
+        let mut bundle = bundle_with_duplicate_nullifier_fvks([first_fvk, second_fvk]);
+        let snapshot = snapshot_spend_fvks(&bundle);
+
+        bundle.actions[0].spend.fvk = None;
+        bundle.actions[1].spend.fvk = None;
+
+        restore_spend_fvks(&mut bundle, &snapshot).expect("actions were not modified");
+
+        assert_eq!(bundle.actions[0].spend.fvk, first_fvk);
+        assert_eq!(bundle.actions[1].spend.fvk, second_fvk);
+    }
+
+    #[test]
+    fn restore_spend_fvks_rejects_reordered_actions() {
+        let first_fvk = Some([7u8; 96]);
+        let second_fvk = Some([9u8; 96]);
+        let mut bundle = bundle_with_duplicate_nullifier_fvks([first_fvk, second_fvk]);
+        let snapshot = snapshot_spend_fvks(&bundle);
+
+        // A signing closure swaps the two actions; their distinct wire `rk`s move too.
+        bundle.actions.swap(0, 1);
+
+        assert!(matches!(
+            restore_spend_fvks(&mut bundle, &snapshot),
+            Err(OrchardParseError::SigningClosureModifiedActions)
+        ));
+        // Left as the closure left it: `fvk`s were not restored onto swapped actions.
+        assert_eq!(bundle.actions[0].spend.fvk, second_fvk);
+        assert_eq!(bundle.actions[1].spend.fvk, first_fvk);
+    }
+
+    /// Returns a two-action bundle whose spends share a nullifier but carry
+    /// distinct wire `rk`s and the given distinct `fvk`s.
+    fn bundle_with_duplicate_nullifier_fvks(fvks: [Option<[u8; 96]>; 2]) -> Bundle {
+        Bundle {
+            actions: fvks
+                .into_iter()
+                .enumerate()
+                // Distinct `rk` per action (`[10; 32]`, `[11; 32]`), shared
+                // nullifier `[3; 32]`.
+                .map(|(i, fvk)| Action {
+                    cv_net: [0; 32],
+                    spend: Spend {
+                        nullifier: [3u8; 32],
+                        rk: [10 + i as u8; 32],
+                        spend_auth_sig: None,
+                        recipient: None,
+                        value: None,
+                        rho: None,
+                        rseed: None,
+                        fvk,
+                        witness: None,
+                        alpha: None,
+                        zip32_derivation: None,
+                        dummy_sk: None,
+                        proprietary: BTreeMap::new(),
+                    },
+                    output: Output {
+                        cmx: [0; 32],
+                        ephemeral_key: [0; 32],
+                        enc_ciphertext: Vec::new(),
+                        out_ciphertext: Vec::new(),
+                        recipient: None,
+                        value: None,
+                        rseed: None,
+                        ock: None,
+                        zip32_derivation: None,
+                        user_address: Option::<String>::None,
+                        proprietary: BTreeMap::new(),
+                    },
+                    rcv: None,
+                })
+                .collect(),
+            flags: 0,
+            value_sum: (0, false),
+            anchor: [0; 32],
+            note_version: NoteVersion::V2,
+            zkproof: None,
+            bsk: None,
+        }
     }
 }

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -156,7 +156,7 @@ fn snapshot_spend_fvks(bundle: &crate::orchard::Bundle) -> SpendFvkSnapshot {
 }
 
 /// Restores the wire `fvk` bytes from [`snapshot_spend_fvks`] into each spend by
-/// position, after proving the signing closure did not resize or reorder the action
+/// position, after checking the signing closure did not resize or reorder the action
 /// list.
 ///
 /// Positional restore is only sound if each position still holds its original action,

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -11,13 +11,14 @@ use orchard::tree::MerkleHashOrchard;
 use pczt::{
     Pczt,
     roles::{
-        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, prover::Prover,
-        signer::Signer, spend_finalizer::SpendFinalizer, tx_extractor::TransactionExtractor,
-        updater::Updater,
+        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
+        prover::Prover, signer::Signer, spend_finalizer::SpendFinalizer,
+        tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
     },
     v1, v2,
 };
-use rand_core::OsRng;
+use rand_chacha::ChaCha20Rng;
+use rand_core::{OsRng, SeedableRng};
 use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use zcash_note_encryption::try_note_decryption;
 use zcash_primitives::transaction::{
@@ -697,4 +698,438 @@ fn orchard_to_orchard() {
     let tx = TransactionExtractor::new(pczt).extract().unwrap();
 
     assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+/// Extracts each action's wire `fvk` bytes from the Orchard or Ironwood pool of the
+/// PCZT, via the Verifier role's full (FVK-deriving) parse.
+fn wire_spend_fvks(pczt: &Pczt, ironwood: bool) -> Vec<Option<[u8; 96]>> {
+    use std::convert::Infallible;
+
+    fn collect(bundle: &orchard::pczt::Bundle) -> Vec<Option<[u8; 96]>> {
+        bundle
+            .actions()
+            .iter()
+            .map(|action| action.spend().fvk().as_ref().map(|fvk| fvk.to_bytes()))
+            .collect()
+    }
+
+    let mut fvks = None;
+    let verifier = Verifier::new(pczt.clone());
+    if ironwood {
+        verifier
+            .with_ironwood::<Infallible, _>(|bundle| {
+                fvks = Some(collect(bundle));
+                Ok(())
+            })
+            .expect("Ironwood bundle parses fully");
+    } else {
+        verifier
+            .with_orchard::<Infallible, _>(|bundle| {
+                fvks = Some(collect(bundle));
+                Ok(())
+            })
+            .expect("Orchard bundle parses fully");
+    }
+    fvks.expect("closure ran")
+}
+
+/// Computes the spend authorization signature for the action at `index` of the
+/// Orchard or Ironwood pool, over the Verifier role's full (FVK-deriving) parse of
+/// the PCZT, using a [`ChaCha20Rng`] seeded with `seed`.
+///
+/// This is the reference value for asserting that the low-level Signer's preverified
+/// signing parse produces a byte-identical signature.
+fn expected_spend_auth_sig(
+    pczt: &Pczt,
+    ironwood: bool,
+    index: usize,
+    ask: &orchard::keys::SpendAuthorizingKey,
+    sighash: [u8; 32],
+    seed: [u8; 32],
+) -> [u8; 64] {
+    use std::convert::Infallible;
+
+    let mut sig = None;
+    let mut compute = |bundle: &orchard::pczt::Bundle| {
+        let spend = bundle.actions()[index].spend();
+        // The full parse derives the FVK (in contrast to the preverified parse).
+        assert!(spend.fvk().is_some());
+        let alpha = spend
+            .alpha()
+            .as_ref()
+            .expect("alpha is set after IO finalization");
+        let rsk = ask.randomize(alpha);
+        sig = Some(<[u8; 64]>::from(
+            &rsk.sign(ChaCha20Rng::from_seed(seed), &sighash),
+        ));
+        Ok::<(), pczt::roles::verifier::OrchardError<Infallible>>(())
+    };
+
+    let verifier = Verifier::new(pczt.clone());
+    if ironwood {
+        verifier
+            .with_ironwood(&mut compute)
+            .expect("Ironwood bundle parses fully");
+    } else {
+        verifier
+            .with_orchard(&mut compute)
+            .expect("Orchard bundle parses fully");
+    }
+    sig.expect("closure ran")
+}
+
+/// Asserts that `sig` is a valid RedPallas spend authorization signature for the
+/// randomized verification key `rk`, over `sighash`.
+///
+/// This proves the signature the preverified path produced actually authorizes the
+/// spend (matching what [`orchard::pczt::Action::apply_signature`] checks), not just
+/// that it is byte-equal to the reference.
+fn assert_valid_spend_auth_sig(rk: &[u8; 32], sighash: [u8; 32], sig: [u8; 64]) {
+    use orchard::primitives::redpallas::{self, SpendAuth};
+
+    let rk = redpallas::VerificationKey::<SpendAuth>::try_from(*rk).expect("`rk` is a valid key");
+    let sig = redpallas::Signature::<SpendAuth>::from(sig);
+    rk.verify(&sighash, &sig)
+        .expect("spend authorization signature verifies against `rk`");
+}
+
+#[test]
+fn orchard_low_level_signer_uses_preverified_signing_parse() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to send funds from.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received a note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // Use the tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    // Build the Orchard bundle we'll be using.
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: None,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(100_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_fvk.to_ovk(zip32::Scope::Internal)),
+            orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal),
+            Zatoshis::const_from_u64(890_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    // Create the base PCZT, and finalize the I/O.
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+
+    // Create the proof before signing, so that the byte-losslessness check below
+    // covers a maximal bundle (witnesses, proof, and FVKs all present).
+    let pczt = Prover::new(pczt)
+        .create_orchard_proof(orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_round_trip(&pczt);
+
+    // A no-op signing pass must be byte-lossless: the preverified parse drops the
+    // wire `fvk` bytes, but the Signer restores them after serialization.
+    let noop = low_level_signer::Signer::new(pczt.clone())
+        .sign_orchard_with::<low_level_signer::OrchardParseError, _>(|_, _, _| Ok(()))
+        .unwrap()
+        .finish();
+    assert_eq!(
+        noop.serialize().unwrap(),
+        pczt.clone().serialize().unwrap(),
+        "no-op low-level Orchard signing pass must preserve every wire byte",
+    );
+
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    let sighash = Signer::new(pczt.clone()).unwrap().shielded_sighash();
+    let seed = [42; 32];
+
+    // Compute the reference signature over the Verifier's full parse, and snapshot
+    // the wire `fvk` bytes it observes.
+    let expected_sig = expected_spend_auth_sig(&pczt, false, index, &orchard_ask, sighash, seed);
+    let fvks_before = wire_spend_fvks(&pczt, false);
+    assert_eq!(fvks_before[index], Some(orchard_fvk.to_bytes()));
+
+    // Sign through the low-level Signer's preverified path with the same seed.
+    let signed = low_level_signer::Signer::new(pczt.clone())
+        .sign_orchard_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            // The preverified signing parse skips FVK derivation entirely.
+            assert!(bundle.actions()[index].spend().fvk().is_none());
+            bundle.actions_mut()[index]
+                .sign(sighash, &orchard_ask, ChaCha20Rng::from_seed(seed))
+                .expect("signing succeeds");
+            Ok(())
+        })
+        .unwrap()
+        .finish();
+    check_round_trip(&signed);
+
+    // The preverified signing parse must yield a byte-identical signature to the
+    // full-parse path.
+    let produced_sig = signed.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_eq!(produced_sig, expected_sig);
+
+    // ...and that signature must actually verify against the spend's `rk`.
+    assert_valid_spend_auth_sig(
+        signed.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    // The wire `fvk` bytes must be preserved (unchanged) after signing.
+    assert_eq!(wire_spend_fvks(&signed, false), fvks_before);
+
+    // The signed PCZT remains fully usable: we should be able to extract the fully
+    // authorized transaction.
+    let tx = TransactionExtractor::new(signed).extract().unwrap();
+
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+/// Checks that the PCZT round-trips through the default (v2) encoding.
+///
+/// This is [`check_round_trip`] minus the v1 encoding check: v6 PCZTs (which carry
+/// an Ironwood bundle) are not representable in the legacy v1 encoding.
+fn check_v2_round_trip(pczt: &Pczt) {
+    let encoded = pczt.clone().serialize().expect("serialization succeeds");
+    let reencoded = Pczt::parse(&encoded)
+        .expect("can parse encoded PCZT")
+        .serialize()
+        .expect("serialization succeeds");
+    assert_eq!(encoded, reencoded);
+}
+
+/// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
+fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
+    use zcash_protocol::consensus::BlockHeight;
+
+    zcash_protocol::local_consensus::LocalNetwork {
+        overwinter: Some(BlockHeight::from_u32(1)),
+        sapling: Some(BlockHeight::from_u32(2)),
+        blossom: Some(BlockHeight::from_u32(3)),
+        heartwood: Some(BlockHeight::from_u32(4)),
+        canopy: Some(BlockHeight::from_u32(5)),
+        nu5: Some(BlockHeight::from_u32(6)),
+        nu6: Some(BlockHeight::from_u32(7)),
+        nu6_1: Some(BlockHeight::from_u32(8)),
+        nu6_2: Some(BlockHeight::from_u32(9)),
+        nu6_3: Some(BlockHeight::from_u32(10)),
+        #[cfg(zcash_unstable = "nu7")]
+        nu7: None,
+    }
+}
+
+#[test]
+fn ironwood_low_level_signer_uses_preverified_signing_parse() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to send funds from.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Ironwood note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::IronwoodDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V3);
+        note
+    };
+
+    // Use the Ironwood tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    // Build the Ironwood bundle we'll be using.
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: None,
+            ironwood_anchor: Some(anchor),
+        },
+    );
+    builder
+        .add_ironwood_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        ironwood_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    // Create the base PCZT, and finalize the I/O.
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    check_v2_round_trip(&pczt);
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+    check_v2_round_trip(&pczt);
+
+    // A no-op signing pass must be byte-lossless: the preverified parse drops the
+    // wire `fvk` bytes, but the Signer restores them after serialization.
+    let noop = low_level_signer::Signer::new(pczt.clone())
+        .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, _, _| Ok(()))
+        .unwrap()
+        .finish();
+    assert_eq!(
+        noop.serialize().unwrap(),
+        pczt.clone().serialize().unwrap(),
+        "no-op low-level Ironwood signing pass must preserve every wire byte",
+    );
+
+    let index = ironwood_meta.spend_action_index(0).unwrap();
+    let sighash = Signer::new(pczt.clone()).unwrap().shielded_sighash();
+    let seed = [7; 32];
+
+    // Compute the reference signature over the Verifier's full parse, and snapshot
+    // the wire `fvk` bytes it observes.
+    let expected_sig = expected_spend_auth_sig(&pczt, true, index, &orchard_ask, sighash, seed);
+    let fvks_before = wire_spend_fvks(&pczt, true);
+    assert_eq!(fvks_before[index], Some(orchard_fvk.to_bytes()));
+
+    // Sign through the low-level Signer's preverified path with the same seed.
+    let signed = low_level_signer::Signer::new(pczt.clone())
+        .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            // The preverified signing parse skips FVK derivation entirely.
+            assert!(bundle.actions()[index].spend().fvk().is_none());
+            bundle.actions_mut()[index]
+                .sign(sighash, &orchard_ask, ChaCha20Rng::from_seed(seed))
+                .expect("signing succeeds");
+            Ok(())
+        })
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&signed);
+
+    // The preverified signing parse must yield a byte-identical signature to the
+    // full-parse path.
+    let produced_sig = signed.ironwood().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_eq!(produced_sig, expected_sig);
+
+    // ...and that signature must actually verify against the spend's `rk`.
+    assert_valid_spend_auth_sig(
+        signed.ironwood().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    // The wire `fvk` bytes must be preserved (unchanged) after signing.
+    assert_eq!(wire_spend_fvks(&signed, true), fvks_before);
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,9 @@ audit-as-crates-io = true
 [policy.f4jumble]
 audit-as-crates-io = true
 
+[policy.orchard]
+audit-as-crates-io = true
+
 [policy.pczt]
 audit-as-crates-io = true
 
@@ -833,6 +836,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.oorandom]]
 version = "11.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.orchard]]
+version = "0.15.0-pre.1@git:20c10904ae84af19fe657bbbb7369c4dac4f142a"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -839,7 +839,7 @@ version = "11.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.15.0-pre.1@git:20c10904ae84af19fe657bbbb7369c4dac4f142a"
+version = "0.15.0-pre.1@git:ab7c5fae83d3c197ba045b6485fa0206d68dc6f4"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]


### PR DESCRIPTION
## Summary

The low-level Signer now parses with a preverified fast path that skips deriving each spend's `FullViewingKey` from its wire `fvk` bytes (a Pallas point decompression plus two `commit_ivk` Sinsemilla hashes per spend). The spend authorization signature does not depend on `fvk`, so signatures are byte-identical to the full parse.

`sign_orchard_with` and `sign_ironwood_with` snapshot each spend's `(rk, fvk)` before parsing and restore the `fvk` after serialization, so signing leaves the wire bytes unchanged. The restore is enforced rather than documented: it returns `OrchardParseError::SigningClosureModifiedActions` if the signing closure changes the action count or reorders actions, detected by comparing each position's wire `rk` to the snapshot, and it makes no changes when it rejects.

The Orchard action parse is also refactored from `.map(...).collect()` into a bounded `#[inline(never)]` loop, which keeps a single per-action parse frame live at a time so a constrained signer such as an embedded hardware wallet does not overflow its task stack. This is behaviorally identical (same order, same first error), and the full `parse` used by the Verifier, Prover, and Updater is unchanged. Callers of the preverified path must have already run the full Verifier checks over the same PCZT bytes; a spend parsed this way has `fvk: None` and must not go to the Verifier check path, the Prover, or an `fvk`-preserving serialization.

## Dependency

This depends on orchard's `parse_preverified_for_signing`, which is not yet in a released orchard. The workspace temporarily `[patch]`es orchard to the branch that adds it, with a matching temporary cargo-vet exemption. Both are placeholders: once that orchard change lands and releases, they are dropped in favor of an orchard version bump.

## Testing

`cargo test -p pczt --all-features`. Two new end-to-end tests (Orchard and Ironwood) prove byte-identical signatures against the full-parse path, wire-`fvk` preservation across a signing pass, and that the produced signature verifies against `rk`. Unit tests cover the positional restore and the reorder guard.
