### PR TITLE
zcash_client_sqlite: Truncate the Ironwood note commitment tree on rewind

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,8 +11,74 @@ workspace.
 ## [0.24.0] - PLANNED
 
 ### Added
+- Received Ironwood notes can now be selected and spent. `InputSource`
+  implementations select Ironwood notes when the Ironwood pool is active at the
+  target height, the greedy input selector spends them (attributing each spent
+  note to the Ironwood bundle for correct fee and action accounting), and the
+  proposal represents Orchard-receiver payments and Ironwood-spend change as
+  Ironwood-pool outputs that the transaction builder places in the Ironwood
+  bundle. `zcash_client_backend::data_api::ReceivedNotes` gains an
+  `ironwood` accessor and `take_ironwood`/`ironwood_value` methods, and
+  `NoteRetention` gains `should_retain_ironwood` (behind the `orchard` feature
+  flag).
+- The greedy input selector may combine shielded inputs from any of the pools
+  that are spendable at the target height (Sapling and Orchard, plus Ironwood
+  once it is active). It spends from a single pool when one can cover the
+  required amount by itself — preferring the pool matching the payment's
+  outputs, to avoid unnecessary pool crossings — and otherwise accumulates
+  pools in preference order, drawing upon the legacy Orchard pool last. The
+  Orchard turnstile (see `ProposalError::OrchardPoolValueCreation`) is enforced
+  by the change strategies and by proposal validation rather than by
+  restricting input selection.
+- `zcash_client_backend::wallet::Note::pool`, which returns the shielded value
+  pool (`Sapling`, `Orchard`, or `Ironwood`) to which a note belongs, classifying
+  version-3 Orchard notes as belonging to the Ironwood pool. This replaces the
+  removed `Note::protocol` accessor, which reported only the cryptographic
+  protocol (Sapling or Orchard).
+- `zcash_client_backend::proposal::Proposal::input_count_in_pool`, which returns
+  the total number of inputs from a given pool across all steps of the proposal.
+- `zcash_client_backend::data_api::AccountBalance::ironwood_balance` and
+  `AccountBalance::with_ironwood_balance_mut`, exposing the balance of Ironwood
+  funds in an account. Received Ironwood notes are now included in the account's
+  total, spendable, pending, and uneconomic balances alongside Sapling and
+  Orchard.
+- `zcash_client_backend::scanning::ScanningKeys::ironwood` (behind the `orchard`
+  feature flag), an accessor for the Ironwood scanning keys. Ironwood outputs
+  are trial-decrypted with the account's Orchard viewing keys but are tracked as
+  a pool distinct from Orchard. `ScanningKeys::new` now also takes the Ironwood
+  key map.
+- The block scanner now tracks Ironwood outputs as a pool distinct from Orchard
+  (behind the `orchard` feature flag). `ScannedBlock::ironwood`,
+  `ScannedBlockCommitments::ironwood`, `BlockMetadata::ironwood_tree_size`,
+  `WalletTx::ironwood_spends`/`ironwood_outputs`, and `Nullifiers::ironwood`
+  expose the Ironwood note commitments, tree size, and detected notes. The
+  `BlockMetadata::from_parts` and `WalletTx::new` constructors now also take the
+  corresponding Ironwood arguments.
+- Received Ironwood notes are now stored during `put_blocks`, and Ironwood
+  nullifiers are tracked for spend detection (behind the `orchard` feature
+  flag). `WalletRead::get_ironwood_nullifiers` and the low-level
+  `detect_ironwood_spend`/`put_received_ironwood_note`/`mark_ironwood_note_spent`/
+  `track_block_ironwood_nullifiers` methods mirror their Orchard counterparts.
+- `zcash_client_backend::data_api::chain::ChainState::final_ironwood_tree` and
+  `zcash_client_backend::proto::service::TreeState::ironwood_tree` (behind the
+  `orchard` feature flag), exposing the Ironwood note commitment tree frontier
+  as a pool distinct from Orchard. `ChainState::new` now also takes the final
+  Ironwood tree frontier. An absent `ironwood_tree` treestate field parses as an
+  empty tree, which is the correct Ironwood treestate at pool activation.
+- `put_blocks` now persists the Ironwood note commitment tree and Ironwood block
+  metadata, mirroring the Orchard handling. Checkpoint reconciliation across the
+  note commitment trees now spans all three shielded pools, so each tree gains a
+  checkpoint at every height checkpointed in any other pool.
+- `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
+  an optional accessor that wallet backends can override to provide the Ironwood
+  anchors and witnesses used by the transaction builder.
+- `zcash_client_backend::data_api::IRONWOOD_SHARD_HEIGHT`, the shard height of
+  the Ironwood note commitment tree (equal to the Orchard shard height).
 - `zcash_client_backend::data_api::NoteCommitmentTree`
 - `zcash_client_backend::data_api::SentTransactionOutput::note_commitment_tree`
+- `zcash_client_backend::proto::proposal::ValuePool::Ironwood`, so that a proposal
+  that spends Ironwood notes can be serialized to and parsed back from the
+  protobuf proposal format.
 - `zcash_client_backend::fees::orchard::BundleView::bundle_version`, replacing
   the `bundle_type` accessor; it returns the `orchard::bundle::BundleVersion`
   used to compute the Orchard action count.
@@ -33,29 +99,14 @@ workspace.
   general (non-shielding) transfers do not spend them; coinbase funds are
   shielded separately via `propose_shielding_coinbase`.
 - `zcash_client_backend::data_api::InputSource::select_spendable_transparent_outputs`
-  method (behind `transparent-inputs`), a value-bounded counterpart to
-  `InputSource::get_spendable_transparent_outputs[_for_addresses]`, used by
+  (behind `transparent-inputs`), a value-bounded counterpart to
+  `get_spendable_transparent_outputs[_for_addresses]` used by
   `GreedyInputSelector::propose_transaction` when the `TransparentSpendPolicy`
-  requires gathering the account's transparent UTXOs. Implementations order
-  eligible outputs by descending value and accumulate them, recomputing the
-  cumulative marginal fee cost of the gathered inputs (per the supplied
-  `fee_rule: &StandardFeeRule` argument) at each step, so that the returned
-  set covers the requested post-fee value without needing to materialize
-  every spendable UTXO for the account. This fee estimate always uses
-  `StandardFeeRule::Zip317`, independent of the `ChangeStrategy::FeeRule`
-  actually configured for the proposal; it is a heuristic bound only, and
-  `GreedyInputSelector` re-gathers with a corrected `TargetValue` if the
-  caller's actual change strategy reports `InsufficientFunds`. A `max_inputs`
-  argument additionally bounds the number of outputs the gather may select,
-  independent of the target value, so that a wallet holding a very large
-  number of small UTXOs cannot produce an arbitrarily large transaction; when
-  the cap is reached before the target value, the shortfall is likewise
-  surfaced as `InsufficientFunds`. An `address_allow_list` argument restricts
-  the gather to outputs received at the given transparent addresses (`None`
-  meaning any address belonging to the account); `GreedyInputSelector` uses
-  this to enforce `TransparentSpendPolicy::FromAddresses`. The restriction is
-  applied within the gather itself (not to its results), so that ineligible
-  outputs do not consume the value bound.
+  requires spending the account's transparent UTXOs. It returns a set of outputs
+  covering a requested `TargetValue`, ordered by descending value and bounded by
+  a `max_inputs` cap and an optional `address_allow_list`; an insufficient result
+  (from either bound) is surfaced as `InsufficientFunds`. See the method
+  documentation for the fee-estimation heuristic used to size the gather.
 - A new `spend-index` feature flag, for consumers whose chain-data source can
   resolve the spend of an individual transparent output (e.g. a full node with a
   spent-outpoint index). It gates:
@@ -72,15 +123,12 @@ workspace.
   satisfy the request with a single query. Shielding now uses this method, avoiding a per-address
   database round-trip when gathering inputs from wallets with many transparent addresses.
 - `zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelector::with_shielding_block_space_percent`,
-  which configures the maximum fraction of a block's space (as an integer percentage, default 10)
-  that a single transaction's transparent inputs may occupy. When shielding gathers more
-  spendable transparent outputs than fit within this bound, the highest-value outputs are selected
-  first and the remainder are left unspent, to be consolidated by a subsequent shielding
-  transaction. The same bound also applies to the transparent gather performed for general
-  (non-shielding) transfers when the active `TransparentSpendPolicy` requires it; if the cap is
-  reached before the requested value, the proposal fails with `InsufficientFunds` rather than
-  producing an oversized transaction. This bounds the size of any transaction with gathered
-  transparent inputs for wallets that hold very large numbers of transparent UTXOs.
+  which caps the fraction of a block's space (an integer percentage, default 10)
+  that a transaction's gathered transparent inputs may occupy, bounding
+  transaction size for wallets holding very large numbers of transparent UTXOs.
+  When the cap is reached the highest-value outputs are selected first; the
+  remainder are left for a later transaction (when shielding), or the proposal
+  fails with `InsufficientFunds` (for general transfers).
 - `zcash_client_backend::data_api::ll::wallet::PutBlocksError::ShardTreeForBlockRange`,
   a new variant that wraps a `shardtree` insertion error together with the
   shielded pool whose note commitment tree was being updated and the range of
@@ -102,6 +150,7 @@ workspace.
   - `recipient_account`
   - `recipient_key_scope`
   - `funding_account`
+  - `transfer_type`
 - `zcash_client_backend::wallet::Recipient::InternalTransparent` (behind
   the `transparent-inputs` feature flag): a new variant for recording the
   send side of a transparent output whose recipient address belongs to a
@@ -116,6 +165,13 @@ workspace.
 - `zcash_client_backend::proposal::ProposalError::ShieldingRequiresShieldedRecipient`,
   returned by `propose_shielding_coinbase` when the supplied `to_address` is
   a transparent or TEX address.
+- `zcash_client_backend::proposal::ProposalError::OrchardPoolValueCreation`
+  (behind the `orchard` feature flag), returned by proposal construction when a
+  step proposed for a post-NU6.3 target height would return as much or more
+  value to the Orchard pool as change than the step's Orchard inputs remove.
+  (A payment directed to the Orchard pool after NU6.3 activation is a
+  programming error, which step construction enforces by assertion: payment
+  classification always delivers such payments via the Ironwood bundle.)
 - `zcash_client_backend::data_api::wallet::ProposeShieldingCoinbaseErrT` type
   alias, parallel to `ProposeShieldingErrT` but parameterized on a `FeeRule`
   instead of a `ChangeStrategy`.
@@ -129,65 +185,83 @@ workspace.
 - `zcash_client_backend::sync`:
   - `decryptor` module, behind the `sync-decryptor` feature flag, providing a
     Tokio-based batch decryption engine for full blocks and transactions.
-- `zcash_client_backend::proposal::Step` methods for counting the inputs and
-  outputs of a proposal step by pool, paralleling the existing
-  `input_in_pool`/`output_in_pool`/`change_in_pool` predicates:
-  - `input_count_in_pool`
-  - `output_count_in_pool`
-  - `change_count_in_pool`
+- `zcash_client_backend::proposal::Step` predicates and counters for classifying
+  a step's inputs, outputs, and change by pool. Ironwood inputs (version-3
+  Orchard notes) are counted for `PoolType::Ironwood`, and the Orchard variants
+  exclude them:
+  - `input_in_pool`, `output_in_pool`, `change_in_pool`
+  - `input_count_in_pool`, `output_count_in_pool`, `change_count_in_pool`
   - `orchard_action_count`, the number of Orchard actions a step requires
     (the greater of its Orchard spends and its Orchard outputs plus change).
-- A new `spend-index` feature flag, for consumers whose chain-data source can
-  resolve the spend of an individual transparent output (e.g. a full node with a
-  spent-outpoint index). It gates:
-  - `zcash_client_backend::data_api::TransactionDataRequest::GetSpendingTx`,
-    a per-outpoint request to detect the spend of a specific transparent output.
-  - `zcash_client_backend::data_api::WalletWrite::notify_output_verified_unspent`,
-    which records that a transparent outpoint was confirmed unspent as of a given
-    height.
-- `zcash_client_backend::data_api::error::Error::ExpiryHeightBelowTargetHeight`
-  (behind the `pczt` feature flag), returned by `create_pczt_from_proposal`
-  when the caller-supplied `target_expiry_height` is a nonzero height below
-  the proposal's minimum target height.
 
 ### Changed
-- `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
-  an optional accessor that wallet backends can override to provide Ironwood
-  anchors and witnesses to the transaction builder.
+- When a transaction spends Orchard notes once the Ironwood pool is active, its
+  Orchard-pool change now stays in the Orchard pool instead of being routed into
+  the Ironwood bundle. The change is returned to a spent note's own address,
+  which the Orchard V3 cross-address restriction permits (via the builder's
+  dedicated change entry point), so only the payment crosses the turnstile into
+  Ironwood. Orchard-pool change is still routed into the Ironwood bundle when the
+  transaction spends no Orchard notes (e.g. an Orchard-receiver payment funded
+  from the Sapling and Ironwood pools).
 - Migrated to `lightwallet-protocol v0.5.0`, `zcash_protocol 0.10.0-pre.0`,
   `zcash_address 0.13.0-pre.0`, `zcash_transparent 0.9.0-pre.0`,
   `zcash_keys 0.15.0-pre.0`, `zcash_primitives 0.29.0-pre.0`,
-  `zcash_proofs 0.29.0-pre.0`.
+  `zcash_proofs 0.29.0-pre.0`. The `lightwallet-protocol v0.5.0` migration
+  changes `zcash_client_backend::proto`:
+  - Adds the `service::PoolType::Ironwood` and `service::ShieldedProtocol::Ironwood`
+    variants.
+  - Adds the `compact_formats::ChainMetadata::ironwood_commitment_tree_size` and
+    `compact_formats::CompactTx::ironwood_actions` fields.
+  - Removes the `compact_formats::CompactBlock::proto_version` field.
+- Many APIs that previously identified a shielded pool by
+  `zcash_protocol::ShieldedProtocol` (Sapling or Orchard) now take or return
+  `zcash_protocol::ShieldedPool` (Sapling, Orchard, or Ironwood). Affected items
+  include `InputSource::{get_spendable_note, select_spendable_notes, select_unspent_notes}`,
+  `wallet::NoteId::{new, protocol}`, `data_api::AccountMeta::note_count`,
+  `fees::ChangeValue::shielded`, the `fees` change-strategy constructors, and the
+  `scanning::ScanError` pool fields.
+- `zcash_client_backend::data_api::AccountMeta` now tracks Ironwood notes:
+  `AccountMeta::new` takes an additional `ironwood` argument, an `ironwood`
+  accessor has been added, and `total_note_count`, `total_value`, and
+  `note_count(ShieldedPool::Ironwood)` now include Ironwood notes, so
+  change-output splitting accounts for the account's Ironwood holdings.
 - Fee and change calculation now derive the Orchard bundle version — and hence
   the Orchard action-count policy — from the proposal's target height, instead
   of unconditionally using the legacy (pre-NU6.3) policy. Proposals targeting
   heights at or beyond NU6.3 activation now count one action per Orchard spend
   or output, matching the post-NU6.3 transaction builder.
 - `zcash_client_backend::fees::ChangeStrategy::compute_balance` now takes an
-  additional `ironwood` bundle view and an `orchard_change_to_ironwood` flag
-  (behind the `orchard` feature flag), alongside the existing `orchard` view. A
-  V6 transaction carries a separate Ironwood bundle that is charged its own
-  actions, so the built-in change strategies populate the view — and route the
-  Orchard-pool change output into the Ironwood bundle when the builder will —
-  from the same routing decision the transaction builder uses. Pass an empty
-  view and `false` when nothing targets the Ironwood pool.
-- `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
-  routes Orchard-recipient spends and outputs through the Ironwood transaction
-  builder when Ironwood is active, unless an explicit legacy V5 transaction is
-  requested.
+  additional `ironwood` bundle view (behind the `orchard` feature flag),
+  alongside the existing `orchard` view. A V6 transaction carries a separate
+  Ironwood bundle that is charged its own actions, so the built-in change
+  strategies count Ironwood spends, outputs, and change against that bundle.
+  Pass an empty view when nothing targets the Ironwood pool.
+- `zcash_client_backend::fees::ChangeError::DustInputs` has an additional
+  `ironwood` field (behind the `orchard` feature flag) identifying Ironwood
+  inputs that would cost more to spend than they are worth; the built-in
+  change strategies now model Ironwood dust the same way as Orchard dust.
+  Exhaustive matches on the variant must bind or ignore the new field.
+- Once Ironwood is active, input selection represents Orchard-receiver payments
+  and the change from Ironwood spends as Ironwood-pool outputs in the proposal
+  (each delivered to the recipient's Orchard receiver via the Ironwood bundle), so
+  that a proposal a user inspects reflects the Ironwood outputs being created.
+  `zcash_client_backend::data_api::wallet::create_proposed_transactions` builds
+  those outputs through the Ironwood transaction builder.
 - `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` continues
   to use legacy Orchard routing for Orchard-recipient proposals until PCZT has
   Ironwood role support.
-- Renamed `zcash_client_backend::data_api::TransparentOutputFilter` to `CoinbaseFilter`
+- Renamed `zcash_client_backend::data_api::TransparentOutputFilter` to
+  `CoinbaseFilter`, and its `All` variant to `AllTransparentOutputs`.
 - During scanning, transparent `OP_RETURN` (nulldata) outputs are now recognized as
   unspendable data outputs and skipped silently, instead of being logged as
   unsupported script kinds. Other unrecognized transparent script kinds continue to
   be logged.
 - `zcash_client_backend::data_api`:
   - Changes to the `InputSource` trait:
-    - The result types of `InputSource::get_unspent_transparent_output` and
-      `InputSource::get_unspent_transparent_outputs` have each changed; these
-      have reverted to returning `WalletTransparentOutput`.
+    - `InputSource::get_unspent_transparent_output` and
+      `InputSource::get_spendable_transparent_outputs` have reverted to returning
+      `WalletTransparentOutput` (now carrying an account id) instead of
+      `WalletUtxo`.
 - `zcash_client_backend::data_api::SentTransaction`: the `account_id` field
   and accessor have been renamed to `funding_account`, to disambiguate from
   the recipient-account terminology now used by `WalletTransparentOutput`.
@@ -200,9 +274,41 @@ workspace.
     fail with `RewindError::RewindBeyondBirthdays`; the caller should re-try
     with the affected account ids included in the `reset_account_birthdays`
     argument to acknowledge that those birthdays will be lowered.
+- `zcash_client_backend::DecryptedOutput` now records the value pool of the
+  decrypted output: `DecryptedOutput::new` takes an additional
+  `zcash_protocol::ShieldedPool` argument, a `value_pool` accessor has been added,
+  and the `DecryptedOrchardOutput` associated type now carries the Orchard
+  `ValuePool` so Ironwood outputs are distinguished from Orchard.
+- `zcash_client_backend::decrypt_transaction` now decrypts the transaction's
+  Ironwood bundle under the Ironwood note-encryption domain, so
+  `decrypt_and_store_transaction` detects and stores received Ironwood notes
+  (previously the Ironwood bundle was decrypted under the Orchard domain and no
+  Ironwood note was found). `zcash_client_backend::data_api::DecryptedTransaction`
+  tracks these separately: `DecryptedTransaction::new` takes an additional
+  `ironwood_outputs` argument and an `ironwood_outputs` accessor has been added,
+  both behind the `orchard` feature flag.
 - `zcash_client_backend::proposal`:
   - `Proposal::single_step` and `Step::from_parts` now take transparent inputs
-    as `Vec<WalletTransparentOutput<()>>` (explicitly with no account ID).
+    as `Vec<WalletTransparentOutput<()>>` (explicitly with no account ID), and
+    take the step's anchor height as an explicit `BlockHeight` argument.
+  - `Proposal::single_step` and `Step::from_parts` also take an
+    `ironwood_active` flag (behind the `orchard` feature flag) indicating
+    whether the Ironwood pool is active at the target height; when set, the
+    step is validated against the Orchard turnstile (see
+    `ProposalError::OrchardPoolValueCreation`).
+  - The shielded anchor height has moved from `ShieldedInputs` to `Step`:
+    `Step::anchor_height` is new, `ShieldedInputs::from_parts` no longer takes an
+    anchor height, and `ShieldedInputs::anchor_height` has been removed.
+- `zcash_client_backend::proto::proposal::Proposal::try_into_standard_proposal`
+  now takes the network parameters as an additional argument, in order to
+  validate decoded proposals against the Orchard turnstile when Ironwood is
+  active at the proposal's target height.
+- The change strategies in `zcash_client_backend::fees` now enforce the Orchard
+  turnstile when selecting the change pool for a proposal with a post-NU6.3
+  target height: change is directed to the Orchard pool only when the
+  transaction spends Orchard notes and strictly less value would return to the
+  pool than the notes remove; otherwise Orchard-pool change is directed to the
+  Ironwood pool.
 - `zcash_client_backend::data_api::wallet::propose_transfer` and
   `zcash_client_backend::data_api::wallet::input_selection::InputSelector::propose_transaction`
   now take an additional `&TransparentSpendPolicy` argument (behind the
@@ -230,20 +336,13 @@ workspace.
   `zcash_primitives::transaction::fees::FeeRule::fee_required`. Code that calls
   `fee_required` directly or implements the trait must thread through the number
   of Ironwood actions, passing `0` for transactions without an Ironwood bundle.
-- During scanning, transparent `OP_RETURN` (nulldata) outputs are now recognized as
-  unspendable data outputs and skipped silently, instead of being logged as
-  unsupported script kinds. Other unrecognized transparent script kinds continue to
-  be logged.
-- `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes
-  an additional `target_expiry_height: Option<BlockHeight>` argument. `Some`
-  pins the PCZT expiry before finalization, while `None` preserves the
-  builder-derived expiry. Nonzero heights below the proposal's minimum target
-  height are rejected with `Error::ExpiryHeightBelowTargetHeight`; zero still
-  disables expiry. The `test-dependencies` helper mirrors this signature.
 
 ### Removed
 - `zcash_client_backend::data_api::WalletUtxo` (use `WalletTransparentOutput`
   instead).
+- `zcash_client_backend::wallet::Note::protocol` (use `Note::pool` instead).
+- `zcash_client_backend::ShieldedProtocol` re-export (use
+  `zcash_client_backend::ShieldedPool` instead).
 
 ## [0.23.0] - 2026-06-02
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -196,8 +196,8 @@ transparent-key-import = ["transparent-inputs"]
 
 ## Enables per-outpoint transparent spend queries, for consumers that have access
 ## to a spent-outpoint index (e.g. a full node's spend index). Adds the
-## `TransactionDataRequest::SpendsOfTransparentOutput` request variant and the
-## `WalletWrite::notify_outpoint_unspent_checked` method, and is what a wallet
+## `TransactionDataRequest::GetSpendingTx` request variant and the
+## `WalletWrite::notify_output_verified_unspent` method, and is what a wallet
 ## targeting such a data source enables instead of relying on address-based
 ## `TransactionsInvolvingAddress` requests for transparent spend detection.
 spend-index = ["transparent-inputs"]

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -54,6 +54,10 @@ enum ValuePool {
     Sapling = 2;
     // The Orchard value pool
     Orchard = 3;
+    // The Ironwood value pool (ZIP 2005). Ironwood notes are Orchard-shaped but
+    // belong to a distinct pool; older decoders that do not recognize this value
+    // will reject the proposal rather than misattribute it to Orchard.
+    Ironwood = 4;
 }
 
 // A mapping from ZIP 321 payment index to the output pool that has been chosen

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1341,12 +1341,23 @@ impl PoolMeta {
 pub struct AccountMeta {
     sapling: Option<PoolMeta>,
     orchard: Option<PoolMeta>,
+    ironwood: Option<PoolMeta>,
 }
 
 impl AccountMeta {
     /// Constructs a new [`AccountMeta`] value from its constituent parts.
-    pub fn new(sapling: Option<PoolMeta>, orchard: Option<PoolMeta>) -> Self {
-        Self { sapling, orchard }
+    ///
+    /// Ironwood metadata is tracked separately from Orchard, as Ironwood is a distinct pool.
+    pub fn new(
+        sapling: Option<PoolMeta>,
+        orchard: Option<PoolMeta>,
+        ironwood: Option<PoolMeta>,
+    ) -> Self {
+        Self {
+            sapling,
+            orchard,
+            ironwood,
+        }
     }
 
     /// Returns metadata about Sapling notes belonging to the account for which this was generated.
@@ -1365,6 +1376,15 @@ impl AccountMeta {
         self.orchard.as_ref()
     }
 
+    /// Returns metadata about Ironwood notes belonging to the account for which this was generated.
+    ///
+    /// Ironwood notes are Orchard-shaped but belong to a pool distinct from Orchard. Returns
+    /// [`None`] if no metadata is available or it was not possible to evaluate the query described
+    /// by a [`NoteFilter`] given the available wallet data.
+    pub fn ironwood(&self) -> Option<&PoolMeta> {
+        self.ironwood.as_ref()
+    }
+
     fn sapling_note_count(&self) -> Option<usize> {
         self.sapling.as_ref().map(|m| m.note_count)
     }
@@ -1373,12 +1393,16 @@ impl AccountMeta {
         self.orchard.as_ref().map(|m| m.note_count)
     }
 
-    /// Returns the number of unspent notes in the wallet for the given shielded protocol.
+    fn ironwood_note_count(&self) -> Option<usize> {
+        self.ironwood.as_ref().map(|m| m.note_count)
+    }
+
+    /// Returns the number of unspent notes in the wallet for the given shielded pool.
     pub fn note_count(&self, protocol: ShieldedPool) -> Option<usize> {
         match protocol {
             ShieldedPool::Sapling => self.sapling_note_count(),
             ShieldedPool::Orchard => self.orchard_note_count(),
-            ShieldedPool::Ironwood => todo!("Ironwood note counts are not yet tracked"),
+            ShieldedPool::Ironwood => self.ironwood_note_count(),
         }
     }
 
@@ -1389,9 +1413,14 @@ impl AccountMeta {
     /// described by a [`NoteFilter`] given the available wallet data. If metadata is available
     /// only for a single pool, the metadata for that pool will be returned.
     pub fn total_note_count(&self) -> Option<usize> {
-        let s = self.sapling_note_count();
-        let o = self.orchard_note_count();
-        s.zip(o).map(|(s, o)| s + o).or(s).or(o)
+        [
+            self.sapling_note_count(),
+            self.orchard_note_count(),
+            self.ironwood_note_count(),
+        ]
+        .into_iter()
+        .flatten()
+        .reduce(|a, b| a + b)
     }
 
     fn sapling_value(&self) -> Option<Zatoshis> {
@@ -1402,18 +1431,24 @@ impl AccountMeta {
         self.orchard.as_ref().map(|m| m.value)
     }
 
+    fn ironwood_value(&self) -> Option<Zatoshis> {
+        self.ironwood.as_ref().map(|m| m.value)
+    }
+
     /// Returns the total value of shielded notes represented by [`Self::total_note_count`]
     ///
     /// Returns [`None`] if no metadata is available or it was not possible to evaluate the query
     /// described by a [`NoteFilter`] given the available wallet data. If metadata is available
     /// only for a single pool, the metadata for that pool will be returned.
     pub fn total_value(&self) -> Option<Zatoshis> {
-        let s = self.sapling_value();
-        let o = self.orchard_value();
-        s.zip(o)
-            .map(|(s, o)| (s + o).expect("Does not overflow Zcash maximum value."))
-            .or(s)
-            .or(o)
+        [
+            self.sapling_value(),
+            self.orchard_value(),
+            self.ironwood_value(),
+        ]
+        .into_iter()
+        .flatten()
+        .reduce(|a, b| (a + b).expect("Does not overflow Zcash maximum value."))
     }
 }
 
@@ -2667,15 +2702,21 @@ pub struct DecryptedTransaction<'a, Tx: DecryptableTransaction<AccountId>, Accou
     sapling_outputs: Vec<Tx::DecryptedSaplingOutput>,
     #[cfg(feature = "orchard")]
     orchard_outputs: Vec<Tx::DecryptedOrchardOutput>,
+    #[cfg(feature = "orchard")]
+    ironwood_outputs: Vec<Tx::DecryptedOrchardOutput>,
 }
 
 impl<'a, Tx: DecryptableTransaction<AccountId>, AccountId> DecryptedTransaction<'a, Tx, AccountId> {
     /// Constructs a new [`DecryptedTransaction`] from its constituent parts.
+    ///
+    /// Ironwood outputs are Orchard-shaped but belong to a distinct pool, and are passed and
+    /// tracked separately from Orchard outputs.
     pub fn new(
         mined_height: Option<BlockHeight>,
         tx: &'a Tx,
         sapling_outputs: Vec<Tx::DecryptedSaplingOutput>,
         #[cfg(feature = "orchard")] orchard_outputs: Vec<Tx::DecryptedOrchardOutput>,
+        #[cfg(feature = "orchard")] ironwood_outputs: Vec<Tx::DecryptedOrchardOutput>,
     ) -> Self {
         Self {
             mined_height,
@@ -2683,6 +2724,8 @@ impl<'a, Tx: DecryptableTransaction<AccountId>, AccountId> DecryptedTransaction<
             sapling_outputs,
             #[cfg(feature = "orchard")]
             orchard_outputs,
+            #[cfg(feature = "orchard")]
+            ironwood_outputs,
         }
     }
 
@@ -2704,11 +2747,19 @@ impl<'a, Tx: DecryptableTransaction<AccountId>, AccountId> DecryptedTransaction<
         &self.orchard_outputs
     }
 
+    /// Returns the Ironwood outputs that were decrypted from the transaction.
+    ///
+    /// Ironwood outputs are Orchard-shaped but belong to a pool distinct from Orchard.
+    #[cfg(feature = "orchard")]
+    pub fn ironwood_outputs(&self) -> &[Tx::DecryptedOrchardOutput] {
+        &self.ironwood_outputs
+    }
+
     /// Returns whether the transaction has decrypted outputs
     pub fn has_decrypted_outputs(&self) -> bool {
         let has_sapling = !self.sapling_outputs.is_empty();
         #[cfg(feature = "orchard")]
-        let has_orchard = !self.orchard_outputs.is_empty();
+        let has_orchard = !self.orchard_outputs.is_empty() || !self.ironwood_outputs.is_empty();
         #[cfg(not(feature = "orchard"))]
         let has_orchard = false;
 
@@ -3784,6 +3835,31 @@ mod tests {
     use transparent::address::TransparentAddress;
     use zcash_keys::address::{Address, UnifiedAddress};
     use zip32::DiversifierIndex;
+
+    #[test]
+    fn account_meta_totals_include_ironwood() {
+        let meta = AccountMeta::new(
+            Some(PoolMeta::new(2, Zatoshis::const_from_u64(200))),
+            Some(PoolMeta::new(3, Zatoshis::const_from_u64(300))),
+            Some(PoolMeta::new(5, Zatoshis::const_from_u64(500))),
+        );
+        assert_eq!(meta.note_count(ShieldedPool::Ironwood), Some(5));
+        assert_eq!(meta.total_note_count(), Some(10));
+        assert_eq!(meta.total_value(), Some(Zatoshis::const_from_u64(1000)));
+
+        // With metadata for only the Ironwood pool, the totals reflect that pool alone.
+        let ironwood_only = AccountMeta::new(
+            None,
+            None,
+            Some(PoolMeta::new(4, Zatoshis::const_from_u64(400))),
+        );
+        assert_eq!(ironwood_only.note_count(ShieldedPool::Ironwood), Some(4));
+        assert_eq!(ironwood_only.total_note_count(), Some(4));
+        assert_eq!(
+            ironwood_only.total_value(),
+            Some(Zatoshis::const_from_u64(400))
+        );
+    }
 
     fn derived_source() -> AddressSource {
         AddressSource::Derived {

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -325,6 +325,7 @@ impl core::ops::Add<Balance> for Balance {
 pub struct AccountBalance {
     sapling_balance: Balance,
     orchard_balance: Balance,
+    ironwood_balance: Balance,
     unshielded_balance: Balance,
 }
 
@@ -333,12 +334,14 @@ impl AccountBalance {
     pub const ZERO: Self = Self {
         sapling_balance: Balance::ZERO,
         orchard_balance: Balance::ZERO,
+        ironwood_balance: Balance::ZERO,
         unshielded_balance: Balance::ZERO,
     };
 
     fn check_total(&self) -> Result<Zatoshis, BalanceError> {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
+            + self.ironwood_balance.total()
             + self.unshielded_balance.total())
         .ok_or(BalanceError::Overflow)
     }
@@ -373,6 +376,23 @@ impl AccountBalance {
         f: impl FnOnce(&mut Balance) -> Result<A, E>,
     ) -> Result<A, E> {
         let result = f(&mut self.orchard_balance)?;
+        self.check_total()?;
+        Ok(result)
+    }
+
+    /// Returns the [`Balance`] of Ironwood funds in the account.
+    pub fn ironwood_balance(&self) -> &Balance {
+        &self.ironwood_balance
+    }
+
+    /// Provides a mutable reference to the [`Balance`] of Ironwood funds in the account
+    /// to the specified callback, checking invariants after the callback's action has been
+    /// evaluated.
+    pub fn with_ironwood_balance_mut<A, E: From<BalanceError>>(
+        &mut self,
+        f: impl FnOnce(&mut Balance) -> Result<A, E>,
+    ) -> Result<A, E> {
+        let result = f(&mut self.ironwood_balance)?;
         self.check_total()?;
         Ok(result)
     }
@@ -414,14 +434,17 @@ impl AccountBalance {
     pub fn total(&self) -> Zatoshis {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
+            + self.ironwood_balance.total()
             + self.unshielded_balance.total())
         .expect("Account balance cannot overflow MAX_MONEY")
     }
 
-    /// Returns the total value of shielded (Sapling and Orchard) funds that may immediately be
-    /// spent.
+    /// Returns the total value of shielded (Sapling, Orchard, and Ironwood) funds that may
+    /// immediately be spent.
     pub fn spendable_value(&self) -> Zatoshis {
-        (self.sapling_balance.spendable_value + self.orchard_balance.spendable_value)
+        (self.sapling_balance.spendable_value
+            + self.orchard_balance.spendable_value
+            + self.ironwood_balance.spendable_value)
             .expect("Account balance cannot overflow MAX_MONEY")
     }
 
@@ -429,7 +452,8 @@ impl AccountBalance {
     /// sufficient confirmations for spendability.
     pub fn change_pending_confirmation(&self) -> Zatoshis {
         (self.sapling_balance.change_pending_confirmation
-            + self.orchard_balance.change_pending_confirmation)
+            + self.orchard_balance.change_pending_confirmation
+            + self.ironwood_balance.change_pending_confirmation)
             .expect("Account balance cannot overflow MAX_MONEY")
     }
 
@@ -437,7 +461,8 @@ impl AccountBalance {
     /// is required before it will be possible to derive witnesses for the associated notes.
     pub fn value_pending_spendability(&self) -> Zatoshis {
         (self.sapling_balance.value_pending_spendability
-            + self.orchard_balance.value_pending_spendability)
+            + self.orchard_balance.value_pending_spendability
+            + self.ironwood_balance.value_pending_spendability)
             .expect("Account balance cannot overflow MAX_MONEY")
     }
 
@@ -446,6 +471,7 @@ impl AccountBalance {
     pub fn uneconomic_value(&self) -> Zatoshis {
         (self.sapling_balance.uneconomic_value
             + self.orchard_balance.uneconomic_value
+            + self.ironwood_balance.uneconomic_value
             + self.unshielded_balance.uneconomic_value)
             .expect("Account balance cannot overflow MAX_MONEY")
     }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -932,12 +932,18 @@ pub trait NoteRetention<NoteRef> {
     /// Returns whether the specified Orchard note should be retained.
     #[cfg(feature = "orchard")]
     fn should_retain_orchard(&self, note: &ReceivedNote<NoteRef, orchard::note::Note>) -> bool;
+    /// Returns whether the specified Ironwood note should be retained. Ironwood notes are
+    /// Orchard-shaped, so this uses the same note type as Orchard.
+    #[cfg(feature = "orchard")]
+    fn should_retain_ironwood(&self, note: &ReceivedNote<NoteRef, orchard::note::Note>) -> bool;
 }
 
 pub(crate) struct SimpleNoteRetention {
     pub(crate) sapling: bool,
     #[cfg(feature = "orchard")]
     pub(crate) orchard: bool,
+    #[cfg(feature = "orchard")]
+    pub(crate) ironwood: bool,
 }
 
 impl<NoteRef> NoteRetention<NoteRef> for SimpleNoteRetention {
@@ -949,6 +955,11 @@ impl<NoteRef> NoteRetention<NoteRef> for SimpleNoteRetention {
     fn should_retain_orchard(&self, _: &ReceivedNote<NoteRef, orchard::note::Note>) -> bool {
         self.orchard
     }
+
+    #[cfg(feature = "orchard")]
+    fn should_retain_ironwood(&self, _: &ReceivedNote<NoteRef, orchard::note::Note>) -> bool {
+        self.ironwood
+    }
 }
 
 /// Shielded outputs that were received by the wallet.
@@ -957,12 +968,19 @@ pub struct ReceivedNotes<NoteRef> {
     sapling: Vec<ReceivedNote<NoteRef, sapling::Note>>,
     #[cfg(feature = "orchard")]
     orchard: Vec<ReceivedNote<NoteRef, orchard::note::Note>>,
+    // Ironwood notes are Orchard-shaped `orchard::note::Note` values (note plaintext version 3),
+    // but are tracked as a distinct pool so that Orchard and Ironwood value and bundle action
+    // counts are accounted for separately.
+    #[cfg(feature = "orchard")]
+    ironwood: Vec<ReceivedNote<NoteRef, orchard::note::Note>>,
 }
 
 impl<NoteRef> ReceivedNotes<NoteRef> {
     /// Construct a new empty [`ReceivedNotes`].
     pub fn empty() -> Self {
         Self::new(
+            vec![],
+            #[cfg(feature = "orchard")]
             vec![],
             #[cfg(feature = "orchard")]
             vec![],
@@ -973,11 +991,14 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
     pub fn new(
         sapling: Vec<ReceivedNote<NoteRef, sapling::Note>>,
         #[cfg(feature = "orchard")] orchard: Vec<ReceivedNote<NoteRef, orchard::note::Note>>,
+        #[cfg(feature = "orchard")] ironwood: Vec<ReceivedNote<NoteRef, orchard::note::Note>>,
     ) -> Self {
         Self {
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
         }
     }
 
@@ -1003,6 +1024,18 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
         self.orchard
     }
 
+    /// Returns the set of spendable Ironwood notes.
+    #[cfg(feature = "orchard")]
+    pub fn ironwood(&self) -> &[ReceivedNote<NoteRef, orchard::note::Note>] {
+        self.ironwood.as_ref()
+    }
+
+    /// Consumes this value and returns the Ironwood notes contained within it.
+    #[cfg(feature = "orchard")]
+    pub fn take_ironwood(self) -> Vec<ReceivedNote<NoteRef, orchard::note::Note>> {
+        self.ironwood
+    }
+
     /// Computes the total value of Sapling notes.
     pub fn sapling_value(&self) -> Result<Zatoshis, BalanceError> {
         self.sapling.iter().try_fold(Zatoshis::ZERO, |acc, n| {
@@ -1010,10 +1043,18 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
         })
     }
 
-    /// Computes the total value of Sapling notes.
+    /// Computes the total value of Orchard notes.
     #[cfg(feature = "orchard")]
     pub fn orchard_value(&self) -> Result<Zatoshis, BalanceError> {
         self.orchard.iter().try_fold(Zatoshis::ZERO, |acc, n| {
+            (acc + n.note_value()?).ok_or(BalanceError::Overflow)
+        })
+    }
+
+    /// Computes the total value of Ironwood notes.
+    #[cfg(feature = "orchard")]
+    pub fn ironwood_value(&self) -> Result<Zatoshis, BalanceError> {
+        self.ironwood.iter().try_fold(Zatoshis::ZERO, |acc, n| {
             (acc + n.note_value()?).ok_or(BalanceError::Overflow)
         })
     }
@@ -1024,7 +1065,8 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
         return self.sapling_value();
 
         #[cfg(feature = "orchard")]
-        return (self.sapling_value()? + self.orchard_value()?).ok_or(BalanceError::Overflow);
+        return (self.sapling_value()? + self.orchard_value()? + self.ironwood_value()?)
+            .ok_or(BalanceError::Overflow);
     }
 
     /// Consumes this [`ReceivedNotes`] value and produces a vector of
@@ -1041,9 +1083,24 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
 
         #[cfg(feature = "orchard")]
         let iter = iter.chain(self.orchard.into_iter().filter_map(|n| {
-            retention
-                .should_retain_orchard(&n)
-                .then(|| n.map_note(Note::Orchard))
+            retention.should_retain_orchard(&n).then(|| {
+                n.map_note(|note| Note::Orchard {
+                    note,
+                    pool: orchard::ValuePool::Orchard,
+                })
+            })
+        }));
+
+        // Ironwood notes are `orchard::note::Note` values, so they are emitted as `Note::Orchard`;
+        // the transaction builder routes them to the Ironwood bundle by their version 3 plaintext.
+        #[cfg(feature = "orchard")]
+        let iter = iter.chain(self.ironwood.into_iter().filter_map(|n| {
+            retention.should_retain_ironwood(&n).then(|| {
+                n.map_note(|note| Note::Orchard {
+                    note,
+                    pool: orchard::ValuePool::Ironwood,
+                })
+            })
         }));
 
         iter.collect()
@@ -2596,7 +2653,7 @@ pub trait DecryptableTransaction<AccountId> {
 impl<AccountId> DecryptableTransaction<AccountId> for Transaction {
     type DecryptedSaplingOutput = DecryptedOutput<sapling::Note, AccountId>;
     #[cfg(feature = "orchard")]
-    type DecryptedOrchardOutput = DecryptedOutput<orchard::Note, AccountId>;
+    type DecryptedOrchardOutput = DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>;
 }
 
 /// A transaction that was detected during scanning of the blockchain,

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -639,7 +639,7 @@ where
         .get_unified_full_viewing_keys()
         .map_err(Error::Wallet)?;
     let scanning_keys = ScanningKeys::from_account_ufvks(account_ufvks);
-    let mut runners = BatchRunners::<_, (), ()>::for_keys(100, &scanning_keys);
+    let mut runners = BatchRunners::<_, (), (), ()>::for_keys(100, &scanning_keys);
 
     block_source.with_blocks::<_, DbT::Error>(Some(from_height), Some(limit), |block| {
         runners.add_block(params, block).map_err(|e| e.into())
@@ -664,7 +664,7 @@ where
         Some(limit),
         |block: CompactBlock| {
             scan_summary.scanned_range.end = block.height() + 1;
-            let scanned_block = scan_block_with_runners::<_, _, _, (), ()>(
+            let scanned_block = scan_block_with_runners::<_, _, _, (), (), ()>(
                 params,
                 block,
                 &scanning_keys,

--- a/zcash_client_backend/src/data_api/ll.rs
+++ b/zcash_client_backend/src/data_api/ll.rs
@@ -20,7 +20,7 @@ use zcash_primitives::{
     transaction::{Transaction, TransactionData},
 };
 use zcash_protocol::{
-    PoolType, ShieldedPool, TxId,
+    ShieldedPool, TxId,
     consensus::{BlockHeight, TxIndex},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -637,17 +637,20 @@ pub trait LowLevelWalletWrite: LowLevelWalletRead {
 
 /// This trait provides a generalization over output representations.
 pub trait ReceivedShieldedOutput {
-    const POOL_TYPE: PoolType;
     type AccountId;
-    type Note: Into<crate::wallet::Note>;
+    type Note;
     type Nullifier;
 
     /// Returns the index of the output within its corresponding bundle.
     fn index(&self) -> usize;
     /// Returns the account ID for the account that received this output.
     fn account_id(&self) -> Self::AccountId;
-    /// Returns the received note.
+    /// Returns the note.
     fn note(&self) -> &Self::Note;
+    /// Returns the received note, as a [`Note`].
+    ///
+    /// [`Note`]: crate::wallet::Note
+    fn to_wallet_note(&self) -> crate::wallet::Note;
     /// Returns any memo associated with the output.
     fn memo(&self) -> Option<&MemoBytes>;
     /// Returns a [`TransferType`] value that is determined based upon what type of key was used to
@@ -677,7 +680,6 @@ impl<T: ReceivedShieldedOutput<Note = ::sapling::Note, Nullifier = ::sapling::Nu
 }
 
 impl<AccountId: Copy> ReceivedShieldedOutput for WalletSaplingOutput<AccountId> {
-    const POOL_TYPE: PoolType = PoolType::SAPLING;
     type AccountId = AccountId;
     type Note = ::sapling::Note;
     type Nullifier = ::sapling::Nullifier;
@@ -688,8 +690,11 @@ impl<AccountId: Copy> ReceivedShieldedOutput for WalletSaplingOutput<AccountId> 
     fn account_id(&self) -> Self::AccountId {
         *WalletSaplingOutput::account_id(self)
     }
-    fn note(&self) -> &::sapling::Note {
+    fn note(&self) -> &Self::Note {
         WalletSaplingOutput::note(self)
+    }
+    fn to_wallet_note(&self) -> crate::wallet::Note {
+        crate::wallet::Note::Sapling(self.note().clone())
     }
     fn memo(&self) -> Option<&MemoBytes> {
         None
@@ -716,7 +721,6 @@ impl<AccountId: Copy> ReceivedShieldedOutput for WalletSaplingOutput<AccountId> 
 }
 
 impl<AccountId: Copy> ReceivedShieldedOutput for DecryptedOutput<::sapling::Note, AccountId> {
-    const POOL_TYPE: PoolType = PoolType::SAPLING;
     type AccountId = AccountId;
     type Note = ::sapling::Note;
     type Nullifier = ::sapling::Nullifier;
@@ -727,8 +731,11 @@ impl<AccountId: Copy> ReceivedShieldedOutput for DecryptedOutput<::sapling::Note
     fn account_id(&self) -> Self::AccountId {
         *self.account()
     }
-    fn note(&self) -> &::sapling::Note {
-        self.note()
+    fn note(&self) -> &Self::Note {
+        DecryptedOutput::note(self)
+    }
+    fn to_wallet_note(&self) -> crate::wallet::Note {
+        crate::wallet::Note::Sapling(self.note().clone())
     }
     fn memo(&self) -> Option<&MemoBytes> {
         Some(self.memo())
@@ -768,7 +775,6 @@ impl<T: ReceivedShieldedOutput<Note = ::orchard::Note, Nullifier = ::orchard::no
 
 #[cfg(feature = "orchard")]
 impl<AccountId: Copy> ReceivedShieldedOutput for WalletOrchardOutput<AccountId> {
-    const POOL_TYPE: PoolType = PoolType::ORCHARD;
     type AccountId = AccountId;
     type Note = ::orchard::Note;
     type Nullifier = ::orchard::note::Nullifier;
@@ -779,8 +785,15 @@ impl<AccountId: Copy> ReceivedShieldedOutput for WalletOrchardOutput<AccountId> 
     fn account_id(&self) -> Self::AccountId {
         *WalletOrchardOutput::account_id(self)
     }
-    fn note(&self) -> &::orchard::note::Note {
-        WalletOrchardOutput::note(self)
+    fn note(&self) -> &Self::Note {
+        &self.note().0
+    }
+    fn to_wallet_note(&self) -> crate::wallet::Note {
+        let (note, pool) = self.note();
+        crate::wallet::Note::Orchard {
+            note: *note,
+            pool: *pool,
+        }
     }
     fn memo(&self) -> Option<&MemoBytes> {
         None
@@ -807,8 +820,9 @@ impl<AccountId: Copy> ReceivedShieldedOutput for WalletOrchardOutput<AccountId> 
 }
 
 #[cfg(feature = "orchard")]
-impl<AccountId: Copy> ReceivedShieldedOutput for DecryptedOutput<::orchard::Note, AccountId> {
-    const POOL_TYPE: PoolType = PoolType::ORCHARD;
+impl<AccountId: Copy> ReceivedShieldedOutput
+    for DecryptedOutput<(::orchard::Note, ::orchard::ValuePool), AccountId>
+{
     type AccountId = AccountId;
     type Note = ::orchard::Note;
     type Nullifier = ::orchard::note::Nullifier;
@@ -819,8 +833,15 @@ impl<AccountId: Copy> ReceivedShieldedOutput for DecryptedOutput<::orchard::Note
     fn account_id(&self) -> Self::AccountId {
         *self.account()
     }
-    fn note(&self) -> &orchard::note::Note {
-        self.note()
+    fn note(&self) -> &Self::Note {
+        &self.note().0
+    }
+    fn to_wallet_note(&self) -> crate::wallet::Note {
+        let (note, pool) = self.note();
+        crate::wallet::Note::Orchard {
+            note: *note,
+            pool: *pool,
+        }
     }
     fn memo(&self) -> Option<&MemoBytes> {
         Some(self.memo())

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1094,12 +1094,11 @@ where
     DbT: LowLevelWalletWrite,
     P: consensus::Parameters,
     Output: ReceivedShieldedOutput<AccountId = <DbT as LowLevelWalletRead>::AccountId>,
-    Output::Note: Clone,
 {
     for output in outputs {
         let sent_output = match output.transfer_type() {
             TransferType::Outgoing => {
-                let note = output.note().clone().into();
+                let note = output.to_wallet_note();
 
                 let recipient = Recipient::External {
                     recipient_address: external_address(
@@ -1108,7 +1107,7 @@ where
                         output.account_id(),
                         note.receiver(),
                     )?,
-                    output_pool: Output::POOL_TYPE,
+                    output_pool: PoolType::Shielded(note.pool()),
                 };
 
                 Some((output.account_id(), recipient, note.value()))
@@ -1117,7 +1116,7 @@ where
                 let spent_in = detect_note_spent_in(wallet_db, output)?;
                 put_received_note(wallet_db, output, tx_ref, spent_in)?;
 
-                let note = output.note().clone().into();
+                let note = output.to_wallet_note();
                 let value = note.value();
 
                 let recipient = Recipient::InternalAccount {
@@ -1134,7 +1133,7 @@ where
                 on_external_account(output.account_id());
 
                 if let Some(account_id) = funding_account {
-                    let note = output.note().clone().into();
+                    let note = output.to_wallet_note();
                     let value = note.value();
 
                     // Even if the recipient address is external, record the send as internal.

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -809,6 +809,7 @@ where
         #[cfg(feature = "orchard")]
         {
             tx_has_wallet_outputs |= !d_tx.orchard_outputs().is_empty();
+            tx_has_wallet_outputs |= !d_tx.ironwood_outputs().is_empty();
         }
 
         // Two cases handled here:
@@ -850,6 +851,25 @@ where
         |_, _| Ok(None),
         |wallet_db, output, tx_ref, spent_in| {
             wallet_db.put_received_orchard_note(output, tx_ref, d_tx.mined_height(), spent_in)
+        },
+        |_account_id| {
+            #[cfg(feature = "transparent-inputs")]
+            gap_update_set.insert((_account_id, TransparentKeyScope::EXTERNAL));
+        },
+    )?;
+
+    // Ironwood outputs are Orchard-shaped but belong to a distinct pool; store them in the
+    // Ironwood tables rather than misfiling them alongside Orchard notes.
+    #[cfg(feature = "orchard")]
+    put_shielded_outputs(
+        wallet_db,
+        Some(params),
+        tx_ref,
+        funding_account,
+        d_tx.ironwood_outputs(),
+        |_, _| Ok(None),
+        |wallet_db, output, tx_ref, spent_in| {
+            wallet_db.put_received_ironwood_note(output, tx_ref, d_tx.mined_height(), spent_in)
         },
         |_account_id| {
             #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1711,6 +1711,16 @@ impl<A> TestBuilder<A, ()> {
 }
 
 impl<A, B> TestBuilder<A, B> {
+    /// Overrides the network parameters used by the test (the default is
+    /// [`TestBuilder::DEFAULT_NETWORK`]). This must be called before the account birthday is
+    /// established (i.e. before `with_account_from_sapling_activation` /
+    /// `with_account_having_current_birthday`), because the birthday is derived from the network's
+    /// activation heights.
+    pub fn with_network(mut self, network: LocalNetwork) -> Self {
+        self.network = network;
+        self
+    }
+
     #[cfg(feature = "transparent-inputs")]
     pub fn with_gap_limits(self, gap_limits: GapLimits) -> TestBuilder<A, B> {
         TestBuilder {

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1220,7 +1220,7 @@ where
         );
 
         if let Ok(proposal) = &result {
-            check_proposal_serialization_roundtrip(self.wallet(), proposal);
+            check_proposal_serialization_roundtrip(&network, self.wallet(), proposal);
         }
 
         result
@@ -1567,12 +1567,13 @@ pub fn single_output_change_strategy<DbT: InputSource>(
 
 // Checks that a protobuf proposal serialized from the provided proposal value correctly parses to
 // the same proposal value.
-fn check_proposal_serialization_roundtrip<DbT: InputSource>(
+fn check_proposal_serialization_roundtrip<ParamsT: consensus::Parameters, DbT: InputSource>(
+    params: &ParamsT,
     wallet_data: &DbT,
     proposal: &Proposal<StandardFeeRule, DbT::NoteRef>,
 ) {
     let proposal_proto = crate::proto::proposal::Proposal::from_standard_proposal(proposal);
-    let deserialized_proposal = proposal_proto.try_into_standard_proposal(wallet_data);
+    let deserialized_proposal = proposal_proto.try_into_standard_proposal(params, wallet_data);
     assert_matches!(deserialized_proposal, Ok(r) if &r == proposal);
 }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -267,11 +267,12 @@ pub struct CachedBlock {
     chain_state: ChainState,
     sapling_end_size: u32,
     orchard_end_size: u32,
+    ironwood_end_size: u32,
 }
 
 impl CachedBlock {
-    /// Produces metadata for a block "before shielded time", when the Sapling and Orchard
-    /// trees were (by definition) empty.
+    /// Produces metadata for a block "before shielded time", when the Sapling, Orchard, and
+    /// Ironwood trees were (by definition) empty.
     ///
     /// `block_height` must be a height before Sapling activation (and therefore also
     /// before NU5 activation).
@@ -280,11 +281,17 @@ impl CachedBlock {
             chain_state: ChainState::empty(block_height, BlockHash([0; 32])),
             sapling_end_size: 0,
             orchard_end_size: 0,
+            ironwood_end_size: 0,
         }
     }
 
     /// Produces metadata for a block as of the given chain state.
-    pub fn at(chain_state: ChainState, sapling_end_size: u32, orchard_end_size: u32) -> Self {
+    pub fn at(
+        chain_state: ChainState,
+        sapling_end_size: u32,
+        orchard_end_size: u32,
+        ironwood_end_size: u32,
+    ) -> Self {
         assert_eq!(
             chain_state.final_sapling_tree().tree_size() as u32,
             sapling_end_size
@@ -294,11 +301,17 @@ impl CachedBlock {
             chain_state.final_orchard_tree().tree_size() as u32,
             orchard_end_size
         );
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            chain_state.final_ironwood_tree().tree_size() as u32,
+            ironwood_end_size
+        );
 
         Self {
             chain_state,
             sapling_end_size,
             orchard_end_size,
+            ironwood_end_size,
         }
     }
 
@@ -329,6 +342,25 @@ impl CachedBlock {
             sz + (tx.actions.len() as u32)
         });
 
+        #[cfg(feature = "orchard")]
+        let ironwood_final_tree = cb
+            .vtx
+            .iter()
+            .flat_map(|tx| tx.ironwood_actions.iter())
+            .fold(
+                self.chain_state.final_ironwood_tree().clone(),
+                |mut acc, c_act| {
+                    acc.append(MerkleHashOrchard::from_cmx(&c_act.cmx().unwrap()));
+                    acc
+                },
+            );
+        #[cfg(feature = "orchard")]
+        let ironwood_end_size = ironwood_final_tree.tree_size() as u32;
+        #[cfg(not(feature = "orchard"))]
+        let ironwood_end_size = cb.vtx.iter().fold(self.ironwood_end_size, |sz, tx| {
+            sz + (tx.ironwood_actions.len() as u32)
+        });
+
         Self {
             chain_state: ChainState::new(
                 cb.height(),
@@ -337,10 +369,11 @@ impl CachedBlock {
                 #[cfg(feature = "orchard")]
                 orchard_final_tree,
                 #[cfg(feature = "orchard")]
-                incrementalmerkletree::frontier::Frontier::empty(),
+                ironwood_final_tree,
             ),
             sapling_end_size,
             orchard_end_size,
+            ironwood_end_size,
         }
     }
 
@@ -362,6 +395,11 @@ impl CachedBlock {
     /// Returns the size of the Orchard note commitment tree as of the end of this block.
     pub fn orchard_end_size(&self) -> u32 {
         self.orchard_end_size
+    }
+
+    /// Returns the size of the Ironwood note commitment tree as of the end of this block.
+    pub fn ironwood_end_size(&self) -> u32 {
+        self.ironwood_end_size
     }
 }
 
@@ -591,6 +629,7 @@ where
             outputs,
             prior_cached_block.sapling_end_size,
             prior_cached_block.orchard_end_size,
+            prior_cached_block.ironwood_end_size,
             false,
         );
 
@@ -623,8 +662,7 @@ where
         cb.chain_metadata = Some(compact_formats::ChainMetadata {
             sapling_commitment_tree_size: prior_cached_block.sapling_end_size,
             orchard_commitment_tree_size: prior_cached_block.orchard_end_size,
-            // The test framework does not generate Ironwood notes.
-            ironwood_commitment_tree_size: 0,
+            ironwood_commitment_tree_size: prior_cached_block.ironwood_end_size,
         });
 
         let res = self.cache_block(&prior_cached_block, cb);
@@ -646,6 +684,7 @@ where
         outputs: &[FakeCompactOutput<Fvk>],
         initial_sapling_tree_size: u32,
         initial_orchard_tree_size: u32,
+        initial_ironwood_tree_size: u32,
         allow_broken_hash_chain: bool,
     ) -> (Cache::InsertResult, Vec<Fvk::Nullifier>) {
         let mut prior_cached_block = self
@@ -655,6 +694,7 @@ where
         assert!(prior_cached_block.chain_state.block_height() < height);
         assert!(prior_cached_block.sapling_end_size <= initial_sapling_tree_size);
         assert!(prior_cached_block.orchard_end_size <= initial_orchard_tree_size);
+        assert!(prior_cached_block.ironwood_end_size <= initial_ironwood_tree_size);
 
         // If the block height has increased or the Sapling and/or Orchard tree sizes have changed,
         // we need to generate a new prior cached block that the block to be generated can
@@ -685,6 +725,16 @@ where
                     },
                 );
 
+            #[cfg(feature = "orchard")]
+            let final_ironwood_tree =
+                (prior_cached_block.ironwood_end_size..initial_ironwood_tree_size).fold(
+                    prior_cached_block.chain_state.final_ironwood_tree().clone(),
+                    |mut acc, _| {
+                        acc.append(MerkleHashOrchard::random(&mut self.rng));
+                        acc
+                    },
+                );
+
             prior_cached_block = CachedBlock::at(
                 ChainState::new(
                     height - 1,
@@ -693,10 +743,11 @@ where
                     #[cfg(feature = "orchard")]
                     final_orchard_tree,
                     #[cfg(feature = "orchard")]
-                    incrementalmerkletree::frontier::Frontier::empty(),
+                    final_ironwood_tree,
                 ),
                 initial_sapling_tree_size,
                 initial_orchard_tree_size,
+                initial_ironwood_tree_size,
             );
 
             self.cached_blocks
@@ -711,6 +762,7 @@ where
             outputs,
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            initial_ironwood_tree_size,
             &mut self.rng,
         );
         assert_eq!(cb.height(), height);
@@ -746,6 +798,7 @@ where
             value,
             prior_cached_block.sapling_end_size,
             prior_cached_block.orchard_end_size,
+            prior_cached_block.ironwood_end_size,
             &mut self.rng,
         );
         assert_eq!(cb.height(), height);
@@ -800,6 +853,7 @@ where
             tx,
             prior_cached_block.sapling_end_size,
             prior_cached_block.orchard_end_size,
+            prior_cached_block.ironwood_end_size,
             &mut self.rng,
         );
         assert_eq!(cb.height(), height);
@@ -1879,6 +1933,10 @@ impl<Cache, DsFactory: DataStoreFactory> TestBuilder<Cache, DsFactory> {
             #[cfg(feature = "orchard")]
             let _final_orchard_tree_size =
                 initial_state.chain_state.final_orchard_tree().tree_size() as u32;
+            let _final_ironwood_tree_size = 0;
+            #[cfg(feature = "orchard")]
+            let _final_ironwood_tree_size =
+                initial_state.chain_state.final_ironwood_tree().tree_size() as u32;
 
             cached_blocks.insert(
                 initial_state.chain_state.block_height(),
@@ -1886,6 +1944,7 @@ impl<Cache, DsFactory: DataStoreFactory> TestBuilder<Cache, DsFactory> {
                     chain_state: initial_state.chain_state.clone(),
                     sapling_end_size: final_sapling_tree_size,
                     orchard_end_size: _final_orchard_tree_size,
+                    ironwood_end_size: _final_ironwood_tree_size,
                 },
             );
         };
@@ -2263,6 +2322,116 @@ impl TestFvk for ::orchard::keys::FullViewingKey {
     }
 }
 
+/// A test-only viewing key that receives Ironwood (version 3) notes. It wraps the account's Orchard
+/// full viewing key, but its outputs are version 3 notes placed in `tx.ironwood_actions` and
+/// encrypted under the Ironwood note-encryption domain, so a wallet scanning them exercises the
+/// Ironwood receive path.
+#[cfg(feature = "orchard")]
+#[derive(Clone)]
+pub struct IronwoodFvk(pub ::orchard::keys::FullViewingKey);
+
+#[cfg(feature = "orchard")]
+impl TestFvk for IronwoodFvk {
+    type Nullifier = ::orchard::note::Nullifier;
+    type OutgoingViewingKey = ::orchard::keys::OutgoingViewingKey;
+
+    fn to_ovk(&self, scope: zip32::Scope) -> Self::OutgoingViewingKey {
+        self.0.to_ovk(scope)
+    }
+
+    fn ovk_bytes(&self, scope: zip32::Scope) -> [u8; 32] {
+        *self.0.to_ovk(scope).as_ref()
+    }
+
+    fn add_spend<R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        nullifier_to_reveal: Self::Nullifier,
+        rng: &mut R,
+    ) {
+        // Generate a dummy recipient; the output will be zero-valued and be encrypted with a
+        // random OVK.
+        let recipient = loop {
+            let mut bytes = [0; 32];
+            rng.fill_bytes(&mut bytes);
+            let sk = ::orchard::keys::SpendingKey::from_bytes(bytes);
+            if sk.is_some().into() {
+                break ::orchard::keys::FullViewingKey::from(&sk.unwrap())
+                    .address_at(0u32, zip32::Scope::External);
+            }
+        };
+
+        let (cact, _) =
+            compact_ironwood_action(nullifier_to_reveal, recipient, Zatoshis::ZERO, None, rng);
+        ctx.ironwood_actions.push(cact);
+    }
+
+    fn add_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        _: &P,
+        _: BlockHeight,
+        sender_ovk: Option<&Self::OutgoingViewingKey>,
+        recipient_address_type: AddressType,
+        value: Zatoshis,
+        _: u32, // the position is not required for computing the Orchard nullifier
+        mut rng: &mut R,
+    ) -> Self::Nullifier {
+        // Generate a dummy nullifier for the spend
+        let nullifier_to_reveal =
+            ::orchard::note::Nullifier::from_bytes(&pallas::Base::random(&mut rng).to_repr())
+                .unwrap();
+
+        let (j, scope) = match recipient_address_type {
+            AddressType::DefaultExternal => (0u32.into(), zip32::Scope::External),
+            AddressType::DiversifiedExternal(idx) => (idx, zip32::Scope::External),
+            AddressType::Internal => (0u32.into(), zip32::Scope::Internal),
+        };
+
+        let (cact, note) = compact_ironwood_action(
+            nullifier_to_reveal,
+            self.0.address_at(j, scope),
+            value,
+            sender_ovk,
+            rng,
+        );
+        ctx.ironwood_actions.push(cact);
+
+        note.nullifier(&self.0)
+    }
+
+    fn add_logical_action<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        _: &P,
+        _: BlockHeight,
+        nf_to_reveal_in_spend: Self::Nullifier,
+        sender_ovk: Option<&Self::OutgoingViewingKey>,
+        recipient_address_type: AddressType,
+        value: Zatoshis,
+        _: u32, // the position is not required for computing the Orchard nullifier
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        let (j, scope) = match recipient_address_type {
+            AddressType::DefaultExternal => (0u32.into(), zip32::Scope::External),
+            AddressType::DiversifiedExternal(idx) => (idx, zip32::Scope::External),
+            AddressType::Internal => (0u32.into(), zip32::Scope::Internal),
+        };
+
+        let (cact, note) = compact_ironwood_action(
+            nf_to_reveal_in_spend,
+            self.0.address_at(j, scope),
+            value,
+            sender_ovk,
+            rng,
+        );
+        ctx.ironwood_actions.push(cact);
+
+        // Return the nullifier of the newly created output note
+        note.nullifier(&self.0)
+    }
+}
+
 /// Configures how a [`TestFvk`] receives a particular output.
 ///
 /// Used with [`TestFvk::add_output`] and [`TestFvk::add_logical_action`].
@@ -2359,6 +2528,57 @@ fn compact_orchard_action<R: RngCore + CryptoRng>(
     )
 }
 
+/// Builds a version 3 (Ironwood) compact action paying `recipient` the given value, encrypted
+/// under the Ironwood note-encryption domain, for placement in `tx.ironwood_actions`. Returns the
+/// `CompactOrchardAction` and the note. This mirrors [`compact_orchard_action`], but constructs the
+/// action directly because the orchard crate's `fake_compact_action` only produces version 2 notes.
+#[cfg(feature = "orchard")]
+fn compact_ironwood_action<R: RngCore + CryptoRng>(
+    nf_old: ::orchard::note::Nullifier,
+    recipient: ::orchard::Address,
+    value: Zatoshis,
+    sender_ovk: Option<&::orchard::keys::OutgoingViewingKey>,
+    rng: &mut R,
+) -> (CompactOrchardAction, ::orchard::Note) {
+    use ::orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
+    use ::orchard::note_encryption::{IronwoodDomain, IronwoodNoteEncryption};
+    use zcash_note_encryption::Domain;
+
+    // Derive `rho` from the revealed nullifier exactly as the crate does internally
+    // (`Rho::from_nf_old(nf) == Rho(nf.inner())`), so that the domain the scanner reconstructs via
+    // `IronwoodDomain::for_compact_action(nf_old)` matches and decryption succeeds.
+    let rho = Rho::from_bytes(&nf_old.to_bytes()).unwrap();
+    let rseed = loop {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        if let Some(rseed) = Option::from(RandomSeed::from_bytes(bytes, &rho)) {
+            break rseed;
+        }
+    };
+    let note = Note::from_parts(
+        recipient,
+        ::orchard::value::NoteValue::from_raw(value.into_u64()),
+        rho,
+        rseed,
+        NoteVersion::V3,
+    )
+    .unwrap();
+    let encryptor = IronwoodNoteEncryption::new(sender_ovk.cloned(), note, [0u8; 512]);
+    let cmx = ExtractedNoteCommitment::from(note.commitment());
+    let ephemeral_key = IronwoodDomain::epk_bytes(encryptor.epk());
+    let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+    (
+        CompactOrchardAction {
+            nullifier: nf_old.to_bytes().to_vec(),
+            cmx: cmx.to_bytes().to_vec(),
+            ephemeral_key: ephemeral_key.0.to_vec(),
+            ciphertext: enc_ciphertext[..52].to_vec(),
+        },
+        note,
+    )
+}
+
 /// Creates a fake `CompactTx` with a random transaction ID and no spends or outputs.
 fn fake_compact_tx<R: RngCore + CryptoRng>(rng: &mut R) -> CompactTx {
     let mut ctx = CompactTx::default();
@@ -2415,6 +2635,7 @@ fn fake_compact_block<P: consensus::Parameters, Fvk: TestFvk>(
     outputs: &[FakeCompactOutput<Fvk>],
     initial_sapling_tree_size: u32,
     initial_orchard_tree_size: u32,
+    initial_ironwood_tree_size: u32,
     mut rng: impl RngCore + CryptoRng,
 ) -> (CompactBlock, Vec<Fvk::Nullifier>) {
     // Create a fake CompactBlock containing the note
@@ -2440,6 +2661,7 @@ fn fake_compact_block<P: consensus::Parameters, Fvk: TestFvk>(
         prev_hash,
         initial_sapling_tree_size,
         initial_orchard_tree_size,
+        initial_ironwood_tree_size,
         rng,
     );
     (cb, nfs)
@@ -2447,6 +2669,7 @@ fn fake_compact_block<P: consensus::Parameters, Fvk: TestFvk>(
 
 /// Create a fake CompactBlock at the given height containing only the given transaction.
 // TODO: `tx` could be a slice and we could add multiple transactions here
+#[allow(clippy::too_many_arguments)]
 fn fake_compact_block_from_tx(
     height: BlockHeight,
     prev_hash: BlockHash,
@@ -2454,6 +2677,7 @@ fn fake_compact_block_from_tx(
     tx: &Transaction,
     initial_sapling_tree_size: u32,
     initial_orchard_tree_size: u32,
+    initial_ironwood_tree_size: u32,
     rng: impl RngCore,
 ) -> CompactBlock {
     // Create a fake CompactTx containing the transaction.
@@ -2479,12 +2703,20 @@ fn fake_compact_block_from_tx(
         }
     }
 
+    #[cfg(feature = "orchard")]
+    if let Some(bundle) = tx.ironwood_bundle() {
+        for action in bundle.actions() {
+            ctx.ironwood_actions.push(action.into());
+        }
+    }
+
     fake_compact_block_from_compact_tx(
         ctx,
         height,
         prev_hash,
         initial_sapling_tree_size,
         initial_orchard_tree_size,
+        initial_ironwood_tree_size,
         rng,
     )
 }
@@ -2502,6 +2734,7 @@ fn fake_compact_block_spending<P: consensus::Parameters, Fvk: TestFvk>(
     value: Zatoshis,
     initial_sapling_tree_size: u32,
     initial_orchard_tree_size: u32,
+    initial_ironwood_tree_size: u32,
     mut rng: impl RngCore + CryptoRng,
 ) -> CompactBlock {
     let mut ctx = fake_compact_tx(&mut rng);
@@ -2590,6 +2823,7 @@ fn fake_compact_block_spending<P: consensus::Parameters, Fvk: TestFvk>(
         prev_hash,
         initial_sapling_tree_size,
         initial_orchard_tree_size,
+        initial_ironwood_tree_size,
         rng,
     )
 }
@@ -2600,6 +2834,7 @@ fn fake_compact_block_from_compact_tx(
     prev_hash: BlockHash,
     initial_sapling_tree_size: u32,
     initial_orchard_tree_size: u32,
+    initial_ironwood_tree_size: u32,
     mut rng: impl RngCore,
 ) -> CompactBlock {
     let mut cb = CompactBlock {
@@ -2618,8 +2853,11 @@ fn fake_compact_block_from_compact_tx(
             + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
         orchard_commitment_tree_size: initial_orchard_tree_size
             + cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum::<u32>(),
-        // The test framework does not generate Ironwood notes.
-        ironwood_commitment_tree_size: 0,
+        ironwood_commitment_tree_size: initial_ironwood_tree_size
+            + cb.vtx
+                .iter()
+                .map(|tx| tx.ironwood_actions.len() as u32)
+                .sum::<u32>(),
     });
     cb
 }

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -185,7 +185,10 @@ impl ShieldedPoolTester for OrchardPoolTester {
             if result.is_some() {
                 return result.map(|(note, addr, memo)| {
                     (
-                        Note::Orchard(note),
+                        Note::Orchard {
+                            note,
+                            pool: orchard::ValuePool::Orchard,
+                        },
                         UnifiedAddress::from_receivers(Some(addr), None, None)
                             .unwrap()
                             .into(),

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -7191,3 +7191,93 @@ pub fn propose_and_build_shielding_coinbase_succeeds<T: ShieldedPoolTester, Dsf>
         proposal,
     );
 }
+
+/// Verifies that once Ironwood is active, `propose_shielding_coinbase` resolves a destination
+/// with an Orchard receiver to the Ironwood pool — the payment is delivered to the Orchard
+/// receiver via the Ironwood bundle — and that the proposed transaction builds.
+#[cfg(all(feature = "orchard", feature = "pczt", feature = "transparent-inputs"))]
+pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+    <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    use super::orchard::OrchardPoolTester;
+    use zcash_protocol::consensus::COINBASE_MATURITY_BLOCKS;
+
+    // A network on which Ironwood (NU6.3) is active from the Sapling activation height.
+    let ironwood_active_network = {
+        let activation = BlockHeight::from_u32(100_000);
+        LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        }
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+    let account = st.get_account();
+    let (t_addr, _) = account.usk().default_transparent_address();
+    let coinbase_value = Zatoshis::const_from_u64(100000);
+    let coinbase_build_result = build_transparent_coinbase_tx(
+        st.network(),
+        TargetHeight::from(st.sapling_activation_height()),
+        coinbase_value,
+        t_addr,
+        None,
+    );
+    let coinbase_tx = coinbase_build_result.transaction();
+    let (h, _) = st.generate_next_block_from_tx(0, coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), coinbase_tx, Some(h)).unwrap();
+    // Coinbase outputs require 100 confirmations.
+    st.add_empty_blocks(COINBASE_MATURITY_BLOCKS as usize);
+
+    // The destination has an Orchard receiver controlled by a separate spending key.
+    let to_extsk = OrchardPoolTester::sk(&[0xcd; 32]);
+    let to_address =
+        OrchardPoolTester::sk_default_address(&to_extsk).to_zcash_address(st.network());
+
+    let proposal = st
+        .propose_shielding_coinbase(
+            &GreedyInputSelector::new(),
+            &StandardFeeRule::Zip317,
+            Zatoshis::ZERO,
+            &[t_addr],
+            to_address,
+            None,
+            None,
+        )
+        .expect("propose_shielding_coinbase to an Orchard receiver should succeed post-NU6.3");
+
+    // The Orchard-receiver payment is represented as an Ironwood-pool output, matching the
+    // bundle the builder will deliver it through; an Orchard-pool payment would violate the
+    // Orchard turnstile.
+    assert_eq!(
+        proposal.steps().head.payment_pools().get(&0),
+        Some(&PoolType::IRONWOOD),
+    );
+
+    let build_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(
+        &build_result,
+        Ok(txids) if txids.len() == 1,
+        "create_proposed_transactions must succeed for proposal {:?}",
+        proposal,
+    );
+}

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3876,6 +3876,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, Dsf: DataStoreFactory>(
     let not_our_value = Zatoshis::const_from_u64(10000);
     let sapling_end_size = st.latest_cached_block().unwrap().sapling_end_size();
     let orchard_end_size = st.latest_cached_block().unwrap().orchard_end_size();
+    let ironwood_end_size = st.latest_cached_block().unwrap().ironwood_end_size();
     st.generate_block_at(
         account.birthday().height() + 10,
         BlockHash([0; 32]),
@@ -3886,6 +3887,7 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, Dsf: DataStoreFactory>(
         )],
         sapling_end_size,
         orchard_end_size,
+        ironwood_end_size,
         false,
     );
 
@@ -4474,6 +4476,7 @@ pub fn invalid_chain_cache_disconnected<T: ShieldedPoolTester>(
         )],
         2,
         2,
+        0,
         true,
     );
     st.generate_next_block(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3785,6 +3785,10 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
                 .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
                 .collect::<Vec<_>>();
 
+            // Ironwood is not active at these test heights, so its tree is empty.
+            #[cfg(feature = "orchard")]
+            let ironwood_initial_tree = Frontier::empty();
+
             InitialChainState {
                 chain_state: ChainState::new(
                     birthday_height - 1,
@@ -3793,7 +3797,7 @@ pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
                     #[cfg(feature = "orchard")]
                     orchard_initial_tree,
                     #[cfg(feature = "orchard")]
-                    Frontier::empty(),
+                    ironwood_initial_tree,
                 ),
                 prior_sapling_roots,
                 #[cfg(feature = "orchard")]
@@ -4705,6 +4709,10 @@ pub fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester, Dsf>(
                 .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 100, root))
                 .collect::<Vec<_>>();
 
+            // Ironwood is not active at these test heights, so its tree is empty.
+            #[cfg(feature = "orchard")]
+            let ironwood_initial_tree = Frontier::empty();
+
             InitialChainState {
                 chain_state: ChainState::new(
                     birthday_height - 1,
@@ -4713,7 +4721,7 @@ pub fn truncate_to_chain_state_below_birthday<T: ShieldedPoolTester, Dsf>(
                     #[cfg(feature = "orchard")]
                     orchard_initial_tree,
                     #[cfg(feature = "orchard")]
-                    Frontier::empty(),
+                    ironwood_initial_tree,
                 ),
                 prior_sapling_roots,
                 #[cfg(feature = "orchard")]
@@ -4851,6 +4859,9 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
         shard_2_tree_size,
         NonZeroU8::new(16).unwrap(),
     );
+    // Ironwood is not active at these test heights, so its tree is empty.
+    #[cfg(feature = "orchard")]
+    let shard2_ironwood_frontier = Frontier::empty();
 
     let target_chain_state = ChainState::new(
         target_height,
@@ -4859,7 +4870,7 @@ pub fn truncate_to_chain_state_above_scanned<T: ShieldedPoolTester, Dsf>(
         #[cfg(feature = "orchard")]
         shard2_orchard_frontier,
         #[cfg(feature = "orchard")]
-        Frontier::empty(),
+        shard2_ironwood_frontier,
     );
 
     // Verify the scan queue extends beyond the target.
@@ -5292,6 +5303,10 @@ where
                 .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
                 .collect::<Vec<_>>();
 
+            // Ironwood is not active at these test heights, so its tree is empty.
+            #[cfg(feature = "orchard")]
+            let ironwood_initial_tree = Frontier::empty();
+
             InitialChainState {
                 chain_state: ChainState::new(
                     birthday_height - 1,
@@ -5300,7 +5315,7 @@ where
                     #[cfg(feature = "orchard")]
                     orchard_initial_tree,
                     #[cfg(feature = "orchard")]
-                    Frontier::empty(),
+                    ironwood_initial_tree,
                 ),
                 prior_sapling_roots,
                 #[cfg(feature = "orchard")]
@@ -5556,6 +5571,10 @@ where
                 .map(|root| CommitmentTreeRoot::from_parts(birthday_height - 500, root))
                 .collect::<Vec<_>>();
 
+            // Ironwood is not active at these test heights, so its tree is empty.
+            #[cfg(feature = "orchard")]
+            let ironwood_initial_tree = Frontier::empty();
+
             InitialChainState {
                 chain_state: ChainState::new(
                     birthday_height - 1,
@@ -5564,7 +5583,7 @@ where
                     #[cfg(feature = "orchard")]
                     orchard_initial_tree,
                     #[cfg(feature = "orchard")]
-                    Frontier::empty(),
+                    ironwood_initial_tree,
                 ),
                 prior_sapling_roots,
                 #[cfg(feature = "orchard")]
@@ -6138,6 +6157,10 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
                 network.activation_height(NetworkUpgrade::Canopy).unwrap() + ZIP212_GRACE_PERIOD,
             );
 
+            // Ironwood is not active at these test heights, so its tree is empty.
+            #[cfg(feature = "orchard")]
+            let ironwood_initial_tree = Frontier::empty();
+
             InitialChainState {
                 chain_state: ChainState::new(
                     birthday_height - 1,
@@ -6146,7 +6169,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
                     #[cfg(feature = "orchard")]
                     Frontier::empty(),
                     #[cfg(feature = "orchard")]
-                    Frontier::empty(),
+                    ironwood_initial_tree,
                 ),
                 prior_sapling_roots: vec![],
                 #[cfg(feature = "orchard")]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -43,8 +43,6 @@ use std::{
 
 use shardtree::error::{QueryError, ShardTreeError};
 
-#[cfg(feature = "transparent-inputs")]
-use super::CoinbaseFilter;
 use super::InputSource;
 use crate::{
     data_api::{
@@ -86,6 +84,7 @@ use zip321::Payment;
 
 #[cfg(feature = "transparent-inputs")]
 use {
+    super::CoinbaseFilter,
     crate::{
         fees::ChangeValue,
         proposal::StepOutput,
@@ -96,6 +95,9 @@ use {
     std::collections::HashMap,
     transparent::bundle::TxOut,
 };
+
+#[cfg(feature = "orchard")]
+use zcash_protocol::consensus::NetworkUpgrade;
 
 #[cfg(feature = "transparent-key-import")]
 use zcash_script::script::{self as zs_script, Evaluable};
@@ -128,38 +130,11 @@ const PROPRIETARY_PROPOSAL_INFO: &str = "zcash_client_backend:proposal_info";
 const PROPRIETARY_OUTPUT_INFO: &str = "zcash_client_backend:output_info";
 
 #[cfg(feature = "orchard")]
-fn legacy_orchard_bundle_requested(
-    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
-) -> bool {
-    #[cfg(feature = "unstable")]
-    {
-        matches!(proposed_version, Some(TxVersion::V5))
-    }
-    #[cfg(not(feature = "unstable"))]
-    {
-        false
-    }
-}
-
-#[cfg(feature = "orchard")]
-fn ironwood_active_at<ParamsT: consensus::Parameters>(
+fn ironwood_active_at<ParamsT: consensus::Parameters, H: Into<BlockHeight>>(
     params: &ParamsT,
-    target_height: BlockHeight,
+    target_height: H,
 ) -> bool {
-    params.is_nu_active(consensus::NetworkUpgrade::Nu6_3, target_height)
-}
-
-#[cfg(feature = "orchard")]
-fn orchard_outputs_to_ironwood<ParamsT: consensus::Parameters>(
-    params: &ParamsT,
-    target_height: TargetHeight,
-    #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
-) -> bool {
-    ironwood_active_at(params, BlockHeight::from(target_height))
-        && !legacy_orchard_bundle_requested(
-            #[cfg(feature = "unstable")]
-            proposed_version,
-        )
+    params.is_nu_active(NetworkUpgrade::Nu6_3, target_height.into())
 }
 
 /// Maps an Ironwood bundle output index to its index in the wallet's combined
@@ -175,26 +150,6 @@ fn stored_ironwood_output_index(tx: &Transaction, raw_ironwood_output_index: usi
         .map_or(raw_ironwood_output_index, |bundle| {
             bundle.actions().len() + raw_ironwood_output_index
         })
-}
-
-/// How a proposal step's Orchard-recipient spends and outputs are routed between
-/// the Orchard and Ironwood bundles.
-///
-/// This is derived once from the proposal and the activation state so the
-/// spend-anchor, input, and output-routing decisions cannot drift apart.
-#[cfg(feature = "orchard")]
-enum OrchardBuildMode {
-    /// A legacy V5 transaction was explicitly requested: use the Orchard bundle
-    /// only. Spending Ironwood notes in this mode is unsupported.
-    LegacyV5,
-    /// Spend Ironwood (`NoteVersion::V3`) notes; Orchard-pool outputs are routed
-    /// to the Ironwood bundle.
-    IronwoodSpends,
-    /// No Ironwood spends, but Orchard-pool outputs are routed to a fresh Ironwood
-    /// bundle.
-    IronwoodOutputs,
-    /// Plain Orchard: spends and outputs both use the Orchard bundle.
-    Orchard,
 }
 
 #[cfg(feature = "pczt")]
@@ -1283,46 +1238,6 @@ where
 {
     #[cfg(feature = "transparent-inputs")]
     let step_index = prior_step_results.len();
-    // The shielded inputs of this step, if any of them are Ironwood (`V3`) notes.
-    #[cfg(feature = "orchard")]
-    let ironwood_spend_inputs = proposal_step.shielded_inputs().filter(|inputs| {
-        inputs.notes().iter().any(|selected| {
-            matches!(
-                selected.note(),
-                Note::Orchard(note) if note.version() == orchard::note::NoteVersion::V3
-            )
-        })
-    });
-    #[cfg(feature = "orchard")]
-    let orchard_build_mode = if legacy_orchard_bundle_requested(
-        #[cfg(feature = "unstable")]
-        proposed_version,
-    ) {
-        // A legacy V5 transaction cannot carry an Ironwood bundle, so spending
-        // Ironwood notes is unsupported in that mode.
-        if ironwood_spend_inputs.is_some() {
-            return Err(Error::ProposalNotSupported);
-        }
-        OrchardBuildMode::LegacyV5
-    } else if ironwood_spend_inputs.is_some() {
-        OrchardBuildMode::IronwoodSpends
-    } else if orchard_outputs_to_ironwood(
-        params,
-        min_target_height,
-        #[cfg(feature = "unstable")]
-        proposed_version,
-    ) {
-        OrchardBuildMode::IronwoodOutputs
-    } else {
-        OrchardBuildMode::Orchard
-    };
-    // Orchard-pool payment and change outputs are routed to the Ironwood bundle
-    // in exactly the Ironwood spend and Ironwood output modes.
-    #[cfg(feature = "orchard")]
-    let orchard_outputs_are_ironwood = matches!(
-        orchard_build_mode,
-        OrchardBuildMode::IronwoodSpends | OrchardBuildMode::IronwoodOutputs
-    );
 
     // We only support spending transparent payments or transparent ephemeral outputs from a
     // prior step (when "transparent-inputs" is enabled).
@@ -1384,7 +1299,7 @@ where
                                 .map_err(Error::from)
                                 .transpose(),
                             #[cfg(feature = "orchard")]
-                            Note::Orchard(_) => None,
+                            Note::Orchard { .. } => None,
                         })
                         .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()?;
 
@@ -1414,26 +1329,22 @@ where
                         .iter()
                         .filter_map(|selected| match selected.note() {
                             #[cfg(feature = "orchard")]
-                            Note::Orchard(note)
-                                if note.version() != orchard::note::NoteVersion::V3 =>
-                            {
-                                orchard_tree
-                                    .witness_at_checkpoint_id_caching(
-                                        selected.note_commitment_tree_position(),
-                                        &inputs.anchor_height(),
-                                    )
-                                    .and_then(|witness| {
-                                        witness.ok_or(ShardTreeError::Query(
-                                            QueryError::CheckpointPruned,
-                                        ))
-                                    })
-                                    .map(|merkle_path| Some((note, merkle_path.into())))
-                                    .map_err(Error::from)
-                                    .transpose()
-                            }
-                            #[cfg(feature = "orchard")]
-                            Note::Orchard(_) => None,
-                            Note::Sapling(_) => None,
+                            Note::Orchard {
+                                note,
+                                pool: orchard::ValuePool::Orchard,
+                            } => orchard_tree
+                                .witness_at_checkpoint_id_caching(
+                                    selected.note_commitment_tree_position(),
+                                    &inputs.anchor_height(),
+                                )
+                                .and_then(|witness| {
+                                    witness
+                                        .ok_or(ShardTreeError::Query(QueryError::CheckpointPruned))
+                                })
+                                .map(|merkle_path| Some((note, merkle_path.into())))
+                                .map_err(Error::from)
+                                .transpose(),
+                            _ => None,
                         })
                         .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()?;
 
@@ -1447,66 +1358,63 @@ where
     #[cfg(not(feature = "orchard"))]
     let orchard_anchor = None;
 
+    // The Ironwood builder must be available whenever the transaction will interact with the
+    // Ironwood bundle: either the proposal itself involves the Ironwood pool, or Ironwood is active
+    // at the target height and the builder will route Orchard-pool outputs into a fresh Ironwood
+    // bundle. The anchor must be a real Ironwood tree root so a transaction with only routed
+    // outputs is indistinguishable from one that spends real Ironwood notes.
     #[cfg(feature = "orchard")]
-    let (ironwood_anchor, ironwood_inputs) = match orchard_build_mode {
-        OrchardBuildMode::IronwoodSpends => {
-            // `IronwoodSpends` is constructed only when `ironwood_spend_inputs` is
-            // `Some`, so the inputs are always present here.
-            let Some(inputs) = ironwood_spend_inputs else {
-                return Err(Error::ProposalNotSupported);
-            };
+    let (ironwood_anchor, ironwood_inputs) = if proposal_step
+        .involves(PoolType::Shielded(ShieldedPool::Ironwood))
+        || ironwood_active_at(params, min_target_height)
+    {
+        let Some(inputs) = proposal_step.shielded_inputs() else {
+            // A shielding proposal carries no shielded anchor height, so there is no valid Ironwood
+            // anchor to bind to. This path is not yet supported.
+            return Err(Error::ProposalNotSupported);
+        };
+        wallet_db
+            .with_ironwood_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|ironwood_tree| {
+                let anchor = ironwood_tree
+                    .root_at_checkpoint_id(&inputs.anchor_height())?
+                    .ok_or(ProposalError::AnchorNotFound(inputs.anchor_height()))?
+                    .into();
 
-            wallet_db
-                .with_ironwood_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|ironwood_tree| {
-                    let anchor = ironwood_tree
-                        .root_at_checkpoint_id(&inputs.anchor_height())?
-                        .ok_or(ProposalError::AnchorNotFound(inputs.anchor_height()))?
-                        .into();
+                let mut ironwood_inputs = Vec::<(&orchard::Note, orchard::tree::MerklePath)>::new();
 
-                    let mut ironwood_inputs =
-                        Vec::<(&orchard::Note, orchard::tree::MerklePath)>::new();
+                for ironwood_input in
+                    inputs
+                        .notes()
+                        .iter()
+                        .filter_map(|selected| match selected.note() {
+                            Note::Orchard {
+                                note,
+                                pool: orchard::ValuePool::Ironwood,
+                            } => ironwood_tree
+                                .witness_at_checkpoint_id_caching(
+                                    selected.note_commitment_tree_position(),
+                                    &inputs.anchor_height(),
+                                )
+                                .and_then(|witness| {
+                                    witness
+                                        .ok_or(ShardTreeError::Query(QueryError::CheckpointPruned))
+                                })
+                                .map(|merkle_path| Some((note, merkle_path.into())))
+                                .map_err(Error::from)
+                                .transpose(),
+                            _ => None,
+                        })
+                {
+                    ironwood_inputs.push(ironwood_input?);
+                }
 
-                    for ironwood_input in
-                        inputs
-                            .notes()
-                            .iter()
-                            .filter_map(|selected| match selected.note() {
-                                Note::Orchard(note)
-                                    if note.version() == orchard::note::NoteVersion::V3 =>
-                                {
-                                    ironwood_tree
-                                        .witness_at_checkpoint_id_caching(
-                                            selected.note_commitment_tree_position(),
-                                            &inputs.anchor_height(),
-                                        )
-                                        .and_then(|witness| {
-                                            witness.ok_or(ShardTreeError::Query(
-                                                QueryError::CheckpointPruned,
-                                            ))
-                                        })
-                                        .map(|merkle_path| Some((note, merkle_path.into())))
-                                        .map_err(Error::from)
-                                        .transpose()
-                                }
-                                _ => None,
-                            })
-                    {
-                        ironwood_inputs.push(ironwood_input?);
-                    }
-
-                    Ok((Some(anchor), ironwood_inputs))
-                })?
-                .ok_or(Error::ProposalNotSupported)?
-        }
-        OrchardBuildMode::IronwoodOutputs => (
-            Some(orchard::Anchor::empty_tree()),
-            Vec::<(&orchard::Note, orchard::tree::MerklePath)>::new(),
-        ),
-        OrchardBuildMode::LegacyV5 | OrchardBuildMode::Orchard => (
-            None,
-            Vec::<(&orchard::Note, orchard::tree::MerklePath)>::new(),
-        ),
+                Ok((Some(anchor), ironwood_inputs))
+            })?
+            .ok_or(Error::ProposalNotSupported)?
+    } else {
+        (None, vec![])
     };
+
     #[cfg(not(feature = "orchard"))]
     let ironwood_anchor = None;
 
@@ -1567,6 +1475,8 @@ where
         )?;
     }
 
+    // Post-NU6.3 the Orchard bundle enforces the cross-address restriction, so Orchard-pool
+    // change must be returned to a spent Orchard note's own address to remain in the Orchard pool
     #[cfg(feature = "orchard")]
     for (orchard_note, merkle_path) in orchard_inputs.into_iter() {
         builder.add_orchard_spend(
@@ -1841,7 +1751,7 @@ where
                 #[cfg(feature = "orchard")]
                 PoolType::Shielded(ShieldedPool::Orchard) => {
                     let to = *ua.orchard().expect("The mapping between payment pool and receiver is checked in step construction");
-                    if orchard_outputs_are_ironwood {
+                    if ironwood_active_at(params, min_target_height) {
                         add_ironwood_output(&mut builder, &mut ironwood_output_meta, to)?;
                     } else {
                         add_orchard_output(&mut builder, &mut orchard_output_meta, to)?;
@@ -1913,22 +1823,25 @@ where
                 {
                     let orchard_fvk = ufvk
                         .orchard()
-                        .cloned()
                         .ok_or(Error::KeyNotAvailable(PoolType::ORCHARD))?;
+
                     let change_address =
                         orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal);
 
-                    if orchard_outputs_are_ironwood {
-                        // The Ironwood builder enables cross-address transfers, so
-                        // change is an ordinary owned output; `add_ironwood_output`
-                        // covers it (the dedicated change entry point was dropped).
-                        builder.add_ironwood_output(
+                    if ironwood_active_at(params, min_target_height) {
+                        // Post-NU6.3 with an Orchard spend: the change stays in the Orchard pool,
+                        // returned to a spent note's own address so it satisfies the Orchard V3
+                        // cross-address restriction. Only the payment crosses into Ironwood. The
+                        // Orchard V3 bundle forbids ordinary outputs, so the change is added via
+                        // `add_orchard_change_output`, which pairs it with a fabricated same-address
+                        builder.add_orchard_change_output(
+                            orchard_fvk.clone(),
                             internal_ovk.map(|k| k.into()),
                             change_address,
                             change_value.value(),
                             memo.clone(),
                         )?;
-                        ironwood_output_meta.push((
+                        orchard_output_meta.push((
                             BuildRecipient::InternalAccount {
                                 receiving_account: account_id,
                                 external_address: None,
@@ -1959,7 +1872,33 @@ where
                 return Err(Error::UnsupportedChangeType(output_pool));
             }
             PoolType::Shielded(ShieldedPool::Ironwood) => {
-                todo!("Ironwood pool support is not yet implemented")
+                #[cfg(not(feature = "orchard"))]
+                return Err(Error::UnsupportedChangeType(output_pool));
+
+                #[cfg(feature = "orchard")]
+                {
+                    let orchard_fvk = ufvk
+                        .orchard()
+                        .ok_or(Error::KeyNotAvailable(PoolType::ORCHARD))?;
+
+                    let change_address =
+                        orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal);
+
+                    builder.add_ironwood_output(
+                        internal_ovk.map(|k| k.into()),
+                        change_address,
+                        change_value.value(),
+                        memo.clone(),
+                    )?;
+                    ironwood_output_meta.push((
+                        BuildRecipient::InternalAccount {
+                            receiving_account: account_id,
+                            external_address: None,
+                        },
+                        change_value.value(),
+                        Some(memo),
+                    ))
+                }
             }
         }
     }
@@ -2119,6 +2058,11 @@ where
     let orchard_fvk: orchard::keys::FullViewingKey = spending_keys.usk.orchard().into();
     #[cfg(feature = "orchard")]
     let orchard_internal_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::Internal);
+    // Same-address Orchard change (post-NU6.3, when spending Orchard notes) is returned to a spent
+    // note's own address, which may be external-scoped; try the external IVK as well so such change
+    // outputs remain decryptable for recording.
+    #[cfg(feature = "orchard")]
+    let orchard_external_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
     #[cfg(feature = "orchard")]
     let orchard_outputs = build_state.orchard_output_meta.into_iter().enumerate().map(
         |(i, (recipient, value, memo))| {
@@ -2134,7 +2078,13 @@ where
                     .and_then(|bundle| {
                         bundle
                             .decrypt_output_with_key(output_index, &orchard_internal_ivk)
-                            .map(|(note, _, _)| Note::Orchard(note))
+                            .or_else(|| {
+                                bundle.decrypt_output_with_key(output_index, &orchard_external_ivk)
+                            })
+                            .map(|(note, _, _)| Note::Orchard {
+                                note,
+                                pool: orchard::ValuePool::Orchard,
+                            })
                     })
                     .expect("Wallet-internal outputs must be decryptable with the wallet's IVK")
             });
@@ -2169,7 +2119,7 @@ where
                     .and_then(|bundle| {
                         bundle
                             .decrypt_output_with_key(raw_output_index, &orchard_internal_ivk)
-                            .map(|(note, _, _)| Note::Orchard(note))
+                            .map(|(note, _, _)| Note::Orchard { note, pool: orchard::ValuePool::Ironwood })
                     })
                     .expect(
                         "Wallet-internal Ironwood outputs must be decryptable with the wallet's IVK",
@@ -2890,7 +2840,10 @@ where
                             external_address,
                             |note| note.value().inner(),
                             |memo| memo,
-                            Note::Orchard,
+                            |note| Note::Orchard {
+                                note,
+                                pool: orchard::ValuePool::Orchard,
+                            },
                         )
                     })
                 })

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -870,8 +870,8 @@ where
     InputsT: ShieldingSelector<InputSource = DbT>,
     ChangeT: ChangeStrategy<MetaSource = DbT>,
 {
-    let chain_tip_height = wallet_db
-        .chain_height()
+    let (target_height, anchor_height) = wallet_db
+        .get_target_and_anchor_heights(confirmations_policy.trusted)
         .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
@@ -883,7 +883,8 @@ where
             shielding_threshold,
             from_addrs,
             to_account,
-            (chain_tip_height + 1).into(),
+            target_height,
+            anchor_height,
             confirmations_policy,
             output_filter,
         )
@@ -953,8 +954,8 @@ where
     InputsT: ShieldingSelector<InputSource = DbT>,
     FeeRuleT: FeeRule + Clone,
 {
-    let chain_tip_height = wallet_db
-        .chain_height()
+    let (target_height, anchor_height) = wallet_db
+        .get_target_and_anchor_heights(ConfirmationsPolicy::default().trusted)
         .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
@@ -968,7 +969,8 @@ where
             to_address,
             memo,
             limit,
-            (chain_tip_height + 1).into(),
+            target_height,
+            anchor_height,
         )
         .map_err(Error::from)
 }
@@ -1268,26 +1270,32 @@ where
         return Err(Error::ProposalNotSupported);
     }
 
+    // Each shielded-tree anchor is derived from the step's single anchor height so that a
+    // transaction with only routed shielded outputs (for example, an Orchard-recipient payment
+    // routed by the builder into a fresh Ironwood bundle post-NU6.3) is indistinguishable from
+    // one that spends real notes in that pool.
+    let anchor_height = proposal_step.anchor_height();
+
     let (sapling_anchor, sapling_inputs) = if proposal_step
         .involves(PoolType::Shielded(ShieldedPool::Sapling))
     {
-        proposal_step.shielded_inputs().map_or_else(
-            || Ok((Some(sapling::Anchor::empty_tree()), vec![])),
-            |inputs| {
-                wallet_db.with_sapling_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|sapling_tree| {
-                    let anchor = sapling_tree
-                        .root_at_checkpoint_id(&inputs.anchor_height())?
-                        .ok_or(ProposalError::AnchorNotFound(inputs.anchor_height()))?
-                        .into();
+        wallet_db.with_sapling_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|sapling_tree| {
+            let anchor = sapling_tree
+                .root_at_checkpoint_id(&anchor_height)?
+                .ok_or(ProposalError::AnchorNotFound(anchor_height))?
+                .into();
 
-                    let sapling_inputs = inputs
+            let sapling_inputs = proposal_step
+                .shielded_inputs()
+                .map(|inputs| {
+                    inputs
                         .notes()
                         .iter()
                         .filter_map(|selected| match selected.note() {
                             Note::Sapling(note) => sapling_tree
                                 .witness_at_checkpoint_id_caching(
                                     selected.note_commitment_tree_position(),
-                                    &inputs.anchor_height(),
+                                    &anchor_height,
                                 )
                                 .and_then(|witness| {
                                     witness
@@ -1301,12 +1309,13 @@ where
                             #[cfg(feature = "orchard")]
                             Note::Orchard { .. } => None,
                         })
-                        .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()?;
-
-                    Ok((Some(anchor), sapling_inputs))
+                        .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()
                 })
-            },
-        )?
+                .transpose()?
+                .unwrap_or_default();
+
+            Ok((Some(anchor), sapling_inputs))
+        })?
     } else {
         (None, vec![])
     };
@@ -1315,27 +1324,26 @@ where
     let (orchard_anchor, orchard_inputs) = if proposal_step
         .involves(PoolType::Shielded(ShieldedPool::Orchard))
     {
-        proposal_step.shielded_inputs().map_or_else(
-            || Ok((Some(orchard::Anchor::empty_tree()), vec![])),
-            |inputs| {
-                wallet_db.with_orchard_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|orchard_tree| {
-                    let anchor = orchard_tree
-                        .root_at_checkpoint_id(&inputs.anchor_height())?
-                        .ok_or(ProposalError::AnchorNotFound(inputs.anchor_height()))?
-                        .into();
+        wallet_db.with_orchard_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|orchard_tree| {
+            let anchor = orchard_tree
+                .root_at_checkpoint_id(&anchor_height)?
+                .ok_or(ProposalError::AnchorNotFound(anchor_height))?
+                .into();
 
-                    let orchard_inputs = inputs
+            let orchard_inputs = proposal_step
+                .shielded_inputs()
+                .map(|inputs| {
+                    inputs
                         .notes()
                         .iter()
                         .filter_map(|selected| match selected.note() {
-                            #[cfg(feature = "orchard")]
                             Note::Orchard {
                                 note,
                                 pool: orchard::ValuePool::Orchard,
                             } => orchard_tree
                                 .witness_at_checkpoint_id_caching(
                                     selected.note_commitment_tree_position(),
-                                    &inputs.anchor_height(),
+                                    &anchor_height,
                                 )
                                 .and_then(|witness| {
                                     witness
@@ -1346,12 +1354,13 @@ where
                                 .transpose(),
                             _ => None,
                         })
-                        .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()?;
-
-                    Ok((Some(anchor), orchard_inputs))
+                        .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()
                 })
-            },
-        )?
+                .transpose()?
+                .unwrap_or_default();
+
+            Ok((Some(anchor), orchard_inputs))
+        })?
     } else {
         (None, vec![])
     };
@@ -1359,54 +1368,50 @@ where
     let orchard_anchor = None;
 
     // The Ironwood builder must be available whenever the transaction will interact with the
-    // Ironwood bundle: either the proposal itself involves the Ironwood pool, or Ironwood is active
-    // at the target height and the builder will route Orchard-pool outputs into a fresh Ironwood
-    // bundle. The anchor must be a real Ironwood tree root so a transaction with only routed
-    // outputs is indistinguishable from one that spends real Ironwood notes.
+    // Ironwood bundle: either the proposal itself involves the Ironwood pool, or Ironwood is
+    // active at the target height and the builder will route Orchard-pool outputs into a fresh
+    // Ironwood bundle.
     #[cfg(feature = "orchard")]
     let (ironwood_anchor, ironwood_inputs) = if proposal_step
         .involves(PoolType::Shielded(ShieldedPool::Ironwood))
         || ironwood_active_at(params, min_target_height)
     {
-        let Some(inputs) = proposal_step.shielded_inputs() else {
-            // A shielding proposal carries no shielded anchor height, so there is no valid Ironwood
-            // anchor to bind to. This path is not yet supported.
-            return Err(Error::ProposalNotSupported);
-        };
         wallet_db
             .with_ironwood_tree_mut::<_, _, Error<_, _, _, _, _, _>>(|ironwood_tree| {
                 let anchor = ironwood_tree
-                    .root_at_checkpoint_id(&inputs.anchor_height())?
-                    .ok_or(ProposalError::AnchorNotFound(inputs.anchor_height()))?
+                    .root_at_checkpoint_id(&anchor_height)?
+                    .ok_or(ProposalError::AnchorNotFound(anchor_height))?
                     .into();
 
-                let mut ironwood_inputs = Vec::<(&orchard::Note, orchard::tree::MerklePath)>::new();
-
-                for ironwood_input in
-                    inputs
-                        .notes()
-                        .iter()
-                        .filter_map(|selected| match selected.note() {
-                            Note::Orchard {
-                                note,
-                                pool: orchard::ValuePool::Ironwood,
-                            } => ironwood_tree
-                                .witness_at_checkpoint_id_caching(
-                                    selected.note_commitment_tree_position(),
-                                    &inputs.anchor_height(),
-                                )
-                                .and_then(|witness| {
-                                    witness
-                                        .ok_or(ShardTreeError::Query(QueryError::CheckpointPruned))
-                                })
-                                .map(|merkle_path| Some((note, merkle_path.into())))
-                                .map_err(Error::from)
-                                .transpose(),
-                            _ => None,
-                        })
-                {
-                    ironwood_inputs.push(ironwood_input?);
-                }
+                let ironwood_inputs = proposal_step
+                    .shielded_inputs()
+                    .map(|inputs| {
+                        inputs
+                            .notes()
+                            .iter()
+                            .filter_map(|selected| match selected.note() {
+                                Note::Orchard {
+                                    note,
+                                    pool: orchard::ValuePool::Ironwood,
+                                } => ironwood_tree
+                                    .witness_at_checkpoint_id_caching(
+                                        selected.note_commitment_tree_position(),
+                                        &anchor_height,
+                                    )
+                                    .and_then(|witness| {
+                                        witness.ok_or(ShardTreeError::Query(
+                                            QueryError::CheckpointPruned,
+                                        ))
+                                    })
+                                    .map(|merkle_path| Some((note, merkle_path.into())))
+                                    .map_err(Error::from)
+                                    .transpose(),
+                                _ => None,
+                            })
+                            .collect::<Result<Vec<_>, Error<_, _, _, _, _, _>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
 
                 Ok((Some(anchor), ironwood_inputs))
             })?
@@ -1750,12 +1755,11 @@ where
                 }
                 #[cfg(feature = "orchard")]
                 PoolType::Shielded(ShieldedPool::Orchard) => {
+                    // Legacy Orchard payment (pre-NU6.3). Once Ironwood is active, input
+                    // selection assigns Orchard-receiver payments the Ironwood output pool
+                    // instead, so this arm always builds a plain Orchard output.
                     let to = *ua.orchard().expect("The mapping between payment pool and receiver is checked in step construction");
-                    if ironwood_active_at(params, min_target_height) {
-                        add_ironwood_output(&mut builder, &mut ironwood_output_meta, to)?;
-                    } else {
-                        add_orchard_output(&mut builder, &mut orchard_output_meta, to)?;
-                    }
+                    add_orchard_output(&mut builder, &mut orchard_output_meta, to)?;
                 }
                 PoolType::Shielded(ShieldedPool::Sapling) => {
                     let to = *ua.sapling().expect("The mapping between payment pool and receiver is checked in step construction");
@@ -1765,8 +1769,16 @@ where
                     let to = *ua.transparent().expect("The mapping between payment pool and receiver is checked in step construction");
                     add_transparent_output(&mut builder, &mut transparent_output_meta, to)?;
                 }
+                #[cfg(feature = "orchard")]
                 PoolType::Shielded(ShieldedPool::Ironwood) => {
-                    todo!("Ironwood pool support is not yet implemented")
+                    // Ironwood payment (post-NU6.3): delivered to the recipient's Orchard
+                    // receiver, but through the Ironwood bundle, a pool distinct from Orchard.
+                    let to = *ua.orchard().expect("The mapping between payment pool and receiver is checked in step construction");
+                    add_ironwood_output(&mut builder, &mut ironwood_output_meta, to)?;
+                }
+                #[cfg(not(feature = "orchard"))]
+                PoolType::Shielded(ShieldedPool::Ironwood) => {
+                    return Err(Error::ProposalNotSupported);
                 }
             },
             Address::Sapling(to) => {

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -976,12 +976,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // built. We reuse the builder's own routing predicate so the proposal
             // and build paths cannot drift.
             #[cfg(feature = "orchard")]
-            let orchard_outputs_are_ironwood = super::orchard_outputs_to_ironwood(
-                params,
-                target_height,
-                #[cfg(feature = "unstable")]
-                proposed_version,
-            );
+            let orchard_outputs_are_ironwood = super::ironwood_active_at(params, target_height);
 
             // The Orchard bundle keeps the Orchard spends; its outputs move to the
             // Ironwood bundle when routing is active. Ironwood has no spends yet
@@ -1056,6 +1051,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             sapling: use_sapling,
                             #[cfg(feature = "orchard")]
                             orchard: use_orchard,
+                            #[cfg(feature = "orchard")]
+                            ironwood: false,
                         }))
                         .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
 
@@ -1412,6 +1409,8 @@ where
         sapling: use_sapling,
         #[cfg(feature = "orchard")]
         orchard: use_orchard,
+        #[cfg(feature = "orchard")]
+        ironwood: false,
     }))
     .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1153,6 +1153,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         transparent_inputs,
                         transaction_request,
                         payment_pools,
+                        #[cfg(feature = "orchard")]
+                        ironwood_active_at(params, target_height),
                         #[cfg(feature = "transparent-inputs")]
                         ephemeral_output_value.zip(tr1_balance_opt).map(
                             |(ephemeral_output_value, tr1_balance)| EphemeralStepConfig {
@@ -1591,6 +1593,8 @@ where
         vec![],
         transaction_request,
         payment_pools,
+        #[cfg(feature = "orchard")]
+        ironwood_active_at(params, target_height),
         #[cfg(feature = "transparent-inputs")]
         ephemeral_output_value
             .zip(tr1_fee)
@@ -1623,6 +1627,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
     transparent_inputs: Vec<WalletTransparentOutput<()>>,
     transaction_request: TransactionRequest,
     payment_pools: BTreeMap<usize, PoolType>,
+    #[cfg(feature = "orchard")] ironwood_active: bool,
     #[cfg(feature = "transparent-inputs")] ephemeral_step_opt: Option<EphemeralStepConfig>,
 ) -> Result<Proposal<FeeRuleT, NoteRef>, ProposalError> {
     #[cfg(feature = "transparent-inputs")]
@@ -1674,6 +1679,8 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             vec![],
             tr0_balance,
             false,
+            #[cfg(feature = "orchard")]
+            ironwood_active,
         )?);
 
         let tr1 =
@@ -1688,6 +1695,8 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             vec![ephemeral_stepoutput],
             tr1_balance,
             false,
+            #[cfg(feature = "orchard")]
+            ironwood_active,
         )?);
 
         return Proposal::multi_step(
@@ -1707,6 +1716,8 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         fee_rule.clone(),
         target_height,
         false,
+        #[cfg(feature = "orchard")]
+        ironwood_active,
     )
 }
 
@@ -1768,6 +1779,8 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 (*change_strategy.fee_rule()).clone(),
                 target_height,
                 true,
+                #[cfg(feature = "orchard")]
+                ironwood_active_at(params, target_height),
             )
             .map_err(InputSelectorError::Proposal)
         } else {
@@ -1821,8 +1834,11 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 .min(shielding_max_inputs(self.shielding_block_space_percent)),
         )?;
 
-        let destination_pool =
-            resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(&to_address, params)?;
+        let destination_pool = resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(
+            &to_address,
+            params,
+            target_height,
+        )?;
 
         let (sapling_output_count, orchard_action_count, ironwood_action_count) =
             match destination_pool {
@@ -1832,6 +1848,8 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                         .expect("sapling DEFAULT bundle type permits any (spends, outputs) count");
                     (count, 0usize, 0usize)
                 }
+                // A pre-NU6.3 payment to an Orchard receiver; after Ironwood activation,
+                // `resolve_shielded_destination` assigns such payments to the Ironwood pool.
                 #[cfg(feature = "orchard")]
                 PoolType::ORCHARD => {
                     let count = orchard_fees::transactional_action_count(
@@ -1840,11 +1858,19 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                         1,
                     )
                     .expect("every Orchard bundle version permits spending and output creation");
-                    if ironwood_active_at(params, target_height) {
-                        (0usize, 0usize, count)
-                    } else {
-                        (0usize, count, 0usize)
-                    }
+                    (0usize, count, 0usize)
+                }
+                // A post-NU6.3 payment to an Orchard receiver, delivered via the Ironwood
+                // bundle and charged to its action count.
+                #[cfg(feature = "orchard")]
+                PoolType::IRONWOOD => {
+                    let count = orchard_fees::transactional_action_count(
+                        ironwood_bundle_version_for_height(params, target_height),
+                        0,
+                        1,
+                    )
+                    .expect("the Ironwood bundle version permits spending and output creation");
+                    (0usize, 0usize, count)
                 }
                 // Unreachable: `resolve_shielded_destination` rejects transparent
                 // destinations earlier with `ShieldingRequiresShieldedRecipient`.
@@ -1924,6 +1950,8 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             fee_rule.clone(),
             target_height,
             false,
+            #[cfg(feature = "orchard")]
+            ironwood_active_at(params, target_height),
         )
         .map_err(InputSelectorError::Proposal)
     }
@@ -2024,6 +2052,7 @@ where
 fn resolve_shielded_destination<DbT, ChangeErrT, ParamsT>(
     addr: &ZcashAddress,
     params: &ParamsT,
+    target_height: TargetHeight,
 ) -> Result<
     PoolType,
     InputSelectorError<
@@ -2037,14 +2066,26 @@ where
     DbT: InputSource,
     ParamsT: consensus::Parameters,
 {
+    #[cfg(not(feature = "orchard"))]
+    let _ = target_height;
+
     let resolved: Address = addr
         .clone()
         .convert_if_network(params.network_type())
         .map_err(InputSelectorError::Address)?;
     match resolved {
         Address::Sapling(_) => Ok(PoolType::SAPLING),
+        // A payment to an Orchard-protocol receiver is an Ironwood-pool output once
+        // Ironwood is active (delivered to the recipient's Orchard receiver via the
+        // Ironwood bundle), and an Orchard-pool output otherwise.
         #[cfg(feature = "orchard")]
-        Address::Unified(ua) if ua.has_orchard() => Ok(PoolType::ORCHARD),
+        Address::Unified(ua) if ua.has_orchard() => {
+            Ok(if ironwood_active_at(params, target_height) {
+                PoolType::IRONWOOD
+            } else {
+                PoolType::ORCHARD
+            })
+        }
         Address::Unified(ua) if ua.has_sapling() => Ok(PoolType::SAPLING),
         Address::Unified(ua) => Err(InputSelectorError::Selection(
             GreedyInputSelectorError::UnsupportedAddress(Box::new(ua)),

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -50,7 +50,7 @@ use {
 };
 
 #[cfg(feature = "orchard")]
-use crate::fees::orchard as orchard_fees;
+use crate::{data_api::wallet::ironwood_active_at, fees::orchard as orchard_fees};
 
 #[cfg(feature = "unstable")]
 use zcash_primitives::transaction::TxVersion;
@@ -262,6 +262,7 @@ pub trait ShieldingSelector {
         source_addrs: &[TransparentAddress],
         to_account: <Self::InputSource as InputSource>::AccountId,
         target_height: TargetHeight,
+        anchor_height: BlockHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
     ) -> Result<
@@ -327,6 +328,7 @@ pub trait ShieldingSelector {
         memo: Option<MemoBytes>,
         limit: Option<usize>,
         target_height: TargetHeight,
+        anchor_height: BlockHeight,
     ) -> Result<
         Proposal<FeeRuleT, Infallible>,
         InputSelectorError<
@@ -713,6 +715,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             })?;
         #[cfg(not(feature = "unstable"))]
         let (sapling_supported, orchard_supported) = (true, cfg!(feature = "orchard"));
+        // Without the `orchard` feature there are no Orchard-family pools to select from, so
+        // `orchard_supported` (always false) is only referenced by Orchard-gated code.
+        #[cfg(not(feature = "orchard"))]
+        let _ = orchard_supported;
 
         let mut transparent_outputs = vec![];
         let mut sapling_outputs = vec![];
@@ -783,7 +789,17 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 Address::Unified(addr) => {
                     #[cfg(feature = "orchard")]
                     if addr.has_orchard() && orchard_supported {
-                        payment_pools.insert(*idx, PoolType::ORCHARD);
+                        // Represent an Orchard-receiver payment as an Ironwood-pool output once
+                        // Ironwood is active (its value is accounted to the Ironwood bundle
+                        // below), and as an Orchard-pool output otherwise.
+                        payment_pools.insert(
+                            *idx,
+                            if ironwood_active_at(params, target_height) {
+                                PoolType::IRONWOOD
+                            } else {
+                                PoolType::ORCHARD
+                            },
+                        );
                         orchard_outputs.push(OrchardPayment(payment_amount));
                         continue;
                     }
@@ -852,31 +868,83 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         let mut amount_required = Zatoshis::ZERO;
         let mut exclude: Vec<DbT::NoteRef> = vec![];
 
+        // The single pool-preference order that governs both which pools notes are
+        // selected from and which of the selected notes are spent: the pool matching
+        // the payment's outputs comes first, and later pools are drawn upon only when
+        // the earlier ones cannot cover the required amount, so that pool crossing is
+        // minimized. For a payment to an Orchard receiver the Orchard-family pools
+        // lead: once NU6.3 is active such payments are constructed in the Ironwood
+        // bundle — moving their value into the Ironwood pool — so Ironwood is
+        // preferred, with the legacy Orchard pool last within the family.
+        #[cfg(feature = "orchard")]
+        let pool_preference = selectable_pool_preference(
+            params,
+            target_height,
+            sapling_supported,
+            orchard_supported,
+            !orchard_outputs.is_empty(),
+        );
+        #[cfg(not(feature = "orchard"))]
+        let pool_preference = {
+            let mut pools = vec![];
+            if sapling_supported {
+                pools.push(ShieldedPool::Sapling);
+            }
+            pools
+        };
+
         // This loop is guaranteed to terminate because on each iteration we check that the amount
         // of funds selected is strictly increasing. The loop will either return a successful
         // result or the wallet will eventually run out of funds to select.
         loop {
             #[cfg(not(feature = "orchard"))]
-            let use_sapling = true;
+            let sapling_bundle_required = true;
             #[cfg(feature = "orchard")]
-            let (use_sapling, use_orchard) = {
-                let (sapling_input_total, orchard_input_total) = (
-                    shielded_inputs.sapling_value()?,
-                    shielded_inputs.orchard_value()?,
-                );
+            let (sapling_bundle_required, orchard_bundle_required, ironwood_bundle_required) = {
+                // Trim the selected notes to the pools that are actually needed: the first
+                // pool (in `pool_preference` order) whose selected notes cover the required
+                // amount is spent alone; otherwise pools are accumulated in preference order
+                // until the running total covers the amount, or all pools are in use.
+                let pool_values = [
+                    (ShieldedPool::Sapling, shielded_inputs.sapling_value()?),
+                    (ShieldedPool::Orchard, shielded_inputs.orchard_value()?),
+                    (ShieldedPool::Ironwood, shielded_inputs.ironwood_value()?),
+                ];
+                let value_of = |pool: ShieldedPool| {
+                    pool_values
+                        .iter()
+                        .find(|(p, _)| *p == pool)
+                        .map(|(_, v)| *v)
+                        .expect("all shielded pools are present in pool_values")
+                };
 
-                // Use Sapling inputs if there are no Orchard outputs or if there are insufficient
-                // funds from Orchard inputs to cover the amount required.
-                let use_sapling =
-                    orchard_outputs.is_empty() || amount_required > orchard_input_total;
-                // Use Orchard inputs if there are insufficient funds from Sapling inputs to cover
-                // the amount required.
-                let use_orchard = !use_sapling || amount_required > sapling_input_total;
+                let use_pools: Vec<ShieldedPool> = if let Some(single) = pool_preference
+                    .iter()
+                    .find(|p| value_of(**p) >= amount_required)
+                {
+                    vec![*single]
+                } else {
+                    let mut running = Zatoshis::ZERO;
+                    let mut used = vec![];
+                    for pool in &pool_preference {
+                        if running >= amount_required {
+                            break;
+                        }
+                        running = (running + value_of(*pool))
+                            .ok_or(GreedyInputSelectorError::Balance(BalanceError::Overflow))?;
+                        used.push(*pool);
+                    }
+                    used
+                };
 
-                (use_sapling, use_orchard)
+                (
+                    use_pools.contains(&ShieldedPool::Sapling),
+                    use_pools.contains(&ShieldedPool::Orchard),
+                    use_pools.contains(&ShieldedPool::Ironwood),
+                )
             };
 
-            let sapling_inputs = if use_sapling {
+            let sapling_inputs = if sapling_bundle_required {
                 shielded_inputs
                     .sapling()
                     .iter()
@@ -887,9 +955,22 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             };
 
             #[cfg(feature = "orchard")]
-            let orchard_inputs = if use_orchard {
+            let orchard_inputs = if orchard_bundle_required {
                 shielded_inputs
                     .orchard()
+                    .iter()
+                    .map(|i| (*i.internal_note_id(), i.note().value()))
+                    .collect()
+            } else {
+                vec![]
+            };
+
+            // Ironwood inputs are attributed to the Ironwood bundle for action-count and fee
+            // purposes.
+            #[cfg(feature = "orchard")]
+            let ironwood_inputs = if ironwood_bundle_required {
+                shielded_inputs
+                    .ironwood()
                     .iter()
                     .map(|i| (*i.internal_note_id(), i.note().value()))
                     .collect()
@@ -901,6 +982,9 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             let selected_input_ids =
                 selected_input_ids.chain(orchard_inputs.iter().map(|(id, _)| id));
+            #[cfg(feature = "orchard")]
+            let selected_input_ids =
+                selected_input_ids.chain(ironwood_inputs.iter().map(|(id, _)| id));
 
             let selected_input_ids = selected_input_ids.cloned().collect::<Vec<_>>();
 
@@ -919,6 +1003,23 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // The ephemeral input going into transaction 1 must be able to pay that
                     // transaction's fee, as well as the TEX address payments.
 
+                    // Transaction 1 carries no shielded spends or outputs, but the change
+                    // strategy may still model hypothetical shielded change against these
+                    // views, so they carry the bundle versions in effect at the target
+                    // height rather than a fixed default.
+                    #[cfg(feature = "orchard")]
+                    let empty_orchard_view = (
+                        orchard_bundle_version_for_height(params, target_height),
+                        &[] as &[Infallible],
+                        &[] as &[Infallible],
+                    );
+                    #[cfg(feature = "orchard")]
+                    let empty_ironwood_view = (
+                        ironwood_bundle_version_for_height(params, target_height),
+                        &[] as &[Infallible],
+                        &[] as &[Infallible],
+                    );
+
                     // First compute the required total with an additional zero input,
                     // catching the `InsufficientFunds` error to obtain the required amount
                     // given the provided change strategy. Ignore the change memo in order
@@ -931,11 +1032,9 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             &tr1_transparent_outputs,
                             &sapling::EmptyBundleView,
                             #[cfg(feature = "orchard")]
-                            &orchard_fees::EmptyBundleView,
+                            &empty_orchard_view,
                             #[cfg(feature = "orchard")]
-                            &orchard_fees::EmptyBundleView,
-                            #[cfg(feature = "orchard")]
-                            false,
+                            &empty_ironwood_view,
                             Some(EphemeralBalance::Input(Zatoshis::ZERO)),
                             &wallet_meta,
                         ) {
@@ -956,11 +1055,9 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         &tr1_transparent_outputs,
                         &sapling::EmptyBundleView,
                         #[cfg(feature = "orchard")]
-                        &orchard_fees::EmptyBundleView,
+                        &empty_orchard_view,
                         #[cfg(feature = "orchard")]
-                        &orchard_fees::EmptyBundleView,
-                        #[cfg(feature = "orchard")]
-                        false,
+                        &empty_ironwood_view,
                         Some(EphemeralBalance::Input(tr1_required_input_value)),
                         &wallet_meta,
                     )?;
@@ -970,36 +1067,29 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 }
             };
 
-            // When the builder will route Orchard-pool outputs into a separate
-            // Ironwood bundle, mirror that split here so the proposal's per-bundle
-            // action counts (and hence the fee) match the transaction that gets
-            // built. We reuse the builder's own routing predicate so the proposal
-            // and build paths cannot drift.
-            #[cfg(feature = "orchard")]
-            let orchard_outputs_are_ironwood = super::ironwood_active_at(params, target_height);
-
-            // The Orchard bundle keeps the Orchard spends; its outputs move to the
-            // Ironwood bundle when routing is active. Ironwood has no spends yet
-            // (the wallet does not select Ironwood notes until note detection lands),
-            // so `&orchard_inputs[..0]` is an empty slice of the correct type.
+            // The Orchard bundle keeps the Orchard (version 2) spends; its outputs move to the
+            // Ironwood bundle when routing is active. The Ironwood bundle takes the Ironwood
+            // (version 3) spends, and its outputs when routing is active. Attributing each pool's
+            // spends to its own bundle keeps the action counts (and hence the fee) matching the
+            // transaction the builder produces.
             #[cfg(feature = "orchard")]
             let orchard_view = (
                 orchard_bundle_version_for_height(params, target_height),
                 &orchard_inputs[..],
-                if orchard_outputs_are_ironwood {
-                    &orchard_outputs[..0]
+                if ironwood_active_at(params, target_height) {
+                    &[]
                 } else {
                     &orchard_outputs[..]
                 },
             );
             #[cfg(feature = "orchard")]
             let ironwood_view = (
-                ::orchard::bundle::BundleVersion::ironwood_v3(),
-                &orchard_inputs[..0],
-                if orchard_outputs_are_ironwood {
+                ironwood_bundle_version_for_height(params, target_height),
+                &ironwood_inputs[..],
+                if ironwood_active_at(params, target_height) {
                     &orchard_outputs[..]
                 } else {
-                    &orchard_outputs[..0]
+                    &[]
                 },
             );
 
@@ -1036,8 +1126,6 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 &orchard_view,
                 #[cfg(feature = "orchard")]
                 &ironwood_view,
-                #[cfg(feature = "orchard")]
-                orchard_outputs_are_ironwood,
                 ephemeral_output_value.map(EphemeralBalance::Output),
                 &wallet_meta,
             );
@@ -1048,18 +1136,19 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // return here.
                     let shielded_inputs =
                         NonEmpty::from_vec(shielded_inputs.into_vec(&SimpleNoteRetention {
-                            sapling: use_sapling,
+                            sapling: sapling_bundle_required,
                             #[cfg(feature = "orchard")]
-                            orchard: use_orchard,
+                            orchard: orchard_bundle_required,
                             #[cfg(feature = "orchard")]
-                            ironwood: false,
+                            ironwood: ironwood_bundle_required,
                         }))
-                        .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
+                        .map(ShieldedInputs::from_parts);
 
                     return build_proposal(
                         change_strategy.fee_rule(),
                         tr0_balance,
                         target_height,
+                        anchor_height,
                         shielded_inputs,
                         transparent_inputs,
                         transaction_request,
@@ -1082,11 +1171,15 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     mut sapling,
                     #[cfg(feature = "orchard")]
                     mut orchard,
+                    #[cfg(feature = "orchard")]
+                    mut ironwood,
                     ..
                 }) => {
                     exclude.append(&mut sapling);
                     #[cfg(feature = "orchard")]
                     exclude.append(&mut orchard);
+                    #[cfg(feature = "orchard")]
+                    exclude.append(&mut ironwood);
                     #[cfg(feature = "transparent-inputs")]
                     {
                         let len_before = transparent_inputs.len();
@@ -1141,23 +1234,17 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 Err(other) => return Err(InputSelectorError::Change(other)),
             }
 
-            let selectable_pools = {
-                if orchard_supported && sapling_supported {
-                    &[ShieldedPool::Sapling, ShieldedPool::Orchard][..]
-                } else if orchard_supported {
-                    &[ShieldedPool::Orchard][..]
-                } else if sapling_supported {
-                    &[ShieldedPool::Sapling][..]
-                } else {
-                    &[]
-                }
-            };
-
+            // Candidate notes are selected from the pools of `pool_preference` — the
+            // same order the pool-usage trimming at the top of the loop applies — so
+            // the notes offered for spending and the notes actually spent are governed
+            // by one policy: pool crossing is minimized, and a payment to an Orchard
+            // receiver draws on the pool its output is constructed in (the Ironwood
+            // pool once NU6.3 is active).
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
                     TargetValue::AtLeast(amount_required),
-                    selectable_pools,
+                    &pool_preference,
                     target_height,
                     confirmations_policy,
                     &exclude,
@@ -1180,21 +1267,81 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
     }
 }
 
+/// Returns the shielded pools from which the greedy input selector may spend at the
+/// given target height, in preference order.
+///
+/// The pool family matching the payment's outputs comes first, so that single-pool
+/// coverage avoids unnecessary pool crossings: for an Orchard-family payment this is
+/// Ironwood (when active) and then Orchard — an Orchard-receiver payment is delivered
+/// via the Ironwood bundle once Ironwood is active — and for other payments it is
+/// Sapling. The legacy Orchard pool comes last otherwise, so that it is drawn upon
+/// only when the more current pools cannot cover the required amount.
+#[cfg(feature = "orchard")]
+fn selectable_pool_preference<ParamsT: consensus::Parameters>(
+    params: &ParamsT,
+    target_height: TargetHeight,
+    sapling_supported: bool,
+    orchard_supported: bool,
+    prefer_orchard_family: bool,
+) -> Vec<ShieldedPool> {
+    let ironwood_selectable = orchard_supported && ironwood_active_at(params, target_height);
+    let mut preference = Vec::with_capacity(3);
+    if prefer_orchard_family {
+        if ironwood_selectable {
+            preference.push(ShieldedPool::Ironwood);
+        }
+        if orchard_supported {
+            preference.push(ShieldedPool::Orchard);
+        }
+        if sapling_supported {
+            preference.push(ShieldedPool::Sapling);
+        }
+    } else {
+        if sapling_supported {
+            preference.push(ShieldedPool::Sapling);
+        }
+        if ironwood_selectable {
+            preference.push(ShieldedPool::Ironwood);
+        }
+        if orchard_supported {
+            preference.push(ShieldedPool::Orchard);
+        }
+    }
+    preference
+}
+
 /// Returns the Orchard bundle version whose action-count policy applies to
 /// transactions constructed for the given target height.
 #[cfg(feature = "orchard")]
-fn orchard_bundle_version_for_height<ParamsT: consensus::Parameters>(
+fn orchard_bundle_version_for_height<ParamsT: consensus::Parameters, H: Into<BlockHeight>>(
     params: &ParamsT,
-    target_height: TargetHeight,
+    target_height: H,
 ) -> ::orchard::bundle::BundleVersion {
     zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
-        consensus::BranchId::for_height(params, BlockHeight::from(target_height)),
+        consensus::BranchId::for_height(params, target_height.into()),
         ::orchard::ValuePool::Orchard,
     )
     // Orchard did not exist prior to NU5, so no Orchard bundle (and no Orchard
     // action) can be produced for a pre-NU5 target height; every bundle version
     // yields the correct action count (zero) for an empty bundle.
     .unwrap_or(::orchard::bundle::BundleVersion::orchard_insecure_v1())
+}
+
+/// Returns the Ironwood bundle version whose action-count policy applies to
+/// transactions constructed for the given target height.
+#[cfg(feature = "orchard")]
+fn ironwood_bundle_version_for_height<ParamsT: consensus::Parameters, H: Into<BlockHeight>>(
+    params: &ParamsT,
+    target_height: H,
+) -> ::orchard::bundle::BundleVersion {
+    zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+        consensus::BranchId::for_height(params, target_height.into()),
+        ::orchard::ValuePool::Ironwood,
+    )
+    // The Ironwood pool did not exist prior to NU6.3, so no Ironwood bundle (and
+    // no Ironwood action) can be produced for an earlier target height; every
+    // bundle version yields the correct action count (zero) for an empty bundle.
+    .unwrap_or(::orchard::bundle::BundleVersion::ironwood_v3())
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
@@ -1253,32 +1400,53 @@ where
             .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?
     };
 
-    let use_sapling = !spendable_notes.sapling().is_empty() || sapling_output_count > 0;
+    let sapling_bundle_required = !spendable_notes.sapling().is_empty() || sapling_output_count > 0;
+
+    // A payment to an Orchard receiver is represented in the proposal as an Ironwood-pool output
+    // once Ironwood is active (delivered to the Orchard receiver via the Ironwood bundle), and as
+    // an Orchard-pool output otherwise. The per-bundle action counts below reflect that split.
+    #[cfg(feature = "orchard")]
+    let orchard_receiver_present = recipient.can_receive_as(PoolType::ORCHARD);
+    #[cfg(feature = "orchard")]
+    let orchard_receivers_fill_ironwood = ironwood_active_at(params, target_height);
+    #[cfg(feature = "orchard")]
+    if orchard_receiver_present {
+        payment_pools.insert(
+            0,
+            if orchard_receivers_fill_ironwood {
+                PoolType::IRONWOOD
+            } else {
+                PoolType::ORCHARD
+            },
+        );
+    }
 
     #[cfg(feature = "orchard")]
-    let orchard_action_count = {
-        let requested_orchard_actions: usize = if recipient.can_receive_as(PoolType::ORCHARD) {
-            payment_pools.insert(0, PoolType::ORCHARD);
-            1
-        } else {
-            0
-        };
-        orchard_fees::transactional_action_count(
-            orchard_bundle_version_for_height(params, target_height),
-            spendable_notes.orchard.len(),
-            requested_orchard_actions,
-        )
-        .map_err(|e| InputSelectorError::Change(ChangeError::BundleError(e)))?
-    };
+    let orchard_action_count = orchard_fees::transactional_action_count(
+        orchard_bundle_version_for_height(params, target_height),
+        spendable_notes.orchard.len(),
+        usize::from(orchard_receiver_present && !orchard_receivers_fill_ironwood),
+    )
+    .map_err(|e| InputSelectorError::Change(ChangeError::BundleError(e)))?;
     #[cfg(not(feature = "orchard"))]
     let orchard_action_count: usize = 0;
 
     #[cfg(feature = "orchard")]
-    let use_orchard = orchard_action_count > 0;
+    let orchard_bundle_required = orchard_action_count > 0;
 
-    // The wallet does not yet construct Ironwood bundles, so they contribute no
-    // actions to the fee.
+    #[cfg(feature = "orchard")]
+    let ironwood_action_count = orchard::builder::BundleType::DEFAULT
+        .num_actions(
+            orchard::bundle::Flags::ENABLED,
+            spendable_notes.ironwood.len(),
+            usize::from(orchard_receiver_present && orchard_receivers_fill_ironwood),
+        )
+        .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?;
+    #[cfg(not(feature = "orchard"))]
     let ironwood_action_count: usize = 0;
+
+    #[cfg(feature = "orchard")]
+    let ironwood_bundle_required = ironwood_action_count > 0;
 
     let recipient_address: Address = recipient
         .clone()
@@ -1406,18 +1574,19 @@ where
         })?;
 
     let shielded_inputs = NonEmpty::from_vec(spendable_notes.into_vec(&SimpleNoteRetention {
-        sapling: use_sapling,
+        sapling: sapling_bundle_required,
         #[cfg(feature = "orchard")]
-        orchard: use_orchard,
+        orchard: orchard_bundle_required,
         #[cfg(feature = "orchard")]
-        ironwood: false,
+        ironwood: ironwood_bundle_required,
     }))
-    .map(|notes| ShieldedInputs::from_parts(anchor_height, notes));
+    .map(ShieldedInputs::from_parts);
 
     build_proposal(
         fee_rule,
         tr0_balance,
         target_height,
+        anchor_height,
         shielded_inputs,
         vec![],
         transaction_request,
@@ -1449,6 +1618,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
     fee_rule: &FeeRuleT,
     tr0_balance: TransactionBalance,
     target_height: TargetHeight,
+    anchor_height: BlockHeight,
     shielded_inputs: Option<ShieldedInputs<NoteRef>>,
     transparent_inputs: Vec<WalletTransparentOutput<()>>,
     transaction_request: TransactionRequest,
@@ -1500,6 +1670,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             payment_pools,
             transparent_inputs,
             shielded_inputs,
+            anchor_height,
             vec![],
             tr0_balance,
             false,
@@ -1513,6 +1684,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             ephemeral_step.tr1_payment_pools,
             vec![],
             None,
+            anchor_height,
             vec![ephemeral_stepoutput],
             tr1_balance,
             false,
@@ -1530,6 +1702,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         payment_pools,
         transparent_inputs,
         shielded_inputs,
+        anchor_height,
         tr0_balance,
         fee_rule.clone(),
         target_height,
@@ -1552,6 +1725,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         source_addrs: &[TransparentAddress],
         to_account: <Self::InputSource as InputSource>::AccountId,
         target_height: TargetHeight,
+        anchor_height: BlockHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
     ) -> Result<
@@ -1589,6 +1763,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 BTreeMap::new(),
                 transparent_inputs,
                 None,
+                anchor_height,
                 balance,
                 (*change_strategy.fee_rule()).clone(),
                 target_height,
@@ -1615,6 +1790,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         memo: Option<MemoBytes>,
         limit: Option<usize>,
         target_height: TargetHeight,
+        anchor_height: BlockHeight,
     ) -> Result<
         Proposal<FeeRuleT, Infallible>,
         InputSelectorError<<DbT as InputSource>::Error, Self::Error, FeeRuleT::Error, Infallible>,
@@ -1648,47 +1824,36 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         let destination_pool =
             resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(&to_address, params)?;
 
-        // Compute the fee directly from the fee rule. This method produces no
-        // change in any pool, so there is no change-strategy or wallet-metadata
-        // computation to perform. The proposal will carry exactly one shielded
-        // payment output (in `destination_pool`) and zero transparent outputs.
-        //
-        // Both Sapling and Orchard transactional bundles pad up to a minimum
-        // of 2 outputs/actions when any output is added (see `MIN_ACTIONS` /
-        // `MIN_SHIELDED_OUTPUTS` in the respective crates). The proposal fee
-        // must reflect the *padded* counts that the builder will actually
-        // produce, otherwise the subsequent `create_proposed_transactions`
-        // call fails with `InsufficientFunds(need additional <marginal_fee>)`.
-        // We query each bundle type for the count it will materialize.
-        let (sapling_output_count, orchard_action_count) = match destination_pool {
-            PoolType::SAPLING => {
-                let count = ::sapling::builder::BundleType::DEFAULT
-                    .num_outputs(0, 1)
-                    .expect("sapling DEFAULT bundle type permits any (spends, outputs) count");
-                (count, 0usize)
-            }
-            #[cfg(feature = "orchard")]
-            PoolType::ORCHARD => {
-                let count = orchard_fees::transactional_action_count(
-                    orchard_bundle_version_for_height(params, target_height),
-                    0,
-                    1,
-                )
-                .expect("every Orchard bundle version permits spending and output creation");
-                (0usize, count)
-            }
-            // Unreachable: `resolve_shielded_destination` rejects transparent
-            // destinations earlier with `ShieldingRequiresShieldedRecipient`.
-            _ => {
-                return Err(InputSelectorError::Proposal(
-                    ProposalError::ShieldingRequiresShieldedRecipient,
-                ));
-            }
-        };
-
-        // The wallet does not yet construct Ironwood bundles, so they contribute
-        // no actions to the fee.
-        let ironwood_action_count = 0;
+        let (sapling_output_count, orchard_action_count, ironwood_action_count) =
+            match destination_pool {
+                PoolType::SAPLING => {
+                    let count = ::sapling::builder::BundleType::DEFAULT
+                        .num_outputs(0, 1)
+                        .expect("sapling DEFAULT bundle type permits any (spends, outputs) count");
+                    (count, 0usize, 0usize)
+                }
+                #[cfg(feature = "orchard")]
+                PoolType::ORCHARD => {
+                    let count = orchard_fees::transactional_action_count(
+                        orchard_bundle_version_for_height(params, target_height),
+                        0,
+                        1,
+                    )
+                    .expect("every Orchard bundle version permits spending and output creation");
+                    if ironwood_active_at(params, target_height) {
+                        (0usize, 0usize, count)
+                    } else {
+                        (0usize, count, 0usize)
+                    }
+                }
+                // Unreachable: `resolve_shielded_destination` rejects transparent
+                // destinations earlier with `ShieldingRequiresShieldedRecipient`.
+                _ => {
+                    return Err(InputSelectorError::Proposal(
+                        ProposalError::ShieldingRequiresShieldedRecipient,
+                    ));
+                }
+            };
 
         let fee = fee_rule
             .fee_required(
@@ -1754,6 +1919,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             payment_pools,
             transparent_inputs,
             None,
+            anchor_height,
             final_balance,
             fee_rule.clone(),
             target_height,
@@ -1946,9 +2112,14 @@ where
 }
 
 /// Helper for `propose_shielding`'s balance computation that calls
-/// `change_strategy.compute_balance` with empty Sapling and Orchard bundle
-/// views, allowing the change strategy to direct all available transparent
-/// input value into change.
+/// `change_strategy.compute_balance` with empty shielded bundle views, allowing
+/// the change strategy to direct all available transparent input value into
+/// change.
+///
+/// The empty Orchard-family views carry the bundle versions in effect at the
+/// target height (rather than a fixed default), because the change the strategy
+/// directs into a shielded pool is charged against that pool's bundle under its
+/// version's action-count policy.
 #[cfg(feature = "transparent-inputs")]
 #[allow(clippy::type_complexity)]
 fn compute_shielding_balance<DbT, ChangeT, ParamsT>(
@@ -1963,6 +2134,19 @@ where
     ChangeT: ChangeStrategy<MetaSource = DbT>,
     ParamsT: consensus::Parameters,
 {
+    #[cfg(feature = "orchard")]
+    let empty_orchard_view = (
+        orchard_bundle_version_for_height(params, target_height),
+        &[] as &[Infallible],
+        &[] as &[Infallible],
+    );
+    #[cfg(feature = "orchard")]
+    let empty_ironwood_view = (
+        ironwood_bundle_version_for_height(params, target_height),
+        &[] as &[Infallible],
+        &[] as &[Infallible],
+    );
+
     change_strategy.compute_balance(
         params,
         target_height,
@@ -1970,11 +2154,9 @@ where
         &[] as &[TxOut],
         &sapling::EmptyBundleView,
         #[cfg(feature = "orchard")]
-        &orchard_fees::EmptyBundleView,
+        &empty_orchard_view,
         #[cfg(feature = "orchard")]
-        &orchard_fees::EmptyBundleView,
-        #[cfg(feature = "orchard")]
-        false,
+        &empty_ironwood_view,
         None,
         wallet_meta,
     )

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -17,7 +17,9 @@ use zip32::Scope;
 use crate::data_api::DecryptedTransaction;
 
 #[cfg(feature = "orchard")]
-use orchard::note_encryption::OrchardDomain;
+use orchard::note_encryption::{
+    DomainVersion, IronwoodVersion, NoteEncryptionDomain, OrchardVersion,
+};
 
 /// An enumeration of the possible relationships a TXO can have to the wallet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -199,15 +201,25 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         })
         .collect();
 
+    // Trial-decrypt an Orchard-family (Orchard or Ironwood) bundle. The two bundle kinds are
+    // protocol-equivalent for trial decryption: both are Orchard-shaped and use the account's
+    // Orchard viewing keys. They differ only in the note plaintext version their domain accepts
+    // (selected by `V`: version 2 for [`OrchardVersion`], version 3 for [`IronwoodVersion`]) and
+    // in the value pool their notes belong to. Decrypting a bundle under the other kind's domain
+    // would silently detect nothing.
     #[cfg(feature = "orchard")]
-    fn decrypt_orchard_bundle<AccountId: Copy>(
+    fn decrypt_orchard_protocol_bundle<V: DomainVersion, AccountId: Copy>(
         ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
         bundle: &orchard::bundle::Bundle<
             orchard::bundle::Authorized,
             zcash_protocol::value::ZatBalance,
         >,
-        value_pool: orchard::ValuePool,
+        pool: orchard::ValuePool,
     ) -> impl Iterator<Item = DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>> {
+        let shielded_pool = match pool {
+            orchard::ValuePool::Orchard => ShieldedPool::Orchard,
+            orchard::ValuePool::Ironwood => ShieldedPool::Ironwood,
+        };
         ufvks
             .iter()
             .flat_map(|(account, ufvk)| ufvk.orchard().into_iter().map(|fvk| (*account, fvk)))
@@ -223,7 +235,7 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
                     .iter()
                     .enumerate()
                     .flat_map(move |(index, action)| {
-                        let domain = OrchardDomain::for_action(action);
+                        let domain = NoteEncryptionDomain::<V>::for_action(action);
                         try_note_decryption(&domain, &ivk_external, action)
                             .map(|ret| (ret, TransferType::Incoming))
                             .or_else(|| {
@@ -244,8 +256,8 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
                             .map(move |((note, _, memo), transfer_type)| {
                                 DecryptedOutput::new(
                                     index,
-                                    (note, value_pool),
-                                    ShieldedPool::Orchard,
+                                    (note, pool),
+                                    shielded_pool,
                                     account,
                                     MemoBytes::from_bytes(&memo).expect("correct length"),
                                     transfer_type,
@@ -256,14 +268,30 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
     }
 
     #[cfg(feature = "orchard")]
-    let orchard_outputs =
-        tx.orchard_bundle()
-            .iter()
-            .flat_map(|bundle| decrypt_orchard_bundle(ufvks, bundle, orchard::ValuePool::Orchard))
-            .chain(tx.ironwood_bundle().iter().flat_map(|bundle| {
-                decrypt_orchard_bundle(ufvks, bundle, orchard::ValuePool::Ironwood)
-            }))
-            .collect();
+    let orchard_outputs = tx
+        .orchard_bundle()
+        .iter()
+        .flat_map(|bundle| {
+            decrypt_orchard_protocol_bundle::<OrchardVersion, _>(
+                ufvks,
+                bundle,
+                orchard::ValuePool::Orchard,
+            )
+        })
+        .collect();
+
+    #[cfg(feature = "orchard")]
+    let ironwood_outputs = tx
+        .ironwood_bundle()
+        .iter()
+        .flat_map(|bundle| {
+            decrypt_orchard_protocol_bundle::<IronwoodVersion, _>(
+                ufvks,
+                bundle,
+                orchard::ValuePool::Ironwood,
+            )
+        })
+        .collect();
 
     DecryptedTransaction::new(
         mined_height,
@@ -271,5 +299,7 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         sapling_outputs,
         #[cfg(feature = "orchard")]
         orchard_outputs,
+        #[cfg(feature = "orchard")]
+        ironwood_outputs,
     )
 }

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -7,6 +7,7 @@ use zcash_primitives::{
     transaction::Transaction, transaction::components::sapling::zip212_enforcement,
 };
 use zcash_protocol::{
+    ShieldedPool,
     consensus::{self, BlockHeight, NetworkUpgrade},
     memo::MemoBytes,
     value::Zatoshis,
@@ -42,6 +43,7 @@ pub enum TransferType {
 pub struct DecryptedOutput<Note, AccountId> {
     index: usize,
     note: Note,
+    value_pool: ShieldedPool,
     account: AccountId,
     memo: MemoBytes,
     transfer_type: TransferType,
@@ -51,6 +53,7 @@ impl<Note, AccountId> DecryptedOutput<Note, AccountId> {
     pub fn new(
         index: usize,
         note: Note,
+        value_pool: ShieldedPool,
         account: AccountId,
         memo: MemoBytes,
         transfer_type: TransferType,
@@ -58,6 +61,7 @@ impl<Note, AccountId> DecryptedOutput<Note, AccountId> {
         Self {
             index,
             note,
+            value_pool,
             account,
             memo,
             transfer_type,
@@ -74,7 +78,10 @@ impl<Note, AccountId> DecryptedOutput<Note, AccountId> {
     pub fn note(&self) -> &Note {
         &self.note
     }
-
+    /// Returns the value pool to which the note contributes its value.
+    pub fn value_pool(&self) -> ShieldedPool {
+        self.value_pool
+    }
     /// The account that decrypted the note.
     pub fn account(&self) -> &AccountId {
         &self.account
@@ -181,6 +188,7 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
                                     DecryptedOutput::new(
                                         index,
                                         note,
+                                        ShieldedPool::Sapling,
                                         account,
                                         MemoBytes::from_bytes(&memo).expect("correct length"),
                                         transfer_type,
@@ -192,59 +200,70 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         .collect();
 
     #[cfg(feature = "orchard")]
-    let orchard_bundle = tx.orchard_bundle();
-    #[cfg(feature = "orchard")]
-    let orchard_outputs = orchard_bundle
-        .iter()
-        .flat_map(|bundle| {
-            ufvks
-                .iter()
-                .flat_map(|(account, ufvk)| ufvk.orchard().into_iter().map(|fvk| (*account, fvk)))
-                .flat_map(|(account, fvk)| {
-                    let ivk_external = orchard::keys::PreparedIncomingViewingKey::new(
-                        &fvk.to_ivk(Scope::External),
-                    );
-                    let ivk_internal = orchard::keys::PreparedIncomingViewingKey::new(
-                        &fvk.to_ivk(Scope::Internal),
-                    );
-                    let ovk = fvk.to_ovk(Scope::External);
+    fn decrypt_orchard_bundle<AccountId: Copy>(
+        ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
+        bundle: &orchard::bundle::Bundle<
+            orchard::bundle::Authorized,
+            zcash_protocol::value::ZatBalance,
+        >,
+        value_pool: orchard::ValuePool,
+    ) -> impl Iterator<Item = DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>> {
+        ufvks
+            .iter()
+            .flat_map(|(account, ufvk)| ufvk.orchard().into_iter().map(|fvk| (*account, fvk)))
+            .flat_map(move |(account, fvk)| {
+                let ivk_external =
+                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::External));
+                let ivk_internal =
+                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::Internal));
+                let ovk = fvk.to_ovk(Scope::External);
 
-                    bundle
-                        .actions()
-                        .iter()
-                        .enumerate()
-                        .flat_map(move |(index, action)| {
-                            let domain = OrchardDomain::for_action(action);
-                            try_note_decryption(&domain, &ivk_external, action)
-                                .map(|ret| (ret, TransferType::Incoming))
-                                .or_else(|| {
-                                    try_note_decryption(&domain, &ivk_internal, action)
-                                        .map(|ret| (ret, TransferType::AccountInternal))
-                                })
-                                .or_else(|| {
-                                    try_output_recovery_with_ovk(
-                                        &domain,
-                                        &ovk,
-                                        action,
-                                        action.cv_net(),
-                                        &action.encrypted_note().out_ciphertext,
-                                    )
-                                    .map(|ret| (ret, TransferType::Outgoing))
-                                })
-                                .into_iter()
-                                .map(move |((note, _, memo), transfer_type)| {
-                                    DecryptedOutput::new(
-                                        index,
-                                        note,
-                                        account,
-                                        MemoBytes::from_bytes(&memo).expect("correct length"),
-                                        transfer_type,
-                                    )
-                                })
-                        })
-                })
-        })
-        .collect();
+                bundle
+                    .actions()
+                    .iter()
+                    .enumerate()
+                    .flat_map(move |(index, action)| {
+                        let domain = OrchardDomain::for_action(action);
+                        try_note_decryption(&domain, &ivk_external, action)
+                            .map(|ret| (ret, TransferType::Incoming))
+                            .or_else(|| {
+                                try_note_decryption(&domain, &ivk_internal, action)
+                                    .map(|ret| (ret, TransferType::AccountInternal))
+                            })
+                            .or_else(|| {
+                                try_output_recovery_with_ovk(
+                                    &domain,
+                                    &ovk,
+                                    action,
+                                    action.cv_net(),
+                                    &action.encrypted_note().out_ciphertext,
+                                )
+                                .map(|ret| (ret, TransferType::Outgoing))
+                            })
+                            .into_iter()
+                            .map(move |((note, _, memo), transfer_type)| {
+                                DecryptedOutput::new(
+                                    index,
+                                    (note, value_pool),
+                                    ShieldedPool::Orchard,
+                                    account,
+                                    MemoBytes::from_bytes(&memo).expect("correct length"),
+                                    transfer_type,
+                                )
+                            })
+                    })
+            })
+    }
+
+    #[cfg(feature = "orchard")]
+    let orchard_outputs =
+        tx.orchard_bundle()
+            .iter()
+            .flat_map(|bundle| decrypt_orchard_bundle(ufvks, bundle, orchard::ValuePool::Orchard))
+            .chain(tx.ironwood_bundle().iter().flat_map(|bundle| {
+                decrypt_orchard_bundle(ufvks, bundle, orchard::ValuePool::Ironwood)
+            }))
+            .collect();
 
     DecryptedTransaction::new(
         mined_height,

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -233,6 +233,10 @@ pub enum ChangeError<E, NoteRefT> {
         /// have economic value in the context of this input selection.
         #[cfg(feature = "orchard")]
         orchard: Vec<NoteRefT>,
+        /// The identifiers for Ironwood inputs that could not be determined to
+        /// have economic value in the context of this input selection.
+        #[cfg(feature = "orchard")]
+        ironwood: Vec<NoteRefT>,
     },
     /// An error occurred that was specific to the change selection strategy in use.
     StrategyError(E),
@@ -257,9 +261,11 @@ impl<CE: fmt::Display, N: fmt::Display> fmt::Display for ChangeError<CE, N> {
                 sapling,
                 #[cfg(feature = "orchard")]
                 orchard,
+                #[cfg(feature = "orchard")]
+                ironwood,
             } => {
                 #[cfg(feature = "orchard")]
-                let orchard_len = orchard.len();
+                let orchard_len = orchard.len() + ironwood.len();
                 #[cfg(not(feature = "orchard"))]
                 let orchard_len = 0;
 
@@ -562,12 +568,6 @@ pub trait ChangeStrategy {
     ///   transaction carries a separate Ironwood bundle, distinct from `orchard`,
     ///   with its own action count; pass an empty view when nothing targets the
     ///   Ironwood pool.
-    /// - `orchard_change_to_ironwood`: whether Orchard-pool change should be counted
-    ///   in the Ironwood bundle, mirroring how the builder routes Orchard-pool
-    ///   outputs into a separate Ironwood bundle when Ironwood is active. This is a
-    ///   single boolean rather than a richer type because it simply carries the
-    ///   builder's already-computed routing decision, so the proposal and the built
-    ///   transaction stay in lock-step.
     /// - `ephemeral_balance`: if the transaction is to be constructed with either an
     ///   ephemeral transparent input or an ephemeral transparent output this argument
     ///   may be used to provide the value of that input or output. The value of this
@@ -588,7 +588,6 @@ pub trait ChangeStrategy {
         sapling: &impl sapling::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard::BundleView<NoteRefT>,
-        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>>;

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -158,6 +158,11 @@ pub(crate) fn select_change_pool(
     if _net_flows.orchard_in.is_positive() || _net_flows.orchard_out.is_positive() {
         // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
         ShieldedPool::Orchard
+    } else if _net_flows.ironwood_in.is_positive() || _net_flows.ironwood_out.is_positive() {
+        // Send change to Ironwood if we're spending Ironwood inputs or creating Ironwood outputs
+        // (and no Orchard flows), so that change from an Ironwood spend stays in the Ironwood pool
+        // rather than crossing the turnstile back into Orchard.
+        ShieldedPool::Ironwood
     } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
         // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
         // Sapling outputs, so that we avoid pool-crossing.
@@ -176,6 +181,7 @@ pub(crate) struct OutputManifest {
     transparent: usize,
     sapling: usize,
     orchard: usize,
+    ironwood: usize,
 }
 
 impl OutputManifest {
@@ -183,6 +189,7 @@ impl OutputManifest {
         transparent: 0,
         sapling: 0,
         orchard: 0,
+        ironwood: 0,
     };
 
     pub(crate) fn sapling(&self) -> usize {
@@ -193,8 +200,12 @@ impl OutputManifest {
         self.orchard
     }
 
+    pub(crate) fn ironwood(&self) -> usize {
+        self.ironwood
+    }
+
     pub(crate) fn total_shielded(&self) -> usize {
-        self.sapling + self.orchard
+        self.sapling + self.orchard + self.ironwood
     }
 }
 
@@ -244,11 +255,6 @@ pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clo
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
-    // Whether Orchard-pool change is routed into the Ironwood bundle (the builder
-    // does this when Ironwood is active). Orchard-pool payment outputs are already
-    // routed into the `ironwood` view by the caller; this carries the same decision
-    // for the change output, which is computed here.
-    #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
     change_memo: Option<&MemoBytes>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<TransactionBalance, ChangeError<E, NoteRefT>>
@@ -275,6 +281,7 @@ where
     )?;
 
     let change_pool = select_change_pool(&net_flows, cfg.fallback_change_pool);
+
     let target_change_count = wallet_meta.map_or(1, |m| {
         usize::from(cfg.split_policy.target_output_count)
             // If we cannot determine a total note count, fall back to a single output
@@ -289,6 +296,11 @@ where
             0
         },
         orchard: if change_pool == ShieldedPool::Orchard {
+            target_change_count
+        } else {
+            0
+        },
+        ironwood: if change_pool == ShieldedPool::Ironwood {
             target_change_count
         } else {
             0
@@ -324,6 +336,8 @@ where
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
             cfg.marginal_fee,
             cfg.grace_actions,
             &possible_change[..],
@@ -396,15 +410,6 @@ where
             Ok(0)
         }
     };
-
-    // When Ironwood is active, the builder routes Orchard-pool change into the
-    // Ironwood bundle (Orchard-pool payment outputs are already routed into the
-    // `ironwood` view by the caller). Mirror that here so the change output is
-    // counted in the same bundle the builder will place it in.
-    #[cfg(feature = "orchard")]
-    let route_change_to_ironwood = orchard_change_to_ironwood;
-    #[cfg(not(feature = "orchard"))]
-    let route_change_to_ironwood = false;
 
     let transparent_input_sizes = transparent_inputs
         .iter()
@@ -485,16 +490,8 @@ where
                         transparent_output_sizes.clone(),
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
-                        orchard_action_count(if route_change_to_ironwood {
-                            0
-                        } else {
-                            target_change_counts.orchard()
-                        })?,
-                        ironwood_action_count(if route_change_to_ironwood {
-                            target_change_counts.orchard()
-                        } else {
-                            0
-                        })?,
+                        orchard_action_count(target_change_counts.orchard())?,
+                        ironwood_action_count(target_change_counts.ironwood())?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?,
             );
@@ -529,20 +526,16 @@ where
                         } else {
                             0
                         })?,
-                        orchard_action_count(
-                            if change_pool == ShieldedPool::Orchard && !route_change_to_ironwood {
-                                split_count
-                            } else {
-                                0
-                            },
-                        )?,
-                        ironwood_action_count(
-                            if change_pool == ShieldedPool::Orchard && route_change_to_ironwood {
-                                split_count
-                            } else {
-                                0
-                            },
-                        )?,
+                        orchard_action_count(if change_pool == ShieldedPool::Orchard {
+                            split_count
+                        } else {
+                            0
+                        })?,
+                        ironwood_action_count(if change_pool == ShieldedPool::Ironwood {
+                            split_count
+                        } else {
+                            0
+                        })?,
                     )
                     .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?
             } else {
@@ -660,16 +653,17 @@ where
 /// practice they would not cause the fee to increase. Outputs with value
 /// greater than the marginal fee will never be excluded.
 ///
-/// `possible_change` is a slice of `(transparent_change, sapling_change, orchard_change)`
-/// tuples indicating possible combinations of how many change outputs (0 or 1)
-/// might be included in the transaction for each pool. The shape of the tuple
-/// does not depend on which protocol features are enabled.
+/// `possible_change` is a slice of [`OutputManifest`] values indicating possible
+/// combinations of how many change outputs (0 or 1) might be included in the
+/// transaction for each pool. The shape of the manifest does not depend on which
+/// protocol features are enabled.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     transparent_inputs: &[impl transparent::InputView],
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
+    #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
     marginal_fee: Zatoshis,
     grace_actions: usize,
     possible_change: &[OutputManifest],
@@ -715,8 +709,23 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     #[cfg(not(feature = "orchard"))]
     let mut o_dust: Vec<NoteRefT> = vec![];
 
+    #[cfg(feature = "orchard")]
+    let mut i_dust: Vec<NoteRefT> = ironwood
+        .inputs()
+        .iter()
+        .filter_map(|i| {
+            if orchard_fees::InputView::<NoteRefT>::value(i) <= marginal_fee {
+                Some(orchard_fees::InputView::<NoteRefT>::note_id(i).clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    #[cfg(not(feature = "orchard"))]
+    let mut i_dust: Vec<NoteRefT> = vec![];
+
     // If we don't have any dust inputs, there is nothing to check.
-    if t_dust.is_empty() && s_dust.is_empty() && o_dust.is_empty() {
+    if t_dust.is_empty() && s_dust.is_empty() && o_dust.is_empty() && i_dust.is_empty() {
         return Ok(());
     }
 
@@ -729,10 +738,15 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     let (o_inputs_len, o_outputs_len) = (orchard.inputs().len(), orchard.outputs().len());
     #[cfg(not(feature = "orchard"))]
     let (o_inputs_len, o_outputs_len) = (0usize, 0usize);
+    #[cfg(feature = "orchard")]
+    let (i_inputs_len, i_outputs_len) = (ironwood.inputs().len(), ironwood.outputs().len());
+    #[cfg(not(feature = "orchard"))]
+    let (i_inputs_len, i_outputs_len) = (0usize, 0usize);
 
     let t_non_dust = t_inputs_len.checked_sub(t_dust.len()).unwrap();
     let s_non_dust = s_inputs_len.checked_sub(s_dust.len()).unwrap();
     let o_non_dust = o_inputs_len.checked_sub(o_dust.len()).unwrap();
+    let i_non_dust = i_inputs_len.checked_sub(i_dust.len()).unwrap();
 
     // Return the number of allowed dust inputs from each pool.
     let allowed_dust = |change: &OutputManifest| {
@@ -760,12 +774,18 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             o_dust.len(),
             (o_outputs_len + change.orchard).saturating_sub(o_non_dust),
         );
+        let i_allowed = min(
+            i_dust.len(),
+            (i_outputs_len + change.ironwood).saturating_sub(i_non_dust),
+        );
 
         // We'll be spending the non-dust and allowed dust in each pool.
         let t_req_inputs = t_non_dust + t_allowed;
         let s_req_inputs = s_non_dust + s_allowed;
         #[cfg(feature = "orchard")]
         let o_req_inputs = o_non_dust + o_allowed;
+        #[cfg(feature = "orchard")]
+        let i_req_inputs = i_non_dust + i_allowed;
 
         // This calculates the hypothetical number of actions with given extra inputs,
         // for ZIP 317 and the padding rules in effect. The padding rules for each
@@ -774,7 +794,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
         // whether we can freely add an extra input from a given pool, we need to call
         // them both with and without that input; if the number of actions does not
         // increase, then the input is free to add.
-        let hypothetical_actions = |t_extra, s_extra, _o_extra| {
+        let hypothetical_actions = |t_extra, s_extra, _o_extra, _i_extra| {
             let s_spend_count = sapling
                 .bundle_type()
                 .num_spends(s_req_inputs + s_extra)
@@ -795,41 +815,56 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             #[cfg(not(feature = "orchard"))]
             let o_action_count = 0;
 
+            #[cfg(feature = "orchard")]
+            let i_action_count = orchard_fees::transactional_action_count(
+                ironwood.bundle_version(),
+                i_req_inputs + _i_extra,
+                i_outputs_len + change.ironwood,
+            )
+            .map_err(ChangeError::BundleError)?;
+            #[cfg(not(feature = "orchard"))]
+            let i_action_count = 0;
+
             // To calculate the number of unused actions, we assume that transparent inputs
             // and outputs are P2PKH.
             Ok(
                 max(t_req_inputs + t_extra, t_outputs_len + change.transparent)
                     + max(s_spend_count, s_output_count)
-                    + o_action_count,
+                    + o_action_count
+                    + i_action_count,
             )
         };
 
         // First calculate the baseline number of logical actions with only the definitely
         // allowed inputs estimated above. If it is less than `grace_actions`, try to allocate
-        // a grace input first to transparent dust, then to Sapling dust, then to Orchard dust.
-        // If the number of actions increases, it was not possible to allocate that input for
-        // free. This approach is sufficient because at most one such input can be allocated,
-        // since `grace_actions` is at most 2 for ZIP 317 and there must be at least one
-        // logical action. (If `grace_actions` were greater than 2 then the code would still
-        // be correct, it would just not find all potential extra inputs.)
+        // a grace input first to transparent dust, then to Sapling dust, then to Orchard
+        // dust, then to Ironwood dust. If the number of actions increases, it was not
+        // possible to allocate that input for free. This approach is sufficient because at
+        // most one such input can be allocated, since `grace_actions` is at most 2 for
+        // ZIP 317 and there must be at least one logical action. (If `grace_actions` were
+        // greater than 2 then the code would still be correct, it would just not find all
+        // potential extra inputs.)
 
-        let baseline = hypothetical_actions(0, 0, 0)?;
+        let baseline = hypothetical_actions(0, 0, 0, 0)?;
 
-        let (t_extra, s_extra, o_extra) = if baseline >= grace_actions {
-            (0, 0, 0)
-        } else if t_dust.len() > t_allowed && hypothetical_actions(1, 0, 0)? <= baseline {
-            (1, 0, 0)
-        } else if s_dust.len() > s_allowed && hypothetical_actions(0, 1, 0)? <= baseline {
-            (0, 1, 0)
-        } else if o_dust.len() > o_allowed && hypothetical_actions(0, 0, 1)? <= baseline {
-            (0, 0, 1)
+        let (t_extra, s_extra, o_extra, i_extra) = if baseline >= grace_actions {
+            (0, 0, 0, 0)
+        } else if t_dust.len() > t_allowed && hypothetical_actions(1, 0, 0, 0)? <= baseline {
+            (1, 0, 0, 0)
+        } else if s_dust.len() > s_allowed && hypothetical_actions(0, 1, 0, 0)? <= baseline {
+            (0, 1, 0, 0)
+        } else if o_dust.len() > o_allowed && hypothetical_actions(0, 0, 1, 0)? <= baseline {
+            (0, 0, 1, 0)
+        } else if i_dust.len() > i_allowed && hypothetical_actions(0, 0, 0, 1)? <= baseline {
+            (0, 0, 0, 1)
         } else {
-            (0, 0, 0)
+            (0, 0, 0, 0)
         };
         Ok(OutputManifest {
             transparent: t_allowed + t_extra,
             sapling: s_allowed + s_extra,
             orchard: o_allowed + o_extra,
+            ironwood: i_allowed + i_extra,
         })
     };
 
@@ -843,6 +878,7 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             transparent: min(l.transparent, r.transparent),
             sapling: min(l.sapling, r.sapling),
             orchard: min(l.orchard, r.orchard),
+            ironwood: min(l.ironwood, r.ironwood),
         })
         .expect("possible_change is nonempty");
 
@@ -851,8 +887,9 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     let t_dust = t_dust.split_off(allowed.transparent);
     let s_dust = s_dust.split_off(allowed.sapling);
     let o_dust = o_dust.split_off(allowed.orchard);
+    let i_dust = i_dust.split_off(allowed.ironwood);
 
-    if t_dust.is_empty() && s_dust.is_empty() && o_dust.is_empty() {
+    if t_dust.is_empty() && s_dust.is_empty() && o_dust.is_empty() && i_dust.is_empty() {
         Ok(())
     } else {
         Err(ChangeError::DustInputs {
@@ -860,6 +897,57 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             sapling: s_dust,
             #[cfg(feature = "orchard")]
             orchard: o_dust,
+            #[cfg(feature = "orchard")]
+            ironwood: i_dust,
         })
+    }
+}
+
+#[cfg(all(test, feature = "orchard"))]
+mod tests {
+    use super::{NetFlows, select_change_pool};
+    use zcash_protocol::{ShieldedPool, value::Zatoshis};
+
+    fn flows(orchard_in: u64, ironwood_in: u64, sapling_in: u64) -> NetFlows {
+        NetFlows {
+            t_in: Zatoshis::ZERO,
+            t_out: Zatoshis::ZERO,
+            sapling_in: Zatoshis::const_from_u64(sapling_in),
+            sapling_out: Zatoshis::ZERO,
+            orchard_in: Zatoshis::const_from_u64(orchard_in),
+            orchard_out: Zatoshis::ZERO,
+            ironwood_in: Zatoshis::const_from_u64(ironwood_in),
+            ironwood_out: Zatoshis::ZERO,
+        }
+    }
+
+    #[test]
+    fn select_change_pool_routes_ironwood_spend_to_ironwood() {
+        // Spending Ironwood funds (no Orchard or Sapling flows) sends change to Ironwood,
+        // keeping it in the pool being spent rather than crossing back into Orchard.
+        assert_eq!(
+            select_change_pool(&flows(0, 10_000, 0), ShieldedPool::Sapling),
+            ShieldedPool::Ironwood
+        );
+
+        // Spending Orchard funds keeps change in Orchard even when Ironwood funds are also
+        // spent, so that Ironwood-routed change cannot reveal the spent Orchard notes' balances.
+        assert_eq!(
+            select_change_pool(&flows(10_000, 10_000, 0), ShieldedPool::Sapling),
+            ShieldedPool::Orchard
+        );
+
+        // A combined Sapling + Ironwood spend routes change to Ironwood (Ironwood is preferred
+        // over Sapling).
+        assert_eq!(
+            select_change_pool(&flows(0, 10_000, 10_000), ShieldedPool::Sapling),
+            ShieldedPool::Ironwood
+        );
+
+        // A Sapling-only spend keeps change in Sapling.
+        assert_eq!(
+            select_change_pool(&flows(0, 0, 10_000), ShieldedPool::Orchard),
+            ShieldedPool::Sapling
+        );
     }
 }

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -6,7 +6,7 @@ use zcash_primitives::transaction::fees::{
 };
 use zcash_protocol::{
     ShieldedPool,
-    consensus::{self, BlockHeight},
+    consensus::{self, BlockHeight, NetworkUpgrade},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
 };
@@ -149,28 +149,54 @@ where
 }
 
 /// Decide which shielded pool change should go to if there is any.
+///
+/// `max_change_value` is an upper bound on the value of the change the transaction will
+/// produce: the value that would remain if it paid only the minimum (changeless) fee.
+/// After Ironwood activation it determines whether change may be returned to the Orchard
+/// pool without violating the turnstile requirement that the pool's balance strictly
+/// decrease.
 pub(crate) fn select_change_pool(
     _net_flows: &NetFlows,
     _fallback_change_pool: ShieldedPool,
+    _ironwood_active: bool,
+    _max_change_value: Zatoshis,
 ) -> ShieldedPool {
     // TODO: implement a less naive strategy for selecting the pool to which change will be sent.
     #[cfg(feature = "orchard")]
-    if _net_flows.orchard_in.is_positive() || _net_flows.orchard_out.is_positive() {
-        // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
-        ShieldedPool::Orchard
-    } else if _net_flows.ironwood_in.is_positive() || _net_flows.ironwood_out.is_positive() {
-        // Send change to Ironwood if we're spending Ironwood inputs or creating Ironwood outputs
-        // (and no Orchard flows), so that change from an Ironwood spend stays in the Ironwood pool
-        // rather than crossing the turnstile back into Orchard.
-        ShieldedPool::Ironwood
-    } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
-        // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
-        // Sapling outputs, so that we avoid pool-crossing.
-        ShieldedPool::Sapling
-    } else {
-        // The flows are transparent, so there may not be change. If there is, the caller
-        // gets to decide where to shield it.
-        _fallback_change_pool
+    {
+        let preferred = if _net_flows.orchard_in.is_positive()
+            || _net_flows.orchard_out.is_positive()
+        {
+            // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
+            ShieldedPool::Orchard
+        } else if _net_flows.ironwood_in.is_positive() || _net_flows.ironwood_out.is_positive() {
+            // Send change to Ironwood if we're spending Ironwood inputs or creating Ironwood outputs
+            // (and no Orchard flows), so that change from an Ironwood spend stays in the Ironwood pool
+            // rather than crossing the turnstile back into Orchard.
+            ShieldedPool::Ironwood
+        } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
+            // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
+            // Sapling outputs, so that we avoid pool-crossing.
+            ShieldedPool::Sapling
+        } else {
+            // The flows are transparent, so there may not be change. If there is, the caller
+            // gets to decide where to shield it.
+            _fallback_change_pool
+        };
+
+        // After Ironwood activation, the turnstile forbids value from entering the
+        // Orchard pool: change may return to Orchard only when the transaction spends
+        // Orchard notes, and only if strictly less value returns to the pool than the
+        // notes remove from it. Change that cannot go to Orchard flows onward to the
+        // Ironwood pool.
+        if _ironwood_active
+            && preferred == ShieldedPool::Orchard
+            && (!_net_flows.orchard_in.is_positive() || _max_change_value >= _net_flows.orchard_in)
+        {
+            ShieldedPool::Ironwood
+        } else {
+            preferred
+        }
     }
     #[cfg(not(feature = "orchard"))]
     ShieldedPool::Sapling
@@ -280,70 +306,8 @@ where
         ephemeral_balance,
     )?;
 
-    let change_pool = select_change_pool(&net_flows, cfg.fallback_change_pool);
-
-    let target_change_count = wallet_meta.map_or(1, |m| {
-        usize::from(cfg.split_policy.target_output_count)
-            // If we cannot determine a total note count, fall back to a single output
-            .saturating_sub(m.total_note_count().unwrap_or(usize::MAX))
-            .max(1)
-    });
-    let target_change_counts = OutputManifest {
-        transparent: 0,
-        sapling: if change_pool == ShieldedPool::Sapling {
-            target_change_count
-        } else {
-            0
-        },
-        orchard: if change_pool == ShieldedPool::Orchard {
-            target_change_count
-        } else {
-            0
-        },
-        ironwood: if change_pool == ShieldedPool::Ironwood {
-            target_change_count
-        } else {
-            0
-        },
-    };
-    assert!(target_change_counts.total_shielded() == target_change_count);
-
     // We don't create a fully-transparent transaction if a change memo is used.
     let fully_transparent = net_flows.is_transparent() && change_memo.is_none();
-
-    // If we have a non-zero marginal fee, we need to check for uneconomic inputs.
-    // This is basically assuming that fee rules with non-zero marginal fee are
-    // "ZIP 317-like", but we can generalize later if needed.
-    if cfg.marginal_fee.is_positive() {
-        // Is it certain that there will be a change output? If it is not certain,
-        // we should call `check_for_uneconomic_inputs` with `possible_change`
-        // including both possibilities.
-        let possible_change = {
-            // These are the situations where we might not have a change output.
-            if fully_transparent
-                || (cfg.dust_output_policy.action() == DustAction::AddDustToFee
-                    && change_memo.is_none())
-            {
-                vec![OutputManifest::ZERO, target_change_counts]
-            } else {
-                vec![target_change_counts]
-            }
-        };
-
-        check_for_uneconomic_inputs(
-            transparent_inputs,
-            transparent_outputs,
-            sapling,
-            #[cfg(feature = "orchard")]
-            orchard,
-            #[cfg(feature = "orchard")]
-            ironwood,
-            cfg.marginal_fee,
-            cfg.grace_actions,
-            &possible_change[..],
-            ephemeral_balance,
-        )?;
-    }
 
     let total_in = net_flows
         .total_in()
@@ -463,6 +427,76 @@ where
         .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?;
 
     let total_out_with_min_fee = (subtotal_out + min_fee).ok_or_else(overflow)?;
+
+    // The value that would remain if the transaction paid only the minimum (changeless)
+    // fee is an upper bound on the change value: the fee never falls below `min_fee`.
+    let change_pool = select_change_pool(
+        &net_flows,
+        cfg.fallback_change_pool,
+        cfg.params
+            .is_nu_active(NetworkUpgrade::Nu6_3, target_height.into()),
+        (total_in - total_out_with_min_fee).unwrap_or(Zatoshis::ZERO),
+    );
+
+    let target_change_count = wallet_meta.map_or(1, |m| {
+        usize::from(cfg.split_policy.target_output_count)
+            // If we cannot determine a total note count, fall back to a single output
+            .saturating_sub(m.total_note_count().unwrap_or(usize::MAX))
+            .max(1)
+    });
+    let target_change_counts = OutputManifest {
+        transparent: 0,
+        sapling: if change_pool == ShieldedPool::Sapling {
+            target_change_count
+        } else {
+            0
+        },
+        orchard: if change_pool == ShieldedPool::Orchard {
+            target_change_count
+        } else {
+            0
+        },
+        ironwood: if change_pool == ShieldedPool::Ironwood {
+            target_change_count
+        } else {
+            0
+        },
+    };
+    assert!(target_change_counts.total_shielded() == target_change_count);
+
+    // If we have a non-zero marginal fee, we need to check for uneconomic inputs.
+    // This is basically assuming that fee rules with non-zero marginal fee are
+    // "ZIP 317-like", but we can generalize later if needed.
+    if cfg.marginal_fee.is_positive() {
+        // Is it certain that there will be a change output? If it is not certain,
+        // we should call `check_for_uneconomic_inputs` with `possible_change`
+        // including both possibilities.
+        let possible_change = {
+            // These are the situations where we might not have a change output.
+            if fully_transparent
+                || (cfg.dust_output_policy.action() == DustAction::AddDustToFee
+                    && change_memo.is_none())
+            {
+                vec![OutputManifest::ZERO, target_change_counts]
+            } else {
+                vec![target_change_counts]
+            }
+        };
+
+        check_for_uneconomic_inputs(
+            transparent_inputs,
+            transparent_outputs,
+            sapling,
+            #[cfg(feature = "orchard")]
+            orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
+            cfg.marginal_fee,
+            cfg.grace_actions,
+            &possible_change[..],
+            ephemeral_balance,
+        )?;
+    }
 
     #[allow(unused_mut)]
     let (mut change, fee) = match total_in.cmp(&total_out_with_min_fee) {
@@ -926,28 +960,108 @@ mod tests {
         // Spending Ironwood funds (no Orchard or Sapling flows) sends change to Ironwood,
         // keeping it in the pool being spent rather than crossing back into Orchard.
         assert_eq!(
-            select_change_pool(&flows(0, 10_000, 0), ShieldedPool::Sapling),
+            select_change_pool(
+                &flows(0, 10_000, 0),
+                ShieldedPool::Sapling,
+                true,
+                Zatoshis::const_from_u64(5_000)
+            ),
             ShieldedPool::Ironwood
         );
 
         // Spending Orchard funds keeps change in Orchard even when Ironwood funds are also
         // spent, so that Ironwood-routed change cannot reveal the spent Orchard notes' balances.
         assert_eq!(
-            select_change_pool(&flows(10_000, 10_000, 0), ShieldedPool::Sapling),
+            select_change_pool(
+                &flows(10_000, 10_000, 0),
+                ShieldedPool::Sapling,
+                true,
+                Zatoshis::const_from_u64(5_000)
+            ),
             ShieldedPool::Orchard
         );
 
         // A combined Sapling + Ironwood spend routes change to Ironwood (Ironwood is preferred
         // over Sapling).
         assert_eq!(
-            select_change_pool(&flows(0, 10_000, 10_000), ShieldedPool::Sapling),
+            select_change_pool(
+                &flows(0, 10_000, 10_000),
+                ShieldedPool::Sapling,
+                true,
+                Zatoshis::const_from_u64(5_000)
+            ),
             ShieldedPool::Ironwood
         );
 
         // A Sapling-only spend keeps change in Sapling.
         assert_eq!(
-            select_change_pool(&flows(0, 0, 10_000), ShieldedPool::Orchard),
+            select_change_pool(
+                &flows(0, 0, 10_000),
+                ShieldedPool::Orchard,
+                true,
+                Zatoshis::const_from_u64(5_000)
+            ),
             ShieldedPool::Sapling
+        );
+    }
+
+    #[test]
+    fn select_change_pool_enforces_orchard_turnstile() {
+        // Before Ironwood activation, Orchard-spend change stays in Orchard regardless of
+        // the change bound: value may freely enter the pool.
+        assert_eq!(
+            select_change_pool(
+                &flows(10_000, 0, 10_000),
+                ShieldedPool::Sapling,
+                false,
+                Zatoshis::const_from_u64(15_000)
+            ),
+            ShieldedPool::Orchard
+        );
+
+        // After activation, change may return to Orchard while the pool balance strictly
+        // decreases: the change bound is below the Orchard input value.
+        assert_eq!(
+            select_change_pool(
+                &flows(10_000, 0, 10_000),
+                ShieldedPool::Sapling,
+                true,
+                Zatoshis::const_from_u64(9_999)
+            ),
+            ShieldedPool::Orchard
+        );
+
+        // After activation, change that could equal or exceed the Orchard input value would
+        // grow the pool, so it flows onward to Ironwood instead.
+        assert_eq!(
+            select_change_pool(
+                &flows(10_000, 0, 10_000),
+                ShieldedPool::Sapling,
+                true,
+                Zatoshis::const_from_u64(10_000)
+            ),
+            ShieldedPool::Ironwood
+        );
+
+        // A post-activation Orchard fallback for transparent-only flows is corrected to
+        // Ironwood: with no Orchard inputs, no value may enter the Orchard pool.
+        assert_eq!(
+            select_change_pool(
+                &NetFlows {
+                    t_in: Zatoshis::const_from_u64(10_000),
+                    t_out: Zatoshis::ZERO,
+                    sapling_in: Zatoshis::ZERO,
+                    sapling_out: Zatoshis::ZERO,
+                    orchard_in: Zatoshis::ZERO,
+                    orchard_out: Zatoshis::ZERO,
+                    ironwood_in: Zatoshis::ZERO,
+                    ironwood_out: Zatoshis::ZERO,
+                },
+                ShieldedPool::Orchard,
+                true,
+                Zatoshis::const_from_u64(10_000)
+            ),
+            ShieldedPool::Ironwood
         );
     }
 }

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -84,7 +84,6 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
-        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -111,8 +110,6 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
-            #[cfg(feature = "orchard")]
-            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -174,8 +171,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -226,8 +221,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -126,7 +126,6 @@ where
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
-        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         _wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -153,8 +152,6 @@ where
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
-            #[cfg(feature = "orchard")]
-            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -242,7 +239,6 @@ where
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] ironwood: &impl orchard_fees::BundleView<NoteRefT>,
-        #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
         ephemeral_balance: Option<EphemeralBalance>,
         wallet_meta: &Self::AccountMetaT,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
@@ -268,8 +264,6 @@ where
             orchard,
             #[cfg(feature = "orchard")]
             ironwood,
-            #[cfg(feature = "orchard")]
-            orchard_change_to_ironwood,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -336,8 +330,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -386,10 +378,8 @@ mod tests {
                     &orchard_fees::EmptyBundleView,
                     #[cfg(feature = "orchard")]
                     &orchard_fees::EmptyBundleView,
-                    #[cfg(feature = "orchard")]
-                    false,
                     None,
-                    &AccountMeta::new(Some(PoolMeta::new(existing_notes, total)), None),
+                    &AccountMeta::new(Some(PoolMeta::new(existing_notes, total)), None, None),
                 )
             };
 
@@ -441,12 +431,11 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
-                #[cfg(feature = "orchard")]
-                false,
                 None,
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
+                    None,
                 ),
             );
 
@@ -486,13 +475,12 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
-                #[cfg(feature = "orchard")]
-                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
+                    None,
                 ),
             );
 
@@ -526,13 +514,12 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
-                #[cfg(feature = "orchard")]
-                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
+                    None,
                 ),
             );
 
@@ -574,13 +561,12 @@ mod tests {
                 &orchard_fees::EmptyBundleView,
                 #[cfg(feature = "orchard")]
                 &orchard_fees::EmptyBundleView,
-                #[cfg(feature = "orchard")]
-                false,
                 None,
                 // after excluding the inputs we're spending, we have no notes in the wallet
                 &AccountMeta::new(
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
                     Some(PoolMeta::new(0, Zatoshis::ZERO)),
+                    None,
                 ),
             );
 
@@ -626,7 +612,6 @@ mod tests {
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
             &orchard_fees::EmptyBundleView,
-            false,
             None,
             &(),
         );
@@ -673,7 +658,6 @@ mod tests {
                 &[OrchardPayment::new(Zatoshis::const_from_u64(30000))][..],
             ),
             &orchard_fees::EmptyBundleView,
-            false,
             None,
             &(),
         );
@@ -729,7 +713,6 @@ mod tests {
                 &sapling_view,
                 &orchard_view,
                 &orchard_fees::EmptyBundleView,
-                false,
                 None,
                 &(),
             )
@@ -748,7 +731,6 @@ mod tests {
                     &[] as &[Infallible],
                     &orchard_outputs[..],
                 ),
-                false,
                 None,
                 &(),
             )
@@ -766,81 +748,6 @@ mod tests {
             with_ironwood.fee_required(),
             Zatoshis::const_from_u64(30000)
         );
-    }
-
-    #[test]
-    #[cfg(feature = "orchard")]
-    fn orchard_change_routes_to_ironwood_bundle() {
-        // With `orchard_change_to_ironwood` set (the builder routes Orchard-pool
-        // outputs into a separate Ironwood bundle when Ironwood is active), the
-        // Orchard-pool change output must be counted in the Ironwood bundle, not the
-        // Orchard bundle — matching where the builder places it. This exercises the
-        // change-routing path directly: an Orchard payment forces the change to the
-        // Orchard pool, and two Ironwood payments make the Ironwood bundle large
-        // enough that moving the change into it raises its action count, so routing
-        // the change has an observable effect on the fee.
-        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
-            Zip317FeeRule::standard(),
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        );
-
-        let height = Network::TestNetwork
-            .activation_height(NetworkUpgrade::Nu5)
-            .unwrap()
-            .into();
-        let sapling_inputs = [TestSaplingInput {
-            note_id: 0,
-            value: Zatoshis::const_from_u64(100000),
-        }];
-        let orchard_outputs = [OrchardPayment::new(Zatoshis::const_from_u64(10000))];
-        let ironwood_outputs = [
-            OrchardPayment::new(Zatoshis::const_from_u64(10000)),
-            OrchardPayment::new(Zatoshis::const_from_u64(10000)),
-        ];
-        let sapling_view = (
-            sapling::builder::BundleType::DEFAULT,
-            &sapling_inputs[..],
-            &[] as &[Infallible],
-        );
-        let orchard_view = (
-            ::orchard::bundle::BundleVersion::orchard_v2(),
-            &[] as &[Infallible],
-            &orchard_outputs[..],
-        );
-        let ironwood_view = (
-            ::orchard::bundle::BundleVersion::ironwood_v3(),
-            &[] as &[Infallible],
-            &ironwood_outputs[..],
-        );
-
-        let fee_for = |orchard_change_to_ironwood: bool| {
-            change_strategy
-                .compute_balance(
-                    &Network::TestNetwork,
-                    height,
-                    &[] as &[TestTransparentInput],
-                    &[] as &[TxOut],
-                    &sapling_view,
-                    &orchard_view,
-                    &ironwood_view,
-                    orchard_change_to_ironwood,
-                    None,
-                    &(),
-                )
-                .unwrap()
-                .fee_required()
-        };
-
-        // Change in Orchard: sapling (2) + orchard (1 payment + 1 change = 2) +
-        // ironwood (2 payments = 2) = 6 actions = 30000. Routing the change into
-        // Ironwood: orchard (1 payment = 2) + ironwood (2 payments + 1 change = 3)
-        // = 7 actions = 35000.
-        let change_in_orchard = fee_for(false);
-        let change_in_ironwood = fee_for(true);
-        assert_eq!(change_in_orchard, Zatoshis::const_from_u64(30000));
-        assert_eq!(change_in_ironwood, Zatoshis::const_from_u64(35000));
     }
 
     #[test]
@@ -888,8 +795,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -938,8 +843,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -988,8 +891,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -1044,8 +945,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -1109,8 +1008,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );
@@ -1164,8 +1061,6 @@ mod tests {
             &orchard_fees::EmptyBundleView,
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
-            #[cfg(feature = "orchard")]
-            false,
             None,
             &(),
         );

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -78,6 +78,19 @@ pub enum ProposalError {
     /// transaction is intended.
     #[cfg(feature = "unstable")]
     IncompatibleTxVersion(BranchId),
+    /// After Ironwood activation, a proposal step would create value in the Orchard pool.
+    /// The turnstile only permits value to leave the pool: a step may return change to it
+    /// only when strictly less value returns than the step's Orchard inputs remove.
+    /// (Payments may never be directed to the Orchard pool after Ironwood activation;
+    /// payment classification maintains that invariant, and step construction enforces it
+    /// by assertion.)
+    #[cfg(feature = "orchard")]
+    OrchardPoolValueCreation {
+        /// The total value of the Orchard notes spent by the step.
+        input_total: Zatoshis,
+        /// The total value of the Orchard-pool change outputs created by the step.
+        output_total: Zatoshis,
+    },
 }
 
 impl Display for ProposalError {
@@ -159,6 +172,16 @@ impl Display for ProposalError {
             ProposalError::ShieldingRequiresShieldedRecipient => write!(
                 f,
                 "A shielding proposal's destination must have a shielded receiver."
+            ),
+            #[cfg(feature = "orchard")]
+            ProposalError::OrchardPoolValueCreation {
+                input_total,
+                output_total,
+            } => write!(
+                f,
+                "After Ironwood activation, a step that spends {} zatoshis from the Orchard pool may not return {} zatoshis to it.",
+                u64::from(*input_total),
+                u64::from(*output_total),
             ),
             #[cfg(feature = "unstable")]
             ProposalError::IncompatibleTxVersion(branch_id) => write!(
@@ -300,6 +323,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// * `min_target_height`: The minimum block height at which the transaction may be created.
     /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
     ///   transaction.
+    /// * `ironwood_active`: See [`Step::from_parts`].
     #[allow(clippy::too_many_arguments)]
     pub fn single_step(
         transaction_request: TransactionRequest,
@@ -311,6 +335,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
         fee_rule: FeeRuleT,
         min_target_height: TargetHeight,
         is_shielding: bool,
+        #[cfg(feature = "orchard")] ironwood_active: bool,
     ) -> Result<Self, ProposalError> {
         Ok(Self {
             fee_rule,
@@ -325,6 +350,8 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
                 vec![],
                 balance,
                 is_shielding,
+                #[cfg(feature = "orchard")]
+                ironwood_active,
             )?),
         })
     }
@@ -448,6 +475,11 @@ impl<NoteRef> Step<NoteRef> {
     /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
     /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
     ///   transaction.
+    /// * `ironwood_active`: Whether the Ironwood pool is active at the target height for
+    ///   which this step is proposed. When active, the step is checked against the
+    ///   Orchard turnstile: no payment may be directed to the Orchard pool, and change
+    ///   may be returned to it only when strictly less value returns than the step's
+    ///   Orchard inputs remove.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
         prior_steps: &[Step<NoteRef>],
@@ -459,6 +491,7 @@ impl<NoteRef> Step<NoteRef> {
         prior_step_inputs: Vec<StepOutput>,
         balance: TransactionBalance,
         is_shielding: bool,
+        #[cfg(feature = "orchard")] ironwood_active: bool,
     ) -> Result<Self, ProposalError> {
         // Verify that the set of payment pools matches exactly a set of valid payment recipients
         if transaction_request.payments().len() != payment_pools.len() {
@@ -541,6 +574,48 @@ impl<NoteRef> Step<NoteRef> {
                 || request_total > Zatoshis::ZERO)
         {
             return Err(ProposalError::ShieldingInvalid);
+        }
+
+        // After Ironwood activation, the Orchard turnstile only permits value to leave
+        // the pool: payments may not be directed to the Orchard pool, and change may be
+        // returned to it only when strictly less value returns than the step's Orchard
+        // inputs remove.
+        #[cfg(feature = "orchard")]
+        if ironwood_active {
+            // With Ironwood active, payment classification routes every Orchard-receiver
+            // payment to the Ironwood pool before a step is constructed, so a payment
+            // directed to the Orchard pool here is a programming error, not a condition a
+            // well-formed proposal can exhibit. The only Orchard-pool outputs a step may
+            // create are change, which is validated below.
+            assert!(
+                !payment_pools
+                    .iter()
+                    .any(|(_, pool)| *pool == PoolType::ORCHARD),
+                "with Ironwood active, no payment may be directed to the Orchard pool",
+            );
+
+            let orchard_input_total = shielded_inputs
+                .iter()
+                .flat_map(|s_in| s_in.notes().iter())
+                .filter(|n| n.note().pool() == ShieldedPool::Orchard)
+                .map(|n| n.note().value())
+                .try_fold(Zatoshis::ZERO, |acc, a| acc + a)
+                .ok_or(ProposalError::Overflow)?;
+
+            let orchard_change_total = balance
+                .proposed_change()
+                .iter()
+                .filter(|c| c.output_pool() == PoolType::ORCHARD)
+                .map(|c| c.value())
+                .try_fold(Zatoshis::ZERO, |acc, a| acc + a)
+                .ok_or(ProposalError::Overflow)?;
+
+            if orchard_change_total.is_positive() && orchard_change_total >= orchard_input_total {
+                return Err(ProposalError::OrchardPoolValueCreation {
+                    input_total: orchard_input_total,
+                    output_total: orchard_change_total,
+                });
+            }
         }
 
         if input_total == output_total {
@@ -742,8 +817,12 @@ mod tests {
     use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
     use zip321::TransactionRequest;
 
-    use super::{Proposal, ShieldedInputs, Step};
-    use crate::{data_api::wallet::TargetHeight, fees::TransactionBalance, wallet::Note};
+    use super::{Proposal, ProposalError, ShieldedInputs, Step};
+    use crate::{
+        data_api::wallet::TargetHeight,
+        fees::{ChangeValue, TransactionBalance},
+        wallet::Note,
+    };
 
     // Builds an Orchard note of the given version and value. The recipient, rho, and rseed are
     // fixed; only the version and value vary, which is all `Note::pool`/`Note::protocol` depend on.
@@ -761,8 +840,8 @@ mod tests {
         ))
     }
 
-    // Wraps a list of notes into a single `Step` whose only inputs are those shielded notes.
-    fn step_with_notes(notes: Vec<Note>) -> Step<u32> {
+    // Wraps a list of notes as the shielded inputs of a step.
+    fn shielded_inputs_for(notes: Vec<Note>) -> Option<ShieldedInputs<u32>> {
         let received = notes
             .into_iter()
             .enumerate()
@@ -779,7 +858,12 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let shielded_inputs = NonEmpty::from_vec(received).map(ShieldedInputs::from_parts);
+        NonEmpty::from_vec(received).map(ShieldedInputs::from_parts)
+    }
+
+    // Wraps a list of notes into a single `Step` whose only inputs are those shielded notes.
+    fn step_with_notes(notes: Vec<Note>) -> Step<u32> {
+        let shielded_inputs = shielded_inputs_for(notes);
         Step {
             transaction_request: TransactionRequest::empty(),
             payment_pools: BTreeMap::new(),
@@ -790,6 +874,163 @@ mod tests {
             balance: TransactionBalance::new(vec![], Zatoshis::ZERO).unwrap(),
             is_shielding: false,
         }
+    }
+
+    // Constructs a validated step spending the given notes, with no payments.
+    fn validated_step(
+        notes: Vec<Note>,
+        balance: TransactionBalance,
+        ironwood_active: bool,
+    ) -> Result<Step<u32>, ProposalError> {
+        Step::from_parts(
+            &[],
+            TransactionRequest::empty(),
+            BTreeMap::new(),
+            vec![],
+            shielded_inputs_for(notes),
+            BlockHeight::from_u32(100),
+            vec![],
+            balance,
+            false,
+            ironwood_active,
+        )
+    }
+
+    fn shielded_change(pool: ShieldedPool, value: u64) -> ChangeValue {
+        ChangeValue::shielded(pool, Zatoshis::const_from_u64(value), None)
+    }
+
+    #[test]
+    fn orchard_turnstile_permits_only_strict_pool_balance_decrease() {
+        // Post-activation, change may return to Orchard when strictly less value returns
+        // than the step's Orchard inputs remove: 6_000 change < 10_000 input.
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(1, 0),
+                TransactionBalance::new(
+                    vec![shielded_change(ShieldedPool::Orchard, 6_000)],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                true,
+            ),
+            Ok(_)
+        );
+
+        // Post-activation, Orchard change equal to the Orchard input total would leave the
+        // pool balance unchanged, which the turnstile forbids.
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(1, 1),
+                TransactionBalance::new(
+                    vec![
+                        shielded_change(ShieldedPool::Orchard, 10_000),
+                        shielded_change(ShieldedPool::Ironwood, 16_000),
+                    ],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                true,
+            ),
+            Err(ProposalError::OrchardPoolValueCreation {
+                input_total,
+                output_total,
+            }) if input_total == Zatoshis::const_from_u64(10_000)
+                && output_total == Zatoshis::const_from_u64(10_000)
+        );
+
+        // Post-activation, a step that spends no Orchard notes may not create Orchard
+        // change at all.
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(0, 1),
+                TransactionBalance::new(
+                    vec![shielded_change(ShieldedPool::Orchard, 16_000)],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                true,
+            ),
+            Err(ProposalError::OrchardPoolValueCreation {
+                input_total,
+                output_total,
+            }) if input_total == Zatoshis::ZERO
+                && output_total == Zatoshis::const_from_u64(16_000)
+        );
+
+        // Before activation, value may freely enter the Orchard pool: the same step is
+        // valid.
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(0, 1),
+                TransactionBalance::new(
+                    vec![shielded_change(ShieldedPool::Orchard, 16_000)],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                false,
+            ),
+            Ok(_)
+        );
+    }
+
+    // Constructs a step that spends a 10_000-zatoshi Orchard note to pay 6_000 zatoshis to
+    // an Orchard receiver, with the payment assigned to the given pool.
+    fn orchard_payment_step(
+        pool: PoolType,
+        ironwood_active: bool,
+    ) -> Result<Step<u32>, ProposalError> {
+        use zcash_keys::address::{Address, UnifiedAddress};
+        use zcash_protocol::consensus::Network;
+
+        let sk: SpendingKey = Option::from(SpendingKey::from_bytes([0x2a; 32])).unwrap();
+        let recipient = FullViewingKey::from(&sk).address_at(0u32, zip32::Scope::External);
+        let ua = UnifiedAddress::from_receivers(Some(recipient), None, None).unwrap();
+        let to = Address::Unified(ua).to_zcash_address(&Network::TestNetwork);
+
+        let request = TransactionRequest::new(vec![
+            zip321::Payment::new(
+                to,
+                Some(Zatoshis::const_from_u64(6_000)),
+                None,
+                None,
+                None,
+                vec![],
+            )
+            .unwrap(),
+        ])
+        .unwrap();
+
+        Step::from_parts(
+            &[],
+            request,
+            BTreeMap::from([(0usize, pool)]),
+            vec![],
+            shielded_inputs_for(orchard_and_ironwood_notes(1, 0)),
+            BlockHeight::from_u32(100),
+            vec![],
+            TransactionBalance::new(vec![], Zatoshis::const_from_u64(4_000)).unwrap(),
+            false,
+            ironwood_active,
+        )
+    }
+
+    #[test]
+    fn orchard_turnstile_permits_routed_and_pre_activation_payments() {
+        // A payment routed through the Ironwood bundle (the post-activation representation
+        // of an Orchard-receiver payment) is valid.
+        assert_matches!(orchard_payment_step(PoolType::IRONWOOD, true), Ok(_));
+
+        // Before activation, an Orchard-pool payment is valid.
+        assert_matches!(orchard_payment_step(PoolType::ORCHARD, false), Ok(_));
+    }
+
+    // Post-activation, payment classification never assigns a payment to the Orchard pool,
+    // so a step constructed with one is a programming error and step construction asserts.
+    #[test]
+    #[should_panic(expected = "no payment may be directed to the Orchard pool")]
+    fn orchard_pool_payment_with_ironwood_active_is_a_programming_error() {
+        let _ = orchard_payment_step(PoolType::ORCHARD, true);
     }
 
     // Builds `n` version-2 (Orchard) notes followed by `m` version-3 (Ironwood) notes.

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -174,26 +174,13 @@ impl std::error::Error for ProposalError {}
 /// The Sapling inputs to a proposed transaction.
 #[derive(Clone, PartialEq, Eq)]
 pub struct ShieldedInputs<NoteRef> {
-    anchor_height: BlockHeight,
     notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
 }
 
 impl<NoteRef> ShieldedInputs<NoteRef> {
     /// Constructs a [`ShieldedInputs`] from its constituent parts.
-    pub fn from_parts(
-        anchor_height: BlockHeight,
-        notes: NonEmpty<ReceivedNote<NoteRef, Note>>,
-    ) -> Self {
-        Self {
-            anchor_height,
-            notes,
-        }
-    }
-
-    /// Returns the anchor height for Sapling inputs that should be used when constructing the
-    /// proposed transaction.
-    pub fn anchor_height(&self) -> BlockHeight {
-        self.anchor_height
+    pub fn from_parts(notes: NonEmpty<ReceivedNote<NoteRef, Note>>) -> Self {
+        Self { notes }
     }
 
     /// Returns the list of Sapling notes to be used as inputs to the proposed transaction.
@@ -307,6 +294,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// * `payment_pools`: A map from payment index to pool type.
     /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
     /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
+    /// * `anchor_height`: See [`Step::from_parts`].
     /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
     /// * `fee_rule`: The fee rule observed by the proposed transaction.
     /// * `min_target_height`: The minimum block height at which the transaction may be created.
@@ -318,6 +306,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
         payment_pools: BTreeMap<usize, PoolType>,
         transparent_inputs: Vec<WalletTransparentOutput<()>>,
         shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+        anchor_height: BlockHeight,
         balance: TransactionBalance,
         fee_rule: FeeRuleT,
         min_target_height: TargetHeight,
@@ -332,6 +321,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
                 payment_pools,
                 transparent_inputs,
                 shielded_inputs,
+                anchor_height,
                 vec![],
                 balance,
                 is_shielding,
@@ -425,6 +415,12 @@ pub struct Step<NoteRef> {
     payment_pools: BTreeMap<usize, PoolType>,
     transparent_inputs: Vec<WalletTransparentOutput<()>>,
     shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+    /// The anchor height that binds every shielded-tree lookup performed while building this
+    /// step's transaction — both shielded-input witnesses and shielded-output anchors. A single
+    /// anchor per step is required so that transactions with only routed shielded outputs (for
+    /// example, an Orchard-recipient payment post-NU6.3 that the builder routes into a fresh
+    /// Ironwood bundle) are indistinguishable from transactions that spend real shielded notes.
+    anchor_height: BlockHeight,
     prior_step_inputs: Vec<StepOutput>,
     balance: TransactionBalance,
     is_shielding: bool,
@@ -446,6 +442,9 @@ impl<NoteRef> Step<NoteRef> {
     ///   addresses).
     /// * `transparent_inputs`: The set of previous transparent outputs to be spent.
     /// * `shielded_inputs`: The sets of previous shielded outputs to be spent.
+    /// * `anchor_height`: The anchor height that binds every shielded-tree lookup performed
+    ///   while building this step's transaction — both shielded-input witnesses and
+    ///   shielded-output anchors.
     /// * `balance`: The change outputs to be added the transaction and the fee to be paid.
     /// * `is_shielding`: A flag that identifies whether this is a wallet-internal shielding
     ///   transaction.
@@ -456,6 +455,7 @@ impl<NoteRef> Step<NoteRef> {
         payment_pools: BTreeMap<usize, PoolType>,
         transparent_inputs: Vec<WalletTransparentOutput<()>>,
         shielded_inputs: Option<ShieldedInputs<NoteRef>>,
+        anchor_height: BlockHeight,
         prior_step_inputs: Vec<StepOutput>,
         balance: TransactionBalance,
         is_shielding: bool,
@@ -466,7 +466,15 @@ impl<NoteRef> Step<NoteRef> {
         }
         for (idx, pool) in &payment_pools {
             if let Some(payment) = transaction_request.payments().get(idx) {
-                if !payment.recipient_address().can_receive_as(*pool) {
+                // Ironwood notes are Orchard-shaped and delivered to the recipient's Orchard
+                // receiver, so an Ironwood-pool payment is valid whenever the recipient can
+                // receive Orchard.
+                let deliverable = payment.recipient_address().can_receive_as(*pool)
+                    || (*pool == PoolType::IRONWOOD
+                        && payment
+                            .recipient_address()
+                            .can_receive_as(PoolType::ORCHARD));
+                if !deliverable {
                     return Err(ProposalError::PaymentPoolsMismatch);
                 }
                 if payment.amount().is_none() {
@@ -541,6 +549,7 @@ impl<NoteRef> Step<NoteRef> {
                 payment_pools,
                 transparent_inputs,
                 shielded_inputs,
+                anchor_height,
                 prior_step_inputs,
                 balance,
                 is_shielding,
@@ -569,6 +578,11 @@ impl<NoteRef> Step<NoteRef> {
     /// Returns the shielded inputs that have been selected to fund the transaction.
     pub fn shielded_inputs(&self) -> Option<&ShieldedInputs<NoteRef>> {
         self.shielded_inputs.as_ref()
+    }
+    /// Returns the anchor height that binds every shielded-tree lookup performed while building
+    /// this step's transaction.
+    pub fn anchor_height(&self) -> BlockHeight {
+        self.anchor_height
     }
     /// Returns the inputs that should be obtained from the outputs of the transaction
     /// created to satisfy a previous step of the proposal.
@@ -704,10 +718,7 @@ impl<NoteRef> Debug for Step<NoteRef> {
                 &self.shielded_inputs().map(|i| i.notes.len()),
             )
             .field("prior_step_inputs", &self.prior_step_inputs)
-            .field(
-                "anchor_height",
-                &self.shielded_inputs().map(|i| i.anchor_height),
-            )
+            .field("anchor_height", &self.anchor_height)
             .field("balance", &self.balance)
             .field("is_shielding", &self.is_shielding)
             .finish_non_exhaustive()
@@ -768,13 +779,13 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let shielded_inputs = NonEmpty::from_vec(received)
-            .map(|notes| ShieldedInputs::from_parts(BlockHeight::from_u32(100), notes));
+        let shielded_inputs = NonEmpty::from_vec(received).map(ShieldedInputs::from_parts);
         Step {
             transaction_request: TransactionRequest::empty(),
             payment_pools: BTreeMap::new(),
             transparent_inputs: vec![],
             shielded_inputs,
+            anchor_height: BlockHeight::from_u32(100),
             prior_step_inputs: vec![],
             balance: TransactionBalance::new(vec![], Zatoshis::ZERO).unwrap(),
             is_shielding: false,

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -275,7 +275,10 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
                     match &s_out.note() {
                         Note::Sapling(_) => PoolType::SAPLING,
                         #[cfg(feature = "orchard")]
-                        Note::Orchard(_) => PoolType::ORCHARD,
+                        Note::Orchard { pool, .. } => match pool {
+                            orchard::ValuePool::Orchard => PoolType::ORCHARD,
+                            orchard::ValuePool::Ironwood => PoolType::IRONWOOD,
+                        },
                     },
                     *s_out.txid(),
                     s_out.output_index().into(),
@@ -353,6 +356,20 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// be generated as a result of this proposal.
     pub fn steps(&self) -> &NonEmpty<Step<NoteRef>> {
         &self.steps
+    }
+
+    /// Returns the total number of inputs across all steps of this proposal that belong to the
+    /// given pool.
+    ///
+    /// For a shielded pool this is the number of spent notes of that pool (Ironwood notes are
+    /// counted for [`PoolType::IRONWOOD`], not [`PoolType::ORCHARD`]); for
+    /// [`PoolType::Transparent`] it is the number of transparent inputs. See
+    /// [`Step::input_count_in_pool`].
+    pub fn input_count_in_pool(&self, pool_type: PoolType) -> usize {
+        self.steps
+            .iter()
+            .map(|step| step.input_count_in_pool(pool_type))
+            .sum()
     }
 }
 
@@ -587,14 +604,18 @@ impl<NoteRef> Step<NoteRef> {
             PoolType::SAPLING => self.shielded_inputs().iter().any(|s_in| {
                 s_in.notes()
                     .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Sapling))
+                    .any(|note| matches!(note.note().pool(), ShieldedPool::Sapling))
             }),
             PoolType::ORCHARD => self.shielded_inputs().iter().any(|s_in| {
                 s_in.notes()
                     .iter()
-                    .any(|note| matches!(note.note().protocol(), ShieldedPool::Orchard))
+                    .any(|note| matches!(note.note().pool(), ShieldedPool::Orchard))
             }),
-            PoolType::IRONWOOD => todo!("Ironwood pool support is not yet implemented"),
+            PoolType::IRONWOOD => self.shielded_inputs().iter().any(|s_in| {
+                s_in.notes()
+                    .iter()
+                    .any(|note| matches!(note.note().pool(), ShieldedPool::Ironwood))
+            }),
         }
     }
 
@@ -624,15 +645,20 @@ impl<NoteRef> Step<NoteRef> {
                 .shielded_inputs()
                 .iter()
                 .flat_map(|s_in| s_in.notes())
-                .filter(|note| note.note().protocol() == ShieldedPool::Sapling)
+                .filter(|note| note.note().pool() == ShieldedPool::Sapling)
                 .count(),
             PoolType::ORCHARD => self
                 .shielded_inputs()
                 .iter()
                 .flat_map(|s_in| s_in.notes())
-                .filter(|note| note.note().protocol() == ShieldedPool::Orchard)
+                .filter(|note| note.note().pool() == ShieldedPool::Orchard)
                 .count(),
-            PoolType::IRONWOOD => todo!("Ironwood pool support is not yet implemented"),
+            PoolType::IRONWOOD => self
+                .shielded_inputs()
+                .iter()
+                .flat_map(|s_in| s_in.notes())
+                .filter(|note| note.note().pool() == ShieldedPool::Ironwood)
+                .count(),
         }
     }
 
@@ -685,5 +711,153 @@ impl<NoteRef> Debug for Step<NoteRef> {
             .field("balance", &self.balance)
             .field("is_shielding", &self.is_shielding)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(all(test, feature = "orchard"))]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use incrementalmerkletree::Position;
+    use nonempty::NonEmpty;
+    use orchard::{
+        ValuePool,
+        keys::{FullViewingKey, SpendingKey},
+        note::{Note as OrchardNote, NoteVersion, RandomSeed, Rho},
+        value::NoteValue,
+    };
+    use proptest::prelude::*;
+    use zcash_primitives::transaction::TxId;
+    use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
+    use zip321::TransactionRequest;
+
+    use super::{Proposal, ShieldedInputs, Step};
+    use crate::{data_api::wallet::TargetHeight, fees::TransactionBalance, wallet::Note};
+
+    // Builds an Orchard note of the given version and value. The recipient, rho, and rseed are
+    // fixed; only the version and value vary, which is all `Note::pool`/`Note::protocol` depend on.
+    fn orchard_note(value: u64, version: NoteVersion) -> Option<OrchardNote> {
+        let sk: SpendingKey = Option::from(SpendingKey::from_bytes([0x2a; 32]))?;
+        let recipient = FullViewingKey::from(&sk).address_at(0u32, zip32::Scope::External);
+        let rho = Option::from(Rho::from_bytes(&[0; 32]))?;
+        let rseed = Option::from(RandomSeed::from_bytes([0x1b; 32], &rho))?;
+        Option::from(OrchardNote::from_parts(
+            recipient,
+            NoteValue::from_raw(value),
+            rho,
+            rseed,
+            version,
+        ))
+    }
+
+    // Wraps a list of notes into a single `Step` whose only inputs are those shielded notes.
+    fn step_with_notes(notes: Vec<Note>) -> Step<u32> {
+        let received = notes
+            .into_iter()
+            .enumerate()
+            .map(|(i, note)| {
+                crate::wallet::ReceivedNote::from_parts(
+                    i as u32,
+                    TxId::from_bytes([0; 32]),
+                    i as u16,
+                    note,
+                    zip32::Scope::External,
+                    Position::from(i as u64),
+                    Some(BlockHeight::from_u32(100)),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let shielded_inputs = NonEmpty::from_vec(received)
+            .map(|notes| ShieldedInputs::from_parts(BlockHeight::from_u32(100), notes));
+        Step {
+            transaction_request: TransactionRequest::empty(),
+            payment_pools: BTreeMap::new(),
+            transparent_inputs: vec![],
+            shielded_inputs,
+            prior_step_inputs: vec![],
+            balance: TransactionBalance::new(vec![], Zatoshis::ZERO).unwrap(),
+            is_shielding: false,
+        }
+    }
+
+    // Builds `n` version-2 (Orchard) notes followed by `m` version-3 (Ironwood) notes.
+    fn orchard_and_ironwood_notes(n: usize, m: usize) -> Vec<Note> {
+        let mut notes = Vec::with_capacity(n + m);
+        for _ in 0..n {
+            notes.push(Note::Orchard {
+                note: orchard_note(10_000, NoteVersion::V2).unwrap(),
+                pool: ValuePool::Orchard,
+            });
+        }
+        for _ in 0..m {
+            notes.push(Note::Orchard {
+                note: orchard_note(20_000, NoteVersion::V3).unwrap(),
+                pool: ValuePool::Ironwood,
+            });
+        }
+        notes
+    }
+
+    proptest! {
+        // `Note::pool` reports the `ValuePool` recorded alongside an Orchard note.
+        #[test]
+        fn note_pool_reports_stored_value_pool(
+            value in 1u64..1_000_000_000u64,
+            is_ironwood in any::<bool>(),
+        ) {
+            let (version, pool, expected) = if is_ironwood {
+                (NoteVersion::V3, ValuePool::Ironwood, ShieldedPool::Ironwood)
+            } else {
+                (NoteVersion::V2, ValuePool::Orchard, ShieldedPool::Orchard)
+            };
+            let Some(note) = orchard_note(value, version) else {
+                // A handful of (value, rho, rseed) combinations do not form a valid note; skip them.
+                return Err(TestCaseError::reject("invalid orchard note"));
+            };
+            let note = Note::Orchard { note, pool };
+            prop_assert_eq!(note.pool(), expected);
+        }
+
+        // `Step::input_count_in_pool` returns the number of selected notes in each pool, splitting
+        // Orchard (version 2) from Ironwood (version 3); Sapling is zero here. `input_in_pool`
+        // agrees with `input_count_in_pool > 0`, and `Proposal::input_count_in_pool` sums the
+        // per-step counts.
+        #[test]
+        fn step_and_proposal_input_counts_match_constructed_notes(
+            n_orchard in 0usize..5,
+            n_ironwood in 0usize..5,
+            m_orchard in 0usize..5,
+            m_ironwood in 0usize..5,
+        ) {
+            let step1 = step_with_notes(orchard_and_ironwood_notes(n_orchard, n_ironwood));
+            prop_assert_eq!(step1.input_count_in_pool(PoolType::SAPLING), 0);
+            prop_assert_eq!(step1.input_count_in_pool(PoolType::ORCHARD), n_orchard);
+            prop_assert_eq!(step1.input_count_in_pool(PoolType::IRONWOOD), n_ironwood);
+
+            for pool in [ShieldedPool::Sapling, ShieldedPool::Orchard, ShieldedPool::Ironwood] {
+                let pool_type = PoolType::Shielded(pool);
+                prop_assert_eq!(
+                    step1.input_in_pool(pool_type),
+                    step1.input_count_in_pool(pool_type) > 0
+                );
+            }
+
+            let step2 = step_with_notes(orchard_and_ironwood_notes(m_orchard, m_ironwood));
+            let proposal = Proposal::<(), u32> {
+                fee_rule: (),
+                min_target_height: TargetHeight::from(100u32),
+                steps: NonEmpty::from_vec(vec![step1, step2]).unwrap(),
+            };
+            prop_assert_eq!(proposal.input_count_in_pool(PoolType::SAPLING), 0);
+            prop_assert_eq!(
+                proposal.input_count_in_pool(PoolType::ORCHARD),
+                n_orchard + m_orchard
+            );
+            prop_assert_eq!(
+                proposal.input_count_in_pool(PoolType::IRONWOOD),
+                n_ironwood + m_ironwood
+            );
+        }
     }
 }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -577,6 +577,7 @@ fn pool_type<T>(pool_id: i32) -> Result<PoolType, ProposalDecodingError<T>> {
         Ok(proposal::ValuePool::Transparent) => Ok(PoolType::TRANSPARENT),
         Ok(proposal::ValuePool::Sapling) => Ok(PoolType::SAPLING),
         Ok(proposal::ValuePool::Orchard) => Ok(PoolType::ORCHARD),
+        Ok(proposal::ValuePool::Ironwood) => Ok(PoolType::IRONWOOD),
         _ => Err(ProposalDecodingError::ValuePoolNotSupported(pool_id)),
     }
 }
@@ -611,11 +612,7 @@ impl From<ShieldedPool> for proposal::ValuePool {
         match value {
             ShieldedPool::Sapling => proposal::ValuePool::Sapling,
             ShieldedPool::Orchard => proposal::ValuePool::Orchard,
-            ShieldedPool::Ironwood => {
-                todo!(
-                    "Ironwood value pool is not yet representable in the protobuf proposal format"
-                )
-            }
+            ShieldedPool::Ironwood => proposal::ValuePool::Ironwood,
         }
     }
 }
@@ -632,9 +629,7 @@ impl proposal::Proposal {
             .map(|step| {
                 let transaction_request = step.transaction_request().to_uri();
 
-                let anchor_height = step
-                    .shielded_inputs()
-                    .map_or_else(|| 0, |i| u32::from(i.anchor_height()));
+                let anchor_height = u32::from(step.anchor_height());
 
                 let inputs = step
                     .transparent_inputs()
@@ -871,8 +866,8 @@ impl proposal::Proposal {
                         }
                     }
 
-                    let shielded_inputs = NonEmpty::from_vec(received_notes)
-                        .map(|notes| ShieldedInputs::from_parts(step.anchor_height.into(), notes));
+                    let shielded_inputs =
+                        NonEmpty::from_vec(received_notes).map(ShieldedInputs::from_parts);
 
                     let proto_balance = step
                         .balance
@@ -901,6 +896,10 @@ impl proposal::Proposal {
                                     (PoolType::Shielded(ShieldedPool::Orchard), false) => {
                                         Ok(ChangeValue::orchard(value, memo))
                                     }
+                                    #[cfg(feature = "orchard")]
+                                    (PoolType::Shielded(ShieldedPool::Ironwood), false) => Ok(
+                                        ChangeValue::shielded(ShieldedPool::Ironwood, value, memo),
+                                    ),
                                     (PoolType::Transparent, _) if memo.is_some() => {
                                         Err(ProposalDecodingError::TransparentMemo)
                                     }
@@ -928,6 +927,7 @@ impl proposal::Proposal {
                         payment_pools,
                         transparent_inputs,
                         shielded_inputs,
+                        step.anchor_height.into(),
                         prior_step_inputs,
                         balance,
                         step.is_shielding,

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -735,11 +735,13 @@ impl proposal::Proposal {
 
     /// Attempts to parse a [`Proposal`] based upon a supported [`StandardFeeRule`] from its
     /// protobuf representation.
-    pub fn try_into_standard_proposal<DbT, DbError>(
+    pub fn try_into_standard_proposal<ParamsT, DbT, DbError>(
         &self,
+        params: &ParamsT,
         wallet_db: &DbT,
     ) -> Result<Proposal<StandardFeeRule, DbT::NoteRef>, ProposalDecodingError<DbError>>
     where
+        ParamsT: consensus::Parameters,
         DbT: InputSource<Error = DbError>,
     {
         use self::proposal::proposed_input::Value::*;
@@ -753,6 +755,15 @@ impl proposal::Proposal {
                 };
 
                 let target_height = TargetHeight::from(self.min_target_height);
+                // Steps are checked against the Orchard turnstile when Ironwood is
+                // active at the height for which the proposal was constructed.
+                #[cfg(feature = "orchard")]
+                let ironwood_active = params.is_nu_active(
+                    consensus::NetworkUpgrade::Nu6_3,
+                    BlockHeight::from(target_height),
+                );
+                #[cfg(not(feature = "orchard"))]
+                let _ = params;
 
                 let mut steps = Vec::with_capacity(self.steps.len());
                 for step in &self.steps {
@@ -931,6 +942,8 @@ impl proposal::Proposal {
                         prior_step_inputs,
                         balance,
                         step.is_shielding,
+                        #[cfg(feature = "orchard")]
+                        ironwood_active,
                     )
                     .map_err(ProposalDecodingError::ProposalInvalid)?;
 

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -651,7 +651,7 @@ impl proposal::Proposal {
                         s_in.notes().iter().map(|rec_note| proposal::ProposedInput {
                             value: Some(proposed_input::Value::ReceivedOutput(ReceivedOutput {
                                 txid: rec_note.txid().as_ref().to_vec(),
-                                value_pool: proposal::ValuePool::from(rec_note.note().protocol())
+                                value_pool: proposal::ValuePool::from(rec_note.note().pool())
                                     .into(),
                                 index: rec_note.output_index().into(),
                                 value: rec_note.note().value().into(),

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -158,6 +158,10 @@ pub enum ValuePool {
     Sapling = 2,
     /// The Orchard value pool
     Orchard = 3,
+    /// The Ironwood value pool (ZIP 2005). Ironwood notes are Orchard-shaped but
+    /// belong to a distinct pool; older decoders that do not recognize this value
+    /// will reject the proposal rather than misattribute it to Orchard.
+    Ironwood = 4,
 }
 impl ValuePool {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -170,6 +174,7 @@ impl ValuePool {
             Self::Transparent => "Transparent",
             Self::Sapling => "Sapling",
             Self::Orchard => "Orchard",
+            Self::Ironwood => "Ironwood",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -179,6 +184,7 @@ impl ValuePool {
             "Transparent" => Some(Self::Transparent),
             "Sapling" => Some(Self::Sapling),
             "Orchard" => Some(Self::Orchard),
+            "Ironwood" => Some(Self::Ironwood),
             _ => None,
         }
     }

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -212,19 +212,48 @@ impl<AccountId> ScanningKeyOps<OrchardDomain, AccountId, orchard::note::Nullifie
 
 /// The note-encryption domain used to trial-decrypt Ironwood outputs.
 ///
-/// Ironwood ([ZIP 2005], NU6.3) is a distinct shielded pool with its own note commitment tree,
-/// but its notes are Orchard-shaped: they are decrypted under the Orchard note-encryption domain
-/// and use the Orchard commitment and nullifier types. These aliases name that reuse so that
-/// Ironwood can share the underlying Orchard primitives without being modelled as part of an
-/// "Orchard family"; the two pools are kept strictly separate throughout the scanner.
+/// Ironwood ([ZIP 2005], NU6.3) is a distinct shielded pool. Its notes are Orchard-shaped and use
+/// the Orchard commitment and nullifier types, and are decrypted with the same Orchard viewing
+/// keys, but they carry version 3 note plaintexts and so require the Ironwood note-encryption
+/// domain, which is distinct from [`OrchardDomain`] (that domain accepts only version 2
+/// plaintexts). This is why Ironwood is a separate pool rather than a variant of Orchard.
 ///
 /// [ZIP 2005]: https://zips.z.cash/zip-2005
 #[cfg(feature = "orchard")]
-pub(crate) type IronwoodDomain = OrchardDomain;
+pub(crate) type IronwoodDomain = orchard::note_encryption::IronwoodDomain;
 
-/// The nullifier type for Ironwood notes. See [`IronwoodDomain`].
+/// The nullifier type for Ironwood notes. This is the Orchard nullifier type, which does not
+/// depend on the note plaintext version. See [`IronwoodDomain`].
 #[cfg(feature = "orchard")]
 pub(crate) type IronwoodNullifier = orchard::note::Nullifier;
+
+/// An Orchard viewing key trial-decrypts Ironwood outputs under the Ironwood note-encryption
+/// domain. The key material is the same as for Orchard; only the domain (and thus the accepted
+/// note plaintext version) differs.
+#[cfg(feature = "orchard")]
+impl<AccountId> ScanningKeyOps<IronwoodDomain, AccountId, orchard::note::Nullifier>
+    for ScanningKey<orchard::keys::IncomingViewingKey, orchard::keys::FullViewingKey, AccountId>
+{
+    fn prepare(&self) -> orchard::keys::PreparedIncomingViewingKey {
+        orchard::keys::PreparedIncomingViewingKey::new(&self.ivk)
+    }
+
+    fn nf(
+        &self,
+        note: &orchard::note::Note,
+        _position: Position,
+    ) -> Option<orchard::note::Nullifier> {
+        self.nk.as_ref().map(|key| note.nullifier(key))
+    }
+
+    fn account_id(&self) -> &AccountId {
+        &self.account_id
+    }
+
+    fn key_scope(&self) -> Option<Scope> {
+        self.key_scope
+    }
+}
 
 /// A set of keys to be used in scanning for decryptable transaction outputs.
 pub struct ScanningKeys<AccountId, IvkTag> {
@@ -744,7 +773,7 @@ where
     AccountId: Default + Eq + Hash + ConditionallySelectable + Send + Sync + 'static,
     IvkTag: Copy + std::hash::Hash + Eq + Send + 'static,
 {
-    compact::scan_block_with_runners::<_, _, _, (), ()>(
+    compact::scan_block_with_runners::<_, _, _, (), (), ()>(
         params,
         block,
         scanning_keys,

--- a/zcash_client_backend/src/scanning.rs
+++ b/zcash_client_backend/src/scanning.rs
@@ -880,6 +880,7 @@ fn find_received<
     SK: ScanningKeyOps<D, AccountId, Nf>,
     Output: ShieldedOutput<D, CIPHERTEXT_SIZE>,
     NoteCommitment,
+    Note,
     const CIPHERTEXT_SIZE: usize,
 >(
     block_height: BlockHeight,
@@ -895,8 +896,9 @@ fn find_received<
         &[(D, Output)],
     ) -> Vec<Option<((D::Note, D::Recipient, M), usize)>>,
     extract_note_commitment: impl Fn(&Output) -> NoteCommitment,
+    enrich_note: impl Fn(D::Note) -> Note,
 ) -> (
-    Vec<WalletOutput<D::Note, Nf, AccountId>>,
+    Vec<WalletOutput<Note, Nf, AccountId>>,
     Vec<(NoteCommitment, Retention<BlockHeight>)>,
 ) {
     // Check for incoming notes while incrementing tree and witnesses
@@ -976,7 +978,7 @@ fn find_received<
             shielded_outputs.push(WalletOutput::from_parts(
                 output_idx,
                 output.ephemeral_key(),
-                note,
+                enrich_note(note),
                 is_change,
                 note_commitment_tree_position,
                 nf,

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -60,10 +60,12 @@ type TaggedOrchardBatchRunner<IvkTag, Tasks> = BatchRunner<
     Tasks,
 >;
 
-// Ironwood outputs are Orchard-shaped, so an Ironwood batch is identical in type to an Orchard
-// batch (`IronwoodDomain` aliases `OrchardDomain`). This means the Orchard task type `TO` already
-// satisfies the bound for the Ironwood runner, and no separate `IronwoodTasks` is required; the
-// alias exists only to name the Ironwood runner as belonging to its own pool.
+// Ironwood outputs are decrypted under the Ironwood note-encryption domain, which is distinct from
+// the Orchard domain (it accepts version 3 note plaintexts), so an Ironwood batch is a distinct
+// type from an Orchard batch and requires its own task type.
+#[cfg(feature = "orchard")]
+type TaggedIronwoodBatch<IvkTag> =
+    Batch<IvkTag, IronwoodDomain, orchard::note_encryption::CompactAction, CompactDecryptor>;
 #[cfg(feature = "orchard")]
 type TaggedIronwoodBatchRunner<IvkTag, Tasks> = BatchRunner<
     IvkTag,
@@ -86,21 +88,37 @@ pub(crate) trait OrchardTasks<IvkTag>: Tasks<TaggedOrchardBatch<IvkTag>> {}
 #[cfg(feature = "orchard")]
 impl<IvkTag, T: Tasks<TaggedOrchardBatch<IvkTag>>> OrchardTasks<IvkTag> for T {}
 
-pub(crate) struct BatchRunners<IvkTag, TS: SaplingTasks<IvkTag>, TO: OrchardTasks<IvkTag>> {
+#[cfg(not(feature = "orchard"))]
+pub(crate) trait IronwoodTasks<IvkTag> {}
+#[cfg(not(feature = "orchard"))]
+impl<IvkTag, T> IronwoodTasks<IvkTag> for T {}
+
+#[cfg(feature = "orchard")]
+pub(crate) trait IronwoodTasks<IvkTag>: Tasks<TaggedIronwoodBatch<IvkTag>> {}
+#[cfg(feature = "orchard")]
+impl<IvkTag, T: Tasks<TaggedIronwoodBatch<IvkTag>>> IronwoodTasks<IvkTag> for T {}
+
+pub(crate) struct BatchRunners<
+    IvkTag,
+    TS: SaplingTasks<IvkTag>,
+    TO: OrchardTasks<IvkTag>,
+    TI: IronwoodTasks<IvkTag>,
+> {
     sapling: TaggedSaplingBatchRunner<IvkTag, TS>,
     #[cfg(feature = "orchard")]
     orchard: TaggedOrchardBatchRunner<IvkTag, TO>,
     #[cfg(feature = "orchard")]
-    ironwood: TaggedIronwoodBatchRunner<IvkTag, TO>,
+    ironwood: TaggedIronwoodBatchRunner<IvkTag, TI>,
     #[cfg(not(feature = "orchard"))]
-    orchard: PhantomData<TO>,
+    orchard: PhantomData<(TO, TI)>,
 }
 
-impl<IvkTag, TS, TO> BatchRunners<IvkTag, TS, TO>
+impl<IvkTag, TS, TO, TI> BatchRunners<IvkTag, TS, TO, TI>
 where
     IvkTag: Clone + Send + 'static,
     TS: SaplingTasks<IvkTag>,
     TO: OrchardTasks<IvkTag>,
+    TI: IronwoodTasks<IvkTag>,
 {
     pub(crate) fn for_keys<AccountId>(
         batch_size_threshold: usize,
@@ -199,7 +217,7 @@ where
             self.ironwood.add_outputs(
                 block_hash,
                 txid,
-                OrchardDomain::for_compact_action,
+                IronwoodDomain::for_compact_action,
                 tx.ironwood_actions
                     .iter()
                     .enumerate()
@@ -220,13 +238,13 @@ where
 }
 
 #[tracing::instrument(skip_all, fields(height = block.height))]
-pub(crate) fn scan_block_with_runners<P, AccountId, IvkTag, TS, TO>(
+pub(crate) fn scan_block_with_runners<P, AccountId, IvkTag, TS, TO, TI>(
     params: &P,
     block: CompactBlock,
     scanning_keys: &ScanningKeys<AccountId, IvkTag>,
     nullifiers: &Nullifiers<AccountId>,
     prior_block_metadata: Option<&BlockMetadata>,
-    mut batch_runners: Option<&mut BatchRunners<IvkTag, TS, TO>>,
+    mut batch_runners: Option<&mut BatchRunners<IvkTag, TS, TO, TI>>,
 ) -> Result<ScannedBlock<AccountId>, ScanError>
 where
     P: consensus::Parameters + Send + 'static,
@@ -234,6 +252,7 @@ where
     IvkTag: Copy + std::hash::Hash + Eq + Send + 'static,
     TS: SaplingTasks<IvkTag> + Sync,
     TO: OrchardTasks<IvkTag> + Sync,
+    TI: IronwoodTasks<IvkTag> + Sync,
 {
     fn check_hash_continuity(
         block: &CompactBlock,
@@ -445,7 +464,7 @@ where
                             index: i,
                         }
                     })?;
-                    Ok((OrchardDomain::for_compact_action(&action), action))
+                    Ok((IronwoodDomain::for_compact_action(&action), action))
                 })
                 .collect::<Result<Vec<_>, _>>()?,
             batch_runners
@@ -783,7 +802,7 @@ mod tests {
             assert_eq!(cb.vtx.len(), 2);
 
             let mut batch_runners = if scan_multithreaded {
-                let mut runners = BatchRunners::<_, (), ()>::for_keys(10, &scanning_keys);
+                let mut runners = BatchRunners::<_, (), (), ()>::for_keys(10, &scanning_keys);
                 runners
                     .add_block(&Network::TestNetwork, cb.clone())
                     .unwrap();
@@ -848,6 +867,156 @@ mod tests {
         go(true);
     }
 
+    #[cfg(feature = "orchard")]
+    proptest::proptest! {
+        #![proptest_config(proptest::test_runner::Config::with_cases(24))]
+
+        /// An Ironwood output (a version 3 note in `tx.ironwood_actions`) is detected by the
+        /// scanner using the account's Orchard viewing key under the Ironwood note-encryption
+        /// domain, and is reported as an Ironwood output distinct from the Orchard pool. This
+        /// exercises the fix that decrypts Ironwood notes with `IronwoodDomain` rather than
+        /// `OrchardDomain` (which, accepting only version 2 plaintexts, would silently fail to
+        /// detect the note). Fuzzing the value, diversified address index, and key scope covers a
+        /// range of notes the wallet must detect.
+        #[test]
+        fn scan_block_detects_ironwood_note(
+            value in 1u64..=1_000_000_000u64,
+            diversifier_index in 0u32..8,
+            internal in proptest::bool::ANY,
+        ) {
+            use orchard::{
+                keys::Scope,
+                note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho},
+                note_encryption::{IronwoodDomain, IronwoodNoteEncryption},
+                value::NoteValue,
+            };
+            use pasta_curves::{
+                group::ff::{Field, PrimeField},
+                pallas,
+            };
+            use proptest::prelude::*;
+            use rand_core::{OsRng, RngCore};
+            use zcash_note_encryption::Domain;
+
+            use crate::proto::compact_formats::{
+                ChainMetadata, CompactBlock, CompactOrchardAction, CompactTx,
+            };
+
+            let network = Network::TestNetwork;
+            let account = AccountId::ZERO;
+            let usk =
+                UnifiedSpendingKey::from_seed(&network, &[0u8; 32], account).expect("Valid USK");
+            let ufvk = usk.to_unified_full_viewing_key();
+            let orchard_fvk = ufvk.orchard().expect("Orchard key is present").clone();
+            let scanning_keys = ScanningKeys::from_account_ufvks([(account, ufvk)]);
+
+            let scope = if internal { Scope::Internal } else { Scope::External };
+            let mut rng = OsRng;
+            let recipient = orchard_fvk.address_at(diversifier_index, scope);
+
+            // Build a version 3 (Ironwood) compact action. `rho` is derived from the revealed
+            // nullifier exactly as the crate does internally (`Rho::from_nf_old(nf) ==
+            // Rho(nf.inner())`, which `Rho::from_bytes(&nf.to_bytes())` reconstructs), so the domain
+            // the scanner builds via `IronwoodDomain::for_compact_action` will match and decryption
+            // will succeed.
+            let nf_old =
+                orchard::note::Nullifier::from_bytes(&pallas::Base::random(&mut rng).to_repr())
+                    .unwrap();
+            let rho = Rho::from_bytes(&nf_old.to_bytes()).unwrap();
+            let rseed = loop {
+                let mut bytes = [0u8; 32];
+                rng.fill_bytes(&mut bytes);
+                if let Some(rseed) = Option::from(RandomSeed::from_bytes(bytes, &rho)) {
+                    break rseed;
+                }
+            };
+            let note = Note::from_parts(
+                recipient,
+                NoteValue::from_raw(value),
+                rho,
+                rseed,
+                NoteVersion::V3,
+            )
+            .unwrap();
+            let encryptor = IronwoodNoteEncryption::new(
+                Some(orchard_fvk.to_ovk(Scope::External)),
+                note,
+                [0u8; 512],
+            );
+            let cmx = ExtractedNoteCommitment::from(note.commitment());
+            let ephemeral_key = IronwoodDomain::epk_bytes(encryptor.epk());
+            let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+            let action = CompactOrchardAction {
+                nullifier: nf_old.to_bytes().to_vec(),
+                cmx: cmx.to_bytes().to_vec(),
+                ephemeral_key: ephemeral_key.0.to_vec(),
+                ciphertext: enc_ciphertext[..52].to_vec(),
+            };
+
+            let mut ctx = CompactTx::default();
+            let mut txid = vec![0u8; 32];
+            rng.fill_bytes(&mut txid);
+            ctx.txid = txid;
+            ctx.ironwood_actions.push(action);
+
+            let mut cb = CompactBlock {
+                hash: {
+                    let mut hash = vec![0u8; 32];
+                    rng.fill_bytes(&mut hash);
+                    hash
+                },
+                prev_hash: vec![0u8; 32],
+                height: 1,
+                ..Default::default()
+            };
+            cb.vtx.push(ctx);
+            // The block contains a single Ironwood action and no Sapling or Orchard outputs, so
+            // only the Ironwood tree grows (from 0 to 1).
+            cb.chain_metadata = Some(ChainMetadata {
+                sapling_commitment_tree_size: 0,
+                orchard_commitment_tree_size: 0,
+                ironwood_commitment_tree_size: 1,
+            });
+
+            let mut runners = BatchRunners::<_, (), (), ()>::for_keys(10, &scanning_keys);
+            runners.add_block(&network, cb.clone()).unwrap();
+            runners.flush();
+
+            let scanned_block = scan_block_with_runners(
+                &network,
+                cb,
+                &scanning_keys,
+                &Nullifiers::empty(),
+                Some(&BlockMetadata::from_parts(
+                    BlockHeight::from(0),
+                    BlockHash([0u8; 32]),
+                    Some(0),
+                    Some(0),
+                    Some(0),
+                )),
+                Some(&mut runners),
+            )
+            .unwrap();
+
+            let txs = scanned_block.transactions();
+            prop_assert_eq!(txs.len(), 1);
+            let tx = &txs[0];
+            // The note appears as an Ironwood output, not an Orchard one.
+            prop_assert_eq!(tx.orchard_outputs().len(), 0);
+            prop_assert_eq!(tx.ironwood_outputs().len(), 1);
+            prop_assert_eq!(tx.ironwood_outputs()[0].account_id(), &account);
+            prop_assert_eq!(tx.ironwood_outputs()[0].note().value().inner(), value);
+            prop_assert_eq!(
+                tx.ironwood_outputs()[0].note_commitment_tree_position(),
+                Position::from(0)
+            );
+
+            prop_assert_eq!(scanned_block.ironwood().final_tree_size(), 1);
+            prop_assert_eq!(scanned_block.orchard().final_tree_size(), 0);
+        }
+    }
+
     #[test]
     fn scan_block_with_txs_after_my_tx() {
         fn go(scan_multithreaded: bool) {
@@ -871,7 +1040,7 @@ mod tests {
             assert_eq!(cb.vtx.len(), 3);
 
             let mut batch_runners = if scan_multithreaded {
-                let mut runners = BatchRunners::<_, (), ()>::for_keys(10, &scanning_keys);
+                let mut runners = BatchRunners::<_, (), (), ()>::for_keys(10, &scanning_keys);
                 runners
                     .add_block(&Network::TestNetwork, cb.clone())
                     .unwrap();

--- a/zcash_client_backend/src/scanning/compact.rs
+++ b/zcash_client_backend/src/scanning/compact.rs
@@ -403,6 +403,7 @@ where
                     .collect()
             },
             |output| sapling::Node::from_cmu(&output.cmu),
+            |note| note,
         );
         sapling_note_commitments.append(&mut sapling_nc);
         let has_sapling = !(sapling_spends.is_empty() && sapling_outputs.is_empty());
@@ -440,6 +441,7 @@ where
                     .collect()
             },
             |output| MerkleHashOrchard::from_cmx(&output.cmx()),
+            |note| (note, orchard::ValuePool::Orchard),
         );
         #[cfg(feature = "orchard")]
         orchard_note_commitments.append(&mut orchard_nc);
@@ -477,6 +479,7 @@ where
                     .collect()
             },
             |output| MerkleHashOrchard::from_cmx(&output.cmx()),
+            |note| (note, orchard::ValuePool::Ironwood),
         );
         #[cfg(feature = "orchard")]
         ironwood_note_commitments.append(&mut ironwood_nc);
@@ -1006,7 +1009,7 @@ mod tests {
             prop_assert_eq!(tx.orchard_outputs().len(), 0);
             prop_assert_eq!(tx.ironwood_outputs().len(), 1);
             prop_assert_eq!(tx.ironwood_outputs()[0].account_id(), &account);
-            prop_assert_eq!(tx.ironwood_outputs()[0].note().value().inner(), value);
+            prop_assert_eq!(tx.ironwood_outputs()[0].note().0.value().inner(), value);
             prop_assert_eq!(
                 tx.ironwood_outputs()[0].note_commitment_tree_position(),
                 Position::from(0)

--- a/zcash_client_backend/src/scanning/full.rs
+++ b/zcash_client_backend/src/scanning/full.rs
@@ -611,6 +611,7 @@ where
                     Some(move |_| sapling_decrypted),
                     batch::try_note_decryption,
                     |output| sapling::Node::from_cmu(output.cmu()),
+                    |note| note,
                 )
             })
             .unwrap_or_default();
@@ -636,6 +637,7 @@ where
                     Some(move |_| orchard_decrypted),
                     batch::try_note_decryption,
                     |action| MerkleHashOrchard::from_cmx(action.cmx()),
+                    |note| (note, orchard::ValuePool::Orchard),
                 )
             })
             .unwrap_or_default();
@@ -661,6 +663,7 @@ where
                     Some(move |_| ironwood_decrypted),
                     batch::try_note_decryption,
                     |action| MerkleHashOrchard::from_cmx(action.cmx()),
+                    |note| (note, orchard::ValuePool::Ironwood),
                 )
             })
             .unwrap_or_default();

--- a/zcash_client_backend/src/scanning/full.rs
+++ b/zcash_client_backend/src/scanning/full.rs
@@ -72,9 +72,16 @@ type TaggedOrchardBatchRunner<IvkTag, Tasks> = BatchRunner<
     Tasks,
 >;
 
-// An Ironwood batch is type-identical to an Orchard batch (`IronwoodDomain` aliases
-// `OrchardDomain`), so the Orchard task type already satisfies the runner's bound and no separate
-// task type is required; the alias only names the runner as belonging to the Ironwood pool.
+// Ironwood outputs are decrypted under the Ironwood note-encryption domain, which is distinct from
+// the Orchard domain (it accepts version 3 note plaintexts), so an Ironwood batch is a distinct
+// type from an Orchard batch and requires its own task type.
+#[cfg(feature = "orchard")]
+type TaggedIronwoodBatch<IvkTag> = Batch<
+    IvkTag,
+    IronwoodDomain,
+    orchard::Action<redpallas::Signature<redpallas::SpendAuth>>,
+    FullDecryptor,
+>;
 #[cfg(feature = "orchard")]
 type TaggedIronwoodBatchRunner<IvkTag, Tasks> = BatchRunner<
     IvkTag,
@@ -97,21 +104,37 @@ pub(crate) trait OrchardTasks<IvkTag>: Tasks<TaggedOrchardBatch<IvkTag>> {}
 #[cfg(feature = "orchard")]
 impl<IvkTag, T: Tasks<TaggedOrchardBatch<IvkTag>>> OrchardTasks<IvkTag> for T {}
 
-pub(crate) struct BatchRunners<IvkTag, TS: SaplingTasks<IvkTag>, TO: OrchardTasks<IvkTag>> {
+#[cfg(not(feature = "orchard"))]
+pub(crate) trait IronwoodTasks<IvkTag> {}
+#[cfg(not(feature = "orchard"))]
+impl<IvkTag, T> IronwoodTasks<IvkTag> for T {}
+
+#[cfg(feature = "orchard")]
+pub(crate) trait IronwoodTasks<IvkTag>: Tasks<TaggedIronwoodBatch<IvkTag>> {}
+#[cfg(feature = "orchard")]
+impl<IvkTag, T: Tasks<TaggedIronwoodBatch<IvkTag>>> IronwoodTasks<IvkTag> for T {}
+
+pub(crate) struct BatchRunners<
+    IvkTag,
+    TS: SaplingTasks<IvkTag>,
+    TO: OrchardTasks<IvkTag>,
+    TI: IronwoodTasks<IvkTag>,
+> {
     sapling: TaggedSaplingBatchRunner<IvkTag, TS>,
     #[cfg(feature = "orchard")]
     orchard: TaggedOrchardBatchRunner<IvkTag, TO>,
     #[cfg(feature = "orchard")]
-    ironwood: TaggedIronwoodBatchRunner<IvkTag, TO>,
+    ironwood: TaggedIronwoodBatchRunner<IvkTag, TI>,
     #[cfg(not(feature = "orchard"))]
-    orchard: PhantomData<TO>,
+    orchard: PhantomData<(TO, TI)>,
 }
 
-impl<IvkTag, TS, TO> BatchRunners<IvkTag, TS, TO>
+impl<IvkTag, TS, TO, TI> BatchRunners<IvkTag, TS, TO, TI>
 where
     IvkTag: Clone + Send + 'static,
     TS: SaplingTasks<IvkTag>,
     TO: OrchardTasks<IvkTag>,
+    TI: IronwoodTasks<IvkTag>,
 {
     /// Constructs a fresh set of batch runners that will trial-decrypt outputs using the
     /// given scanning keys.
@@ -191,7 +214,7 @@ where
         #[cfg(feature = "orchard")]
         let ironwood_batch = tx.ironwood_bundle().map(|bundle| {
             self.ironwood
-                .process_outputs(OrchardDomain::for_action, bundle.actions().iter().cloned())
+                .process_outputs(IronwoodDomain::for_action, bundle.actions().iter().cloned())
         });
 
         PendingBatch {
@@ -312,7 +335,7 @@ where
     P: consensus::Parameters + Send + 'static,
     IvkTag: Copy + Send + 'static,
 {
-    let mut runners = BatchRunners::<_, (), ()>::for_keys(
+    let mut runners = BatchRunners::<_, (), (), ()>::for_keys(
         DEFAULT_BATCH_SIZE_THRESHOLD,
         #[cfg(feature = "orchard")]
         DEFAULT_BATCH_SIZE_THRESHOLD,
@@ -633,7 +656,7 @@ where
                     &bundle
                         .actions()
                         .iter()
-                        .map(|action| (OrchardDomain::for_action(action), action.clone()))
+                        .map(|action| (IronwoodDomain::for_action(action), action.clone()))
                         .collect::<Vec<_>>(),
                     Some(move |_| ironwood_decrypted),
                     batch::try_note_decryption,

--- a/zcash_client_backend/src/sync/decryptor.rs
+++ b/zcash_client_backend/src/sync/decryptor.rs
@@ -339,7 +339,7 @@ where
         P: consensus::Parameters + Send + 'static,
     {
         let mut scanning_keys = Arc::new(reload_keys()?);
-        let mut runners = BatchRunners::<_, (), ()>::for_keys(
+        let mut runners = BatchRunners::<_, (), (), ()>::for_keys(
             self.sapling_batch_size_threshold,
             #[cfg(feature = "orchard")]
             self.orchard_batch_size_threshold,

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -563,35 +563,24 @@ pub type WalletSaplingOutput<AccountId> =
 /// [`Action`]: orchard::Action
 #[cfg(feature = "orchard")]
 pub type WalletOrchardOutput<AccountId> =
-    WalletOutput<orchard::note::Note, orchard::note::Nullifier, AccountId>;
+    WalletOutput<(orchard::note::Note, orchard::ValuePool), orchard::note::Nullifier, AccountId>;
 
-/// A type alias for Ironwood [`WalletOutput`]s.
+/// The output part of an Ironwood [`Action`] that was decrypted in the process of scanning.
 ///
-/// Ironwood notes are Orchard-shaped and therefore share the Orchard note and nullifier types, but
-/// Ironwood is a distinct pool from Orchard.
+/// [`Action`]: orchard::Action
 #[cfg(feature = "orchard")]
 pub type WalletIronwoodOutput<AccountId> =
-    WalletOutput<orchard::note::Note, orchard::note::Nullifier, AccountId>;
+    WalletOutput<(orchard::note::Note, orchard::ValuePool), orchard::note::Nullifier, AccountId>;
 
 /// An enumeration of supported shielded note types for use in [`ReceivedNote`]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Note {
     Sapling(sapling::Note),
     #[cfg(feature = "orchard")]
-    Orchard(orchard::Note),
-}
-
-impl From<sapling::Note> for Note {
-    fn from(note: sapling::Note) -> Self {
-        Note::Sapling(note)
-    }
-}
-
-#[cfg(feature = "orchard")]
-impl From<orchard::Note> for Note {
-    fn from(note: orchard::Note) -> Self {
-        Note::Orchard(note)
-    }
+    Orchard {
+        note: orchard::Note,
+        pool: orchard::ValuePool,
+    },
 }
 
 impl Note {
@@ -600,7 +589,7 @@ impl Note {
         match self {
             Note::Sapling(n) => Receiver::Sapling(n.recipient()),
             #[cfg(feature = "orchard")]
-            Note::Orchard(n) => Receiver::Orchard(n.recipient()),
+            Note::Orchard { note, .. } => Receiver::Orchard(note.recipient()),
         }
     }
 
@@ -610,18 +599,21 @@ impl Note {
                 "Sapling notes must have values in the range of valid non-negative ZEC values.",
             ),
             #[cfg(feature = "orchard")]
-            Note::Orchard(n) => Zatoshis::from_u64(n.value().inner()).expect(
+            Note::Orchard { note, .. } => Zatoshis::from_u64(note.value().inner()).expect(
                 "Orchard notes must have values in the range of valid non-negative ZEC values.",
             ),
         }
     }
 
-    /// Returns the shielded protocol used by this note.
-    pub fn protocol(&self) -> ShieldedPool {
+    /// Returns the shielded value pool to which this note belongs.
+    pub fn pool(&self) -> ShieldedPool {
         match self {
             Note::Sapling(_) => ShieldedPool::Sapling,
             #[cfg(feature = "orchard")]
-            Note::Orchard(_) => ShieldedPool::Orchard,
+            Note::Orchard { pool, .. } => match pool {
+                orchard::ValuePool::Ironwood => ShieldedPool::Ironwood,
+                orchard::ValuePool::Orchard => ShieldedPool::Orchard,
+            },
         }
     }
 }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -115,6 +115,12 @@ workspace.
   received at the address — moves to the deriving account, since successful derivation
   establishes that account's ownership of the address. Funds received at such an address
   become spendable once the account derives it.
+- Rewinding the wallet now truncates the Ironwood note commitment tree alongside the Sapling
+  and Orchard trees. Previously the Ironwood tree retained data for reorged-away blocks, so
+  re-scanning the replacement blocks failed with a shard root conflict on every attempt,
+  leaving the wallet unable to make sync progress. Truncation-height selection, the shared
+  minimum-checkpoint query, chain-state frontier re-anchoring, and the pruning-window
+  checkpoint-parity check now all account for the Ironwood tree as well.
 
 ## [0.21.1] - 2026-06-19
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -492,12 +492,39 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     index,
                     target_height,
                 )
-                .map(|opt| opt.map(|n| n.map_note(Note::Orchard)));
+                .map(|opt| {
+                    opt.map(|n| {
+                        n.map_note(|note| Note::Orchard {
+                            note,
+                            pool: ::orchard::ValuePool::Orchard,
+                        })
+                    })
+                });
 
                 #[cfg(not(feature = "orchard"))]
                 return Err(SqliteClientError::UnsupportedPoolType(PoolType::ORCHARD));
             }
-            ShieldedPool::Ironwood => todo!("Ironwood pool support is not yet implemented"),
+            ShieldedPool::Ironwood => {
+                #[cfg(feature = "orchard")]
+                return wallet::orchard::get_spendable_ironwood_note(
+                    self.conn.borrow(),
+                    &self.params,
+                    txid,
+                    index,
+                    target_height,
+                )
+                .map(|opt| {
+                    opt.map(|n| {
+                        n.map_note(|note| Note::Orchard {
+                            note,
+                            pool: ::orchard::ValuePool::Ironwood,
+                        })
+                    })
+                });
+
+                #[cfg(not(feature = "orchard"))]
+                return Err(SqliteClientError::UnsupportedPoolType(PoolType::IRONWOOD));
+            }
         }
     }
 
@@ -527,6 +554,20 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             #[cfg(feature = "orchard")]
             if sources.contains(&ShieldedPool::Orchard) {
                 wallet::orchard::select_spendable_orchard_notes(
+                    self.conn.borrow(),
+                    &self.params,
+                    account,
+                    target_value,
+                    target_height,
+                    confirmations_policy,
+                    exclude,
+                )?
+            } else {
+                vec![]
+            },
+            #[cfg(feature = "orchard")]
+            if sources.contains(&ShieldedPool::Ironwood) {
+                wallet::orchard::select_spendable_ironwood_notes(
                     self.conn.borrow(),
                     &self.params,
                     account,
@@ -574,6 +615,22 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ConfirmationsPolicy::MIN,
                     exclude,
                     ShieldedPool::Orchard,
+                    wallet::orchard::to_received_note,
+                    wallet::common::NoteRequest::Unspent,
+                )?
+            } else {
+                vec![]
+            },
+            #[cfg(feature = "orchard")]
+            if sources.contains(&ShieldedPool::Ironwood) {
+                wallet::common::select_unspent_notes(
+                    self.conn.borrow(),
+                    &self.params,
+                    account,
+                    target_height,
+                    ConfirmationsPolicy::MIN,
+                    exclude,
+                    ShieldedPool::Ironwood,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
                 )?

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -744,7 +744,23 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         #[cfg(not(feature = "orchard"))]
         let orchard_pool_meta = None;
 
-        Ok(AccountMeta::new(sapling_pool_meta, orchard_pool_meta))
+        #[cfg(feature = "orchard")]
+        let ironwood_pool_meta = unspent_notes_meta(
+            self.conn.borrow(),
+            ShieldedPool::Ironwood,
+            target_height,
+            account_id,
+            selector,
+            exclude,
+        )?;
+        #[cfg(not(feature = "orchard"))]
+        let ironwood_pool_meta = None;
+
+        Ok(AccountMeta::new(
+            sapling_pool_meta,
+            orchard_pool_meta,
+            ironwood_pool_meta,
+        ))
     }
 }
 

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -800,3 +800,15 @@ pub(crate) fn propose_and_build_shielding_coinbase_succeeds<T: ShieldedPoolTeste
         _,
     >(TestDbFactory::default(), BlockCache::new());
 }
+
+#[cfg(all(
+    feature = "orchard",
+    feature = "pczt-tests",
+    feature = "transparent-inputs"
+))]
+pub(crate) fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood() {
+    zcash_client_backend::data_api::testing::pool::shielding_coinbase_to_orchard_receiver_delivers_via_ironwood(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3676,28 +3676,26 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
 }
 
 /// Returns the minimum checkpoint height that exists in all note commitment trees that contain
-/// data. When both trees have checkpoints, returns the minimum of their intersection. When only
-/// one tree has checkpoints, returns that tree's minimum. Returns `None` when both are empty.
+/// data. A height qualifies when every tree that has any checkpoints has a checkpoint at that
+/// height. Returns `None` when all trees are empty.
 fn min_shared_checkpoint_height(
     conn: &rusqlite::Connection,
 ) -> Result<Option<BlockHeight>, SqliteClientError> {
     Ok(conn
         .query_row(
             "SELECT MIN(checkpoint_id) FROM (
-                -- When both trees have checkpoints, returns the minimum of their intersection.
-                SELECT MIN(sc.checkpoint_id) AS checkpoint_id
-                    FROM sapling_tree_checkpoints sc
-                    JOIN orchard_tree_checkpoints oc ON oc.checkpoint_id = sc.checkpoint_id
-                -- When only one tree has checkpoints, returns that tree's minimum.
-                UNION ALL
-                    SELECT MIN(sc.checkpoint_id) AS checkpoint_id
-                    FROM sapling_tree_checkpoints sc
-                    WHERE NOT EXISTS (SELECT 1 FROM orchard_tree_checkpoints)
-                UNION ALL
-                    SELECT MIN(oc.checkpoint_id) AS checkpoint_id
-                    FROM orchard_tree_checkpoints oc
-                    WHERE NOT EXISTS (SELECT 1 FROM sapling_tree_checkpoints)
-             )",
+                SELECT checkpoint_id FROM sapling_tree_checkpoints
+                UNION
+                SELECT checkpoint_id FROM orchard_tree_checkpoints
+                UNION
+                SELECT checkpoint_id FROM ironwood_tree_checkpoints
+             )
+             WHERE (checkpoint_id IN (SELECT checkpoint_id FROM sapling_tree_checkpoints)
+                    OR NOT EXISTS (SELECT 1 FROM sapling_tree_checkpoints))
+             AND (checkpoint_id IN (SELECT checkpoint_id FROM orchard_tree_checkpoints)
+                  OR NOT EXISTS (SELECT 1 FROM orchard_tree_checkpoints))
+             AND (checkpoint_id IN (SELECT checkpoint_id FROM ironwood_tree_checkpoints)
+                  OR NOT EXISTS (SELECT 1 FROM ironwood_tree_checkpoints))",
             [],
             |row| row.get::<_, Option<u32>>(0),
         )
@@ -3713,7 +3711,7 @@ fn min_shared_checkpoint_height(
 /// "active" is defined according to the features enabled on this crate.
 ///
 /// This will return the height that has a checkpoint in every tree that contains data. The orchard
-/// table exists unconditionally but is empty when the orchard feature is not active.
+/// and ironwood tables exist unconditionally but are empty when the orchard feature is not active.
 fn select_truncation_height(
     conn: &rusqlite::Transaction,
     requested_height: BlockHeight,
@@ -3725,6 +3723,8 @@ fn select_truncation_height(
             AND height IN (SELECT checkpoint_id FROM sapling_tree_checkpoints)
             AND (height IN (SELECT checkpoint_id FROM orchard_tree_checkpoints)
                  OR NOT EXISTS (SELECT 1 FROM orchard_tree_checkpoints))
+            AND (height IN (SELECT checkpoint_id FROM ironwood_tree_checkpoints)
+                 OR NOT EXISTS (SELECT 1 FROM ironwood_tree_checkpoints))
             "#,
         named_params! {":requested_height": u32::from(requested_height)},
         |row| row.get::<_, Option<u32>>(0),
@@ -3760,8 +3760,8 @@ fn select_truncation_height(
 ///   checkpoint at or below `max_height` to truncate to. The error payload reports the
 ///   safe rewind height, if one could be determined.
 /// - [`SqliteClientError::TruncateCommitmentTree`] if truncating one of the wallet's
-///   Sapling or Orchard note commitment trees to the resolved checkpoint fails. The error
-///   payload identifies the affected shielded pool and the target height.
+///   Sapling, Orchard, or Ironwood note commitment trees to the resolved checkpoint fails.
+///   The error payload identifies the affected shielded pool and the target height.
 /// - [`SqliteClientError::DbError`] if an underlying SQLite operation fails.
 pub(crate) fn truncate_to_height<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
@@ -3862,6 +3862,16 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
                 })?;
             Ok::<_, SqliteClientError>(())
         })?;
+        #[cfg(feature = "orchard")]
+        wdb.with_ironwood_tree_mut(|tree| {
+            tree.truncate_to_checkpoint(&truncation_height)
+                .map_err(|error| SqliteClientError::TruncateCommitmentTree {
+                    pool: ShieldedPool::Ironwood,
+                    height: truncation_height,
+                    error,
+                })?;
+            Ok::<_, SqliteClientError>(())
+        })?;
 
         // Do not delete sent notes; this can contain data that is not recoverable
         // from the chain. Wallets must continue to operate correctly in the
@@ -3903,11 +3913,12 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
 ///
 /// # Errors
 ///
-/// - [`SqliteClientError::TruncateCommitmentTree`] if inserting the chain-state frontier as a
-///   checkpoint, or truncating one of the wallet's Sapling or Orchard note commitment trees to a
-///   checkpoint, fails. The error payload identifies the affected shielded pool and the target
-///   height. Unlike [`truncate_to_height`], a missing checkpoint at the target height is not an
-///   error here: it is recovered from by inserting the provided frontier as a new checkpoint.
+/// - [`SqliteClientError::TruncateCommitmentTree`] if inserting a chain-state frontier as a
+///   checkpoint, or truncating one of the wallet's Sapling, Orchard, or Ironwood note commitment
+///   trees to a checkpoint, fails. The error payload identifies the affected shielded pool and the
+///   target height. Unlike [`truncate_to_height`], a missing checkpoint at the target height is
+///   not an error here: it is recovered from by inserting the provided frontier as a new
+///   checkpoint.
 /// - [`SqliteClientError::DbError`] if an underlying SQLite operation fails.
 pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
     wdb: &mut WalletDb<SqlTransaction<'_>, P, CL, R>,
@@ -4002,6 +4013,23 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
             )
             .map_err(|error| SqliteClientError::TruncateCommitmentTree {
                 pool: ShieldedPool::Orchard,
+                height: target_height,
+                error,
+            })?;
+            Ok::<_, SqliteClientError>(())
+        })?;
+
+        #[cfg(feature = "orchard")]
+        wdb.with_ironwood_tree_mut(|tree| {
+            tree.insert_frontier(
+                chain_state.final_ironwood_tree().clone(),
+                Retention::Checkpoint {
+                    id: target_height,
+                    marking: Marking::None,
+                },
+            )
+            .map_err(|error| SqliteClientError::TruncateCommitmentTree {
+                pool: ShieldedPool::Ironwood,
                 height: target_height,
                 error,
             })?;
@@ -4142,8 +4170,8 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
 
             #[cfg(feature = "orchard")]
             {
-                // Check that Orchard checkpoint matches the Sapling checkpoint. These should
-                // always match unless the database is corrupted.
+                // Check that the Orchard and Ironwood checkpoints match the Sapling checkpoint.
+                // These should always match unless the database is corrupted.
                 let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
                     conn,
                     crate::ORCHARD_TABLES_PREFIX,
@@ -4155,6 +4183,20 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
                 if orchard_window_floor != sapling_window_floor {
                     return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
                         "Sapling and Orchard should have the same checkpoints".into(),
+                    )));
+                }
+
+                let ironwood_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+                    conn,
+                    crate::IRONWOOD_TABLES_PREFIX,
+                    truncation_target,
+                )
+                .map_err(ShardTreeError::Storage)
+                .map_err(SqliteClientError::from)
+                .map_err(RewindError::DataSource)?;
+                if ironwood_window_floor != sapling_window_floor {
+                    return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
+                        "Sapling and Ironwood should have the same checkpoints".into(),
                     )));
                 }
             }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2695,6 +2695,33 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         drop(orchard_trace);
     }
 
+    #[cfg(feature = "orchard")]
+    {
+        let ironwood_trace = tracing::info_span!("ironwood_balances").entered();
+        with_pool_balances(
+            tx,
+            target_height,
+            anchor_height,
+            confirmations_policy,
+            &mut account_balances,
+            ShieldedPool::Ironwood,
+            |balances,
+             spendable_value,
+             change_pending_confirmation,
+             value_pending_spendability,
+             uneconomic_value| {
+                balances.with_ironwood_balance_mut::<_, SqliteClientError>(|bal| {
+                    bal.add_spendable_value(spendable_value)?;
+                    bal.add_pending_change_value(change_pending_confirmation)?;
+                    bal.add_pending_spendable_value(value_pending_spendability)?;
+                    bal.add_uneconomic_value(uneconomic_value)?;
+                    Ok(())
+                })
+            },
+        )?;
+        drop(ironwood_trace);
+    }
+
     let sapling_trace = tracing::info_span!("sapling_balances").entered();
     with_pool_balances(
         tx,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3399,6 +3399,18 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
         #[cfg(not(feature = "orchard"))]
         panic!("Sent a transaction with Orchard Actions without `orchard` enabled?");
     }
+    if let Some(_bundle) = sent_tx.tx().ironwood_bundle() {
+        #[cfg(feature = "orchard")]
+        {
+            detectable_via_scanning = true;
+            for action in _bundle.actions() {
+                orchard::mark_ironwood_note_spent(conn, tx_ref, action.nullifier())?;
+            }
+        }
+
+        #[cfg(not(feature = "orchard"))]
+        panic!("Sent a transaction with Ironwood Actions without `orchard` enabled?");
+    }
 
     #[cfg(feature = "transparent-inputs")]
     for utxo_outpoint in sent_tx.utxos_spent() {
@@ -3467,6 +3479,7 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                         &DecryptedOutput::new(
                             output.output_index(),
                             note.clone(),
+                            ShieldedPool::Sapling,
                             *receiving_account,
                             output
                                 .memo()
@@ -3479,13 +3492,10 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                     )?;
                 }
                 #[cfg(feature = "orchard")]
-                Note::Orchard(note) => {
-                    // The decrypted-transaction path handles a single Orchard-domain output
-                    // stream, so the target pool table is selected from the note's plaintext
-                    // version: version 2 notes belong to Orchard, version 3 notes to Ironwood.
-                    let shielded_pool = match note.version() {
-                        ::orchard::note::NoteVersion::V2 => ShieldedPool::Orchard,
-                        ::orchard::note::NoteVersion::V3 => ShieldedPool::Ironwood,
+                Note::Orchard { note, pool } => {
+                    let shielded_pool = match pool {
+                        ::orchard::ValuePool::Orchard => ShieldedPool::Orchard,
+                        ::orchard::ValuePool::Ironwood => ShieldedPool::Ironwood,
                     };
                     orchard::put_received_note(
                         conn,
@@ -3493,7 +3503,8 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                         shielded_pool,
                         &DecryptedOutput::new(
                             output.output_index(),
-                            *note,
+                            (*note, *pool),
+                            shielded_pool,
                             *receiving_account,
                             output
                                 .memo()
@@ -4787,7 +4798,7 @@ fn recipient_params<P: consensus::Parameters>(
                 from_account_id,
                 external_address.as_ref().map(|a| a.encode()),
                 Some(to_account),
-                PoolType::Shielded(note.protocol()),
+                PoolType::Shielded(note.pool()),
             ))
         }
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5395,6 +5395,7 @@ mod tests {
             )],
             0,
             0,
+            0,
             false,
         );
         let (mid_height, _, _) =
@@ -5540,6 +5541,7 @@ mod tests {
             )],
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            0,
             false,
         );
         for _ in 1..10 {
@@ -5693,6 +5695,7 @@ mod tests {
             )],
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            0,
             false,
         );
         for _ in 1..10 {
@@ -5866,6 +5869,7 @@ mod tests {
             )],
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            0,
             false,
         );
         for _ in 1..10 {

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -397,7 +397,6 @@ pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
-    ironwood_shardtree::MIGRATION_ID,
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
     add_transparent_receiver_address_index::MIGRATION_ID,
@@ -469,6 +468,26 @@ pub(crate) mod tests {
         testing::db::{test_clock, test_rng},
         wallet::init::WalletMigrator,
     };
+
+    /// `CURRENT_LEAF_MIGRATIONS` must list exactly the leaves of the migration dependency graph
+    /// (the migrations that no other migration depends on), so that migrating to the current
+    /// state reaches every migration. This recomputes the leaves from the graph and checks them
+    /// against the constant, so a newly added migration that supersedes an existing leaf cannot
+    /// silently leave a stale entry behind.
+    #[test]
+    fn current_leaf_migrations_are_the_dag_leaves() {
+        use schemerz::Migration;
+
+        let migrations =
+            super::all_migrations(&Network::TestNetwork, test_clock(), test_rng(), None);
+
+        let all_ids: HashSet<Uuid> = migrations.iter().map(|m| m.id()).collect();
+        let depended: HashSet<Uuid> = migrations.iter().flat_map(|m| m.dependencies()).collect();
+        let computed_leaves: HashSet<Uuid> = all_ids.difference(&depended).copied().collect();
+
+        let listed_leaves: HashSet<Uuid> = super::CURRENT_LEAF_MIGRATIONS.iter().copied().collect();
+        assert_eq!(computed_leaves, listed_leaves);
+    }
 
     /// A synthetic set of Orchard note payload values, for exercising migrations that touch the
     /// `orchard_received_notes` table.

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -197,6 +197,8 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                         vec![],
                         #[cfg(feature = "orchard")]
                         vec![],
+                        #[cfg(feature = "orchard")]
+                        vec![],
                     );
 
                     queue_transparent_input_retrieval(conn, tx_ref, &d_tx)?;

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -157,6 +157,52 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
     )
 }
 
+/// Returns a single spendable Ironwood note, identified by the transaction that produced it and
+/// its action index. Ironwood notes are Orchard-shaped, so this reuses the Orchard note
+/// reconstruction; only the pool (and thus the `ironwood_received_notes` table) differs.
+pub(crate) fn get_spendable_ironwood_note<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    txid: &TxId,
+    index: u32,
+    target_height: TargetHeight,
+) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    super::common::get_spendable_note(
+        conn,
+        params,
+        txid,
+        index,
+        ShieldedPool::Ironwood,
+        target_height,
+        to_received_note,
+    )
+}
+
+/// Selects spendable Ironwood notes to satisfy the given target value. Ironwood notes are
+/// Orchard-shaped, so this reuses the Orchard note reconstruction; only the pool (and thus the
+/// `ironwood_received_notes` table) differs.
+pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    target_value: TargetValue,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    exclude: &[ReceivedNoteId],
+) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    super::common::select_spendable_notes(
+        conn,
+        params,
+        account,
+        target_value,
+        target_height,
+        confirmations_policy,
+        exclude,
+        ShieldedPool::Ironwood,
+        to_received_note,
+    )
+}
+
 pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -871,6 +917,7 @@ pub(crate) mod tests {
     #[test]
     fn put_received_note_records_to_caller_selected_table() {
         use orchard::{
+            ValuePool,
             keys::{FullViewingKey, SpendingKey},
             note::{Note, NoteVersion, RandomSeed, Rho},
             value::NoteValue,
@@ -909,10 +956,15 @@ pub(crate) mod tests {
             ))
             .unwrap()
         };
-        let output = |index: usize, note: Note| {
+        let output = |index: usize, note: Note, pool: ValuePool| {
+            let shielded_pool = match pool {
+                ValuePool::Orchard => ShieldedPool::Orchard,
+                ValuePool::Ironwood => ShieldedPool::Ironwood,
+            };
             DecryptedOutput::new(
                 index,
-                note,
+                (note, pool),
+                shielded_pool,
                 account_uuid,
                 MemoBytes::empty(),
                 TransferType::AccountInternal,
@@ -936,7 +988,7 @@ pub(crate) mod tests {
             &tx,
             &network,
             ShieldedPool::Orchard,
-            &output(0, note(10_000, NoteVersion::V2)),
+            &output(0, note(10_000, NoteVersion::V2), ValuePool::Orchard),
             tx_ref,
             None,
             None,
@@ -946,7 +998,7 @@ pub(crate) mod tests {
             &tx,
             &network,
             ShieldedPool::Ironwood,
-            &output(0, note(20_000, NoteVersion::V3)),
+            &output(0, note(20_000, NoteVersion::V3), ValuePool::Ironwood),
             tx_ref,
             None,
             None,
@@ -1036,6 +1088,143 @@ pub(crate) mod tests {
         assert!(ironwood_shards > 0);
     }
 
+    /// End-to-end: a wallet that has received an Ironwood note can select and spend it. The
+    /// resulting transaction spends the Ironwood note (it carries an Ironwood bundle), pays a
+    /// nonzero fee, records the note as spent, and reduces the account balance.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn spend_received_ironwood_note() {
+        use std::convert::Infallible;
+
+        use zcash_client_backend::{
+            data_api::{
+                Account, WalletRead,
+                testing::{
+                    AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+                    pool::ShieldedPoolTester,
+                },
+                wallet::ConfirmationsPolicy,
+                wallet::input_selection::GreedyInputSelector,
+            },
+            fees::{DustOutputPolicy, StandardFeeRule, standard},
+            wallet::OvkPolicy,
+        };
+        use zcash_keys::address::Address;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{
+            ShieldedPool, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
+        };
+        use zip321::{Payment, TransactionRequest};
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        // A network on which Ironwood (NU6.3) is active from the same height as Sapling, so
+        // received Ironwood notes are offered by input selection (which gates on NU6.3 activation)
+        // and can be spent.
+        let activation = BlockHeight::from_u32(100_000);
+        let network = LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        };
+
+        let mut st = TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let account_id = account.id();
+
+        // Receive an Ironwood note, comfortably larger than the payment and fee.
+        let received = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
+        let note_value = Zatoshis::const_from_u64(100_000);
+        let (h, _, _) = st.generate_next_block(&received, AddressType::DefaultExternal, note_value);
+        st.scan_cached_blocks(h, 1);
+        assert_eq!(st.get_total_balance(account_id), note_value);
+
+        // Advance the chain so the note's shard is fully scanned and an anchor is available.
+        for _ in 0..5 {
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+        }
+
+        // Propose and create a transfer that must spend the Ironwood note.
+        let to_sk = OrchardPoolTester::sk(&[0xf5; 32]);
+        let to: Address = OrchardPoolTester::sk_default_address(&to_sk);
+        let payment_value = Zatoshis::const_from_u64(10_000);
+        let request = TransactionRequest::new(vec![Payment::without_memo(
+            to.to_zcash_address(st.network()),
+            payment_value,
+        )])
+        .unwrap();
+
+        let fee_rule = StandardFeeRule::Zip317;
+        let change_strategy = standard::SingleOutputChangeStrategy::new(
+            fee_rule,
+            None,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+        );
+        let input_selector = GreedyInputSelector::new();
+
+        let proposal = st
+            .propose_transfer(
+                account_id,
+                &input_selector,
+                &change_strategy,
+                request,
+                ConfirmationsPolicy::MIN,
+            )
+            .unwrap();
+
+        let fee = proposal.steps().last().balance().fee_required();
+        assert!(fee.into_u64() > 0, "the transaction must pay a fee");
+
+        let created = st
+            .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                account.usk(),
+                OvkPolicy::Sender,
+                &proposal,
+            )
+            .unwrap();
+        assert_eq!(created.len(), 1);
+        let sent_txid = created[0];
+
+        // The created transaction spends into the Ironwood bundle.
+        let tx = st
+            .wallet()
+            .get_transaction(sent_txid)
+            .unwrap()
+            .expect("The sent transaction was stored.");
+        assert!(
+            tx.ironwood_bundle().is_some(),
+            "the transaction must contain an Ironwood bundle"
+        );
+
+        // The received Ironwood note is now recorded as spent.
+        let ironwood_spends: i64 = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT COUNT(*) FROM ironwood_received_note_spends",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ironwood_spends, 1, "the Ironwood note must be spent");
+
+        // The balance decreased by at least the payment plus the fee.
+        assert!(
+            st.get_total_balance(account_id) <= (note_value - payment_value - fee).unwrap(),
+            "the account balance must decrease by the payment and fee"
+        );
+    }
+
     #[test]
     #[cfg(feature = "orchard")]
     fn get_unspent_orchard_notes_at_historical_height_boundary_heights() {
@@ -1110,5 +1299,472 @@ pub(crate) mod tests {
             .sum::<Option<Zatoshis>>()
             .unwrap();
         assert_eq!(total, ((value - spend_value).unwrap() + value3).unwrap());
+    }
+
+    /// Property tests for the shielded-input pool-exclusivity rules enforced by input selection
+    /// once the Ironwood pool (NU6.3) is active:
+    ///
+    /// 1. Orchard inputs are never combined with Sapling or Ironwood inputs. Spending Orchard is a
+    ///    migration that drains the legacy pool, so it must be a pure Orchard-input transaction.
+    /// 2. Sapling and Ironwood inputs may be combined in a single transaction.
+    /// 3. If an amount would require Orchard PLUS another pool, input selection reports insufficient
+    ///    funds: the API user must first move the Orchard funds out (to Sapling or Ironwood) in a
+    ///    separate transaction.
+    /// 4. A payment to an Orchard receiver is routed to the Ironwood bundle once NU6.3 is active
+    ///    (no new Orchard payment outputs), and such a transaction builds successfully.
+    #[cfg(feature = "orchard")]
+    mod ironwood_privacy_invariants {
+        use std::convert::Infallible;
+
+        use proptest::prelude::*;
+
+        use zcash_client_backend::{
+            data_api::{
+                Account, WalletRead,
+                testing::{
+                    AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+                    pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+                },
+                wallet::{ConfirmationsPolicy, input_selection::GreedyInputSelector},
+            },
+            fees::{DustOutputPolicy, StandardFeeRule, standard},
+            wallet::OvkPolicy,
+        };
+        use zcash_keys::address::Address;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{
+            PoolType, ShieldedPool, consensus::BlockHeight, local_consensus::LocalNetwork,
+            value::Zatoshis,
+        };
+        use zip321::{Payment, TransactionRequest};
+
+        use crate::testing::{
+            BlockCache,
+            db::{TestDb, TestDbFactory},
+        };
+
+        // A network on which Ironwood (NU6.3) is active from the Sapling activation height, so
+        // received Ironwood notes are offered by input selection (which gates on NU6.3 activation).
+        fn ironwood_active_network() -> LocalNetwork {
+            let activation = BlockHeight::from_u32(100_000);
+            LocalNetwork {
+                nu6: Some(activation),
+                nu6_1: Some(activation),
+                nu6_2: Some(activation),
+                nu6_3: Some(activation),
+                ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+            }
+        }
+
+        // A single-output ZIP 317 change strategy. Its nominal change pool is Orchard, but once
+        // Ironwood is active any Orchard-pool change is routed into the Ironwood bundle (the
+        // Orchard V3 bundle forbids cross-address outputs, so change cannot stay in it).
+        fn orchard_change_strategy() -> standard::SingleOutputChangeStrategy<TestDb> {
+            standard::SingleOutputChangeStrategy::new(
+                StandardFeeRule::Zip317,
+                None,
+                ShieldedPool::Orchard,
+                DustOutputPolicy::default(),
+            )
+        }
+
+        // Returns the shielded input notes selected across a proposal as a
+        // (sapling, orchard, ironwood) tuple, using `Proposal::input_count_in_pool`.
+        fn input_pool_counts<FeeRuleT, NoteRef>(
+            proposal: &zcash_client_backend::proposal::Proposal<FeeRuleT, NoteRef>,
+        ) -> (usize, usize, usize) {
+            (
+                proposal.input_count_in_pool(PoolType::SAPLING),
+                proposal.input_count_in_pool(PoolType::ORCHARD),
+                proposal.input_count_in_pool(PoolType::IRONWOOD),
+            )
+        }
+
+        // Requests a payment of `payment_zats` to an Orchard receiver that is not owned by the
+        // wallet.
+        fn orchard_payment_request(
+            st_network: &LocalNetwork,
+            payment_zats: u64,
+        ) -> TransactionRequest {
+            let to_sk = OrchardPoolTester::sk(&[0xf5; 32]);
+            let to: Address = OrchardPoolTester::sk_default_address(&to_sk);
+            TransactionRequest::new(vec![Payment::without_memo(
+                to.to_zcash_address(st_network),
+                Zatoshis::from_u64(payment_zats).unwrap(),
+            )])
+            .unwrap()
+        }
+
+        prop_compose! {
+            // An Orchard note value (which may or may not, on its own, cover the payment) alongside
+            // large Sapling and Ironwood notes that always cover it, plus a small payment. This lets
+            // input selection freely choose between spending Orchard alone or the Sapling+Ironwood
+            // group.
+            fn arb_mixed_pool_amounts()(
+                orchard_zats in 5_000u64..300_000u64,
+                payment_zats in 10_000u64..40_000u64,
+            ) -> (u64, u64) {
+                (orchard_zats, payment_zats)
+            }
+        }
+
+        prop_compose! {
+            // Two moderate note values (used for Sapling and Ironwood) and a payment that exceeds
+            // either note on its own but is covered by the two together, with a comfortable fee
+            // margin: `2 * pool_zats - payment == pool_zats - extra_zats >= 50_000`, which safely
+            // exceeds the fee of a multi-bundle transaction.
+            fn arb_combined_amounts()(
+                pool_zats in 70_000u64..90_000u64,
+                extra_zats in 5_000u64..20_000u64,
+            ) -> (u64, u64) {
+                // payment is strictly greater than a single note but below the two combined.
+                (pool_zats, pool_zats + extra_zats)
+            }
+        }
+
+        prop_compose! {
+            // A single Orchard note value large enough to fund the payment and fee, leaving change,
+            // plus the payment amount.
+            fn arb_single_pool_amount()(
+                note_zats in 80_000u64..400_000u64,
+                payment_zats in 10_000u64..40_000u64,
+            ) -> (u64, u64) {
+                (note_zats, payment_zats)
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(8))]
+
+            /// Rule 1: Orchard inputs are never combined with Sapling or Ironwood inputs. The wallet
+            /// holds notes in all three pools; whenever an Orchard note is spent, no Sapling or
+            /// Ironwood note is spent in the same transaction. (When the Orchard note alone covers
+            /// the amount it is preferred, draining the legacy pool; otherwise the Sapling+Ironwood
+            /// group funds the payment and no Orchard note is touched.)
+            #[test]
+            fn orchard_inputs_are_never_combined_with_sapling_or_ironwood(
+                (orchard_zats, payment_zats) in arb_mixed_pool_amounts(),
+            ) {
+                let mut st = TestBuilder::new()
+                    .with_network(ironwood_active_network())
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_block_cache(BlockCache::new())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account = st.test_account().cloned().unwrap();
+                let account_id = account.id();
+
+                // Receive one Orchard note, one Sapling note, and one Ironwood note. The Sapling and
+                // Ironwood notes are large enough to fund the payment on their own.
+                let (h, _, _) = st.generate_next_block(
+                    &OrchardPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(orchard_zats).unwrap(),
+                );
+                st.generate_next_block(
+                    &SaplingPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::const_from_u64(200_000),
+                );
+                st.generate_next_block(
+                    &IronwoodFvk(OrchardPoolTester::test_account_fvk(&st)),
+                    AddressType::DefaultExternal,
+                    Zatoshis::const_from_u64(200_000),
+                );
+                st.scan_cached_blocks(h, 3);
+
+                for _ in 0..5 {
+                    let (h, _) = st.generate_empty_block();
+                    st.scan_cached_blocks(h, 1);
+                }
+
+                let request = orchard_payment_request(st.network(), payment_zats);
+                let change_strategy = orchard_change_strategy();
+                let input_selector = GreedyInputSelector::new();
+                let proposal = st
+                    .propose_transfer(
+                        account_id,
+                        &input_selector,
+                        &change_strategy,
+                        request,
+                        ConfirmationsPolicy::MIN,
+                    )
+                    .unwrap();
+
+                let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
+                prop_assert!(
+                    sapling + orchard + ironwood > 0,
+                    "the transaction must spend some notes"
+                );
+                // Orchard is never combined with Sapling or Ironwood.
+                if orchard > 0 {
+                    prop_assert_eq!(
+                        (sapling, ironwood),
+                        (0, 0),
+                        "Orchard inputs must not be combined with Sapling ({}) or Ironwood ({})",
+                        sapling,
+                        ironwood,
+                    );
+                }
+            }
+
+            /// Rule 2: Sapling and Ironwood inputs may be combined. The wallet holds only a Sapling
+            /// note and an Ironwood note, each too small to fund the payment alone; the transaction
+            /// spends both, and no Orchard note is involved.
+            #[test]
+            fn sapling_and_ironwood_inputs_may_be_combined(
+                (pool_zats, payment_zats) in arb_combined_amounts(),
+            ) {
+                let mut st = TestBuilder::new()
+                    .with_network(ironwood_active_network())
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_block_cache(BlockCache::new())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account = st.test_account().cloned().unwrap();
+                let account_id = account.id();
+
+                let (h, _, _) = st.generate_next_block(
+                    &SaplingPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.generate_next_block(
+                    &IronwoodFvk(OrchardPoolTester::test_account_fvk(&st)),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.scan_cached_blocks(h, 2);
+
+                for _ in 0..5 {
+                    let (h, _) = st.generate_empty_block();
+                    st.scan_cached_blocks(h, 1);
+                }
+
+                let request = orchard_payment_request(st.network(), payment_zats);
+                let change_strategy = orchard_change_strategy();
+                let input_selector = GreedyInputSelector::new();
+                let proposal = st
+                    .propose_transfer(
+                        account_id,
+                        &input_selector,
+                        &change_strategy,
+                        request,
+                        ConfirmationsPolicy::MIN,
+                    )
+                    .unwrap();
+
+                let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
+                prop_assert_eq!(orchard, 0, "no Orchard note is present to spend");
+                prop_assert!(sapling > 0, "a Sapling note must be spent");
+                prop_assert!(
+                    ironwood > 0,
+                    "an Ironwood note must be spent (combined with Sapling)"
+                );
+            }
+
+            /// Rule 3: an amount that would require Orchard PLUS another pool must fail. The wallet
+            /// holds an Orchard note and a Sapling note, each too small to fund the payment alone;
+            /// since Orchard cannot be combined with Sapling, input selection reports insufficient
+            /// funds rather than spending both.
+            #[test]
+            fn orchard_plus_another_pool_is_insufficient(
+                (pool_zats, payment_zats) in arb_combined_amounts(),
+            ) {
+                let mut st = TestBuilder::new()
+                    .with_network(ironwood_active_network())
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_block_cache(BlockCache::new())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account = st.test_account().cloned().unwrap();
+                let account_id = account.id();
+
+                let (h, _, _) = st.generate_next_block(
+                    &OrchardPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.generate_next_block(
+                    &SaplingPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.scan_cached_blocks(h, 2);
+
+                for _ in 0..5 {
+                    let (h, _) = st.generate_empty_block();
+                    st.scan_cached_blocks(h, 1);
+                }
+
+                let request = orchard_payment_request(st.network(), payment_zats);
+                let change_strategy = orchard_change_strategy();
+                let input_selector = GreedyInputSelector::new();
+                let result = st.propose_transfer(
+                    account_id,
+                    &input_selector,
+                    &change_strategy,
+                    request,
+                    ConfirmationsPolicy::MIN,
+                );
+
+                let err = result.expect_err(
+                    "spending must fail: Orchard cannot be combined with Sapling to reach the amount",
+                );
+                prop_assert!(
+                    format!("{err:?}").contains("InsufficientFunds"),
+                    "expected an InsufficientFunds error, got: {:?}",
+                    err,
+                );
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(2))]
+
+            /// Rule 4 at the built-transaction level: when the wallet spends an Orchard note to pay
+            /// an Orchard receiver, the payment is carried by the Ironwood bundle while the change
+            /// stays in the Orchard bundle (returned to the spent note's own address), and the
+            /// transaction builds successfully. This proves the transaction the builder actually
+            /// constructs, not just the proposal.
+            #[test]
+            fn orchard_payment_routes_to_ironwood_and_builds(
+                (note_zats, payment_zats) in arb_single_pool_amount(),
+            ) {
+                let mut st = TestBuilder::new()
+                    .with_network(ironwood_active_network())
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_block_cache(BlockCache::new())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account = st.test_account().cloned().unwrap();
+                let account_id = account.id();
+
+                let (h, _, _) = st.generate_next_block(
+                    &OrchardPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(note_zats).unwrap(),
+                );
+                st.scan_cached_blocks(h, 1);
+
+                for _ in 0..5 {
+                    let (h, _) = st.generate_empty_block();
+                    st.scan_cached_blocks(h, 1);
+                }
+
+                let request = orchard_payment_request(st.network(), payment_zats);
+                let change_strategy = orchard_change_strategy();
+                let input_selector = GreedyInputSelector::new();
+                let proposal = st
+                    .propose_transfer(
+                        account_id,
+                        &input_selector,
+                        &change_strategy,
+                        request,
+                        ConfirmationsPolicy::MIN,
+                    )
+                    .unwrap();
+
+                // Only the Orchard note is spent (single-pool inputs).
+                let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
+                prop_assert!(orchard > 0, "the Orchard note must be spent");
+                prop_assert_eq!(
+                    (sapling, ironwood),
+                    (0, 0),
+                    "only Orchard notes should be spent"
+                );
+
+                let created = st
+                    .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                        account.usk(),
+                        OvkPolicy::Sender,
+                        &proposal,
+                    )
+                    .unwrap();
+                prop_assert_eq!(created.len(), 1);
+
+                let tx = st
+                    .wallet()
+                    .get_transaction(created[0])
+                    .unwrap()
+                    .expect("the sent transaction was stored");
+
+                // The Orchard-receiver payment is carried by the Ironwood bundle; the Orchard bundle
+                // carries the Orchard spend and the same-address change.
+                prop_assert!(
+                    tx.ironwood_bundle().is_some(),
+                    "the payment to an Orchard receiver must be routed to the Ironwood bundle",
+                );
+
+                // The spend of the received Orchard note must be represented in the Orchard
+                // bundle, not mistakenly in the Ironwood bundle (an easy protocol confusion):
+                // the nullifier the wallet recorded for the note must appear among the Orchard
+                // bundle's action nullifiers and be absent from the Ironwood bundle's.
+                let spent_nf: [u8; 32] = st
+                    .wallet_mut()
+                    .conn_mut()
+                    .query_row(
+                        // The spent note is the only one that has been scanned, and thus the
+                        // only one whose nullifier has been recorded; the change note stored
+                        // when the transaction was sent has not yet been mined.
+                        "SELECT nf FROM orchard_received_notes WHERE nf IS NOT NULL",
+                        [],
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .unwrap()
+                    .try_into()
+                    .expect("nullifiers are 32 bytes");
+                prop_assert!(
+                    tx.orchard_bundle()
+                        .into_iter()
+                        .flat_map(|bundle| bundle.actions())
+                        .any(|action| action.nullifier().to_bytes() == spent_nf),
+                    "the Orchard spend must remain in the Orchard bundle",
+                );
+                prop_assert!(
+                    !tx.ironwood_bundle()
+                        .into_iter()
+                        .flat_map(|bundle| bundle.actions())
+                        .any(|action| action.nullifier().to_bytes() == spent_nf),
+                    "the Orchard spend must not be represented in the Ironwood bundle",
+                );
+
+                // The change stays in the Orchard pool. Only the payment crosses the turnstile into
+                // Ironwood (to a receiver the wallet does not own), so the wallet owns no Ironwood
+                // note, and the retained change is recorded as an Orchard note of the expected value.
+                let fee = proposal.steps().head.balance().fee_required();
+                let expected_change = (Zatoshis::from_u64(note_zats).unwrap()
+                    - Zatoshis::from_u64(payment_zats).unwrap()
+                    - fee)
+                    .unwrap();
+                prop_assume!(expected_change.into_u64() > 0);
+
+                let conn = st.wallet_mut().conn_mut();
+                let ironwood_notes: i64 = conn
+                    .query_row("SELECT COUNT(*) FROM ironwood_received_notes", [], |r| r.get(0))
+                    .unwrap();
+                prop_assert_eq!(
+                    ironwood_notes,
+                    0,
+                    "the change must not cross the turnstile into the Ironwood pool"
+                );
+                let orchard_change: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM orchard_received_notes WHERE value = ?1",
+                        [i64::try_from(expected_change.into_u64()).unwrap()],
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                prop_assert_eq!(
+                    orchard_change,
+                    1,
+                    "the change must be retained as an Orchard note of the expected value"
+                );
+            }
+        }
     }
 }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1094,6 +1094,78 @@ pub(crate) mod tests {
         assert!(ironwood_shards > 0);
     }
 
+    /// Regression test: rewinding the wallet must truncate the Ironwood note commitment tree
+    /// along with the Sapling and Orchard trees. Stale Ironwood tree state that survives a
+    /// rewind conflicts with the replacement chain's commitments, so every re-scan of the
+    /// reorged range fails with a shard root conflict and no retry can repair the wallet.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn truncation_resets_the_ironwood_tree() {
+        use zcash_client_backend::data_api::testing::{
+            AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+            pool::ShieldedPoolTester,
+        };
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::value::Zatoshis;
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let orchard_fvk = OrchardPoolTester::test_account_fvk(&st);
+        let ironwood_recipient = IronwoodFvk(orchard_fvk.clone());
+
+        // Establish a rewind target below any Ironwood activity.
+        let (h1, _, _) = st.generate_next_block(
+            &orchard_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10_000),
+        );
+        st.scan_cached_blocks(h1, 1);
+
+        // The next block pays an Ironwood note, giving the Ironwood tree data above the target.
+        let (h2, _, _) = st.generate_next_block(
+            &ironwood_recipient,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(20_000),
+        );
+        st.scan_cached_blocks(h2, 1);
+
+        // Reorg away the Ironwood block.
+        st.truncate_to_height(h1);
+
+        // The replacement block pays a different Ironwood note at the same height, so its note
+        // commitment differs from the reorged-away one at the same tree position.
+        let (h2b, _, _) = st.generate_next_block(
+            &ironwood_recipient,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(30_000),
+        );
+        assert_eq!(h2b, h2);
+        st.scan_cached_blocks(h2b, 1);
+
+        // Only the replacement chain's Ironwood note is mined; the reorged-away note survives
+        // solely as un-mined transaction data.
+        let (mined_count, mined_value): (i64, i64) = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT COUNT(*), COALESCE(MIN(irn.value), 0)
+                 FROM ironwood_received_notes irn
+                 JOIN transactions tx ON tx.id_tx = irn.transaction_id
+                 WHERE tx.mined_height IS NOT NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(mined_count, 1);
+        assert_eq!(mined_value as u64, 30_000);
+    }
+
     /// End-to-end: a wallet that has received an Ironwood note can select and spend it. The
     /// resulting transaction spends the Ironwood note (it carries an Ironwood bundle), pays a
     /// nonzero fee, records the note as spent, and reduces the account balance.

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -966,9 +966,8 @@ pub(crate) mod tests {
     }
 
     /// End-to-end: a wallet that scans a block containing an Ironwood (version 3) note stores it in
-    /// `ironwood_received_notes` as note version 3, persists the Ironwood note commitment tree, and
-    /// records nothing in the Orchard tables. The note is not yet reflected in the wallet balance
-    /// (see the TODO below).
+    /// `ironwood_received_notes` as note version 3, counts it in the wallet balance, persists the
+    /// Ironwood note commitment tree, and records nothing in the Orchard tables.
     #[test]
     #[cfg(feature = "orchard")]
     fn scan_block_stores_received_ironwood_note() {
@@ -1023,12 +1022,8 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(orchard_count, 0);
 
-        // TODO: Ironwood notes are stored but are not yet reflected in the wallet balance. The
-        // `AccountBalance` model computed by `get_wallet_summary` has Sapling and Orchard
-        // components but no Ironwood component, so `get_total_balance` currently reports zero for a
-        // wallet holding only Ironwood notes. Change this assertion to expect `value` once an
-        // Ironwood balance is added to the wallet summary.
-        assert_eq!(st.get_total_balance(account_id), Zatoshis::ZERO);
+        // The received Ironwood note is reflected in the wallet balance.
+        assert_eq!(st.get_total_balance(account_id), value);
 
         // The Ironwood note commitment tree was persisted.
         let ironwood_shards: i64 = st

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1182,6 +1182,40 @@ pub(crate) mod tests {
             )
             .unwrap();
 
+        // Change from spending Ironwood notes stays in the Ironwood pool rather than crossing
+        // the turnstile back into Orchard.
+        let change = proposal.steps().last().balance().proposed_change();
+        assert!(!change.is_empty(), "the spend must produce change");
+        assert!(
+            change
+                .iter()
+                .all(|c| c.output_pool() == zcash_protocol::PoolType::IRONWOOD),
+            "change from an Ironwood spend must stay in the Ironwood pool"
+        );
+
+        // The Orchard-receiver payment is represented in the proposal as an Ironwood-pool
+        // output, since Ironwood is active; a user inspecting the proposal sees the Ironwood
+        // output being created.
+        assert!(
+            proposal
+                .steps()
+                .last()
+                .payment_pools()
+                .values()
+                .all(|p| *p == zcash_protocol::PoolType::IRONWOOD),
+            "the Orchard-receiver payment must be represented as an Ironwood output"
+        );
+
+        // A wallet application serializes the proposal to protobuf (e.g. to hand it across
+        // FFI for review/signing) before creating the transaction. A proposal that spends
+        // Ironwood notes must survive that round-trip.
+        let proposal_proto =
+            zcash_client_backend::proto::proposal::Proposal::from_standard_proposal(&proposal);
+        let roundtripped = proposal_proto
+            .try_into_standard_proposal(st.wallet())
+            .expect("Ironwood proposal round-trips through protobuf");
+        assert_eq!(roundtripped, proposal);
+
         let fee = proposal.steps().last().balance().fee_required();
         assert!(fee.into_u64() > 0, "the transaction must pay a fee");
 
@@ -1222,6 +1256,138 @@ pub(crate) mod tests {
         assert!(
             st.get_total_balance(account_id) <= (note_value - payment_value - fee).unwrap(),
             "the account balance must decrease by the payment and fee"
+        );
+    }
+
+    /// `decrypt_transaction` must decrypt a transaction's Ironwood bundle under the Ironwood
+    /// note-encryption domain, detecting a wallet-owned Ironwood output as an Ironwood note (and
+    /// not as Orchard). Decrypting under the Orchard domain would silently detect nothing.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn decrypt_transaction_detects_ironwood_output() {
+        use std::collections::HashMap;
+        use std::convert::Infallible;
+
+        use zcash_client_backend::{
+            data_api::{
+                Account, WalletRead,
+                testing::{
+                    AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+                    pool::ShieldedPoolTester,
+                },
+                wallet::ConfirmationsPolicy,
+                wallet::input_selection::GreedyInputSelector,
+            },
+            decrypt_transaction,
+            fees::{DustOutputPolicy, StandardFeeRule, standard},
+            wallet::OvkPolicy,
+        };
+        use zcash_keys::address::Address;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{
+            ShieldedPool, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
+        };
+        use zip321::{Payment, TransactionRequest};
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        let activation = BlockHeight::from_u32(100_000);
+        let network = LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        };
+
+        let mut st = TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let account_id = account.id();
+        let account_fvk = OrchardPoolTester::test_account_fvk(&st);
+
+        // Receive an Ironwood note to fund the transfer.
+        let received = IronwoodFvk(account_fvk.clone());
+        let note_value = Zatoshis::const_from_u64(100_000);
+        let (h, _, _) = st.generate_next_block(&received, AddressType::DefaultExternal, note_value);
+        st.scan_cached_blocks(h, 1);
+        for _ in 0..5 {
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+        }
+
+        // Pay the account's own Orchard address; while Ironwood is active this produces a
+        // wallet-owned Ironwood output.
+        let to: Address = OrchardPoolTester::fvk_default_address(&account_fvk);
+        let payment_value = Zatoshis::const_from_u64(10_000);
+        let request = TransactionRequest::new(vec![Payment::without_memo(
+            to.to_zcash_address(st.network()),
+            payment_value,
+        )])
+        .unwrap();
+
+        let change_strategy = standard::SingleOutputChangeStrategy::new(
+            StandardFeeRule::Zip317,
+            None,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+        );
+        let input_selector = GreedyInputSelector::new();
+        let proposal = st
+            .propose_transfer(
+                account_id,
+                &input_selector,
+                &change_strategy,
+                request,
+                ConfirmationsPolicy::MIN,
+            )
+            .unwrap();
+        let created = st
+            .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                account.usk(),
+                OvkPolicy::Sender,
+                &proposal,
+            )
+            .unwrap();
+        let tx = st
+            .wallet()
+            .get_transaction(created[0])
+            .unwrap()
+            .expect("The sent transaction was stored.");
+
+        // Decrypt the full transaction with the account's viewing keys.
+        let mut ufvks = HashMap::new();
+        ufvks.insert(account_id, account.ufvk().unwrap().clone());
+        let d_tx = decrypt_transaction(st.network(), None, None, &tx, &ufvks);
+
+        // The wallet-owned Ironwood outputs are detected under the Ironwood domain (not
+        // Orchard). Spending Ironwood funds to the account's own Orchard receiver produces both
+        // an Ironwood payment output and Ironwood change, so the payment is detected among them.
+        let ironwood: Vec<_> = d_tx
+            .ironwood_outputs()
+            .iter()
+            .filter(|o| o.value_pool() == ShieldedPool::Ironwood)
+            .collect();
+        assert!(
+            !ironwood.is_empty(),
+            "wallet-owned Ironwood outputs must be detected under the Ironwood domain"
+        );
+        assert!(
+            ironwood
+                .iter()
+                .any(|o| o.note().0.value().inner() == payment_value.into_u64()),
+            "the Ironwood self-payment output must be detected"
+        );
+        assert!(
+            d_tx.orchard_outputs()
+                .iter()
+                .all(|o| o.value_pool() == ShieldedPool::Orchard),
+            "Ironwood notes must not be misfiled as Orchard outputs"
         );
     }
 
@@ -1301,17 +1467,19 @@ pub(crate) mod tests {
         assert_eq!(total, ((value - spend_value).unwrap() + value3).unwrap());
     }
 
-    /// Property tests for the shielded-input pool-exclusivity rules enforced by input selection
-    /// once the Ironwood pool (NU6.3) is active:
+    /// Property tests for the Orchard-turnstile behavior of input selection and transaction
+    /// construction once the Ironwood pool (NU6.3) is active. The governing consensus rule is
+    /// that the Orchard value pool balance must be nonnegative: value may leave the Orchard
+    /// pool, but may not enter it. Consequently:
     ///
-    /// 1. Orchard inputs are never combined with Sapling or Ironwood inputs. Spending Orchard is a
-    ///    migration that drains the legacy pool, so it must be a pure Orchard-input transaction.
-    /// 2. Sapling and Ironwood inputs may be combined in a single transaction.
-    /// 3. If an amount would require Orchard PLUS another pool, input selection reports insufficient
-    ///    funds: the API user must first move the Orchard funds out (to Sapling or Ironwood) in a
-    ///    separate transaction.
-    /// 4. A payment to an Orchard receiver is routed to the Ironwood bundle once NU6.3 is active
-    ///    (no new Orchard payment outputs), and such a transaction builds successfully.
+    /// 1. A payment to an Orchard receiver is delivered via the Ironwood bundle (no new
+    ///    Orchard payment outputs), and such a transaction builds successfully.
+    /// 2. Pool crossing is minimized: when a single pool's notes can cover a payment, notes
+    ///    are spent from that pool alone, preferring the pool that matches the payment's
+    ///    outputs.
+    /// 3. Pools may be combined to fund a payment — including the legacy Orchard pool —
+    ///    with change directed to the Orchard pool only when strictly less value returns to
+    ///    that pool than the transaction's Orchard inputs remove from it.
     #[cfg(feature = "orchard")]
     mod ironwood_privacy_invariants {
         use std::convert::Infallible;
@@ -1357,8 +1525,9 @@ pub(crate) mod tests {
         }
 
         // A single-output ZIP 317 change strategy. Its nominal change pool is Orchard, but once
-        // Ironwood is active any Orchard-pool change is routed into the Ironwood bundle (the
-        // Orchard V3 bundle forbids cross-address outputs, so change cannot stay in it).
+        // Ironwood is active the change strategy observes the Orchard turnstile: change goes to
+        // Orchard only when Orchard notes are spent and strictly less value returns to the pool
+        // than the notes remove; otherwise Orchard-preferred change flows onward to Ironwood.
         fn orchard_change_strategy() -> standard::SingleOutputChangeStrategy<TestDb> {
             standard::SingleOutputChangeStrategy::new(
                 StandardFeeRule::Zip317,
@@ -1436,13 +1605,11 @@ pub(crate) mod tests {
         proptest! {
             #![proptest_config(ProptestConfig::with_cases(8))]
 
-            /// Rule 1: Orchard inputs are never combined with Sapling or Ironwood inputs. The wallet
-            /// holds notes in all three pools; whenever an Orchard note is spent, no Sapling or
-            /// Ironwood note is spent in the same transaction. (When the Orchard note alone covers
-            /// the amount it is preferred, draining the legacy pool; otherwise the Sapling+Ironwood
-            /// group funds the payment and no Orchard note is touched.)
+            /// A payment to an Orchard receiver is funded from the Ironwood pool when an Ironwood
+            /// note can cover it alone: the pool matching the payment's (Ironwood-routed) output
+            /// is preferred, and the other pools are left untouched.
             #[test]
-            fn orchard_inputs_are_never_combined_with_sapling_or_ironwood(
+            fn orchard_family_payment_prefers_ironwood_inputs(
                 (orchard_zats, payment_zats) in arb_mixed_pool_amounts(),
             ) {
                 let mut st = TestBuilder::new()
@@ -1494,22 +1661,20 @@ pub(crate) mod tests {
 
                 let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
                 prop_assert!(
-                    sapling + orchard + ironwood > 0,
-                    "the transaction must spend some notes"
+                    ironwood > 0,
+                    "the Ironwood note must fund the payment"
                 );
-                // Orchard is never combined with Sapling or Ironwood.
-                if orchard > 0 {
-                    prop_assert_eq!(
-                        (sapling, ironwood),
-                        (0, 0),
-                        "Orchard inputs must not be combined with Sapling ({}) or Ironwood ({})",
-                        sapling,
-                        ironwood,
-                    );
-                }
+                prop_assert_eq!(
+                    (sapling, orchard),
+                    (0, 0),
+                    "the Ironwood note covers the payment alone; Sapling ({}) and Orchard ({}) \
+                     notes must be left untouched",
+                    sapling,
+                    orchard,
+                );
             }
 
-            /// Rule 2: Sapling and Ironwood inputs may be combined. The wallet holds only a Sapling
+            /// Sapling and Ironwood inputs may be combined. The wallet holds only a Sapling
             /// note and an Ironwood note, each too small to fund the payment alone; the transaction
             /// spends both, and no Orchard note is involved.
             #[test]
@@ -1565,12 +1730,13 @@ pub(crate) mod tests {
                 );
             }
 
-            /// Rule 3: an amount that would require Orchard PLUS another pool must fail. The wallet
-            /// holds an Orchard note and a Sapling note, each too small to fund the payment alone;
-            /// since Orchard cannot be combined with Sapling, input selection reports insufficient
-            /// funds rather than spending both.
+            /// An amount that no single pool can cover is funded by combining pools — including
+            /// the legacy Orchard pool. The wallet holds an Orchard note and a Sapling note, each
+            /// too small to fund the payment alone; the transaction spends both, observes the
+            /// turnstile (strictly less value returns to the Orchard pool as change than the
+            /// Orchard inputs remove from it), and builds successfully.
             #[test]
-            fn orchard_plus_another_pool_is_insufficient(
+            fn orchard_combines_with_other_pools_within_turnstile(
                 (pool_zats, payment_zats) in arb_combined_amounts(),
             ) {
                 let mut st = TestBuilder::new()
@@ -1603,21 +1769,145 @@ pub(crate) mod tests {
                 let request = orchard_payment_request(st.network(), payment_zats);
                 let change_strategy = orchard_change_strategy();
                 let input_selector = GreedyInputSelector::new();
-                let result = st.propose_transfer(
-                    account_id,
-                    &input_selector,
-                    &change_strategy,
-                    request,
-                    ConfirmationsPolicy::MIN,
-                );
+                let proposal = st
+                    .propose_transfer(
+                        account_id,
+                        &input_selector,
+                        &change_strategy,
+                        request,
+                        ConfirmationsPolicy::MIN,
+                    )
+                    .unwrap();
 
-                let err = result.expect_err(
-                    "spending must fail: Orchard cannot be combined with Sapling to reach the amount",
+                let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
+                prop_assert!(
+                    orchard > 0 && sapling > 0,
+                    "the payment requires combining the Orchard note ({orchard}) with the \
+                     Sapling note ({sapling})",
+                );
+                prop_assert_eq!(ironwood, 0, "no Ironwood note is present to spend");
+
+                // Every step observes the turnstile: strictly less value returns to the Orchard
+                // pool as change than the step's Orchard inputs remove from it. (Proposal
+                // construction validates this; the check here guards against the selector and
+                // that validation drifting apart.)
+                for step in proposal.steps() {
+                    let orchard_in = step
+                        .shielded_inputs()
+                        .iter()
+                        .flat_map(|s_in| s_in.notes().iter())
+                        .filter(|n| n.note().pool() == ShieldedPool::Orchard)
+                        .map(|n| n.note().value())
+                        .try_fold(Zatoshis::ZERO, |acc, v| acc + v)
+                        .unwrap();
+                    let orchard_change = step
+                        .balance()
+                        .proposed_change()
+                        .iter()
+                        .filter(|c| c.output_pool() == PoolType::ORCHARD)
+                        .map(|c| c.value())
+                        .try_fold(Zatoshis::ZERO, |acc, v| acc + v)
+                        .unwrap();
+                    if orchard_change.into_u64() > 0 {
+                        prop_assert!(
+                            orchard_change < orchard_in,
+                            "Orchard change {:?} must be strictly less than the Orchard input \
+                             total {:?}",
+                            orchard_change,
+                            orchard_in,
+                        );
+                    }
+                }
+
+                // The mixed-pool transaction builds: the same-address Orchard change output is
+                // anchored by the transaction's real Orchard spend.
+                let created = st
+                    .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                        account.usk(),
+                        OvkPolicy::Sender,
+                        &proposal,
+                    )
+                    .unwrap();
+                prop_assert_eq!(created.len(), 1);
+            }
+
+            /// Orchard and Ironwood inputs may be combined in a single transaction, with both
+            /// Orchard-family bundles carrying spends: the Orchard bundle carries the legacy
+            /// spend and its same-address change, and the Ironwood bundle carries the Ironwood
+            /// spend and the routed payment output.
+            #[test]
+            fn orchard_and_ironwood_inputs_combine_and_build(
+                (pool_zats, payment_zats) in arb_combined_amounts(),
+            ) {
+                let mut st = TestBuilder::new()
+                    .with_network(ironwood_active_network())
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_block_cache(BlockCache::new())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account = st.test_account().cloned().unwrap();
+                let account_id = account.id();
+
+                let (h, _, _) = st.generate_next_block(
+                    &OrchardPoolTester::test_account_fvk(&st),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.generate_next_block(
+                    &IronwoodFvk(OrchardPoolTester::test_account_fvk(&st)),
+                    AddressType::DefaultExternal,
+                    Zatoshis::from_u64(pool_zats).unwrap(),
+                );
+                st.scan_cached_blocks(h, 2);
+
+                for _ in 0..5 {
+                    let (h, _) = st.generate_empty_block();
+                    st.scan_cached_blocks(h, 1);
+                }
+
+                let request = orchard_payment_request(st.network(), payment_zats);
+                let change_strategy = orchard_change_strategy();
+                let input_selector = GreedyInputSelector::new();
+                let proposal = st
+                    .propose_transfer(
+                        account_id,
+                        &input_selector,
+                        &change_strategy,
+                        request,
+                        ConfirmationsPolicy::MIN,
+                    )
+                    .unwrap();
+
+                let (sapling, orchard, ironwood) = input_pool_counts(&proposal);
+                prop_assert!(
+                    orchard > 0 && ironwood > 0,
+                    "the payment requires combining the Orchard note ({orchard}) with the \
+                     Ironwood note ({ironwood})",
+                );
+                prop_assert_eq!(sapling, 0, "no Sapling note is present to spend");
+
+                let created = st
+                    .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                        account.usk(),
+                        OvkPolicy::Sender,
+                        &proposal,
+                    )
+                    .unwrap();
+                prop_assert_eq!(created.len(), 1);
+
+                let tx = st
+                    .wallet()
+                    .get_transaction(created[0])
+                    .unwrap()
+                    .expect("the sent transaction was stored");
+                prop_assert!(
+                    tx.orchard_bundle().is_some(),
+                    "the Orchard spend must be carried by the Orchard bundle",
                 );
                 prop_assert!(
-                    format!("{err:?}").contains("InsufficientFunds"),
-                    "expected an InsufficientFunds error, got: {:?}",
-                    err,
+                    tx.ironwood_bundle().is_some(),
+                    "the Ironwood spend and routed payment must be carried by the Ironwood bundle",
                 );
             }
         }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -910,6 +910,12 @@ pub(crate) mod tests {
         testing::pool::propose_and_build_shielding_coinbase_succeeds::<OrchardPoolTester>();
     }
 
+    #[cfg(all(feature = "pczt-tests", feature = "transparent-inputs"))]
+    #[test]
+    fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood() {
+        testing::pool::shielding_coinbase_to_orchard_receiver_delivers_via_ironwood();
+    }
+
     /// `put_received_note` records a note in the received-notes table chosen by the caller,
     /// preserving the note's plaintext version in the `note_version` column. An Orchard-pool note
     /// and an Ironwood-pool note sharing an action index may both be recorded in their respective
@@ -1212,7 +1218,7 @@ pub(crate) mod tests {
         let proposal_proto =
             zcash_client_backend::proto::proposal::Proposal::from_standard_proposal(&proposal);
         let roundtripped = proposal_proto
-            .try_into_standard_proposal(st.wallet())
+            .try_into_standard_proposal(st.network(), st.wallet())
             .expect("Ironwood proposal round-trips through protobuf");
         assert_eq!(roundtripped, proposal);
 

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -965,6 +965,82 @@ pub(crate) mod tests {
         assert_eq!(note_row("ironwood"), (20_000, 3));
     }
 
+    /// End-to-end: a wallet that scans a block containing an Ironwood (version 3) note stores it in
+    /// `ironwood_received_notes` as note version 3, persists the Ironwood note commitment tree, and
+    /// records nothing in the Orchard tables. The note is not yet reflected in the wallet balance
+    /// (see the TODO below).
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn scan_block_stores_received_ironwood_note() {
+        use zcash_client_backend::data_api::{
+            Account,
+            testing::{
+                AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+                pool::ShieldedPoolTester,
+            },
+        };
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::value::Zatoshis;
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        // The account's Ironwood outputs are trial-decrypted with its Orchard viewing key.
+        let recipient = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
+
+        let value = Zatoshis::const_from_u64(60_000);
+        let (h, _, _) = st.generate_next_block(&recipient, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        // The note is stored in `ironwood_received_notes` as note version 3, with its value.
+        let (ironwood_count, stored_value, note_version): (i64, i64, i64) = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT COUNT(*), COALESCE(MIN(value), 0), COALESCE(MIN(note_version), 0)
+                 FROM ironwood_received_notes",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(ironwood_count, 1);
+        assert_eq!(stored_value as u64, value.into_u64());
+        assert_eq!(note_version, 3);
+
+        // The note went to the Ironwood pool, not Orchard.
+        let orchard_count: i64 = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row("SELECT COUNT(*) FROM orchard_received_notes", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(orchard_count, 0);
+
+        // TODO: Ironwood notes are stored but are not yet reflected in the wallet balance. The
+        // `AccountBalance` model computed by `get_wallet_summary` has Sapling and Orchard
+        // components but no Ironwood component, so `get_total_balance` currently reports zero for a
+        // wallet holding only Ironwood notes. Change this assertion to expect `value` once an
+        // Ironwood balance is added to the wallet summary.
+        assert_eq!(st.get_total_balance(account_id), Zatoshis::ZERO);
+
+        // The Ironwood note commitment tree was persisted.
+        let ironwood_shards: i64 = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row("SELECT COUNT(*) FROM ironwood_tree_shards", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(ironwood_shards > 0);
+    }
+
     #[test]
     #[cfg(feature = "orchard")]
     fn get_unspent_orchard_notes_at_historical_height_boundary_heights() {

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -850,6 +850,7 @@ pub(crate) mod tests {
             )],
             initial_sapling_tree_size,
             initial_orchard_tree_size,
+            0,
             false,
         );
 
@@ -1305,6 +1306,7 @@ pub(crate) mod tests {
             )],
             frontier_tree_size + 10,
             frontier_tree_size + 10,
+            0,
             false,
         );
         st.scan_cached_blocks(max_scanned, 1);
@@ -1517,6 +1519,7 @@ pub(crate) mod tests {
             )],
             frontier_tree_size + 10,
             frontier_tree_size + 10,
+            0,
             false,
         );
         st.scan_cached_blocks(max_scanned, 1);


### PR DESCRIPTION
Rewinding a wallet past blocks that contained Ironwood outputs left the Ironwood note commitment tree untouched: the truncate paths handled only the Sapling and Orchard trees. After a reorg, the stale Ironwood tree state conflicted with the replacement chain's commitments, so every re-scan failed with `Insert(Conflict(..))` on the Ironwood tree and the wallet could never make sync progress again. We hit this in production on testnet, where a routine one-block reorg permanently wedged a wallet built against this branch.

The fix extends the rewind plane to the third pool:

- `truncate_to_height_internal` truncates the Ironwood tree to the target checkpoint.
- `select_truncation_height` requires the selected height to be checkpointed in the Ironwood tree when that tree contains data. Checkpoints are written in lockstep across all three trees by `put_blocks`, so any height it selects satisfies this; the clause matters because `ShardTree::truncate_to_checkpoint` silently no-ops when the checkpoint id is absent.
- `min_shared_checkpoint_height` is generalized from the two-pool case enumeration to a uniform per-pool form covering all trees that contain data.
- `truncate_to_chain_state` re-anchors the Ironwood tree from `ChainState::final_ironwood_tree` when the target checkpoint has been pruned.
- `rewind_to_chain_state` extends the pruning-window checkpoint-parity corruption check to the Ironwood tree.

The regression test reproduces the wedge: scan a block paying an Ironwood note, reorg it away, and re-scan a replacement block paying a different Ironwood note at the same height. Without the fix the re-scan fails with `PutBlocksCommitmentTree { pool: Ironwood, .. }` carrying the shard conflict; with it, the replacement chain scans cleanly.