### PR TITLE
Fixes to #2539 from review

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -82,16 +82,27 @@ workspace.
 - `zcash_client_backend::fees::orchard::BundleView::bundle_version`, replacing
   the `bundle_type` accessor; it returns the `orchard::bundle::BundleVersion`
   used to compute the Orchard action count.
+- `zcash_client_backend::data_api::wallet::input_selection::SpendPolicy`:
+  expresses which sources of funds an input selector may draw upon to satisfy a
+  transfer. It names the shielded pools notes may be selected from and, behind
+  the `transparent-inputs` feature flag, an optional `TransparentSpendPolicy`.
+  The default permits every shielded pool present in the build and no transparent
+  spending, preserving the historical fully-shielded behavior; a caller restricts
+  the shielded set (e.g. to `{Orchard}`) to forbid pool crossing, since combining
+  notes across shielded pools reduces privacy and must be an explicit choice.
 - `zcash_client_backend::data_api::wallet::input_selection::TransparentSpendPolicy`
-  (behind the `transparent-inputs` feature flag): expresses a wallet's explicit,
-  privacy-acknowledging intent to spend transparent UTXOs in a transfer. Variants
-  are `ShieldedOnly` (the default; no transparent spends), `AnyAccountTaddr`
-  (the legacy `ANY_TADDR` behavior, spending from arbitrary account transparent
-  receivers and potentially linking them), and `FromAddresses` (spending only
-  from an explicitly named set of transparent addresses).
+  (behind the `transparent-inputs` feature flag): specifies how transparent UTXOs
+  may be spent when a `SpendPolicy` permits it — a `TransparentSource`
+  (`AnyAccountAddr`, the legacy `ANY_TADDR` behavior; or `FromAddresses`, an
+  explicitly named set) together with a `CoinbasePolicy`. Constructed via
+  `any_account_addr`, `from_addresses`, or `from_one_address` (all spending
+  non-coinbase UTXOs by default) and refined with `with_coinbase`.
+- `zcash_client_backend::data_api::wallet::input_selection::CoinbasePolicy`
+  (`OnlyCoinbase` / `NonCoinbase`): the caller's choice of which coinbase
+  transparent outputs a transparent spend may draw upon.
 - `zcash_client_backend::data_api::wallet::input_selection::NonEmptyBTreeSet`
   (behind the `transparent-inputs` feature flag): a minimal non-empty
-  `BTreeSet` wrapper used by `TransparentSpendPolicy::FromAddresses` to hold
+  `BTreeSet` wrapper used by `TransparentSource::FromAddresses` to hold
   the explicit set of transparent addresses to spend from.
 - `zcash_client_backend::data_api::CoinbaseFilter::NonCoinbaseOnly` (behind
   `transparent-inputs`): a selection control (not an encoding of any
@@ -311,11 +322,13 @@ workspace.
   Ironwood pool.
 - `zcash_client_backend::data_api::wallet::propose_transfer` and
   `zcash_client_backend::data_api::wallet::input_selection::InputSelector::propose_transaction`
-  now take an additional `&TransparentSpendPolicy` argument (behind the
-  `transparent-inputs` feature flag) that controls whether and how the
-  account's transparent UTXOs may be spent. The default policy preserves the
-  previous shielded-only behavior; transparent UTXOs are never spent unless the
-  caller explicitly opts in.
+  now take an additional `&SpendPolicy` argument (no longer behind the
+  `transparent-inputs` feature flag) that controls which shielded pools notes may
+  be selected from and whether and how the account's transparent UTXOs may be
+  spent. The default policy preserves the previous behavior (every shielded pool
+  permitted, no transparent spending); a pool the policy does not name is never
+  drawn upon, so restricting the policy causes input selection to report
+  `InsufficientFunds` rather than crossing into a non-permitted pool.
 - `zcash_client_backend::TransferType::WalletInternal` semantics have
   narrowed: it now specifically indicates a cross-account internal transfer
   (recipient and funder are distinct wallet accounts). Code that previously

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -72,6 +72,11 @@ workspace.
 - `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
   an optional accessor that wallet backends can override to provide the Ironwood
   anchors and witnesses used by the transaction builder.
+- `zcash_client_backend::data_api::WalletCommitmentTrees::put_ironwood_subtree_roots`,
+  the Ironwood counterpart of `put_orchard_subtree_roots` for populating the
+  Ironwood note commitment tree from a subtree-root source. It defaults to a
+  no-op for backends that do not track an Ironwood tree, mirroring
+  `with_ironwood_tree_mut`.
 - `zcash_client_backend::data_api::IRONWOOD_SHARD_HEIGHT`, the shard height of
   the Ironwood note commitment tree (equal to the Orchard shard height).
 - `zcash_client_backend::data_api::NoteCommitmentTree`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3780,6 +3780,25 @@ pub trait WalletCommitmentTrees {
         Ok(None)
     }
 
+    /// Adds a sequence of Ironwood note commitment tree subtree roots to the data store, if this
+    /// backend tracks an Ironwood tree.
+    ///
+    /// Each such value should be the Merkle root of a subtree of the Ironwood note commitment tree
+    /// containing 2^[`ORCHARD_SHARD_HEIGHT`] note commitments; Ironwood shares the Orchard note
+    /// commitment tree's shape, so the same shard height applies.
+    ///
+    /// The default implementation is a no-op, for backends that do not track an Ironwood tree
+    /// (mirroring [`WalletCommitmentTrees::with_ironwood_tree_mut`]). Backends that track Ironwood
+    /// note commitments should override this.
+    #[cfg(feature = "orchard")]
+    fn put_ironwood_subtree_roots(
+        &mut self,
+        _start_index: u64,
+        _roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        Ok(())
+    }
+
     /// Releases all retained ("anchor") checkpoints with height strictly less than `max_height`
     /// from the wallet's note commitment trees, allowing them to be pruned normally.
     ///

--- a/zcash_client_backend/src/data_api/ll.rs
+++ b/zcash_client_backend/src/data_api/ll.rs
@@ -59,6 +59,13 @@ pub trait TxMeta {
     #[cfg(feature = "orchard")]
     fn orchard_spent_note_nullifiers(&self) -> impl Iterator<Item = &::orchard::note::Nullifier>;
 
+    /// Returns an iterator over the nullifiers of Ironwood notes spent in this transaction.
+    ///
+    /// Ironwood nullifiers share the Orchard nullifier type, but identify notes in the Ironwood
+    /// pool (the transaction's Ironwood bundle, distinct from its Orchard bundle).
+    #[cfg(feature = "orchard")]
+    fn ironwood_spent_note_nullifiers(&self) -> impl Iterator<Item = &::orchard::note::Nullifier>;
+
     /// Returns the fee paid by this transaction, given a function that can retrieve the value of
     /// prior transparent outputs spent in the transaction.
     ///
@@ -96,6 +103,13 @@ impl TxMeta for Transaction {
     #[cfg(feature = "orchard")]
     fn orchard_spent_note_nullifiers(&self) -> impl Iterator<Item = &::orchard::note::Nullifier> {
         self.orchard_bundle()
+            .into_iter()
+            .flat_map(|bundle| bundle.actions().iter().map(|action| action.nullifier()))
+    }
+
+    #[cfg(feature = "orchard")]
+    fn ironwood_spent_note_nullifiers(&self) -> impl Iterator<Item = &::orchard::note::Nullifier> {
+        self.ironwood_bundle()
             .into_iter()
             .flat_map(|bundle| bundle.actions().iter().map(|action| action.nullifier()))
     }
@@ -153,6 +167,10 @@ pub trait LowLevelWalletRead {
 
         #[cfg(feature = "orchard")]
         funding_accounts.extend(self.detect_accounts_orchard(tx.orchard_spent_note_nullifiers())?);
+
+        #[cfg(feature = "orchard")]
+        funding_accounts
+            .extend(self.detect_accounts_ironwood(tx.ironwood_spent_note_nullifiers())?);
 
         Ok(funding_accounts)
     }
@@ -224,6 +242,20 @@ pub trait LowLevelWalletRead {
     /// [`Nullifier`]: orchard::note::Nullifier
     #[cfg(feature = "orchard")]
     fn detect_accounts_orchard<'a>(
+        &self,
+        spends: impl Iterator<Item = &'a orchard::note::Nullifier>,
+    ) -> Result<HashSet<Self::AccountId>, Self::Error>;
+
+    /// Detects the set of accounts that received Ironwood outputs that, when spent, reveal(ed) the
+    /// given [`Nullifier`]s. This is used to determine which account(s) funded a given
+    /// transaction.
+    ///
+    /// Ironwood notes share the Orchard nullifier type but are tracked separately, so this is
+    /// distinct from [`LowLevelWalletRead::detect_accounts_orchard`].
+    ///
+    /// [`Nullifier`]: orchard::note::Nullifier
+    #[cfg(feature = "orchard")]
+    fn detect_accounts_ironwood<'a>(
         &self,
         spends: impl Iterator<Item = &'a orchard::note::Nullifier>,
     ) -> Result<HashSet<Self::AccountId>, Self::Error>;

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -57,7 +57,7 @@ use super::{
     scanning::ScanRange,
     wallet::{
         ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
-        input_selection::{GreedyInputSelector, InputSelector},
+        input_selection::{GreedyInputSelector, InputSelector, SpendPolicy},
         propose_send_max_transfer, propose_standard_transfer_to_address, propose_transfer,
     },
 };
@@ -78,7 +78,7 @@ use crate::{
 use {
     super::{
         CoinbaseFilter, TransactionsInvolvingAddress, TransparentBalances,
-        wallet::input_selection::{ShieldingSelector, TransparentSpendPolicy},
+        wallet::input_selection::ShieldingSelector,
     },
     crate::wallet::TransparentAddressMetadata,
     ::transparent::address::TransparentAddress,
@@ -1059,8 +1059,7 @@ where
             change_strategy,
             request,
             confirmations_policy,
-            #[cfg(feature = "transparent-inputs")]
-            &TransparentSpendPolicy::default(),
+            &SpendPolicy::default(),
             #[cfg(feature = "unstable")]
             None,
         )?;
@@ -1104,20 +1103,19 @@ where
             change_strategy,
             request,
             confirmations_policy,
-            #[cfg(feature = "transparent-inputs")]
-            &TransparentSpendPolicy::default(),
+            &SpendPolicy::default(),
             #[cfg(feature = "unstable")]
             None,
         )
     }
 
     /// Invokes [`propose_transfer`] with the given arguments and an explicit
-    /// [`TransparentSpendPolicy`].
+    /// [`SpendPolicy`].
     ///
-    /// Unlike [`Self::propose_transfer`], which always uses the default
-    /// (shielded-only) spend policy, this allows tests to opt in to spending the
-    /// account's transparent UTXOs.
-    #[cfg(feature = "transparent-inputs")]
+    /// Unlike [`Self::propose_transfer`], which always uses the default spend
+    /// policy (every shielded pool, no transparent), this allows tests to opt in
+    /// to spending the account's transparent UTXOs or to restrict the shielded
+    /// pools notes may be drawn from.
     #[allow(clippy::type_complexity)]
     pub fn propose_transfer_with_policy<InputsT, ChangeT>(
         &mut self,
@@ -1126,7 +1124,7 @@ where
         change_strategy: &ChangeT,
         request: zip321::TransactionRequest,
         confirmations_policy: ConfirmationsPolicy,
-        spend_policy: &TransparentSpendPolicy,
+        spend_policy: &SpendPolicy,
     ) -> Result<
         Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
         super::wallet::ProposeTransferErrT<DbT, Infallible, InputsT, ChangeT>,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -30,7 +30,7 @@ use crate::{
         testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
-            input_selection::{GreedyInputSelector, TransparentSpendPolicy},
+            input_selection::{GreedyInputSelector, SpendPolicy, TransparentSpendPolicy},
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
@@ -1903,7 +1903,7 @@ where
         &change_strategy,
         request,
         ConfirmationsPolicy::MIN,
-        &TransparentSpendPolicy::shielded_only(),
+        &SpendPolicy::default(),
     );
 
     assert_matches!(
@@ -1942,7 +1942,8 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &TransparentSpendPolicy::from_any_account_transparent_addresses(),
+            &SpendPolicy::default()
+                .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
         )
         .expect("transparent spend must succeed under AnyAccountTaddr");
 
@@ -2090,7 +2091,8 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &TransparentSpendPolicy::from_any_account_transparent_addresses(),
+            &SpendPolicy::default()
+                .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
         )
         .expect(
             "transparent spend should succeed via the re-gather fallback despite the \
@@ -2198,7 +2200,8 @@ where
         &change_strategy,
         request,
         ConfirmationsPolicy::MIN,
-        &TransparentSpendPolicy::from_any_account_transparent_addresses(),
+        &SpendPolicy::default()
+            .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
     );
 
     assert_matches!(
@@ -2296,7 +2299,9 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &TransparentSpendPolicy::from_one_transparent_address(addr_named),
+            &SpendPolicy::default().with_transparent(
+                TransparentSpendPolicy::from_one_transparent_address(addr_named),
+            ),
         )
         .expect("transparent spend from named address must succeed");
 

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1874,7 +1874,7 @@ fn t2t_request(network: &LocalNetwork, amount: Zatoshis) -> TransactionRequest {
 }
 
 /// Regression test enforcing the privacy invariant: with the default
-/// [`TransparentSpendPolicy::ShieldedOnly`] policy, a transfer must NOT silently spend
+/// default spend policy (which permits no transparent spending), a transfer must NOT silently spend
 /// the account's transparent UTXOs as a fallback. An account holding only transparent
 /// funds must fail with [`InsufficientFunds`] rather than producing a t->t proposal.
 ///
@@ -1913,7 +1913,7 @@ where
     );
 }
 
-/// With [`TransparentSpendPolicy::AnyAccountTaddr`] (the legacy `ANY_TADDR` behavior), a
+/// With `TransparentSpendPolicy::any_account_addr` (the legacy `ANY_TADDR` behavior), a
 /// transfer may spend the account's transparent UTXOs. Verifies that the funding UTXO is
 /// selected as a transparent input and that the proposal balance is consistent.
 pub fn propose_t2t_any_account_taddr<DSF>(dsf: DSF, cache: impl TestCache)
@@ -1942,10 +1942,9 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &SpendPolicy::default()
-                .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
+            &SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr()),
         )
-        .expect("transparent spend must succeed under AnyAccountTaddr");
+        .expect("transparent spend must succeed under any-account-address transparent spending");
 
     // A pure t->t transfer is a single step (no ZIP-320 ephemeral roundtrip).
     assert_eq!(proposal.steps().len(), 1);
@@ -2091,8 +2090,7 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &SpendPolicy::default()
-                .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
+            &SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr()),
         )
         .expect(
             "transparent spend should succeed via the re-gather fallback despite the \
@@ -2200,8 +2198,7 @@ where
         &change_strategy,
         request,
         ConfirmationsPolicy::MIN,
-        &SpendPolicy::default()
-            .with_transparent(TransparentSpendPolicy::from_any_account_transparent_addresses()),
+        &SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr()),
     );
 
     assert_matches!(
@@ -2213,7 +2210,7 @@ where
     );
 }
 
-/// With [`TransparentSpendPolicy::FromAddresses`], only the explicitly named transparent
+/// With a `TransparentSource::FromAddresses` transparent source, only the explicitly named transparent
 /// addresses are eligible. Funds two of the account's external receivers but names only
 /// one; the proposal must select solely from the named address.
 pub fn propose_t2t_from_addresses<DSF>(dsf: DSF, cache: impl TestCache)
@@ -2299,9 +2296,8 @@ where
             &change_strategy,
             request,
             ConfirmationsPolicy::MIN,
-            &SpendPolicy::default().with_transparent(
-                TransparentSpendPolicy::from_one_transparent_address(addr_named),
-            ),
+            &SpendPolicy::default()
+                .with_transparent(TransparentSpendPolicy::from_one_address(addr_named)),
         )
         .expect("transparent spend from named address must succeed");
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1714,7 +1714,10 @@ where
                 ironwood_output_meta.push((
                     BuildRecipient::External {
                         recipient_address: recipient_address.clone(),
-                        output_pool: PoolType::ORCHARD,
+                        // The payment is built into the Ironwood bundle, so its sent-note record
+                        // belongs to the Ironwood pool. (Post-NU6.3 an Orchard-pool payment output
+                        // is forbidden when spending Orchard; only change may return to Orchard.)
+                        output_pool: PoolType::IRONWOOD,
                     },
                     payment_amount,
                     Some(memo),

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -659,7 +659,7 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     change_strategy: &ChangeT,
     request: zip321::TransactionRequest,
     confirmations_policy: ConfirmationsPolicy,
-    #[cfg(feature = "transparent-inputs")] spend_policy: &input_selection::TransparentSpendPolicy,
+    spend_policy: &input_selection::SpendPolicy,
     #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
@@ -691,7 +691,6 @@ where
         spend_from_account,
         request,
         change_strategy,
-        #[cfg(feature = "transparent-inputs")]
         spend_policy,
         #[cfg(feature = "unstable")]
         proposed_version,
@@ -784,8 +783,7 @@ where
         &change_strategy,
         request,
         confirmations_policy,
-        #[cfg(feature = "transparent-inputs")]
-        &input_selection::TransparentSpendPolicy::default(),
+        &input_selection::SpendPolicy::default(),
         #[cfg(feature = "unstable")]
         proposed_version,
     )

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -137,21 +137,6 @@ fn ironwood_active_at<ParamsT: consensus::Parameters, H: Into<BlockHeight>>(
     params.is_nu_active(NetworkUpgrade::Nu6_3, target_height.into())
 }
 
-/// Maps an Ironwood bundle output index to its index in the wallet's combined
-/// Orchard-family output space.
-///
-/// A V6 transaction's Orchard and Ironwood outputs share a single stored index
-/// space, with the Orchard bundle's actions placed first, so the Ironwood output
-/// at raw index `i` is stored at `orchard_actions + i`. When the transaction has
-/// no Orchard bundle, the raw index is used unchanged.
-#[cfg(feature = "orchard")]
-fn stored_ironwood_output_index(tx: &Transaction, raw_ironwood_output_index: usize) -> usize {
-    tx.orchard_bundle()
-        .map_or(raw_ironwood_output_index, |bundle| {
-            bundle.actions().len() + raw_ironwood_output_index
-        })
-}
-
 #[cfg(feature = "pczt")]
 fn serialize_target_height<S>(
     target_height: &TargetHeight,
@@ -2123,8 +2108,6 @@ where
                 .ironwood_meta()
                 .output_action_index(i)
                 .expect("An action should exist in the transaction for each Ironwood output.");
-            let output_index =
-                stored_ironwood_output_index(build_result.transaction(), raw_output_index);
 
             let recipient = recipient.into_recipient_with_note(|| {
                 build_result
@@ -2140,9 +2123,13 @@ where
                     )
             });
 
+            // The Ironwood output is stored at its raw index within the Ironwood bundle — the same
+            // index the scanner assigns — so the send and scan write paths agree. Each shielded
+            // pool has its own received-notes table keyed by (transaction, action_index), so
+            // Orchard and Ironwood indices never collide despite both starting at zero.
             SentTransactionOutput::from_parts_in_tree(
                 Some(NoteCommitmentTree::Ironwood),
-                output_index,
+                raw_output_index,
                 recipient,
                 value,
                 memo,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -191,12 +191,14 @@ pub trait InputSelector {
     /// If insufficient funds are available to satisfy the required outputs for the shielding
     /// request, this operation must fail and return [`InputSelectorError::InsufficientFunds`].
     ///
-    /// `spend_policy` (behind the `transparent-inputs` feature flag) controls whether, and
-    /// from which addresses, the account's transparent UTXOs may additionally be spent to
-    /// help satisfy the request. Under the default [`TransparentSpendPolicy::ShieldedOnly`],
-    /// implementations must not spend transparent UTXOs even as a fallback; other policies
-    /// require the caller to have explicitly opted in, since spending transparent funds
-    /// links the chosen addresses on-chain.
+    /// `spend_policy` controls which sources of funds the implementation may draw upon. It names
+    /// the shielded pools from which notes may be selected — the implementation must not select
+    /// notes from a pool the policy does not permit, returning
+    /// [`InputSelectorError::InsufficientFunds`] rather than crossing into a non-permitted pool —
+    /// and, behind the `transparent-inputs` feature flag, whether and from which addresses the
+    /// account's transparent UTXOs may additionally be spent. Spending transparent funds, or
+    /// combining notes across shielded pools, reduces privacy, so the caller must opt in
+    /// explicitly by naming the permitted sources.
     #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
     fn propose_transaction<ParamsT, ChangeT>(
@@ -209,7 +211,7 @@ pub trait InputSelector {
         account: <Self::InputSource as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
-        #[cfg(feature = "transparent-inputs")] spend_policy: &TransparentSpendPolicy,
+        spend_policy: &SpendPolicy,
         #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, <Self::InputSource as InputSource>::NoteRef>,
@@ -778,7 +780,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         account: <DbT as InputSource>::AccountId,
         transaction_request: TransactionRequest,
         change_strategy: &ChangeT,
-        #[cfg(feature = "transparent-inputs")] spend_policy: &TransparentSpendPolicy,
+        spend_policy: &SpendPolicy,
         #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
     ) -> Result<
         Proposal<<ChangeT as ChangeStrategy>::FeeRule, DbT::NoteRef>,
@@ -918,12 +920,12 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         #[cfg(feature = "transparent-inputs")]
         let mut amount_at_transparent_gather = Zatoshis::ZERO;
         #[cfg(feature = "transparent-inputs")]
-        let mut transparent_inputs = match spend_policy {
-            TransparentSpendPolicy::ShieldedOnly => {
-                // For `ShieldedOnly`, we don't need any transparent inputs; skip the gather entirely.
+        let mut transparent_inputs = match spend_policy.transparent() {
+            None | Some(TransparentSpendPolicy::ShieldedOnly) => {
+                // No transparent spending is permitted; skip the gather entirely.
                 Vec::new()
             }
-            TransparentSpendPolicy::AnyAccountTaddr => self.gather_transparent::<ChangeT>(
+            Some(TransparentSpendPolicy::AnyAccountTaddr) => self.gather_transparent::<ChangeT>(
                 wallet_db,
                 target_height,
                 confirmations_policy,
@@ -933,8 +935,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                 &transaction_request,
                 &mut amount_at_transparent_gather,
             )?,
-            TransparentSpendPolicy::FromAddresses(_) => {
-                let address_allow_list = transparent_address_allow_list(spend_policy);
+            Some(transparent @ TransparentSpendPolicy::FromAddresses(_)) => {
+                let address_allow_list = transparent_address_allow_list(transparent);
                 self.gather_transparent::<ChangeT>(
                     wallet_db,
                     target_height,
@@ -967,7 +969,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         // bundle — moving their value into the Ironwood pool — so Ironwood is
         // preferred, with the legacy Orchard pool last within the family.
         #[cfg(feature = "orchard")]
-        let pool_preference = selectable_pool_preference(
+        let mut pool_preference = selectable_pool_preference(
             params,
             target_height,
             sapling_supported,
@@ -975,13 +977,19 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             !orchard_outputs.is_empty(),
         );
         #[cfg(not(feature = "orchard"))]
-        let pool_preference = {
+        let mut pool_preference = {
             let mut pools = vec![];
             if sapling_supported {
                 pools.push(ShieldedPool::Sapling);
             }
             pools
         };
+
+        // Restrict selection to the shielded pools the caller's spend policy permits. Crossing a
+        // pool boundary is privacy-breaking, so a pool the policy does not name is never drawn
+        // upon — not even as a fallback when the permitted pools cannot cover the request, in
+        // which case input selection reports `InsufficientFunds`.
+        pool_preference.retain(|pool| spend_policy.permits_shielded(*pool));
 
         // This loop is guaranteed to terminate because on each iteration we check that the amount
         // of funds selected is strictly increasing. The loop will either return a successful
@@ -1293,11 +1301,12 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // defensive fallback. The common case (fee estimate was close) is
                     // a no-op.
                     #[cfg(feature = "transparent-inputs")]
+                    if let Some(transparent) = spend_policy
+                        .transparent()
+                        .filter(|tp| !matches!(tp, TransparentSpendPolicy::ShieldedOnly))
                     {
-                        if !matches!(spend_policy, TransparentSpendPolicy::ShieldedOnly)
-                            && required > amount_at_transparent_gather
-                        {
-                            let address_allow_list = transparent_address_allow_list(spend_policy);
+                        if required > amount_at_transparent_gather {
+                            let address_allow_list = transparent_address_allow_list(transparent);
                             transparent_inputs = wallet_db
                                 .select_spendable_transparent_outputs(
                                     account,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -2,7 +2,7 @@
 use core::marker::PhantomData;
 use nonempty::NonEmpty;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     error,
     fmt::{self, Debug, Display},
 };
@@ -42,7 +42,6 @@ use {
         fees::{ChangeValue, StandardFeeRule},
         proposal::{Step, StepOutput, StepOutputIndex},
     },
-    std::collections::BTreeSet,
     std::convert::Infallible,
     transparent::{address::TransparentAddress, bundle::OutPoint},
     zcash_primitives::transaction::fees::transparent as transparent_fees,
@@ -474,13 +473,104 @@ impl<T> NonEmptyBTreeSet<T> {
     }
 }
 
+/// The sources of funds an [`InputSelector`] is permitted to draw upon when satisfying a
+/// transaction request.
+///
+/// Crossing a shielded pool boundary reduces privacy, so it must be an explicit choice of the
+/// caller: the selector only spends notes from the shielded pools named in [`Self::shielded`], and
+/// only spends transparent UTXOs when a [`TransparentSpendPolicy`] is provided. When a single
+/// permitted pool cannot cover the request, the selector may combine the permitted pools (drawing
+/// on the legacy Orchard pool last); if no combination of permitted sources suffices it returns
+/// [`InputSelectorError::InsufficientFunds`] rather than reaching into a pool the caller did not
+/// permit.
+///
+/// The default permits every shielded pool present in the build and no transparent spending,
+/// preserving the historical fully-shielded behavior while letting a caller restrict the set to,
+/// for example, `{Orchard}` to forbid pool crossing.
+#[derive(Clone, Debug)]
+pub struct SpendPolicy {
+    shielded: BTreeSet<ShieldedPool>,
+    #[cfg(feature = "transparent-inputs")]
+    transparent: Option<TransparentSpendPolicy>,
+}
+
+impl Default for SpendPolicy {
+    fn default() -> Self {
+        Self::shielded_pools([
+            ShieldedPool::Sapling,
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Orchard,
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Ironwood,
+        ])
+    }
+}
+
+impl SpendPolicy {
+    /// Constructs a policy permitting selection from exactly the given shielded pools, with no
+    /// transparent spending.
+    pub fn shielded_pools(pools: impl IntoIterator<Item = ShieldedPool>) -> Self {
+        Self {
+            shielded: pools.into_iter().collect(),
+            #[cfg(feature = "transparent-inputs")]
+            transparent: None,
+        }
+    }
+
+    /// Returns whether notes may be selected from the given shielded pool.
+    pub fn permits_shielded(&self, pool: ShieldedPool) -> bool {
+        self.shielded.contains(&pool)
+    }
+
+    /// Returns the set of shielded pools from which notes may be selected.
+    pub fn shielded(&self) -> &BTreeSet<ShieldedPool> {
+        &self.shielded
+    }
+
+    /// Adds a transparent spend policy, permitting transparent UTXOs to be spent as described.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_transparent(mut self, transparent: TransparentSpendPolicy) -> Self {
+        self.transparent = Some(transparent);
+        self
+    }
+
+    /// Returns the transparent spend policy, or `None` if transparent UTXOs may not be spent.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn transparent(&self) -> Option<&TransparentSpendPolicy> {
+        self.transparent.as_ref()
+    }
+}
+
+/// The caller's choice of which coinbase transparent outputs a transparent spend may draw upon.
+///
+/// Consensus requires coinbase funds to be spent to a single shielded output with no change and
+/// without being mixed with non-coinbase inputs, so a transparent spend commits to one or the
+/// other rather than combining them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CoinbasePolicy {
+    /// Spend only coinbase transparent outputs.
+    OnlyCoinbase,
+    /// Spend only non-coinbase transparent outputs.
+    NonCoinbase,
+}
+
+#[cfg(feature = "transparent-inputs")]
+impl From<CoinbasePolicy> for CoinbaseFilter {
+    fn from(policy: CoinbasePolicy) -> Self {
+        match policy {
+            CoinbasePolicy::OnlyCoinbase => CoinbaseFilter::CoinbaseOnly,
+            CoinbasePolicy::NonCoinbase => CoinbaseFilter::NonCoinbaseOnly,
+        }
+    }
+}
+
 #[cfg(feature = "transparent-inputs")]
 /// Specifies the wallet's intent to spend transparent UTXOs in a transfer.
 ///
 /// Spending transparent funds links the chosen transparent addresses on-chain,
 /// reducing privacy; callers must opt in explicitly. Corresponds to the legacy
 /// `AllowTransparentAddressLinking` privacy policy / `ANY_TADDR`.
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub enum TransparentSpendPolicy {
     /// Do not spend any transparent UTXOs (default; fully-shielded behavior).
     #[default]
@@ -2215,5 +2305,50 @@ mod tests {
         assert_eq!(shielding_max_inputs(1), 133); // 20_000 / 150
         assert_eq!(shielding_max_inputs(10), 1333); // 200_000 / 150
         assert_eq!(shielding_max_inputs(100), 13333); // 2_000_000 / 150
+    }
+}
+
+#[cfg(test)]
+mod spend_policy_tests {
+    use super::*;
+
+    // The default spend policy preserves the historical `ShieldedOnly` behavior: notes may be
+    // selected from every shielded pool present in the build, and no transparent UTXOs are
+    // spent. Restricting the set is what a caller does to prevent pool crossing.
+    #[test]
+    fn default_permits_all_shielded_pools_and_no_transparent() {
+        let policy = SpendPolicy::default();
+        assert!(policy.permits_shielded(ShieldedPool::Sapling));
+        #[cfg(feature = "orchard")]
+        {
+            assert!(policy.permits_shielded(ShieldedPool::Orchard));
+            assert!(policy.permits_shielded(ShieldedPool::Ironwood));
+        }
+        #[cfg(feature = "transparent-inputs")]
+        assert!(policy.transparent().is_none());
+    }
+
+    // A caller can restrict selection to a single pool; other pools are then not permitted.
+    #[test]
+    fn shielded_pools_restricts_the_permitted_set() {
+        let policy = SpendPolicy::shielded_pools([ShieldedPool::Orchard]);
+        assert!(policy.permits_shielded(ShieldedPool::Orchard));
+        assert!(!policy.permits_shielded(ShieldedPool::Sapling));
+        assert!(!policy.permits_shielded(ShieldedPool::Ironwood));
+    }
+
+    // The caller-facing coinbase choice maps onto the internal `CoinbaseFilter` query control.
+    #[cfg(feature = "transparent-inputs")]
+    #[test]
+    fn coinbase_policy_maps_to_filter() {
+        use crate::data_api::CoinbaseFilter;
+        assert_eq!(
+            CoinbaseFilter::from(CoinbasePolicy::OnlyCoinbase),
+            CoinbaseFilter::CoinbaseOnly
+        );
+        assert_eq!(
+            CoinbaseFilter::from(CoinbasePolicy::NonCoinbase),
+            CoinbaseFilter::NonCoinbaseOnly
+        );
     }
 }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -566,49 +566,85 @@ impl From<CoinbasePolicy> for CoinbaseFilter {
     }
 }
 
-#[cfg(feature = "transparent-inputs")]
-/// Specifies the wallet's intent to spend transparent UTXOs in a transfer.
+/// Specifies how transparent UTXOs may be spent in a transfer, when a [`SpendPolicy`] permits
+/// transparent spending.
 ///
-/// Spending transparent funds links the chosen transparent addresses on-chain,
-/// reducing privacy; callers must opt in explicitly. Corresponds to the legacy
-/// `AllowTransparentAddressLinking` privacy policy / `ANY_TADDR`.
-#[derive(Clone, Debug, Default)]
-pub enum TransparentSpendPolicy {
-    /// Do not spend any transparent UTXOs (default; fully-shielded behavior).
-    #[default]
-    ShieldedOnly,
-    /// Spend from arbitrary transparent receivers belonging to the account, as
-    /// needed to satisfy the request. The proposer chooses the addresses,
-    /// potentially linking them. (`ANY_TADDR`)
-    AnyAccountTaddr,
-    /// Spend only from the specified transparent addresses, intentionally
-    /// linking them.
-    FromAddresses(NonEmptyBTreeSet<TransparentAddress>),
+/// Spending transparent funds links the chosen transparent addresses on-chain, reducing privacy,
+/// so a caller opts in by attaching this to a [`SpendPolicy`] via [`SpendPolicy::with_transparent`]
+/// (the absence of a policy — the default — spends no transparent UTXOs). The policy names the
+/// [`TransparentSource`] the UTXOs may be drawn from and, via [`CoinbasePolicy`], whether coinbase
+/// or non-coinbase outputs are spent.
+#[cfg(feature = "transparent-inputs")]
+#[derive(Clone, Debug)]
+pub struct TransparentSpendPolicy {
+    source: TransparentSource,
+    coinbase: CoinbasePolicy,
 }
 
 #[cfg(feature = "transparent-inputs")]
 impl TransparentSpendPolicy {
-    /// Creates a policy that only spends from shielded UTXOs.
-    pub fn shielded_only() -> Self {
-        Self::ShieldedOnly
+    /// Spends non-coinbase UTXOs from arbitrary transparent receivers belonging to the account,
+    /// as needed to satisfy the request. The proposer chooses the addresses, potentially linking
+    /// them. (The legacy `ANY_TADDR` behavior.)
+    pub fn any_account_addr() -> Self {
+        Self {
+            source: TransparentSource::AnyAccountAddr,
+            coinbase: CoinbasePolicy::NonCoinbase,
+        }
     }
 
-    /// Creates a policy that spends from arbitrary transparent receivers
-    /// belonging to the account.
-    pub fn from_any_account_transparent_addresses() -> Self {
-        Self::AnyAccountTaddr
+    /// Spends non-coinbase UTXOs only from the specified transparent addresses, intentionally
+    /// linking them.
+    pub fn from_addresses(taddrs: NonEmpty<TransparentAddress>) -> Self {
+        Self {
+            source: TransparentSource::FromAddresses(NonEmptyBTreeSet::from_nonempty(taddrs)),
+            coinbase: CoinbasePolicy::NonCoinbase,
+        }
     }
 
-    /// Creates a policy that only spends from the specified transparent addresses,
-    /// potentially leaking them. (`ANY_TADDR`)
-    pub fn from_specific_transparent_addresses(taddrs: NonEmpty<TransparentAddress>) -> Self {
-        Self::FromAddresses(NonEmptyBTreeSet::from_nonempty(taddrs))
+    /// Spends non-coinbase UTXOs only from a single transparent address.
+    pub fn from_one_address(taddr: TransparentAddress) -> Self {
+        Self {
+            source: TransparentSource::FromAddresses(NonEmptyBTreeSet::singleton(taddr)),
+            coinbase: CoinbasePolicy::NonCoinbase,
+        }
     }
 
-    /// Creates a policy that only spends from a single transparent address.
-    pub fn from_one_transparent_address(taddr: TransparentAddress) -> Self {
-        Self::FromAddresses(NonEmptyBTreeSet::singleton(taddr))
+    /// Returns a copy of this policy with the given coinbase policy in effect.
+    pub fn with_coinbase(mut self, coinbase: CoinbasePolicy) -> Self {
+        self.coinbase = coinbase;
+        self
     }
+
+    /// Returns the transparent source from which UTXOs may be drawn.
+    pub fn source(&self) -> &TransparentSource {
+        &self.source
+    }
+
+    /// Returns the coinbase policy in effect for this transparent spend.
+    pub fn coinbase(&self) -> CoinbasePolicy {
+        self.coinbase
+    }
+
+    /// Returns the explicit list of transparent addresses UTXOs may be drawn from, or `None` if
+    /// any of the account's transparent receivers are permitted.
+    fn address_allow_list(&self) -> Option<Vec<TransparentAddress>> {
+        match &self.source {
+            TransparentSource::FromAddresses(addrs) => Some(addrs.iter().copied().collect()),
+            TransparentSource::AnyAccountAddr => None,
+        }
+    }
+}
+
+/// The transparent receivers a [`TransparentSpendPolicy`] may draw UTXOs from.
+#[cfg(feature = "transparent-inputs")]
+#[derive(Clone, Debug)]
+pub enum TransparentSource {
+    /// Any transparent receiver belonging to the account. The proposer chooses which, potentially
+    /// linking them.
+    AnyAccountAddr,
+    /// Only the specified transparent addresses.
+    FromAddresses(NonEmptyBTreeSet<TransparentAddress>),
 }
 
 /// An [`InputSelector`] implementation that uses a greedy strategy to select between available
@@ -673,6 +709,8 @@ impl<DbT> GreedyInputSelector<DbT> {
         // The list used to filter addresses.
         // If `None`, any address is allowed.
         address_allow_list: Option<&[TransparentAddress]>,
+        // Which coinbase outputs are eligible for selection.
+        coinbase: CoinbaseFilter,
         transaction_request: &TransactionRequest,
         amount_at_transparent_gather: &mut Zatoshis,
     ) -> Result<
@@ -720,7 +758,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 account,
                 target_height,
                 confirmations_policy,
-                CoinbaseFilter::NonCoinbaseOnly,
+                coinbase,
                 address_allow_list,
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
@@ -740,23 +778,6 @@ impl<DbT> GreedyInputSelector<DbT> {
 #[cfg(feature = "transparent-inputs")]
 fn shielding_max_inputs(block_space_percent: u32) -> usize {
     (MAX_BLOCK_BYTES.saturating_mul(block_space_percent as usize) / 100) / P2PKH_STANDARD_INPUT_SIZE
-}
-
-/// Returns the set of transparent addresses that `spend_policy` permits the transparent
-/// gather to select from, or `None` if any of the account's transparent receivers are
-/// eligible.
-///
-/// This must be applied *within* the gather (not to its results), so that outputs excluded
-/// by the policy do not consume the gather's value bound; see
-/// [`InputSource::select_spendable_transparent_outputs`].
-#[cfg(feature = "transparent-inputs")]
-fn transparent_address_allow_list(
-    spend_policy: &TransparentSpendPolicy,
-) -> Option<Vec<TransparentAddress>> {
-    match spend_policy {
-        TransparentSpendPolicy::FromAddresses(addrs) => Some(addrs.iter().copied().collect()),
-        TransparentSpendPolicy::ShieldedOnly | TransparentSpendPolicy::AnyAccountTaddr => None,
-    }
 }
 
 impl<DbT> Default for GreedyInputSelector<DbT> {
@@ -921,28 +942,19 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
         let mut amount_at_transparent_gather = Zatoshis::ZERO;
         #[cfg(feature = "transparent-inputs")]
         let mut transparent_inputs = match spend_policy.transparent() {
-            None | Some(TransparentSpendPolicy::ShieldedOnly) => {
+            None => {
                 // No transparent spending is permitted; skip the gather entirely.
                 Vec::new()
             }
-            Some(TransparentSpendPolicy::AnyAccountTaddr) => self.gather_transparent::<ChangeT>(
-                wallet_db,
-                target_height,
-                confirmations_policy,
-                account,
-                // Pass an empty set as the allow list
-                None,
-                &transaction_request,
-                &mut amount_at_transparent_gather,
-            )?,
-            Some(transparent @ TransparentSpendPolicy::FromAddresses(_)) => {
-                let address_allow_list = transparent_address_allow_list(transparent);
+            Some(transparent) => {
+                let address_allow_list = transparent.address_allow_list();
                 self.gather_transparent::<ChangeT>(
                     wallet_db,
                     target_height,
                     confirmations_policy,
                     account,
                     address_allow_list.as_deref(),
+                    transparent.coinbase().into(),
                     &transaction_request,
                     &mut amount_at_transparent_gather,
                 )?
@@ -1301,18 +1313,15 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // defensive fallback. The common case (fee estimate was close) is
                     // a no-op.
                     #[cfg(feature = "transparent-inputs")]
-                    if let Some(transparent) = spend_policy
-                        .transparent()
-                        .filter(|tp| !matches!(tp, TransparentSpendPolicy::ShieldedOnly))
-                    {
+                    if let Some(transparent) = spend_policy.transparent() {
                         if required > amount_at_transparent_gather {
-                            let address_allow_list = transparent_address_allow_list(transparent);
+                            let address_allow_list = transparent.address_allow_list();
                             transparent_inputs = wallet_db
                                 .select_spendable_transparent_outputs(
                                     account,
                                     target_height,
                                     confirmations_policy,
-                                    CoinbaseFilter::NonCoinbaseOnly,
+                                    transparent.coinbase().into(),
                                     address_allow_list.as_deref(),
                                     TargetValue::AtLeast(required),
                                     shielding_max_inputs(self.shielding_block_space_percent),
@@ -2359,5 +2368,18 @@ mod spend_policy_tests {
             CoinbaseFilter::from(CoinbasePolicy::NonCoinbase),
             CoinbaseFilter::NonCoinbaseOnly
         );
+    }
+
+    // A transparent spend policy spends non-coinbase UTXOs by default, and `with_coinbase`
+    // overrides that choice while preserving the source.
+    #[cfg(feature = "transparent-inputs")]
+    #[test]
+    fn transparent_policy_coinbase_defaults_and_override() {
+        let policy = TransparentSpendPolicy::any_account_addr();
+        assert_eq!(policy.coinbase(), CoinbasePolicy::NonCoinbase);
+
+        let policy = policy.with_coinbase(CoinbasePolicy::OnlyCoinbase);
+        assert_eq!(policy.coinbase(), CoinbasePolicy::OnlyCoinbase);
+        assert!(matches!(policy.source(), TransparentSource::AnyAccountAddr));
     }
 }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -900,6 +900,50 @@ mod tests {
         ChangeValue::shielded(pool, Zatoshis::const_from_u64(value), None)
     }
 
+    /// Proposal construction conserves value: the total output value of a step (payments +
+    /// change + fee) may never exceed its total input value. A step whose outputs exceed its
+    /// inputs is rejected with [`ProposalError::BalanceError`] rather than being constructed.
+    /// This is the value-conservation floor that pool-selection policy builds on: no selection
+    /// of inputs can ever be assembled into a proposal that spends more than it takes in.
+    #[test]
+    fn proposal_construction_conserves_value() {
+        // Inputs: one 10_000 Orchard note. Outputs: 8_000 change + 4_000 fee = 12_000, which
+        // exceeds the 10_000 of input value. (ironwood_active = false so the balance check,
+        // not the turnstile, is what rejects this.)
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(1, 0),
+                TransactionBalance::new(
+                    vec![shielded_change(ShieldedPool::Orchard, 8_000)],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                false,
+            ),
+            Err(ProposalError::BalanceError {
+                input_total,
+                output_total,
+            }) if input_total == Zatoshis::const_from_u64(10_000)
+                && output_total == Zatoshis::const_from_u64(12_000)
+        );
+
+        // The matching balanced step (6_000 change + 4_000 fee == 10_000 input) is accepted,
+        // confirming the rejection above is due to the value imbalance and not some unrelated
+        // constraint.
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes(1, 0),
+                TransactionBalance::new(
+                    vec![shielded_change(ShieldedPool::Orchard, 6_000)],
+                    Zatoshis::const_from_u64(4_000),
+                )
+                .unwrap(),
+                false,
+            ),
+            Ok(_)
+        );
+    }
+
     #[test]
     fn orchard_turnstile_permits_only_strict_pool_balance_decrease() {
         // Post-activation, change may return to Orchard when strictly less value returns

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2611,6 +2611,28 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL, R> Wallet
     }
 
     #[cfg(feature = "orchard")]
+    fn put_ironwood_subtree_roots(
+        &mut self,
+        start_index: u64,
+        roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        let tx = self
+            .conn
+            .borrow_mut()
+            .transaction()
+            .map_err(|e| ShardTreeError::Storage(commitment_tree::Error::Query(e)))?;
+        put_shard_roots::<_, { ORCHARD_SHARD_HEIGHT * 2 }, ORCHARD_SHARD_HEIGHT>(
+            &tx,
+            IRONWOOD_TABLES_PREFIX,
+            start_index,
+            roots,
+        )?;
+        tx.commit()
+            .map_err(|e| ShardTreeError::Storage(commitment_tree::Error::Query(e)))?;
+        Ok(())
+    }
+
+    #[cfg(feature = "orchard")]
     fn with_ironwood_tree_mut<F, A, E>(&mut self, mut callback: F) -> Result<Option<A>, E>
     where
         for<'a> F:
@@ -2689,6 +2711,20 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
         put_shard_roots::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>(
             self.conn.0,
             ORCHARD_TABLES_PREFIX,
+            start_index,
+            roots,
+        )
+    }
+
+    #[cfg(feature = "orchard")]
+    fn put_ironwood_subtree_roots(
+        &mut self,
+        start_index: u64,
+        roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        put_shard_roots::<_, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }, ORCHARD_SHARD_HEIGHT>(
+            self.conn.0,
+            IRONWOOD_TABLES_PREFIX,
             start_index,
             roots,
         )

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2025,8 +2025,21 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         &self,
         spends: impl Iterator<Item = &'t orchard::note::Nullifier>,
     ) -> Result<std::collections::HashSet<Self::AccountId>, Self::Error> {
-        wallet::orchard::detect_spending_accounts(self.conn.borrow(), spends)
+        wallet::orchard::detect_spending_accounts(self.conn.borrow(), ORCHARD_TABLES_PREFIX, spends)
             .map_err(SqliteClientError::from)
+    }
+
+    #[cfg(feature = "orchard")]
+    fn detect_accounts_ironwood<'t>(
+        &self,
+        spends: impl Iterator<Item = &'t orchard::note::Nullifier>,
+    ) -> Result<std::collections::HashSet<Self::AccountId>, Self::Error> {
+        wallet::orchard::detect_spending_accounts(
+            self.conn.borrow(),
+            IRONWOOD_TABLES_PREFIX,
+            spends,
+        )
+        .map_err(SqliteClientError::from)
     }
 
     #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3862,6 +3862,16 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
                 })?;
             Ok::<_, SqliteClientError>(())
         })?;
+        #[cfg(feature = "orchard")]
+        wdb.with_ironwood_tree_mut(|tree| {
+            tree.truncate_to_checkpoint(&truncation_height)
+                .map_err(|error| SqliteClientError::TruncateCommitmentTree {
+                    pool: ShieldedPool::Ironwood,
+                    height: truncation_height,
+                    error,
+                })?;
+            Ok::<_, SqliteClientError>(())
+        })?;
 
         // Do not delete sent notes; this can contain data that is not recoverable
         // from the chain. Wallets must continue to operate correctly in the
@@ -4002,6 +4012,22 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
             )
             .map_err(|error| SqliteClientError::TruncateCommitmentTree {
                 pool: ShieldedPool::Orchard,
+                height: target_height,
+                error,
+            })?;
+            Ok::<_, SqliteClientError>(())
+        })?;
+        #[cfg(feature = "orchard")]
+        wdb.with_ironwood_tree_mut(|tree| {
+            tree.insert_frontier(
+                chain_state.final_ironwood_tree().clone(),
+                Retention::Checkpoint {
+                    id: target_height,
+                    marking: Marking::None,
+                },
+            )
+            .map_err(|error| SqliteClientError::TruncateCommitmentTree {
+                pool: ShieldedPool::Ironwood,
                 height: target_height,
                 error,
             })?;

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -35,7 +35,7 @@ use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
 #[cfg(feature = "orchard")]
-use crate::{ORCHARD_TABLES_PREFIX, orchard_tree};
+use crate::{ORCHARD_TABLES_PREFIX, ironwood_tree, orchard_tree};
 
 use super::common::{TableConstants, table_constants};
 
@@ -1274,6 +1274,31 @@ pub(crate) fn check_witnesses(
 
         for addr in orchard_incomplete {
             let range = super::get_block_range(conn, ShieldedPool::Orchard, addr)?;
+            scan_ranges.extend(range);
+        }
+
+        let unspent_ironwood_note_meta = super::common::select_unspent_note_meta(
+            conn,
+            ShieldedPool::Ironwood,
+            wallet_birthday,
+            anchor_height,
+        )?;
+        let mut ironwood_incomplete = vec![];
+        let ironwood_tree = ironwood_tree(conn)?;
+        for m in unspent_ironwood_note_meta.iter() {
+            match ironwood_tree.witness_at_checkpoint_depth(m.commitment_tree_position(), 0) {
+                Ok(_) => {}
+                Err(ShardTreeError::Query(QueryError::TreeIncomplete(mut addrs))) => {
+                    ironwood_incomplete.append(&mut addrs);
+                }
+                Err(other) => {
+                    return Err(SqliteClientError::CommitmentTree(other));
+                }
+            }
+        }
+
+        for addr in ironwood_incomplete {
+            let range = super::get_block_range(conn, ShieldedPool::Ironwood, addr)?;
             scan_ranges.extend(range);
         }
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1570,6 +1570,68 @@ pub(crate) mod tests {
             .unwrap()
         }
 
+        /// When the caller restricts the spend policy to the Orchard pool, input selection may
+        /// not cross into another pool to cover a shortfall: if the wallet's Orchard notes cannot
+        /// fund the payment on their own, the proposal fails with `InsufficientFunds` even though
+        /// an ample Sapling note exists. Crossing a pool boundary is privacy-breaking and must be
+        /// an explicit choice, expressed by permitting the other pool in the `SpendPolicy`.
+        #[test]
+        fn restricting_spend_policy_to_orchard_forbids_crossing_into_sapling() {
+            use zcash_client_backend::data_api::wallet::input_selection::SpendPolicy;
+
+            let mut st = TestBuilder::new()
+                .with_network(ironwood_active_network())
+                .with_data_store_factory(TestDbFactory::default())
+                .with_block_cache(BlockCache::new())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+
+            let account = st.test_account().cloned().unwrap();
+            let account_id = account.id();
+
+            // A small Orchard note that cannot fund the payment on its own, plus a large Sapling
+            // note that easily could.
+            let (h, _, _) = st.generate_next_block(
+                &OrchardPoolTester::test_account_fvk(&st),
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(30_000),
+            );
+            st.generate_next_block(
+                &SaplingPoolTester::test_account_fvk(&st),
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(200_000),
+            );
+            st.scan_cached_blocks(h, 2);
+
+            for _ in 0..5 {
+                let (h, _) = st.generate_empty_block();
+                st.scan_cached_blocks(h, 1);
+            }
+
+            // Pay more than the Orchard note holds, so covering it would require crossing into
+            // Sapling — which the restricted policy forbids.
+            let request = orchard_payment_request(st.network(), 80_000);
+            let change_strategy = orchard_change_strategy();
+            let input_selector = GreedyInputSelector::new();
+
+            let result = st.propose_transfer_with_policy(
+                account_id,
+                &input_selector,
+                &change_strategy,
+                request,
+                ConfirmationsPolicy::MIN,
+                &SpendPolicy::shielded_pools([ShieldedPool::Orchard]),
+            );
+
+            let err = result.expect_err(
+                "restricting to Orchard must forbid crossing into Sapling to cover the shortfall",
+            );
+            assert!(
+                format!("{err:?}").contains("InsufficientFunds"),
+                "expected InsufficientFunds, got: {err:?}",
+            );
+        }
+
         prop_compose! {
             // An Orchard note value (which may or may not, on its own, cover the payment) alongside
             // large Sapling and Ironwood notes that always cover it, plus a small payment. This lets

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -518,14 +518,17 @@ pub(crate) fn get_ironwood_nullifiers(
 
 pub(crate) fn detect_spending_accounts<'a>(
     conn: &Connection,
+    table_prefix: &str,
     nfs: impl Iterator<Item = &'a Nullifier>,
 ) -> Result<HashSet<AccountUuid>, rusqlite::Error> {
-    let mut account_q = conn.prepare_cached(
+    // Orchard and Ironwood notes share the Orchard nullifier type but live in separate tables;
+    // the caller selects which via `table_prefix`.
+    let mut account_q = conn.prepare_cached(&format!(
         "SELECT a.uuid
-         FROM orchard_received_notes rn
+         FROM {table_prefix}_received_notes rn
          JOIN accounts a ON a.id = rn.account_id
          WHERE rn.nf IN rarray(:nf_ptr)",
-    )?;
+    ))?;
 
     let nf_values: Vec<Value> = nfs.map(|nf| Value::Blob(nf.to_bytes().to_vec())).collect();
     let nf_ptr = Rc::new(nf_values);
@@ -1799,6 +1802,161 @@ pub(crate) mod tests {
             assert_eq!(
                 stale_checkpoints, 0,
                 "truncation must remove Ironwood tree checkpoints above the truncation height",
+            );
+        }
+
+        /// A transaction may be connected to the wallet solely by spending one of its Ironwood
+        /// notes: it produces an Ironwood bundle revealing that note's nullifier, but has no
+        /// wallet-owned outputs. `get_funding_accounts` must recognize such a spend, otherwise
+        /// storing the decrypted transaction sees no wallet involvement, drops it, and never
+        /// records the note as spent — leaving the spent note counted as spendable.
+        #[test]
+        fn get_funding_accounts_detects_ironwood_only_spends() {
+            use orchard::keys::{FullViewingKey, Scope, SpendAuthorizingKey};
+            use rand_core::OsRng;
+            use transparent::builder::TransparentSigningSet;
+            use zcash_client_backend::data_api::{
+                TargetValue, WalletCommitmentTrees,
+                wallet::{TargetHeight, decrypt_and_store_transaction},
+            };
+            use zcash_primitives::transaction::{
+                builder::{BuildConfig, Builder},
+                fees::zip317,
+            };
+            use zcash_protocol::memo::MemoBytes;
+
+            use crate::error::SqliteClientError;
+            use crate::wallet::orchard::select_spendable_ironwood_notes;
+
+            let mut st = TestBuilder::new()
+                .with_network(ironwood_active_network())
+                .with_data_store_factory(TestDbFactory::default())
+                .with_block_cache(BlockCache::new())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+
+            let account = st.test_account().cloned().unwrap();
+            let account_id = account.id();
+            let network = st.network().clone();
+
+            // Receive a single Ironwood note, scan it, then add confirmations.
+            let fvk = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
+            let (received_height, _, _) = st.generate_next_block(
+                &fvk,
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(100_000),
+            );
+            st.scan_cached_blocks(received_height, 1);
+            for _ in 0..5 {
+                let (h, _) = st.generate_empty_block();
+                st.scan_cached_blocks(h, 1);
+            }
+
+            // The anchor is the Ironwood tree state as of the height at which the note was
+            // received, and the spend targets the next block.
+            let anchor_height = received_height;
+            let target_height = TargetHeight::from(anchor_height + 1);
+
+            // Retrieve the received note (and its commitment tree position) from the wallet.
+            let received = select_spendable_ironwood_notes(
+                st.wallet().conn(),
+                &network,
+                account_id,
+                TargetValue::AtLeast(Zatoshis::const_from_u64(1)),
+                target_height,
+                ConfirmationsPolicy::MIN,
+                &[],
+            )
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("the received Ironwood note is spendable");
+            let note = *received.note();
+            let position = received.note_commitment_tree_position();
+
+            // Build the anchor and Merkle path from the wallet's Ironwood tree at the note's
+            // receipt height.
+            let (anchor, merkle_path) = st
+                .wallet_mut()
+                .with_ironwood_tree_mut::<_, _, SqliteClientError>(|tree| {
+                    let anchor: orchard::Anchor = tree
+                        .root_at_checkpoint_id(&anchor_height)?
+                        .expect("a checkpoint exists at the note's receipt height")
+                        .into();
+                    let merkle_path: orchard::tree::MerklePath = tree
+                        .witness_at_checkpoint_id_caching(position, &anchor_height)?
+                        .expect("the received note can be witnessed at its receipt height")
+                        .into();
+                    Ok((anchor, merkle_path))
+                })
+                .unwrap()
+                .expect("the wallet tracks an Ironwood tree");
+
+            // Spend the note, sending its whole balance less the fee to an external Ironwood
+            // recipient. The transaction thus has no wallet-owned outputs: its only connection to
+            // the wallet is the Ironwood spend.
+            let usk = account.usk();
+            let spend_fvk = FullViewingKey::from(usk.orchard());
+            let orchard_sak = SpendAuthorizingKey::from(usk.orchard());
+
+            let external_sk = OrchardPoolTester::sk(&[0xf5; 32]);
+            let external_recipient =
+                FullViewingKey::from(&external_sk).address_at(0u32, Scope::External);
+
+            let mut builder = Builder::new(
+                network.clone(),
+                BlockHeight::from(target_height),
+                BuildConfig::Standard {
+                    sapling_anchor: None,
+                    orchard_anchor: None,
+                    ironwood_anchor: Some(anchor),
+                },
+            );
+            builder
+                .add_ironwood_spend::<zip317::FeeRule>(spend_fvk, note, merkle_path)
+                .unwrap();
+            builder
+                .add_ironwood_output::<zip317::FeeRule>(
+                    None,
+                    external_recipient,
+                    Zatoshis::const_from_u64(90_000),
+                    MemoBytes::empty(),
+                )
+                .unwrap();
+            let tx = builder
+                .mock_build(&TransparentSigningSet::new(), &[], &[orchard_sak], OsRng)
+                .unwrap()
+                .transaction()
+                .clone();
+
+            let spends_before: i64 = st
+                .wallet()
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM ironwood_received_note_spends",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(spends_before, 0, "the note has not yet been spent");
+
+            // Storing the decrypted (unmined) transaction must detect the Ironwood spend as
+            // wallet-funded and record the note as spent.
+            decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, None).unwrap();
+
+            let spends_after: i64 = st
+                .wallet()
+                .conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM ironwood_received_note_spends",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                spends_after, 1,
+                "storing a transaction that spends an Ironwood note must record the note as \
+                 spent, which requires get_funding_accounts to detect the Ironwood spend",
             );
         }
 

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1748,6 +1748,60 @@ pub(crate) mod tests {
             );
         }
 
+        /// A reorg truncation must roll back the Ironwood note commitment tree along with the
+        /// Sapling and Orchard trees. If it does not, checkpoints (and commitments) for the
+        /// rolled-back blocks remain, and a later re-scan appends onto a stale frontier,
+        /// corrupting the Ironwood anchors.
+        #[test]
+        fn truncate_rolls_back_the_ironwood_tree() {
+            use zcash_client_backend::data_api::WalletWrite;
+
+            let mut st = TestBuilder::new()
+                .with_network(ironwood_active_network())
+                .with_data_store_factory(TestDbFactory::default())
+                .with_block_cache(BlockCache::new())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+
+            // Receive Ironwood notes in three consecutive blocks and scan them, so the Ironwood
+            // tree gains a checkpoint at each height.
+            let fvk = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
+            let (h0, _, _) = st.generate_next_block(
+                &fvk,
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(100_000),
+            );
+            st.generate_next_block(
+                &fvk,
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(100_000),
+            );
+            st.generate_next_block(
+                &fvk,
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(100_000),
+            );
+            st.scan_cached_blocks(h0, 3);
+
+            // A reorg truncates the wallet back to h0; the Ironwood tree must roll back with the
+            // Sapling and Orchard trees.
+            st.wallet_mut().truncate_to_height(h0).unwrap();
+
+            let stale_checkpoints: i64 = st
+                .wallet_mut()
+                .conn_mut()
+                .query_row(
+                    "SELECT COUNT(*) FROM ironwood_tree_checkpoints WHERE checkpoint_id > ?1",
+                    [u32::from(h0)],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                stale_checkpoints, 0,
+                "truncation must remove Ironwood tree checkpoints above the truncation height",
+            );
+        }
+
         prop_compose! {
             // An Orchard note value (which may or may not, on its own, cover the payment) alongside
             // large Sapling and Ironwood notes that always cover it, plus a small payment. This lets

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -2122,6 +2122,23 @@ pub(crate) mod tests {
                     1,
                     "the change must be retained as an Orchard note of the expected value"
                 );
+
+                // The payment output is carried by the Ironwood bundle, so its sent-note record
+                // must be attributed to the Ironwood pool. Post-NU6.3 an Orchard-pool payment
+                // output is forbidden when spending Orchard (only change may return to Orchard),
+                // so a payment tagged Orchard here is both a mis-file and a protocol violation.
+                let payment_pool: i64 = conn
+                    .query_row(
+                        "SELECT output_pool FROM sent_notes WHERE value = ?1",
+                        [i64::try_from(payment_zats).unwrap()],
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                prop_assert_eq!(
+                    payment_pool,
+                    crate::wallet::encoding::pool_code(PoolType::IRONWOOD),
+                    "the Ironwood-bundle payment must be recorded as an Ironwood-pool sent output",
+                );
             }
         }
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1632,6 +1632,122 @@ pub(crate) mod tests {
             );
         }
 
+        /// A transaction that spends an Orchard note (producing an Orchard bundle) and returns
+        /// wallet-owned Ironwood change must record that change at the same action index the
+        /// scanner assigns — the raw index within the Ironwood bundle. The send path shifted the
+        /// Ironwood index by the Orchard action count (mapping into a "combined Orchard-family
+        /// space"), so the send-stored index disagreed with the scanned index and, when both were
+        /// written, the change was recorded twice (inflating the balance). The two indices must
+        /// agree.
+        #[test]
+        fn ironwood_change_is_stored_at_the_raw_bundle_index() {
+            use std::collections::HashMap;
+            use std::convert::Infallible;
+
+            use zcash_client_backend::{data_api::WalletRead, decrypt_transaction};
+
+            let mut st = TestBuilder::new()
+                .with_network(ironwood_active_network())
+                .with_data_store_factory(TestDbFactory::default())
+                .with_block_cache(BlockCache::new())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+
+            let account = st.test_account().cloned().unwrap();
+            let account_id = account.id();
+
+            // A small Orchard note (so returning the change to Orchard would violate the turnstile,
+            // spilling it into Ironwood) plus Ironwood and Sapling notes that are jointly required
+            // to cover the payment, forcing the Orchard note to be spent (and an Orchard bundle to
+            // be built).
+            let (h, _, _) = st.generate_next_block(
+                &OrchardPoolTester::test_account_fvk(&st),
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(10_000),
+            );
+            st.generate_next_block(
+                &IronwoodFvk(OrchardPoolTester::test_account_fvk(&st)),
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(60_000),
+            );
+            st.generate_next_block(
+                &SaplingPoolTester::test_account_fvk(&st),
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(90_000),
+            );
+            st.scan_cached_blocks(h, 3);
+            for _ in 0..5 {
+                let (h, _) = st.generate_empty_block();
+                st.scan_cached_blocks(h, 1);
+            }
+
+            // No single note covers the payment, so all three pools are combined; the small
+            // Orchard note is drained and its change spills into Ironwood.
+            let request = orchard_payment_request(st.network(), 100_000);
+            let change_strategy = orchard_change_strategy();
+            let input_selector = GreedyInputSelector::new();
+            let proposal = st
+                .propose_transfer(
+                    account_id,
+                    &input_selector,
+                    &change_strategy,
+                    request,
+                    ConfirmationsPolicy::MIN,
+                )
+                .unwrap();
+
+            let created = st
+                .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                    account.usk(),
+                    OvkPolicy::Sender,
+                    &proposal,
+                )
+                .unwrap();
+            let tx = st
+                .wallet()
+                .get_transaction(created[0])
+                .unwrap()
+                .expect("the sent transaction was stored");
+            assert!(
+                tx.orchard_bundle().is_some(),
+                "the Orchard spend must produce an Orchard bundle",
+            );
+            assert!(
+                tx.ironwood_bundle().is_some(),
+                "the Ironwood change must produce an Ironwood bundle",
+            );
+
+            // The send path recorded the wallet-owned Ironwood change as a received note. It is
+            // distinguished from the spent 60k input note (also in this table) by having no
+            // nullifier recorded: the change note has not been scanned, so no `nf` is known yet.
+            let stored_index: i64 = st
+                .wallet_mut()
+                .conn_mut()
+                .query_row(
+                    "SELECT action_index FROM ironwood_received_notes WHERE nf IS NULL",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("the Ironwood change must be recorded on the send path");
+
+            // The canonical index is the raw within-bundle index the decrypt/scan path assigns.
+            let mut ufvks = HashMap::new();
+            ufvks.insert(account_id, account.ufvk().unwrap().clone());
+            let d_tx = decrypt_transaction(st.network(), None, None, &tx, &ufvks);
+            let change = d_tx
+                .ironwood_outputs()
+                .iter()
+                .find(|o| o.value_pool() == ShieldedPool::Ironwood)
+                .expect("the wallet-owned Ironwood change is detected on decryption");
+            let raw_index = i64::try_from(change.index()).unwrap();
+
+            assert_eq!(
+                stored_index, raw_index,
+                "the send path must record the Ironwood change at the raw bundle index the \
+                 scanner uses, so the two write paths agree and the note is not counted twice",
+            );
+        }
+
         prop_compose! {
             // An Orchard note value (which may or may not, on its own, cover the payment) alongside
             // large Sapling and Ironwood notes that always cover it, plus a small payment. This lets

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -522,20 +522,21 @@ pub(crate) fn update_chain_tip<P: consensus::Parameters>(
     // `ScanRange` uses an exclusive upper bound.
     let chain_end = new_tip + 1;
 
-    // Read the maximum height from each of the shards tables. The minimum of the two
-    // gives the start of a height range that covers the last incomplete shard of both the
-    // Sapling and Orchard pools.
+    // Read the maximum height from each of the shards tables. The minimum across the pools gives
+    // the start of a height range that covers the last incomplete shard of every pool, so that
+    // none is left behind. The Ironwood pool is included: post-NU6.3 it is sparse, so its last
+    // shard can end well below the Sapling and Orchard tips.
     let sapling_shard_tip = tip_shard_end_height(conn, ShieldedPool::Sapling)?;
     #[cfg(feature = "orchard")]
     let orchard_shard_tip = tip_shard_end_height(conn, ShieldedPool::Orchard)?;
+    #[cfg(feature = "orchard")]
+    let ironwood_shard_tip = tip_shard_end_height(conn, ShieldedPool::Ironwood)?;
 
     #[cfg(feature = "orchard")]
-    let min_shard_tip = match (sapling_shard_tip, orchard_shard_tip) {
-        (None, None) => None,
-        (None, Some(o)) => Some(o),
-        (Some(s), None) => Some(s),
-        (Some(s), Some(o)) => Some(std::cmp::min(s, o)),
-    };
+    let min_shard_tip = [sapling_shard_tip, orchard_shard_tip, ironwood_shard_tip]
+        .into_iter()
+        .flatten()
+        .min();
     #[cfg(not(feature = "orchard"))]
     let min_shard_tip = sapling_shard_tip;
 
@@ -2122,6 +2123,65 @@ pub(crate) mod tests {
             stored,
             Some(u32::from(shard_end)),
             "put_ironwood_subtree_roots must record the subtree end height in ironwood_tree_shards",
+        );
+    }
+
+    /// `update_chain_tip` must fold the Ironwood shard tip into the ChainTip-priority scan range,
+    /// alongside the Sapling and Orchard shard tips. Post-NU6.3 the Ironwood pool is sparse, so
+    /// its last shard can end well below the others; if it is omitted from the minimum, the
+    /// ChainTip range starts at the higher Sapling/Orchard tip and the incomplete Ironwood shard
+    /// is not scheduled for scanning at ChainTip priority.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn update_chain_tip_covers_the_ironwood_shard_tip() {
+        use ScanPriority::*;
+
+        let (mut st, _, birthday, _sap_active) =
+            test_with_nu5_birthday_offset::<OrchardPoolTester>(76, 1000, BlockHash([0; 32]), true);
+        let b = birthday.height();
+
+        // Sapling and Orchard complete a shard high above the birthday; the Ironwood shard ends
+        // at a lower height (the sparse-pool reality).
+        let high = b + 1000;
+        let low = b + 400;
+        st.put_subtree_roots(
+            1,
+            &[CommitmentTreeRoot::from_parts(
+                high,
+                ::sapling::Node::empty_leaf(),
+            )],
+            1,
+            &[CommitmentTreeRoot::from_parts(
+                high,
+                MerkleHashOrchard::empty_leaf(),
+            )],
+        )
+        .unwrap();
+        st.wallet_mut()
+            .put_ironwood_subtree_roots(
+                1,
+                &[CommitmentTreeRoot::from_parts(
+                    low,
+                    MerkleHashOrchard::empty_leaf(),
+                )],
+            )
+            .unwrap();
+
+        st.wallet_mut().update_chain_tip(high + 20).unwrap();
+
+        // The lowest-starting ChainTip range must reach down to the Ironwood shard tip, not stop
+        // at the higher Sapling/Orchard tip.
+        let ranges = suggest_scan_ranges(st.wallet().conn(), Ignored).unwrap();
+        let chain_tip_start = ranges
+            .iter()
+            .filter(|r| r.priority() == ChainTip)
+            .map(|r| r.block_range().start)
+            .min()
+            .expect("there must be a ChainTip scan range");
+        assert!(
+            chain_tip_start <= low,
+            "the ChainTip range must cover the Ironwood shard tip {low:?}, but started at \
+             {chain_tip_start:?}",
         );
     }
 }

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -2085,4 +2085,43 @@ pub(crate) mod tests {
 
         assert_matches!(proposal, Ok(_));
     }
+
+    /// `put_ironwood_subtree_roots` records Ironwood subtree roots (and their end heights) in the
+    /// wallet's Ironwood shard table, exactly as the Sapling and Orchard equivalents do for their
+    /// pools. Without it, a wallet restoring from a subtree-root source cannot populate its
+    /// Ironwood tree at all.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn put_ironwood_subtree_roots_records_the_shard_end_height() {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let shard_end = st.sapling_activation_height() + 500;
+        st.wallet_mut()
+            .put_ironwood_subtree_roots(
+                0,
+                &[CommitmentTreeRoot::from_parts(
+                    shard_end,
+                    MerkleHashOrchard::empty_leaf(),
+                )],
+            )
+            .unwrap();
+
+        let stored: Option<u32> = st
+            .wallet()
+            .conn()
+            .query_row(
+                "SELECT MAX(subtree_end_height) FROM ironwood_tree_shards",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            Some(u32::from(shard_end)),
+            "put_ironwood_subtree_roots must record the subtree end height in ironwood_tree_shards",
+        );
+    }
 }


### PR DESCRIPTION
Stacked on #2539 (`dw/ironwood-scan-model`); this PR's base is that branch.

Gives callers explicit control over which sources of funds input selection may draw upon, so that crossing a shielded pool boundary — which reduces privacy — is an opt-in choice rather than a silent fallback. Restricting the policy to a single pool (e.g. `{Orchard}`) forces a transaction that spends only that pool, returning `InsufficientFunds` instead of silently reaching into another.

Commits:

- **Add `SpendPolicy`** — the set of shielded pools notes may be selected from, plus (behind `transparent-inputs`) an optional transparent policy, plus the caller-facing `CoinbasePolicy`. The default permits every shielded pool present in the build and no transparent spending, preserving the historical fully-shielded behavior. Includes a proposal balance-conservation unit test pinning that a step's output value can never exceed its input value.
- **Enforce shielded-pool selection** — threads `&SpendPolicy` through `InputSelector::propose_transaction` and `propose_transfer` (no longer behind `transparent-inputs`), and filters the greedy selector's pool-preference order to the permitted pools. A pool the policy does not name is never drawn upon, even as a fallback.
- **Coinbase-aware transparent policy** — replaces the `TransparentSpendPolicy` enum with a struct pairing a `TransparentSource` (`AnyAccountAddr` / `FromAddresses`) and a `CoinbasePolicy` (`OnlyCoinbase` / `NonCoinbase`); the transparent gather takes its coinbase filter from the policy (defaulting to non-coinbase, so existing behavior is unchanged).

CHANGELOG updated. All `--all-features` tests for `zcash_client_backend` and `zcash_client_sqlite` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MybuUMM5BaUFAjr3oWB11v
