### PR TITLE
pczt: Preserve absent shielded anchors across roles

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -92,6 +92,15 @@ workspace.
   add, remove, or reorder actions; doing so now returns the new
   `pczt::roles::low_level_signer::OrchardParseError::SigningClosureModifiedActions`
   error and leaves the PCZT unmodified.
+- PCZT roles that do not consume shielded anchors now preserve absent Sapling,
+  Orchard, and Ironwood anchors while parsing v6 transactions. Proving and
+  transaction extraction still require anchors for Sapling bundles with spends
+  and Orchard or Ironwood bundles with actions.
+- The Sapling, Orchard, and Ironwood Provers now reject non-zero-valued spends
+  whose witnesses do not root to the bundle anchor before creating proofs.
+- PCZT parse errors surfaced by Sapling and Orchard role APIs now use
+  `pczt::sapling::ParseError` and `pczt::orchard::ParseError`, so callers can
+  distinguish missing anchors from other malformed bundle data.
 
 ### Added
 - `pczt::roles::creator::Error`, the error type returned by the now-fallible
@@ -156,6 +165,11 @@ workspace.
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,
   `pczt::roles::verifier::OrchardError`, and `pczt::roles::prover::OrchardError`.
+- `pczt::sapling::ParseError`, `pczt::sapling::AnchorConsistencyError`
+- `pczt::orchard::ParseError`, `pczt::orchard::AnchorConsistencyError`
+- `pczt::roles::prover::SaplingError::InconsistentWitness`
+- `pczt::roles::prover::OrchardError::InconsistentWitness`
+- `pczt::roles::prover::IronwoodError::InconsistentWitness`
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -94,8 +94,8 @@ workspace.
   error and leaves the PCZT unmodified.
 - PCZT roles that do not consume shielded anchors now preserve absent Sapling,
   Orchard, and Ironwood anchors while parsing v6 transactions. Proving and
-  transaction extraction still require anchors for Sapling bundles with spends
-  and Orchard or Ironwood bundles with actions.
+  transaction extraction still require anchors for non-empty Sapling, Orchard,
+  and Ironwood bundles.
 - The Sapling, Orchard, and Ironwood Provers now reject non-zero-valued spends
   whose witnesses do not root to the bundle anchor before creating proofs.
 - PCZT parse errors surfaced by Sapling and Orchard role APIs now use

--- a/pczt/src/common.rs
+++ b/pczt/src/common.rs
@@ -19,8 +19,8 @@ pub(crate) const FLAG_SHIELDED_MODIFIABLE: u8 = 0b1000_0000;
 /// encoding for the Sapling, Orchard, and Ironwood note commitment trees.
 pub(crate) const PLACEHOLDER_ANCHOR: [u8; 32] = [0; 32];
 
-/// Governs whether a shielded bundle's `anchor` must be set in order to parse it into
-/// the form used by the payment protocol crates.
+/// Governs whether a non-empty shielded bundle's `anchor` must be set in order to parse
+/// it into the form used by the payment protocol crates.
 ///
 /// [ZIP 374](https://zips.z.cash/zip-0374) makes the anchor of a v6 transaction's
 /// shielded bundles deferrable until proving, so operations that do not depend on the
@@ -36,7 +36,7 @@ pub(crate) enum AnchorRequirement {
     #[cfg_attr(not(any(feature = "orchard", feature = "sapling")), allow(dead_code))]
     NotRequired,
     /// The operation requires the anchor's real value; parsing fails if it is absent
-    /// and a bundle item consumes it.
+    /// from a non-empty bundle.
     Required,
 }
 
@@ -57,25 +57,22 @@ impl AnchorRequirement {
     }
 
     /// Resolves a shielded bundle's wire `anchor` to the anchor that should be used
-    /// when parsing it, given whether the bundle has no items that consume the anchor
-    /// (no Sapling spends or no Orchard-protocol actions).
+    /// when parsing it, given whether the bundle has no transaction items (no Sapling
+    /// spends or outputs, or no Orchard-protocol actions).
     ///
     /// Returns `None` to mean "the anchor is absent and required"; callers should map
-    /// that case to their own missing-anchor error. An absent anchor that no bundle
-    /// item consumes always resolves to [`PLACEHOLDER_ANCHOR`], since no operation on
-    /// the parsed bundle can read the anchor's value in that case.
+    /// that case to their own missing-anchor error. An absent anchor on an empty bundle
+    /// resolves to [`PLACEHOLDER_ANCHOR`], since there is nothing to prove or extract.
     pub(crate) fn resolve(
         self,
         anchor: Option<[u8; 32]>,
-        anchor_is_unused: bool,
+        bundle_is_empty: bool,
     ) -> Option<[u8; 32]> {
-        match anchor {
-            Some(anchor) => Some(anchor),
-            None if anchor_is_unused => Some(PLACEHOLDER_ANCHOR),
-            None => match self {
-                AnchorRequirement::NotRequired => Some(PLACEHOLDER_ANCHOR),
-                AnchorRequirement::Required => None,
-            },
+        match (self, anchor) {
+            (_, Some(anchor)) => Some(anchor),
+            (AnchorRequirement::NotRequired, None) => Some(PLACEHOLDER_ANCHOR),
+            (AnchorRequirement::Required, None) if bundle_is_empty => Some(PLACEHOLDER_ANCHOR),
+            (AnchorRequirement::Required, None) => None,
         }
     }
 }

--- a/pczt/src/common.rs
+++ b/pczt/src/common.rs
@@ -14,6 +14,72 @@ pub(crate) const FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE: u8 = 0b0000_0010;
 pub(crate) const FLAG_HAS_SIGHASH_SINGLE: u8 = 0b0000_0100;
 pub(crate) const FLAG_SHIELDED_MODIFIABLE: u8 = 0b1000_0000;
 
+/// A placeholder anchor used internally when parsing a shielded bundle for an
+/// operation that does not read the anchor's value. Zero is always a valid anchor
+/// encoding for the Sapling, Orchard, and Ironwood note commitment trees.
+pub(crate) const PLACEHOLDER_ANCHOR: [u8; 32] = [0; 32];
+
+/// Governs whether a shielded bundle's `anchor` must be set in order to parse it into
+/// the form used by the payment protocol crates.
+///
+/// [ZIP 374](https://zips.z.cash/zip-0374) makes the anchor of a v6 transaction's
+/// shielded bundles deferrable until proving, so operations that do not depend on the
+/// anchor's value (for example computing a v6 sighash, which excludes anchors, or
+/// updating unrelated fields) can proceed with it absent.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum AnchorRequirement {
+    /// The operation does not read the anchor, so an absent anchor is parsed using a
+    /// placeholder value.
+    ///
+    /// Only constructed when the `orchard` or `sapling` feature is enabled, as those
+    /// are the only operations lenient enough to use it.
+    #[cfg_attr(not(any(feature = "orchard", feature = "sapling")), allow(dead_code))]
+    NotRequired,
+    /// The operation requires the anchor's real value; parsing fails if it is absent
+    /// and a bundle item consumes it.
+    Required,
+}
+
+impl AnchorRequirement {
+    /// Returns the requirement for operations that do not themselves consume the
+    /// anchor, but still parse bundles through the protocol crates.
+    ///
+    /// V6 signatures do not commit to shielded anchors, so signing and IO
+    /// finalization can proceed before anchors are set. V5 signatures do commit to
+    /// anchors for Sapling spends and Orchard-protocol actions, so those bundles must
+    /// keep requiring them.
+    pub(crate) fn for_pre_authorization(tx_version: u32) -> Self {
+        if tx_version == zcash_protocol::constants::V6_TX_VERSION {
+            AnchorRequirement::NotRequired
+        } else {
+            AnchorRequirement::Required
+        }
+    }
+
+    /// Resolves a shielded bundle's wire `anchor` to the anchor that should be used
+    /// when parsing it, given whether the bundle has no items that consume the anchor
+    /// (no Sapling spends or no Orchard-protocol actions).
+    ///
+    /// Returns `None` to mean "the anchor is absent and required"; callers should map
+    /// that case to their own missing-anchor error. An absent anchor that no bundle
+    /// item consumes always resolves to [`PLACEHOLDER_ANCHOR`], since no operation on
+    /// the parsed bundle can read the anchor's value in that case.
+    pub(crate) fn resolve(
+        self,
+        anchor: Option<[u8; 32]>,
+        anchor_is_unused: bool,
+    ) -> Option<[u8; 32]> {
+        match anchor {
+            Some(anchor) => Some(anchor),
+            None if anchor_is_unused => Some(PLACEHOLDER_ANCHOR),
+            None => match self {
+                AnchorRequirement::NotRequired => Some(PLACEHOLDER_ANCHOR),
+                AnchorRequirement::Required => None,
+            },
+        }
+    }
+}
+
 /// Global fields that are relevant to the transaction as a whole.
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Global {

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -452,6 +452,7 @@ impl Pczt {
     #[cfg(any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"))]
     pub(crate) fn extract_tx_data<A, E>(
         self,
+        anchor_requirement: common::AnchorRequirement,
         extract_transparent: impl FnOnce(
             &::transparent::pczt::Bundle,
         ) -> Result<
@@ -525,26 +526,28 @@ impl Pczt {
         let transparent = transparent
             .into_parsed()
             .map_err(ExtractError::TransparentParse)?;
-        let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
+        let sapling = sapling
+            .into_parsed(anchor_requirement)
+            .map_err(ExtractError::SaplingParse)?;
         let orchard_bundle_version = crate::orchard::bundle_version_for_revision(
             orchard_protocol_revision,
             ::orchard::ValuePool::Orchard,
         )
         .expect("the Orchard pool is supported under every protocol revision");
         let orchard = orchard
-            .into_parsed_with_version(orchard_bundle_version, global.tx_version)
+            .into_parsed_with_version(orchard_bundle_version, anchor_requirement)
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
-            .into_ironwood_parsed()
+            .into_ironwood_parsed(anchor_requirement)
             .map_err(ExtractError::IronwoodParse)?;
 
         let lock_time = determine_lock_time(&global, transparent.inputs())
             .ok_or(ExtractError::IncompatibleLockTimes)?;
 
         let transparent_bundle = extract_transparent(&transparent)?;
-        let sapling_bundle = extract_sapling(&sapling)?;
-        let orchard_bundle = extract_orchard(&orchard)?;
-        let ironwood_bundle = extract_ironwood(&ironwood)?;
+        let sapling_bundle = extract_sapling(&sapling.bundle)?;
+        let orchard_bundle = extract_orchard(&orchard.bundle)?;
+        let ironwood_bundle = extract_ironwood(&ironwood.bundle)?;
 
         let tx_data = match version {
             TxVersion::V6 => TransactionData::from_parts_v6(
@@ -585,7 +588,11 @@ impl Pczt {
     /// Gets the effects of this transaction.
     #[cfg(any(feature = "io-finalizer", feature = "signer"))]
     pub fn into_effects(self) -> Result<TransactionData<EffectsOnly>, ExtractError> {
+        let anchor_requirement =
+            common::AnchorRequirement::for_pre_authorization(self.global.tx_version);
+
         self.extract_tx_data(
+            anchor_requirement,
             |t| {
                 t.extract_effects()
                     .map_err(ExtractError::TransparentExtract)
@@ -607,9 +614,9 @@ impl Pczt {
 pub(crate) struct ParsedPczt<A: Authorization> {
     pub(crate) global: Global,
     pub(crate) transparent: ::transparent::pczt::Bundle,
-    pub(crate) sapling: ::sapling::pczt::Bundle,
-    pub(crate) orchard: ::orchard::pczt::Bundle,
-    pub(crate) ironwood: ::orchard::pczt::Bundle,
+    pub(crate) sapling: crate::sapling::Parsed,
+    pub(crate) orchard: crate::orchard::Parsed,
+    pub(crate) ironwood: crate::orchard::Parsed,
     pub(crate) tx_data: TransactionData<A>,
 }
 
@@ -653,15 +660,15 @@ pub enum ExtractError {
     /// support an Ironwood bundle.
     IronwoodNotSupported,
     /// An error occurred parsing the Ironwood PCZT bundle from the PCZT data.
-    IronwoodParse(::orchard::pczt::ParseError),
+    IronwoodParse(crate::orchard::ParseError),
     /// An error occurred extracting the Orchard protocol bundle from the Orchard PCZT bundle.
     OrchardExtract(::orchard::pczt::TxExtractorError),
     /// An error occurred parsing the Orchard PCZT bundle from the PCZT data.
-    OrchardParse(::orchard::pczt::ParseError),
+    OrchardParse(crate::orchard::ParseError),
     /// An error occurred extracting the Sapling protocol bundle from the Sapling PCZT bundle.
     SaplingExtract(::sapling::pczt::TxExtractorError),
     /// An error occurred parsing the Sapling PCZT bundle from the PCZT data.
-    SaplingParse(::sapling::pczt::ParseError),
+    SaplingParse(crate::sapling::ParseError),
     /// An error occurred extracting the transparent protocol bundle from the
     /// transparent PCZT bundle.
     TransparentExtract(::transparent::pczt::TxExtractorError),

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -229,7 +229,7 @@ pub(crate) mod testing {
                 proprietary: BTreeMap::new(),
             },
             output: Output {
-                cmx: [4; 32],
+                cmx: Some([4; 32]),
                 ephemeral_key: [5; 32],
                 enc_ciphertext: EncCiphertext::Encrypted(alloc::vec![6; 580]),
                 out_ciphertext: alloc::vec![7; 80],
@@ -1632,6 +1632,7 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
 /// Ironwood) into the form used by the `orchard` crate.
 #[cfg(feature = "orchard")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The operation requires the bundle's `anchor` to be set, but it was absent.
     ///
@@ -1653,6 +1654,7 @@ impl From<orchard::pczt::ParseError> for ParseError {
 /// witnesses are consistent with its anchor.
 #[cfg(feature = "orchard")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AnchorConsistencyError {
     /// A non-zero-valued spend has a `witness` but is missing other note data required
     /// to compute its Merkle path root.

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -143,6 +143,109 @@ impl fmt::Display for MemoPlaintextError {
     }
 }
 
+/// The result of parsing a logical Orchard-protocol bundle (Orchard or Ironwood) via
+/// [`Bundle::into_parsed_with_version`] or one of its siblings.
+///
+/// Carries the bundle's original wire `anchor` alongside the parsed form, so that
+/// [`Parsed::reserialize`] can restore it after an operation that does not itself
+/// change the anchor, even though parsing may have substituted a placeholder for it
+/// (see [ZIP 374: Anchors and pre-authorization](https://zips.z.cash/zip-0374#anchors-and-pre-authorization)).
+#[cfg(feature = "orchard")]
+pub(crate) struct Parsed {
+    pub(crate) bundle: orchard::pczt::Bundle,
+    pub(crate) wire_anchor: Option<[u8; 32]>,
+}
+
+#[cfg(feature = "orchard")]
+impl Parsed {
+    /// Serializes the parsed bundle back into its wire representation, using
+    /// [`Self::wire_anchor`] as the result's `anchor` in place of any placeholder
+    /// substituted while parsing.
+    ///
+    /// Must not be used after an operation that legitimately changes the anchor;
+    /// such operations should set `wire_anchor` to the new value first.
+    pub(crate) fn reserialize(self) -> Bundle {
+        Bundle {
+            anchor: self.wire_anchor,
+            ..Bundle::serialize_from(self.bundle)
+        }
+    }
+}
+
+/// Shared fixtures for hand-crafting Orchard-protocol PCZT test data.
+#[cfg(all(test, feature = "orchard"))]
+pub(crate) mod testing {
+    use alloc::collections::BTreeMap;
+
+    use pasta_curves::pallas;
+
+    use super::{Action, EncCiphertext, Output, Spend};
+
+    /// Derives a valid Orchard value commitment encoding for the given value and
+    /// trapdoor, so that hand-crafted `Action`s pass the structural validity check
+    /// applied when parsing (regardless of anchor consistency, which is unrelated).
+    pub(crate) fn value_commitment(value: u64, rcv: [u8; 32]) -> [u8; 32] {
+        let rcv = orchard::value::ValueCommitTrapdoor::from_bytes(rcv)
+            .into_option()
+            .unwrap();
+        let value_sum =
+            orchard::value::NoteValue::from_raw(value) - orchard::value::NoteValue::from_raw(0);
+        orchard::value::ValueCommitment::derive(value_sum, rcv).to_bytes()
+    }
+
+    /// Derives a valid, randomized `rk` encoding (a curve point, unlike an arbitrary
+    /// byte string) so that hand-crafted `Spend`s pass the structural validity check
+    /// applied when parsing.
+    pub(crate) fn randomized_verification_key() -> [u8; 32] {
+        use ff::Field;
+
+        let sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
+        let ask = orchard::keys::SpendAuthorizingKey::from(&sk);
+        let randomized_signing_key = ask.randomize(&pallas::Scalar::ONE);
+        let rk: orchard::primitives::redpallas::VerificationKey<
+            orchard::primitives::redpallas::SpendAuth,
+        > = (&randomized_signing_key).into();
+        (&rk).into()
+    }
+
+    /// A structurally valid dummy Orchard action with no witness (so it is exempt
+    /// from anchor-consistency checks), for use as a base in hand-crafted test PCZTs.
+    pub(crate) fn dummy_action() -> Action {
+        Action {
+            cv_net: Some(value_commitment(0, [3; 32])),
+            spend: Spend {
+                nullifier: [2; 32],
+                rk: randomized_verification_key(),
+                spend_auth_sig: None,
+                recipient: None,
+                value: None,
+                rho: None,
+                rseed: None,
+                fvk: None,
+                witness: None,
+                alpha: None,
+                zip32_derivation: None,
+                dummy_sk: None,
+                proprietary: BTreeMap::new(),
+            },
+            output: Output {
+                cmx: [4; 32],
+                ephemeral_key: [5; 32],
+                enc_ciphertext: EncCiphertext::Encrypted(alloc::vec![6; 580]),
+                out_ciphertext: alloc::vec![7; 80],
+                recipient: None,
+                value: None,
+                rseed: None,
+                ock: None,
+                zip32_derivation: None,
+                user_address: None,
+                proprietary: BTreeMap::new(),
+            },
+            rcv: None,
+        }
+    }
+}
+
 /// A memo plaintext with all trailing zero bytes stripped.
 ///
 /// This is the memo portion of an Orchard note plaintext, not the full note
@@ -1525,6 +1628,88 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
         .and_then(|revision| bundle_version_for_revision(revision, orchard::ValuePool::Orchard))
 }
 
+/// Errors that can occur while parsing a logical Orchard-protocol bundle (Orchard or
+/// Ironwood) into the form used by the `orchard` crate.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum ParseError {
+    /// The operation requires the bundle's `anchor` to be set, but it was absent.
+    ///
+    /// For a v6 transaction, an Updater can resolve this by setting the anchor; see
+    /// [ZIP 374: Anchors and pre-authorization](https://zips.z.cash/zip-0374#anchors-and-pre-authorization).
+    MissingAnchor,
+    /// The bundle's remaining fields were structurally invalid.
+    Bundle(orchard::pczt::ParseError),
+}
+
+#[cfg(feature = "orchard")]
+impl From<orchard::pczt::ParseError> for ParseError {
+    fn from(e: orchard::pczt::ParseError) -> Self {
+        ParseError::Bundle(e)
+    }
+}
+
+/// Errors that can occur while checking that an Orchard-protocol bundle's spend
+/// witnesses are consistent with its anchor.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum AnchorConsistencyError {
+    /// A non-zero-valued spend has a `witness` but is missing other note data required
+    /// to compute its Merkle path root.
+    IncompleteSpendData,
+    /// A non-zero-valued spend's `witness` does not root to the given anchor.
+    WitnessDoesNotRootToAnchor,
+}
+
+/// Checks that every non-zero-valued spend in `bundle` whose `witness` is present has a
+/// Merkle path that roots to `anchor` (\[ZIP 374\] "Anchors and pre-authorization").
+///
+/// Zero-valued spends are skipped, as their Merkle paths are not checked by the Orchard
+/// circuit.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374#anchors-and-pre-authorization
+#[cfg(feature = "orchard")]
+pub(crate) fn verify_witnesses_root_to_anchor(
+    bundle: &orchard::pczt::Bundle,
+    anchor: orchard::Anchor,
+) -> Result<(), AnchorConsistencyError> {
+    for action in bundle.actions() {
+        let spend = action.spend();
+
+        let Some(witness) = spend.witness() else {
+            continue;
+        };
+        let Some(value) = spend.value() else {
+            continue;
+        };
+        if value.inner() == 0 {
+            continue;
+        }
+
+        let recipient = spend
+            .recipient()
+            .ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+        let rho = spend
+            .rho()
+            .ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+        let rseed = spend
+            .rseed()
+            .ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+
+        let note = orchard::Note::from_parts(recipient, *value, rho, rseed, *spend.note_version())
+            .into_option()
+            .ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+        let cmx = orchard::note::ExtractedNoteCommitment::from(note.commitment());
+        let computed_anchor = witness.root(cmx);
+
+        if computed_anchor != anchor {
+            return Err(AnchorConsistencyError::WitnessDoesNotRootToAnchor);
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "orchard")]
 impl Output {
     /// Recomputes `cmx`, if this output carries it as an omitted field.
@@ -1677,23 +1862,6 @@ impl Action {
 }
 
 #[cfg(feature = "orchard")]
-#[allow(dead_code)]
-#[derive(Clone, Copy)]
-enum AnchorParseMode {
-    Strict,
-    AllowMissing,
-}
-
-#[cfg(feature = "orchard")]
-fn anchor_parse_mode(tx_version: u32, has_actions: bool) -> AnchorParseMode {
-    if tx_version == zcash_protocol::constants::V6_TX_VERSION || !has_actions {
-        AnchorParseMode::AllowMissing
-    } else {
-        AnchorParseMode::Strict
-    }
-}
-
-#[cfg(feature = "orchard")]
 impl Bundle {
     /// Resolves fields that are optionally redacted in the PCZT but implied by
     /// other known fields.
@@ -1724,25 +1892,22 @@ impl Bundle {
     /// `FullViewingKey` from its wire `fvk` bytes.
     pub(crate) fn into_ironwood_parsed(
         self,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(
-            BundleVersion::ironwood_v3(),
-            false,
-            AnchorParseMode::AllowMissing,
-        )
+        anchor_requirement: crate::common::AnchorRequirement,
+    ) -> Result<Parsed, ParseError> {
+        self.into_parsed_with_version(BundleVersion::ironwood_v3(), anchor_requirement)
     }
 
     /// Parses this bundle as an Ironwood-pool bundle for a preverified signing
-    /// pass, using a parse-only placeholder if the anchor has been redacted.
-    ///
-    /// [`Bundle::serialize_from`] encodes the placeholder as a redacted anchor.
+    /// pass, skipping each spend's `FullViewingKey` derivation. See
+    /// [`Bundle::into_parsed_with_version_preverified_for_signing`] for the invariant
+    /// callers must uphold.
     pub(crate) fn into_ironwood_parsed_preverified_for_signing(
         self,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(
+        anchor_requirement: crate::common::AnchorRequirement,
+    ) -> Result<Parsed, ParseError> {
+        self.into_parsed_with_version_preverified_for_signing(
             BundleVersion::ironwood_v3(),
-            true,
-            AnchorParseMode::AllowMissing,
+            anchor_requirement,
         )
     }
 
@@ -1756,10 +1921,9 @@ impl Bundle {
     pub(crate) fn into_parsed_with_version(
         self,
         bundle_version: BundleVersion,
-        tx_version: u32,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        let anchor_parse_mode = anchor_parse_mode(tx_version, !self.actions.is_empty());
-        self.into_parsed_inner(bundle_version, false, anchor_parse_mode)
+        anchor_requirement: crate::common::AnchorRequirement,
+    ) -> Result<Parsed, ParseError> {
+        self.into_parsed_inner(bundle_version, anchor_requirement, false)
     }
 
     /// Parses this bundle with the given bundle version for a preverified signing
@@ -1779,10 +1943,9 @@ impl Bundle {
     pub(crate) fn into_parsed_with_version_preverified_for_signing(
         self,
         bundle_version: BundleVersion,
-        tx_version: u32,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        let anchor_parse_mode = anchor_parse_mode(tx_version, !self.actions.is_empty());
-        self.into_parsed_inner(bundle_version, true, anchor_parse_mode)
+        anchor_requirement: crate::common::AnchorRequirement,
+    ) -> Result<Parsed, ParseError> {
+        self.into_parsed_inner(bundle_version, anchor_requirement, true)
     }
 
     /// The shared body of [`Bundle::into_parsed_with_version`] and
@@ -1791,10 +1954,14 @@ impl Bundle {
     fn into_parsed_inner(
         mut self,
         bundle_version: BundleVersion,
+        anchor_requirement: crate::common::AnchorRequirement,
         preverified: bool,
-        anchor_parse_mode: AnchorParseMode,
-    ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+    ) -> Result<Parsed, ParseError> {
         self.resolve_fields()?;
+        let wire_anchor = self.anchor;
+        let anchor = anchor_requirement
+            .resolve(wire_anchor, self.actions.is_empty())
+            .ok_or(ParseError::MissingAnchor)?;
 
         // We parse actions through a helper that is specifically `#[inline(never)]`.
         // This is because if this gets inlined in a loop (e.g. `.map(..).collect()`),
@@ -1898,15 +2065,8 @@ impl Bundle {
         for action in self.actions {
             actions.push(parse_action_inner(action, note_version, preverified)?);
         }
-        let anchor = match (self.anchor, anchor_parse_mode) {
-            (Some(anchor), _) => anchor,
-            (None, AnchorParseMode::Strict) => {
-                return Err(orchard::pczt::ParseError::InvalidAnchor);
-            }
-            (None, AnchorParseMode::AllowMissing) => DEFAULT_ANCHOR,
-        };
 
-        orchard::pczt::Bundle::parse(
+        let bundle = orchard::pczt::Bundle::parse(
             actions,
             self.flags,
             bundle_version,
@@ -1914,7 +2074,12 @@ impl Bundle {
             anchor,
             self.zkproof,
             self.bsk,
-        )
+        )?;
+
+        Ok(Parsed {
+            bundle,
+            wire_anchor,
+        })
     }
 
     #[allow(dead_code)]
@@ -2022,7 +2187,7 @@ impl Bundle {
             actions,
             flags: bundle.flag_byte(),
             value_sum,
-            anchor: (anchor != DEFAULT_ANCHOR).then_some(anchor),
+            anchor: Some(anchor),
             note_version,
             zkproof: bundle
                 .zkproof()

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -44,21 +44,9 @@ impl IoFinalizer {
         if pczt.transparent.outputs.is_empty() && !has_shielded_outputs {
             return Err(Error::NoOutputs);
         }
-        if has_orchard_actions && pczt.orchard.anchor.is_none() {
-            return Err(Error::Extract(ExtractError::OrchardParse(
-                ::orchard::pczt::ParseError::InvalidAnchor,
-            )));
-        }
-        if has_sapling_spends && pczt.sapling.anchor.is_none() {
-            return Err(Error::Extract(ExtractError::SaplingParse(
-                ::sapling::pczt::ParseError::InvalidAnchor,
-            )));
-        }
-        if has_ironwood_actions && pczt.ironwood.anchor.is_none() {
-            return Err(Error::Extract(ExtractError::IronwoodParse(
-                ::orchard::pczt::ParseError::InvalidAnchor,
-            )));
-        }
+
+        let anchor_requirement =
+            crate::common::AnchorRequirement::for_pre_authorization(pczt.global.tx_version);
 
         let ParsedPczt {
             mut global,
@@ -68,6 +56,7 @@ impl IoFinalizer {
             mut ironwood,
             tx_data,
         } = pczt.extract_tx_data(
+            anchor_requirement,
             |t| {
                 t.extract_effects()
                     .map_err(ExtractError::TransparentExtract)
@@ -91,6 +80,7 @@ impl IoFinalizer {
         // Transaction Extractor, the Sapling one requires `bsk` to be set even when
         // the bundle is empty.
         sapling
+            .bundle
             .finalize_io(shielded_sighash, OsRng)
             .map_err(Error::SaplingFinalize)?;
         // An empty Orchard-protocol bundle carries no value commitment information
@@ -99,11 +89,13 @@ impl IoFinalizer {
         // representable in, the serialization formats).
         if has_orchard_actions {
             orchard
+                .bundle
                 .finalize_io(shielded_sighash, OsRng)
                 .map_err(Error::OrchardFinalize)?;
         }
         if has_ironwood_actions {
             ironwood
+                .bundle
                 .finalize_io(shielded_sighash, OsRng)
                 .map_err(Error::IronwoodFinalize)?;
         }
@@ -111,9 +103,9 @@ impl IoFinalizer {
         Ok(Pczt {
             global,
             transparent: crate::transparent::Bundle::serialize_from(transparent),
-            sapling: crate::sapling::Bundle::serialize_from(sapling),
-            orchard: crate::orchard::Bundle::serialize_from(orchard),
-            ironwood: crate::orchard::Bundle::serialize_from(ironwood),
+            sapling: sapling.reserialize(),
+            orchard: orchard.reserialize(),
+            ironwood: ironwood.reserialize(),
         })
     }
 }

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -33,18 +33,20 @@ impl Signer {
         let mut pczt = self.pczt;
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
+        let anchor_requirement =
+            crate::common::AnchorRequirement::for_pre_authorization(pczt.global.tx_version);
 
         let fvk_snapshot = snapshot_spend_fvks(&pczt.ironwood);
-        let mut bundle = pczt
+        let mut parsed = pczt
             .ironwood
             .clone()
-            .into_ironwood_parsed_preverified_for_signing()
+            .into_ironwood_parsed_preverified_for_signing(anchor_requirement)
             .map_err(OrchardParseError::Parse)?;
 
-        f(&pczt, &mut bundle, &mut tx_modifiable)?;
+        f(&pczt, &mut parsed.bundle, &mut tx_modifiable)?;
 
         pczt.global.tx_modifiable = tx_modifiable;
-        pczt.ironwood = crate::orchard::Bundle::serialize_from(bundle);
+        pczt.ironwood = parsed.reserialize();
         restore_spend_fvks(&mut pczt.ironwood, &fvk_snapshot).map_err(E::from)?;
 
         Ok(Self { pczt })
@@ -71,23 +73,22 @@ impl Signer {
         let mut pczt = self.pczt;
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
+        let anchor_requirement =
+            crate::common::AnchorRequirement::for_pre_authorization(pczt.global.tx_version);
 
         let bundle_version = crate::orchard::orchard_bundle_version(&pczt.global)
             .ok_or(OrchardParseError::UnsupportedConsensusBranchId)?;
         let fvk_snapshot = snapshot_spend_fvks(&pczt.orchard);
-        let mut bundle = pczt
+        let mut parsed = pczt
             .orchard
             .clone()
-            .into_parsed_with_version_preverified_for_signing(
-                bundle_version,
-                pczt.global.tx_version,
-            )
+            .into_parsed_with_version_preverified_for_signing(bundle_version, anchor_requirement)
             .map_err(OrchardParseError::Parse)?;
 
-        f(&pczt, &mut bundle, &mut tx_modifiable)?;
+        f(&pczt, &mut parsed.bundle, &mut tx_modifiable)?;
 
         pczt.global.tx_modifiable = tx_modifiable;
-        pczt.orchard = crate::orchard::Bundle::serialize_from(bundle);
+        pczt.orchard = parsed.reserialize();
         restore_spend_fvks(&mut pczt.orchard, &fvk_snapshot).map_err(E::from)?;
 
         Ok(Self { pczt })
@@ -97,19 +98,21 @@ impl Signer {
     #[cfg(feature = "sapling")]
     pub fn sign_sapling_with<E, F>(self, f: F) -> Result<Self, E>
     where
-        E: From<sapling::pczt::ParseError>,
+        E: From<crate::sapling::ParseError>,
         F: FnOnce(&Pczt, &mut sapling::pczt::Bundle, &mut u8) -> Result<(), E>,
     {
         let mut pczt = self.pczt;
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
+        let anchor_requirement =
+            crate::common::AnchorRequirement::for_pre_authorization(pczt.global.tx_version);
 
-        let mut bundle = pczt.sapling.clone().into_parsed()?;
+        let mut parsed = pczt.sapling.clone().into_parsed(anchor_requirement)?;
 
-        f(&pczt, &mut bundle, &mut tx_modifiable)?;
+        f(&pczt, &mut parsed.bundle, &mut tx_modifiable)?;
 
         pczt.global.tx_modifiable = tx_modifiable;
-        pczt.sapling = crate::sapling::Bundle::serialize_from(bundle);
+        pczt.sapling = parsed.reserialize();
 
         Ok(Self { pczt })
     }
@@ -194,7 +197,7 @@ fn restore_spend_fvks(
 #[derive(Debug)]
 pub enum OrchardParseError {
     /// The bundle data was structurally invalid.
-    Parse(orchard::pczt::ParseError),
+    Parse(crate::orchard::ParseError),
     /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
     /// the Orchard protocol is not supported).
     UnsupportedConsensusBranchId,
@@ -205,8 +208,8 @@ pub enum OrchardParseError {
 }
 
 #[cfg(feature = "orchard")]
-impl From<orchard::pczt::ParseError> for OrchardParseError {
-    fn from(e: orchard::pczt::ParseError) -> Self {
+impl From<crate::orchard::ParseError> for OrchardParseError {
+    fn from(e: crate::orchard::ParseError) -> Self {
         OrchardParseError::Parse(e)
     }
 }

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -1,7 +1,7 @@
 use orchard::circuit::ProvingKey;
 use rand_core::OsRng;
 
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement};
 
 impl super::Prover {
     pub fn create_orchard_proof(self, pk: &ProvingKey) -> Result<Self, OrchardError> {
@@ -13,21 +13,19 @@ impl super::Prover {
             ironwood,
         } = self.pczt;
 
-        if !orchard.actions.is_empty() && orchard.anchor.is_none() {
-            return Err(OrchardError::Parser(
-                orchard::pczt::ParseError::InvalidAnchor,
-            ));
-        }
-
-        let mut bundle = orchard
+        let mut parsed = orchard
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
-                global.tx_version,
+                AnchorRequirement::Required,
             )
             .map_err(OrchardError::Parser)?;
 
-        bundle
+        crate::orchard::verify_witnesses_root_to_anchor(&parsed.bundle, *parsed.bundle.anchor())
+            .map_err(OrchardError::InconsistentWitness)?;
+
+        parsed
+            .bundle
             .create_proof(pk, OsRng)
             .map_err(OrchardError::Prover)?;
 
@@ -36,7 +34,7 @@ impl super::Prover {
                 global,
                 transparent,
                 sapling,
-                orchard: crate::orchard::Bundle::serialize_from(bundle),
+                orchard: parsed.reserialize(),
                 ironwood,
             },
         })
@@ -51,17 +49,15 @@ impl super::Prover {
             ironwood,
         } = self.pczt;
 
-        if !ironwood.actions.is_empty() && ironwood.anchor.is_none() {
-            return Err(IronwoodError::Parser(
-                orchard::pczt::ParseError::InvalidAnchor,
-            ));
-        }
-
-        let mut bundle = ironwood
-            .into_ironwood_parsed()
+        let mut parsed = ironwood
+            .into_ironwood_parsed(AnchorRequirement::Required)
             .map_err(IronwoodError::Parser)?;
 
-        bundle
+        crate::orchard::verify_witnesses_root_to_anchor(&parsed.bundle, *parsed.bundle.anchor())
+            .map_err(IronwoodError::InconsistentWitness)?;
+
+        parsed
+            .bundle
             .create_proof(pk, OsRng)
             .map_err(IronwoodError::Prover)?;
 
@@ -71,7 +67,7 @@ impl super::Prover {
                 transparent,
                 sapling,
                 orchard,
-                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+                ironwood: parsed.reserialize(),
             },
         })
     }
@@ -80,7 +76,9 @@ impl super::Prover {
 /// Errors that can occur while creating Orchard proofs for a PCZT.
 #[derive(Debug)]
 pub enum OrchardError {
-    Parser(orchard::pczt::ParseError),
+    /// A non-zero-valued spend's `witness` does not root to the bundle's anchor.
+    InconsistentWitness(crate::orchard::AnchorConsistencyError),
+    Parser(crate::orchard::ParseError),
     Prover(orchard::pczt::ProverError),
     /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
     /// the Orchard protocol is not supported).
@@ -90,6 +88,108 @@ pub enum OrchardError {
 /// Errors that can occur while creating Ironwood proofs for a PCZT.
 #[derive(Debug)]
 pub enum IronwoodError {
-    Parser(orchard::pczt::ParseError),
+    /// A non-zero-valued spend's `witness` does not root to the bundle's anchor.
+    InconsistentWitness(crate::orchard::AnchorConsistencyError),
+    Parser(crate::orchard::ParseError),
     Prover(orchard::pczt::ProverError),
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::sync::OnceLock;
+
+    use zcash_protocol::consensus::BranchId;
+
+    use super::{IronwoodError, OrchardError};
+    use crate::{orchard::testing::dummy_action, roles::creator::Creator, roles::prover::Prover};
+
+    static PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+
+    fn proving_key() -> &'static orchard::circuit::ProvingKey {
+        PROVING_KEY.get_or_init(|| {
+            orchard::circuit::ProvingKey::build(
+                orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+            )
+        })
+    }
+
+    #[test]
+    fn create_orchard_proof_fails_when_anchor_absent() {
+        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        pczt.orchard.actions.push(dummy_action());
+
+        assert!(matches!(
+            Prover::new(pczt).create_orchard_proof(proving_key()),
+            Err(OrchardError::Parser(
+                crate::orchard::ParseError::MissingAnchor
+            ))
+        ));
+    }
+
+    #[test]
+    fn create_ironwood_proof_fails_when_anchor_absent() {
+        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        pczt.ironwood.actions.push(dummy_action());
+
+        assert!(matches!(
+            Prover::new(pczt).create_ironwood_proof(proving_key()),
+            Err(IronwoodError::Parser(
+                crate::orchard::ParseError::MissingAnchor
+            ))
+        ));
+    }
+
+    /// An untouched, empty Orchard bundle has no actions, so parsing substitutes a
+    /// placeholder anchor even though the Prover requires the anchor to be set. Proving
+    /// such a bundle is a no-op, but the wire anchor must stay absent afterwards.
+    #[test]
+    fn create_orchard_proof_preserves_absent_anchor_for_untouched_bundle() {
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let pczt = Prover::new(pczt)
+            .create_orchard_proof(proving_key())
+            .unwrap()
+            .finish();
+
+        assert_eq!(pczt.orchard, crate::orchard::EMPTY_ORCHARD);
+
+        let bytes = pczt.clone().serialize().unwrap();
+        assert_eq!(
+            crate::parse(&bytes).unwrap().orchard,
+            crate::orchard::EMPTY_ORCHARD
+        );
+    }
+
+    /// See [`create_orchard_proof_preserves_absent_anchor_for_untouched_bundle`].
+    #[test]
+    fn create_ironwood_proof_preserves_absent_anchor_for_untouched_bundle() {
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let pczt = Prover::new(pczt)
+            .create_ironwood_proof(proving_key())
+            .unwrap()
+            .finish();
+
+        assert_eq!(pczt.ironwood, crate::orchard::EMPTY_IRONWOOD);
+
+        let bytes = pczt.clone().serialize().unwrap();
+        assert_eq!(
+            crate::parse(&bytes).unwrap().ironwood,
+            crate::orchard::EMPTY_IRONWOOD
+        );
+    }
 }

--- a/pczt/src/roles/prover/sapling.rs
+++ b/pczt/src/roles/prover/sapling.rs
@@ -1,7 +1,7 @@
 use rand_core::OsRng;
 use sapling::prover::{OutputProver, SpendProver};
 
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement};
 
 impl super::Prover {
     pub fn create_sapling_proofs<S, O>(
@@ -21,9 +21,15 @@ impl super::Prover {
             ironwood,
         } = self.pczt;
 
-        let mut bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
+        let mut parsed = sapling
+            .into_parsed(AnchorRequirement::Required)
+            .map_err(SaplingError::Parser)?;
 
-        bundle
+        crate::sapling::verify_witnesses_root_to_anchor(&parsed.bundle, *parsed.bundle.anchor())
+            .map_err(SaplingError::InconsistentWitness)?;
+
+        parsed
+            .bundle
             .create_proofs(spend_prover, output_prover, OsRng)
             .map_err(SaplingError::Prover)?;
 
@@ -31,7 +37,7 @@ impl super::Prover {
             pczt: Pczt {
                 global,
                 transparent,
-                sapling: crate::sapling::Bundle::serialize_from(bundle),
+                sapling: parsed.reserialize(),
                 orchard,
                 ironwood,
             },
@@ -42,6 +48,82 @@ impl super::Prover {
 /// Errors that can occur while creating Sapling proofs for a PCZT.
 #[derive(Debug)]
 pub enum SaplingError {
-    Parser(sapling::pczt::ParseError),
+    /// A non-zero-valued spend's `witness` does not root to the bundle's anchor.
+    InconsistentWitness(crate::sapling::AnchorConsistencyError),
+    Parser(crate::sapling::ParseError),
     Prover(sapling::pczt::ProverError),
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+
+    use zcash_proofs::prover::LocalTxProver;
+    use zcash_protocol::consensus::BranchId;
+
+    use super::SaplingError;
+    use crate::{roles::creator::Creator, roles::prover::Prover, sapling::Spend};
+
+    #[test]
+    fn create_sapling_proofs_fails_when_anchor_absent() {
+        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        // A non-empty bundle whose anchor is absent MUST be rejected with a typed
+        // error before proving is attempted, rather than panicking.
+        pczt.sapling.spends.push(Spend {
+            cv: [1; 32],
+            nullifier: [2; 32],
+            rk: [3; 32],
+            zkproof: None,
+            spend_auth_sig: None,
+            recipient: None,
+            value: None,
+            rcm: None,
+            rseed: None,
+            rcv: None,
+            proof_generation_key: None,
+            witness: None,
+            alpha: None,
+            zip32_derivation: None,
+            dummy_ask: None,
+            proprietary: BTreeMap::new(),
+        });
+
+        let prover = LocalTxProver::bundled();
+        assert!(matches!(
+            Prover::new(pczt).create_sapling_proofs(&prover, &prover),
+            Err(SaplingError::Parser(
+                crate::sapling::ParseError::MissingAnchor
+            ))
+        ));
+    }
+
+    /// An untouched, empty Sapling bundle has no spends or outputs, so `into_parsed`
+    /// substitutes a placeholder anchor for its absent one even though the Prover
+    /// requires the anchor to be set. Proving such a bundle is a no-op, but the wire
+    /// anchor MUST stay absent afterwards rather than picking up the placeholder, so
+    /// that the bundle remains canonically empty.
+    #[test]
+    fn create_sapling_proofs_preserves_absent_anchor_for_untouched_bundle() {
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let prover = LocalTxProver::bundled();
+        let pczt = Prover::new(pczt)
+            .create_sapling_proofs(&prover, &prover)
+            .unwrap()
+            .finish();
+
+        assert_eq!(pczt.sapling, crate::sapling::EMPTY_BUNDLE);
+
+        let bytes = pczt.clone().serialize().unwrap();
+        assert_eq!(
+            crate::parse(&bytes).unwrap().sapling,
+            crate::sapling::EMPTY_BUNDLE
+        );
+    }
 }

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -118,9 +118,9 @@ pub fn extract_orchard_spend_auth_signatures(pczt: &Pczt) -> Vec<SpendAuthSignat
 pub struct Signer {
     global: Global,
     transparent: transparent::pczt::Bundle,
-    sapling: sapling::pczt::Bundle,
-    orchard: orchard::pczt::Bundle,
-    ironwood: orchard::pczt::Bundle,
+    sapling: crate::sapling::Parsed,
+    orchard: crate::orchard::Parsed,
+    ironwood: crate::orchard::Parsed,
     empty_ironwood: Option<crate::orchard::Bundle>,
     /// Cached across multiple signatures.
     tx_data: TransactionData<EffectsOnly>,
@@ -132,6 +132,8 @@ pub struct Signer {
 impl Signer {
     /// Instantiates the Signer role with the given PCZT.
     pub fn new(pczt: Pczt) -> Result<Self, Error> {
+        let anchor_requirement =
+            crate::common::AnchorRequirement::for_pre_authorization(pczt.global.tx_version);
         let empty_ironwood = pczt
             .ironwood
             .actions
@@ -146,6 +148,7 @@ impl Signer {
             ironwood,
             tx_data,
         } = pczt.extract_tx_data(
+            anchor_requirement,
             |t| {
                 t.extract_effects()
                     .map_err(ExtractError::TransparentExtract)
@@ -331,6 +334,7 @@ impl Signer {
     {
         let spend = self
             .sapling
+            .bundle
             .spends_mut()
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
@@ -420,6 +424,7 @@ impl Signer {
     {
         let action = self
             .orchard
+            .bundle
             .actions_mut()
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
@@ -486,6 +491,7 @@ impl Signer {
     {
         let action = self
             .ironwood
+            .bundle
             .actions_mut()
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
@@ -532,10 +538,9 @@ impl Signer {
         Pczt {
             global,
             transparent: crate::transparent::Bundle::serialize_from(transparent),
-            sapling: crate::sapling::Bundle::serialize_from(sapling),
-            orchard: crate::orchard::Bundle::serialize_from(orchard),
-            ironwood: empty_ironwood
-                .unwrap_or_else(|| crate::orchard::Bundle::serialize_from(ironwood)),
+            sapling: sapling.reserialize(),
+            orchard: orchard.reserialize(),
+            ironwood: empty_ironwood.unwrap_or_else(|| ironwood.reserialize()),
         }
     }
 }
@@ -557,5 +562,82 @@ pub enum Error {
 impl From<crate::ExtractError> for Error {
     fn from(e: crate::ExtractError) -> Self {
         Error::Extract(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ff::{Field, PrimeField};
+    use pasta_curves::pallas;
+    use zcash_protocol::consensus::BranchId;
+
+    use super::Signer;
+    use crate::{
+        orchard::{Action, Spend},
+        roles::{creator::Creator, io_finalizer::IoFinalizer, updater::Updater},
+    };
+
+    /// Builds a fully-dummy (zero-valued, freshly-random-key) Ironwood action, whose
+    /// spend the IO Finalizer signs itself via `dummy_sk`. This lets the IO Finalizer
+    /// and Signer roles be exercised without going through the transaction builder
+    /// (which requires a concrete anchor to add any real spend).
+    fn dummy_action() -> Action {
+        let sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
+        let alpha = pallas::Scalar::ONE;
+        let base = crate::orchard::testing::dummy_action();
+
+        Action {
+            spend: Spend {
+                alpha: Some(alpha.to_repr()),
+                dummy_sk: Some(*sk.to_bytes()),
+                ..base.spend
+            },
+            rcv: Some([3; 32]),
+            ..base
+        }
+    }
+
+    /// [ZIP 374] "Anchors and pre-authorization" requires that, for a v6 transaction,
+    /// signing (including the IO Finalizer's dummy-spend signing) works even while a
+    /// shielded bundle's anchor is absent. The Ironwood bundle here is built by
+    /// hand (rather than via the transaction builder, which requires a concrete
+    /// anchor up front to add any spend) specifically to exercise that state; the
+    /// full sign-then-prove-then-extract pipeline is covered by the end-to-end
+    /// Ironwood tests, whose transaction builder requires the anchor to be set at the
+    /// point the spend is added.
+    ///
+    /// [ZIP 374]: https://zips.z.cash/zip-0374#anchors-and-pre-authorization
+    #[test]
+    fn io_finalizer_and_signer_succeed_with_absent_ironwood_anchor() {
+        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 100, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        pczt.ironwood.actions.push(dummy_action());
+
+        assert!(pczt.ironwood.anchor.is_none());
+
+        let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+        assert!(pczt.ironwood.anchor.is_none());
+        assert!(pczt.ironwood.bsk.is_some());
+        // The IO Finalizer signs and clears the dummy spending key.
+        assert!(pczt.ironwood.actions[0].spend.dummy_sk.is_none());
+        assert!(pczt.ironwood.actions[0].spend.spend_auth_sig.is_some());
+
+        // `Signer::new` computes the shielded sighash and extracts transaction
+        // effects; this must succeed with the anchor still absent (a v6 sighash
+        // does not commit to it).
+        let signer = Signer::new(pczt).unwrap();
+        let pczt = signer.finish();
+        assert!(pczt.ironwood.anchor.is_none());
+
+        // The anchor may now be set by an Updater, at any point before the Prover
+        // runs; nothing about signing required it to be present.
+        let anchor = orchard::Anchor::empty_tree();
+        let pczt = Updater::new(pczt)
+            .set_ironwood_anchor(anchor)
+            .unwrap()
+            .finish();
+        assert_eq!(pczt.ironwood.anchor, Some(anchor.to_bytes()));
     }
 }

--- a/pczt/src/roles/tx_extractor/mod.rs
+++ b/pczt/src/roles/tx_extractor/mod.rs
@@ -78,6 +78,7 @@ impl<'a> TransactionExtractor<'a> {
         } = self;
 
         let crate::ParsedPczt { tx_data, .. } = pczt.extract_tx_data::<Unbound, Error>(
+            crate::common::AnchorRequirement::Required,
             |t| {
                 t.extract()
                     .map_err(|e| Error::Transparent(TransparentError::Extract(e)))

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -1,6 +1,6 @@
-use orchard::pczt::{ParseError, Updater, UpdaterError};
+use orchard::pczt::{Updater, UpdaterError};
 
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement, orchard::ParseError};
 
 impl super::Updater {
     /// Updates the Orchard bundle with information in the given closure.
@@ -15,23 +15,27 @@ impl super::Updater {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let mut bundle = orchard
+        let mut parsed = orchard
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
-                global.tx_version,
+                anchor_requirement,
             )
             .map_err(OrchardError::Parser)?;
 
-        bundle.update_with(f).map_err(OrchardError::Updater)?;
+        parsed
+            .bundle
+            .update_with(f)
+            .map_err(OrchardError::Updater)?;
 
         Ok(Self {
             pczt: Pczt {
                 global,
                 transparent,
                 sapling,
-                orchard: crate::orchard::Bundle::serialize_from(bundle),
+                orchard: parsed.reserialize(),
                 ironwood,
             },
         })
@@ -49,12 +53,16 @@ impl super::Updater {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let mut bundle = ironwood
-            .into_ironwood_parsed()
+        let mut parsed = ironwood
+            .into_ironwood_parsed(anchor_requirement)
             .map_err(OrchardError::Parser)?;
 
-        bundle.update_with(f).map_err(OrchardError::Updater)?;
+        parsed
+            .bundle
+            .update_with(f)
+            .map_err(OrchardError::Updater)?;
 
         Ok(Self {
             pczt: Pczt {
@@ -62,7 +70,7 @@ impl super::Updater {
                 transparent,
                 sapling,
                 orchard,
-                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+                ironwood: parsed.reserialize(),
             },
         })
     }

--- a/pczt/src/roles/updater/sapling.rs
+++ b/pczt/src/roles/updater/sapling.rs
@@ -1,6 +1,6 @@
-use sapling::pczt::{ParseError, Updater, UpdaterError};
+use sapling::pczt::{Updater, UpdaterError};
 
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement, sapling::ParseError};
 
 impl super::Updater {
     /// Updates the Sapling bundle with information in the given closure.
@@ -15,16 +15,22 @@ impl super::Updater {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let mut bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
+        let mut parsed = sapling
+            .into_parsed(anchor_requirement)
+            .map_err(SaplingError::Parser)?;
 
-        bundle.update_with(f).map_err(SaplingError::Updater)?;
+        parsed
+            .bundle
+            .update_with(f)
+            .map_err(SaplingError::Updater)?;
 
         Ok(Self {
             pczt: Pczt {
                 global,
                 transparent,
-                sapling: crate::sapling::Bundle::serialize_from(bundle),
+                sapling: parsed.reserialize(),
                 orchard,
                 ironwood,
             },

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -1,4 +1,4 @@
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement};
 
 impl super::Verifier {
     /// Parses the Orchard bundle and then verifies it in the given closure.
@@ -13,23 +13,24 @@ impl super::Verifier {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let bundle = orchard
+        let parsed = orchard
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
-                global.tx_version,
+                anchor_requirement,
             )
             .map_err(OrchardError::Parse)?;
 
-        f(&bundle)?;
+        f(&parsed.bundle)?;
 
         Ok(Self {
             pczt: Pczt {
                 global,
                 transparent,
                 sapling,
-                orchard: crate::orchard::Bundle::serialize_from(bundle),
+                orchard: parsed.reserialize(),
                 ironwood,
             },
         })
@@ -47,12 +48,13 @@ impl super::Verifier {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let bundle = ironwood
-            .into_ironwood_parsed()
+        let parsed = ironwood
+            .into_ironwood_parsed(anchor_requirement)
             .map_err(OrchardError::Parse)?;
 
-        f(&bundle)?;
+        f(&parsed.bundle)?;
 
         Ok(Self {
             pczt: Pczt {
@@ -60,7 +62,7 @@ impl super::Verifier {
                 transparent,
                 sapling,
                 orchard,
-                ironwood: crate::orchard::Bundle::serialize_from(bundle),
+                ironwood: parsed.reserialize(),
             },
         })
     }
@@ -69,7 +71,7 @@ impl super::Verifier {
 /// Errors that can occur while verifying the Orchard bundle of a PCZT.
 #[derive(Debug)]
 pub enum OrchardError<E> {
-    Parse(orchard::pczt::ParseError),
+    Parse(crate::orchard::ParseError),
     /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
     /// the Orchard protocol is not supported).
     UnsupportedConsensusBranchId,

--- a/pczt/src/roles/verifier/sapling.rs
+++ b/pczt/src/roles/verifier/sapling.rs
@@ -1,4 +1,4 @@
-use crate::Pczt;
+use crate::{Pczt, common::AnchorRequirement};
 
 impl super::Verifier {
     /// Parses the Sapling bundle and then verifies it in the given closure.
@@ -13,16 +13,19 @@ impl super::Verifier {
             orchard,
             ironwood,
         } = self.pczt;
+        let anchor_requirement = AnchorRequirement::for_pre_authorization(global.tx_version);
 
-        let bundle = sapling.into_parsed().map_err(SaplingError::Parser)?;
+        let parsed = sapling
+            .into_parsed(anchor_requirement)
+            .map_err(SaplingError::Parser)?;
 
-        f(&bundle)?;
+        f(&parsed.bundle)?;
 
         Ok(Self {
             pczt: Pczt {
                 global,
                 transparent,
-                sapling: crate::sapling::Bundle::serialize_from(bundle),
+                sapling: parsed.reserialize(),
                 orchard,
                 ironwood,
             },
@@ -33,7 +36,7 @@ impl super::Verifier {
 /// Errors that can occur while verifying the Sapling bundle of a PCZT.
 #[derive(Debug)]
 pub enum SaplingError<E> {
-    Parser(sapling::pczt::ParseError),
+    Parser(crate::sapling::ParseError),
     Verifier(sapling::pczt::VerifyError),
     Custom(E),
 }

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -531,8 +531,23 @@ pub(crate) mod v2 {
 
 #[cfg(feature = "sapling")]
 impl Bundle {
-    pub(crate) fn into_parsed(self) -> Result<sapling::pczt::Bundle, sapling::pczt::ParseError> {
-        let has_spends = !self.spends.is_empty();
+    /// Parses this bundle into the form used by the `sapling` crate.
+    ///
+    /// If the bundle's `anchor` is absent and `anchor_requirement` is
+    /// [`AnchorRequirement::Required`], returns [`ParseError::MissingAnchor`] unless the
+    /// bundle has no spends (in which case no operation on the parsed bundle can read
+    /// the anchor's value).
+    ///
+    /// [`AnchorRequirement::Required`]: crate::common::AnchorRequirement::Required
+    pub(crate) fn into_parsed(
+        self,
+        anchor_requirement: crate::common::AnchorRequirement,
+    ) -> Result<Parsed, ParseError> {
+        let wire_anchor = self.anchor;
+        let anchor = anchor_requirement
+            .resolve(wire_anchor, self.spends.is_empty())
+            .ok_or(ParseError::MissingAnchor)?;
+
         let spends = self
             .spends
             .into_iter()
@@ -597,13 +612,13 @@ impl Bundle {
             })
             .collect::<Result<_, _>>()?;
 
-        let anchor = match self.anchor {
-            Some(anchor) => anchor,
-            None if !has_spends => DEFAULT_ANCHOR,
-            None => return Err(sapling::pczt::ParseError::InvalidAnchor),
-        };
+        let bundle =
+            sapling::pczt::Bundle::parse(spends, outputs, self.value_sum, anchor, self.bsk)?;
 
-        sapling::pczt::Bundle::parse(spends, outputs, self.value_sum, anchor, self.bsk)
+        Ok(Parsed {
+            bundle,
+            wire_anchor,
+        })
     }
 
     pub(crate) fn serialize_from(bundle: sapling::pczt::Bundle) -> Self {
@@ -687,9 +702,152 @@ impl Bundle {
             spends,
             outputs,
             value_sum: bundle.value_sum().to_raw(),
-            anchor: (bundle.anchor().to_bytes() != DEFAULT_ANCHOR)
-                .then_some(bundle.anchor().to_bytes()),
+            anchor: Some(bundle.anchor().to_bytes()),
             bsk: bundle.bsk().map(|bsk| bsk.into()),
         }
+    }
+}
+
+/// Errors that can occur while parsing a Sapling bundle into the form used by
+/// the `sapling` crate.
+#[cfg(feature = "sapling")]
+#[derive(Debug)]
+pub enum ParseError {
+    /// The operation requires the bundle's `anchor` to be set, but it was absent.
+    ///
+    /// For a v6 transaction, an Updater can resolve this by setting the anchor; see
+    /// [ZIP 374: Anchors and pre-authorization](https://zips.z.cash/zip-0374#anchors-and-pre-authorization).
+    MissingAnchor,
+    /// The bundle's remaining fields were structurally invalid.
+    Bundle(sapling::pczt::ParseError),
+}
+
+#[cfg(feature = "sapling")]
+impl From<sapling::pczt::ParseError> for ParseError {
+    fn from(e: sapling::pczt::ParseError) -> Self {
+        ParseError::Bundle(e)
+    }
+}
+
+/// Errors that can occur while checking that a Sapling bundle's spend witnesses are
+/// consistent with its anchor.
+#[cfg(feature = "sapling")]
+#[derive(Debug)]
+pub enum AnchorConsistencyError {
+    /// A non-zero-valued spend has a `witness` but is missing other note data required
+    /// to compute its Merkle path root.
+    IncompleteSpendData,
+    /// A non-zero-valued spend's `witness` does not root to the given anchor.
+    WitnessDoesNotRootToAnchor,
+}
+
+/// Checks that every non-zero-valued spend in `bundle` whose `witness` is present has a
+/// Merkle path that roots to `anchor` (\[ZIP 374\] "Anchors and pre-authorization").
+///
+/// Zero-valued spends are skipped, as their Merkle paths are not checked by the Sapling
+/// circuit.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374#anchors-and-pre-authorization
+#[cfg(feature = "sapling")]
+pub(crate) fn verify_witnesses_root_to_anchor(
+    bundle: &sapling::pczt::Bundle,
+    anchor: sapling::Anchor,
+) -> Result<(), AnchorConsistencyError> {
+    for spend in bundle.spends() {
+        let Some(witness) = spend.witness() else {
+            continue;
+        };
+        let Some(value) = spend.value() else {
+            continue;
+        };
+        if value.inner() == 0 {
+            continue;
+        }
+
+        let recipient = spend
+            .recipient()
+            .ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+        let rseed = (*spend.rseed()).ok_or(AnchorConsistencyError::IncompleteSpendData)?;
+
+        let note = sapling::Note::from_parts(recipient, *value, rseed);
+        let leaf = sapling::Node::from_cmu(&note.cmu());
+        let computed_anchor: sapling::Anchor = witness.root(leaf).into();
+
+        if computed_anchor != anchor {
+            return Err(AnchorConsistencyError::WitnessDoesNotRootToAnchor);
+        }
+    }
+
+    Ok(())
+}
+
+/// The result of parsing a Sapling bundle via [`Bundle::into_parsed`].
+///
+/// Carries the bundle's original wire `anchor` alongside the parsed form, so that
+/// [`Parsed::reserialize`] can restore it after an operation that does not itself
+/// change the anchor, even though parsing may have substituted a placeholder for it
+/// (see [ZIP 374: Anchors and pre-authorization](https://zips.z.cash/zip-0374#anchors-and-pre-authorization)).
+#[cfg(feature = "sapling")]
+pub(crate) struct Parsed {
+    pub(crate) bundle: sapling::pczt::Bundle,
+    pub(crate) wire_anchor: Option<[u8; 32]>,
+}
+
+#[cfg(feature = "sapling")]
+impl Parsed {
+    /// Serializes the parsed bundle back into its wire representation, using
+    /// [`Self::wire_anchor`] as the result's `anchor` in place of any placeholder
+    /// substituted while parsing.
+    ///
+    /// Must not be used after an operation that legitimately changes the anchor;
+    /// such operations should set `wire_anchor` to the new value first.
+    pub(crate) fn reserialize(self) -> Bundle {
+        Bundle {
+            anchor: self.wire_anchor,
+            ..Bundle::serialize_from(self.bundle)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sapling"))]
+mod tests {
+    use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
+
+    use super::Bundle;
+    use crate::common::AnchorRequirement;
+
+    #[test]
+    fn output_only_bundle_parses_without_anchor() {
+        let recipient = sapling::zip32::ExtendedSpendingKey::master(&[0; 32])
+            .to_diversifiable_full_viewing_key()
+            .default_address()
+            .1;
+        let mut builder = sapling::builder::Builder::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+            sapling::builder::BundleType::DEFAULT,
+            sapling::Anchor::empty_tree(),
+        );
+        builder
+            .add_output(
+                None,
+                recipient,
+                sapling::value::NoteValue::from_raw(1),
+                [0; 512],
+            )
+            .unwrap();
+        let (bundle, _) = builder
+            .build_for_pczt(ChaCha20Rng::from_seed([0; 32]))
+            .unwrap();
+        let output_count = bundle.outputs().len();
+        let mut bundle = Bundle::serialize_from(bundle);
+        bundle.anchor = None;
+
+        let parsed = bundle.into_parsed(AnchorRequirement::Required).unwrap();
+        assert!(parsed.bundle.spends().is_empty());
+        assert_eq!(parsed.bundle.outputs().len(), output_count);
+
+        let reserialized = parsed.reserialize();
+        assert!(reserialized.anchor.is_none());
+        assert_eq!(reserialized.outputs.len(), output_count);
     }
 }

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -535,8 +535,8 @@ impl Bundle {
     ///
     /// If the bundle's `anchor` is absent and `anchor_requirement` is
     /// [`AnchorRequirement::Required`], returns [`ParseError::MissingAnchor`] unless the
-    /// bundle has no spends (in which case no operation on the parsed bundle can read
-    /// the anchor's value).
+    /// bundle has no spends or outputs (in which case there is nothing to prove or
+    /// extract).
     ///
     /// [`AnchorRequirement::Required`]: crate::common::AnchorRequirement::Required
     pub(crate) fn into_parsed(
@@ -545,7 +545,10 @@ impl Bundle {
     ) -> Result<Parsed, ParseError> {
         let wire_anchor = self.anchor;
         let anchor = anchor_requirement
-            .resolve(wire_anchor, self.spends.is_empty())
+            .resolve(
+                wire_anchor,
+                self.spends.is_empty() && self.outputs.is_empty(),
+            )
             .ok_or(ParseError::MissingAnchor)?;
 
         let spends = self
@@ -712,6 +715,7 @@ impl Bundle {
 /// the `sapling` crate.
 #[cfg(feature = "sapling")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The operation requires the bundle's `anchor` to be set, but it was absent.
     ///
@@ -733,6 +737,7 @@ impl From<sapling::pczt::ParseError> for ParseError {
 /// consistent with its anchor.
 #[cfg(feature = "sapling")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AnchorConsistencyError {
     /// A non-zero-valued spend has a `witness` but is missing other note data required
     /// to compute its Merkle path root.
@@ -813,11 +818,10 @@ impl Parsed {
 mod tests {
     use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
-    use super::Bundle;
+    use super::{Bundle, ParseError};
     use crate::common::AnchorRequirement;
 
-    #[test]
-    fn output_only_bundle_parses_without_anchor() {
+    fn output_only_bundle() -> Bundle {
         let recipient = sapling::zip32::ExtendedSpendingKey::master(&[0; 32])
             .to_diversifiable_full_viewing_key()
             .default_address()
@@ -838,11 +842,25 @@ mod tests {
         let (bundle, _) = builder
             .build_for_pczt(ChaCha20Rng::from_seed([0; 32]))
             .unwrap();
-        let output_count = bundle.outputs().len();
         let mut bundle = Bundle::serialize_from(bundle);
         bundle.anchor = None;
+        bundle
+    }
 
-        let parsed = bundle.into_parsed(AnchorRequirement::Required).unwrap();
+    #[test]
+    fn output_only_bundle_requires_anchor_when_required() {
+        assert!(matches!(
+            output_only_bundle().into_parsed(AnchorRequirement::Required),
+            Err(ParseError::MissingAnchor)
+        ));
+    }
+
+    #[test]
+    fn output_only_bundle_preserves_absent_anchor_when_not_required() {
+        let bundle = output_only_bundle();
+        let output_count = bundle.outputs.len();
+
+        let parsed = bundle.into_parsed(AnchorRequirement::NotRequired).unwrap();
         assert!(parsed.bundle.spends().is_empty());
         assert_eq!(parsed.bundle.outputs().len(), output_count);
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -2196,7 +2196,8 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
         resolved.ironwood().actions()[index].cv_net(),
         pczt.ironwood().actions()[index].cv_net()
     );
-    assert!(IoFinalizer::new(redacted.clone()).finalize_io().is_err());
+    let finalized = IoFinalizer::new(redacted.clone()).finalize_io().unwrap();
+    assert!(finalized.ironwood().anchor().is_none());
     assert!(
         Prover::new(redacted.clone())
             .create_ironwood_proof(orchard_proving_key())


### PR DESCRIPTION
V6 PCZTs can omit shielded anchors during pre-authorization; Sapling bundles without spends do not consume an anchor at any stage.

This keeps placeholder anchors internal to roles that do not read the anchor. IO finalization, signing, updating, and verification can parse such PCZTs without serializing a placeholder back out. V5 signing paths and operations that consume anchors still require them for Sapling spends and Orchard-protocol actions.

Proving now rejects non-zero-valued spends whose witnesses do not root to the bundle anchor before creating Sapling, Orchard, or Ironwood proofs. The changelog records the role behavior and public parse/consistency error names.
