### PR TITLE
zcash_client_backend: Support creation of transparent change

### DIFF
--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1058,6 +1058,7 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
             ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
                 .then(orchard::Anchor::empty_tree),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -115,6 +115,13 @@ workspace.
   such a change value is represented by the existing transparent `valuePool`
   with `isEphemeral` unset; decoding this combination previously returned
   `ProposalDecodingError::InvalidChangeRecipient`.
+- `zcash_client_backend::data_api::WalletWrite::reserve_next_n_internal_addresses`
+  (behind `transparent-inputs`): reserves the next `n` available
+  internal-scope (change) transparent addresses for an account, parallel to
+  the existing `reserve_next_n_ephemeral_addresses` method.
+  `create_proposed_transactions` uses this to allocate the recipient
+  address(es) for non-ephemeral transparent change outputs, which it records
+  using the existing `Recipient::InternalTransparent` variant.
 - `zcash_client_backend::data_api::NoteCommitmentTree`
 - `zcash_client_backend::data_api::SentTransactionOutput::note_commitment_tree`
 - `zcash_client_backend::proto::proposal::ValuePool::Ironwood`, so that a proposal

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -92,6 +92,29 @@ workspace.
   `with_ironwood_tree_mut`.
 - `zcash_client_backend::data_api::IRONWOOD_SHARD_HEIGHT`, the shard height of
   the Ironwood note commitment tree (equal to the Orchard shard height).
+- `zcash_client_backend::fees::TransparentChangePolicy` (behind the
+  `transparent-inputs` feature flag): expresses whether change for a
+  transaction whose net flows are fully transparent should be shielded (the
+  default, `ShieldChange`) or returned to the transparent pool
+  (`TransparentChangeAllowed`) at an internal-scope (change) transparent
+  address of the wallet, as described under the BIP 44 `change` path level.
+  The policy has no effect on transactions that involve any shielded flows;
+  change for such transactions is always shielded. This enables `zallet` to
+  replicate `zcashd`'s `z_sendmany` behavior for fully-transparent spends.
+- `with_transparent_change_policy` builder methods (behind
+  `transparent-inputs`) on the ZIP 317 change strategies
+  `zcash_client_backend::fees::zip317::{SingleOutputChangeStrategy, MultiOutputChangeStrategy}`
+  and on `zcash_client_backend::fees::fixed::SingleOutputChangeStrategy`.
+  When transparent change is produced it is always emitted as a single
+  output; the `SplitPolicy` configured for `MultiOutputChangeStrategy`
+  applies only to shielded change.
+- `zcash_client_backend::fees::ChangeValue::transparent` (behind
+  `transparent-inputs`): constructs a non-ephemeral transparent change value,
+  distinct from the ephemeral (ZIP 320) transparent output value constructed
+  by `ChangeValue::ephemeral_transparent`. In the proposal protobuf encoding,
+  such a change value is represented by the existing transparent `valuePool`
+  with `isEphemeral` unset; decoding this combination previously returned
+  `ProposalDecodingError::InvalidChangeRecipient`.
 - `zcash_client_backend::data_api::NoteCommitmentTree`
 - `zcash_client_backend::data_api::SentTransactionOutput::note_commitment_tree`
 - `zcash_client_backend::proto::proposal::ValuePool::Ironwood`, so that a proposal

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -148,6 +148,10 @@ message TransactionBalance {
 // an ephemeral output, which must be spent by a subsequent step. This is
 // only supported for transparent outputs. Each ephemeral output will be
 // given a unique t-address.
+//
+// When the transparent value pool is selected and the `isEphemeral` field
+// is not set, the value represents transparent change, which will be sent
+// to an internal-scope (change) transparent address of the wallet.
 message ChangeValue {
     // The value of a change or ephemeral output to be created, in zatoshis.
     uint64 value = 1;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3604,6 +3604,38 @@ pub trait WalletWrite: WalletRead {
         )
     }
 
+    /// Reserves the next `n` available internal-scope (change) transparent addresses for
+    /// the given account, as described in [BIP 44] under the `change` path level. This
+    /// cannot be undone, so as far as possible, errors associated with transaction
+    /// construction should have been reported before calling this method.
+    ///
+    /// Internal-scope transparent addresses are used to receive change for transactions
+    /// having fully-transparent value flows, when the change strategy in use is configured
+    /// with [`TransparentChangePolicy::TransparentChangeAllowed`].
+    ///
+    /// To ensure that funds sent to internal-scope addresses are recoverable, implementations
+    /// of this method should observe a gap limit as described in [BIP 44]; change addresses
+    /// receive funds immediately upon reservation, so a smaller gap limit than the one used
+    /// for external addresses may be observed.
+    ///
+    /// Returns an error if there is insufficient space within the gap limit to allocate
+    /// the given number of addresses, or if the account identifier does not correspond
+    /// to a known account.
+    ///
+    /// [BIP 44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+    /// [`TransparentChangePolicy::TransparentChangeAllowed`]: crate::fees::TransparentChangePolicy::TransparentChangeAllowed
+    #[cfg(feature = "transparent-inputs")]
+    fn reserve_next_n_internal_addresses(
+        &mut self,
+        _account_id: Self::AccountId,
+        _n: usize,
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        unimplemented!(
+            "WalletWrite::reserve_next_n_internal_addresses must be overridden for wallets to \
+             create transactions that produce transparent change"
+        )
+    }
+
     /// Updates the wallet backend with respect to the status of a specific transaction, from the
     /// perspective of the main chain.
     ///

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -3402,6 +3402,15 @@ impl WalletWrite for MockWalletDb {
         Err(())
     }
 
+    #[cfg(feature = "transparent-inputs")]
+    fn reserve_next_n_internal_addresses(
+        &mut self,
+        _account_id: Self::AccountId,
+        _n: usize,
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        Err(())
+    }
+
     fn set_transaction_status(
         &mut self,
         _txid: TxId,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -2441,3 +2441,293 @@ where
         .expect("AllFunds gather should succeed");
     assert_eq!(all.len(), n_dust);
 }
+
+/// Tests that [`WalletWrite::reserve_next_n_internal_addresses`] reserves sequential
+/// internal-scope (change) addresses, that reservation observes the internal-scope gap
+/// limit, and that internal-scope reservations are accounted independently of
+/// ephemeral-scope reservations.
+///
+/// This test expects the data store to be configured with the default gap limits, under
+/// which the internal-scope gap limit is 5.
+///
+/// The `is_reached_gap_limit` predicate must return `true` if and only if the provided
+/// error is the backend's exact "reached gap limit" error variant, the scope reported by
+/// that error is [`TransparentKeyScope::INTERNAL`], and the address index reported by that
+/// error equals the provided expected index. It must not match any other error. (A
+/// predicate is used because this test cannot name the backend's concrete error type
+/// without inverting the crate dependency.)
+pub fn reserve_next_n_internal_addresses_gap_limit<DSF>(
+    dsf: DSF,
+    cache: impl TestCache,
+    is_reached_gap_limit: impl Fn(
+        &<DSF::DataStore as crate::data_api::WalletRead>::Error,
+        DSF::AccountId,
+        u32,
+    ) -> bool,
+) where
+    DSF: DataStoreFactory,
+{
+    use std::collections::HashSet;
+    use transparent::keys::NonHardenedChildIndex;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+    let account_id = st.test_account().cloned().unwrap().id();
+
+    // Seed the chain so that a chain height is known; address reservation records the
+    // exposure height of each reserved address.
+    let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+    let not_our_value = Zatoshis::const_from_u64(10000);
+    let (start_height, _, _) =
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    st.scan_cached_blocks(start_height, 1);
+
+    // Reserving internal addresses yields distinct, sequentially-indexed addresses derived
+    // under the internal (change) key scope.
+    let reserved = st
+        .wallet_mut()
+        .reserve_next_n_internal_addresses(account_id, 3)
+        .unwrap();
+    assert_eq!(reserved.len(), 3);
+    for (i, (_, meta)) in reserved.iter().enumerate() {
+        assert_eq!(meta.scope(), Some(TransparentKeyScope::INTERNAL));
+        assert_eq!(
+            meta.address_index(),
+            Some(NonHardenedChildIndex::const_from_index(
+                u32::try_from(i).unwrap()
+            )),
+        );
+    }
+    // None of the reserved addresses have received funds, so the gap cannot advance: with
+    // the default internal-scope gap limit of 5, only two more addresses may be reserved.
+    // Reservation continues at the next sequential indices, so the returned addresses are
+    // distinct from those of the first batch.
+    let more = st
+        .wallet_mut()
+        .reserve_next_n_internal_addresses(account_id, 2)
+        .unwrap();
+    assert_eq!(more.len(), 2);
+    for (i, (_, meta)) in more.iter().enumerate() {
+        assert_eq!(meta.scope(), Some(TransparentKeyScope::INTERNAL));
+        assert_eq!(
+            meta.address_index(),
+            Some(NonHardenedChildIndex::const_from_index(
+                u32::try_from(reserved.len() + i).unwrap()
+            )),
+        );
+    }
+    let unique_addrs = reserved
+        .iter()
+        .chain(more.iter())
+        .map(|(a, _)| *a)
+        .collect::<HashSet<_>>();
+    assert_eq!(unique_addrs.len(), reserved.len() + more.len());
+
+    assert_matches!(
+        st.wallet_mut().reserve_next_n_internal_addresses(account_id, 1),
+        Err(e) if is_reached_gap_limit(&e, account_id, 5)
+    );
+
+    // Internal-scope reservations must not consume ephemeral-scope gap space.
+    let ephemeral = st
+        .wallet_mut()
+        .reserve_next_n_ephemeral_addresses(account_id, 1)
+        .unwrap();
+    assert_eq!(ephemeral[0].1.scope(), Some(TransparentKeyScope::EPHEMERAL),);
+    assert_eq!(
+        ephemeral[0].1.address_index(),
+        Some(NonHardenedChildIndex::const_from_index(0)),
+    );
+}
+
+/// Tests the full lifecycle of a t->t transfer with transparent change: a change strategy
+/// configured with [`TransparentChangePolicy::TransparentChangeAllowed`] must propose a
+/// non-ephemeral transparent change output, and transaction creation must send that change
+/// to a previously-unexposed internal-scope (change) transparent address of the spending
+/// account, where it is recorded as received and becomes spendable once mined.
+///
+/// [`TransparentChangePolicy::TransparentChangeAllowed`]: crate::fees::TransparentChangePolicy::TransparentChangeAllowed
+pub fn propose_t2t_with_transparent_change<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    use std::convert::Infallible;
+
+    use crate::{
+        fees::{ChangeValue, TransparentChangePolicy},
+        wallet::{Exposure, OvkPolicy},
+    };
+
+    let utxo_value = Zatoshis::const_from_u64(100_000);
+    let transfer_amount = Zatoshis::const_from_u64(40_000);
+    let (mut st, account, outpoint) = setup_transparent_only_account(dsf, cache, utxo_value);
+
+    let network = *st.network();
+    let request = t2t_request(&network, transfer_amount);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedPool::Sapling,
+        DustOutputPolicy::default(),
+    )
+    .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+    let proposal = st
+        .propose_transfer_with_policy(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+            &SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr()),
+        )
+        .expect("t->t proposal with transparent change must succeed");
+
+    // A t->t transfer with non-ephemeral transparent change is a single step.
+    assert_eq!(proposal.steps().len(), 1);
+    let step = &proposal.steps().head;
+    assert_eq!(step.transparent_inputs().len(), 1);
+    assert_eq!(step.transparent_inputs()[0].outpoint(), &outpoint);
+    assert!(step.shielded_inputs().is_none());
+
+    // Under ZIP 317, one P2PKH input and two P2PKH outputs (the payment plus the change
+    // output) require `5_000 * max(1, 2) = 10_000` zats in fees.
+    let expected_fee = Zatoshis::const_from_u64(10_000);
+    let expected_change = ((utxo_value - transfer_amount).unwrap() - expected_fee).unwrap();
+    assert_eq!(step.balance().fee_required(), expected_fee);
+    assert_eq!(
+        step.balance().proposed_change(),
+        [ChangeValue::transparent(expected_change)],
+    );
+    assert!(!step.balance().proposed_change()[0].is_ephemeral());
+
+    // A proposal containing a transparent change output must survive a serialization
+    // round trip.
+    super::check_proposal_serialization_roundtrip(&network, st.wallet(), &proposal);
+
+    // Creating the transaction should reserve an internal-scope address for the change.
+    let txids = st
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("transaction creation must succeed");
+    assert_eq!(txids.len(), 1);
+    let txid = txids.head;
+
+    // The transaction must be fully transparent, with exactly the payment and change outputs.
+    let tx = st
+        .wallet()
+        .get_transaction(txid)
+        .unwrap()
+        .expect("the created transaction is retrievable");
+    assert!(tx.sapling_bundle().is_none());
+    #[cfg(feature = "orchard")]
+    assert!(tx.orchard_bundle().is_none());
+    let bundle = tx
+        .transparent_bundle()
+        .expect("the transaction has a transparent bundle");
+    assert_eq!(bundle.vin.len(), 1);
+    assert_eq!(bundle.vout.len(), 2);
+
+    // Identify the change output as the output that does not pay the external recipient.
+    let payment_recipient = TransparentAddress::PublicKeyHash([7u8; 20]);
+    let change_outputs: Vec<_> = bundle
+        .vout
+        .iter()
+        .filter(|out| out.recipient_address() != Some(payment_recipient))
+        .collect();
+    assert_eq!(change_outputs.len(), 1);
+    let change_output = change_outputs[0];
+    assert_eq!(change_output.value(), expected_change);
+    let change_address = change_output
+        .recipient_address()
+        .expect("the change output pays a standard P2PKH address");
+
+    // The change address must be an internal-scope (change) address of the spending account,
+    // exposed at the current chain height by having been reserved for change.
+    let receivers = st
+        .wallet()
+        .get_transparent_receivers(account.id(), true, false)
+        .unwrap();
+    let change_meta = receivers
+        .get(&change_address)
+        .expect("the change address belongs to the spending account");
+    assert_eq!(change_meta.scope(), Some(TransparentKeyScope::INTERNAL));
+    let cur_height = st.wallet().chain_height().unwrap().unwrap();
+    assert_matches!(
+        change_meta.exposure(),
+        Exposure::Exposed { at_height, .. } if at_height == cur_height
+    );
+
+    // Mine the transaction; the change output should then be spendable at the change address.
+    let (h, _) = st.generate_next_block_including(txid);
+    st.scan_cached_blocks(h, 1);
+
+    let mut expected_balance = Balance::ZERO;
+    expected_balance
+        .add_spendable_value(expected_change)
+        .unwrap();
+    check_balance::<DSF>(
+        &st,
+        &account,
+        &change_address,
+        ConfirmationsPolicy::MIN,
+        &expected_balance,
+    );
+}
+
+/// Tests that when a fully-transparent transaction balances exactly (input value equals
+/// payments plus the minimum fee), no transparent change output is produced even when the
+/// change strategy is configured with [`TransparentChangePolicy::TransparentChangeAllowed`].
+///
+/// [`TransparentChangePolicy::TransparentChangeAllowed`]: crate::fees::TransparentChangePolicy::TransparentChangeAllowed
+pub fn propose_t2t_transparent_change_exact_match<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    use crate::fees::TransparentChangePolicy;
+
+    // Under ZIP 317, one P2PKH input and one P2PKH output require the minimum fee of
+    // 10_000 zats, so a 50_000-zat UTXO exactly covers a 40_000-zat payment.
+    let utxo_value = Zatoshis::const_from_u64(50_000);
+    let transfer_amount = Zatoshis::const_from_u64(40_000);
+    let (mut st, account, _outpoint) = setup_transparent_only_account(dsf, cache, utxo_value);
+
+    let network = *st.network();
+    let request = t2t_request(&network, transfer_amount);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedPool::Sapling,
+        DustOutputPolicy::default(),
+    )
+    .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+    let proposal = st
+        .propose_transfer_with_policy(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+            &SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr()),
+        )
+        .expect("exactly-balanced t->t proposal must succeed");
+
+    assert_eq!(proposal.steps().len(), 1);
+    let step = &proposal.steps().head;
+    assert_eq!(
+        step.balance().fee_required(),
+        Zatoshis::const_from_u64(10_000),
+    );
+    assert_eq!(step.balance().proposed_change(), []);
+}

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -186,6 +186,12 @@ enum PcztRecipient<AccountId> {
     InternalAccount {
         receiving_account: AccountId,
     },
+    // This variant is placed at the end of the enum in order to preserve the encoded
+    // representation of the prior variants.
+    #[cfg(feature = "transparent-inputs")]
+    InternalTransparent {
+        receiving_account: AccountId,
+    },
 }
 
 #[cfg(feature = "pczt")]
@@ -200,6 +206,13 @@ impl<AccountId: Copy> PcztRecipient<AccountId> {
                 receiving_account, ..
             } => (
                 PcztRecipient::EphemeralTransparent { receiving_account },
+                None,
+            ),
+            #[cfg(feature = "transparent-inputs")]
+            BuildRecipient::InternalTransparent {
+                receiving_account, ..
+            } => (
+                PcztRecipient::InternalTransparent { receiving_account },
                 None,
             ),
             BuildRecipient::InternalAccount {
@@ -1133,6 +1146,11 @@ enum BuildRecipient<AccountId> {
         receiving_account: AccountId,
         ephemeral_address: TransparentAddress,
     },
+    #[cfg(feature = "transparent-inputs")]
+    InternalTransparent {
+        receiving_account: AccountId,
+        recipient_address: TransparentAddress,
+    },
     InternalAccount {
         receiving_account: AccountId,
         external_address: Option<ZcashAddress>,
@@ -1151,6 +1169,8 @@ impl<AccountId> BuildRecipient<AccountId> {
             },
             #[cfg(feature = "transparent-inputs")]
             BuildRecipient::EphemeralTransparent { .. } => unreachable!(),
+            #[cfg(feature = "transparent-inputs")]
+            BuildRecipient::InternalTransparent { .. } => unreachable!(),
             BuildRecipient::InternalAccount {
                 receiving_account,
                 external_address,
@@ -1182,6 +1202,14 @@ impl<AccountId> BuildRecipient<AccountId> {
                 receiving_account,
                 ephemeral_address,
                 outpoint,
+            },
+            #[cfg(feature = "transparent-inputs")]
+            BuildRecipient::InternalTransparent {
+                receiving_account,
+                recipient_address,
+            } => Recipient::InternalTransparent {
+                receiving_account,
+                recipient_address,
             },
             BuildRecipient::InternalAccount { .. } => unreachable!(),
         }
@@ -1889,6 +1917,9 @@ where
                 }
             }
             PoolType::Transparent => {
+                // Transparent change outputs (both ephemeral outputs used in multi-step
+                // proposals and non-ephemeral change sent to internal-scope addresses)
+                // are added to the transaction below, after address reservation.
                 #[cfg(not(feature = "transparent-inputs"))]
                 return Err(Error::UnsupportedChangeType(output_pool));
             }
@@ -1960,6 +1991,48 @@ where
                 change_value.value(),
                 StepOutputIndex::Change(*change_index),
             ))
+        }
+    }
+
+    // Add any transparent change outputs, sending them to the next available internal-scope
+    // (change) transparent addresses of the account. As with ephemeral addresses above, this
+    // reserves the internal addresses even if transaction construction subsequently fails.
+    #[cfg(feature = "transparent-inputs")]
+    {
+        let transparent_change_outputs: Vec<(usize, &ChangeValue)> = proposal_step
+            .balance()
+            .proposed_change()
+            .iter()
+            .enumerate()
+            .filter(|(_, change_value)| {
+                !change_value.is_ephemeral() && change_value.output_pool() == PoolType::Transparent
+            })
+            .collect();
+
+        if !transparent_change_outputs.is_empty() {
+            let addresses_and_metadata = wallet_db
+                .reserve_next_n_internal_addresses(account_id, transparent_change_outputs.len())
+                .map_err(Error::DataSource)?;
+            assert_eq!(
+                addresses_and_metadata.len(),
+                transparent_change_outputs.len()
+            );
+
+            for ((change_index, change_value), (change_address, _)) in transparent_change_outputs
+                .iter()
+                .zip(addresses_and_metadata)
+            {
+                builder.add_transparent_output(&change_address, change_value.value())?;
+                transparent_output_meta.push((
+                    BuildRecipient::InternalTransparent {
+                        receiving_account: account_id,
+                        recipient_address: change_address,
+                    },
+                    change_address,
+                    change_value.value(),
+                    StepOutputIndex::Change(*change_index),
+                ))
+            }
         }
     }
 
@@ -2902,6 +2975,10 @@ where
             (PcztRecipient::EphemeralTransparent { .. }, _) => Err(PcztError::Invalid(
                 "shielded output cannot be EphemeralTransparent".into(),
             )),
+            #[cfg(feature = "transparent-inputs")]
+            (PcztRecipient::InternalTransparent { .. }, _) => Err(PcztError::Invalid(
+                "shielded output cannot be InternalTransparent".into(),
+            )),
             (PcztRecipient::InternalAccount { receiving_account }, external_address) => {
                 Ok(Recipient::InternalAccount {
                     receiving_account,
@@ -3023,6 +3100,17 @@ where
                                     receiving_account,
                                     ephemeral_address,
                                     outpoint,
+                                }),
+                            #[cfg(feature = "transparent-inputs")]
+                            (PcztRecipient::InternalTransparent { receiving_account }, _) => output
+                                .recipient_address()
+                                .ok_or(PcztError::Invalid(
+                                    "Transparent change outputs cannot have a non-standard script_pubkey"
+                                        .into(),
+                                ))
+                                .map(|recipient_address| Recipient::InternalTransparent {
+                                    receiving_account,
+                                    recipient_address,
                                 }),
                             (
                                 PcztRecipient::InternalAccount {

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -64,9 +64,46 @@ impl FeeRule for StandardFeeRule {
     }
 }
 
+/// A policy that determines how change should be returned to the wallet when the net flows of a
+/// transaction under construction are fully transparent.
+///
+/// This policy has no effect on transactions that have any shielded inputs or outputs; change
+/// for such transactions is always returned to a shielded pool, irrespective of the policy in
+/// use. When the flows of a transaction are fully transparent, shielding change (the default)
+/// reveals the change amount as the value of the shielded output(s) in an otherwise-transparent
+/// transaction; returning the change to the transparent pool matches the behavior of
+/// transparent-only wallets (including `zcashd`) at the cost of the change remaining unshielded.
+///
+/// Transparent change is currently always sent to a P2PKH address derived under the wallet
+/// account's internal scope; returning change to the originating address when spending from a
+/// P2SH (e.g. multisig) address is not yet supported. See [zcash/librustzcash#2570] for
+/// details.
+///
+/// [zcash/librustzcash#2570]: https://github.com/zcash/librustzcash/issues/2570
+#[cfg(feature = "transparent-inputs")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TransparentChangePolicy {
+    /// Change is always returned to a shielded pool, even when the net flows of the transaction
+    /// are fully transparent.
+    ///
+    /// This is the default policy.
+    #[default]
+    ShieldChange,
+    /// When the net flows of the transaction are fully transparent, change is returned to the
+    /// transparent pool at an internal-scope (change) transparent address of the wallet, as
+    /// described in [BIP 44].
+    ///
+    /// [BIP 44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+    TransparentChangeAllowed,
+}
+
 /// `ChangeValue` represents either a proposed change output to a shielded pool
 /// (with an optional change memo), or if the "transparent-inputs" feature is
-/// enabled, an ephemeral output to the transparent pool.
+/// enabled, an output to the transparent pool: either an ephemeral output as
+/// part of a [ZIP 320] transaction pair, or a change output to an
+/// internal-scope (change) transparent address of the wallet.
+///
+/// [ZIP 320]: https://zips.z.cash/zip-0320
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChangeValue(ChangeValueInner);
 
@@ -79,6 +116,8 @@ enum ChangeValueInner {
     },
     #[cfg(feature = "transparent-inputs")]
     EphemeralTransparent { value: Zatoshis },
+    #[cfg(feature = "transparent-inputs")]
+    Transparent { value: Zatoshis },
 }
 
 impl ChangeValue {
@@ -86,6 +125,13 @@ impl ChangeValue {
     #[cfg(feature = "transparent-inputs")]
     pub fn ephemeral_transparent(value: Zatoshis) -> Self {
         Self(ChangeValueInner::EphemeralTransparent { value })
+    }
+
+    /// Constructs a new change value that will be created as a non-ephemeral transparent output
+    /// sent to an internal-scope (change) transparent address of the wallet.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn transparent(value: Zatoshis) -> Self {
+        Self(ChangeValueInner::Transparent { value })
     }
 
     /// Constructs a new change value that will be created as a shielded output.
@@ -114,6 +160,8 @@ impl ChangeValue {
             ChangeValueInner::Shielded { protocol, .. } => PoolType::Shielded(*protocol),
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { .. } => PoolType::Transparent,
+            #[cfg(feature = "transparent-inputs")]
+            ChangeValueInner::Transparent { .. } => PoolType::Transparent,
         }
     }
 
@@ -123,6 +171,8 @@ impl ChangeValue {
             ChangeValueInner::Shielded { value, .. } => *value,
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { value } => *value,
+            #[cfg(feature = "transparent-inputs")]
+            ChangeValueInner::Transparent { value } => *value,
         }
     }
 
@@ -132,6 +182,8 @@ impl ChangeValue {
             ChangeValueInner::Shielded { memo, .. } => memo.as_ref(),
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { .. } => None,
+            #[cfg(feature = "transparent-inputs")]
+            ChangeValueInner::Transparent { .. } => None,
         }
     }
 
@@ -146,6 +198,8 @@ impl ChangeValue {
             ChangeValueInner::Shielded { .. } => false,
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { .. } => true,
+            #[cfg(feature = "transparent-inputs")]
+            ChangeValueInner::Transparent { .. } => false,
         }
     }
 }

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -18,6 +18,8 @@ use super::{
     TransactionBalance, sapling as sapling_fees,
 };
 
+#[cfg(feature = "transparent-inputs")]
+use super::TransparentChangePolicy;
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
@@ -242,6 +244,8 @@ pub(crate) struct SinglePoolBalanceConfig<'a, P, F> {
     default_dust_threshold: Zatoshis,
     split_policy: &'a SplitPolicy,
     fallback_change_pool: ShieldedPool,
+    #[cfg(feature = "transparent-inputs")]
+    transparent_change_policy: TransparentChangePolicy,
     marginal_fee: Zatoshis,
     grace_actions: usize,
 }
@@ -255,6 +259,7 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
         default_dust_threshold: Zatoshis,
         split_policy: &'a SplitPolicy,
         fallback_change_pool: ShieldedPool,
+        #[cfg(feature = "transparent-inputs")] transparent_change_policy: TransparentChangePolicy,
         marginal_fee: Zatoshis,
         grace_actions: usize,
     ) -> Self {
@@ -265,6 +270,8 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
             default_dust_threshold,
             split_policy,
             fallback_change_pool,
+            #[cfg(feature = "transparent-inputs")]
+            transparent_change_policy,
             marginal_fee,
             grace_actions,
         }
@@ -313,6 +320,16 @@ where
 
     // We don't create a fully-transparent transaction if a change memo is used.
     let fully_transparent = net_flows.is_transparent() && change_memo.is_none();
+
+    // Whether change should be returned to the transparent pool instead of being shielded.
+    // Transparent change is only ever produced when the flows of the transaction are fully
+    // transparent, so that shielded flows never leak change information to the transparent
+    // pool.
+    #[cfg(feature = "transparent-inputs")]
+    let wants_transparent_change = fully_transparent
+        && cfg.transparent_change_policy == TransparentChangePolicy::TransparentChangeAllowed;
+    #[cfg(not(feature = "transparent-inputs"))]
+    let wants_transparent_change = false;
 
     let total_in = net_flows
         .total_in()
@@ -445,31 +462,47 @@ where
         (total_in - total_out_with_min_fee).unwrap_or(Zatoshis::ZERO),
     );
 
-    let target_change_count = wallet_meta.map_or(1, |m| {
-        usize::from(cfg.split_policy.target_output_count)
-            // If we cannot determine a total note count, fall back to a single output
-            .saturating_sub(m.total_note_count().unwrap_or(usize::MAX))
-            .max(1)
-    });
-    let target_change_counts = OutputManifest {
-        transparent: 0,
-        sapling: if change_pool == ShieldedPool::Sapling {
-            target_change_count
-        } else {
-            0
-        },
-        orchard: if change_pool == ShieldedPool::Orchard {
-            target_change_count
-        } else {
-            0
-        },
-        ironwood: if change_pool == ShieldedPool::Ironwood {
-            target_change_count
-        } else {
-            0
-        },
+    let (target_change_count, target_change_counts) = if wants_transparent_change {
+        // Transparent change is always emitted as a single output; the note-splitting policy
+        // exists to improve the spendability of shielded notes and does not apply to
+        // transparent outputs.
+        (
+            1,
+            OutputManifest {
+                transparent: 1,
+                sapling: 0,
+                orchard: 0,
+                ironwood: 0,
+            },
+        )
+    } else {
+        let target_change_count = wallet_meta.map_or(1, |m| {
+            usize::from(cfg.split_policy.target_output_count)
+                // If we cannot determine a total note count, fall back to a single output
+                .saturating_sub(m.total_note_count().unwrap_or(usize::MAX))
+                .max(1)
+        });
+        let target_change_counts = OutputManifest {
+            transparent: 0,
+            sapling: if change_pool == ShieldedPool::Sapling {
+                target_change_count
+            } else {
+                0
+            },
+            orchard: if change_pool == ShieldedPool::Orchard {
+                target_change_count
+            } else {
+                0
+            },
+            ironwood: if change_pool == ShieldedPool::Ironwood {
+                target_change_count
+            } else {
+                0
+            },
+        };
+        assert!(target_change_counts.total_shielded() == target_change_count);
+        (target_change_count, target_change_counts)
     };
-    assert!(target_change_counts.total_shielded() == target_change_count);
 
     // If we have a non-zero marginal fee, we need to check for uneconomic inputs.
     // This is basically assuming that fee rules with non-zero marginal fee are
@@ -530,7 +563,11 @@ where
                         cfg.params,
                         BlockHeight::from(target_height),
                         transparent_input_sizes.clone(),
-                        transparent_output_sizes.clone(),
+                        transparent_output_sizes
+                            .clone()
+                            // Count the standard size of the P2PKH change output when change is
+                            // to be returned to the transparent pool.
+                            .chain(wants_transparent_change.then_some(P2PKH_STANDARD_OUTPUT_SIZE)),
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
                         orchard_action_count(target_change_counts.orchard())?,
@@ -543,17 +580,22 @@ where
 
             // We obtain a split count based on the total number of notes of sufficient size
             // available in the wallet, irrespective of pool. If we don't have any wallet metadata
-            // available, we fall back to generating a single change output.
-            let split_count = usize::from(wallet_meta.map_or(NonZeroUsize::MIN, |wm| {
-                cfg.split_policy.split_count(
-                    wm.total_note_count(),
-                    wm.total_value(),
-                    // We use a saturating subtraction here because there may be insufficient funds to pay
-                    // the fee, *if* the requested number of split outputs are created. If there is no
-                    // proposed change, the split policy should recommend only a single change output.
-                    (total_in - total_out_with_max_fee).unwrap_or(Zatoshis::ZERO),
-                )
-            }));
+            // available, we fall back to generating a single change output. Transparent change is
+            // always emitted as a single output.
+            let split_count = if wants_transparent_change {
+                1
+            } else {
+                usize::from(wallet_meta.map_or(NonZeroUsize::MIN, |wm| {
+                    cfg.split_policy.split_count(
+                        wm.total_note_count(),
+                        wm.total_value(),
+                        // We use a saturating subtraction here because there may be insufficient funds to pay
+                        // the fee, *if* the requested number of split outputs are created. If there is no
+                        // proposed change, the split policy should recommend only a single change output.
+                        (total_in - total_out_with_max_fee).unwrap_or(Zatoshis::ZERO),
+                    )
+                }))
+            };
 
             // If we don't have as many change outputs as we expected, recompute the fee.
             let total_fee = if split_count < target_change_count {
@@ -596,6 +638,22 @@ where
                 NonZeroU64::new(u64::try_from(split_count).expect("usize fits into u64")).unwrap(),
             );
             let simple_case = || {
+                #[cfg(feature = "transparent-inputs")]
+                if wants_transparent_change {
+                    return (
+                        if total_change.is_zero() {
+                            // A zero-valued transparent output would be unspendable, so we omit
+                            // it. Unlike the shielded change case, omitting the output does not
+                            // reveal additional information, because transparent output values
+                            // are already publicly visible.
+                            vec![]
+                        } else {
+                            vec![ChangeValue::transparent(total_change)]
+                        },
+                        total_fee,
+                    );
+                }
+
                 (
                     (0usize..split_count)
                         .map(|i| {

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -18,6 +18,8 @@ use super::{
     sapling as sapling_fees,
 };
 
+#[cfg(feature = "transparent-inputs")]
+use super::TransparentChangePolicy;
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
@@ -30,6 +32,8 @@ pub struct SingleOutputChangeStrategy<I> {
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
+    #[cfg(feature = "transparent-inputs")]
+    transparent_change_policy: TransparentChangePolicy,
     meta_source: PhantomData<I>,
 }
 
@@ -50,8 +54,25 @@ impl<I> SingleOutputChangeStrategy<I> {
             change_memo,
             fallback_change_pool,
             dust_output_policy,
+            #[cfg(feature = "transparent-inputs")]
+            transparent_change_policy: TransparentChangePolicy::ShieldChange,
             meta_source: PhantomData,
         }
+    }
+
+    /// Sets the [`TransparentChangePolicy`] to be used by this change strategy, determining
+    /// whether change may be returned to the transparent pool when the flows of the transaction
+    /// under construction are fully transparent.
+    ///
+    /// The default is [`TransparentChangePolicy::ShieldChange`]. This policy has no effect on
+    /// transactions that involve any shielded flows.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_transparent_change_policy(
+        mut self,
+        transparent_change_policy: TransparentChangePolicy,
+    ) -> Self {
+        self.transparent_change_policy = transparent_change_policy;
+        self
     }
 }
 
@@ -95,6 +116,8 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             self.fee_rule.fixed_fee(),
             &split_policy,
             self.fallback_change_pool,
+            #[cfg(feature = "transparent-inputs")]
+            self.transparent_change_policy,
             Zatoshis::ZERO,
             0,
         );

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -25,6 +25,8 @@ use super::{
     sapling as sapling_fees,
 };
 
+#[cfg(feature = "transparent-inputs")]
+use super::TransparentChangePolicy;
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
 
@@ -69,6 +71,8 @@ pub struct SingleOutputChangeStrategy<R, I> {
     dust_output_policy: DustOutputPolicy,
     #[cfg(feature = "orchard")]
     unpadded_orchard_pool_bundles: bool,
+    #[cfg(feature = "transparent-inputs")]
+    transparent_change_policy: TransparentChangePolicy,
     meta_source: PhantomData<I>,
 }
 
@@ -91,6 +95,8 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
             dust_output_policy,
             #[cfg(feature = "orchard")]
             unpadded_orchard_pool_bundles: false,
+            #[cfg(feature = "transparent-inputs")]
+            transparent_change_policy: TransparentChangePolicy::ShieldChange,
             meta_source: PhantomData,
         }
     }
@@ -107,6 +113,21 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
     #[cfg(feature = "orchard")]
     pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
         self.unpadded_orchard_pool_bundles = true;
+        self
+    }
+
+    /// Sets the [`TransparentChangePolicy`] to be used by this change strategy, determining
+    /// whether change may be returned to the transparent pool when the flows of the transaction
+    /// under construction are fully transparent.
+    ///
+    /// The default is [`TransparentChangePolicy::ShieldChange`]. This policy has no effect on
+    /// transactions that involve any shielded flows.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_transparent_change_policy(
+        mut self,
+        transparent_change_policy: TransparentChangePolicy,
+    ) -> Self {
+        self.transparent_change_policy = transparent_change_policy;
         self
     }
 }
@@ -156,6 +177,8 @@ where
             self.fee_rule.marginal_fee(),
             &split_policy,
             self.fallback_change_pool,
+            #[cfg(feature = "transparent-inputs")]
+            self.transparent_change_policy,
             self.fee_rule.marginal_fee(),
             self.fee_rule.grace_actions(),
         );
@@ -196,6 +219,8 @@ pub struct MultiOutputChangeStrategy<R, I> {
     split_policy: SplitPolicy,
     #[cfg(feature = "orchard")]
     unpadded_orchard_pool_bundles: bool,
+    #[cfg(feature = "transparent-inputs")]
+    transparent_change_policy: TransparentChangePolicy,
     meta_source: PhantomData<I>,
 }
 
@@ -226,6 +251,8 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
             split_policy,
             #[cfg(feature = "orchard")]
             unpadded_orchard_pool_bundles: false,
+            #[cfg(feature = "transparent-inputs")]
+            transparent_change_policy: TransparentChangePolicy::ShieldChange,
             meta_source: PhantomData,
         }
     }
@@ -242,6 +269,23 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
     #[cfg(feature = "orchard")]
     pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
         self.unpadded_orchard_pool_bundles = true;
+        self
+    }
+
+    /// Sets the [`TransparentChangePolicy`] to be used by this change strategy, determining
+    /// whether change may be returned to the transparent pool when the flows of the transaction
+    /// under construction are fully transparent.
+    ///
+    /// The default is [`TransparentChangePolicy::ShieldChange`]. This policy has no effect on
+    /// transactions that involve any shielded flows. When transparent change is produced, it is
+    /// always emitted as a single output; the [`SplitPolicy`] configured for this strategy applies
+    /// only to shielded change.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_transparent_change_policy(
+        mut self,
+        transparent_change_policy: TransparentChangePolicy,
+    ) -> Self {
+        self.transparent_change_policy = transparent_change_policy;
         self
     }
 }
@@ -296,6 +340,8 @@ where
             self.fee_rule.marginal_fee(),
             &self.split_policy,
             self.fallback_change_pool,
+            #[cfg(feature = "transparent-inputs")]
+            self.transparent_change_policy,
             self.fee_rule.marginal_fee(),
             self.fee_rule.grace_actions(),
         );
@@ -1096,6 +1142,367 @@ mod tests {
             Ok(balance) if
                 balance.proposed_change() == [ChangeValue::sapling(Zatoshis::const_from_u64(1000), None)] &&
                 balance.fee_required() == Zatoshis::const_from_u64(15000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_with_transparent_change() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO that is sufficient to pay the fee. The change is
+        // returned to the transparent pool: one P2PKH input and two P2PKH outputs (the
+        // payment plus the change output) require `5000 * max(1, 2) = 10000` zats in fees,
+        // rather than the 15000 zats required when the change is shielded.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(63000),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(13000))] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_exact_match_with_transparent_change() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO that exactly covers the payment plus the minimum
+        // fee; no change output should be produced.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(50000),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change().is_empty() &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_policy_has_no_effect_on_shielded_flows() {
+        use crate::fees::TransparentChangePolicy;
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single Sapling note; because the transaction involves shielded flows, the
+        // change must be shielded even though transparent change is allowed by the policy.
+        let result = change_strategy.compute_balance(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[] as &[TestTransparentInput],
+            &[] as &[TxOut],
+            &(
+                sapling::builder::BundleType::DEFAULT,
+                &[TestSaplingInput {
+                    note_id: 0,
+                    value: Zatoshis::const_from_u64(55000),
+                }][..],
+                &[SaplingPayment::new(Zatoshis::const_from_u64(40000))][..],
+            ),
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::sapling(Zatoshis::const_from_u64(5000), None)] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_is_not_split() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = MultiOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+            SplitPolicy::with_min_output_value(
+                NonZeroUsize::new(5).unwrap(),
+                Zatoshis::const_from_u64(100_0000),
+            ),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO with change value sufficient to produce five
+        // split outputs under the split policy; because the change is returned to the
+        // transparent pool, it must nevertheless be emitted as a single output.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(750_0000),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(100_0000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &AccountMeta::new(Some(PoolMeta::new(0, Zatoshis::ZERO)), None, None),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(649_0000))] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_rejects_dust() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO that would result in a 100-zat transparent change
+        // output; under the default dust policy this must be rejected. The 55000-zat
+        // requirement reflects the 5000-zat default dust threshold: adding 4900 zats to the
+        // input value would produce change exactly at the threshold.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(50100),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Err(ChangeError::InsufficientFunds { available, required })
+                if available == Zatoshis::const_from_u64(50100)
+                   && required == Zatoshis::const_from_u64(55000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_allows_dust() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::new(
+                DustAction::AllowDustChange,
+                Some(Zatoshis::const_from_u64(1000)),
+            ),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO that results in a 100-zat transparent change
+        // output; the `AllowDustChange` policy permits emitting it even though it is below
+        // the 1000-zat dust threshold.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(50100),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(100))] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_dust_added_to_fee() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::new(DustAction::AddDustToFee, None),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Spend a single transparent UTXO that would result in a 100-zat transparent change
+        // output; under the `AddDustToFee` policy the dust value is instead added to the
+        // fee and no change output is produced.
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(50100),
+                    TransparentAddress::PublicKeyHash([0u8; 20]).script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change().is_empty() &&
+                balance.fee_required() == Zatoshis::const_from_u64(10100)
         );
     }
 

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -969,6 +969,14 @@ impl proposal::Proposal {
                                     (PoolType::Transparent, true) => {
                                         Ok(ChangeValue::ephemeral_transparent(value))
                                     }
+                                    #[cfg(feature = "transparent-inputs")]
+                                    (PoolType::Transparent, false) => {
+                                        Ok(ChangeValue::transparent(value))
+                                    }
+                                    // When all pool features are enabled, the explicit arms above
+                                    // are exhaustive over the non-ephemeral cases; this fallback
+                                    // remains reachable when some pool features are disabled.
+                                    #[allow(unreachable_patterns)]
                                     (pool, false) => {
                                         Err(ProposalDecodingError::InvalidChangeRecipient(pool))
                                     }

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -145,6 +145,10 @@ pub struct TransactionBalance {
 /// an ephemeral output, which must be spent by a subsequent step. This is
 /// only supported for transparent outputs. Each ephemeral output will be
 /// given a unique t-address.
+///
+/// When the transparent value pool is selected and the `isEphemeral` field
+/// is not set, the value represents transparent change, which will be sent
+/// to an internal-scope (change) transparent address of the wallet.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChangeValue {
     /// The value of a change or ephemeral output to be created, in zatoshis.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,16 @@ workspace.
 ## Unreleased
 
 ### Added
+- `WalletDb` now implements the new
+  `WalletWrite::reserve_next_n_internal_addresses` method (behind the
+  `transparent-inputs` feature flag), reserving internal-scope (change)
+  transparent addresses subject to the internal-scope gap limit. This is used
+  to allocate recipient addresses for non-ephemeral transparent change
+  outputs when a change strategy is configured with
+  `zcash_client_backend::fees::TransparentChangePolicy::TransparentChangeAllowed`.
+  No new migration is required: internal-scope gap addresses are already
+  generated at account creation, and received transparent change outputs are
+  recorded via the existing `Recipient::InternalTransparent` handling.
 - A new migration adds a `note_version` column to `orchard_received_notes`,
   recording the note plaintext version from which each received note was
   obtained. The Orchard note encryption domain accepts only version 2 note

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1496,6 +1496,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.reserve_next_n_ephemeral_addresses(account_id, n))
     }
 
+    #[cfg(feature = "transparent-inputs")]
+    fn reserve_next_n_internal_addresses(
+        &mut self,
+        account_id: Self::AccountId,
+        n: usize,
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        self.transactionally(|wdb| wdb.reserve_next_n_internal_addresses(account_id, n))
+    }
+
     fn set_transaction_status(
         &mut self,
         txid: TxId,
@@ -1875,6 +1884,25 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
             account_id,
             TransparentKeyScope::EPHEMERAL,
             self.gap_limits.ephemeral(),
+            n,
+        )?;
+
+        Ok(reserved.into_iter().map(|(_, a, m)| (a, m)).collect())
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    fn reserve_next_n_internal_addresses(
+        &mut self,
+        account_id: Self::AccountId,
+        n: usize,
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+        let account_id = wallet::get_account_ref(self.conn.0, account_id)?;
+        let reserved = wallet::transparent::reserve_next_n_addresses(
+            self.conn.0,
+            &self.params,
+            account_id,
+            TransparentKeyScope::INTERNAL,
+            self.gap_limits.internal(),
             n,
         )?;
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2936,6 +2936,37 @@ mod tests {
     }
 
     #[test]
+    fn reserve_next_n_internal_addresses_gap_limit() {
+        zcash_client_backend::data_api::testing::transparent::reserve_next_n_internal_addresses_gap_limit(
+            TestDbFactory::default(),
+            BlockCache::new(),
+            |e, _, expected_bad_index| {
+                matches!(
+                    e,
+                    SqliteClientError::ReachedGapLimit(scope, bad_index)
+                    if scope == &TransparentKeyScope::INTERNAL && bad_index == &expected_bad_index
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn propose_t2t_with_transparent_change() {
+        zcash_client_backend::data_api::testing::transparent::propose_t2t_with_transparent_change(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
+    fn propose_t2t_transparent_change_exact_match() {
+        zcash_client_backend::data_api::testing::transparent::propose_t2t_transparent_change_exact_match(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
     fn propose_t2shielded_requires_transparent_regather() {
         zcash_client_backend::data_api::testing::transparent::propose_t2shielded_requires_transparent_regather(
             TestDbFactory::default(),


### PR DESCRIPTION
Closes #1839.

Adds support for returning change to the transparent pool when the net flows of a transaction under construction are fully transparent, enabling `zallet` to replicate `zcashd`'s `z_sendmany` behavior for fully-transparent spends. Builds on the transparent-spending support for `propose_transaction` added in #2422.

All new API surface is gated on the `transparent-inputs` feature flag.

## Design

- **`fees::TransparentChangePolicy`** — a new policy enum with variants `ShieldChange` (the default, preserving existing behavior) and `TransparentChangeAllowed`. Configured on the ZIP 317 and fixed change strategies via new `with_transparent_change_policy` builder methods. The policy only takes effect when the transaction's net flows are fully transparent; transactions involving shielded flows always shield their change, so no shielded change information is ever leaked to the transparent pool.
- **`ChangeValue::transparent(value)`** — a new non-ephemeral transparent change value, distinct from the ephemeral (ZIP 320) transparent output value. Transparent change is always emitted as a single output (the note-splitting policy applies only to shielded change), the exact-balance no-change case is preserved, zero-valued transparent outputs are never created, and the existing `DustOutputPolicy` machinery applies. The proposal protobuf encoding is wire-compatible: transparent change is encoded with the existing transparent `valuePool` and `isEphemeral` unset, a combination that previously failed to decode.
- **`WalletWrite::reserve_next_n_internal_addresses`** — reserves BIP 44 internal-scope (change) transparent addresses, parallel to the existing ephemeral reservation API. The `zcash_client_sqlite` implementation reuses the existing scope-generic reservation machinery and internal-scope gap limit; no migration is required, since internal-scope gap addresses are already generated at account creation and received change is recorded via the existing `Recipient::InternalTransparent` handling.
- `create_proposed_transactions` (and the PCZT construction/extraction paths) now realize transparent change outputs by reserving internal-scope addresses and recording the outputs against the receiving account.

Because general (non-shielding) transfers exclude coinbase UTXOs from input selection (`CoinbaseFilter::NonCoinbaseOnly`), transparent change can never be produced by a transaction that spends coinbase outputs, structurally satisfying `zcashd`'s coinbase-spend-forbids-change rule.

## Testing

- Fees-level unit tests covering the transparent-change branch, the exact-match no-change case, the shielded-flows no-op, non-splitting of transparent change, and dust rejection.
- End-to-end tests of the full t→t-with-change lifecycle: proposal, proposal serialization round trip, transaction creation, internal-scope address reservation/exposure, and post-mining spendability of the change output at the change address.
- Gap-limit enforcement tests for internal-scope address reservation, including independence from ephemeral-scope reservations.
- Verified with `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, workspace checks across feature combinations (`--no-default-features`, `transparent-inputs` alone and with `orchard`), intra-doc link validation, and the full `zcash_client_sqlite` test suite (319 passed).

## AI disclosure

The commits in this PR were prepared with AI assistance (Claude / opencode) and carry `Co-Authored-By` trailers accordingly. I have reviewed and take responsibility for all changes.