### PR TITLE
DNM: WIP: Make remaining Orchard PCZT fields optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=64a887a5826e14228d1d49d77b92d555e0e807bb#64a887a5826e14228d1d49d77b92d555e0e807bb"
+source = "git+https://github.com/zcash/orchard?rev=4d32867fa2b403e474df907d74a7e2e1c4108ac3#4d32867fa2b403e474df907d74a7e2e1c4108ac3"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,4 +235,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
-orchard = { git = "https://github.com/zcash/orchard", rev = "64a887a5826e14228d1d49d77b92d555e0e807bb" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "4d32867fa2b403e474df907d74a7e2e1c4108ac3" }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -57,9 +57,6 @@ workspace.
   version separately from the version 1 serialization format.
 - PCZT version 2 serialization now omits empty Transparent, Sapling, and
   Orchard bundles.
-- PCZT version 2 Orchard bundle encodings now represent the bundle anchor and
-  per-action `cv_net` as optional fields. Absent values are restored as all zero
-  bytes in the logical `pczt::orchard` model.
 - Direct `serde` serialization implementations have been removed from the
   logical `pczt::orchard::{Bundle, Action, Spend, Output}` types.
 - `pczt::Pczt::serialize` now consumes `self` and returns
@@ -74,8 +71,50 @@ workspace.
   add, remove, or reorder actions; doing so now returns the new
   `pczt::roles::low_level_signer::OrchardParseError::SigningClosureModifiedActions`
   error and leaves the PCZT unmodified.
+- The derived fields of the logical Orchard-shaped bundles are now optional, so
+  a producer can elide them from the serialized encoding and let the receiver
+  recompute them (byte-identically) from the note component fields it already
+  holds:
+  - `pczt::orchard::Action::cv_net`, `pczt::orchard::Spend::{nullifier, rk}`,
+    and `pczt::orchard::Output::{cmx, ephemeral_key, enc_ciphertext}` (and their
+    getters) are now `Option`al. `Output::out_ciphertext` remains required, as
+    it is RNG-derived and can never be recomputed.
+  - `pczt::orchard::Bundle::anchor` (and its getter) is now `Option`al. An
+    elided anchor is refilled with the fixed `Anchor::empty_tree()` placeholder
+    rather than recomputed, which is only sound on transports where the anchor
+    is not part of the signed data (the v6 transaction format excludes it from
+    the txid/sighash digest). Fill and parse paths reject anchor elision before
+    v6; the extracting wallet must install the real anchor.
+  - The Combiner merges these fields like other optional fields, so a
+    fully-populated copy fills a peer's omissions.
+  - Parsing an Orchard-shaped bundle (in any role) recomputes elided fields
+    before constructing the protocol types, so every parsing consumer continues
+    to see fully-populated actions. In particular the low-level Signer accepts
+    an elided PCZT and returns it filled.
+  - The version 2 encoding carries these fields as optional (and each output's
+    memo-kind tag), so an elided PCZT serializes without them. The released
+    version 1 encoding is unchanged on the wire; it cannot represent the
+    omissions and rejects such PCZTs with the new
+    `pczt::EncodingError::RequiresV2`.
 
 ### Added
+- `pczt::orchard::MemoKind`, a one-byte tag naming the memo (dummy, or the ZIP
+  302 empty memo) under which an elided `enc_ciphertext` is reconstructed.
+- `pczt::orchard::Output::memo_kind`, the elision metadata set by the Redactor
+  and consumed by the fill.
+- `pczt::Pczt::fill_derived_fields` and
+  `pczt::orchard::Bundle::fill_derived_fields`, which recompute and fill every
+  elided derived field in place (the inverse of the redactor's `clear_*`
+  methods), for consumers that read the wire-format fields directly.
+- `pczt::orchard::FillError`, the error type of the fill. Its
+  `AnchorElisionRequiresV6` variant is returned when a pre-v6 PCZT elides an
+  anchor.
+- `pczt::roles::low_level_signer::OrchardParseError::Fill`.
+- Redactor methods for eliding the recomputable fields:
+  `pczt::roles::redactor::orchard::ActionRedactor::{clear_cv_net,
+  clear_nullifier, clear_rk, clear_cmx, clear_ephemeral_key,
+  clear_enc_ciphertext}` and
+  `pczt::roles::redactor::orchard::OrchardRedactor::clear_anchor`.
 - `pczt::roles::creator::Error`, the error type returned by the now-fallible
   `Creator` methods.
 - `pczt::parse`, a free function for parsing PCZT encodings.
@@ -83,10 +122,15 @@ workspace.
 - `pczt::EncodingError::UnsupportedOrchardNoteVersion`, returned when an
   Orchard note plaintext version cannot be represented in the version 1 PCZT
   encoding.
+- `pczt::EncodingError::RequiresV2`, returned when a PCZT that elides derived
+  fields or an anchor (or carries a memo-kind tag) is encoded to the version 1
+  PCZT encoding, which cannot represent the omissions.
 - `pczt::v1`, a module providing the version 1 PCZT serialization format via
   `pczt::v1::Pczt`.
 - PCZT version 2 serialization, which encodes the Orchard note plaintext
-  version at the Orchard bundle level.
+  version at the Orchard bundle level, and in which the six derived
+  Orchard-shaped fields and the bundle anchor may be omitted and each output
+  carries an optional memo-kind tag.
 - `PartialEq` is now derived for the logical `pczt::transparent::{Bundle, Input,
   Output}`, `pczt::sapling::{Bundle, Spend, Output}`, and
   `pczt::orchard::{Bundle, Action, Spend, Output}` types (used to detect empty
@@ -104,6 +148,9 @@ workspace.
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,
   `pczt::roles::verifier::OrchardError`, and `pczt::roles::prover::OrchardError`.
+- `Pczt::fill_missing_spend_fvks_for_zip32_path` and
+  `pczt::orchard::Bundle::fill_missing_spend_fvks_for_zip32_path` for restoring
+  omitted spend FVKs from wallet-known ZIP 32 account keys before signing.
 
 ## [0.7.0] - 2026-06-02
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -191,6 +191,14 @@ pub mod v1 {
 }
 
 /// Types and operations for the v2 Pczt encoding.
+///
+/// In the Orchard-shaped bundles of this encoding the derived fields (`cv_net`,
+/// `nullifier`, `rk`, `cmx`, `ephemeral_key`, `enc_ciphertext`) and the bundle
+/// `anchor` are optional, and each output carries an optional
+/// [`MemoKind`](crate::orchard::MemoKind) tag. A producer elides those fields with the
+/// Redactor to shrink the encoding, and the receiver recomputes them with
+/// `Pczt::fill_derived_fields` (which requires the `orchard` feature; parsing the
+/// bundles also performs the fill implicitly).
 pub mod v2 {
     use alloc::vec::Vec;
     use serde::{Deserialize, Serialize};
@@ -225,19 +233,18 @@ pub mod v2 {
     }
 
     /// Encodes the in-memory [`super::Pczt`] into the v2 serialization type [`Pczt`],
-    /// omitting empty Transparent, Sapling, and Orchard bundles.
-    impl TryFrom<super::Pczt> for Pczt {
-        type Error = super::EncodingError;
-
-        fn try_from(pczt: super::Pczt) -> Result<Self, Self::Error> {
-            Ok(Self {
+    /// omitting empty Transparent, Sapling, and Orchard bundles. Infallible: the v2
+    /// encoding can represent every in-memory PCZT.
+    impl From<super::Pczt> for Pczt {
+        fn from(pczt: super::Pczt) -> Self {
+            Self {
                 global: pczt.global,
                 transparent: (pczt.transparent != transparent::EMPTY_BUNDLE)
                     .then_some(pczt.transparent),
                 sapling: (pczt.sapling != sapling::EMPTY_BUNDLE).then_some(pczt.sapling),
-                orchard: orchard::v2::encode(pczt.orchard, &orchard::EMPTY_ORCHARD)?,
-                ironwood: orchard::v2::encode(pczt.ironwood, &orchard::EMPTY_IRONWOOD)?,
-            })
+                orchard: orchard::v2::encode(pczt.orchard, &orchard::EMPTY_ORCHARD),
+                ironwood: orchard::v2::encode(pczt.ironwood, &orchard::EMPTY_IRONWOOD),
+            }
         }
     }
 
@@ -274,7 +281,7 @@ pub mod v2 {
                 .unwrap()
                 .build();
 
-            let encoded = Pczt::try_from(pczt).unwrap();
+            let encoded = Pczt::from(pczt);
 
             assert!(encoded.transparent.is_none());
             assert!(encoded.sapling.is_none());
@@ -304,7 +311,7 @@ pub mod v2 {
                 .unwrap()
                 .build();
 
-            let encoded = Pczt::try_from(pczt).unwrap();
+            let encoded = Pczt::from(pczt);
 
             assert!(encoded.transparent.is_none());
             assert!(encoded.sapling.is_some());
@@ -313,7 +320,7 @@ pub mod v2 {
             let decoded = crate::parse(&encoded.serialize()).unwrap();
 
             assert_eq!(decoded.sapling.anchor, [1; 32]);
-            assert_eq!(decoded.orchard.anchor, [2; 32]);
+            assert_eq!(decoded.orchard.anchor, Some([2; 32]));
         }
 
         #[test]
@@ -326,7 +333,7 @@ pub mod v2 {
 
             // A bundle whose flags or note version differ from the canonical empty
             // bundle is not omitted, so that those fields round-trip losslessly.
-            let encoded = Pczt::try_from(pczt.clone()).unwrap();
+            let encoded = Pczt::from(pczt.clone());
             assert!(encoded.orchard.is_some());
 
             let decoded = crate::Pczt::from(encoded);
@@ -346,6 +353,10 @@ pub enum EncodingError {
     UnsupportedTxVersion,
     /// The v1 PCZT encoding does not support this Orchard note plaintext version.
     UnsupportedOrchardNoteVersion,
+    /// The PCZT elides fields this encoding cannot represent (an elided derived
+    /// Orchard-shaped field, an elided bundle anchor, or a memo-kind tag). Encode it
+    /// with [`v2`] instead.
+    RequiresV2,
 }
 
 impl Pczt {
@@ -374,7 +385,40 @@ impl Pczt {
     ///
     /// To serialize a specific PCZT version, e.g. v1, use [`v1::Pczt::serialize`].
     pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
-        Ok(v2::Pczt::try_from(self)?.serialize())
+        Ok(v2::Pczt::from(self).serialize())
+    }
+
+    /// Recomputes and fills, in place, every elided derived field across the PCZT's
+    /// Orchard and Ironwood bundles; see
+    /// [`orchard::Bundle::fill_derived_fields`](crate::orchard::Bundle::fill_derived_fields)
+    /// for the per-bundle contract. On error the PCZT may be left partially filled.
+    #[cfg(feature = "orchard")]
+    pub fn fill_derived_fields(&mut self) -> Result<(), crate::orchard::FillError> {
+        let tx_version = self.global.tx_version;
+        self.orchard.fill_derived_fields(tx_version)?;
+        self.ironwood.fill_derived_fields(tx_version)
+    }
+
+    /// Fills missing Orchard and Ironwood spend FVK bytes for actions whose ZIP 32
+    /// derivation matches the supplied seed fingerprint and account path.
+    ///
+    /// This prepares a PCZT whose wire encoding omitted account FVKs for
+    /// [`Self::fill_derived_fields`], allowing `nullifier` and `rk` to be
+    /// recomputed from a locally derived FVK.
+    #[cfg(feature = "orchard")]
+    pub fn fill_missing_spend_fvks_for_zip32_path(
+        &mut self,
+        seed_fingerprint: &[u8; 32],
+        derivation_path: &[u32],
+        fvk: [u8; 96],
+    ) -> usize {
+        self.orchard
+            .fill_missing_spend_fvks_for_zip32_path(seed_fingerprint, derivation_path, fvk)
+            + self.ironwood.fill_missing_spend_fvks_for_zip32_path(
+                seed_fingerprint,
+                derivation_path,
+                fvk,
+            )
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided
@@ -462,6 +506,7 @@ impl Pczt {
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
         let orchard = orchard
             .into_parsed_with_version(
+                global.tx_version,
                 crate::orchard::bundle_version_for_revision(
                     orchard_protocol_revision,
                     ::orchard::ValuePool::Orchard,
@@ -470,7 +515,7 @@ impl Pczt {
             )
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
-            .into_ironwood_parsed()
+            .into_ironwood_parsed(global.tx_version)
             .map_err(ExtractError::IronwoodParse)?;
 
         let lock_time = determine_lock_time(&global, transparent.inputs())

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -12,6 +12,7 @@ use getset::Getters;
 use orchard::bundle::BundleVersion;
 #[cfg(feature = "orchard")]
 pub(crate) use orchard::note::NoteVersion;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     common::{Global, Zip32Derivation},
@@ -57,9 +58,13 @@ pub struct Bundle {
 
     /// The Orchard anchor for this transaction.
     ///
-    /// Set by the Creator.
+    /// Set by the Creator. A producer may elide it on transports where the anchor is
+    /// not part of the signed data (the v6 transaction format excludes it from the
+    /// txid/sighash digest); the receiver refills it with a fixed placeholder (see
+    /// `Bundle::fill_derived_fields`, which requires the `orchard` feature), and the
+    /// extracting wallet must install the real anchor.
     #[getset(get = "pub")]
-    pub(crate) anchor: [u8; 32],
+    pub(crate) anchor: Option<[u8; 32]>,
 
     /// The note plaintext version for notes in this bundle.
     pub(crate) note_version: NoteVersion,
@@ -86,6 +91,21 @@ pub(crate) const ORCHARD_SPENDS_AND_OUTPUTS_ENABLED: u8 = 0b0000_0011;
 /// and the flag value of an empty bundle for serialization purposes.
 pub(crate) const IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED: u8 = 0b0000_0111;
 
+/// The byte encoding of `orchard::Anchor::empty_tree()` at `MERKLE_DEPTH_ORCHARD`.
+///
+/// This placeholder is installed only after decoding: `clear_anchor` serializes
+/// the omission as `None`, so these bytes are not sent on the wire. When
+/// `fill_derived_fields` sees that omission, it installs this value so
+/// parse/signing paths that require a concrete anchor can build the protocol
+/// bundle. This is sound for the v6 signer transport because the anchor is not
+/// part of the txid/sighash digest. A finalizing wallet must still restore the
+/// real anchor before proving/extraction, and the Combiner treats this value as
+/// replaceable in unproved v6 bundles.
+const EMPTY_TREE_ANCHOR: [u8; 32] = [
+    0xae, 0x29, 0x35, 0xf1, 0xdf, 0xd8, 0xa2, 0x4a, 0xed, 0x7c, 0x70, 0xdf, 0x7d, 0xe3, 0xa6, 0x68,
+    0xeb, 0x7a, 0x49, 0xb1, 0x31, 0x98, 0x80, 0xdd, 0xe2, 0xbb, 0xd9, 0x03, 0x1a, 0xe5, 0xd8, 0x2f,
+];
+
 /// The canonical empty Orchard-pool bundle: the form the Orchard slot of a PCZT takes
 /// when it carries no Orchard-protocol data. The Creator, the v1 decoder, and the v2
 /// decoder all produce exactly this value for an absent bundle, so that copies of a
@@ -94,7 +114,7 @@ pub(crate) const EMPTY_ORCHARD: Bundle = Bundle {
     actions: Vec::new(),
     flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
     value_sum: (0, false),
-    anchor: [0; 32],
+    anchor: Some([0; 32]),
     note_version: NoteVersion::V2,
     zkproof: None,
     bsk: None,
@@ -105,11 +125,42 @@ pub(crate) const EMPTY_IRONWOOD: Bundle = Bundle {
     actions: Vec::new(),
     flags: IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
     value_sum: (0, false),
-    anchor: [0; 32],
+    anchor: Some([0; 32]),
     note_version: NoteVersion::V3,
     zkproof: None,
     bsk: None,
 };
+
+/// The memo carried by an output whose `enc_ciphertext` has been elided from the wire.
+///
+/// Reconstructing an elided `enc_ciphertext` (see `Bundle::fill_derived_fields`, which
+/// requires the `orchard` feature) requires the note's 512-byte memo. Wallets that
+/// elide it only ever attach one of two memo constants, so the wire carries this
+/// one-byte tag in its place.
+///
+/// The variant order is part of the v2 wire encoding (postcard serializes the variant
+/// index: `Dummy` = 0, `Empty` = 1) and must not change.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoKind {
+    /// The all-zero memo, `[0u8; 512]`, as attached to dummy outputs.
+    Dummy,
+    /// The [ZIP 302] empty memo: `0xF6` followed by 511 zero bytes.
+    ///
+    /// [ZIP 302]: https://zips.z.cash/zip-0302
+    Empty,
+}
+
+impl MemoKind {
+    /// Returns the 512-byte memo this tag denotes.
+    #[cfg(feature = "orchard")]
+    fn memo(self) -> [u8; 512] {
+        let mut memo = [0u8; 512];
+        if let MemoKind::Empty = self {
+            memo[0] = 0xF6;
+        }
+        memo
+    }
+}
 
 /// Information about an Orchard action within a transaction.
 #[derive(Clone, Debug, PartialEq, Getters)]
@@ -117,11 +168,13 @@ pub struct Action {
     //
     // Action effecting data.
     //
-    // These are required fields that are part of the final transaction, and are filled in
-    // by the Constructor when adding an output.
+    // These fields are part of the final transaction. The Constructor fills them in
+    // when adding an output, but a producer may elide any of the derived ones (here,
+    // `cv_net`) and let the receiver recompute it from the note component fields. See
+    // [`Bundle::fill_derived_fields`].
     //
     #[getset(get = "pub")]
-    pub(crate) cv_net: [u8; 32],
+    pub(crate) cv_net: Option<[u8; 32]>,
     #[getset(get = "pub")]
     pub(crate) spend: Spend,
     #[getset(get = "pub")]
@@ -145,13 +198,16 @@ pub struct Spend {
     //
     // Spend-specific Action effecting data.
     //
-    // These are required fields that are part of the final transaction, and are filled in
-    // by the Constructor when adding a spend.
+    // These fields are part of the final transaction. The Constructor fills them in
+    // when adding a spend, but a producer may elide the derived ones (`nullifier` and
+    // `rk`) and let the receiver recompute them; the recomputation requires the wire
+    // `fvk`, so a producer that redacts `fvk` must keep them. See
+    // [`Bundle::fill_derived_fields`].
     //
     #[getset(get = "pub")]
-    pub(crate) nullifier: [u8; 32],
+    pub(crate) nullifier: Option<[u8; 32]>,
     #[getset(get = "pub")]
-    pub(crate) rk: [u8; 32],
+    pub(crate) rk: Option<[u8; 32]>,
 
     /// The spend authorization signature.
     ///
@@ -231,21 +287,34 @@ pub struct Output {
     //
     // Output-specific Action effecting data.
     //
-    // These are required fields that are part of the final transaction, and are filled in
-    // by the Constructor when adding an output.
+    // These fields are part of the final transaction. The Constructor fills them in
+    // when adding an output, but a producer may elide the derived ones (`cmx`,
+    // `ephemeral_key`, and `enc_ciphertext`) and let the receiver recompute them from
+    // the note component fields. See [`Bundle::fill_derived_fields`].
+    // `out_ciphertext` is NOT recomputable (it is derived using RNG), so it remains
+    // required.
     //
     #[getset(get = "pub")]
-    pub(crate) cmx: [u8; 32],
+    pub(crate) cmx: Option<[u8; 32]>,
     #[getset(get = "pub")]
-    pub(crate) ephemeral_key: [u8; 32],
+    pub(crate) ephemeral_key: Option<[u8; 32]>,
     /// The encrypted note plaintext for the output.
     ///
     /// Encoded as a `Vec<u8>` because its length depends on the transaction version.
     ///
     /// Once we have memo bundles, we will be able to set memos independently of Outputs.
     /// For now, the Constructor sets both at the same time.
+    ///
+    /// A producer may elide it, recording the note's memo as [`Output::memo_kind`] so
+    /// the receiver can re-encrypt the note deterministically.
     #[getset(get = "pub")]
-    pub(crate) enc_ciphertext: Vec<u8>,
+    pub(crate) enc_ciphertext: Option<Vec<u8>>,
+    /// The memo carried by an elided `enc_ciphertext`; see [`MemoKind`].
+    ///
+    /// Set by the Redactor when eliding `enc_ciphertext`, and consumed (cleared) by
+    /// `Bundle::fill_derived_fields` when reconstructing it.
+    #[getset(get = "pub")]
+    pub(crate) memo_kind: Option<MemoKind>,
     /// The encrypted note plaintext for the output.
     ///
     /// Encoded as a `Vec<u8>` because its length depends on the transaction version.
@@ -384,10 +453,14 @@ pub mod v1 {
             }
 
             Ok(Self {
-                actions: bundle.actions.into_iter().map(Action::from).collect(),
+                actions: bundle
+                    .actions
+                    .into_iter()
+                    .map(Action::try_from)
+                    .collect::<Result<_, _>>()?,
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: bundle.anchor.ok_or(crate::EncodingError::RequiresV2)?,
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
             })
@@ -404,8 +477,267 @@ pub mod v1 {
                     .collect(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: Some(bundle.anchor),
                 note_version: NoteVersion::V2,
+                zkproof: bundle.zkproof,
+                bsk: bundle.bsk,
+            }
+        }
+    }
+
+    impl TryFrom<super::Action> for Action {
+        type Error = crate::EncodingError;
+
+        fn try_from(action: super::Action) -> Result<Self, Self::Error> {
+            Ok(Self {
+                // This encoding has no representation for an elided derived field;
+                // reject any action that has redacted one (see
+                // [`crate::EncodingError::RequiresV2`]).
+                cv_net: action.cv_net.ok_or(crate::EncodingError::RequiresV2)?,
+                spend: Spend::try_from(action.spend)?,
+                output: Output::try_from(action.output)?,
+                rcv: action.rcv,
+            })
+        }
+    }
+
+    impl From<Action> for super::Action {
+        fn from(action: Action) -> Self {
+            Self {
+                // This encoding always carries the derived fields; wrap them in `Some`
+                // for the live (optional) representation.
+                cv_net: Some(action.cv_net),
+                spend: super::Spend::from(action.spend),
+                output: super::Output::from(action.output),
+                rcv: action.rcv,
+            }
+        }
+    }
+
+    impl TryFrom<super::Spend> for Spend {
+        type Error = crate::EncodingError;
+
+        fn try_from(spend: super::Spend) -> Result<Self, Self::Error> {
+            Ok(Self {
+                nullifier: spend.nullifier.ok_or(crate::EncodingError::RequiresV2)?,
+                rk: spend.rk.ok_or(crate::EncodingError::RequiresV2)?,
+                spend_auth_sig: spend.spend_auth_sig,
+                recipient: spend.recipient,
+                value: spend.value,
+                rho: spend.rho,
+                rseed: spend.rseed,
+                fvk: spend.fvk,
+                witness: spend.witness,
+                alpha: spend.alpha,
+                zip32_derivation: spend.zip32_derivation,
+                dummy_sk: spend.dummy_sk,
+                proprietary: spend.proprietary,
+            })
+        }
+    }
+
+    impl From<Spend> for super::Spend {
+        fn from(spend: Spend) -> Self {
+            Self {
+                nullifier: Some(spend.nullifier),
+                rk: Some(spend.rk),
+                spend_auth_sig: spend.spend_auth_sig,
+                recipient: spend.recipient,
+                value: spend.value,
+                rho: spend.rho,
+                rseed: spend.rseed,
+                fvk: spend.fvk,
+                witness: spend.witness,
+                alpha: spend.alpha,
+                zip32_derivation: spend.zip32_derivation,
+                dummy_sk: spend.dummy_sk,
+                proprietary: spend.proprietary,
+            }
+        }
+    }
+
+    impl TryFrom<super::Output> for Output {
+        type Error = crate::EncodingError;
+
+        fn try_from(output: super::Output) -> Result<Self, Self::Error> {
+            // A memo-kind tag has no representation in this encoding either; it only
+            // accompanies an elided `enc_ciphertext`, which is rejected below.
+            if output.memo_kind.is_some() {
+                return Err(crate::EncodingError::RequiresV2);
+            }
+            Ok(Self {
+                cmx: output.cmx.ok_or(crate::EncodingError::RequiresV2)?,
+                ephemeral_key: output
+                    .ephemeral_key
+                    .ok_or(crate::EncodingError::RequiresV2)?,
+                enc_ciphertext: output
+                    .enc_ciphertext
+                    .ok_or(crate::EncodingError::RequiresV2)?,
+                out_ciphertext: output.out_ciphertext,
+                recipient: output.recipient,
+                value: output.value,
+                rseed: output.rseed,
+                ock: output.ock,
+                zip32_derivation: output.zip32_derivation,
+                user_address: output.user_address,
+                proprietary: output.proprietary,
+            })
+        }
+    }
+
+    impl From<Output> for super::Output {
+        fn from(output: Output) -> Self {
+            Self {
+                cmx: Some(output.cmx),
+                ephemeral_key: Some(output.ephemeral_key),
+                enc_ciphertext: Some(output.enc_ciphertext),
+                memo_kind: None,
+                out_ciphertext: output.out_ciphertext,
+                recipient: output.recipient,
+                value: output.value,
+                rseed: output.rseed,
+                ock: output.ock,
+                zip32_derivation: output.zip32_derivation,
+                user_address: output.user_address,
+                proprietary: output.proprietary,
+            }
+        }
+    }
+}
+
+/// Types for the v2 Orchard PCZT encoding.
+///
+/// Unlike in [`v1`], the derived fields (`Action.cv_net`, `Spend.nullifier`,
+/// `Spend.rk`, `Output.cmx`, `Output.ephemeral_key`, `Output.enc_ciphertext`) and the
+/// bundle `anchor` are optional, and each output carries an optional [`MemoKind`] tag.
+/// `out_ciphertext` stays required because it is RNG-derived and can never be
+/// recomputed. The live representation is itself optional for the derived fields,
+/// so the conversions here are 1:1 and infallible.
+pub(crate) mod v2 {
+    use alloc::collections::BTreeMap;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    use crate::common::Zip32Derivation;
+
+    use super::{MemoKind, NoteVersion};
+
+    /// A serializable representation of Orchard note plaintext versions.
+    #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+    enum SerializedNoteVersion {
+        V2,
+        V3,
+    }
+
+    impl From<NoteVersion> for SerializedNoteVersion {
+        fn from(note_version: NoteVersion) -> Self {
+            match note_version {
+                NoteVersion::V2 => Self::V2,
+                NoteVersion::V3 => Self::V3,
+            }
+        }
+    }
+
+    impl From<SerializedNoteVersion> for NoteVersion {
+        fn from(note_version: SerializedNoteVersion) -> Self {
+            match note_version {
+                SerializedNoteVersion::V2 => Self::V2,
+                SerializedNoteVersion::V3 => Self::V3,
+            }
+        }
+    }
+
+    /// PCZT fields that are specific to producing the transaction's Orchard bundle.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Bundle {
+        actions: Vec<Action>,
+        flags: u8,
+        value_sum: (u64, bool),
+        anchor: Option<[u8; 32]>,
+        note_version: SerializedNoteVersion,
+        zkproof: Option<Vec<u8>>,
+        bsk: Option<[u8; 32]>,
+    }
+
+    /// Information about an Orchard action within a transaction.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Action {
+        cv_net: Option<[u8; 32]>,
+        spend: Spend,
+        output: Output,
+        rcv: Option<[u8; 32]>,
+    }
+
+    /// Information about the spend part of an Orchard action.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Spend {
+        nullifier: Option<[u8; 32]>,
+        rk: Option<[u8; 32]>,
+        #[serde_as(as = "Option<[_; 64]>")]
+        spend_auth_sig: Option<[u8; 64]>,
+        #[serde_as(as = "Option<[_; 43]>")]
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rho: Option<[u8; 32]>,
+        rseed: Option<[u8; 32]>,
+        #[serde_as(as = "Option<[_; 96]>")]
+        fvk: Option<[u8; 96]>,
+        witness: Option<(u32, [[u8; 32]; 32])>,
+        alpha: Option<[u8; 32]>,
+        zip32_derivation: Option<Zip32Derivation>,
+        dummy_sk: Option<[u8; 32]>,
+        proprietary: BTreeMap<String, Vec<u8>>,
+    }
+
+    /// Information about the output part of an Orchard action.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Output {
+        cmx: Option<[u8; 32]>,
+        ephemeral_key: Option<[u8; 32]>,
+        enc_ciphertext: Option<Vec<u8>>,
+        memo_kind: Option<MemoKind>,
+        out_ciphertext: Vec<u8>,
+        #[serde_as(as = "Option<[_; 43]>")]
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rseed: Option<[u8; 32]>,
+        ock: Option<[u8; 32]>,
+        zip32_derivation: Option<Zip32Derivation>,
+        user_address: Option<String>,
+        proprietary: BTreeMap<String, Vec<u8>>,
+    }
+
+    impl From<super::Bundle> for Bundle {
+        fn from(bundle: super::Bundle) -> Self {
+            Self {
+                actions: bundle.actions.into_iter().map(Action::from).collect(),
+                flags: bundle.flags,
+                value_sum: bundle.value_sum,
+                anchor: bundle.anchor,
+                note_version: bundle.note_version.into(),
+                zkproof: bundle.zkproof,
+                bsk: bundle.bsk,
+            }
+        }
+    }
+
+    impl From<Bundle> for super::Bundle {
+        fn from(bundle: Bundle) -> Self {
+            Self {
+                actions: bundle
+                    .actions
+                    .into_iter()
+                    .map(super::Action::from)
+                    .collect(),
+                flags: bundle.flags,
+                value_sum: bundle.value_sum,
+                anchor: bundle.anchor,
+                note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
             }
@@ -480,6 +812,7 @@ pub mod v1 {
                 cmx: output.cmx,
                 ephemeral_key: output.ephemeral_key,
                 enc_ciphertext: output.enc_ciphertext,
+                memo_kind: output.memo_kind,
                 out_ciphertext: output.out_ciphertext,
                 recipient: output.recipient,
                 value: output.value,
@@ -498,179 +831,7 @@ pub mod v1 {
                 cmx: output.cmx,
                 ephemeral_key: output.ephemeral_key,
                 enc_ciphertext: output.enc_ciphertext,
-                out_ciphertext: output.out_ciphertext,
-                recipient: output.recipient,
-                value: output.value,
-                rseed: output.rseed,
-                ock: output.ock,
-                zip32_derivation: output.zip32_derivation,
-                user_address: output.user_address,
-                proprietary: output.proprietary,
-            }
-        }
-    }
-}
-
-/// Types for the v2 Orchard PCZT encoding.
-pub(crate) mod v2 {
-    use alloc::{collections::BTreeMap, string::String, vec::Vec};
-
-    use getset::Getters;
-    use serde::{Deserialize, Serialize};
-    use serde_with::serde_as;
-
-    use super::{NoteVersion, v1};
-
-    /// A serializable representation of Orchard note plaintext versions.
-    #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-    enum SerializedNoteVersion {
-        V2,
-        V3,
-    }
-
-    impl From<NoteVersion> for SerializedNoteVersion {
-        fn from(note_version: NoteVersion) -> Self {
-            match note_version {
-                NoteVersion::V2 => Self::V2,
-                NoteVersion::V3 => Self::V3,
-            }
-        }
-    }
-
-    impl From<SerializedNoteVersion> for NoteVersion {
-        fn from(note_version: SerializedNoteVersion) -> Self {
-            match note_version {
-                SerializedNoteVersion::V2 => Self::V2,
-                SerializedNoteVersion::V3 => Self::V3,
-            }
-        }
-    }
-
-    const ZERO_BYTES_32: [u8; 32] = [0; 32];
-
-    /// PCZT fields that are specific to producing the transaction's Orchard bundle.
-    #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
-    pub struct Bundle {
-        actions: Vec<Action>,
-        flags: u8,
-        value_sum: (u64, bool),
-        anchor: Option<[u8; 32]>,
-        note_version: SerializedNoteVersion,
-        zkproof: Option<Vec<u8>>,
-        bsk: Option<[u8; 32]>,
-    }
-
-    /// Information about an Orchard action within a transaction.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub(crate) struct Action {
-        cv_net: Option<[u8; 32]>,
-        spend: v1::Spend,
-        output: Output,
-        rcv: Option<[u8; 32]>,
-    }
-
-    /// Information about the output part of an Orchard action.
-    #[serde_as]
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub(crate) struct Output {
-        cmx: [u8; 32],
-        ephemeral_key: [u8; 32],
-        enc_ciphertext: Vec<u8>,
-        out_ciphertext: Vec<u8>,
-        #[serde_as(as = "Option<[_; 43]>")]
-        recipient: Option<[u8; 43]>,
-        value: Option<u64>,
-        rseed: Option<[u8; 32]>,
-        ock: Option<[u8; 32]>,
-        zip32_derivation: Option<crate::common::Zip32Derivation>,
-        user_address: Option<String>,
-        proprietary: BTreeMap<String, Vec<u8>>,
-    }
-
-    impl TryFrom<super::Bundle> for Bundle {
-        type Error = crate::EncodingError;
-
-        fn try_from(bundle: super::Bundle) -> Result<Self, Self::Error> {
-            Ok(Self {
-                actions: bundle
-                    .actions
-                    .into_iter()
-                    .map(Action::from)
-                    .collect::<Vec<_>>(),
-                flags: bundle.flags,
-                value_sum: bundle.value_sum,
-                anchor: (bundle.anchor != ZERO_BYTES_32).then_some(bundle.anchor),
-                note_version: bundle.note_version.into(),
-                zkproof: bundle.zkproof,
-                bsk: bundle.bsk,
-            })
-        }
-    }
-
-    impl From<Bundle> for super::Bundle {
-        fn from(bundle: Bundle) -> Self {
-            Self {
-                actions: bundle
-                    .actions
-                    .into_iter()
-                    .map(super::Action::from)
-                    .collect(),
-                flags: bundle.flags,
-                value_sum: bundle.value_sum,
-                anchor: bundle.anchor.unwrap_or(ZERO_BYTES_32),
-                note_version: bundle.note_version.into(),
-                zkproof: bundle.zkproof,
-                bsk: bundle.bsk,
-            }
-        }
-    }
-
-    impl From<super::Action> for Action {
-        fn from(action: super::Action) -> Self {
-            Self {
-                cv_net: (action.cv_net != ZERO_BYTES_32).then_some(action.cv_net),
-                spend: v1::Spend::from(action.spend),
-                output: Output::from(action.output),
-                rcv: action.rcv,
-            }
-        }
-    }
-
-    impl From<Action> for super::Action {
-        fn from(action: Action) -> Self {
-            Self {
-                cv_net: action.cv_net.unwrap_or(ZERO_BYTES_32),
-                spend: super::Spend::from(action.spend),
-                output: super::Output::from(action.output),
-                rcv: action.rcv,
-            }
-        }
-    }
-
-    impl From<super::Output> for Output {
-        fn from(output: super::Output) -> Self {
-            Self {
-                cmx: output.cmx,
-                ephemeral_key: output.ephemeral_key,
-                enc_ciphertext: output.enc_ciphertext,
-                out_ciphertext: output.out_ciphertext,
-                recipient: output.recipient,
-                value: output.value,
-                rseed: output.rseed,
-                ock: output.ock,
-                zip32_derivation: output.zip32_derivation,
-                user_address: output.user_address,
-                proprietary: output.proprietary,
-            }
-        }
-    }
-
-    impl From<Output> for super::Output {
-        fn from(output: Output) -> Self {
-            Self {
-                cmx: output.cmx,
-                ephemeral_key: output.ephemeral_key,
-                enc_ciphertext: output.enc_ciphertext,
+                memo_kind: output.memo_kind,
                 out_ciphertext: output.out_ciphertext,
                 recipient: output.recipient,
                 value: output.value,
@@ -684,100 +845,13 @@ pub(crate) mod v2 {
     }
 
     /// Encodes a logical Orchard-protocol bundle for the v2 PCZT format, owning the
-    /// decision of whether the bundle can be omitted. A bundle that is exactly equal
+    /// decision of whether the bundle can be omitted: a bundle that is exactly equal
     /// to `empty` (the canonical empty bundle for its slot, [`super::EMPTY_ORCHARD`]
     /// or [`super::EMPTY_IRONWOOD`]) serializes to `None` and is dropped from the
-    /// encoding; any other bundle is converted via the [`Bundle`]-producing
-    /// [`TryFrom`] impl. The reverse direction is [`From<Bundle>`] plus the canonical
-    /// empty bundle for the omitted case.
-    pub(crate) fn encode(
-        bundle: super::Bundle,
-        empty: &super::Bundle,
-    ) -> Result<Option<Bundle>, crate::EncodingError> {
-        (bundle != *empty)
-            .then(|| Bundle::try_from(bundle))
-            .transpose()
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use alloc::{collections::BTreeMap, vec::Vec};
-
-        use super::super::{
-            Action as LogicalAction, Bundle as LogicalBundle, NoteVersion,
-            ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output, Spend,
-        };
-
-        fn logical_action(cv_net: [u8; 32]) -> LogicalAction {
-            LogicalAction {
-                cv_net,
-                spend: Spend {
-                    nullifier: [1; 32],
-                    rk: [2; 32],
-                    spend_auth_sig: None,
-                    recipient: None,
-                    value: None,
-                    rho: None,
-                    rseed: None,
-                    fvk: None,
-                    witness: None,
-                    alpha: None,
-                    zip32_derivation: None,
-                    dummy_sk: None,
-                    proprietary: BTreeMap::new(),
-                },
-                output: Output {
-                    cmx: [3; 32],
-                    ephemeral_key: [4; 32],
-                    enc_ciphertext: Vec::new(),
-                    out_ciphertext: Vec::new(),
-                    recipient: None,
-                    value: None,
-                    rseed: None,
-                    ock: None,
-                    zip32_derivation: None,
-                    user_address: None,
-                    proprietary: BTreeMap::new(),
-                },
-                rcv: None,
-            }
-        }
-
-        fn logical_bundle(anchor: [u8; 32], cv_net: [u8; 32]) -> LogicalBundle {
-            LogicalBundle {
-                actions: vec![logical_action(cv_net)],
-                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
-                value_sum: (0, false),
-                anchor,
-                note_version: NoteVersion::V2,
-                zkproof: None,
-                bsk: None,
-            }
-        }
-
-        #[test]
-        fn zero_anchor_and_cv_net_encode_as_none() {
-            let bundle = logical_bundle([0; 32], [0; 32]);
-
-            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
-            assert!(encoded.anchor.is_none());
-            assert!(encoded.actions[0].cv_net.is_none());
-
-            let decoded = LogicalBundle::from(encoded);
-            assert_eq!(decoded, bundle);
-        }
-
-        #[test]
-        fn nonzero_anchor_and_cv_net_encode_as_some() {
-            let bundle = logical_bundle([5; 32], [6; 32]);
-
-            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
-            assert_eq!(encoded.anchor, Some([5; 32]));
-            assert_eq!(encoded.actions[0].cv_net, Some([6; 32]));
-
-            let decoded = LogicalBundle::from(encoded);
-            assert_eq!(decoded, bundle);
-        }
+    /// encoding. The reverse direction is [`From<Bundle>`] plus the canonical empty
+    /// bundle for the omitted case.
+    pub(crate) fn encode(bundle: super::Bundle, empty: &super::Bundle) -> Option<Bundle> {
+        (bundle != *empty).then(|| Bundle::from(bundle))
     }
 }
 
@@ -839,7 +913,16 @@ impl Bundle {
             },
         }
 
-        if self.anchor != anchor {
+        let self_zkproof_present = self.zkproof.is_some();
+        let other_zkproof_present = zkproof.is_some();
+        if !merge_anchor(
+            &mut self.anchor,
+            anchor,
+            self_global,
+            other_global,
+            self_zkproof_present,
+            other_zkproof_present,
+        ) {
             return None;
         }
 
@@ -874,6 +957,7 @@ impl Bundle {
                         cmx,
                         ephemeral_key,
                         enc_ciphertext,
+                        memo_kind,
                         out_ciphertext,
                         recipient: output_recipient,
                         value: output_value,
@@ -886,18 +970,23 @@ impl Bundle {
                 rcv,
             } = rhs;
 
-            if lhs.cv_net != cv_net
-                || lhs.spend.nullifier != nullifier
-                || lhs.spend.rk != rk
-                || lhs.output.cmx != cmx
-                || lhs.output.ephemeral_key != ephemeral_key
-                || lhs.output.enc_ciphertext != enc_ciphertext
-                || lhs.output.out_ciphertext != out_ciphertext
-            {
+            // `out_ciphertext` is required and never recomputable, so any divergence is
+            // a hard conflict. The derived fields (`cv_net`, `nullifier`, `rk`, `cmx`,
+            // `ephemeral_key`, `enc_ciphertext`) are optional and merge via
+            // `merge_optional`, so a participant that carries one (e.g. a receiver that
+            // recomputed it from a leaner copy) can fill in a peer's omission.
+            if lhs.output.out_ciphertext != out_ciphertext {
                 return None;
             }
 
-            if !(merge_optional(&mut lhs.spend.spend_auth_sig, spend_auth_sig)
+            if !(merge_optional(&mut lhs.cv_net, cv_net)
+                && merge_optional(&mut lhs.spend.nullifier, nullifier)
+                && merge_optional(&mut lhs.spend.rk, rk)
+                && merge_optional(&mut lhs.output.cmx, cmx)
+                && merge_optional(&mut lhs.output.ephemeral_key, ephemeral_key)
+                && merge_optional(&mut lhs.output.enc_ciphertext, enc_ciphertext)
+                && merge_optional(&mut lhs.output.memo_kind, memo_kind)
+                && merge_optional(&mut lhs.spend.spend_auth_sig, spend_auth_sig)
                 && merge_optional(&mut lhs.spend.recipient, recipient)
                 && merge_optional(&mut lhs.spend.value, value)
                 && merge_optional(&mut lhs.spend.rho, rho)
@@ -922,6 +1011,130 @@ impl Bundle {
         }
 
         Some(self)
+    }
+}
+
+fn merge_anchor(
+    lhs: &mut Option<[u8; 32]>,
+    rhs: Option<[u8; 32]>,
+    self_global: &Global,
+    other_global: &Global,
+    lhs_has_zkproof: bool,
+    rhs_has_zkproof: bool,
+) -> bool {
+    let Some(rhs) = rhs else {
+        return true;
+    };
+
+    let Some(lhs_anchor) = lhs.as_mut() else {
+        *lhs = Some(rhs);
+        return true;
+    };
+
+    if lhs_anchor == &rhs {
+        return true;
+    }
+
+    let v6_anchor_placeholder_merge = self_global.tx_version
+        == zcash_protocol::constants::V6_TX_VERSION
+        && other_global.tx_version == zcash_protocol::constants::V6_TX_VERSION
+        && ((*lhs_anchor == EMPTY_TREE_ANCHOR && !lhs_has_zkproof)
+            || (rhs == EMPTY_TREE_ANCHOR && !rhs_has_zkproof));
+
+    if v6_anchor_placeholder_merge {
+        if *lhs_anchor == EMPTY_TREE_ANCHOR && !lhs_has_zkproof {
+            *lhs_anchor = rhs;
+        }
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(all(test, feature = "orchard"))]
+mod tests {
+    use alloc::{collections::BTreeMap, vec::Vec};
+
+    use crate::common::Zip32Derivation;
+
+    use super::{Action, Bundle, NoteVersion, Output, Spend};
+
+    #[test]
+    fn fill_missing_spend_fvks_for_zip32_path_only_fills_matching_missing_fvks() {
+        let seed_fingerprint = [7u8; 32];
+        let matching_path = vec![0x8000_0020, 0x8000_0085, 0x8000_0000];
+        let other_path = vec![0x8000_0020, 0x8000_0085, 0x8000_0001];
+        let fvk = [42u8; 96];
+        let existing_fvk = [99u8; 96];
+
+        let mut bundle = Bundle {
+            actions: vec![
+                action_with_fvk_and_path(None, seed_fingerprint, matching_path.clone()),
+                action_with_fvk_and_path(
+                    Some(existing_fvk),
+                    seed_fingerprint,
+                    matching_path.clone(),
+                ),
+                action_with_fvk_and_path(None, seed_fingerprint, other_path),
+            ],
+            flags: 0,
+            value_sum: (0, false),
+            anchor: Some([0; 32]),
+            note_version: NoteVersion::V2,
+            zkproof: None,
+            bsk: None,
+        };
+
+        assert_eq!(
+            bundle.fill_missing_spend_fvks_for_zip32_path(&seed_fingerprint, &matching_path, fvk,),
+            1,
+        );
+        assert_eq!(bundle.actions[0].spend.fvk, Some(fvk));
+        assert_eq!(bundle.actions[1].spend.fvk, Some(existing_fvk));
+        assert_eq!(bundle.actions[2].spend.fvk, None);
+    }
+
+    fn action_with_fvk_and_path(
+        fvk: Option<[u8; 96]>,
+        seed_fingerprint: [u8; 32],
+        derivation_path: Vec<u32>,
+    ) -> Action {
+        Action {
+            cv_net: Some([0; 32]),
+            spend: Spend {
+                nullifier: Some([1; 32]),
+                rk: Some([2; 32]),
+                spend_auth_sig: None,
+                recipient: None,
+                value: None,
+                rho: None,
+                rseed: None,
+                fvk,
+                witness: None,
+                alpha: None,
+                zip32_derivation: Some(Zip32Derivation {
+                    seed_fingerprint,
+                    derivation_path,
+                }),
+                dummy_sk: None,
+                proprietary: BTreeMap::new(),
+            },
+            output: Output {
+                cmx: Some([3; 32]),
+                ephemeral_key: Some([4; 32]),
+                enc_ciphertext: Some(vec![]),
+                memo_kind: None,
+                out_ciphertext: vec![],
+                recipient: None,
+                value: None,
+                rseed: None,
+                ock: None,
+                zip32_derivation: None,
+                user_address: None,
+                proprietary: BTreeMap::new(),
+            },
+            rcv: None,
+        }
     }
 }
 
@@ -962,14 +1175,247 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
         .and_then(|revision| bundle_version_for_revision(revision, orchard::ValuePool::Orchard))
 }
 
+/// Errors that can occur while [`Bundle::fill_derived_fields`] recomputes elided
+/// derived fields.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FillError {
+    /// A derived field could not be recomputed from the action's note component fields.
+    /// Wraps the [`orchard::pczt::VerifyError`] identifying the component that was
+    /// missing or invalid.
+    Recompute(orchard::pczt::VerifyError),
+    /// An output's `enc_ciphertext` was elided without the [`MemoKind`] tag needed to
+    /// reconstruct it.
+    MissingMemoKind,
+    /// The bundle anchor was elided from a PCZT whose transaction version still commits
+    /// to the anchor in the txid/sighash digest.
+    AnchorElisionRequiresV6,
+}
+
+#[cfg(feature = "orchard")]
+impl From<orchard::pczt::VerifyError> for FillError {
+    fn from(e: orchard::pczt::VerifyError) -> Self {
+        FillError::Recompute(e)
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl FillError {
+    /// Maps this fill failure onto the orchard parse error a parsing consumer reports.
+    fn into_parse_error(self) -> orchard::pczt::ParseError {
+        match self {
+            FillError::Recompute(e) => orchard::pczt::ParseError::Recompute(e),
+            // An elided ciphertext without its memo-kind tag cannot be reconstructed,
+            // so to a parsing consumer the action's `enc_ciphertext` data is unusable.
+            FillError::MissingMemoKind => orchard::pczt::ParseError::InvalidEncCiphertext,
+            // The bundle carries no parseable anchor under this transaction version.
+            FillError::AnchorElisionRequiresV6 => orchard::pczt::ParseError::InvalidAnchor,
+        }
+    }
+}
+
 #[cfg(feature = "orchard")]
 impl Bundle {
+    /// Fills missing spend FVK bytes for actions whose ZIP 32 derivation matches
+    /// the supplied seed fingerprint and account path.
+    ///
+    /// This is intended for constrained signers that can derive the selected
+    /// account's Orchard FVK locally and therefore do not need it supplied on
+    /// the PCZT wire. Existing `fvk` fields are left unchanged.
+    pub fn fill_missing_spend_fvks_for_zip32_path(
+        &mut self,
+        seed_fingerprint: &[u8; 32],
+        derivation_path: &[u32],
+        fvk: [u8; 96],
+    ) -> usize {
+        let mut filled = 0;
+        for action in &mut self.actions {
+            if action.spend.fvk.is_none()
+                && action.spend.zip32_derivation.as_ref().is_some_and(|z| {
+                    &z.seed_fingerprint == seed_fingerprint
+                        && z.derivation_path.as_slice() == derivation_path
+                })
+            {
+                action.spend.fvk = Some(fvk);
+                filled += 1;
+            }
+        }
+        filled
+    }
+
+    /// Recomputes and fills, in place, every elided derived field across this bundle,
+    /// so that afterwards each action's `cv_net`, `nullifier`, `rk`, `cmx`,
+    /// `ephemeral_key`, and `enc_ciphertext`, and the bundle `anchor`, are all present.
+    ///
+    /// This is the inverse of the redactor's `clear_*` methods, and is a strict lazy
+    /// fill: a field that is present is never recomputed or overwritten, and the
+    /// expensive note encryption runs only when `ephemeral_key` or `enc_ciphertext` is
+    /// actually missing, so a fully-populated bundle does zero cryptographic work here.
+    /// Parsing this bundle (and therefore every parsing role) performs the fill
+    /// implicitly; this method is for consumers that read the wire-format fields
+    /// directly.
+    ///
+    /// Each recomputed derived field is byte-identical to the value the producer
+    /// elided: the [`orchard::pczt::recompute`] primitives reproduce the builder's
+    /// derivations exactly, `enc_ciphertext` under the memo named by the output's
+    /// [`MemoKind`] tag (which a successful fill consumes). Two caveats bound that
+    /// guarantee:
+    ///
+    /// - `enc_ciphertext` is byte-identical only if the note's memo really was the
+    ///   tagged constant; a producer must verify this before eliding. A mismatch is
+    ///   not detectable here, but produces a shielded sighash that fails signature
+    ///   verification at extraction.
+    /// - An elided `anchor` is refilled with the fixed placeholder
+    ///   [`Anchor::empty_tree`](orchard::Anchor::empty_tree), not a recomputation, so
+    ///   it only reproduces a producer anchor that was already that constant. This
+    ///   method therefore accepts an elided anchor only when `tx_version` is the v6
+    ///   transaction format, where the anchor is excluded from the txid/sighash
+    ///   digest and a signer sees no difference; the extracting wallet must install
+    ///   the real anchor.
+    ///
+    /// On error the bundle may be left partially filled.
+    pub fn fill_derived_fields(&mut self, tx_version: u32) -> Result<(), FillError> {
+        use orchard::pczt::{VerifyError, recompute};
+
+        if self.anchor.is_none() {
+            if tx_version != zcash_protocol::constants::V6_TX_VERSION {
+                return Err(FillError::AnchorElisionRequiresV6);
+            }
+            self.anchor = Some(EMPTY_TREE_ANCHOR);
+        }
+
+        let note_version = self.note_version;
+        for action in &mut self.actions {
+            // Resolve the spend nullifier lazily: the output note's `rho` derives from
+            // it, so `cmx`, `ephemeral_key`, and `enc_ciphertext` all need it, but only
+            // when one of those (or the nullifier itself) is elided. `None` here means
+            // "not yet computed and not yet needed".
+            let mut resolved_nullifier = action.spend.nullifier;
+            let mut nullifier = |spend: &Spend| -> Result<[u8; 32], FillError> {
+                if let Some(nf) = resolved_nullifier {
+                    return Ok(nf);
+                }
+                let nf = recompute::nullifier(
+                    spend
+                        .recipient
+                        .as_ref()
+                        .ok_or(VerifyError::MissingRecipient)?,
+                    spend.value.ok_or(VerifyError::MissingValue)?,
+                    spend.rho.as_ref().ok_or(VerifyError::MissingRho)?,
+                    spend.rseed.as_ref().ok_or(VerifyError::MissingRandomSeed)?,
+                    spend
+                        .fvk
+                        .as_ref()
+                        .ok_or(VerifyError::MissingFullViewingKey)?,
+                    note_version,
+                )?;
+                resolved_nullifier = Some(nf);
+                Ok(nf)
+            };
+
+            if action.cv_net.is_none() {
+                action.cv_net = Some(recompute::cv_net(
+                    action.spend.value.ok_or(VerifyError::MissingValue)?,
+                    action.output.value.ok_or(VerifyError::MissingValue)?,
+                    action
+                        .rcv
+                        .as_ref()
+                        .ok_or(VerifyError::MissingValueCommitTrapdoor)?,
+                )?);
+            }
+
+            if action.spend.rk.is_none() {
+                action.spend.rk = Some(recompute::rk(
+                    action
+                        .spend
+                        .fvk
+                        .as_ref()
+                        .ok_or(VerifyError::MissingFullViewingKey)?,
+                    action
+                        .spend
+                        .alpha
+                        .as_ref()
+                        .ok_or(VerifyError::MissingSpendAuthRandomizer)?,
+                )?);
+            }
+
+            if action.output.cmx.is_none() {
+                let nf = nullifier(&action.spend)?;
+                action.output.cmx = Some(recompute::cmx(
+                    action
+                        .output
+                        .recipient
+                        .as_ref()
+                        .ok_or(VerifyError::MissingRecipient)?,
+                    action.output.value.ok_or(VerifyError::MissingValue)?,
+                    &nf,
+                    action
+                        .output
+                        .rseed
+                        .as_ref()
+                        .ok_or(VerifyError::MissingRandomSeed)?,
+                    note_version,
+                )?);
+            }
+
+            // `ephemeral_key` and `enc_ciphertext` share the note encryptor, so if
+            // either is missing both are recomputed and the wire value is kept for
+            // whichever was present.
+            if action.output.ephemeral_key.is_none() || action.output.enc_ciphertext.is_none() {
+                let memo = match (&action.output.enc_ciphertext, action.output.memo_kind) {
+                    // Reconstructing the ciphertext requires the note's memo, named
+                    // by the tag.
+                    (None, Some(kind)) => kind.memo(),
+                    (None, None) => return Err(FillError::MissingMemoKind),
+                    // Only `ephemeral_key` is missing; it is memo-independent, so any
+                    // memo serves.
+                    (Some(_), _) => MemoKind::Dummy.memo(),
+                };
+                let nf = nullifier(&action.spend)?;
+                let (recomputed_epk, recomputed_enc) = recompute::ephemeral_key_and_enc_ciphertext(
+                    action
+                        .output
+                        .recipient
+                        .as_ref()
+                        .ok_or(VerifyError::MissingRecipient)?,
+                    action.output.value.ok_or(VerifyError::MissingValue)?,
+                    &nf,
+                    action
+                        .output
+                        .rseed
+                        .as_ref()
+                        .ok_or(VerifyError::MissingRandomSeed)?,
+                    &memo,
+                    note_version,
+                )?;
+                if action.output.ephemeral_key.is_none() {
+                    action.output.ephemeral_key = Some(recomputed_epk);
+                }
+                if action.output.enc_ciphertext.is_none() {
+                    action.output.enc_ciphertext = Some(recomputed_enc);
+                }
+            }
+
+            if action.spend.nullifier.is_none() {
+                action.spend.nullifier = Some(nullifier(&action.spend)?);
+            }
+
+            // The tag exists only to reconstruct an elided ciphertext; with
+            // `enc_ciphertext` now present it is spent, and clearing it restores the
+            // never-redacted encoding.
+            action.output.memo_kind = None;
+        }
+        Ok(())
+    }
+
     /// Parses this bundle as an Ironwood-pool bundle, deriving each spend's
     /// `FullViewingKey` from its wire `fvk` bytes.
     pub(crate) fn into_ironwood_parsed(
         self,
+        tx_version: u32,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_with_version(BundleVersion::ironwood_v3())
+        self.into_parsed_with_version(tx_version, BundleVersion::ironwood_v3())
     }
 
     /// Parses this bundle as an Ironwood-pool bundle for a preverified signing pass,
@@ -978,17 +1424,22 @@ impl Bundle {
     /// callers must uphold.
     pub(crate) fn into_ironwood_parsed_preverified_for_signing(
         self,
+        tx_version: u32,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_with_version_preverified_for_signing(BundleVersion::ironwood_v3())
+        self.into_parsed_with_version_preverified_for_signing(
+            tx_version,
+            BundleVersion::ironwood_v3(),
+        )
     }
 
     /// Parses this bundle with the given bundle version, deriving each spend's
     /// `FullViewingKey` from its wire `fvk` bytes.
     pub(crate) fn into_parsed_with_version(
         self,
+        tx_version: u32,
         bundle_version: BundleVersion,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(bundle_version, false)
+        self.into_parsed_inner(tx_version, bundle_version, false)
     }
 
     /// Parses this bundle with the given bundle version for a preverified signing
@@ -1002,19 +1453,28 @@ impl Bundle {
     /// restores them from a pre-parse snapshot).
     pub(crate) fn into_parsed_with_version_preverified_for_signing(
         self,
+        tx_version: u32,
         bundle_version: BundleVersion,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(bundle_version, true)
+        self.into_parsed_inner(tx_version, bundle_version, true)
     }
 
     /// The shared body of [`Bundle::into_parsed_with_version`] and
     /// [`Bundle::into_parsed_with_version_preverified_for_signing`]: `preverified`
     /// selects between the full parse and the preverified signing parse.
     fn into_parsed_inner(
-        self,
+        mut self,
+        tx_version: u32,
         bundle_version: BundleVersion,
         preverified: bool,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        // Recompute-and-fill any elided derived field (and placeholder anchor) first,
+        // so the parsed protocol structs are fully populated and every downstream
+        // consumer sees complete actions; see `fill_derived_fields`. This is a no-op
+        // for a fully-populated bundle, and justifies the `expect`s below.
+        self.fill_derived_fields(tx_version)
+            .map_err(FillError::into_parse_error)?;
+
         // We parse actions through a helper that is specifically `#[inline(never)]`.
         // This is because if this gets inlined in a loop (e.g. `.map(..).collect()`),
         // it could compile into a stack frame that is tens of KB deep.
@@ -1026,6 +1486,8 @@ impl Bundle {
             note_version: NoteVersion,
             preverified: bool,
         ) -> Result<orchard::pczt::Action, orchard::pczt::ParseError> {
+            const FILLED: &str = "fill_derived_fields populated every derived field";
+
             let spend_zip32_derivation = action
                 .spend
                 .zip32_derivation
@@ -1036,8 +1498,8 @@ impl Bundle {
 
             let spend = if preverified {
                 orchard::pczt::Spend::parse_preverified_for_signing(
-                    action.spend.nullifier,
-                    action.spend.rk,
+                    action.spend.nullifier.expect(FILLED),
+                    action.spend.rk.expect(FILLED),
                     action.spend.spend_auth_sig,
                     action.spend.recipient,
                     action.spend.value,
@@ -1053,8 +1515,8 @@ impl Bundle {
                 )
             } else {
                 orchard::pczt::Spend::parse(
-                    action.spend.nullifier,
-                    action.spend.rk,
+                    action.spend.nullifier.expect(FILLED),
+                    action.spend.rk.expect(FILLED),
                     action.spend.spend_auth_sig,
                     action.spend.recipient,
                     action.spend.value,
@@ -1072,9 +1534,9 @@ impl Bundle {
 
             let output = orchard::pczt::Output::parse(
                 *spend.nullifier(),
-                action.output.cmx,
-                action.output.ephemeral_key,
-                action.output.enc_ciphertext,
+                action.output.cmx.expect(FILLED),
+                action.output.ephemeral_key.expect(FILLED),
+                action.output.enc_ciphertext.expect(FILLED),
                 action.output.out_ciphertext,
                 action.output.recipient,
                 action.output.value,
@@ -1092,7 +1554,7 @@ impl Bundle {
                 action.output.proprietary,
             )?;
 
-            orchard::pczt::Action::parse(action.cv_net, spend, output, action.rcv)
+            orchard::pczt::Action::parse(action.cv_net.expect(FILLED), spend, output, action.rcv)
         }
 
         let note_version = self.note_version;
@@ -1106,7 +1568,8 @@ impl Bundle {
             self.flags,
             bundle_version,
             self.value_sum,
-            self.anchor,
+            self.anchor
+                .expect("fill_derived_fields populated the anchor"),
             self.zkproof,
             self.bsk,
         )
@@ -1131,10 +1594,12 @@ impl Bundle {
                 let output = action.output();
 
                 Action {
-                    cv_net: action.cv_net().to_bytes(),
+                    // A parsed bundle always carries the derived fields, so writing it
+                    // back to the wire always populates them.
+                    cv_net: Some(action.cv_net().to_bytes()),
                     spend: Spend {
-                        nullifier: spend.nullifier().to_bytes(),
-                        rk: spend.rk().into(),
+                        nullifier: Some(spend.nullifier().to_bytes()),
+                        rk: Some(spend.rk().into()),
                         spend_auth_sig: spend.spend_auth_sig().as_ref().map(|s| s.into()),
                         recipient: action
                             .spend()
@@ -1175,9 +1640,10 @@ impl Bundle {
                         proprietary: spend.proprietary().clone(),
                     },
                     output: Output {
-                        cmx: output.cmx().to_bytes(),
-                        ephemeral_key: output.encrypted_note().epk_bytes,
-                        enc_ciphertext: output.encrypted_note().enc_ciphertext.to_vec(),
+                        cmx: Some(output.cmx().to_bytes()),
+                        ephemeral_key: Some(output.encrypted_note().epk_bytes),
+                        enc_ciphertext: Some(output.encrypted_note().enc_ciphertext.to_vec()),
+                        memo_kind: None,
                         out_ciphertext: output.encrypted_note().out_ciphertext.to_vec(),
                         recipient: action
                             .output()
@@ -1213,7 +1679,7 @@ impl Bundle {
             actions,
             flags: bundle.flag_byte(),
             value_sum,
-            anchor: bundle.anchor().to_bytes(),
+            anchor: Some(bundle.anchor().to_bytes()),
             note_version,
             zkproof: bundle
                 .zkproof()

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -229,7 +229,7 @@ impl Creator {
                 actions: vec![],
                 flags: self.orchard_flags,
                 value_sum: (0, false),
-                anchor: self.orchard_anchor,
+                anchor: Some(self.orchard_anchor),
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
                 note_version: self
@@ -243,7 +243,7 @@ impl Creator {
             },
             ironwood: OrchardBundle {
                 flags: self.ironwood_flags,
-                anchor: self.ironwood_anchor,
+                anchor: Some(self.ironwood_anchor),
                 ..crate::orchard::EMPTY_IRONWOOD
             },
         }
@@ -351,6 +351,6 @@ mod tests {
             .with_ironwood_anchor([1; 32])
             .unwrap()
             .build();
-        assert_eq!(pczt.ironwood.anchor, [1; 32]);
+        assert_eq!(pczt.ironwood.anchor, Some([1; 32]));
     }
 }

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -20,10 +20,15 @@ impl Signer {
     /// already run the full Verifier checks over the identical PCZT bytes: they are
     /// not validated here, and the signing closure sees each spend's `fvk` as `None`.
     ///
+    /// Any elided derived fields (and an elided anchor) are recomputed and filled in
+    /// place before parsing, so the returned PCZT carries them populated; see
+    /// [`crate::orchard::Bundle::fill_derived_fields`]. If the fill fails, the
+    /// signing closure is not invoked.
+    ///
     /// The signing closure must not add, remove, or reorder actions. A well-behaved
     /// closure leaves the returned PCZT's wire `fvk` bytes unchanged; a violating one
-    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`],
-    /// leaving the PCZT unmodified.
+    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`]
+    /// without applying its changes.
     #[cfg(feature = "orchard")]
     pub fn sign_ironwood_with<E, F>(self, f: F) -> Result<Self, E>
     where
@@ -34,11 +39,16 @@ impl Signer {
 
         let mut tx_modifiable = pczt.global.tx_modifiable;
 
+        // Fill any elided derived field on the wire bundle first, so the `rk`
+        // snapshotted below is always present.
+        pczt.ironwood
+            .fill_derived_fields(pczt.global.tx_version)
+            .map_err(|e| E::from(OrchardParseError::Fill(e)))?;
         let fvk_snapshot = snapshot_spend_fvks(&pczt.ironwood);
         let mut bundle = pczt
             .ironwood
             .clone()
-            .into_ironwood_parsed_preverified_for_signing()
+            .into_ironwood_parsed_preverified_for_signing(pczt.global.tx_version)
             .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
@@ -58,10 +68,15 @@ impl Signer {
     /// already run the full Verifier checks over the identical PCZT bytes: they are
     /// not validated here, and the signing closure sees each spend's `fvk` as `None`.
     ///
+    /// Any elided derived fields (and an elided anchor) are recomputed and filled in
+    /// place before parsing, so the returned PCZT carries them populated; see
+    /// [`crate::orchard::Bundle::fill_derived_fields`]. If the fill fails, the
+    /// signing closure is not invoked.
+    ///
     /// The signing closure must not add, remove, or reorder actions. A well-behaved
     /// closure leaves the returned PCZT's wire `fvk` bytes unchanged; a violating one
-    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`],
-    /// leaving the PCZT unmodified.
+    /// is detected and returns [`OrchardParseError::SigningClosureModifiedActions`]
+    /// without applying its changes.
     #[cfg(feature = "orchard")]
     pub fn sign_orchard_with<E, F>(self, f: F) -> Result<Self, E>
     where
@@ -74,11 +89,19 @@ impl Signer {
 
         let bundle_version = crate::orchard::orchard_bundle_version(&pczt.global)
             .ok_or(OrchardParseError::UnsupportedConsensusBranchId)?;
+        // Fill any elided derived field on the wire bundle first, so the `rk`
+        // snapshotted below is always present.
+        pczt.orchard
+            .fill_derived_fields(pczt.global.tx_version)
+            .map_err(|e| E::from(OrchardParseError::Fill(e)))?;
         let fvk_snapshot = snapshot_spend_fvks(&pczt.orchard);
         let mut bundle = pczt
             .orchard
             .clone()
-            .into_parsed_with_version_preverified_for_signing(bundle_version)
+            .into_parsed_with_version_preverified_for_signing(
+                pczt.global.tx_version,
+                bundle_version,
+            )
             .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
@@ -142,7 +165,7 @@ impl Signer {
 /// preverified signing parse drops and must restore, paired with the `rk` used as a
 /// per-position tamper check. See [`restore_spend_fvks`].
 #[cfg(feature = "orchard")]
-type SpendFvkSnapshot = alloc::vec::Vec<([u8; 32], Option<[u8; 96]>)>;
+type SpendFvkSnapshot = alloc::vec::Vec<(Option<[u8; 32]>, Option<[u8; 96]>)>;
 
 /// Snapshots each action's spend `(rk, fvk)` wire bytes, by position, for
 /// [`restore_spend_fvks`] to restore after serialization.
@@ -160,10 +183,11 @@ fn snapshot_spend_fvks(bundle: &crate::orchard::Bundle) -> SpendFvkSnapshot {
 /// list.
 ///
 /// Positional restore is only sound if each position still holds its original action,
-/// so this checks the action count and each position's wire `rk` — the one
-/// always-present spend field that pins an action's identity, since a nullifier can
-/// be shared — against the snapshot before writing any `fvk`. On a mismatch it writes
-/// nothing and returns [`OrchardParseError::SigningClosureModifiedActions`].
+/// so this checks the action count and each position's wire `rk` — the spend field
+/// that pins an action's identity (a nullifier can be shared, and the pre-parse fill
+/// guarantees `rk` is present when the snapshot is taken) — against the snapshot
+/// before writing any `fvk`. On a mismatch it writes nothing and returns
+/// [`OrchardParseError::SigningClosureModifiedActions`].
 #[cfg(feature = "orchard")]
 fn restore_spend_fvks(
     bundle: &mut crate::orchard::Bundle,
@@ -189,9 +213,12 @@ fn restore_spend_fvks(
 /// signing.
 #[cfg(feature = "orchard")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum OrchardParseError {
     /// The bundle data was structurally invalid.
     Parse(orchard::pczt::ParseError),
+    /// An elided derived field could not be recomputed and filled before parsing.
+    Fill(crate::orchard::FillError),
     /// The PCZT's consensus branch ID is unrecognized, or predates NU5 (under which
     /// the Orchard protocol is not supported).
     UnsupportedConsensusBranchId,
@@ -265,10 +292,10 @@ mod tests {
                 // Distinct `rk` per action (`[10; 32]`, `[11; 32]`), shared
                 // nullifier `[3; 32]`.
                 .map(|(i, fvk)| Action {
-                    cv_net: [0; 32],
+                    cv_net: Some([0; 32]),
                     spend: Spend {
-                        nullifier: [3u8; 32],
-                        rk: [10 + i as u8; 32],
+                        nullifier: Some([3u8; 32]),
+                        rk: Some([10 + i as u8; 32]),
                         spend_auth_sig: None,
                         recipient: None,
                         value: None,
@@ -282,9 +309,10 @@ mod tests {
                         proprietary: BTreeMap::new(),
                     },
                     output: Output {
-                        cmx: [0; 32],
-                        ephemeral_key: [0; 32],
-                        enc_ciphertext: Vec::new(),
+                        cmx: Some([0; 32]),
+                        ephemeral_key: Some([0; 32]),
+                        enc_ciphertext: Some(Vec::new()),
+                        memo_kind: None,
                         out_ciphertext: Vec::new(),
                         recipient: None,
                         value: None,
@@ -299,7 +327,7 @@ mod tests {
                 .collect(),
             flags: 0,
             value_sum: (0, false),
-            anchor: [0; 32],
+            anchor: Some([0; 32]),
             note_version: NoteVersion::V2,
             zkproof: None,
             bsk: None,

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -15,6 +15,7 @@ impl super::Prover {
 
         let mut bundle = orchard
             .into_parsed_with_version(
+                global.tx_version,
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
             )
@@ -45,7 +46,7 @@ impl super::Prover {
         } = self.pczt;
 
         let mut bundle = ironwood
-            .into_ironwood_parsed()
+            .into_ironwood_parsed(global.tx_version)
             .map_err(IronwoodError::Parser)?;
 
         bundle

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -1,4 +1,4 @@
-use crate::orchard::{Action, Bundle};
+use crate::orchard::{Action, Bundle, MemoKind};
 
 impl super::Redactor {
     /// Redacts the Orchard bundle with the given closure.
@@ -52,6 +52,19 @@ impl OrchardRedactor<'_> {
     pub fn clear_bsk(&mut self) {
         self.0.bsk = None;
     }
+
+    /// Removes the bundle anchor.
+    ///
+    /// The receiver refills it with the fixed placeholder `Anchor::empty_tree()`, not
+    /// the elided value, so this is only lossless if the anchor already was that
+    /// constant. It is only sound on transports where the anchor is not part of the
+    /// signed data (the v6 transaction format excludes it from the txid/sighash
+    /// digest), and fill/parse paths reject the omission before v6. The extracting
+    /// wallet must install the real anchor. See `crate::orchard::Bundle::fill_derived_fields`
+    /// (requires the `orchard` feature).
+    pub fn clear_anchor(&mut self) {
+        self.0.anchor = None;
+    }
 }
 
 /// A Redactor for Orchard actions.
@@ -77,6 +90,69 @@ impl ActionRedactor<'_> {
                 f(action);
             }
         }
+    }
+
+    /// Removes the action's `cv_net` value commitment.
+    ///
+    /// The receiver recomputes it from the spend and output values and `rcv`; see
+    /// `crate::orchard::Bundle::fill_derived_fields` (requires the `orchard` feature;
+    /// likewise for the other derived-field `clear_*` methods below).
+    pub fn clear_cv_net(&mut self) {
+        self.redact(|action| {
+            action.cv_net = None;
+        });
+    }
+
+    /// Removes the spend's `nullifier`.
+    ///
+    /// The receiver recomputes it from the spent note's component fields and `fvk`, so
+    /// this must not be combined with [`Self::clear_spend_fvk`].
+    pub fn clear_nullifier(&mut self) {
+        self.redact(|action| {
+            action.spend.nullifier = None;
+        });
+    }
+
+    /// Removes the spend's randomized verification key `rk`.
+    ///
+    /// The receiver recomputes it from `fvk` and `alpha`, so this must not be combined
+    /// with [`Self::clear_spend_fvk`] or [`Self::clear_spend_alpha`].
+    pub fn clear_rk(&mut self) {
+        self.redact(|action| {
+            action.spend.rk = None;
+        });
+    }
+
+    /// Removes the output's note commitment `cmx`.
+    ///
+    /// The receiver recomputes it from the output note's component fields.
+    pub fn clear_cmx(&mut self) {
+        self.redact(|action| {
+            action.output.cmx = None;
+        });
+    }
+
+    /// Removes the output's `ephemeral_key`.
+    ///
+    /// The receiver recomputes it from the output note's component fields.
+    pub fn clear_ephemeral_key(&mut self) {
+        self.redact(|action| {
+            action.output.ephemeral_key = None;
+        });
+    }
+
+    /// Removes the output's `enc_ciphertext`, recording the note's memo as `memo_kind`.
+    ///
+    /// The receiver re-encrypts the note under the tagged memo. The reconstruction is
+    /// byte-identical only if the note's memo really is the tagged constant; the caller
+    /// must verify this before eliding (a mismatch is caught no earlier than signature
+    /// verification at extraction). `out_ciphertext` cannot be elided this way because
+    /// it is RNG-derived.
+    pub fn clear_enc_ciphertext(&mut self, memo_kind: MemoKind) {
+        self.redact(|action| {
+            action.output.enc_ciphertext = None;
+            action.output.memo_kind = Some(memo_kind);
+        });
     }
 
     /// Removes the spend authorizing signature.

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -18,6 +18,7 @@ impl super::Updater {
 
         let mut bundle = orchard
             .into_parsed_with_version(
+                global.tx_version,
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
             )
@@ -50,7 +51,7 @@ impl super::Updater {
         } = self.pczt;
 
         let mut bundle = ironwood
-            .into_ironwood_parsed()
+            .into_ironwood_parsed(global.tx_version)
             .map_err(OrchardError::Parser)?;
 
         bundle.update_with(f).map_err(OrchardError::Updater)?;

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -16,6 +16,7 @@ impl super::Verifier {
 
         let bundle = orchard
             .into_parsed_with_version(
+                global.tx_version,
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
             )
@@ -48,7 +49,7 @@ impl super::Verifier {
         } = self.pczt;
 
         let bundle = ironwood
-            .into_ironwood_parsed()
+            .into_ironwood_parsed(global.tx_version)
             .map_err(OrchardError::Parse)?;
 
         f(&bundle)?;

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -9,10 +9,11 @@ use ::transparent::{
 };
 use orchard::tree::MerkleHashOrchard;
 use pczt::{
-    Pczt,
+    EncodingError, Pczt,
+    orchard::{FillError, MemoKind},
     roles::{
         combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
-        prover::Prover, signer::Signer, spend_finalizer::SpendFinalizer,
+        prover::Prover, redactor::Redactor, signer::Signer, spend_finalizer::SpendFinalizer,
         tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
     },
     v1, v2,
@@ -30,7 +31,7 @@ use zcash_primitives::transaction::{
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    consensus::MainNetwork,
+    consensus::{BranchId, MainNetwork},
     memo::{Memo, MemoBytes},
     value::Zatoshis,
 };
@@ -51,9 +52,7 @@ fn check_round_trip(pczt: &Pczt) {
         .serialize();
 
     // The default encoding is the latest (v2) encoding.
-    let v2_encoded = v2::Pczt::try_from(pczt.clone())
-        .expect("v2 encoding succeeds")
-        .serialize();
+    let v2_encoded = v2::Pczt::from(pczt.clone()).serialize();
 
     let encoded = pczt.clone().serialize().expect("serialization succeeds");
     assert_eq!(encoded, v2_encoded);
@@ -941,7 +940,11 @@ fn orchard_low_level_signer_uses_preverified_signing_parse() {
 
     // ...and that signature must actually verify against the spend's `rk`.
     assert_valid_spend_auth_sig(
-        signed.orchard().actions()[index].spend().rk(),
+        signed.orchard().actions()[index]
+            .spend()
+            .rk()
+            .as_ref()
+            .expect("signing populates `rk`"),
         sighash,
         produced_sig,
     );
@@ -1125,11 +1128,570 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
 
     // ...and that signature must actually verify against the spend's `rk`.
     assert_valid_spend_auth_sig(
-        signed.ironwood().actions()[index].spend().rk(),
+        signed.ironwood().actions()[index]
+            .spend()
+            .rk()
+            .as_ref()
+            .expect("signing populates `rk`"),
         sighash,
         produced_sig,
     );
 
     // The wire `fvk` bytes must be preserved (unchanged) after signing.
     assert_eq!(wire_spend_fvks(&signed, true), fvks_before);
+}
+
+/// Reads the version field of an encoded PCZT header.
+fn pczt_version(encoded: &[u8]) -> u32 {
+    u32::from_le_bytes(encoded[4..8].try_into().unwrap())
+}
+
+/// The wire encodings of an action's derived Orchard-shaped fields, plus its
+/// memo-kind tag.
+#[derive(Debug, PartialEq, Eq)]
+struct DerivedFieldBytes {
+    cv_net: Option<[u8; 32]>,
+    nullifier: Option<[u8; 32]>,
+    rk: Option<[u8; 32]>,
+    cmx: Option<[u8; 32]>,
+    ephemeral_key: Option<[u8; 32]>,
+    enc_ciphertext: Option<Vec<u8>>,
+    out_ciphertext: Vec<u8>,
+    memo_kind: Option<MemoKind>,
+}
+
+/// Snapshots the derived fields of every action in an Orchard-shaped wire bundle, for
+/// per-field byte-identity assertions.
+fn derived_fields(bundle: &pczt::orchard::Bundle) -> Vec<DerivedFieldBytes> {
+    bundle
+        .actions()
+        .iter()
+        .map(|action| DerivedFieldBytes {
+            cv_net: *action.cv_net(),
+            nullifier: *action.spend().nullifier(),
+            rk: *action.spend().rk(),
+            cmx: *action.output().cmx(),
+            ephemeral_key: *action.output().ephemeral_key(),
+            enc_ciphertext: action.output().enc_ciphertext().clone(),
+            out_ciphertext: action.output().out_ciphertext().clone(),
+            memo_kind: *action.output().memo_kind(),
+        })
+        .collect()
+}
+
+/// Builds a full, IO-finalized Orchard PCZT whose two outputs carry the two memo
+/// constants a migration wallet elides ciphertexts under: requested output 0 the
+/// ZIP 302 empty memo ([`MemoKind::Empty`]) and requested output 1 the all-zero dummy
+/// memo ([`MemoKind::Dummy`]).
+///
+/// Returns the PCZT, its spend authorizing key, the spend's action index, and the two
+/// outputs' action indices in that memo order. Used by the recompute-and-fill tests,
+/// which need derived fields holding genuine cryptographic values so that
+/// reconstruction can be checked to be byte-identical.
+fn orchard_pczt_with_migration_memos()
+-> (Pczt, orchard::keys::SpendAuthorizingKey, usize, [usize; 2]) {
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received a note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // Use the tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: None,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(100_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_fvk.to_ovk(zip32::Scope::Internal)),
+            orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal),
+            Zatoshis::const_from_u64(890_000),
+            MemoBytes::from_bytes(&[0u8; 512]).unwrap(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+
+    let spend_index = orchard_meta.spend_action_index(0).unwrap();
+    let output_indices = [
+        orchard_meta.output_action_index(0).unwrap(),
+        orchard_meta.output_action_index(1).unwrap(),
+    ];
+    (pczt, orchard_ask, spend_index, output_indices)
+}
+
+/// The Ironwood analogue of [`orchard_pczt_with_migration_memos`]: a full,
+/// IO-finalized Ironwood PCZT with a real Ironwood spend and the same two memo
+/// constants on its outputs.
+fn ironwood_pczt_with_migration_memos()
+-> (Pczt, orchard::keys::SpendAuthorizingKey, usize, [usize; 2]) {
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Ironwood note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::IronwoodDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V3);
+        note
+    };
+
+    // Use the Ironwood tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: None,
+            ironwood_anchor: Some(anchor),
+        },
+    );
+    builder
+        .add_ironwood_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(100_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_fvk.to_ovk(zip32::Scope::Internal)),
+            orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal),
+            Zatoshis::const_from_u64(890_000),
+            MemoBytes::from_bytes(&[0u8; 512]).unwrap(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        ironwood_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+
+    let spend_index = ironwood_meta.spend_action_index(0).unwrap();
+    let output_indices = [
+        ironwood_meta.output_action_index(0).unwrap(),
+        ironwood_meta.output_action_index(1).unwrap(),
+    ];
+    (pczt, orchard_ask, spend_index, output_indices)
+}
+
+/// Redacts every derived Orchard-shaped field the migration wire format elides: the
+/// five recomputable fields on every action, each output's `enc_ciphertext` under its
+/// memo-kind tag, and (when requested) the bundle anchor.
+fn redact_derived_fields(
+    pczt: Pczt,
+    ironwood: bool,
+    [empty_memo_action, dummy_memo_action]: [usize; 2],
+    clear_anchor: bool,
+) -> Pczt {
+    let redact = |mut r: pczt::roles::redactor::orchard::OrchardRedactor<'_>| {
+        r.redact_actions(|mut a| {
+            a.clear_cv_net();
+            a.clear_nullifier();
+            a.clear_rk();
+            a.clear_cmx();
+            a.clear_ephemeral_key();
+        });
+        r.redact_action(empty_memo_action, |mut a| {
+            a.clear_enc_ciphertext(MemoKind::Empty);
+        });
+        r.redact_action(dummy_memo_action, |mut a| {
+            a.clear_enc_ciphertext(MemoKind::Dummy);
+        });
+        if clear_anchor {
+            r.clear_anchor();
+        }
+    };
+
+    let redactor = Redactor::new(pczt);
+    if ironwood {
+        redactor.redact_ironwood_with(redact).finish()
+    } else {
+        redactor.redact_orchard_with(redact).finish()
+    }
+}
+
+/// The on-chain-safety gate for the optional-field wire format: eliding every derived
+/// Orchard field (plus both ciphertexts under their memo-kind tags), round-tripping
+/// through the v2 encoding, and recomputing with `fill_derived_fields` must yield a
+/// PCZT BYTE-IDENTICAL to the never-redacted one — first checked field-by-field for
+/// diagnostics, then over the full serialization. The refilled PCZT must then prove,
+/// sign, and extract exactly like the original.
+#[test]
+fn fill_derived_fields_is_byte_identical_to_never_redacted_orchard() {
+    let (full, orchard_ask, spend_index, output_indices) = orchard_pczt_with_migration_memos();
+    let full_bytes = full.clone().serialize().unwrap();
+    assert_eq!(pczt_version(&full_bytes), 2);
+    let original_fields = derived_fields(full.orchard());
+    for f in &original_fields {
+        assert!(f.cv_net.is_some());
+        assert!(f.nullifier.is_some());
+        assert!(f.rk.is_some());
+        assert!(f.cmx.is_some());
+        assert!(f.ephemeral_key.is_some());
+        assert!(f.enc_ciphertext.is_some());
+        assert_eq!(f.memo_kind, None);
+    }
+
+    // Filling an already-complete PCZT is a byte-identical no-op.
+    let mut already_full = full.clone();
+    already_full.fill_derived_fields().unwrap();
+    assert_eq!(already_full.serialize().unwrap(), full_bytes);
+
+    // Elide the derived fields; the v2 encoding carries the omissions directly, and
+    // parsing must preserve them as absent (parse of the wire fields does not
+    // recompute). The released v1 encoding cannot represent them and refuses.
+    let redacted = redact_derived_fields(full, false, output_indices, false);
+    assert!(matches!(
+        v1::Pczt::try_from(redacted.clone()),
+        Err(EncodingError::RequiresV2)
+    ));
+    let encoded = redacted.serialize().unwrap();
+    assert_eq!(pczt_version(&encoded), 2);
+
+    let mut reparsed = Pczt::parse(&encoded).unwrap();
+    for (i, f) in derived_fields(reparsed.orchard()).into_iter().enumerate() {
+        assert_eq!(f.cv_net, None);
+        assert_eq!(f.nullifier, None);
+        assert_eq!(f.rk, None);
+        assert_eq!(f.cmx, None);
+        assert_eq!(f.ephemeral_key, None);
+        assert_eq!(f.enc_ciphertext, None);
+        let expected_kind = if i == output_indices[0] {
+            MemoKind::Empty
+        } else {
+            MemoKind::Dummy
+        };
+        assert_eq!(f.memo_kind, Some(expected_kind));
+    }
+
+    // Recompute-and-fill reproduces every elided field byte-for-byte...
+    reparsed.fill_derived_fields().unwrap();
+    assert_eq!(derived_fields(reparsed.orchard()), original_fields);
+    // ...and the whole PCZT encoding.
+    assert_eq!(reparsed.clone().serialize().unwrap(), full_bytes);
+
+    // The refilled PCZT still proves, signs, and extracts.
+    let pczt = Prover::new(reparsed)
+        .create_orchard_proof(orchard_proving_key())
+        .unwrap()
+        .finish();
+    let mut signer = Signer::new(pczt).unwrap();
+    signer.sign_orchard(spend_index, &orchard_ask).unwrap();
+    let tx = TransactionExtractor::new(signer.finish())
+        .extract()
+        .unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+/// The Ironwood (note version V3) analogue of the byte-identity gate. This is the
+/// load-bearing check for the `note_version` threading: the recomputed
+/// `enc_ciphertext`s must use the V3 note plaintext lead byte, including the ZIP 302
+/// empty memo carried by the real migrated output. It then drives the low-level
+/// Signer over the still-redacted PCZT (the device's inbound path), asserting the
+/// implicit fill produces a signature byte-identical to signing the never-redacted
+/// PCZT.
+#[test]
+fn fill_derived_fields_is_byte_identical_to_never_redacted_ironwood() {
+    let (full, orchard_ask, spend_index, output_indices) = ironwood_pczt_with_migration_memos();
+    let full_bytes = full.clone().serialize().unwrap();
+    assert_eq!(pczt_version(&full_bytes), 2);
+    let original_fields = derived_fields(full.ironwood());
+    assert!(!original_fields.is_empty());
+
+    let redacted = redact_derived_fields(full.clone(), true, output_indices, false);
+    let encoded = redacted.serialize().unwrap();
+    assert_eq!(pczt_version(&encoded), 2);
+
+    let mut reparsed = Pczt::parse(&encoded).unwrap();
+    for f in derived_fields(reparsed.ironwood()) {
+        assert_eq!(f.cv_net, None);
+        assert_eq!(f.enc_ciphertext, None);
+        assert!(f.memo_kind.is_some());
+    }
+    reparsed.fill_derived_fields().unwrap();
+    assert_eq!(derived_fields(reparsed.ironwood()), original_fields);
+    assert_eq!(reparsed.serialize().unwrap(), full_bytes);
+
+    // Device path: sign the redacted PCZT directly through the low-level Signer,
+    // which fills the elided fields itself before its preverified signing parse (in
+    // particular, the recomputed `rk` must not trip the modified-actions check).
+    let sighash = Signer::new(full.clone()).unwrap().shielded_sighash();
+    // A signer given only the redacted wire bytes derives the identical sighash: the
+    // full (Verifier-style) parse also recomputes the elided fields.
+    let redacted_bytes = redact_derived_fields(full.clone(), true, output_indices, false)
+        .serialize()
+        .unwrap();
+    assert_eq!(
+        Signer::new(Pczt::parse(&redacted_bytes).unwrap())
+            .unwrap()
+            .shielded_sighash(),
+        sighash,
+    );
+    let seed = [9; 32];
+    let expected_sig =
+        expected_spend_auth_sig(&full, true, spend_index, &orchard_ask, sighash, seed);
+    let fvks_full = wire_spend_fvks(&full, true);
+
+    let sign = |pczt: Pczt| {
+        low_level_signer::Signer::new(pczt)
+            .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+                bundle.actions_mut()[spend_index]
+                    .sign(sighash, &orchard_ask, ChaCha20Rng::from_seed(seed))
+                    .expect("signing succeeds");
+                Ok(())
+            })
+            .unwrap()
+            .finish()
+    };
+    let signed_redacted = sign(Pczt::parse(&redacted_bytes).unwrap());
+    let signed_full = sign(full);
+
+    // Eliding fields on the wire changes nothing about what is signed: the signature
+    // (and the entire signed PCZT) is byte-identical to the never-redacted path, and
+    // the wire `fvk` bytes are preserved.
+    let produced_sig = signed_redacted.ironwood().actions()[spend_index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_eq!(produced_sig, expected_sig);
+    assert_eq!(wire_spend_fvks(&signed_redacted, true), fvks_full);
+    assert_eq!(
+        signed_redacted.serialize().unwrap(),
+        signed_full.serialize().unwrap()
+    );
+}
+
+/// A single redacted derived field is representable directly in the v2 encoding: the
+/// omission survives a serialize/parse round-trip unchanged, alongside the fields the
+/// redactor left in place.
+#[test]
+fn redacted_derived_field_round_trips() {
+    let (full, _, _, _) = orchard_pczt_with_migration_memos();
+
+    let redacted = Redactor::new(full)
+        .redact_orchard_with(|mut r| {
+            r.redact_actions(|mut a| {
+                a.clear_cmx();
+            });
+        })
+        .finish();
+
+    let encoded = redacted.serialize().unwrap();
+    assert_eq!(pczt_version(&encoded), 2);
+
+    // The omission survives a parse round-trip unchanged, and the neighboring derived
+    // fields stay populated.
+    let reparsed = Pczt::parse(&encoded).unwrap();
+    assert_eq!(reparsed.orchard().actions()[0].output().cmx(), &None);
+    assert!(
+        reparsed.orchard().actions()[0]
+            .output()
+            .ephemeral_key()
+            .is_some()
+    );
+    assert_eq!(reparsed.serialize().unwrap(), encoded);
+}
+
+/// An elided anchor refills as the fixed `Anchor::empty_tree()` placeholder: byte-
+/// identically when the producer's anchor already was that constant (the migration
+/// shape), and as a documented divergence otherwise (the extracting wallet installs
+/// the real anchor).
+#[test]
+fn anchor_elision_refills_the_empty_tree_placeholder() {
+    let empty_tree = orchard::Anchor::empty_tree().to_bytes();
+
+    // Both Orchard-shaped anchors are the placeholder: elision round-trips
+    // byte-identically.
+    let full = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], empty_tree)
+        .unwrap()
+        .with_ironwood_anchor(empty_tree)
+        .unwrap()
+        .build();
+    let full_bytes = full.clone().serialize().unwrap();
+    assert_eq!(pczt_version(&full_bytes), 2);
+
+    let redacted = Redactor::new(full)
+        .redact_orchard_with(|mut r| r.clear_anchor())
+        .redact_ironwood_with(|mut r| r.clear_anchor())
+        .finish();
+    let encoded = redacted.serialize().unwrap();
+    assert_eq!(pczt_version(&encoded), 2);
+
+    let mut reparsed = Pczt::parse(&encoded).unwrap();
+    assert_eq!(reparsed.orchard().anchor(), &None);
+    assert_eq!(reparsed.ironwood().anchor(), &None);
+    reparsed.fill_derived_fields().unwrap();
+    assert_eq!(reparsed.serialize().unwrap(), full_bytes);
+
+    // A non-placeholder anchor is NOT reproduced: the fill installs the placeholder.
+    let mut real_anchor = Redactor::new(
+        Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [9; 32])
+            .unwrap()
+            .build(),
+    )
+    .redact_orchard_with(|mut r| r.clear_anchor())
+    .finish();
+    real_anchor.fill_derived_fields().unwrap();
+    assert_eq!(real_anchor.orchard().anchor(), &Some(empty_tree));
+}
+
+/// Anchor elision is a v6-only transport optimization. Before v6, the anchor is part
+/// of the txid/sighash digest, so fill and parsing paths must reject the omission
+/// instead of silently installing the placeholder.
+#[test]
+fn anchor_elision_is_rejected_before_v6() {
+    let mut redacted = Redactor::new(
+        Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [9; 32])
+            .unwrap()
+            .build(),
+    )
+    .redact_orchard_with(|mut r| r.clear_anchor())
+    .finish();
+
+    assert!(matches!(
+        redacted.fill_derived_fields(),
+        Err(FillError::AnchorElisionRequiresV6)
+    ));
+
+    let encoded = redacted.serialize().unwrap();
+    let reparsed = Pczt::parse(&encoded).unwrap();
+    assert!(matches!(
+        Signer::new(reparsed),
+        Err(pczt::roles::signer::Error::Extract(
+            pczt::ExtractError::OrchardParse(orchard::pczt::ParseError::InvalidAnchor)
+        ))
+    ));
+}
+
+/// The Combiner restores elided derived fields (and an elided anchor) from a
+/// fully-populated peer copy. The memo-kind tag merges like any other optional field
+/// and is scrubbed by `fill_derived_fields` (without recomputation, `enc_ciphertext`
+/// being present), restoring the never-redacted bytes.
+#[test]
+fn combiner_restores_elided_fields_from_a_full_copy() {
+    let (full, _, _, output_indices) = orchard_pczt_with_migration_memos();
+    let full_bytes = full.clone().serialize().unwrap();
+
+    let redacted = redact_derived_fields(full.clone(), false, output_indices, true);
+
+    let mut merged = Combiner::new(vec![redacted, full]).combine().unwrap();
+    merged.fill_derived_fields().unwrap();
+    assert_eq!(merged.serialize().unwrap(), full_bytes);
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -847,7 +847,7 @@ version = "11.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.15.0-pre.2@git:64a887a5826e14228d1d49d77b92d555e0e807bb"
+version = "0.15.0-pre.2@git:4d32867fa2b403e474df907d74a7e2e1c4108ac3"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-float]]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2646,7 +2646,11 @@ where
                     .output()
                     .value()
                     .map(orchard::value::NoteValue::from_raw)?;
-                let rho = orchard::note::Rho::from_bytes(act.spend().nullifier()).into_option()?;
+                // `nullifier` is optional in the PCZT wire format. On this path it is
+                // populated (the PCZT has been through the Prover), but the closure
+                // returns `Option`, so bail out gracefully rather than assume it.
+                let rho = orchard::note::Rho::from_bytes(act.spend().nullifier().as_ref()?)
+                    .into_option()?;
                 let rseed = act.output().rseed().as_ref().and_then(|rseed| {
                     orchard::note::RandomSeed::from_bytes(*rseed, &rho).into_option()
                 })?;


### PR DESCRIPTION
DNM/WIP. This branch isolates the remaining PCZT Orchard optional-field work on a review base that matches the local stack.

It makes the remaining recomputable Orchard-shaped fields optional in the v2 wire encoding, adds `MemoKind` for elided `enc_ciphertext` reconstruction, fills derived fields before parsing/signing, and rejects anchor elision before v6.

Validation:
- `cargo fmt --all`
- `cargo check -p pczt --all-features`
- `cargo test -p pczt --test end_to_end --all-features`
- `git diff --check`