### PR TITLE
Add opt-in unpadded Orchard-pool bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2988,7 +2988,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9#3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9"
+source = "git+https://github.com/zcash/orchard?rev=7e8aa3d2dd174b6db2f0997190eab87d330d2314#7e8aa3d2dd174b6db2f0997190eab87d330d2314"
 dependencies = [
  "aes",
  "bitvec",
@@ -4031,7 +4031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,8 +2988,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
+source = "git+https://github.com/zcash/orchard?rev=3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9#3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=9e45f5fbbedb12bd456b3340e35e535e03c8b6ee#9e45f5fbbedb12bd456b3340e35e535e03c8b6ee"
+source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1614,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2988,7 +2988,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=7e8aa3d2dd174b6db2f0997190eab87d330d2314#7e8aa3d2dd174b6db2f0997190eab87d330d2314"
+source = "git+https://github.com/zcash/orchard?rev=9e45f5fbbedb12bd456b3340e35e535e03c8b6ee#9e45f5fbbedb12bd456b3340e35e535e03c8b6ee"
 dependencies = [
  "aes",
  "bitvec",
@@ -4031,7 +4031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,3 +235,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
+# TEMPORARY: orchard revision that keeps `BundleType::DEFAULT` padded and adds the
+# opt-in `BundleType::DEFAULT_UNPADDED` + `Builder::bundle_type()`; replace with a
+# published orchard release once one carries these.
+orchard = { git = "https://github.com/zcash/orchard", rev = "3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,4 +238,4 @@ incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmer
 # TEMPORARY: orchard revision that keeps `BundleType::DEFAULT` padded and adds the
 # opt-in `BundleType::DEFAULT_UNPADDED` + `Builder::bundle_type()`; replace with a
 # published orchard release once one carries these.
-orchard = { git = "https://github.com/zcash/orchard", rev = "3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "7e8aa3d2dd174b6db2f0997190eab87d330d2314" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,4 +238,4 @@ incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmer
 # TEMPORARY: orchard revision that keeps `BundleType::DEFAULT` padded and adds the
 # opt-in `BundleType::DEFAULT_UNPADDED` + `Builder::bundle_type()`; replace with a
 # published orchard release once one carries these.
-orchard = { git = "https://github.com/zcash/orchard", rev = "9e45f5fbbedb12bd456b3340e35e535e03c8b6ee" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,4 +238,4 @@ incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmer
 # TEMPORARY: orchard revision that keeps `BundleType::DEFAULT` padded and adds the
 # opt-in `BundleType::DEFAULT_UNPADDED` + `Builder::bundle_type()`; replace with a
 # published orchard release once one carries these.
-orchard = { git = "https://github.com/zcash/orchard", rev = "7e8aa3d2dd174b6db2f0997190eab87d330d2314" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "9e45f5fbbedb12bd456b3340e35e535e03c8b6ee" }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -106,6 +106,7 @@ fn transparent_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -271,6 +272,7 @@ fn transparent_p2sh_multisig_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -480,6 +482,7 @@ fn sapling_to_orchard() {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -643,6 +646,7 @@ fn orchard_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -854,6 +858,7 @@ fn orchard_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -1052,6 +1057,7 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: Some(anchor),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -846,6 +846,10 @@ criteria = "safe-to-deploy"
 version = "11.1.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.orchard]]
+version = "0.15.0-pre.2@git:3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9"
+criteria = "safe-to-deploy"
+
 [[exemptions.ordered-float]]
 version = "2.10.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -847,7 +847,7 @@ version = "11.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.15.0-pre.2@git:3340c3cf58dd8dab8bb26ab575c00dfcbeaa9fc9"
+version = "0.15.0-pre.2@git:7e8aa3d2dd174b6db2f0997190eab87d330d2314"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -847,7 +847,7 @@ version = "11.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.15.0-pre.2@git:9e45f5fbbedb12bd456b3340e35e535e03c8b6ee"
+version = "0.15.0-pre.2@git:475ef0ff77d45aebff93cb039d639250d82518a3"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -847,7 +847,7 @@ version = "11.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.15.0-pre.2@git:7e8aa3d2dd174b6db2f0997190eab87d330d2314"
+version = "0.15.0-pre.2@git:9e45f5fbbedb12bd456b3340e35e535e03c8b6ee"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -149,8 +149,18 @@ workspace.
   (behind the `pczt` feature flag), returned by `create_pczt_from_proposal`
   when the caller-supplied `target_expiry_height` is a nonzero height below
   the proposal's minimum target height.
+- `zcash_client_backend::fees::zip317::{SingleOutputChangeStrategy, MultiOutputChangeStrategy}`
+  gained `with_unpadded_orchard_pool_bundles`, which makes fee and change calculation
+  count Orchard and Ironwood bundles without the 2-action padding minimum. The default
+  behavior is unchanged (padded). Proposals created with this option must be executed
+  with a matching unpadded builder configuration.
 
 ### Changed
+- `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes an
+  `orchard_pool_bundle_type` argument (behind the `pczt` feature flag) selecting the
+  transactional bundle type for the Orchard and Ironwood bundles; it must match the
+  change strategy used to create the proposal. Pass
+  `orchard::builder::BundleType::DEFAULT` for the previous (padded) behavior.
 - `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
   an optional accessor that wallet backends can override to provide Ironwood
   anchors and witnesses to the transaction builder.

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -72,7 +72,7 @@ subtle.workspace = true
 # - Shielded protocols
 bls12_381.workspace = true
 group.workspace = true
-orchard = { workspace = true, optional = true }
+orchard.workspace = true
 sapling.workspace = true
 
 # - Transparent protocol
@@ -203,7 +203,12 @@ transparent-key-import = ["transparent-inputs"]
 spend-index = ["transparent-inputs"]
 
 ## Enables receiving and spending Orchard funds.
-orchard = ["dep:orchard", "dep:pasta_curves", "zcash_keys/orchard"]
+##
+## The `orchard` crate itself is an unconditional dependency (via
+## `zcash_primitives`, which always requires it because every v5+ transaction
+## carries an Orchard bundle type); this feature gates the wallet's
+## Orchard note-handling code, not the crate linkage.
+orchard = ["dep:pasta_curves", "zcash_keys/orchard"]
 
 ## Enables compatibility with legacy zcashd wallet data
 zcashd-compat = ["zcash_keys/zcashd-compat"]
@@ -279,7 +284,7 @@ test-dependencies = [
     "dep:rand",
     "dep:rand_chacha",
     "transparent/test-dependencies",
-    "orchard?/test-dependencies",
+    "orchard/test-dependencies",
     "zcash_keys/test-dependencies",
     "zcash_primitives/test-dependencies",
     "zcash_proofs/bundled-prover",

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1304,6 +1304,7 @@ where
             ovk_policy,
             proposal,
             target_expiry_height,
+            ::orchard::builder::BundleType::DEFAULT,
         )
     }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -59,6 +59,7 @@ use crate::{
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
     wallet::{Note, OvkPolicy, Recipient},
 };
+use orchard::builder::BundleType;
 use sapling::{
     note_encryption::{PreparedIncomingViewingKey, try_sapling_note_decryption},
     prover::{OutputProver, SpendProver},
@@ -69,7 +70,6 @@ use zcash_keys::{
     address::Address,
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
 };
-use zcash_primitives::orchard::builder::BundleType;
 use zcash_primitives::transaction::{
     Transaction, TxId,
     builder::{BuildConfig, BuildResult, Builder},

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -69,6 +69,7 @@ use zcash_keys::{
     address::Address,
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
 };
+use zcash_primitives::orchard::builder::BundleType;
 use zcash_primitives::transaction::{
     Transaction, TxId,
     builder::{BuildConfig, BuildResult, Builder},
@@ -1275,6 +1276,9 @@ fn build_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>
         (TransparentAddress, OutPoint),
     >,
     #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
+    // The transactional bundle type for the Orchard and Ironwood bundles; the PCZT path
+    // threads the proposal's configured type here, other callers pass `BundleType::DEFAULT`.
+    orchard_pool_bundle_type: BundleType,
 ) -> Result<BuildState<ParamsT, DbT::AccountId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -1519,6 +1523,7 @@ where
             sapling_anchor,
             orchard_anchor,
             ironwood_anchor,
+            orchard_pool_bundle_type,
         },
     );
 
@@ -2064,6 +2069,8 @@ where
         unused_transparent_outputs,
         #[cfg(feature = "unstable")]
         proposed_version,
+        // The non-PCZT path always builds padded Orchard-pool bundles.
+        BundleType::DEFAULT,
     )?;
 
     // Build the transaction with the specified fee rule
@@ -2297,6 +2304,12 @@ where
 /// [`min_target_height`](Proposal::min_target_height) is rejected with
 /// [`Error::ExpiryHeightBelowTargetHeight`]. A `target_expiry_height` of zero,
 /// which disables expiry, is exempt from this check.
+///
+/// `orchard_pool_bundle_type` selects the transactional bundle type for the Orchard
+/// and Ironwood bundles, and must match the change strategy used to create
+/// `proposal` (see
+/// `zip317::SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles`); pass
+/// [`BundleType::DEFAULT`](orchard::builder::BundleType) otherwise.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "pczt")]
@@ -2307,6 +2320,7 @@ pub fn create_pczt_from_proposal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
     target_expiry_height: Option<BlockHeight>,
+    orchard_pool_bundle_type: BundleType,
 ) -> Result<pczt::Pczt, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -2359,6 +2373,7 @@ where
         unused_transparent_outputs,
         #[cfg(feature = "unstable")]
         proposed_version,
+        orchard_pool_bundle_type,
     )?;
 
     // Build the transaction with the specified fee rule

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1267,6 +1267,9 @@ where
             0
         };
         orchard_fees::transactional_action_count(
+            // Input selection estimates fees with the padded default bundle type; the
+            // unpadded opt-in is applied later by the change strategy.
+            ::orchard::builder::BundleType::DEFAULT,
             orchard_bundle_version_for_height(params, target_height),
             spendable_notes.orchard.len(),
             requested_orchard_actions,
@@ -1671,6 +1674,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
+                    ::orchard::builder::BundleType::DEFAULT,
                     orchard_bundle_version_for_height(params, target_height),
                     0,
                     1,

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -249,6 +249,11 @@ pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clo
     // routed into the `ironwood` view by the caller; this carries the same decision
     // for the change output, which is computed here.
     #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
+    // The transactional bundle type the transaction builder will use for both the
+    // Orchard and Ironwood bundles; the action counts computed here must match it so
+    // the builder's exact-balance check succeeds (see
+    // `orchard_fees::transactional_action_count`).
+    #[cfg(feature = "orchard")] orchard_pool_bundle_type: ::orchard::builder::BundleType,
     change_memo: Option<&MemoBytes>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<TransactionBalance, ChangeError<E, NoteRefT>>
@@ -324,6 +329,8 @@ where
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            orchard_pool_bundle_type,
             cfg.marginal_fee,
             cfg.grace_actions,
             &possible_change[..],
@@ -355,6 +362,7 @@ where
     #[cfg(feature = "orchard")]
     let orchard_action_count = |change_count| {
         orchard_fees::transactional_action_count(
+            orchard_pool_bundle_type,
             orchard.bundle_version(),
             orchard.inputs().len(),
             orchard.outputs().len() + change_count,
@@ -380,6 +388,7 @@ where
     #[cfg(feature = "orchard")]
     let ironwood_action_count = |change_count| {
         orchard_fees::transactional_action_count(
+            orchard_pool_bundle_type,
             ironwood.bundle_version(),
             ironwood.inputs().len(),
             ironwood.outputs().len() + change_count,
@@ -670,6 +679,9 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+    // The Orchard-pool bundle type the builder will use; the action counts computed
+    // for the grace-input check must match it (see `single_pool_output_balance`).
+    #[cfg(feature = "orchard")] orchard_pool_bundle_type: ::orchard::builder::BundleType,
     marginal_fee: Zatoshis,
     grace_actions: usize,
     possible_change: &[OutputManifest],
@@ -787,6 +799,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
 
             #[cfg(feature = "orchard")]
             let o_action_count = orchard_fees::transactional_action_count(
+                orchard_pool_bundle_type,
                 orchard.bundle_version(),
                 o_req_inputs + _o_extra,
                 o_outputs_len + change.orchard,

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -113,6 +113,9 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
+            // The fixed-fee strategy has no unpadded opt-in; keep the padded default.
+            #[cfg(feature = "orchard")]
+            ::orchard::builder::BundleType::DEFAULT,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -6,12 +6,20 @@ use std::convert::Infallible;
 use orchard::{builder::BundleType, bundle::BundleVersion};
 use zcash_protocol::value::Zatoshis;
 
+/// Returns the number of actions the transaction builder will produce for a
+/// transactional (non-coinbase) Orchard-pool bundle of the given bundle type and
+/// version, carrying the given numbers of requested spends and outputs.
+///
+/// The caller must pass the same [`BundleType`](orchard::builder::BundleType) the
+/// transaction builder will be configured with: the builder enforces an exact
+/// balance against the fee computed from these counts.
 pub(crate) fn transactional_action_count(
+    bundle_type: BundleType,
     bundle_version: BundleVersion,
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    BundleType::DEFAULT.num_actions(bundle_version.default_flags(), num_spends, num_outputs)
+    bundle_type.num_actions(bundle_version.default_flags(), num_spends, num_outputs)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -100,7 +100,7 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
     /// bundle to the 2-action minimum.
     ///
     /// The transaction executing the proposal must be built with the matching bundle
-    /// type ([`BundleType::DEFAULT_UNPADDED`](orchard::builder::BundleType)), or the
+    /// type ([`BundleType::UNPADDED`](orchard::builder::BundleType)), or the
     /// builder's balance check will fail. Intended for transactions whose shape is
     /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
     /// documentation for the privacy trade-off.
@@ -163,7 +163,7 @@ where
 
         #[cfg(feature = "orchard")]
         let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
-            ::orchard::builder::BundleType::DEFAULT_UNPADDED
+            ::orchard::builder::BundleType::UNPADDED
         } else {
             ::orchard::builder::BundleType::DEFAULT
         };
@@ -238,7 +238,7 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
     /// bundle to the 2-action minimum.
     ///
     /// The transaction executing the proposal must be built with the matching bundle
-    /// type ([`BundleType::DEFAULT_UNPADDED`](orchard::builder::BundleType)), or the
+    /// type ([`BundleType::UNPADDED`](orchard::builder::BundleType)), or the
     /// builder's balance check will fail. Intended for transactions whose shape is
     /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
     /// documentation for the privacy trade-off.
@@ -306,7 +306,7 @@ where
 
         #[cfg(feature = "orchard")]
         let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
-            ::orchard::builder::BundleType::DEFAULT_UNPADDED
+            ::orchard::builder::BundleType::UNPADDED
         } else {
             ::orchard::builder::BundleType::DEFAULT
         };

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -67,6 +67,8 @@ pub struct SingleOutputChangeStrategy<R, I> {
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
+    #[cfg(feature = "orchard")]
+    unpadded_orchard_pool_bundles: bool,
     meta_source: PhantomData<I>,
 }
 
@@ -87,8 +89,25 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
             change_memo,
             fallback_change_pool,
             dust_output_policy,
+            #[cfg(feature = "orchard")]
+            unpadded_orchard_pool_bundles: false,
             meta_source: PhantomData,
         }
+    }
+
+    /// Requests unpadded Orchard-pool (Orchard and Ironwood) bundles: fee and change
+    /// calculation will count exactly the requested actions instead of padding each
+    /// bundle to the 2-action minimum.
+    ///
+    /// The transaction executing the proposal must be built with the matching bundle
+    /// type ([`BundleType::DEFAULT_UNPADDED`](orchard::builder::BundleType)), or the
+    /// builder's balance check will fail. Intended for transactions whose shape is
+    /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
+    /// documentation for the privacy trade-off.
+    #[cfg(feature = "orchard")]
+    pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
+        self.unpadded_orchard_pool_bundles = true;
+        self
     }
 }
 
@@ -142,6 +161,13 @@ where
             self.fee_rule.grace_actions(),
         );
 
+        #[cfg(feature = "orchard")]
+        let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
+            ::orchard::builder::BundleType::DEFAULT_UNPADDED
+        } else {
+            ::orchard::builder::BundleType::DEFAULT
+        };
+
         single_pool_output_balance(
             cfg,
             None,
@@ -155,6 +181,8 @@ where
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
+            #[cfg(feature = "orchard")]
+            orchard_pool_bundle_type,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -169,6 +197,8 @@ pub struct MultiOutputChangeStrategy<R, I> {
     fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
     split_policy: SplitPolicy,
+    #[cfg(feature = "orchard")]
+    unpadded_orchard_pool_bundles: bool,
     meta_source: PhantomData<I>,
 }
 
@@ -197,8 +227,25 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
             fallback_change_pool,
             dust_output_policy,
             split_policy,
+            #[cfg(feature = "orchard")]
+            unpadded_orchard_pool_bundles: false,
             meta_source: PhantomData,
         }
+    }
+
+    /// Requests unpadded Orchard-pool (Orchard and Ironwood) bundles: fee and change
+    /// calculation will count exactly the requested actions instead of padding each
+    /// bundle to the 2-action minimum.
+    ///
+    /// The transaction executing the proposal must be built with the matching bundle
+    /// type ([`BundleType::DEFAULT_UNPADDED`](orchard::builder::BundleType)), or the
+    /// builder's balance check will fail. Intended for transactions whose shape is
+    /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
+    /// documentation for the privacy trade-off.
+    #[cfg(feature = "orchard")]
+    pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
+        self.unpadded_orchard_pool_bundles = true;
+        self
     }
 }
 
@@ -257,6 +304,13 @@ where
             self.fee_rule.grace_actions(),
         );
 
+        #[cfg(feature = "orchard")]
+        let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
+            ::orchard::builder::BundleType::DEFAULT_UNPADDED
+        } else {
+            ::orchard::builder::BundleType::DEFAULT
+        };
+
         single_pool_output_balance(
             cfg,
             Some(wallet_meta),
@@ -270,6 +324,8 @@ where
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
+            #[cfg(feature = "orchard")]
+            orchard_pool_bundle_type,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -765,6 +821,94 @@ mod tests {
         assert_eq!(
             with_ironwood.fee_required(),
             Zatoshis::const_from_u64(30000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn unpadded_orchard_pool_bundles_lower_the_fee() {
+        // `with_unpadded_orchard_pool_bundles` drops the ZIP 317 2-action padding floor
+        // for the Orchard and Ironwood bundles. This reuses the
+        // `ironwood_outputs_are_charged_actions` scenario, where only the single-output
+        // Ironwood bundle is below the floor, so the unpadded strategy charges it 1
+        // action instead of 2 and the fee falls by exactly one 5000-zat action.
+        let height = Network::TestNetwork
+            .activation_height(NetworkUpgrade::Nu5)
+            .unwrap()
+            .into();
+        let sapling_inputs = [TestSaplingInput {
+            note_id: 0,
+            value: Zatoshis::const_from_u64(100000),
+        }];
+        let orchard_outputs = [OrchardPayment::new(Zatoshis::const_from_u64(30000))];
+        let sapling_view = (
+            sapling::builder::BundleType::DEFAULT,
+            &sapling_inputs[..],
+            &[] as &[Infallible],
+        );
+        let orchard_view = (
+            ::orchard::bundle::BundleVersion::orchard_v2(),
+            &[] as &[Infallible],
+            &orchard_outputs[..],
+        );
+        let ironwood_view = (
+            ::orchard::bundle::BundleVersion::ironwood_v3(),
+            &[] as &[Infallible],
+            &orchard_outputs[..],
+        );
+
+        let padded_fee = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+        )
+        .compute_balance(
+            &Network::TestNetwork,
+            height,
+            &[] as &[TestTransparentInput],
+            &[] as &[TxOut],
+            &sapling_view,
+            &orchard_view,
+            &ironwood_view,
+            false,
+            None,
+            &(),
+        )
+        .unwrap()
+        .fee_required();
+
+        let unpadded_fee = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+        )
+        .with_unpadded_orchard_pool_bundles()
+        .compute_balance(
+            &Network::TestNetwork,
+            height,
+            &[] as &[TestTransparentInput],
+            &[] as &[TxOut],
+            &sapling_view,
+            &orchard_view,
+            &ironwood_view,
+            false,
+            None,
+            &(),
+        )
+        .unwrap()
+        .fee_required();
+
+        // Padded default matches `ironwood_outputs_are_charged_actions`: sapling (2) +
+        // orchard (1 payment + 1 change = 2) + ironwood (1 output, padded to 2) = 6
+        // actions = 30000 zat. Unpadded charges the single-output Ironwood bundle 1
+        // action, so the fee drops by one 5000-zat action to 25000.
+        assert_eq!(padded_fee, Zatoshis::const_from_u64(30000));
+        assert_eq!(unpadded_fee, Zatoshis::const_from_u64(25000));
+        assert_eq!(
+            padded_fee,
+            (unpadded_fee + Zatoshis::const_from_u64(5000)).unwrap()
         );
     }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -363,6 +363,7 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: None,
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let mut transparent_signing_set = TransparentSigningSet::new();

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -12,6 +12,10 @@ workspace.
 
 ### Added
 - `zcash_primitives::transaction::components::orchard::bundle_version_for_branch`
+- `zcash_primitives::orchard`, a re-export of the `orchard` crate, so that downstream
+  crates which make their own `orchard` dependency optional can still name the
+  `orchard` types that appear in this crate's public API (such as the
+  `orchard_pool_bundle_type` field added below).
 
 ### Changed
 - `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes
@@ -27,6 +31,10 @@ workspace.
   in a slot whose value pool is not supported under the transaction's consensus
   branch ID (the Orchard pool prior to NU5; the Ironwood pool prior to NU6.3)
   is now rejected as invalid data.
+- `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries an
+  `orchard_pool_bundle_type` field selecting the transactional bundle type for the
+  Orchard and Ironwood bundles. Pass `orchard::builder::BundleType::DEFAULT` to keep
+  the previous (padded) behavior.
 
 ## [0.29.0-pre.0] - 2026-06-30
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -12,10 +12,6 @@ workspace.
 
 ### Added
 - `zcash_primitives::transaction::components::orchard::bundle_version_for_branch`
-- `zcash_primitives::orchard`, a re-export of the `orchard` crate, so that downstream
-  crates which make their own `orchard` dependency optional can still name the
-  `orchard` types that appear in this crate's public API (such as the
-  `orchard_pool_bundle_type` field added below).
 
 ### Changed
 - `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -26,3 +26,8 @@ pub mod block;
 pub(crate) mod encoding;
 pub mod merkle_tree;
 pub mod transaction;
+
+/// Re-export of the `orchard` crate, whose types appear in this crate's public API
+/// (such as the bundle type carried by `BuildConfig::Standard`). This lets downstream
+/// crates that treat their own `orchard` dependency as optional still name those types.
+pub use orchard;

--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -26,8 +26,3 @@ pub mod block;
 pub(crate) mod encoding;
 pub mod merkle_tree;
 pub mod transaction;
-
-/// Re-export of the `orchard` crate, whose types appear in this crate's public API
-/// (such as the bundle type carried by `BuildConfig::Standard`). This lets downstream
-/// crates that treat their own `orchard` dependency as optional still name those types.
-pub use orchard;

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -260,10 +260,6 @@ pub enum BuildConfig {
         sapling_anchor: Option<sapling::Anchor>,
         orchard_anchor: Option<orchard::Anchor>,
         ironwood_anchor: Option<orchard::Anchor>,
-        /// The [`BundleType`](orchard::builder::BundleType) for the transactional
-        /// Orchard and Ironwood bundles. Use `BundleType::DEFAULT` unless the
-        /// transaction's shape is already public (see
-        /// `BundleType::UNPADDED`).
         orchard_pool_bundle_type: orchard::builder::BundleType,
     },
     Coinbase {

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -260,6 +260,11 @@ pub enum BuildConfig {
         sapling_anchor: Option<sapling::Anchor>,
         orchard_anchor: Option<orchard::Anchor>,
         ironwood_anchor: Option<orchard::Anchor>,
+        /// The [`BundleType`](orchard::builder::BundleType) for the transactional
+        /// Orchard and Ironwood bundles. Use `BundleType::DEFAULT` unless the
+        /// transaction's shape is already public (see
+        /// `BundleType::DEFAULT_UNPADDED`).
+        orchard_pool_bundle_type: orchard::builder::BundleType,
     },
     Coinbase {
         miner_data: Option<PushValue>,
@@ -288,9 +293,13 @@ impl BuildConfig {
         bundle_version: orchard::bundle::BundleVersion,
     ) -> Option<orchard::builder::Builder> {
         match self {
-            BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
+            BuildConfig::Standard {
+                orchard_anchor,
+                orchard_pool_bundle_type,
+                ..
+            } => orchard_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    orchard::builder::BundleType::DEFAULT,
+                    *orchard_pool_bundle_type,
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
@@ -322,10 +331,12 @@ impl BuildConfig {
         let bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
         match self {
             BuildConfig::Standard {
-                ironwood_anchor, ..
+                ironwood_anchor,
+                orchard_pool_bundle_type,
+                ..
             } => ironwood_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    orchard::builder::BundleType::DEFAULT,
+                    *orchard_pool_bundle_type,
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
@@ -362,19 +373,18 @@ fn orchard_action_count(
         .checked_add(builder.changes().len())
         .ok_or("num_outputs + num_changes overflowed")?;
 
+    // The bundle type must match the one the builder was constructed with (see
+    // `orchard_builder` / `ironwood_builder`); read it back from the builder so
+    // the two cannot drift.
+    let bundle_type = builder.bundle_type();
+
     // The flags must match those the builder constructs for each configuration (see
     // `orchard_builder`). For a `Coinbase` bundle `num_actions` ignores the flags, but supplying
     // the matching set keeps the two paths consistent.
-    let (bundle_type, flags) = if is_coinbase {
-        (
-            orchard::builder::BundleType::Coinbase,
-            orchard::bundle::Flags::SPENDS_DISABLED,
-        )
+    let flags = if is_coinbase {
+        orchard::bundle::Flags::SPENDS_DISABLED
     } else {
-        (
-            orchard::builder::BundleType::DEFAULT,
-            bundle_version.default_flags(),
-        )
+        bundle_version.default_flags()
     };
 
     bundle_type.num_actions(flags, num_spends, num_outputs)
@@ -1593,6 +1603,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
 
@@ -1613,6 +1624,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
 
@@ -1727,6 +1739,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -1783,6 +1796,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let recipient = orchard::keys::FullViewingKey::from(
@@ -1817,6 +1831,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -1904,6 +1919,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let (fvk, note, merkle_path) = ironwood_note_with_version(orchard::note::NoteVersion::V2);
@@ -1980,6 +1996,51 @@ mod tests {
         );
     }
 
+    /// `BuildConfig::Standard`'s `orchard_pool_bundle_type` controls padding: the
+    /// padded default counts a single-output bundle as 2 actions, while
+    /// `DEFAULT_UNPADDED` counts exactly the requested single action.
+    #[test]
+    #[cfg(feature = "circuits")]
+    fn orchard_pool_bundle_type_controls_padding() {
+        let recipient = orchard::keys::FullViewingKey::from(
+            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
+        )
+        .address_at(0u32, orchard::keys::Scope::External);
+
+        let config_with = |bundle_type| BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            orchard_pool_bundle_type: bundle_type,
+        };
+
+        // `orchard_v2` here: the NU6.3 `orchard_v3` version disables cross-address
+        // transfers, so a bare output cannot be added.
+        let count_for = |bundle_type| {
+            let config = config_with(bundle_type);
+            let mut builder = config
+                .orchard_builder(orchard::bundle::BundleVersion::orchard_v2())
+                .unwrap();
+            builder
+                .add_output(
+                    None,
+                    recipient,
+                    orchard::value::NoteValue::from_raw(10_000),
+                    [0u8; 512],
+                )
+                .unwrap();
+            super::orchard_action_count(
+                &builder,
+                false,
+                orchard::bundle::BundleVersion::orchard_v2(),
+            )
+            .unwrap()
+        };
+
+        assert_eq!(count_for(orchard::builder::BundleType::DEFAULT), 2);
+        assert_eq!(count_for(orchard::builder::BundleType::DEFAULT_UNPADDED), 1);
+    }
+
     #[test]
     #[cfg(feature = "circuits")]
     fn add_orchard_change_output_records_change() {
@@ -1991,6 +2052,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let fvk = orchard::keys::FullViewingKey::from(
@@ -2037,6 +2099,7 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
             target_height: sapling_activation_height,
             expiry_height: sapling_activation_height + DEFAULT_TX_EXPIRY_DELTA,
@@ -2097,6 +2160,7 @@ mod tests {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         };
         let mut builder =
             Builder::new(TEST_NETWORK, tx_height, build_config).with_expiry_height(0u32.into());
@@ -2185,6 +2249,7 @@ mod tests {
             sapling_anchor: Some(witness1.root().into()),
             orchard_anchor: None,
             ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         };
         let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
 
@@ -2227,6 +2292,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             assert_matches!(
@@ -2248,6 +2314,7 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2272,6 +2339,7 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2295,6 +2363,7 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder.set_zip233_amount(Zatoshis::const_from_u64(50000));
@@ -2322,6 +2391,7 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2359,6 +2429,7 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2405,6 +2476,7 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2454,6 +2526,7 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -263,7 +263,7 @@ pub enum BuildConfig {
         /// The [`BundleType`](orchard::builder::BundleType) for the transactional
         /// Orchard and Ironwood bundles. Use `BundleType::DEFAULT` unless the
         /// transaction's shape is already public (see
-        /// `BundleType::DEFAULT_UNPADDED`).
+        /// `BundleType::UNPADDED`).
         orchard_pool_bundle_type: orchard::builder::BundleType,
     },
     Coinbase {
@@ -1998,7 +1998,7 @@ mod tests {
 
     /// `BuildConfig::Standard`'s `orchard_pool_bundle_type` controls padding: the
     /// padded default counts a single-output bundle as 2 actions, while
-    /// `DEFAULT_UNPADDED` counts exactly the requested single action.
+    /// `UNPADDED` counts exactly the requested single action.
     #[test]
     #[cfg(feature = "circuits")]
     fn orchard_pool_bundle_type_controls_padding() {
@@ -2038,7 +2038,7 @@ mod tests {
         };
 
         assert_eq!(count_for(orchard::builder::BundleType::DEFAULT), 2);
-        assert_eq!(count_for(orchard::builder::BundleType::DEFAULT_UNPADDED), 1);
+        assert_eq!(count_for(orchard::builder::BundleType::UNPADDED), 1);
     }
 
     #[test]


### PR DESCRIPTION
Makes the transactional Orchard/Ironwood bundle type configurable instead of flipping the default: `BuildConfig::Standard` gains `orchard_pool_bundle_type`, the ZIP 317 change strategies gain `with_unpadded_orchard_pool_bundles()`, and `create_pczt_from_proposal` takes the matching bundle type. Defaults are unchanged (padded, same fees as main); a pool-migration wallet can opt in to build a single-output migration as 1 action per bundle. Requires the orchard revision that keeps `BundleType::DEFAULT` padded and adds `DEFAULT_UNPADDED`.

It also re-exports the `orchard` crate from `zcash_primitives` so crates that keep their own `orchard` dependency optional can still name the new field's type.
