### PR TITLE
zcash_client_sqlite: Add feature-gated ZeWIF wallet import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7133,6 +7153,8 @@ version = "0.21.1"
 dependencies = [
  "ambassador",
  "assert_matches",
+ "bech32",
+ "bip0039",
  "bip32",
  "bitflags 2.9.0",
  "bls12_381",
@@ -7179,6 +7201,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zewif",
  "zip32",
  "zip321",
 ]
@@ -7433,6 +7456,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e62113720e311984f461c56b00457ae9981c0bc7859d22306cc2ae2f95571c"
 dependencies = [
  "zerofrom",
+]
+
+[[package]]
+name = "zewif"
+version = "0.1.0"
+source = "git+https://github.com/zcash/zewif.git?branch=main#74f1a1694131386515e1733dfb9f414a6284555f"
+dependencies = [
+ "hex",
+ "minicbor",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,9 @@ bip0039 = { version = "0.12" }
 fpe = { version = "0.6", default-features = false, features = ["alloc"] }
 zip32 = { version = "0.2", default-features = false }
 
+# ZeWIF wallet interchange
+zewif = "0.1.0"
+
 # Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
 time-core = "=0.1.2"
 
@@ -235,3 +238,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
+
+zewif = { git = "https://github.com/zcash/zewif.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,8 @@ exceptions = [
     { name = "foldhash", allow = ["Zlib"] },
     { name = "inotify", allow = ["ISC"] },
     { name = "inotify-sys", allow = ["ISC"] },
+    { name = "minicbor", allow = ["BlueOak-1.0.0"] },
+    { name = "minicbor-derive", allow = ["BlueOak-1.0.0"] },
     { name = "minreq", allow = ["ISC"] },
     { name = "nanorand", allow = ["Zlib"] },
     { name = "notify", allow = ["CC0-1.0"] },

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -83,6 +83,9 @@ audit-as-crates-io = true
 [policy.zcash_transparent]
 audit-as-crates-io = true
 
+[policy.zewif]
+audit-as-crates-io = false
+
 [policy.zip321]
 audit-as-crates-io = true
 
@@ -772,6 +775,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.merlin]]
 version = "3.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.minicbor]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.minicbor-derive]]
+version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -194,6 +194,12 @@ workspace.
   (A payment directed to the Orchard pool after NU6.3 activation is a
   programming error, which step construction enforces by assertion: payment
   classification always delivers such payments via the Ironwood bundle.)
+- `zcash_client_backend::proposal::ProposalError::OrchardReceiverRequiresIronwood`,
+  returned by proposal construction when a transaction version that cannot carry an
+  Ironwood bundle is explicitly requested for a payment to an Orchard receiver at a
+  post-NU6.3 target height. Such a payment must be delivered through the Ironwood pool
+  (a version 6 transaction feature), as the Orchard turnstile forbids adding value to
+  the Orchard pool after NU6.3.
 - `zcash_client_backend::data_api::wallet::ProposeShieldingCoinbaseErrT` type
   alias, parallel to `ProposeShieldingErrT` but parameterized on a `FeeRule`
   instead of a `ChangeStrategy`.

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -7366,3 +7366,167 @@ pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
         proposal,
     );
 }
+
+/// After NU6.3 activation, a payment to an Orchard receiver must be delivered through the
+/// Ironwood pool, which requires a version 6 transaction. Explicitly requesting a version 5
+/// transaction — which has no Ironwood bundle — for such a payment must be rejected at proposal
+/// time with [`ProposalError::OrchardReceiverRequiresIronwood`], rather than producing a proposal
+/// that could only fail later at build time.
+#[cfg(feature = "orchard")]
+pub fn propose_v5_payment_to_orchard_receiver_is_rejected<Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+{
+    use super::orchard::OrchardPoolTester;
+    use crate::data_api::wallet::{input_selection::SpendPolicy, propose_transfer};
+    use crate::proposal::ProposalError;
+    use zcash_primitives::transaction::TxVersion;
+
+    // A network on which Ironwood (NU6.3) is active from the Sapling activation height.
+    let ironwood_active_network = {
+        let activation = BlockHeight::from_u32(100_000);
+        LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        }
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+
+    // Fund the wallet with a single spendable Orchard note.
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60_000));
+
+    // The destination has an Orchard receiver controlled by a separate spending key.
+    let to_extsk = OrchardPoolTester::sk(&[0xf5; 32]);
+    let to = OrchardPoolTester::sk_default_address(&to_extsk);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10_000),
+    )])
+    .unwrap();
+
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedPool::Orchard,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+
+    let account = st.get_account();
+    let network = *st.network();
+    let result = propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account.id(),
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &SpendPolicy::default(),
+        Some(TxVersion::V5),
+    );
+
+    assert_matches!(
+        result,
+        Err(Error::Proposal(
+            ProposalError::OrchardReceiverRequiresIronwood(TxVersion::V5)
+        ))
+    );
+}
+
+/// PCZT construction cannot yet produce an Ironwood bundle (a version 6 transaction feature), so
+/// after NU6.3 a proposal that delivers a payment to an Orchard receiver — routed through the
+/// Ironwood pool — must be rejected by `create_pczt_from_proposal` with a clear
+/// [`Error::ProposalNotSupported`], rather than failing with an opaque builder error.
+#[cfg(all(feature = "orchard", feature = "pczt"))]
+pub fn create_pczt_rejects_ironwood_orchard_receiver_payment<Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <Dsf as DataStoreFactory>::AccountId: serde::Serialize,
+{
+    use super::orchard::OrchardPoolTester;
+
+    // A network on which Ironwood (NU6.3) is active from the Sapling activation height.
+    let ironwood_active_network = {
+        let activation = BlockHeight::from_u32(100_000);
+        LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        }
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+
+    // Fund the wallet with a single spendable Orchard note.
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60_000));
+
+    // The destination has an Orchard receiver controlled by a separate spending key; post-NU6.3
+    // the payment is routed through the Ironwood pool.
+    let to_extsk = OrchardPoolTester::sk(&[0xf5; 32]);
+    let to = OrchardPoolTester::sk_default_address(&to_extsk);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10_000),
+    )])
+    .unwrap();
+
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedPool::Orchard,
+        DustOutputPolicy::default(),
+    );
+    let input_selector = GreedyInputSelector::new();
+
+    let account_id = st.get_account().id();
+    let proposal = st
+        .propose_transfer(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal construction succeeds; the Orchard-receiver payment routes to Ironwood");
+
+    // The payment routes to the Ironwood pool, so realizing this proposal as a PCZT is what is
+    // being rejected below.
+    assert_eq!(
+        proposal.steps().head.payment_pools().get(&0),
+        Some(&PoolType::IRONWOOD),
+    );
+
+    let result = st.create_pczt_from_proposal::<Infallible, _, Infallible>(
+        account_id,
+        OvkPolicy::Sender,
+        &proposal,
+        None,
+    );
+
+    assert_matches!(result, Err(Error::ProposalNotSupported));
+}

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2238,6 +2238,26 @@ where
     })
 }
 
+/// Returns `true` if evaluating this proposal step would move value through the Ironwood pool —
+/// an Orchard-receiver payment after NU6.3, an Ironwood note spend, or Ironwood change. PCZT
+/// construction cannot yet produce the version 6 transaction such a step requires.
+#[cfg(feature = "pczt")]
+fn step_uses_ironwood<N>(step: &Step<N>) -> bool {
+    step.payment_pools()
+        .values()
+        .any(|pool| *pool == PoolType::IRONWOOD)
+        || step
+            .balance()
+            .proposed_change()
+            .iter()
+            .any(|change| change.output_pool() == PoolType::IRONWOOD)
+        || step
+            .shielded_inputs()
+            .iter()
+            .flat_map(|inputs| inputs.notes().iter())
+            .any(|note| note.note().pool() == ShieldedPool::Ironwood)
+}
+
 /// Constructs a transaction using the inputs supplied by the given proposal.
 ///
 /// Only single-step proposals are currently supported.
@@ -2306,6 +2326,14 @@ where
 
     let prior_step_results = &[];
     let proposal_step = proposal.steps().first();
+
+    // PCZT construction cannot yet produce an Ironwood bundle (a version 6 transaction feature),
+    // so a proposal that moves value through the Ironwood pool cannot be realized as a PCZT.
+    // Reject it up front rather than forcing the version 5 build below to fail opaquely with a
+    // builder error.
+    if step_uses_ironwood(proposal_step) {
+        return Err(Error::ProposalNotSupported);
+    }
 
     let unused_transparent_outputs = &mut HashMap::new();
     let proposed_version = Some(TxVersion::V5);

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -901,14 +901,25 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         // Represent an Orchard-receiver payment as an Ironwood-pool output once
                         // Ironwood is active (its value is accounted to the Ironwood bundle
                         // below), and as an Orchard-pool output otherwise.
-                        payment_pools.insert(
-                            *idx,
-                            if ironwood_active_at(params, target_height) {
-                                PoolType::IRONWOOD
-                            } else {
-                                PoolType::ORCHARD
-                            },
-                        );
+                        let pool = if ironwood_active_at(params, target_height) {
+                            // After NU6.3 the Orchard turnstile (a consensus rule) forbids adding
+                            // value to the Orchard pool, so the payment must be delivered through
+                            // the Ironwood bundle, which only a version 6 transaction carries. If a
+                            // transaction version was explicitly requested that cannot carry an
+                            // Ironwood bundle, reject the proposal here rather than constructing one
+                            // that could only fail at build time.
+                            if let Some(v) = proposed_version {
+                                if !v.has_ironwood() {
+                                    return Err(
+                                        ProposalError::OrchardReceiverRequiresIronwood(v).into()
+                                    );
+                                }
+                            }
+                            PoolType::IRONWOOD
+                        } else {
+                            PoolType::ORCHARD
+                        };
+                        payment_pools.insert(*idx, pool);
                         orchard_outputs.push(OrchardPayment(payment_amount));
                         continue;
                     }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use nonempty::NonEmpty;
-use zcash_primitives::transaction::TxId;
+use zcash_primitives::transaction::{TxId, TxVersion};
 use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{BlockHeight, BranchId},
@@ -78,6 +78,12 @@ pub enum ProposalError {
     /// The transaction version requested is not compatible with the consensus branch for which the
     /// transaction is intended.
     IncompatibleTxVersion(BranchId),
+    /// After NU6.3 activation, a payment to an Orchard receiver must be delivered through the
+    /// Ironwood pool, which requires a version 6 transaction. The explicitly-requested transaction
+    /// version has no Ironwood bundle, so it cannot carry the payment. (The Orchard turnstile is a
+    /// consensus rule after NU6.3: no payment may add value to the Orchard pool, so such a payment
+    /// cannot be delivered as a plain Orchard output either.)
+    OrchardReceiverRequiresIronwood(TxVersion),
     /// After Ironwood activation, a proposal step would create value in the Orchard pool.
     /// The turnstile only permits value to leave the pool: a step may return change to it
     /// only when strictly less value returns than the step's Orchard inputs remove.
@@ -186,6 +192,10 @@ impl Display for ProposalError {
             ProposalError::IncompatibleTxVersion(branch_id) => write!(
                 f,
                 "The requested transaction version is incompatible with consensus branch {branch_id:?}"
+            ),
+            ProposalError::OrchardReceiverRequiresIronwood(version) => write!(
+                f,
+                "After NU6.3 activation, a payment to an Orchard receiver requires a version 6 (Ironwood) transaction, but version {version:?} was requested."
             ),
         }
     }

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -42,6 +42,11 @@ transparent.workspace = true
 bip32 = { workspace = true, optional = true }
 bs58.workspace = true
 
+# - ZeWIF wallet interchange
+zewif = { workspace = true, optional = true }
+bech32 = { workspace = true, optional = true }
+bip0039 = { workspace = true, optional = true, features = ["all-languages"] }
+
 # - Logging and metrics
 tracing.workspace = true
 
@@ -160,6 +165,21 @@ transparent-key-import = [
 zcashd-compat = [
   "zcash_keys/zcashd-compat",
   "zcash_client_backend/zcashd-compat"
+]
+
+## Enables importing wallets from ZeWIF (Zcash Wallet Interchange Format)
+## documents. Spending key material carried by a document is diverted to a
+## caller-provided `SecretSink` and is never stored in the wallet
+## database.
+zewif = [
+  "dep:zewif",
+  "dep:bech32",
+  "dep:bip0039",
+  "orchard",
+  "transparent-inputs",
+  "transparent-key-import",
+  "zcashd-compat",
+  "zcash_keys/unstable",
 ]
 
 ## Enables `serde` derives for certain types.

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -152,6 +152,8 @@ pub mod chain;
 pub mod error;
 pub mod util;
 pub mod wallet;
+#[cfg(feature = "zewif")]
+pub mod zewif;
 
 #[cfg(test)]
 mod testing;

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -820,3 +820,19 @@ pub(crate) fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood() {
         BlockCache::new(),
     );
 }
+
+#[cfg(feature = "orchard")]
+pub(crate) fn propose_v5_payment_to_orchard_receiver_is_rejected() {
+    zcash_client_backend::data_api::testing::pool::propose_v5_payment_to_orchard_receiver_is_rejected(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(all(feature = "orchard", feature = "pczt-tests"))]
+pub(crate) fn create_pczt_rejects_ironwood_orchard_receiver_payment() {
+    zcash_client_backend::data_api::testing::pool::create_pczt_rejects_ironwood_orchard_receiver_payment(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -929,6 +929,17 @@ pub(crate) mod tests {
         testing::pool::shielding_coinbase_to_orchard_receiver_delivers_via_ironwood();
     }
 
+    #[test]
+    fn propose_v5_payment_to_orchard_receiver_is_rejected() {
+        testing::pool::propose_v5_payment_to_orchard_receiver_is_rejected();
+    }
+
+    #[cfg(feature = "pczt-tests")]
+    #[test]
+    fn create_pczt_rejects_ironwood_orchard_receiver_payment() {
+        testing::pool::create_pczt_rejects_ironwood_orchard_receiver_payment();
+    }
+
     /// `put_received_note` records a note in the received-notes table chosen by the caller,
     /// preserving the note's plaintext version in the `note_version` column. An Orchard-pool note
     /// and an Ironwood-pool note sharing an action index may both be recorded in their respective

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -1,0 +1,903 @@
+//! Import of wallets from ZeWIF (Zcash Wallet Interchange Format) documents.
+//!
+//! This module populates a [`WalletDb`] from a [`::zewif::Zewif`] document, importing
+//! each account it can represent and diverting all spending key material to a
+//! caller-provided [`SecretSink`]. Secret material is never stored in the wallet
+//! database itself; the sink is expected to persist it in an application keystore
+//! (for example, zallet's age-encrypted keystore).
+//!
+//! # Pipeline
+//!
+//! [`import_wallet`] performs the following steps, in order:
+//!
+//! 1. Verifies that every wallet in the document was recorded for the network the
+//!    database's [`Parameters`] describe.
+//! 2. Delivers every entry of the document's secret store to the [`SecretSink`],
+//!    recording which seeds and spending keys are available so that account
+//!    spendability can be determined.
+//! 3. Imports each account: seed-derived accounts whose seed material is present are
+//!    imported via HD derivation (preserving the recorded ZIP 32 account index);
+//!    all others are imported from their viewing keys, as spending accounts when
+//!    corresponding spending material was delivered to the sink and as view-only
+//!    accounts otherwise. Account birthdays are constructed from the tree-state
+//!    frontiers carried by the document where present.
+//!
+//! The database must already have been initialized with
+//! [`crate::wallet::init::WalletMigrator`] before calling [`import_wallet`].
+//!
+//! # Limitations
+//!
+//! * Sprout accounts and Sprout spending keys are not representable in the wallet
+//!   database. Sprout spending keys are still delivered to the [`SecretSink`];
+//!   Sprout accounts are skipped and recorded in the [`ZewifImportReport`].
+//! * Address book entries have no backing store in this crate and are not
+//!   imported; the caller retains the document and may preserve them elsewhere.
+//! * Received-note spendability requires commitment tree positions, which only
+//!   block scanning can establish. Importing an account seeds the scan queue from
+//!   its birthday; the wallet's balance becomes visible and spendable as the
+//!   post-import rescan progresses.
+//! * Documents recorded against a regtest network are not currently supported,
+//!   as the equivalence of regtest activation schedules cannot be verified here.
+//! * Encrypted secret stores must be decrypted by the caller (using the `zewif`
+//!   crate's decryption support) before import.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use bech32::primitives::decode::CheckedHrpstring;
+use bip0039::{English, Mnemonic};
+use rand::RngCore;
+use secrecy::SecretVec;
+use zcash_client_backend::data_api::{
+    Account as _, AccountBirthday, AccountPurpose, WalletWrite, Zip32Derivation, chain::ChainState,
+};
+use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::consensus::{
+    self, BlockHeight, NetworkConstants as _, NetworkType, NetworkUpgrade, Parameters,
+};
+use zip32::fingerprint::SeedFingerprint;
+
+use crate::{AccountUuid, WalletDb, error::SqliteClientError, util::Clock};
+
+/// The Bech32m human-readable part of the canonical ZIP 32 seed fingerprint
+/// encoding used by ZeWIF documents.
+const SEED_FP_HRP: &str = "zip32seedfp";
+
+/// A destination for the spending key material carried by a ZeWIF document.
+///
+/// The wallet database stores only viewing keys and public metadata; all secret
+/// material encountered during import is delivered to an implementation of this
+/// trait, which is expected to persist it outside the wallet database (for
+/// example, in an age-encrypted keystore such as zallet's). Implementations
+/// should be idempotent with respect to re-delivery of the same entry.
+pub trait SecretSink {
+    /// The error type produced when the sink fails to persist an entry.
+    type Error: std::error::Error;
+
+    /// Persists seed material (a BIP 39 mnemonic or a legacy raw seed), keyed by
+    /// its ZIP 32 seed fingerprint.
+    fn store_seed(&mut self, entry: &::zewif::SeedEntry) -> Result<(), Self::Error>;
+
+    /// Persists a transparent spending key (WIF-encoded), keyed by its public key.
+    fn store_transparent_key(
+        &mut self,
+        entry: &::zewif::TransparentKeyEntry,
+    ) -> Result<(), Self::Error>;
+
+    /// Persists a Sapling extended spending key, keyed by the canonical encoding
+    /// of its extended full viewing key.
+    fn store_sapling_key(&mut self, entry: &::zewif::SaplingKeyEntry) -> Result<(), Self::Error>;
+
+    /// Persists a Sprout spending key, keyed by its Sprout address. Sprout funds
+    /// are not representable in the wallet database, so this is the only
+    /// destination for Sprout key material.
+    fn store_sprout_key(&mut self, entry: &::zewif::SproutKeyEntry) -> Result<(), Self::Error>;
+
+    /// Persists an extracted unified spending key, keyed by the canonical
+    /// encoding of its unified full viewing key.
+    fn store_unified_key(&mut self, entry: &::zewif::UnifiedKeyEntry) -> Result<(), Self::Error>;
+}
+
+/// A [`SecretSink`] that discards all secret material.
+///
+/// Use this only for view-only imports where the document's secret material is
+/// intentionally not being retained.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DiscardSecrets;
+
+impl SecretSink for DiscardSecrets {
+    type Error = core::convert::Infallible;
+
+    fn store_seed(&mut self, _entry: &::zewif::SeedEntry) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn store_transparent_key(
+        &mut self,
+        _entry: &::zewif::TransparentKeyEntry,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn store_sapling_key(&mut self, _entry: &::zewif::SaplingKeyEntry) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn store_sprout_key(&mut self, _entry: &::zewif::SproutKeyEntry) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn store_unified_key(&mut self, _entry: &::zewif::UnifiedKeyEntry) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// The shielded pool to which an invalid tree frontier belongs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontierPool {
+    /// The Sapling note commitment tree.
+    Sapling,
+    /// The Orchard note commitment tree.
+    Orchard,
+    /// The Ironwood note commitment tree.
+    Ironwood,
+}
+
+impl fmt::Display for FrontierPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrontierPool::Sapling => write!(f, "Sapling"),
+            FrontierPool::Orchard => write!(f, "Orchard"),
+            FrontierPool::Ironwood => write!(f, "Ironwood"),
+        }
+    }
+}
+
+/// Errors that can occur while importing a ZeWIF document.
+#[derive(Debug)]
+pub enum ZewifImportError<S> {
+    /// A wallet in the document was recorded for a different network than the one
+    /// described by the database's [`Parameters`].
+    NetworkMismatch {
+        /// The network recorded in the document.
+        document: ::zewif::Network,
+        /// The network type of the database parameters.
+        expected: NetworkType,
+    },
+    /// The document was recorded against a regtest network, which this importer
+    /// does not currently support.
+    UnsupportedRegtest,
+    /// The document's secret store is encrypted; the caller must decrypt it (via
+    /// the `zewif` crate's decryption support) before import.
+    EncryptedSecrets,
+    /// A unified full viewing key in the document could not be parsed.
+    UfvkDecoding {
+        /// The name of the account whose viewing key failed to parse.
+        account_name: String,
+        /// The parse failure diagnostic.
+        message: String,
+    },
+    /// A Sapling extended full viewing key in the document could not be parsed.
+    SaplingFvkDecoding {
+        /// The name of the account whose viewing key failed to parse.
+        account_name: String,
+    },
+    /// A seed fingerprint in the document is not a valid `zip32seedfp` Bech32m
+    /// encoding.
+    SeedFingerprintDecoding {
+        /// The malformed fingerprint encoding.
+        encoding: String,
+    },
+    /// Seed material in the document does not match the fingerprint under which
+    /// it was recorded.
+    SeedFingerprintMismatch {
+        /// The fingerprint recorded in the document.
+        claimed: String,
+    },
+    /// A BIP 39 mnemonic in the document could not be interpreted.
+    InvalidMnemonic {
+        /// The fingerprint of the seed entry containing the mnemonic.
+        fingerprint: String,
+        /// The underlying mnemonic decoding error.
+        source: bip0039::Error,
+    },
+    /// Seed material has a length outside the range ZIP 32 permits (32 to 252
+    /// bytes).
+    InvalidSeedLength {
+        /// The fingerprint of the offending seed entry.
+        fingerprint: String,
+    },
+    /// A recorded ZIP 32 account index is outside the valid hardened range.
+    InvalidAccountIndex {
+        /// The name of the account with the invalid index.
+        account_name: String,
+        /// The recorded index.
+        index: u32,
+    },
+    /// A recorded zcashd legacy address index is outside the valid range.
+    InvalidLegacyAddressIndex {
+        /// The name of the account with the invalid index.
+        account_name: String,
+        /// The recorded index.
+        index: u32,
+    },
+    /// A hash in a note commitment tree frontier is not a valid node for its
+    /// pool.
+    InvalidMerkleNode {
+        /// The name of the account whose birthday contains the invalid node.
+        account_name: String,
+        /// The pool whose frontier contains the invalid node.
+        pool: FrontierPool,
+    },
+    /// A note commitment tree frontier in an account birthday is structurally
+    /// invalid.
+    InvalidFrontier {
+        /// The name of the account whose birthday contains the invalid frontier.
+        account_name: String,
+        /// The pool whose frontier is invalid.
+        pool: FrontierPool,
+        /// The underlying structural error.
+        source: incrementalmerkletree::frontier::FrontierError,
+    },
+    /// An error occurred writing to the wallet database.
+    Wallet(SqliteClientError),
+    /// The [`SecretSink`] failed to persist an entry.
+    Sink(S),
+}
+
+impl<S: fmt::Display> fmt::Display for ZewifImportError<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ZewifImportError::NetworkMismatch { document, expected } => write!(
+                f,
+                "Document was recorded for network {document:?}, but the wallet database is for {expected:?}."
+            ),
+            ZewifImportError::UnsupportedRegtest => write!(
+                f,
+                "Documents recorded against regtest networks are not currently supported."
+            ),
+            ZewifImportError::EncryptedSecrets => write!(
+                f,
+                "The document's secret store is encrypted; decrypt it before import."
+            ),
+            ZewifImportError::UfvkDecoding {
+                account_name,
+                message,
+            } => write!(
+                f,
+                "Unable to parse the unified full viewing key of account \"{account_name}\": {message}"
+            ),
+            ZewifImportError::SaplingFvkDecoding { account_name } => write!(
+                f,
+                "Unable to parse the Sapling extended full viewing key of account \"{account_name}\"."
+            ),
+            ZewifImportError::SeedFingerprintDecoding { encoding } => write!(
+                f,
+                "\"{encoding}\" is not a valid zip32seedfp Bech32m seed fingerprint encoding."
+            ),
+            ZewifImportError::SeedFingerprintMismatch { claimed } => write!(
+                f,
+                "Seed material does not match the fingerprint {claimed} under which it was recorded."
+            ),
+            ZewifImportError::InvalidMnemonic {
+                fingerprint,
+                source,
+            } => write!(
+                f,
+                "The mnemonic recorded under seed fingerprint {fingerprint} is invalid: {source}"
+            ),
+            ZewifImportError::InvalidSeedLength { fingerprint } => write!(
+                f,
+                "The seed recorded under fingerprint {fingerprint} has a length outside the range ZIP 32 permits."
+            ),
+            ZewifImportError::InvalidAccountIndex {
+                account_name,
+                index,
+            } => write!(
+                f,
+                "Account \"{account_name}\" records ZIP 32 account index {index}, which is outside the valid range."
+            ),
+            ZewifImportError::InvalidLegacyAddressIndex {
+                account_name,
+                index,
+            } => write!(
+                f,
+                "Account \"{account_name}\" records legacy address index {index}, which is outside the valid range."
+            ),
+            ZewifImportError::InvalidMerkleNode { account_name, pool } => write!(
+                f,
+                "The {pool} tree frontier in the birthday of account \"{account_name}\" contains an invalid node hash."
+            ),
+            ZewifImportError::InvalidFrontier {
+                account_name,
+                pool,
+                source,
+            } => write!(
+                f,
+                "The {pool} tree frontier in the birthday of account \"{account_name}\" is invalid: {source:?}"
+            ),
+            ZewifImportError::Wallet(e) => write!(f, "Wallet database error: {e}"),
+            ZewifImportError::Sink(e) => write!(f, "Secret sink error: {e}"),
+        }
+    }
+}
+
+impl<S: std::error::Error + 'static> std::error::Error for ZewifImportError<S> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ZewifImportError::InvalidMnemonic { source, .. } => Some(source),
+            ZewifImportError::Wallet(e) => Some(e),
+            ZewifImportError::Sink(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl<S> From<SqliteClientError> for ZewifImportError<S> {
+    fn from(e: SqliteClientError) -> Self {
+        ZewifImportError::Wallet(e)
+    }
+}
+
+/// The reason an account in a ZeWIF document was not imported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountSkipReason {
+    /// The account's viewing capability is a Sprout viewing key; the Sprout pool
+    /// is not representable in the wallet database.
+    SproutViewingKey,
+    /// The account is a bare set of transparent addresses with no unified key
+    /// structure, and no seed material was available from which its contents
+    /// could be re-derived.
+    TransparentAddressSetWithoutSeed,
+}
+
+/// How the birthday of an imported account was determined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BirthdayBasis {
+    /// The document carried the tree state prior to the account's birthday
+    /// height; the birthday is fully precise.
+    ChainState,
+    /// The document carried only a birthday height; scanning will begin there,
+    /// but the note commitment trees must be rebuilt by scanning.
+    BirthdayHeight,
+    /// The document carried no birthday information; scanning will begin at
+    /// Sapling activation to guarantee no account history is missed.
+    SaplingActivation,
+}
+
+/// An account that was successfully imported.
+#[derive(Debug, Clone)]
+pub struct ImportedAccount {
+    /// The name of the account in the document.
+    pub name: String,
+    /// The identifier of the newly created wallet database account.
+    pub account_uuid: AccountUuid,
+    /// How the account's birthday was determined.
+    pub birthday_basis: BirthdayBasis,
+}
+
+/// An account that could not be imported.
+#[derive(Debug, Clone)]
+pub struct SkippedAccount {
+    /// The name of the account in the document.
+    pub name: String,
+    /// Why the account was not imported.
+    pub reason: AccountSkipReason,
+}
+
+/// A summary of the effects of a ZeWIF document import.
+#[derive(Debug, Clone, Default)]
+pub struct ZewifImportReport {
+    /// The accounts that were imported, in document order.
+    pub imported_accounts: Vec<ImportedAccount>,
+    /// The accounts that could not be imported.
+    pub skipped_accounts: Vec<SkippedAccount>,
+    /// The number of address book entries present in the document. Address
+    /// books have no backing store in this crate; the caller retains the
+    /// document and may preserve these entries elsewhere.
+    pub address_book_entries_not_imported: usize,
+}
+
+/// The secret material available for driving account import, indexed by the
+/// public identifiers accounts use to reference it.
+struct AvailableSecrets {
+    /// Seed bytes ready for ZIP 32 derivation, keyed by the canonical Bech32m
+    /// encoding of their verified seed fingerprints.
+    seeds: HashMap<String, SecretVec<u8>>,
+    /// The canonical encodings of Sapling extended full viewing keys whose
+    /// spending keys were delivered to the sink.
+    sapling_fvks: Vec<String>,
+    /// The canonical encodings of unified full viewing keys whose spending keys
+    /// were delivered to the sink.
+    unified_fvks: Vec<String>,
+}
+
+impl AvailableSecrets {
+    fn empty() -> Self {
+        AvailableSecrets {
+            seeds: HashMap::new(),
+            sapling_fvks: vec![],
+            unified_fvks: vec![],
+        }
+    }
+}
+
+/// Decodes a canonical `zip32seedfp` Bech32m seed fingerprint encoding.
+fn decode_seed_fingerprint<S>(encoding: &str) -> Result<SeedFingerprint, ZewifImportError<S>> {
+    let err = || ZewifImportError::SeedFingerprintDecoding {
+        encoding: encoding.to_owned(),
+    };
+    let checked = CheckedHrpstring::new::<bech32::Bech32m>(encoding).map_err(|_| err())?;
+    if checked.hrp().as_str() != SEED_FP_HRP {
+        return Err(err());
+    }
+    let bytes = checked.byte_iter().collect::<Vec<_>>();
+    let bytes: [u8; 32] = bytes.try_into().map_err(|_| err())?;
+    Ok(SeedFingerprint::from_bytes(bytes))
+}
+
+/// Converts the seed material of a document seed entry into the byte form used
+/// for ZIP 32 derivation, verifying it against the fingerprint under which it
+/// was recorded.
+fn seed_entry_bytes<S>(entry: &::zewif::SeedEntry) -> Result<SecretVec<u8>, ZewifImportError<S>> {
+    let claimed_encoding = entry.fingerprint().encoding();
+    let claimed = decode_seed_fingerprint(claimed_encoding)?;
+    let seed_bytes: Vec<u8> = match entry.material() {
+        ::zewif::SeedMaterial::Bip39Mnemonic(m) => {
+            mnemonic_to_seed(m).map_err(|source| ZewifImportError::InvalidMnemonic {
+                fingerprint: claimed_encoding.to_owned(),
+                source,
+            })?
+        }
+        ::zewif::SeedMaterial::LegacySeed(seed) => seed.as_bytes().to_vec(),
+    };
+    let computed =
+        SeedFingerprint::from_seed(&seed_bytes).ok_or(ZewifImportError::InvalidSeedLength {
+            fingerprint: claimed_encoding.to_owned(),
+        })?;
+    if computed.to_bytes() != claimed.to_bytes() {
+        return Err(ZewifImportError::SeedFingerprintMismatch {
+            claimed: claimed_encoding.to_owned(),
+        });
+    }
+    Ok(SecretVec::new(seed_bytes))
+}
+
+/// Converts a BIP 39 mnemonic to its 64-byte seed, using the empty passphrase
+/// (as zcashd and zallet do).
+fn mnemonic_to_seed(m: &::zewif::Bip39Mnemonic) -> Result<Vec<u8>, bip0039::Error> {
+    use ::zewif::MnemonicLanguage as L;
+    use bip0039::{
+        ChineseSimplified, ChineseTraditional, Czech, French, Italian, Japanese, Korean,
+        Portuguese, Spanish,
+    };
+
+    fn seed<L: bip0039::Language>(phrase: &str) -> Result<Vec<u8>, bip0039::Error> {
+        Ok(Mnemonic::<L>::from_phrase(phrase)?.to_seed("").to_vec())
+    }
+
+    let phrase = m.mnemonic().as_str();
+    match m.language() {
+        None | Some(L::English) => seed::<English>(phrase),
+        Some(L::SimplifiedChinese) => seed::<ChineseSimplified>(phrase),
+        Some(L::TraditionalChinese) => seed::<ChineseTraditional>(phrase),
+        Some(L::Czech) => seed::<Czech>(phrase),
+        Some(L::French) => seed::<French>(phrase),
+        Some(L::Italian) => seed::<Italian>(phrase),
+        Some(L::Japanese) => seed::<Japanese>(phrase),
+        Some(L::Korean) => seed::<Korean>(phrase),
+        Some(L::Portuguese) => seed::<Portuguese>(phrase),
+        Some(L::Spanish) => seed::<Spanish>(phrase),
+        // An unrecognized language tag means the phrase cannot be interpreted
+        // as any known wordlist.
+        Some(L::Other(_)) => Err(bip0039::Error::BadWordCount(0)),
+    }
+}
+
+/// Converts a zewif tree frontier into an incrementalmerkletree frontier over
+/// the given node type.
+fn convert_frontier<H, S, const DEPTH: u8>(
+    account_name: &str,
+    pool: FrontierPool,
+    frontier: Option<&::zewif::Frontier>,
+    read_node: impl Fn(&::zewif::MerkleNode) -> Option<H>,
+) -> Result<incrementalmerkletree::frontier::Frontier<H, DEPTH>, ZewifImportError<S>>
+where
+    H: Clone,
+{
+    use incrementalmerkletree::frontier::Frontier;
+    let invalid_node = || ZewifImportError::InvalidMerkleNode {
+        account_name: account_name.to_owned(),
+        pool,
+    };
+    match frontier {
+        None | Some(::zewif::Frontier::Empty) => Ok(Frontier::empty()),
+        Some(::zewif::Frontier::NonEmpty(data)) => {
+            let leaf = read_node(data.leaf()).ok_or_else(invalid_node)?;
+            let ommers = data
+                .ommers()
+                .iter()
+                .map(&read_node)
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(invalid_node)?;
+            Frontier::from_parts(
+                incrementalmerkletree::Position::from(data.position()),
+                leaf,
+                ommers,
+            )
+            .map_err(|source| ZewifImportError::InvalidFrontier {
+                account_name: account_name.to_owned(),
+                pool,
+                source,
+            })
+        }
+    }
+}
+
+/// Constructs an [`AccountBirthday`] for an account from the birthday
+/// information carried by the document.
+fn account_birthday<P: Parameters, S>(
+    params: &P,
+    account: &::zewif::Account,
+) -> Result<(AccountBirthday, BirthdayBasis), ZewifImportError<S>> {
+    let zewif_block_hash =
+        |h: Option<::zewif::BlockHash>| h.map_or(BlockHash([0; 32]), |h| BlockHash(*h.as_bytes()));
+
+    if let Some(cs) = account.birthday_chain_state() {
+        let sapling = convert_frontier(
+            account.name(),
+            FrontierPool::Sapling,
+            cs.sapling_tree(),
+            |n| {
+                let repr = *n.as_bytes();
+                Option::from(::sapling::Node::from_bytes(repr))
+            },
+        )?;
+        let orchard = convert_frontier(
+            account.name(),
+            FrontierPool::Orchard,
+            cs.orchard_tree(),
+            |n| Option::from(orchard::tree::MerkleHashOrchard::from_bytes(n.as_bytes())),
+        )?;
+        let ironwood = convert_frontier(
+            account.name(),
+            FrontierPool::Ironwood,
+            cs.ironwood_tree(),
+            |n| Option::from(orchard::tree::MerkleHashOrchard::from_bytes(n.as_bytes())),
+        )?;
+        let chain_state = ChainState::new(
+            BlockHeight::from(u32::from(cs.height())),
+            zewif_block_hash(cs.block_hash()),
+            sapling,
+            orchard,
+            ironwood,
+        );
+        Ok((
+            AccountBirthday::from_parts(
+                chain_state,
+                account
+                    .recover_until_height()
+                    .map(|h| BlockHeight::from(u32::from(h))),
+            ),
+            BirthdayBasis::ChainState,
+        ))
+    } else {
+        // Without a recorded tree state, we can only choose the height at which
+        // scanning begins; the note commitment trees will be rebuilt by the
+        // scan itself.
+        let (prior_height, basis) = match account.birthday_height() {
+            Some(h) => (
+                BlockHeight::from(u32::from(h)).saturating_sub(1),
+                BirthdayBasis::BirthdayHeight,
+            ),
+            None => {
+                // With no birthday information at all, scan from Sapling
+                // activation so that no account history can be missed.
+                let sapling_activation = params
+                    .activation_height(NetworkUpgrade::Sapling)
+                    .unwrap_or_else(|| BlockHeight::from(0));
+                (
+                    sapling_activation.saturating_sub(1),
+                    BirthdayBasis::SaplingActivation,
+                )
+            }
+        };
+        Ok((
+            AccountBirthday::from_parts(
+                ChainState::empty(prior_height, BlockHash([0; 32])),
+                account
+                    .recover_until_height()
+                    .map(|h| BlockHeight::from(u32::from(h))),
+            ),
+            basis,
+        ))
+    }
+}
+
+/// Delivers the document's secret store to the sink and indexes the material
+/// that account import can make use of.
+fn deliver_secrets<S: SecretSink>(
+    document: &::zewif::Zewif,
+) -> Result<Option<&::zewif::SecretStore>, ZewifImportError<S::Error>> {
+    match document.secrets() {
+        None => Ok(None),
+        Some(::zewif::Secrets::Plain(store)) => Ok(Some(store)),
+        Some(::zewif::Secrets::Encrypted(_)) => Err(ZewifImportError::EncryptedSecrets),
+    }
+}
+
+/// Constructs the ZIP 32 derivation metadata recorded by a derived key source.
+fn zip32_derivation<S>(
+    account_name: &str,
+    source: &::zewif::DerivedKeySource,
+) -> Result<Zip32Derivation, ZewifImportError<S>> {
+    let seed_fp = decode_seed_fingerprint(source.seed_fingerprint().encoding())?;
+    let account_index = zip32::AccountId::try_from(source.account_index()).map_err(|_| {
+        ZewifImportError::InvalidAccountIndex {
+            account_name: account_name.to_owned(),
+            index: source.account_index(),
+        }
+    })?;
+    let legacy_address_index = source
+        .legacy_address_index()
+        .map(|i| {
+            zcash_keys::keys::zcashd::LegacyAddressIndex::try_from(i).map_err(|_| {
+                ZewifImportError::InvalidLegacyAddressIndex {
+                    account_name: account_name.to_owned(),
+                    index: i,
+                }
+            })
+        })
+        .transpose()?;
+    Ok(Zip32Derivation::new(
+        seed_fp,
+        account_index,
+        legacy_address_index,
+    ))
+}
+
+/// Imports the contents of a ZeWIF document into the wallet database.
+///
+/// The database must already have been initialized (or migrated to the current
+/// schema) with [`crate::wallet::init::WalletMigrator`]. All spending key
+/// material carried by the document is delivered to `sink` and is not stored in
+/// the wallet database; see [`SecretSink`].
+///
+/// Returns a report describing the accounts imported and any items that could
+/// not be represented.
+pub fn import_wallet<C, P, CL, R, S>(
+    wdb: &mut WalletDb<C, P, CL, R>,
+    document: &::zewif::Zewif,
+    sink: &mut S,
+) -> Result<ZewifImportReport, ZewifImportError<S::Error>>
+where
+    C: std::borrow::BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
+    S: SecretSink,
+{
+    let params = wdb.params().clone();
+    let expected = params.network_type();
+
+    // Verify that every wallet in the document belongs to the expected network.
+    for wallet in document.wallets() {
+        match (wallet.network(), expected) {
+            (::zewif::Network::Mainnet, NetworkType::Main) => {}
+            (::zewif::Network::Testnet, NetworkType::Test) => {}
+            (::zewif::Network::Regtest(_), _) => {
+                return Err(ZewifImportError::UnsupportedRegtest);
+            }
+            (document_network, _) => {
+                return Err(ZewifImportError::NetworkMismatch {
+                    document: document_network.clone(),
+                    expected,
+                });
+            }
+        }
+    }
+
+    // Deliver all secret material to the sink, indexing what account import can
+    // use.
+    let mut available = AvailableSecrets::empty();
+    if let Some(store) = deliver_secrets::<S>(document)? {
+        for entry in store.seeds() {
+            sink.store_seed(entry).map_err(ZewifImportError::Sink)?;
+            let seed_bytes = seed_entry_bytes(entry)?;
+            // The fingerprint encoding was verified against the material by
+            // `seed_entry_bytes`, so account key sources can match it by
+            // string equality.
+            available
+                .seeds
+                .insert(entry.fingerprint().encoding().to_owned(), seed_bytes);
+        }
+        for entry in store.transparent_keys() {
+            sink.store_transparent_key(entry)
+                .map_err(ZewifImportError::Sink)?;
+        }
+        for entry in store.sapling_keys() {
+            sink.store_sapling_key(entry)
+                .map_err(ZewifImportError::Sink)?;
+            available
+                .sapling_fvks
+                .push(entry.fvk().encoding().to_owned());
+        }
+        for entry in store.sprout_keys() {
+            sink.store_sprout_key(entry)
+                .map_err(ZewifImportError::Sink)?;
+        }
+        for entry in store.unified_keys() {
+            sink.store_unified_key(entry)
+                .map_err(ZewifImportError::Sink)?;
+            available
+                .unified_fvks
+                .push(entry.fvk().encoding().to_owned());
+        }
+    }
+
+    let mut report = ZewifImportReport::default();
+
+    for wallet in document.wallets() {
+        report.address_book_entries_not_imported += wallet.address_book().len();
+
+        for account in wallet.accounts() {
+            import_account(wdb, &params, account, &available, &mut report)?;
+        }
+    }
+
+    Ok(report)
+}
+
+/// Imports a single account, choosing the import path appropriate to its
+/// viewing capability and available secret material.
+fn import_account<C, P, CL, R, S>(
+    wdb: &mut WalletDb<C, P, CL, R>,
+    params: &P,
+    account: &::zewif::Account,
+    available: &AvailableSecrets,
+    report: &mut ZewifImportReport,
+) -> Result<(), ZewifImportError<S>>
+where
+    C: std::borrow::BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
+    S: std::error::Error,
+{
+    let (birthday, birthday_basis) = account_birthday(params, account)?;
+    let key_source = account.provenance().or(Some("zewif"));
+
+    // The seed bytes available for this account, when its key source records a
+    // ZIP 32 derivation from a seed present in the document's secret store.
+    let derived_source = match account.key_source() {
+        Some(::zewif::KeySource::Derived(d)) => Some(d),
+        _ => None,
+    };
+    let available_seed = derived_source
+        .and_then(|d| available.seeds.get(d.seed_fingerprint().encoding()))
+        .map(|seed| (seed, derived_source.expect("checked above")));
+
+    let account_uuid = match account.viewing_key() {
+        ::zewif::AccountViewingKey::Ufvk(ufvk) => {
+            if let Some((seed, source)) = available_seed {
+                // Re-derive the account from its seed, preserving the recorded
+                // ZIP 32 account index.
+                let account_index =
+                    zip32::AccountId::try_from(source.account_index()).map_err(|_| {
+                        ZewifImportError::InvalidAccountIndex {
+                            account_name: account.name().to_owned(),
+                            index: source.account_index(),
+                        }
+                    })?;
+                let (imported, _usk) = wdb
+                    .import_account_hd(account.name(), seed, account_index, &birthday, key_source)
+                    .map_err(ZewifImportError::Wallet)?;
+                imported.id()
+            } else {
+                let decoded =
+                    UnifiedFullViewingKey::decode(params, ufvk.encoding()).map_err(|message| {
+                        ZewifImportError::UfvkDecoding {
+                            account_name: account.name().to_owned(),
+                            message,
+                        }
+                    })?;
+                let purpose = account_purpose(
+                    account,
+                    available.unified_fvks.iter().any(|s| s == ufvk.encoding()),
+                    derived_source,
+                )?;
+                let imported = wdb
+                    .import_account_ufvk(account.name(), &decoded, &birthday, purpose, key_source)
+                    .map_err(ZewifImportError::Wallet)?;
+                imported.id()
+            }
+        }
+        ::zewif::AccountViewingKey::SaplingExtFvk(efvk) => {
+            let decoded = zcash_keys::encoding::decode_extended_full_viewing_key(
+                params
+                    .network_type()
+                    .hrp_sapling_extended_full_viewing_key(),
+                efvk.encoding(),
+            )
+            .map_err(|_| ZewifImportError::SaplingFvkDecoding {
+                account_name: account.name().to_owned(),
+            })?;
+            let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(decoded)
+                .map_err(|e| ZewifImportError::UfvkDecoding {
+                    account_name: account.name().to_owned(),
+                    message: e.to_string(),
+                })?;
+            let purpose = account_purpose(
+                account,
+                available.sapling_fvks.iter().any(|s| s == efvk.encoding()),
+                derived_source,
+            )?;
+            let imported = wdb
+                .import_account_ufvk(account.name(), &ufvk, &birthday, purpose, key_source)
+                .map_err(ZewifImportError::Wallet)?;
+            imported.id()
+        }
+        ::zewif::AccountViewingKey::SproutViewingKey(_) => {
+            report.skipped_accounts.push(SkippedAccount {
+                name: account.name().to_owned(),
+                reason: AccountSkipReason::SproutViewingKey,
+            });
+            return Ok(());
+        }
+        ::zewif::AccountViewingKey::TransparentAddressSet => {
+            if let Some((seed, source)) = available_seed {
+                // A transparent-only account (e.g. the zcashd legacy account)
+                // whose contents can be re-derived from its seed.
+                let account_index =
+                    zip32::AccountId::try_from(source.account_index()).map_err(|_| {
+                        ZewifImportError::InvalidAccountIndex {
+                            account_name: account.name().to_owned(),
+                            index: source.account_index(),
+                        }
+                    })?;
+                let (imported, _usk) = wdb
+                    .import_account_hd(account.name(), seed, account_index, &birthday, key_source)
+                    .map_err(ZewifImportError::Wallet)?;
+                imported.id()
+            } else {
+                report.skipped_accounts.push(SkippedAccount {
+                    name: account.name().to_owned(),
+                    reason: AccountSkipReason::TransparentAddressSetWithoutSeed,
+                });
+                return Ok(());
+            }
+        }
+    };
+
+    report.imported_accounts.push(ImportedAccount {
+        name: account.name().to_owned(),
+        account_uuid,
+        birthday_basis,
+    });
+    Ok(())
+}
+
+/// Determines the [`AccountPurpose`] with which to import a viewing key,
+/// honoring the purpose recorded in the document when present and otherwise
+/// inferring spendability from the secret material delivered to the sink.
+fn account_purpose<S>(
+    account: &::zewif::Account,
+    spending_key_available: bool,
+    derived_source: Option<&::zewif::DerivedKeySource>,
+) -> Result<AccountPurpose, ZewifImportError<S>> {
+    let derivation = derived_source
+        .map(|d| zip32_derivation(account.name(), d))
+        .transpose()?;
+    Ok(match account.purpose() {
+        Some(::zewif::AccountPurpose::ViewOnly) => AccountPurpose::ViewOnly,
+        Some(::zewif::AccountPurpose::Spending) => AccountPurpose::Spending { derivation },
+        None => {
+            if spending_key_available {
+                AccountPurpose::Spending { derivation }
+            } else {
+                AccountPurpose::ViewOnly
+            }
+        }
+    })
+}

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -1320,3 +1320,401 @@ fn account_purpose<S>(
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use bip0039::{English, Mnemonic};
+    use incrementalmerkletree::Hashable as _;
+    use tempfile::NamedTempFile;
+    use zcash_client_backend::data_api::{Account as _, AccountPurpose, AccountSource, WalletRead};
+    use zcash_keys::encoding::AddressCodec;
+    use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
+    use zcash_protocol::consensus;
+    use zip32::fingerprint::SeedFingerprint;
+
+    use super::*;
+    use crate::testing::db::{test_clock, test_rng};
+    use crate::wallet::init::WalletMigrator;
+
+    const TEST_NETWORK: consensus::Network = consensus::Network::TestNetwork;
+
+    /// A [`SecretSink`] that records the identifying halves of the entries
+    /// delivered to it.
+    #[derive(Default)]
+    struct RecordingSink {
+        seeds: Vec<String>,
+        transparent: Vec<Vec<u8>>,
+        sapling: Vec<String>,
+        sprout: Vec<String>,
+        unified: Vec<String>,
+    }
+
+    impl SecretSink for RecordingSink {
+        type Error = core::convert::Infallible;
+
+        fn store_seed(&mut self, entry: &::zewif::SeedEntry) -> Result<(), Self::Error> {
+            self.seeds.push(entry.fingerprint().encoding().to_owned());
+            Ok(())
+        }
+
+        fn store_transparent_key(
+            &mut self,
+            entry: &::zewif::TransparentKeyEntry,
+        ) -> Result<(), Self::Error> {
+            self.transparent.push(entry.pubkey().as_slice().to_vec());
+            Ok(())
+        }
+
+        fn store_sapling_key(
+            &mut self,
+            entry: &::zewif::SaplingKeyEntry,
+        ) -> Result<(), Self::Error> {
+            self.sapling.push(entry.fvk().encoding().to_owned());
+            Ok(())
+        }
+
+        fn store_sprout_key(&mut self, entry: &::zewif::SproutKeyEntry) -> Result<(), Self::Error> {
+            self.sprout.push(entry.address().to_owned());
+            Ok(())
+        }
+
+        fn store_unified_key(
+            &mut self,
+            entry: &::zewif::UnifiedKeyEntry,
+        ) -> Result<(), Self::Error> {
+            self.unified.push(entry.fvk().encoding().to_owned());
+            Ok(())
+        }
+    }
+
+    /// Creates an initialized empty wallet database on the test network.
+    fn test_wallet_db() -> (
+        NamedTempFile,
+        WalletDb<
+            rusqlite::Connection,
+            consensus::Network,
+            crate::util::testing::FixedClock,
+            rand_chacha::ChaChaRng,
+        >,
+    ) {
+        let db_file = NamedTempFile::new().unwrap();
+        let mut wdb =
+            WalletDb::for_path(db_file.path(), TEST_NETWORK, test_clock(), test_rng()).unwrap();
+        WalletMigrator::new().init_or_migrate(&mut wdb).unwrap();
+        (db_file, wdb)
+    }
+
+    /// Encodes a seed fingerprint in the canonical Bech32m form ZeWIF uses.
+    fn encode_seed_fp(fp: &SeedFingerprint) -> String {
+        bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse(SEED_FP_HRP).unwrap(), &fp.to_bytes())
+            .unwrap()
+    }
+
+    /// A mnemonic-backed seed and the document/derived artifacts tests need.
+    struct TestSeed {
+        mnemonic_phrase: String,
+        fingerprint_encoding: String,
+        ufvk: UnifiedFullViewingKey,
+    }
+
+    fn test_seed(account_index: u32) -> TestSeed {
+        let mnemonic = <Mnemonic<English>>::from_entropy([0xAB; 32]).unwrap();
+        let seed = mnemonic.to_seed("");
+        let fp = SeedFingerprint::from_seed(&seed).unwrap();
+        let usk = UnifiedSpendingKey::from_seed(
+            &TEST_NETWORK,
+            &seed,
+            zip32::AccountId::try_from(account_index).unwrap(),
+        )
+        .unwrap();
+        TestSeed {
+            mnemonic_phrase: mnemonic.phrase().to_owned(),
+            fingerprint_encoding: encode_seed_fp(&fp),
+            ufvk: usk.to_unified_full_viewing_key(),
+        }
+    }
+
+    fn seed_entry(ts: &TestSeed) -> ::zewif::SeedEntry {
+        ::zewif::SeedEntry::new(
+            ::zewif::SeedFingerprint::new(ts.fingerprint_encoding.clone()),
+            ::zewif::SeedMaterial::Bip39Mnemonic(::zewif::Bip39Mnemonic::new(
+                ts.mnemonic_phrase.clone(),
+                None,
+            )),
+        )
+    }
+
+    fn document(network: ::zewif::Network) -> (::zewif::Zewif, ::zewif::ZewifWallet) {
+        let doc = ::zewif::Zewif::new(
+            ::zewif::BlockHeight::from(3_000_000),
+            ::zewif::BlockHash::from_bytes([0xEE; 32]),
+        );
+        let wallet = ::zewif::ZewifWallet::new(network);
+        (doc, wallet)
+    }
+
+    #[test]
+    fn network_mismatch_is_rejected() {
+        let (_file, mut wdb) = test_wallet_db();
+        let (mut doc, wallet) = document(::zewif::Network::Mainnet);
+        doc.add_wallet(wallet);
+
+        let result = import_wallet(&mut wdb, &doc, &mut DiscardSecrets);
+        assert!(matches!(
+            result,
+            Err(ZewifImportError::NetworkMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn view_only_ufvk_account_with_chain_state_birthday() {
+        let (_file, mut wdb) = test_wallet_db();
+        let ts = test_seed(0);
+
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::Ufvk(
+            ::zewif::UnifiedFullViewingKey::new(ts.ufvk.encode(&TEST_NETWORK)),
+        ));
+        account.set_name("viewing");
+        account.set_birthday_height(::zewif::BlockHeight::from(2_600_000));
+        let mut chain_state = ::zewif::ChainState::new(::zewif::BlockHeight::from(2_599_999));
+        chain_state.set_block_hash(::zewif::BlockHash::from_bytes([0xBB; 32]));
+        chain_state.set_sapling_tree(::zewif::Frontier::NonEmpty(
+            ::zewif::FrontierData::from_parts(
+                0,
+                ::zewif::MerkleNode::new(::sapling::Node::empty_root(0.into()).to_bytes()),
+                vec![],
+            ),
+        ));
+        chain_state.set_orchard_tree(::zewif::Frontier::Empty);
+        chain_state.set_ironwood_tree(::zewif::Frontier::Empty);
+        account.set_birthday_chain_state(chain_state);
+        account.set_recover_until_height(::zewif::BlockHeight::from(2_900_000));
+
+        let (mut doc, mut wallet) = document(::zewif::Network::Testnet);
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+
+        let report = import_wallet(&mut wdb, &doc, &mut DiscardSecrets).unwrap();
+        assert_eq!(report.imported_accounts.len(), 1);
+        assert_eq!(report.imported_accounts[0].name, "viewing");
+        assert_eq!(
+            report.imported_accounts[0].birthday_basis,
+            BirthdayBasis::ChainState
+        );
+
+        let account_uuid = report.imported_accounts[0].account_uuid;
+        let imported = wdb.get_account(account_uuid).unwrap().unwrap();
+        assert!(matches!(
+            imported.source(),
+            AccountSource::Imported {
+                purpose: AccountPurpose::ViewOnly,
+                ..
+            }
+        ));
+        // The birthday is the height following the recorded prior chain state.
+        assert_eq!(
+            wdb.get_wallet_birthday().unwrap(),
+            Some(consensus::BlockHeight::from(2_600_000))
+        );
+    }
+
+    #[test]
+    fn derived_account_is_imported_via_hd_derivation() {
+        let (_file, mut wdb) = test_wallet_db();
+        let ts = test_seed(0);
+
+        let mut store = ::zewif::SecretStore::new();
+        store.add_seed(seed_entry(&ts));
+
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::Ufvk(
+            ::zewif::UnifiedFullViewingKey::new(ts.ufvk.encode(&TEST_NETWORK)),
+        ));
+        account.set_name("derived");
+        account.set_birthday_height(::zewif::BlockHeight::from(2_600_000));
+        account.set_key_source(::zewif::KeySource::Derived(::zewif::DerivedKeySource::new(
+            ::zewif::SeedFingerprint::new(ts.fingerprint_encoding.clone()),
+            0,
+            None,
+        )));
+
+        let (mut doc, mut wallet) = document(::zewif::Network::Testnet);
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+        doc.set_secrets(::zewif::Secrets::Plain(store));
+
+        let mut sink = RecordingSink::default();
+        let report = import_wallet(&mut wdb, &doc, &mut sink).unwrap();
+
+        assert_eq!(sink.seeds, vec![ts.fingerprint_encoding.clone()]);
+        assert_eq!(report.imported_accounts.len(), 1);
+        assert_eq!(
+            report.imported_accounts[0].birthday_basis,
+            BirthdayBasis::BirthdayHeight
+        );
+
+        let account_uuid = report.imported_accounts[0].account_uuid;
+        let imported = wdb.get_account(account_uuid).unwrap().unwrap();
+        match imported.source() {
+            AccountSource::Derived { derivation, .. } => {
+                assert_eq!(
+                    derivation.seed_fingerprint().to_bytes(),
+                    SeedFingerprint::from_seed(
+                        &<Mnemonic<English>>::from_phrase(&ts.mnemonic_phrase)
+                            .unwrap()
+                            .to_seed("")
+                    )
+                    .unwrap()
+                    .to_bytes()
+                );
+                assert_eq!(derivation.account_index(), zip32::AccountId::ZERO);
+            }
+            other => panic!("expected a derived account, got {other:?}"),
+        }
+        // The account's UFVK is re-derived from the seed and matches the
+        // document's record of it.
+        assert_eq!(
+            imported.ufvk().map(|k| k.encode(&TEST_NETWORK)),
+            Some(ts.ufvk.encode(&TEST_NETWORK)),
+        );
+    }
+
+    #[test]
+    fn sprout_accounts_are_skipped() {
+        let (_file, mut wdb) = test_wallet_db();
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::SproutViewingKey(
+            ::zewif::sprout::SproutViewingKey::new("ZiVtTestViewingKey"),
+        ));
+        account.set_name("sprout");
+
+        let (mut doc, mut wallet) = document(::zewif::Network::Testnet);
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+
+        let report = import_wallet(&mut wdb, &doc, &mut DiscardSecrets).unwrap();
+        assert!(report.imported_accounts.is_empty());
+        assert_eq!(report.skipped_accounts.len(), 1);
+        assert_eq!(
+            report.skipped_accounts[0].reason,
+            AccountSkipReason::SproutViewingKey
+        );
+    }
+
+    #[test]
+    fn secrets_are_delivered_to_the_sink() {
+        let (_file, mut wdb) = test_wallet_db();
+        let ts = test_seed(0);
+
+        let secp = secp256k1::Secp256k1::new();
+        let secret_key = secp256k1::SecretKey::from_slice(&[0x42; 32]).unwrap();
+        let pubkey = secret_key.public_key(&secp);
+        let mut wif_payload = vec![0xEF];
+        wif_payload.extend_from_slice(&secret_key.secret_bytes());
+        wif_payload.push(0x01);
+        let wif = bs58::encode(wif_payload).with_check().into_string();
+
+        let mut store = ::zewif::SecretStore::new();
+        store.add_seed(seed_entry(&ts));
+        store.add_transparent_key(::zewif::TransparentKeyEntry::new(
+            ::zewif::transparent::TransparentPubKey::from_bytes(pubkey.serialize().to_vec())
+                .unwrap(),
+            ::zewif::transparent::TransparentSpendingKey::new(wif),
+        ));
+        store.add_sapling_key(::zewif::SaplingKeyEntry::new(
+            ::zewif::sapling::SaplingExtendedFullViewingKey::new("zxviewtestsapling1aaaa"),
+            ::zewif::sapling::SaplingExtendedSpendingKey::new("secret-extended-key-test1aaaa"),
+        ));
+        store.add_sprout_key(::zewif::SproutKeyEntry::new(
+            "ztTestSproutAddress",
+            ::zewif::sprout::SproutSpendingKey::new("SKTestSproutKey"),
+        ));
+
+        let (mut doc, wallet) = document(::zewif::Network::Testnet);
+        doc.add_wallet(wallet);
+        doc.set_secrets(::zewif::Secrets::Plain(store));
+
+        let mut sink = RecordingSink::default();
+        let report = import_wallet(&mut wdb, &doc, &mut sink).unwrap();
+
+        assert_eq!(sink.seeds.len(), 1);
+        assert_eq!(sink.transparent.len(), 1);
+        assert_eq!(sink.sapling.len(), 1);
+        assert_eq!(sink.sprout.len(), 1);
+        // The transparent key's address is under no account, so it is
+        // delivered to the sink but not registered.
+        assert_eq!(report.transparent_keys_registered, 0);
+        assert_eq!(report.skipped_transparent_keys.len(), 1);
+        assert_eq!(
+            report.skipped_transparent_keys[0].reason,
+            TransparentKeySkipReason::NoOwningAccount
+        );
+    }
+
+    #[test]
+    fn owned_transparent_key_is_registered_and_exposed() {
+        let (_file, mut wdb) = test_wallet_db();
+        let ts = test_seed(0);
+
+        let secp = secp256k1::Secp256k1::new();
+        let secret_key = secp256k1::SecretKey::from_slice(&[0x42; 32]).unwrap();
+        let pubkey = secret_key.public_key(&secp);
+        let address = TransparentAddress::from_pubkey(&pubkey).encode(&TEST_NETWORK);
+        let mut wif_payload = vec![0xEF];
+        wif_payload.extend_from_slice(&secret_key.secret_bytes());
+        wif_payload.push(0x01);
+        let wif = bs58::encode(wif_payload).with_check().into_string();
+
+        let mut store = ::zewif::SecretStore::new();
+        store.add_seed(seed_entry(&ts));
+        store.add_transparent_key(::zewif::TransparentKeyEntry::new(
+            ::zewif::transparent::TransparentPubKey::from_bytes(pubkey.serialize().to_vec())
+                .unwrap(),
+            ::zewif::transparent::TransparentSpendingKey::new(wif),
+        ));
+
+        // The legacy-style account that owns the imported address.
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::TransparentAddressSet);
+        account.set_name("legacy");
+        account.set_birthday_height(::zewif::BlockHeight::from(2_600_000));
+        account.set_key_source(::zewif::KeySource::Derived(::zewif::DerivedKeySource::new(
+            ::zewif::SeedFingerprint::new(ts.fingerprint_encoding.clone()),
+            0x7FFF_FFFF,
+            None,
+        )));
+        let mut taddr = ::zewif::transparent::Address::new(address.clone());
+        taddr.set_pubkey(
+            ::zewif::transparent::TransparentPubKey::from_bytes(pubkey.serialize().to_vec())
+                .unwrap(),
+        );
+        account.add_address(::zewif::Address::new(
+            ::zewif::ProtocolAddress::Transparent(taddr),
+        ));
+
+        let (mut doc, mut wallet) = document(::zewif::Network::Testnet);
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+        doc.set_secrets(::zewif::Secrets::Plain(store));
+
+        let mut sink = RecordingSink::default();
+        let report = import_wallet(&mut wdb, &doc, &mut sink).unwrap();
+
+        assert_eq!(report.imported_accounts.len(), 1);
+        assert_eq!(report.transparent_keys_registered, 1);
+        assert!(report.skipped_transparent_keys.is_empty());
+        assert_eq!(report.addresses_marked_exposed, 1);
+        assert_eq!(report.addresses_not_recognized, 0);
+    }
+
+    #[test]
+    fn transactions_without_raw_data_are_counted() {
+        let (_file, mut wdb) = test_wallet_db();
+        let (mut doc, wallet) = document(::zewif::Network::Testnet);
+        doc.add_wallet(wallet);
+        let txid = ::zewif::TxId::from_bytes([0x11; 32]);
+        doc.add_transaction(txid, ::zewif::Transaction::new(txid));
+
+        let report = import_wallet(&mut wdb, &doc, &mut DiscardSecrets).unwrap();
+        assert_eq!(report.transactions_without_raw_data, 1);
+        assert_eq!(report.transactions_stored, 0);
+        assert_eq!(report.transactions_without_wallet_relevance, 0);
+    }
+}

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -21,7 +21,14 @@
 //!    corresponding spending material was delivered to the sink and as view-only
 //!    accounts otherwise. Account birthdays are constructed from the tree-state
 //!    frontiers carried by the document where present.
-//! 4. Stores the document's transactions: each transaction carrying raw data is
+//! 4. Registers standalone transparent keys: each transparent spending key in the
+//!    secret store whose pay-to-public-key-hash address appears under an imported
+//!    account is registered with that account (its secret half having already been
+//!    delivered to the sink), and P2SH redeem scripts recorded on imported
+//!    accounts' addresses are registered where the wallet can represent them.
+//! 5. Marks the transparent addresses recorded in the document as exposed, so
+//!    that address-based recovery includes them.
+//! 6. Stores the document's transactions: each transaction carrying raw data is
 //!    parsed and trial-decrypted against the imported accounts' viewing keys, and
 //!    stored if it involves the wallet. Transactions that cannot be shown to
 //!    involve the wallet are not stored (the post-import rescan recovers them if
@@ -65,6 +72,9 @@ use zcash_protocol::consensus::{
     self, BlockHeight, NetworkConstants as _, NetworkType, NetworkUpgrade, Parameters,
 };
 use zip32::fingerprint::SeedFingerprint;
+
+use ::transparent::address::TransparentAddress;
+use zcash_keys::encoding::AddressCodec;
 
 use crate::{AccountUuid, WalletDb, error::SqliteClientError, util::Clock};
 
@@ -248,6 +258,24 @@ pub enum ZewifImportError<S> {
         /// The underlying structural error.
         source: incrementalmerkletree::frontier::FrontierError,
     },
+    /// A transparent public key in the document's secret store is not a valid
+    /// secp256k1 point.
+    InvalidTransparentPubKey {
+        /// The underlying secp256k1 error.
+        source: secp256k1::Error,
+    },
+    /// A transparent spending key in the document's secret store is not a valid
+    /// WIF encoding for the document's network.
+    InvalidTransparentKeyEncoding {
+        /// The pay-to-public-key-hash address of the entry's public key.
+        address: String,
+    },
+    /// A transparent spending key in the document's secret store does not
+    /// correspond to the public key under which it was recorded.
+    TransparentKeyMismatch {
+        /// The pay-to-public-key-hash address of the entry's public key.
+        address: String,
+    },
     /// The raw bytes of a transaction in the document could not be parsed as a
     /// Zcash transaction.
     TransactionParse {
@@ -341,6 +369,18 @@ impl<S: fmt::Display> fmt::Display for ZewifImportError<S> {
                 f,
                 "The {pool} tree frontier in the birthday of account \"{account_name}\" is invalid: {source:?}"
             ),
+            ZewifImportError::InvalidTransparentPubKey { source } => write!(
+                f,
+                "A transparent public key in the secret store is not a valid secp256k1 point: {source}"
+            ),
+            ZewifImportError::InvalidTransparentKeyEncoding { address } => write!(
+                f,
+                "The transparent spending key recorded for {address} is not a valid WIF encoding for the document's network."
+            ),
+            ZewifImportError::TransparentKeyMismatch { address } => write!(
+                f,
+                "The transparent spending key recorded for {address} does not correspond to its recorded public key."
+            ),
             ZewifImportError::TransactionParse { txid, source } => write!(
                 f,
                 "Unable to parse the raw data of transaction {txid}: {source}"
@@ -359,6 +399,7 @@ impl<S: std::error::Error + 'static> std::error::Error for ZewifImportError<S> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ZewifImportError::InvalidMnemonic { source, .. } => Some(source),
+            ZewifImportError::InvalidTransparentPubKey { source } => Some(source),
             ZewifImportError::TransactionParse { source, .. } => Some(source),
             ZewifImportError::Wallet(e) => Some(e),
             ZewifImportError::Sink(e) => Some(e),
@@ -419,6 +460,29 @@ pub struct SkippedAccount {
     pub reason: AccountSkipReason,
 }
 
+/// The reason a transparent spending key in the document's secret store was
+/// not registered with the wallet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransparentKeySkipReason {
+    /// The recorded public key is uncompressed; the wallet derives addresses
+    /// only from compressed public keys.
+    UncompressedPubKey,
+    /// The key's pay-to-public-key-hash address does not appear under any
+    /// imported account, so there is no account to register it with.
+    NoOwningAccount,
+}
+
+/// A transparent spending key that was delivered to the [`SecretSink`] but
+/// could not be registered with the wallet.
+#[derive(Debug, Clone)]
+pub struct SkippedTransparentKey {
+    /// The pay-to-public-key-hash address of the key, where derivable; `None`
+    /// for uncompressed public keys.
+    pub address: Option<String>,
+    /// Why the key was not registered.
+    pub reason: TransparentKeySkipReason,
+}
+
 /// A summary of the effects of a ZeWIF document import.
 #[derive(Debug, Clone, Default)]
 pub struct ZewifImportReport {
@@ -426,6 +490,23 @@ pub struct ZewifImportReport {
     pub imported_accounts: Vec<ImportedAccount>,
     /// The accounts that could not be imported.
     pub skipped_accounts: Vec<SkippedAccount>,
+    /// The number of standalone transparent spending keys registered with
+    /// imported accounts.
+    pub transparent_keys_registered: usize,
+    /// Transparent spending keys that were delivered to the [`SecretSink`] but
+    /// could not be registered with the wallet.
+    pub skipped_transparent_keys: Vec<SkippedTransparentKey>,
+    /// The number of P2SH redeem scripts registered with imported accounts.
+    pub redeem_scripts_registered: usize,
+    /// The number of P2SH redeem scripts recorded in the document that the
+    /// wallet cannot represent (for example, non-multisig scripts).
+    pub redeem_scripts_not_representable: usize,
+    /// The number of transparent addresses marked as exposed.
+    pub addresses_marked_exposed: usize,
+    /// The number of transparent addresses recorded in the document that the
+    /// wallet does not recognize as receivers of any imported account, and so
+    /// could not be marked as exposed.
+    pub addresses_not_recognized: usize,
     /// The number of transactions from the document that were stored because
     /// they involve the imported accounts.
     pub transactions_stored: usize,
@@ -781,18 +862,193 @@ where
     }
 
     let mut report = ZewifImportReport::default();
+    let mut taddrs = TransparentAddressRecords::default();
 
     for wallet in document.wallets() {
         report.address_book_entries_not_imported += wallet.address_book().len();
 
         for account in wallet.accounts() {
-            import_account(wdb, &params, account, &available, &mut report)?;
+            import_account(wdb, &params, account, &available, &mut taddrs, &mut report)?;
         }
     }
+
+    register_transparent_keys(
+        wdb,
+        &params,
+        deliver_secrets::<S>(document)?,
+        &taddrs,
+        &mut report,
+    )?;
+    mark_addresses_exposed(wdb, &params, &taddrs, &mut report)?;
 
     import_transactions(wdb, &params, document, &mut report)?;
 
     Ok(report)
+}
+
+/// The transparent addresses recorded under imported accounts, indexed for
+/// standalone key registration and exposure marking.
+#[derive(Default)]
+struct TransparentAddressRecords {
+    /// Maps each transparent address string to the account that recorded it
+    /// and the height at which it is known to have been exposed.
+    owners: HashMap<String, (AccountUuid, BlockHeight)>,
+    /// The P2SH redeem scripts recorded on imported accounts' addresses.
+    redeem_scripts: Vec<(AccountUuid, Vec<u8>)>,
+}
+
+/// Decodes a WIF-encoded transparent spending key, returning the secret key
+/// and whether the corresponding public key uses the compressed encoding.
+fn decode_wif(expected_prefix: u8, wif: &str) -> Option<(secp256k1::SecretKey, bool)> {
+    let payload = bs58::decode(wif).with_check(None).into_vec().ok()?;
+    match payload.as_slice() {
+        [prefix, key_data @ ..] if *prefix == expected_prefix && key_data.len() == 32 => {
+            Some((secp256k1::SecretKey::from_slice(key_data).ok()?, false))
+        }
+        [prefix, key_data @ .., 0x01] if *prefix == expected_prefix && key_data.len() == 32 => {
+            Some((secp256k1::SecretKey::from_slice(key_data).ok()?, true))
+        }
+        _ => None,
+    }
+}
+
+/// Registers the secret store's standalone transparent spending keys with the
+/// accounts that record their addresses, and the recorded P2SH redeem scripts
+/// with the accounts that carry them.
+fn register_transparent_keys<C, P, CL, R, S>(
+    wdb: &mut WalletDb<C, P, CL, R>,
+    params: &P,
+    store: Option<&::zewif::SecretStore>,
+    taddrs: &TransparentAddressRecords,
+    report: &mut ZewifImportReport,
+) -> Result<(), ZewifImportError<S>>
+where
+    C: std::borrow::BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
+    S: std::error::Error,
+{
+    let wif_prefix = match params.network_type() {
+        NetworkType::Main => 0x80,
+        NetworkType::Test | NetworkType::Regtest => 0xEF,
+    };
+    let secp = secp256k1::Secp256k1::new();
+
+    for entry in store.map_or(&[][..], |s| s.transparent_keys()) {
+        if !entry.pubkey().is_compressed() {
+            report.skipped_transparent_keys.push(SkippedTransparentKey {
+                address: None,
+                reason: TransparentKeySkipReason::UncompressedPubKey,
+            });
+            continue;
+        }
+        let pubkey = secp256k1::PublicKey::from_slice(entry.pubkey().as_slice())
+            .map_err(|source| ZewifImportError::InvalidTransparentPubKey { source })?;
+        let address = TransparentAddress::from_pubkey(&pubkey).encode(params);
+
+        // Verify that the spending key corresponds to the recorded public key.
+        let (secret_key, _compressed) = decode_wif(wif_prefix, entry.spending_key().encoding())
+            .ok_or_else(|| ZewifImportError::InvalidTransparentKeyEncoding {
+                address: address.clone(),
+            })?;
+        if secret_key.public_key(&secp) != pubkey {
+            return Err(ZewifImportError::TransparentKeyMismatch { address });
+        }
+
+        match taddrs.owners.get(&address) {
+            Some((account_uuid, _)) => {
+                wdb.import_standalone_transparent_pubkey(*account_uuid, pubkey)
+                    .map_err(ZewifImportError::Wallet)?;
+                report.transparent_keys_registered += 1;
+            }
+            None => {
+                report.skipped_transparent_keys.push(SkippedTransparentKey {
+                    address: Some(address),
+                    reason: TransparentKeySkipReason::NoOwningAccount,
+                });
+            }
+        }
+    }
+
+    for (account_uuid, script_bytes) in &taddrs.redeem_scripts {
+        use zcash_script::script::{Code, Redeem};
+        let parsed = Redeem::parse(&Code(script_bytes.clone()));
+        match parsed {
+            Ok(redeem) => {
+                match wdb.import_standalone_transparent_script(*account_uuid, redeem) {
+                    Ok(()) => report.redeem_scripts_registered += 1,
+                    // The wallet can only represent a subset of redeem scripts
+                    // (e.g. multisig within the P2SH size limit); scripts it
+                    // rejects remain recoverable from the document.
+                    Err(SqliteClientError::BadAccountData(_)) => {
+                        report.redeem_scripts_not_representable += 1;
+                    }
+                    Err(e) => return Err(ZewifImportError::Wallet(e)),
+                }
+            }
+            Err(_) => {
+                report.redeem_scripts_not_representable += 1;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Marks the transparent addresses recorded in the document as exposed, so
+/// that address-based recovery includes them.
+///
+/// Only addresses the wallet recognizes as receivers of an imported account
+/// can be marked; unrecognized addresses are counted in the report.
+fn mark_addresses_exposed<C, P, CL, R, S>(
+    wdb: &mut WalletDb<C, P, CL, R>,
+    params: &P,
+    taddrs: &TransparentAddressRecords,
+    report: &mut ZewifImportReport,
+) -> Result<(), ZewifImportError<S>>
+where
+    C: std::borrow::BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
+    S: std::error::Error,
+{
+    use zcash_client_backend::data_api::WalletRead;
+
+    // The upstream API rejects the entire batch if any address is not a known
+    // receiver, so restrict the batch to the receivers the wallet recognizes.
+    let mut known = std::collections::HashSet::new();
+    let accounts: std::collections::HashSet<AccountUuid> =
+        taddrs.owners.values().map(|(uuid, _)| *uuid).collect();
+    for account_uuid in accounts {
+        known.extend(
+            wdb.get_transparent_receivers(account_uuid, true, true)
+                .map_err(ZewifImportError::Wallet)?
+                .into_keys(),
+        );
+    }
+
+    let mut exposures: Vec<(TransparentAddress, BlockHeight)> = vec![];
+    for (address_str, (_, exposure_height)) in &taddrs.owners {
+        match TransparentAddress::decode(params, address_str) {
+            Ok(taddr) if known.contains(&taddr) => {
+                exposures.push((taddr, *exposure_height));
+            }
+            _ => {
+                report.addresses_not_recognized += 1;
+            }
+        }
+    }
+    exposures.sort();
+
+    if !exposures.is_empty() {
+        wdb.mark_transparent_addresses_exposed(&exposures)
+            .map_err(ZewifImportError::Wallet)?;
+    }
+    report.addresses_marked_exposed = exposures.len();
+
+    Ok(())
 }
 
 /// Stores the document's transactions in the wallet database.
@@ -900,6 +1156,7 @@ fn import_account<C, P, CL, R, S>(
     params: &P,
     account: &::zewif::Account,
     available: &AvailableSecrets,
+    taddrs: &mut TransparentAddressRecords,
     report: &mut ZewifImportReport,
 ) -> Result<(), ZewifImportError<S>>
 where
@@ -1013,6 +1270,24 @@ where
             }
         }
     };
+
+    // Record the account's transparent addresses for standalone key
+    // registration and exposure marking.
+    for address in account.addresses() {
+        if let ::zewif::ProtocolAddress::Transparent(taddr) = address.address() {
+            let exposure_height = address
+                .exposed_at_height()
+                .map_or(birthday.height(), |h| BlockHeight::from(u32::from(h)));
+            taddrs
+                .owners
+                .insert(taddr.address().to_owned(), (account_uuid, exposure_height));
+            if let Some(script) = taddr.redeem_script() {
+                taddrs
+                    .redeem_scripts
+                    .push((account_uuid, script.as_ref().to_vec()));
+            }
+        }
+    }
 
     report.imported_accounts.push(ImportedAccount {
         name: account.name().to_owned(),

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -21,6 +21,11 @@
 //!    corresponding spending material was delivered to the sink and as view-only
 //!    accounts otherwise. Account birthdays are constructed from the tree-state
 //!    frontiers carried by the document where present.
+//! 4. Stores the document's transactions: each transaction carrying raw data is
+//!    parsed and trial-decrypted against the imported accounts' viewing keys, and
+//!    stored if it involves the wallet. Transactions that cannot be shown to
+//!    involve the wallet are not stored (the post-import rescan recovers them if
+//!    they do), and are counted in the report.
 //!
 //! The database must already have been initialized with
 //! [`crate::wallet::init::WalletMigrator`] before calling [`import_wallet`].
@@ -48,11 +53,14 @@ use bech32::primitives::decode::CheckedHrpstring;
 use bip0039::{English, Mnemonic};
 use rand::RngCore;
 use secrecy::SecretVec;
+use zcash_client_backend::data_api::wallet::decrypt_and_store_transaction;
 use zcash_client_backend::data_api::{
     Account as _, AccountBirthday, AccountPurpose, WalletWrite, Zip32Derivation, chain::ChainState,
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::block::BlockHash;
+use zcash_primitives::transaction::Transaction;
+use zcash_protocol::consensus::BranchId;
 use zcash_protocol::consensus::{
     self, BlockHeight, NetworkConstants as _, NetworkType, NetworkUpgrade, Parameters,
 };
@@ -240,6 +248,22 @@ pub enum ZewifImportError<S> {
         /// The underlying structural error.
         source: incrementalmerkletree::frontier::FrontierError,
     },
+    /// The raw bytes of a transaction in the document could not be parsed as a
+    /// Zcash transaction.
+    TransactionParse {
+        /// The id of the unparseable transaction, as recorded in the document.
+        txid: zcash_protocol::TxId,
+        /// The underlying parse error.
+        source: std::io::Error,
+    },
+    /// The raw bytes of a transaction in the document parse to a transaction
+    /// with a different id than the one under which they were recorded.
+    TxidMismatch {
+        /// The id under which the transaction was recorded.
+        recorded: zcash_protocol::TxId,
+        /// The id of the transaction the recorded bytes parse to.
+        parsed: zcash_protocol::TxId,
+    },
     /// An error occurred writing to the wallet database.
     Wallet(SqliteClientError),
     /// The [`SecretSink`] failed to persist an entry.
@@ -317,6 +341,14 @@ impl<S: fmt::Display> fmt::Display for ZewifImportError<S> {
                 f,
                 "The {pool} tree frontier in the birthday of account \"{account_name}\" is invalid: {source:?}"
             ),
+            ZewifImportError::TransactionParse { txid, source } => write!(
+                f,
+                "Unable to parse the raw data of transaction {txid}: {source}"
+            ),
+            ZewifImportError::TxidMismatch { recorded, parsed } => write!(
+                f,
+                "The raw data recorded for transaction {recorded} parses to a transaction with id {parsed}."
+            ),
             ZewifImportError::Wallet(e) => write!(f, "Wallet database error: {e}"),
             ZewifImportError::Sink(e) => write!(f, "Secret sink error: {e}"),
         }
@@ -327,6 +359,7 @@ impl<S: std::error::Error + 'static> std::error::Error for ZewifImportError<S> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ZewifImportError::InvalidMnemonic { source, .. } => Some(source),
+            ZewifImportError::TransactionParse { source, .. } => Some(source),
             ZewifImportError::Wallet(e) => Some(e),
             ZewifImportError::Sink(e) => Some(e),
             _ => None,
@@ -393,6 +426,17 @@ pub struct ZewifImportReport {
     pub imported_accounts: Vec<ImportedAccount>,
     /// The accounts that could not be imported.
     pub skipped_accounts: Vec<SkippedAccount>,
+    /// The number of transactions from the document that were stored because
+    /// they involve the imported accounts.
+    pub transactions_stored: usize,
+    /// The number of transactions from the document that were not stored
+    /// because trial decryption found no involvement with any imported
+    /// account. Such transactions are expected to be recovered by the
+    /// post-import rescan if they do in fact involve the wallet.
+    pub transactions_without_wallet_relevance: usize,
+    /// The number of transactions in the document that carried no raw
+    /// transaction data and therefore could not be stored.
+    pub transactions_without_raw_data: usize,
     /// The number of address book entries present in the document. Address
     /// books have no backing store in this crate; the caller retains the
     /// document and may preserve these entries elsewhere.
@@ -746,7 +790,107 @@ where
         }
     }
 
+    import_transactions(wdb, &params, document, &mut report)?;
+
     Ok(report)
+}
+
+/// Stores the document's transactions in the wallet database.
+///
+/// Transactions are processed in ascending order of mined height (unmined
+/// transactions last) so that funding transactions generally precede the
+/// transactions that spend them. Each transaction carrying raw data is parsed
+/// under the consensus branch in force at its mined height (or, for unmined
+/// transactions, at its expiry height when known, and otherwise at a height
+/// just past the highest mined height in the document, falling back to the
+/// document's export height), verified against its recorded transaction id,
+/// and trial-decrypted against the wallet's tracked viewing keys.
+///
+/// [`decrypt_and_store_transaction`] stores a transaction only when trial
+/// decryption or transparent-output matching shows wallet involvement, so the
+/// count of stored transactions is determined by querying for each transaction
+/// id after the attempt.
+fn import_transactions<C, P, CL, R, S>(
+    wdb: &mut WalletDb<C, P, CL, R>,
+    params: &P,
+    document: &::zewif::Zewif,
+    report: &mut ZewifImportReport,
+) -> Result<(), ZewifImportError<S>>
+where
+    C: std::borrow::BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
+    S: std::error::Error,
+{
+    let mut txs: Vec<&::zewif::Transaction> = document.transactions().values().collect();
+    txs.sort_by_key(|tx| {
+        (
+            tx.mined_height().map_or(u32::MAX, u32::from),
+            *tx.txid().as_bytes(),
+        )
+    });
+
+    // The height at which a transaction of unknown mined height is assumed to
+    // have entered the mempool, for consensus branch id selection.
+    let assumed_mempool_height = txs
+        .iter()
+        .filter_map(|tx| tx.mined_height())
+        .max()
+        .map_or(document.export_height(), |h| h + 1);
+
+    for tx in txs {
+        let raw = match tx.tx_data() {
+            Some(::zewif::TransactionData::Raw(raw)) => raw.data(),
+            // Compact transaction data does not contain the full transaction,
+            // so it cannot be stored; the post-import rescan will recover the
+            // transaction if it involves the wallet.
+            Some(::zewif::TransactionData::Compact(_)) | None => {
+                report.transactions_without_raw_data += 1;
+                continue;
+            }
+        };
+        let recorded_txid = zcash_protocol::TxId::from_bytes(*tx.txid().as_bytes());
+        let mined_height = tx.mined_height().map(|h| BlockHeight::from(u32::from(h)));
+        let branch_height = mined_height.unwrap_or_else(|| {
+            BlockHeight::from(u32::from(
+                tx.expiry_height()
+                    .filter(|h| u32::from(*h) != 0)
+                    .unwrap_or(assumed_mempool_height),
+            ))
+        });
+        let parsed = Transaction::read(raw.as_slice(), BranchId::for_height(params, branch_height))
+            .map_err(|source| ZewifImportError::TransactionParse {
+                txid: recorded_txid,
+                source,
+            })?;
+        if parsed.txid() != recorded_txid {
+            return Err(ZewifImportError::TxidMismatch {
+                recorded: recorded_txid,
+                parsed: parsed.txid(),
+            });
+        }
+
+        decrypt_and_store_transaction(params, wdb, &parsed, mined_height)
+            .map_err(ZewifImportError::Wallet)?;
+
+        let stored = wdb
+            .conn
+            .borrow()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM transactions WHERE txid = :txid)",
+                rusqlite::named_params![":txid": recorded_txid.as_ref()],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|e| ZewifImportError::Wallet(SqliteClientError::from(e)))?;
+        if stored {
+            report.transactions_stored += 1;
+        } else {
+            report.transactions_without_wallet_relevance += 1;
+        }
+    }
+
+    Ok(())
 }
 
 /// Imports a single account, choosing the import path appropriate to its


### PR DESCRIPTION
Stacked on #2539 (the base branch is `dw/ironwood-scan-model`); only the last four commits are new here.

This adds a `zewif` feature to `zcash_client_sqlite` providing `zewif::import_wallet`, which populates a `WalletDb` from a ZeWIF (Zcash Wallet Interchange Format) document. It is intended as the destination side of wallet migrations such as zcashd → zallet, replacing bespoke per-source import pipelines.

## Design

- **Secrets never enter the wallet database.** All spending material in the document's secret store is delivered to a caller-supplied `SecretSink` (e.g. an age-encrypted keystore); the import records which seeds and spending keys are available and uses only the public halves. Seeds are verified against their recorded ZIP 32 fingerprints and WIF keys against their recorded public keys before use.
- **Accounts**: seed-derived accounts whose seed material is present are imported via `import_account_hd`, preserving the recorded ZIP 32 account index (and zcashd legacy address index, via `zcashd-compat`); all others go through `import_account_ufvk`, with `AccountPurpose` inferred from the availability of spending material unless the document records a purpose explicitly. Standalone Sapling FVK accounts are wrapped into UFVKs.
- **Birthdays** are constructed directly from the tree-state frontiers carried by the document (Sapling, Orchard, and Ironwood), so import requires no chain access. Documents without chain state fall back to the recorded birthday height (or Sapling activation), with the imprecision recorded in the returned `ZewifImportReport`.
- **Transactions** are trial-decrypted against the imported viewing keys via `decrypt_and_store_transaction`; consensus branch ids follow the mined height, expiry height, or the document's export height, in that order of preference. Transactions that cannot be shown to involve the wallet are left for the post-import rescan and counted in the report.
- **Standalone transparent keys** are registered against the account whose address list contains their P2PKH address (via `transparent-key-import`), P2SH redeem scripts are registered where representable, and imported addresses are marked exposed so address-based recovery includes them.
- The report is fully typed: skipped accounts, skipped keys, and unimported address-book entries all carry semantic reasons rather than strings.

## Limitations (V1)

- Sprout accounts are not representable and are skipped (their spending keys still reach the sink).
- Address-book entries have no backing store in this crate and are not imported.
- Regtest documents are rejected, since activation-schedule equivalence cannot be verified here.
- Received-note spendability still requires the post-import rescan to establish commitment tree positions.

## Dependencies

`zewif` is consumed via `[patch.crates-io]` pointing at zcash/zewif `main` until its first crates.io release, at which point the patch will be dropped. cargo-vet treats it as first-party (`audit-as-crates-io = false`); its `minicbor` transitives are recorded as exemptions in the usual pattern. The feature also currently requires `zcash_keys/unstable` for `UnifiedFullViewingKey::from_sapling_extended_full_viewing_key`.

## Observations for the Ironwood line of work

While wiring birthdays through: `AccountBirthday` exposes no `ironwood_frontier()` accessor, and the `accounts` table records `birthday_sapling_tree_size`/`birthday_orchard_tree_size` but no Ironwood equivalent. Neither blocks this PR (the frontier flows through `ChainState` into tree checkpointing), but both look like gaps worth closing in #2539's line of work.

## Testing

Seven unit tests drive the import against a real `TestDb` with a recording sink, covering the HD-derivation path, chain-state birthdays, purpose inference, sprout skipping, network mismatch rejection, transparent key registration/exposure, and secret delivery. The full `zcash_client_sqlite` suite passes with the feature enabled. Integration coverage of the trial-decryption path against a real exported wallet document is planned as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)