### PR TITLE
Allow redacting Orchard anchor and cv_net

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -57,9 +57,10 @@ workspace.
   version separately from the version 1 serialization format.
 - PCZT version 2 serialization now omits empty Transparent, Sapling, and
   Orchard bundles.
-- PCZT version 2 Orchard bundle encodings now represent the bundle anchor and
-  per-action `cv_net` as optional fields. Absent values are restored as all zero
-  bytes in the logical `pczt::orchard` model.
+- The Orchard PCZT logical model now represents the bundle anchor and per-action
+  `cv_net` as optional fields, matching the version 2 encoding. Parsing resolves
+  absent `cv_net` values from the note values and `rcv`; absent anchors remain
+  absent until another PCZT copy or caller restores them.
 - The logical Orchard output model now represents its encrypted note plaintext
   as `pczt::orchard::EncCiphertext`, allowing v2 serialization to carry either
   encrypted ciphertext or a trailing-zero-stripped
@@ -92,8 +93,11 @@ workspace.
 - `pczt::orchard::{EncCiphertext, MEMO_SIZE, MemoPlaintext,
   MemoPlaintextError}` for representing encrypted note plaintext data in the
   logical Orchard output model.
-- `pczt::orchard::Bundle::{resolve_fields, resolve_memo_plaintexts}` and
+- `pczt::Pczt::resolve_fields`,
+  `pczt::orchard::Bundle::{resolve_fields, resolve_memo_plaintexts}`, and
   `pczt::roles::redactor::orchard::ActionRedactor::replace_enc_ciphertext_with_memo_plaintext`.
+- `pczt::roles::redactor::orchard::OrchardRedactor::clear_anchor` and
+  `pczt::roles::redactor::orchard::ActionRedactor::clear_cv_net`.
 - `pczt::v1`, a module providing the version 1 PCZT serialization format via
   `pczt::v1::Pczt`.
 - PCZT version 2 serialization, which encodes the Orchard note plaintext

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -313,7 +313,7 @@ pub mod v2 {
             let decoded = crate::parse(&encoded.serialize()).unwrap();
 
             assert_eq!(decoded.sapling.anchor, [1; 32]);
-            assert_eq!(decoded.orchard.anchor, [2; 32]);
+            assert_eq!(decoded.orchard.anchor, Some([2; 32]));
         }
 
         #[test]
@@ -377,6 +377,17 @@ impl Pczt {
     /// To serialize a specific PCZT version, e.g. v1, use [`v1::Pczt::serialize`].
     pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
         Ok(v2::Pczt::try_from(self)?.serialize())
+    }
+
+    /// Resolves derived or compact field representations carried by this PCZT.
+    ///
+    /// For improved efficiency, callers that will pass the same PCZT through
+    /// multiple roles should call this once up front. Parsing also resolves fields
+    /// defensively.
+    #[cfg(feature = "orchard")]
+    pub fn resolve_fields(&mut self) -> Result<(), ::orchard::pczt::ParseError> {
+        self.orchard.resolve_fields()?;
+        self.ironwood.resolve_fields()
     }
 
     /// Parses this PCZT's bundles and constructs a `TransactionData` using caller-provided
@@ -462,14 +473,13 @@ impl Pczt {
             .into_parsed()
             .map_err(ExtractError::TransparentParse)?;
         let sapling = sapling.into_parsed().map_err(ExtractError::SaplingParse)?;
+        let orchard_bundle_version = crate::orchard::bundle_version_for_revision(
+            orchard_protocol_revision,
+            ::orchard::ValuePool::Orchard,
+        )
+        .expect("the Orchard pool is supported under every protocol revision");
         let orchard = orchard
-            .into_parsed_with_version(
-                crate::orchard::bundle_version_for_revision(
-                    orchard_protocol_revision,
-                    ::orchard::ValuePool::Orchard,
-                )
-                .expect("the Orchard pool is supported under every protocol revision"),
-            )
+            .into_parsed_with_version(orchard_bundle_version, global.tx_version)
             .map_err(ExtractError::OrchardParse)?;
         let ironwood = ironwood
             .into_ironwood_parsed()

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -63,7 +63,7 @@ pub struct Bundle {
     ///
     /// Set by the Creator.
     #[getset(get = "pub")]
-    pub(crate) anchor: [u8; 32],
+    pub(crate) anchor: Option<[u8; 32]>,
 
     /// The note plaintext version for notes in this bundle.
     pub(crate) note_version: NoteVersion,
@@ -93,6 +93,8 @@ pub(crate) const IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED: u8 = 0b0000_
 /// The size in bytes of the memo portion of an Orchard note plaintext.
 pub(crate) const MEMO_SIZE: usize = 512;
 
+pub(crate) const DEFAULT_ANCHOR: [u8; 32] = [0; 32];
+
 /// The canonical empty Orchard-pool bundle: the form the Orchard slot of a PCZT takes
 /// when it carries no Orchard-protocol data. The Creator, the v1 decoder, and the v2
 /// decoder all produce exactly this value for an absent bundle, so that copies of a
@@ -101,7 +103,7 @@ pub(crate) const EMPTY_ORCHARD: Bundle = Bundle {
     actions: Vec::new(),
     flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
     value_sum: (0, false),
-    anchor: [0; 32],
+    anchor: None,
     note_version: NoteVersion::V2,
     zkproof: None,
     bsk: None,
@@ -112,7 +114,7 @@ pub(crate) const EMPTY_IRONWOOD: Bundle = Bundle {
     actions: Vec::new(),
     flags: IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
     value_sum: (0, false),
-    anchor: [0; 32],
+    anchor: None,
     note_version: NoteVersion::V3,
     zkproof: None,
     bsk: None,
@@ -350,11 +352,12 @@ pub struct Action {
     //
     // Action effecting data.
     //
-    // These are required fields that are part of the final transaction, and are filled in
-    // by the Constructor when adding an output.
+    // These fields describe the action as a whole. `cv_net` is part of the
+    // final transaction, but may be redacted in v2 and recomputed from the note
+    // values and `rcv`.
     //
     #[getset(get = "pub")]
-    pub(crate) cv_net: [u8; 32],
+    pub(crate) cv_net: Option<[u8; 32]>,
     #[getset(get = "pub")]
     pub(crate) spend: Spend,
     #[getset(get = "pub")]
@@ -620,7 +623,7 @@ pub mod v1 {
                     .collect::<Result<Vec<_>, _>>()?,
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: bundle.anchor.ok_or(crate::EncodingError::RequiresV2)?,
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
             })
@@ -637,7 +640,7 @@ pub mod v1 {
                     .collect(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
+                anchor: Some(bundle.anchor),
                 note_version: NoteVersion::V2,
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -650,7 +653,7 @@ pub mod v1 {
 
         fn try_from(action: super::Action) -> Result<Self, Self::Error> {
             Ok(Self {
-                cv_net: action.cv_net,
+                cv_net: action.cv_net.ok_or(crate::EncodingError::RequiresV2)?,
                 spend: Spend::from(action.spend),
                 output: Output::try_from(action.output)?,
                 rcv: action.rcv,
@@ -661,7 +664,7 @@ pub mod v1 {
     impl From<Action> for super::Action {
         fn from(action: Action) -> Self {
             Self {
-                cv_net: action.cv_net,
+                cv_net: Some(action.cv_net),
                 spend: super::Spend::from(action.spend),
                 output: super::Output::from(action.output),
                 rcv: action.rcv,
@@ -788,8 +791,6 @@ pub(crate) mod v2 {
         }
     }
 
-    const ZERO_BYTES_32: [u8; 32] = [0; 32];
-
     /// PCZT fields that are specific to producing the transaction's Orchard bundle.
     #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
     pub struct Bundle {
@@ -841,7 +842,7 @@ pub(crate) mod v2 {
                     .collect::<Vec<_>>(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: (bundle.anchor != ZERO_BYTES_32).then_some(bundle.anchor),
+                anchor: bundle.anchor,
                 note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -859,7 +860,7 @@ pub(crate) mod v2 {
                     .collect(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor.unwrap_or(ZERO_BYTES_32),
+                anchor: bundle.anchor,
                 note_version: bundle.note_version.into(),
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -870,7 +871,7 @@ pub(crate) mod v2 {
     impl From<super::Action> for Action {
         fn from(action: super::Action) -> Self {
             Self {
-                cv_net: (action.cv_net != ZERO_BYTES_32).then_some(action.cv_net),
+                cv_net: action.cv_net,
                 spend: v1::Spend::from(action.spend),
                 output: Output::from(action.output),
                 rcv: action.rcv,
@@ -881,7 +882,7 @@ pub(crate) mod v2 {
     impl From<Action> for super::Action {
         fn from(action: Action) -> Self {
             Self {
-                cv_net: action.cv_net.unwrap_or(ZERO_BYTES_32),
+                cv_net: action.cv_net,
                 spend: super::Spend::from(action.spend),
                 output: super::Output::from(action.output),
                 rcv: action.rcv,
@@ -929,16 +930,26 @@ pub(crate) mod v2 {
     /// decision of whether the bundle can be omitted. A bundle that is exactly equal
     /// to `empty` (the canonical empty bundle for its slot, [`super::EMPTY_ORCHARD`]
     /// or [`super::EMPTY_IRONWOOD`]) serializes to `None` and is dropped from the
-    /// encoding; any other bundle is converted via the [`Bundle`]-producing
-    /// [`TryFrom`] impl. The reverse direction is [`From<Bundle>`] plus the canonical
-    /// empty bundle for the omitted case.
+    /// encoding. An otherwise-empty bundle carrying [`super::DEFAULT_ANCHOR`] is
+    /// treated as empty for this purpose; any other bundle is converted via the
+    /// [`Bundle`]-producing [`TryFrom`] impl. The reverse direction is
+    /// [`From<Bundle>`] plus the canonical empty bundle for the omitted case.
     pub(crate) fn encode(
         bundle: super::Bundle,
         empty: &super::Bundle,
     ) -> Result<Option<Bundle>, crate::EncodingError> {
-        (bundle != *empty)
+        (!is_default_empty(&bundle, empty))
             .then(|| Bundle::try_from(bundle))
             .transpose()
+    }
+
+    fn is_default_empty(bundle: &super::Bundle, empty: &super::Bundle) -> bool {
+        let mut bundle = bundle.clone();
+        if bundle.anchor == Some(super::DEFAULT_ANCHOR) {
+            bundle.anchor = None;
+        }
+
+        bundle == *empty
     }
 
     #[cfg(test)]
@@ -950,7 +961,7 @@ pub(crate) mod v2 {
             MemoPlaintext, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output, Spend,
         };
 
-        fn logical_action(cv_net: [u8; 32]) -> LogicalAction {
+        fn logical_action(cv_net: Option<[u8; 32]>) -> LogicalAction {
             LogicalAction {
                 cv_net,
                 spend: Spend {
@@ -985,7 +996,7 @@ pub(crate) mod v2 {
             }
         }
 
-        fn logical_bundle(anchor: [u8; 32], cv_net: [u8; 32]) -> LogicalBundle {
+        fn logical_bundle(anchor: Option<[u8; 32]>, cv_net: Option<[u8; 32]>) -> LogicalBundle {
             LogicalBundle {
                 actions: vec![logical_action(cv_net)],
                 flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
@@ -998,27 +1009,17 @@ pub(crate) mod v2 {
         }
 
         #[test]
-        fn zero_anchor_and_cv_net_encode_as_none() {
-            let bundle = logical_bundle([0; 32], [0; 32]);
+        fn anchor_and_cv_net_round_trip_optional_encoding() {
+            for (anchor, cv_net) in [(None, None), (Some([5; 32]), Some([6; 32]))] {
+                let bundle = logical_bundle(anchor, cv_net);
 
-            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
-            assert!(encoded.anchor.is_none());
-            assert!(encoded.actions[0].cv_net.is_none());
+                let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
+                assert_eq!(encoded.anchor, anchor);
+                assert_eq!(encoded.actions[0].cv_net, cv_net);
 
-            let decoded = LogicalBundle::from(encoded);
-            assert_eq!(decoded, bundle);
-        }
-
-        #[test]
-        fn nonzero_anchor_and_cv_net_encode_as_some() {
-            let bundle = logical_bundle([5; 32], [6; 32]);
-
-            let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
-            assert_eq!(encoded.anchor, Some([5; 32]));
-            assert_eq!(encoded.actions[0].cv_net, Some([6; 32]));
-
-            let decoded = LogicalBundle::from(encoded);
-            assert_eq!(decoded, bundle);
+                let decoded = LogicalBundle::from(encoded);
+                assert_eq!(decoded, bundle);
+            }
         }
 
         #[test]
@@ -1068,7 +1069,7 @@ pub(crate) mod v2 {
             let encryptor = OrchardNoteEncryption::new(None, note, memo);
 
             LogicalAction {
-                cv_net: [0; 32],
+                cv_net: Some([0; 32]),
                 spend: Spend {
                     nullifier,
                     rk: [2; 32],
@@ -1176,12 +1177,25 @@ pub(crate) mod v2 {
 
         #[test]
         fn v1_rejects_memo_plaintext_ciphertext_data() {
-            let mut bundle = logical_bundle([5; 32], [6; 32]);
+            let mut bundle = logical_bundle(Some([5; 32]), Some([6; 32]));
             bundle.actions[0].output.enc_ciphertext =
                 EncCiphertext::MemoPlaintext(MemoPlaintext::from_memo([0; MEMO_SIZE]));
 
             assert!(matches!(
                 crate::orchard::v1::Bundle::try_from(bundle),
+                Err(crate::EncodingError::RequiresV2)
+            ));
+        }
+
+        #[test]
+        fn v1_rejects_missing_anchor_and_cv_net() {
+            assert!(matches!(
+                crate::orchard::v1::Bundle::try_from(logical_bundle(None, Some([6; 32]))),
+                Err(crate::EncodingError::RequiresV2)
+            ));
+
+            assert!(matches!(
+                crate::orchard::v1::Bundle::try_from(logical_bundle(Some([5; 32]), None)),
                 Err(crate::EncodingError::RequiresV2)
             ));
         }
@@ -1246,7 +1260,7 @@ impl Bundle {
             },
         }
 
-        if self.anchor != anchor {
+        if !merge_optional(&mut self.anchor, anchor) {
             return None;
         }
 
@@ -1293,8 +1307,7 @@ impl Bundle {
                 rcv,
             } = rhs;
 
-            if lhs.cv_net != cv_net
-                || lhs.spend.nullifier != nullifier
+            if lhs.spend.nullifier != nullifier
                 || lhs.spend.rk != rk
                 || lhs.output.cmx != cmx
                 || lhs.output.ephemeral_key != ephemeral_key
@@ -1304,7 +1317,8 @@ impl Bundle {
                 return None;
             }
 
-            if !(merge_optional(&mut lhs.spend.spend_auth_sig, spend_auth_sig)
+            if !(merge_optional(&mut lhs.cv_net, cv_net)
+                && merge_optional(&mut lhs.spend.spend_auth_sig, spend_auth_sig)
                 && merge_optional(&mut lhs.spend.recipient, recipient)
                 && merge_optional(&mut lhs.spend.value, value)
                 && merge_optional(&mut lhs.spend.rho, rho)
@@ -1438,26 +1452,67 @@ impl Output {
 }
 
 #[cfg(feature = "orchard")]
+impl Action {
+    /// Recomputes `cv_net`, if this action carries it as an omitted field.
+    fn resolve_cv_net(&mut self) -> Result<(), ::orchard::pczt::ParseError> {
+        use ::orchard::{
+            pczt::ParseError,
+            value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
+        };
+
+        if self.cv_net.is_some() {
+            return Ok(());
+        }
+
+        let spend_value: NoteValue =
+            NoteValue::from_raw(self.spend.value.ok_or(ParseError::InvalidValueCommitment)?);
+        let output_value = NoteValue::from_raw(
+            self.output
+                .value
+                .ok_or(ParseError::InvalidValueCommitment)?,
+        );
+        let rcv =
+            ValueCommitTrapdoor::from_bytes(self.rcv.ok_or(ParseError::InvalidValueCommitment)?)
+                .into_option()
+                .ok_or(ParseError::InvalidValueCommitment)?;
+
+        self.cv_net = Some(ValueCommitment::derive(spend_value - output_value, rcv).to_bytes());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+enum AnchorParseMode {
+    Strict,
+    AllowMissing,
+}
+
+#[cfg(feature = "orchard")]
+fn anchor_parse_mode(tx_version: u32, has_actions: bool) -> AnchorParseMode {
+    if tx_version == zcash_protocol::constants::V6_TX_VERSION || !has_actions {
+        AnchorParseMode::AllowMissing
+    } else {
+        AnchorParseMode::Strict
+    }
+}
+
+#[cfg(feature = "orchard")]
 impl Bundle {
     /// Resolves fields that are optionally redacted in the PCZT but implied by
     /// other known fields.
     ///
-    /// This currently recomputes [`Output::enc_ciphertext`] when it is
-    /// represented by memo plaintext.
+    /// This currently recomputes:
+    /// - [`Action::cv_net`] if it is redacted.
+    /// - [`Output::enc_ciphertext`] if it is represented by memo plaintext.
     ///
     /// For improved efficiency, callers that will pass the same bundle through
     /// multiple roles should call this once up front, not in each role. Parsing
     /// also resolves fields defensively.
     pub fn resolve_fields(&mut self) -> Result<(), ::orchard::pczt::ParseError> {
-        self.resolve_memo_plaintexts()
-    }
-
-    /// Recomputes every [`Output::enc_ciphertext`] represented by memo
-    /// plaintext.
-    ///
-    /// This is a no-op for outputs that already carry encrypted ciphertext.
-    pub fn resolve_memo_plaintexts(&mut self) -> Result<(), ::orchard::pczt::ParseError> {
         for action in &mut self.actions {
+            action.resolve_cv_net()?;
             action
                 .output
                 .encrypt_ciphertext_from_memo(self.note_version, action.spend.nullifier)?;
@@ -1471,17 +1526,25 @@ impl Bundle {
     pub(crate) fn into_ironwood_parsed(
         self,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_with_version(BundleVersion::ironwood_v3())
+        self.into_parsed_inner(
+            BundleVersion::ironwood_v3(),
+            false,
+            AnchorParseMode::AllowMissing,
+        )
     }
 
-    /// Parses this bundle as an Ironwood-pool bundle for a preverified signing pass,
-    /// skipping each spend's `FullViewingKey` derivation. See
-    /// [`Bundle::into_parsed_with_version_preverified_for_signing`] for the invariant
-    /// callers must uphold.
+    /// Parses this bundle as an Ironwood-pool bundle for a preverified signing
+    /// pass, using a parse-only placeholder if the anchor has been redacted.
+    ///
+    /// [`Bundle::serialize_from`] encodes the placeholder as a redacted anchor.
     pub(crate) fn into_ironwood_parsed_preverified_for_signing(
         self,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_with_version_preverified_for_signing(BundleVersion::ironwood_v3())
+        self.into_parsed_inner(
+            BundleVersion::ironwood_v3(),
+            true,
+            AnchorParseMode::AllowMissing,
+        )
     }
 
     /// Parses this bundle with the given bundle version, deriving each spend's
@@ -1490,11 +1553,14 @@ impl Bundle {
     /// Callers should prefer [`Bundle::resolve_fields`] before parsing, so
     /// derivations happen once for all uses. This method still resolves
     /// fields defensively for direct callers.
+    #[allow(dead_code)]
     pub(crate) fn into_parsed_with_version(
         self,
         bundle_version: BundleVersion,
+        tx_version: u32,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(bundle_version, false)
+        let anchor_parse_mode = anchor_parse_mode(tx_version, !self.actions.is_empty());
+        self.into_parsed_inner(bundle_version, false, anchor_parse_mode)
     }
 
     /// Parses this bundle with the given bundle version for a preverified signing
@@ -1510,21 +1576,27 @@ impl Bundle {
     /// has `fvk: None`), so the result must not go to the Verifier check path or the
     /// Prover, and re-serializing it drops the wire `fvk`s (the low-level Signer
     /// restores them from a pre-parse snapshot).
+    #[allow(dead_code)]
     pub(crate) fn into_parsed_with_version_preverified_for_signing(
         self,
         bundle_version: BundleVersion,
+        tx_version: u32,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
-        self.into_parsed_inner(bundle_version, true)
+        let anchor_parse_mode = anchor_parse_mode(tx_version, !self.actions.is_empty());
+        self.into_parsed_inner(bundle_version, true, anchor_parse_mode)
     }
 
     /// The shared body of [`Bundle::into_parsed_with_version`] and
     /// [`Bundle::into_parsed_with_version_preverified_for_signing`]: `preverified`
     /// selects between the full parse and the preverified signing parse.
     fn into_parsed_inner(
-        self,
+        mut self,
         bundle_version: BundleVersion,
         preverified: bool,
+        anchor_parse_mode: AnchorParseMode,
     ) -> Result<orchard::pczt::Bundle, orchard::pczt::ParseError> {
+        self.resolve_fields()?;
+
         // We parse actions through a helper that is specifically `#[inline(never)]`.
         // This is because if this gets inlined in a loop (e.g. `.map(..).collect()`),
         // it could compile into a stack frame that is tens of KB deep.
@@ -1590,6 +1662,9 @@ impl Bundle {
                 .enc_ciphertext
                 .into_encrypted()
                 .ok_or(orchard::pczt::ParseError::InvalidEncCiphertext)?;
+            let cv_net = action
+                .cv_net
+                .ok_or(orchard::pczt::ParseError::InvalidValueCommitment)?;
 
             let output = orchard::pczt::Output::parse(
                 *spend.nullifier(),
@@ -1613,7 +1688,7 @@ impl Bundle {
                 action.output.proprietary,
             )?;
 
-            orchard::pczt::Action::parse(action.cv_net, spend, output, action.rcv)
+            orchard::pczt::Action::parse(cv_net, spend, output, action.rcv)
         }
 
         let note_version = self.note_version;
@@ -1621,18 +1696,26 @@ impl Bundle {
         for action in self.actions {
             actions.push(parse_action_inner(action, note_version, preverified)?);
         }
+        let anchor = match (self.anchor, anchor_parse_mode) {
+            (Some(anchor), _) => anchor,
+            (None, AnchorParseMode::Strict) => {
+                return Err(orchard::pczt::ParseError::InvalidAnchor);
+            }
+            (None, AnchorParseMode::AllowMissing) => DEFAULT_ANCHOR,
+        };
 
         orchard::pczt::Bundle::parse(
             actions,
             self.flags,
             bundle_version,
             self.value_sum,
-            self.anchor,
+            anchor,
             self.zkproof,
             self.bsk,
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn serialize_from(bundle: orchard::pczt::Bundle) -> Self {
         let note_version = bundle.bundle_version().note_version();
 
@@ -1652,7 +1735,7 @@ impl Bundle {
                 let output = action.output();
 
                 Action {
-                    cv_net: action.cv_net().to_bytes(),
+                    cv_net: Some(action.cv_net().to_bytes()),
                     spend: Spend {
                         nullifier: spend.nullifier().to_bytes(),
                         rk: spend.rk().into(),
@@ -1731,12 +1814,13 @@ impl Bundle {
             let (magnitude, sign) = bundle.value_sum().magnitude_sign();
             (magnitude, matches!(sign, orchard::value::Sign::Negative))
         };
+        let anchor = bundle.anchor().to_bytes();
 
         Self {
             actions,
             flags: bundle.flag_byte(),
             value_sum,
-            anchor: bundle.anchor().to_bytes(),
+            anchor: (anchor != DEFAULT_ANCHOR).then_some(anchor),
             note_version,
             zkproof: bundle
                 .zkproof()

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -203,6 +203,8 @@ impl Creator {
     }
 
     pub fn build(self) -> Pczt {
+        let optional_anchor = |anchor| (anchor != crate::orchard::DEFAULT_ANCHOR).then_some(anchor);
+
         Pczt {
             global: crate::common::Global {
                 tx_version: self.tx_version,
@@ -229,7 +231,7 @@ impl Creator {
                 actions: vec![],
                 flags: self.orchard_flags,
                 value_sum: (0, false),
-                anchor: self.orchard_anchor,
+                anchor: optional_anchor(self.orchard_anchor),
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
                 note_version: self
@@ -243,7 +245,7 @@ impl Creator {
             },
             ironwood: OrchardBundle {
                 flags: self.ironwood_flags,
-                anchor: self.ironwood_anchor,
+                anchor: optional_anchor(self.ironwood_anchor),
                 ..crate::orchard::EMPTY_IRONWOOD
             },
         }
@@ -351,6 +353,6 @@ mod tests {
             .with_ironwood_anchor([1; 32])
             .unwrap()
             .build();
-        assert_eq!(pczt.ironwood.anchor, [1; 32]);
+        assert_eq!(pczt.ironwood.anchor, Some([1; 32]));
     }
 }

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -44,6 +44,16 @@ impl IoFinalizer {
         if pczt.transparent.outputs.is_empty() && !has_shielded_outputs {
             return Err(Error::NoOutputs);
         }
+        if has_orchard_actions && pczt.orchard.anchor.is_none() {
+            return Err(Error::Extract(ExtractError::OrchardParse(
+                ::orchard::pczt::ParseError::InvalidAnchor,
+            )));
+        }
+        if has_ironwood_actions && pczt.ironwood.anchor.is_none() {
+            return Err(Error::Extract(ExtractError::IronwoodParse(
+                ::orchard::pczt::ParseError::InvalidAnchor,
+            )));
+        }
 
         let ParsedPczt {
             mut global,

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -78,7 +78,10 @@ impl Signer {
         let mut bundle = pczt
             .orchard
             .clone()
-            .into_parsed_with_version_preverified_for_signing(bundle_version)
+            .into_parsed_with_version_preverified_for_signing(
+                bundle_version,
+                pczt.global.tx_version,
+            )
             .map_err(OrchardParseError::Parse)?;
 
         f(&pczt, &mut bundle, &mut tx_modifiable)?;
@@ -265,7 +268,7 @@ mod tests {
                 // Distinct `rk` per action (`[10; 32]`, `[11; 32]`), shared
                 // nullifier `[3; 32]`.
                 .map(|(i, fvk)| Action {
-                    cv_net: [0; 32],
+                    cv_net: Some([0; 32]),
                     spend: Spend {
                         nullifier: [3u8; 32],
                         rk: [10 + i as u8; 32],
@@ -299,7 +302,7 @@ mod tests {
                 .collect(),
             flags: 0,
             value_sum: (0, false),
-            anchor: [0; 32],
+            anchor: Some([0; 32]),
             note_version: NoteVersion::V2,
             zkproof: None,
             bsk: None,

--- a/pczt/src/roles/prover/orchard.rs
+++ b/pczt/src/roles/prover/orchard.rs
@@ -13,10 +13,17 @@ impl super::Prover {
             ironwood,
         } = self.pczt;
 
+        if !orchard.actions.is_empty() && orchard.anchor.is_none() {
+            return Err(OrchardError::Parser(
+                orchard::pczt::ParseError::InvalidAnchor,
+            ));
+        }
+
         let mut bundle = orchard
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+                global.tx_version,
             )
             .map_err(OrchardError::Parser)?;
 
@@ -43,6 +50,12 @@ impl super::Prover {
             orchard,
             ironwood,
         } = self.pczt;
+
+        if !ironwood.actions.is_empty() && ironwood.anchor.is_none() {
+            return Err(IronwoodError::Parser(
+                orchard::pczt::ParseError::InvalidAnchor,
+            ));
+        }
 
         let mut bundle = ironwood
             .into_ironwood_parsed()

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -52,6 +52,14 @@ impl OrchardRedactor<'_> {
     pub fn clear_bsk(&mut self) {
         self.0.bsk = None;
     }
+
+    /// Removes the bundle anchor.
+    ///
+    /// Parsed roles require the real anchor, so a receiver must restore it before
+    /// parsing this bundle.
+    pub fn clear_anchor(&mut self) {
+        self.0.anchor = None;
+    }
 }
 
 /// A Redactor for Orchard actions.
@@ -77,6 +85,15 @@ impl ActionRedactor<'_> {
                 f(action);
             }
         }
+    }
+
+    /// Removes the action's net value commitment.
+    ///
+    /// The receiver recomputes `cv_net` from the spend and output values and `rcv`.
+    pub fn clear_cv_net(&mut self) {
+        self.redact(|action| {
+            action.cv_net = None;
+        });
     }
 
     /// Removes the spend authorizing signature.

--- a/pczt/src/roles/updater/orchard.rs
+++ b/pczt/src/roles/updater/orchard.rs
@@ -20,6 +20,7 @@ impl super::Updater {
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+                global.tx_version,
             )
             .map_err(OrchardError::Parser)?;
 

--- a/pczt/src/roles/verifier/orchard.rs
+++ b/pczt/src/roles/verifier/orchard.rs
@@ -18,6 +18,7 @@ impl super::Verifier {
             .into_parsed_with_version(
                 crate::orchard::orchard_bundle_version(&global)
                     .ok_or(OrchardError::UnsupportedConsensusBranchId)?,
+                global.tx_version,
             )
             .map_err(OrchardError::Parse)?;
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -994,6 +994,109 @@ fn check_v2_round_trip(pczt: &Pczt) {
     assert_eq!(encoded, reencoded);
 }
 
+#[derive(Clone, Copy)]
+enum ShieldedPool {
+    Orchard,
+    Ironwood,
+}
+
+fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
+    if matches!(pool, ShieldedPool::Orchard) {
+        return Creator::new(
+            zcash_protocol::consensus::BranchId::Nu6_3.into(),
+            10_000_000,
+            133,
+            [0; 32],
+            [9; 32],
+        )
+        .unwrap()
+        .build();
+    }
+
+    let transparent_account_sk =
+        AccountPrivKey::from_seed(&MainNetwork, &[1; 32], zip32::AccountId::ZERO).unwrap();
+    let (transparent_addr, address_index) = transparent_account_sk
+        .to_account_pubkey()
+        .derive_external_ivk()
+        .unwrap()
+        .default_address();
+    let transparent_sk = transparent_account_sk
+        .derive_external_secret_key(address_index)
+        .unwrap();
+    let secp = secp256k1::Secp256k1::signing_only();
+    let transparent_pubkey = transparent_sk.public_key(&secp);
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
+            ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
+                .then(orchard::Anchor::empty_tree),
+        },
+    );
+    builder
+        .add_transparent_p2pkh_input(
+            transparent_pubkey,
+            transparent::OutPoint::fake(),
+            transparent::TxOut::new(
+                Zatoshis::const_from_u64(1_000_000),
+                transparent_addr.script().into(),
+            ),
+        )
+        .unwrap();
+
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(985_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+
+    let PcztResult { pczt_parts, .. } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap()
+}
+
+fn redact_anchor(pczt: Pczt, pool: ShieldedPool) -> Pczt {
+    match pool {
+        ShieldedPool::Orchard => Redactor::new(pczt)
+            .redact_orchard_with(|mut r| r.clear_anchor())
+            .finish(),
+        ShieldedPool::Ironwood => Redactor::new(pczt)
+            .redact_ironwood_with(|mut r| r.clear_anchor())
+            .finish(),
+    }
+}
+
+fn assert_anchor_redacted(pczt: &Pczt, pool: ShieldedPool) {
+    match pool {
+        ShieldedPool::Orchard => assert!(pczt.orchard().anchor().is_none()),
+        ShieldedPool::Ironwood => assert!(pczt.ironwood().anchor().is_none()),
+    }
+}
+
+fn assert_redacted_anchor_v2_round_trip(pczt: Pczt, pool: ShieldedPool) {
+    let redacted = redact_anchor(pczt, pool);
+    assert_anchor_redacted(&redacted, pool);
+    check_v2_round_trip(&redacted);
+
+    let reparsed = Pczt::parse(&redacted.serialize().unwrap()).unwrap();
+    assert_anchor_redacted(&reparsed, pool);
+}
+
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
 fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
     use zcash_protocol::consensus::BlockHeight;
@@ -1012,6 +1115,38 @@ fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
         #[cfg(zcash_unstable = "nu7")]
         nu7: None,
     }
+}
+
+#[test]
+fn redacted_orchard_anchor_round_trips_v2() {
+    assert_redacted_anchor_v2_round_trip(
+        pczt_with_anchor(ShieldedPool::Orchard),
+        ShieldedPool::Orchard,
+    );
+}
+
+#[test]
+fn redacted_ironwood_anchor_round_trips_v2() {
+    assert_redacted_anchor_v2_round_trip(
+        pczt_with_anchor(ShieldedPool::Ironwood),
+        ShieldedPool::Ironwood,
+    );
+}
+
+#[test]
+fn redacted_ironwood_anchor_survives_signer_finish() {
+    let redacted = redact_anchor(
+        pczt_with_anchor(ShieldedPool::Ironwood),
+        ShieldedPool::Ironwood,
+    );
+    assert_anchor_redacted(&redacted, ShieldedPool::Ironwood);
+
+    let signed = Signer::new(redacted).unwrap().finish();
+    assert_anchor_redacted(&signed, ShieldedPool::Ironwood);
+    check_v2_round_trip(&signed);
+
+    let reparsed = Pczt::parse(&signed.serialize().unwrap()).unwrap();
+    assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
 }
 
 #[test]
@@ -1126,6 +1261,85 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
     let fvks_before = wire_spend_fvks(&pczt, true);
     assert_eq!(fvks_before[index], Some(orchard_fvk.to_bytes()));
 
+    let redacted = Redactor::new(pczt.clone())
+        .redact_ironwood_with(|mut r| {
+            r.clear_anchor();
+            r.redact_actions(|mut a| {
+                a.clear_cv_net();
+            });
+        })
+        .finish();
+    assert!(redacted.ironwood().anchor().is_none());
+    assert!(
+        redacted
+            .ironwood()
+            .actions()
+            .iter()
+            .all(|action| action.cv_net().is_none())
+    );
+    let verified = Verifier::new(redacted.clone())
+        .with_ironwood::<std::convert::Infallible, _>(|_| {
+            Ok::<(), pczt::roles::verifier::OrchardError<std::convert::Infallible>>(())
+        })
+        .unwrap()
+        .finish();
+    assert!(verified.ironwood().anchor().is_none());
+    let updated = Updater::new(redacted.clone())
+        .update_ironwood_with(|_| Ok(()))
+        .unwrap()
+        .finish();
+    assert!(updated.ironwood().anchor().is_none());
+
+    let mut resolved = redacted.clone();
+    resolved.resolve_fields().unwrap();
+    assert!(resolved.ironwood().anchor().is_none());
+    assert_eq!(
+        resolved.ironwood().actions()[index].cv_net(),
+        pczt.ironwood().actions()[index].cv_net()
+    );
+    assert!(IoFinalizer::new(redacted.clone()).finalize_io().is_err());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_ironwood_proof(orchard_proving_key())
+            .is_err()
+    );
+    assert_eq!(
+        Signer::new(redacted.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let cv_net_redacted = Redactor::new(pczt.clone())
+        .redact_ironwood_with(|mut r| {
+            r.redact_actions(|mut a| {
+                a.clear_cv_net();
+            });
+        })
+        .finish();
+    assert_eq!(
+        Signer::new(cv_net_redacted.clone())
+            .unwrap()
+            .shielded_sighash(),
+        sighash
+    );
+
+    let signed_redacted = low_level_signer::Signer::new(cv_net_redacted)
+        .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            bundle.actions_mut()[index]
+                .sign(sighash, &orchard_ask, ChaCha20Rng::from_seed(seed))
+                .expect("signing succeeds");
+            Ok(())
+        })
+        .unwrap()
+        .finish();
+    assert_eq!(
+        signed_redacted.ironwood().actions()[index]
+            .spend()
+            .spend_auth_sig()
+            .expect("action was signed"),
+        expected_sig
+    );
+    check_v2_round_trip(&signed_redacted);
+
     // Sign through the low-level Signer's preverified path with the same seed.
     let signed = low_level_signer::Signer::new(pczt.clone())
         .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
@@ -1157,4 +1371,26 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
 
     // The wire `fvk` bytes must be preserved (unchanged) after signing.
     assert_eq!(wire_spend_fvks(&signed, true), fvks_before);
+}
+
+#[test]
+fn redacted_anchor_is_not_resolved() {
+    let pczt = Creator::new(
+        zcash_protocol::consensus::BranchId::Nu6.into(),
+        10_000_000,
+        133,
+        [0; 32],
+        [9; 32],
+    )
+    .unwrap()
+    .build();
+
+    let mut redacted = Redactor::new(pczt)
+        .redact_orchard_with(|mut r| {
+            r.clear_anchor();
+        })
+        .finish();
+
+    redacted.resolve_fields().unwrap();
+    assert!(redacted.orchard().anchor().is_none());
 }


### PR DESCRIPTION
## Summary

This PR builds on `dev/pczt-v2-memo-plaintext` and updates PCZT v2 Orchard/Ironwood handling so `anchor` and `cv_net` can be represented as redacted logical fields.

- Represents Orchard bundle anchors as `Option<[u8; 32]>` in the logical PCZT type.
- Represents Orchard action `cv_net` as `Option<[u8; 32]>` and resolves it from note values plus `rcv` when needed.
- Keeps v1 serialization strict: missing anchors or `cv_net` require v2.
- Makes missing-anchor parse behavior derive from transaction version, using `DEFAULT_ANCHOR` only as a parse-time placeholder.
- Preserves redacted anchors when roles serialize parsed bundles back to PCZT.
- Adds redactor helpers and end-to-end coverage for redacted Ironwood anchor / `cv_net` behavior.

## Role Behavior

Verifier, updater, signer, and low-level signer can continue operating with redacted anchors where they do not require the real value. IO finalizer and prover now explicitly reject missing anchors for non-empty bundles because those roles require the real anchor.

## Validation

- `cargo fmt --all`
- `cargo check -p pczt --features orchard`
- `cargo test -p pczt --features orchard v2_round_trips_memo_plaintext_ciphertext_data`
- `cargo test -p pczt --features orchard,internal-tests,spend-finalizer,zcp-builder --test end_to_end ironwood_low_level_signer_uses_preverified_signing_parse`
- `cargo test -p pczt --features orchard,internal-tests,spend-finalizer,zcp-builder --test end_to_end redacted_anchor_is_not_resolved`
- `git diff --check`