### PR TITLE
Make PCZT v2 anchor and cv_net optional

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -57,6 +57,9 @@ workspace.
   version separately from the version 1 serialization format.
 - PCZT version 2 serialization now omits empty Transparent, Sapling, and
   Orchard bundles.
+- PCZT version 2 Orchard bundle encodings now represent the bundle anchor and
+  per-action `cv_net` as optional fields. Absent values are restored as all zero
+  bytes in the logical `pczt::orchard` model.
 - Direct `serde` serialization implementations have been removed from the
   logical `pczt::orchard::{Bundle, Action, Spend, Output}` types.
 - `pczt::Pczt::serialize` now consumes `self` and returns

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -546,13 +546,15 @@ pub(crate) mod v2 {
         }
     }
 
+    const ZERO_BYTES_32: [u8; 32] = [0; 32];
+
     /// PCZT fields that are specific to producing the transaction's Orchard bundle.
     #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
     pub struct Bundle {
         actions: Vec<Action>,
         flags: u8,
         value_sum: (u64, bool),
-        anchor: [u8; 32],
+        anchor: Option<[u8; 32]>,
         note_version: SerializedNoteVersion,
         zkproof: Option<Vec<u8>>,
         bsk: Option<[u8; 32]>,
@@ -561,7 +563,7 @@ pub(crate) mod v2 {
     /// Information about an Orchard action within a transaction.
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub(crate) struct Action {
-        cv_net: [u8; 32],
+        cv_net: Option<[u8; 32]>,
         spend: v1::Spend,
         output: Output,
         rcv: Option<[u8; 32]>,
@@ -597,7 +599,7 @@ pub(crate) mod v2 {
                     .collect::<Vec<_>>(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: (bundle.anchor != ZERO_BYTES_32).then_some(bundle.anchor),
                 note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -615,7 +617,7 @@ pub(crate) mod v2 {
                     .collect(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: bundle.anchor.unwrap_or(ZERO_BYTES_32),
                 note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -626,7 +628,7 @@ pub(crate) mod v2 {
     impl From<super::Action> for Action {
         fn from(action: super::Action) -> Self {
             Self {
-                cv_net: action.cv_net,
+                cv_net: (action.cv_net != ZERO_BYTES_32).then_some(action.cv_net),
                 spend: v1::Spend::from(action.spend),
                 output: Output::from(action.output),
                 rcv: action.rcv,
@@ -637,7 +639,7 @@ pub(crate) mod v2 {
     impl From<Action> for super::Action {
         fn from(action: Action) -> Self {
             Self {
-                cv_net: action.cv_net,
+                cv_net: action.cv_net.unwrap_or(ZERO_BYTES_32),
                 spend: super::Spend::from(action.spend),
                 output: super::Output::from(action.output),
                 rcv: action.rcv,
@@ -695,6 +697,87 @@ pub(crate) mod v2 {
         (bundle != *empty)
             .then(|| Bundle::try_from(bundle))
             .transpose()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use alloc::{collections::BTreeMap, vec::Vec};
+
+        use super::super::{
+            Action as LogicalAction, Bundle as LogicalBundle, NoteVersion,
+            ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output, Spend,
+        };
+
+        fn logical_action(cv_net: [u8; 32]) -> LogicalAction {
+            LogicalAction {
+                cv_net,
+                spend: Spend {
+                    nullifier: [1; 32],
+                    rk: [2; 32],
+                    spend_auth_sig: None,
+                    recipient: None,
+                    value: None,
+                    rho: None,
+                    rseed: None,
+                    fvk: None,
+                    witness: None,
+                    alpha: None,
+                    zip32_derivation: None,
+                    dummy_sk: None,
+                    proprietary: BTreeMap::new(),
+                },
+                output: Output {
+                    cmx: [3; 32],
+                    ephemeral_key: [4; 32],
+                    enc_ciphertext: Vec::new(),
+                    out_ciphertext: Vec::new(),
+                    recipient: None,
+                    value: None,
+                    rseed: None,
+                    ock: None,
+                    zip32_derivation: None,
+                    user_address: None,
+                    proprietary: BTreeMap::new(),
+                },
+                rcv: None,
+            }
+        }
+
+        fn logical_bundle(anchor: [u8; 32], cv_net: [u8; 32]) -> LogicalBundle {
+            LogicalBundle {
+                actions: vec![logical_action(cv_net)],
+                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+                value_sum: (0, false),
+                anchor,
+                note_version: NoteVersion::V2,
+                zkproof: None,
+                bsk: None,
+            }
+        }
+
+        #[test]
+        fn zero_anchor_and_cv_net_encode_as_none() {
+            let bundle = logical_bundle([0; 32], [0; 32]);
+
+            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
+            assert!(encoded.anchor.is_none());
+            assert!(encoded.actions[0].cv_net.is_none());
+
+            let decoded = LogicalBundle::from(encoded);
+            assert_eq!(decoded, bundle);
+        }
+
+        #[test]
+        fn nonzero_anchor_and_cv_net_encode_as_some() {
+            let bundle = logical_bundle([5; 32], [6; 32]);
+
+            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
+            assert_eq!(encoded.anchor, Some([5; 32]));
+            assert_eq!(encoded.actions[0].cv_net, Some([6; 32]));
+
+            let decoded = LogicalBundle::from(encoded);
+            assert_eq!(decoded, bundle);
+        }
     }
 }
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -513,10 +513,11 @@ pub mod v1 {
 
 /// Types for the v2 Orchard PCZT encoding.
 pub(crate) mod v2 {
-    use alloc::vec::Vec;
+    use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
     use getset::Getters;
     use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
 
     use super::{NoteVersion, v1};
 
@@ -548,13 +549,40 @@ pub(crate) mod v2 {
     /// PCZT fields that are specific to producing the transaction's Orchard bundle.
     #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
     pub struct Bundle {
-        actions: Vec<v1::Action>,
+        actions: Vec<Action>,
         flags: u8,
         value_sum: (u64, bool),
         anchor: [u8; 32],
         note_version: SerializedNoteVersion,
         zkproof: Option<Vec<u8>>,
         bsk: Option<[u8; 32]>,
+    }
+
+    /// Information about an Orchard action within a transaction.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Action {
+        cv_net: [u8; 32],
+        spend: v1::Spend,
+        output: Output,
+        rcv: Option<[u8; 32]>,
+    }
+
+    /// Information about the output part of an Orchard action.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Output {
+        cmx: [u8; 32],
+        ephemeral_key: [u8; 32],
+        enc_ciphertext: Vec<u8>,
+        out_ciphertext: Vec<u8>,
+        #[serde_as(as = "Option<[_; 43]>")]
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rseed: Option<[u8; 32]>,
+        ock: Option<[u8; 32]>,
+        zip32_derivation: Option<crate::common::Zip32Derivation>,
+        user_address: Option<String>,
+        proprietary: BTreeMap<String, Vec<u8>>,
     }
 
     impl TryFrom<super::Bundle> for Bundle {
@@ -565,7 +593,7 @@ pub(crate) mod v2 {
                 actions: bundle
                     .actions
                     .into_iter()
-                    .map(v1::Action::from)
+                    .map(Action::from)
                     .collect::<Vec<_>>(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
@@ -591,6 +619,64 @@ pub(crate) mod v2 {
                 note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
+            }
+        }
+    }
+
+    impl From<super::Action> for Action {
+        fn from(action: super::Action) -> Self {
+            Self {
+                cv_net: action.cv_net,
+                spend: v1::Spend::from(action.spend),
+                output: Output::from(action.output),
+                rcv: action.rcv,
+            }
+        }
+    }
+
+    impl From<Action> for super::Action {
+        fn from(action: Action) -> Self {
+            Self {
+                cv_net: action.cv_net,
+                spend: super::Spend::from(action.spend),
+                output: super::Output::from(action.output),
+                rcv: action.rcv,
+            }
+        }
+    }
+
+    impl From<super::Output> for Output {
+        fn from(output: super::Output) -> Self {
+            Self {
+                cmx: output.cmx,
+                ephemeral_key: output.ephemeral_key,
+                enc_ciphertext: output.enc_ciphertext,
+                out_ciphertext: output.out_ciphertext,
+                recipient: output.recipient,
+                value: output.value,
+                rseed: output.rseed,
+                ock: output.ock,
+                zip32_derivation: output.zip32_derivation,
+                user_address: output.user_address,
+                proprietary: output.proprietary,
+            }
+        }
+    }
+
+    impl From<Output> for super::Output {
+        fn from(output: Output) -> Self {
+            Self {
+                cmx: output.cmx,
+                ephemeral_key: output.ephemeral_key,
+                enc_ciphertext: output.enc_ciphertext,
+                out_ciphertext: output.out_ciphertext,
+                recipient: output.recipient,
+                value: output.value,
+                rseed: output.rseed,
+                ock: output.ock,
+                zip32_derivation: output.zip32_derivation,
+                user_address: output.user_address,
+                proprietary: output.proprietary,
             }
         }
     }


### PR DESCRIPTION
PCZT v2 Orchard bundle encoding now represents all-zero bundle anchors and per-action cv_net values as absent optional fields. Missing values decode back to all-zero logical fields, so the in-memory model stays unchanged while the wire format can omit default data.

Test plan: cargo test -p pczt --all-features