### PR TITLE
Revert 2551

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
 incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
-# TEMPORARY: orchard revision that keeps `BundleType::DEFAULT` padded and adds the
-# opt-in `BundleType::DEFAULT_UNPADDED` + `Builder::bundle_type()`; replace with a
-# published orchard release once one carries these.
-orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -106,7 +106,6 @@ fn transparent_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -272,7 +271,6 @@ fn transparent_p2sh_multisig_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -482,7 +480,6 @@ fn sapling_to_orchard() {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -646,7 +643,6 @@ fn orchard_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -858,7 +854,6 @@ fn orchard_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -1057,7 +1052,6 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: Some(anchor),
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -846,10 +846,6 @@ criteria = "safe-to-deploy"
 version = "11.1.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.orchard]]
-version = "0.15.0-pre.2@git:475ef0ff77d45aebff93cb039d639250d82518a3"
-criteria = "safe-to-deploy"
-
 [[exemptions.ordered-float]]
 version = "2.10.1"
 criteria = "safe-to-deploy"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -149,18 +149,8 @@ workspace.
   (behind the `pczt` feature flag), returned by `create_pczt_from_proposal`
   when the caller-supplied `target_expiry_height` is a nonzero height below
   the proposal's minimum target height.
-- `zcash_client_backend::fees::zip317::{SingleOutputChangeStrategy, MultiOutputChangeStrategy}`
-  gained `with_unpadded_orchard_pool_bundles`, which makes fee and change calculation
-  count Orchard and Ironwood bundles without the 2-action padding minimum. The default
-  behavior is unchanged (padded). Proposals created with this option must be executed
-  with a matching unpadded builder configuration.
 
 ### Changed
-- `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes an
-  `orchard_pool_bundle_type` argument (behind the `pczt` feature flag) selecting the
-  transactional bundle type for the Orchard and Ironwood bundles; it must match the
-  change strategy used to create the proposal. Pass
-  `orchard::builder::BundleType::DEFAULT` for the previous (padded) behavior.
 - `zcash_client_backend::data_api::WalletCommitmentTrees::with_ironwood_tree_mut`,
   an optional accessor that wallet backends can override to provide Ironwood
   anchors and witnesses to the transaction builder.

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -72,7 +72,7 @@ subtle.workspace = true
 # - Shielded protocols
 bls12_381.workspace = true
 group.workspace = true
-orchard.workspace = true
+orchard = { workspace = true, optional = true }
 sapling.workspace = true
 
 # - Transparent protocol
@@ -203,12 +203,7 @@ transparent-key-import = ["transparent-inputs"]
 spend-index = ["transparent-inputs"]
 
 ## Enables receiving and spending Orchard funds.
-##
-## The `orchard` crate itself is an unconditional dependency (via
-## `zcash_primitives`, which always requires it because every v5+ transaction
-## carries an Orchard bundle type); this feature gates the wallet's
-## Orchard note-handling code, not the crate linkage.
-orchard = ["dep:pasta_curves", "zcash_keys/orchard"]
+orchard = ["dep:orchard", "dep:pasta_curves", "zcash_keys/orchard"]
 
 ## Enables compatibility with legacy zcashd wallet data
 zcashd-compat = ["zcash_keys/zcashd-compat"]
@@ -284,7 +279,7 @@ test-dependencies = [
     "dep:rand",
     "dep:rand_chacha",
     "transparent/test-dependencies",
-    "orchard/test-dependencies",
+    "orchard?/test-dependencies",
     "zcash_keys/test-dependencies",
     "zcash_primitives/test-dependencies",
     "zcash_proofs/bundled-prover",

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1304,7 +1304,6 @@ where
             ovk_policy,
             proposal,
             target_expiry_height,
-            ::orchard::builder::BundleType::DEFAULT,
         )
     }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -59,7 +59,6 @@ use crate::{
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
     wallet::{Note, OvkPolicy, Recipient},
 };
-use orchard::builder::BundleType;
 use sapling::{
     note_encryption::{PreparedIncomingViewingKey, try_sapling_note_decryption},
     prover::{OutputProver, SpendProver},
@@ -1276,9 +1275,6 @@ fn build_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>
         (TransparentAddress, OutPoint),
     >,
     #[cfg(feature = "unstable")] proposed_version: Option<TxVersion>,
-    // The transactional bundle type for the Orchard and Ironwood bundles; the PCZT path
-    // threads the proposal's configured type here, other callers pass `BundleType::DEFAULT`.
-    orchard_pool_bundle_type: BundleType,
 ) -> Result<BuildState<ParamsT, DbT::AccountId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -1523,7 +1519,6 @@ where
             sapling_anchor,
             orchard_anchor,
             ironwood_anchor,
-            orchard_pool_bundle_type,
         },
     );
 
@@ -2069,8 +2064,6 @@ where
         unused_transparent_outputs,
         #[cfg(feature = "unstable")]
         proposed_version,
-        // The non-PCZT path always builds padded Orchard-pool bundles.
-        BundleType::DEFAULT,
     )?;
 
     // Build the transaction with the specified fee rule
@@ -2304,12 +2297,6 @@ where
 /// [`min_target_height`](Proposal::min_target_height) is rejected with
 /// [`Error::ExpiryHeightBelowTargetHeight`]. A `target_expiry_height` of zero,
 /// which disables expiry, is exempt from this check.
-///
-/// `orchard_pool_bundle_type` selects the transactional bundle type for the Orchard
-/// and Ironwood bundles, and must match the change strategy used to create
-/// `proposal` (see
-/// `zip317::SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles`); pass
-/// [`BundleType::DEFAULT`](orchard::builder::BundleType) otherwise.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "pczt")]
@@ -2320,7 +2307,6 @@ pub fn create_pczt_from_proposal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
     target_expiry_height: Option<BlockHeight>,
-    orchard_pool_bundle_type: BundleType,
 ) -> Result<pczt::Pczt, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -2373,7 +2359,6 @@ where
         unused_transparent_outputs,
         #[cfg(feature = "unstable")]
         proposed_version,
-        orchard_pool_bundle_type,
     )?;
 
     // Build the transaction with the specified fee rule

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1267,9 +1267,6 @@ where
             0
         };
         orchard_fees::transactional_action_count(
-            // Input selection estimates fees with the padded default bundle type; the
-            // unpadded opt-in is applied later by the change strategy.
-            ::orchard::builder::BundleType::DEFAULT,
             orchard_bundle_version_for_height(params, target_height),
             spendable_notes.orchard.len(),
             requested_orchard_actions,
@@ -1674,7 +1671,6 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             PoolType::ORCHARD => {
                 let count = orchard_fees::transactional_action_count(
-                    ::orchard::builder::BundleType::DEFAULT,
                     orchard_bundle_version_for_height(params, target_height),
                     0,
                     1,

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -249,11 +249,6 @@ pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clo
     // routed into the `ironwood` view by the caller; this carries the same decision
     // for the change output, which is computed here.
     #[cfg(feature = "orchard")] orchard_change_to_ironwood: bool,
-    // The transactional bundle type the transaction builder will use for both the
-    // Orchard and Ironwood bundles; the action counts computed here must match it so
-    // the builder's exact-balance check succeeds (see
-    // `orchard_fees::transactional_action_count`).
-    #[cfg(feature = "orchard")] orchard_pool_bundle_type: ::orchard::builder::BundleType,
     change_memo: Option<&MemoBytes>,
     ephemeral_balance: Option<EphemeralBalance>,
 ) -> Result<TransactionBalance, ChangeError<E, NoteRefT>>
@@ -329,8 +324,6 @@ where
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
-            #[cfg(feature = "orchard")]
-            orchard_pool_bundle_type,
             cfg.marginal_fee,
             cfg.grace_actions,
             &possible_change[..],
@@ -362,7 +355,6 @@ where
     #[cfg(feature = "orchard")]
     let orchard_action_count = |change_count| {
         orchard_fees::transactional_action_count(
-            orchard_pool_bundle_type,
             orchard.bundle_version(),
             orchard.inputs().len(),
             orchard.outputs().len() + change_count,
@@ -388,7 +380,6 @@ where
     #[cfg(feature = "orchard")]
     let ironwood_action_count = |change_count| {
         orchard_fees::transactional_action_count(
-            orchard_pool_bundle_type,
             ironwood.bundle_version(),
             ironwood.inputs().len(),
             ironwood.outputs().len() + change_count,
@@ -679,9 +670,6 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     transparent_outputs: &[impl transparent::OutputView],
     sapling: &impl sapling_fees::BundleView<NoteRefT>,
     #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
-    // The Orchard-pool bundle type the builder will use; the action counts computed
-    // for the grace-input check must match it (see `single_pool_output_balance`).
-    #[cfg(feature = "orchard")] orchard_pool_bundle_type: ::orchard::builder::BundleType,
     marginal_fee: Zatoshis,
     grace_actions: usize,
     possible_change: &[OutputManifest],
@@ -799,7 +787,6 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
 
             #[cfg(feature = "orchard")]
             let o_action_count = orchard_fees::transactional_action_count(
-                orchard_pool_bundle_type,
                 orchard.bundle_version(),
                 o_req_inputs + _o_extra,
                 o_outputs_len + change.orchard,

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -113,9 +113,6 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
-            // The fixed-fee strategy has no unpadded opt-in; keep the padded default.
-            #[cfg(feature = "orchard")]
-            ::orchard::builder::BundleType::DEFAULT,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )

--- a/zcash_client_backend/src/fees/orchard.rs
+++ b/zcash_client_backend/src/fees/orchard.rs
@@ -6,20 +6,12 @@ use std::convert::Infallible;
 use orchard::{builder::BundleType, bundle::BundleVersion};
 use zcash_protocol::value::Zatoshis;
 
-/// Returns the number of actions the transaction builder will produce for a
-/// transactional (non-coinbase) Orchard-pool bundle of the given bundle type and
-/// version, carrying the given numbers of requested spends and outputs.
-///
-/// The caller must pass the same [`BundleType`](orchard::builder::BundleType) the
-/// transaction builder will be configured with: the builder enforces an exact
-/// balance against the fee computed from these counts.
 pub(crate) fn transactional_action_count(
-    bundle_type: BundleType,
     bundle_version: BundleVersion,
     num_spends: usize,
     num_outputs: usize,
 ) -> Result<usize, &'static str> {
-    bundle_type.num_actions(bundle_version.default_flags(), num_spends, num_outputs)
+    BundleType::DEFAULT.num_actions(bundle_version.default_flags(), num_spends, num_outputs)
 }
 
 /// A trait that provides a minimized view of Orchard-style bundle configuration

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -67,8 +67,6 @@ pub struct SingleOutputChangeStrategy<R, I> {
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
-    #[cfg(feature = "orchard")]
-    unpadded_orchard_pool_bundles: bool,
     meta_source: PhantomData<I>,
 }
 
@@ -89,25 +87,8 @@ impl<R, I> SingleOutputChangeStrategy<R, I> {
             change_memo,
             fallback_change_pool,
             dust_output_policy,
-            #[cfg(feature = "orchard")]
-            unpadded_orchard_pool_bundles: false,
             meta_source: PhantomData,
         }
-    }
-
-    /// Requests unpadded Orchard-pool (Orchard and Ironwood) bundles: fee and change
-    /// calculation will count exactly the requested actions instead of padding each
-    /// bundle to the 2-action minimum.
-    ///
-    /// The transaction executing the proposal must be built with the matching bundle
-    /// type ([`BundleType::UNPADDED`](orchard::builder::BundleType)), or the
-    /// builder's balance check will fail. Intended for transactions whose shape is
-    /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
-    /// documentation for the privacy trade-off.
-    #[cfg(feature = "orchard")]
-    pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
-        self.unpadded_orchard_pool_bundles = true;
-        self
     }
 }
 
@@ -161,13 +142,6 @@ where
             self.fee_rule.grace_actions(),
         );
 
-        #[cfg(feature = "orchard")]
-        let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
-            ::orchard::builder::BundleType::UNPADDED
-        } else {
-            ::orchard::builder::BundleType::DEFAULT
-        };
-
         single_pool_output_balance(
             cfg,
             None,
@@ -181,8 +155,6 @@ where
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
-            #[cfg(feature = "orchard")]
-            orchard_pool_bundle_type,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -197,8 +169,6 @@ pub struct MultiOutputChangeStrategy<R, I> {
     fallback_change_pool: ShieldedPool,
     dust_output_policy: DustOutputPolicy,
     split_policy: SplitPolicy,
-    #[cfg(feature = "orchard")]
-    unpadded_orchard_pool_bundles: bool,
     meta_source: PhantomData<I>,
 }
 
@@ -227,25 +197,8 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
             fallback_change_pool,
             dust_output_policy,
             split_policy,
-            #[cfg(feature = "orchard")]
-            unpadded_orchard_pool_bundles: false,
             meta_source: PhantomData,
         }
-    }
-
-    /// Requests unpadded Orchard-pool (Orchard and Ironwood) bundles: fee and change
-    /// calculation will count exactly the requested actions instead of padding each
-    /// bundle to the 2-action minimum.
-    ///
-    /// The transaction executing the proposal must be built with the matching bundle
-    /// type ([`BundleType::UNPADDED`](orchard::builder::BundleType)), or the
-    /// builder's balance check will fail. Intended for transactions whose shape is
-    /// already public (e.g. pool migrations); see the orchard `pad_to_minimum`
-    /// documentation for the privacy trade-off.
-    #[cfg(feature = "orchard")]
-    pub fn with_unpadded_orchard_pool_bundles(mut self) -> Self {
-        self.unpadded_orchard_pool_bundles = true;
-        self
     }
 }
 
@@ -304,13 +257,6 @@ where
             self.fee_rule.grace_actions(),
         );
 
-        #[cfg(feature = "orchard")]
-        let orchard_pool_bundle_type = if self.unpadded_orchard_pool_bundles {
-            ::orchard::builder::BundleType::UNPADDED
-        } else {
-            ::orchard::builder::BundleType::DEFAULT
-        };
-
         single_pool_output_balance(
             cfg,
             Some(wallet_meta),
@@ -324,8 +270,6 @@ where
             ironwood,
             #[cfg(feature = "orchard")]
             orchard_change_to_ironwood,
-            #[cfg(feature = "orchard")]
-            orchard_pool_bundle_type,
             self.change_memo.as_ref(),
             ephemeral_balance,
         )
@@ -821,94 +765,6 @@ mod tests {
         assert_eq!(
             with_ironwood.fee_required(),
             Zatoshis::const_from_u64(30000)
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "orchard")]
-    fn unpadded_orchard_pool_bundles_lower_the_fee() {
-        // `with_unpadded_orchard_pool_bundles` drops the ZIP 317 2-action padding floor
-        // for the Orchard and Ironwood bundles. This reuses the
-        // `ironwood_outputs_are_charged_actions` scenario, where only the single-output
-        // Ironwood bundle is below the floor, so the unpadded strategy charges it 1
-        // action instead of 2 and the fee falls by exactly one 5000-zat action.
-        let height = Network::TestNetwork
-            .activation_height(NetworkUpgrade::Nu5)
-            .unwrap()
-            .into();
-        let sapling_inputs = [TestSaplingInput {
-            note_id: 0,
-            value: Zatoshis::const_from_u64(100000),
-        }];
-        let orchard_outputs = [OrchardPayment::new(Zatoshis::const_from_u64(30000))];
-        let sapling_view = (
-            sapling::builder::BundleType::DEFAULT,
-            &sapling_inputs[..],
-            &[] as &[Infallible],
-        );
-        let orchard_view = (
-            ::orchard::bundle::BundleVersion::orchard_v2(),
-            &[] as &[Infallible],
-            &orchard_outputs[..],
-        );
-        let ironwood_view = (
-            ::orchard::bundle::BundleVersion::ironwood_v3(),
-            &[] as &[Infallible],
-            &orchard_outputs[..],
-        );
-
-        let padded_fee = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
-            Zip317FeeRule::standard(),
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        )
-        .compute_balance(
-            &Network::TestNetwork,
-            height,
-            &[] as &[TestTransparentInput],
-            &[] as &[TxOut],
-            &sapling_view,
-            &orchard_view,
-            &ironwood_view,
-            false,
-            None,
-            &(),
-        )
-        .unwrap()
-        .fee_required();
-
-        let unpadded_fee = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
-            Zip317FeeRule::standard(),
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        )
-        .with_unpadded_orchard_pool_bundles()
-        .compute_balance(
-            &Network::TestNetwork,
-            height,
-            &[] as &[TestTransparentInput],
-            &[] as &[TxOut],
-            &sapling_view,
-            &orchard_view,
-            &ironwood_view,
-            false,
-            None,
-            &(),
-        )
-        .unwrap()
-        .fee_required();
-
-        // Padded default matches `ironwood_outputs_are_charged_actions`: sapling (2) +
-        // orchard (1 payment + 1 change = 2) + ironwood (1 output, padded to 2) = 6
-        // actions = 30000 zat. Unpadded charges the single-output Ironwood bundle 1
-        // action, so the fee drops by one 5000-zat action to 25000.
-        assert_eq!(padded_fee, Zatoshis::const_from_u64(30000));
-        assert_eq!(unpadded_fee, Zatoshis::const_from_u64(25000));
-        assert_eq!(
-            padded_fee,
-            (unpadded_fee + Zatoshis::const_from_u64(5000)).unwrap()
         );
     }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -363,7 +363,6 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let mut transparent_signing_set = TransparentSigningSet::new();

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -27,10 +27,6 @@ workspace.
   in a slot whose value pool is not supported under the transaction's consensus
   branch ID (the Orchard pool prior to NU5; the Ironwood pool prior to NU6.3)
   is now rejected as invalid data.
-- `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries an
-  `orchard_pool_bundle_type` field selecting the transactional bundle type for the
-  Orchard and Ironwood bundles. Pass `orchard::builder::BundleType::DEFAULT` to keep
-  the previous (padded) behavior.
 
 ## [0.29.0-pre.0] - 2026-06-30
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -260,7 +260,6 @@ pub enum BuildConfig {
         sapling_anchor: Option<sapling::Anchor>,
         orchard_anchor: Option<orchard::Anchor>,
         ironwood_anchor: Option<orchard::Anchor>,
-        orchard_pool_bundle_type: orchard::builder::BundleType,
     },
     Coinbase {
         miner_data: Option<PushValue>,
@@ -289,13 +288,9 @@ impl BuildConfig {
         bundle_version: orchard::bundle::BundleVersion,
     ) -> Option<orchard::builder::Builder> {
         match self {
-            BuildConfig::Standard {
-                orchard_anchor,
-                orchard_pool_bundle_type,
-                ..
-            } => orchard_anchor.as_ref().map(|a| {
+            BuildConfig::Standard { orchard_anchor, .. } => orchard_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    *orchard_pool_bundle_type,
+                    orchard::builder::BundleType::DEFAULT,
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
@@ -327,12 +322,10 @@ impl BuildConfig {
         let bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
         match self {
             BuildConfig::Standard {
-                ironwood_anchor,
-                orchard_pool_bundle_type,
-                ..
+                ironwood_anchor, ..
             } => ironwood_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    *orchard_pool_bundle_type,
+                    orchard::builder::BundleType::DEFAULT,
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
@@ -369,18 +362,19 @@ fn orchard_action_count(
         .checked_add(builder.changes().len())
         .ok_or("num_outputs + num_changes overflowed")?;
 
-    // The bundle type must match the one the builder was constructed with (see
-    // `orchard_builder` / `ironwood_builder`); read it back from the builder so
-    // the two cannot drift.
-    let bundle_type = builder.bundle_type();
-
     // The flags must match those the builder constructs for each configuration (see
     // `orchard_builder`). For a `Coinbase` bundle `num_actions` ignores the flags, but supplying
     // the matching set keeps the two paths consistent.
-    let flags = if is_coinbase {
-        orchard::bundle::Flags::SPENDS_DISABLED
+    let (bundle_type, flags) = if is_coinbase {
+        (
+            orchard::builder::BundleType::Coinbase,
+            orchard::bundle::Flags::SPENDS_DISABLED,
+        )
     } else {
-        bundle_version.default_flags()
+        (
+            orchard::builder::BundleType::DEFAULT,
+            bundle_version.default_flags(),
+        )
     };
 
     bundle_type.num_actions(flags, num_spends, num_outputs)
@@ -1599,7 +1593,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
 
@@ -1620,7 +1613,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
 
@@ -1735,7 +1727,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -1792,7 +1783,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let recipient = orchard::keys::FullViewingKey::from(
@@ -1827,7 +1817,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -1915,7 +1904,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let (fvk, note, merkle_path) = ironwood_note_with_version(orchard::note::NoteVersion::V2);
@@ -1992,51 +1980,6 @@ mod tests {
         );
     }
 
-    /// `BuildConfig::Standard`'s `orchard_pool_bundle_type` controls padding: the
-    /// padded default counts a single-output bundle as 2 actions, while
-    /// `UNPADDED` counts exactly the requested single action.
-    #[test]
-    #[cfg(feature = "circuits")]
-    fn orchard_pool_bundle_type_controls_padding() {
-        let recipient = orchard::keys::FullViewingKey::from(
-            &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
-        )
-        .address_at(0u32, orchard::keys::Scope::External);
-
-        let config_with = |bundle_type| BuildConfig::Standard {
-            sapling_anchor: None,
-            orchard_anchor: Some(orchard::Anchor::empty_tree()),
-            ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-            orchard_pool_bundle_type: bundle_type,
-        };
-
-        // `orchard_v2` here: the NU6.3 `orchard_v3` version disables cross-address
-        // transfers, so a bare output cannot be added.
-        let count_for = |bundle_type| {
-            let config = config_with(bundle_type);
-            let mut builder = config
-                .orchard_builder(orchard::bundle::BundleVersion::orchard_v2())
-                .unwrap();
-            builder
-                .add_output(
-                    None,
-                    recipient,
-                    orchard::value::NoteValue::from_raw(10_000),
-                    [0u8; 512],
-                )
-                .unwrap();
-            super::orchard_action_count(
-                &builder,
-                false,
-                orchard::bundle::BundleVersion::orchard_v2(),
-            )
-            .unwrap()
-        };
-
-        assert_eq!(count_for(orchard::builder::BundleType::DEFAULT), 2);
-        assert_eq!(count_for(orchard::builder::BundleType::UNPADDED), 1);
-    }
-
     #[test]
     #[cfg(feature = "circuits")]
     fn add_orchard_change_output_records_change() {
@@ -2048,7 +1991,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         let fvk = orchard::keys::FullViewingKey::from(
@@ -2095,7 +2037,6 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
             target_height: sapling_activation_height,
             expiry_height: sapling_activation_height + DEFAULT_TX_EXPIRY_DELTA,
@@ -2156,7 +2097,6 @@ mod tests {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         };
         let mut builder =
             Builder::new(TEST_NETWORK, tx_height, build_config).with_expiry_height(0u32.into());
@@ -2245,7 +2185,6 @@ mod tests {
             sapling_anchor: Some(witness1.root().into()),
             orchard_anchor: None,
             ironwood_anchor: None,
-            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         };
         let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
 
@@ -2288,7 +2227,6 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             assert_matches!(
@@ -2310,7 +2248,6 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2335,7 +2272,6 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2359,7 +2295,6 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder.set_zip233_amount(Zatoshis::const_from_u64(50000));
@@ -2387,7 +2322,6 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2425,7 +2359,6 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2472,7 +2405,6 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2522,7 +2454,6 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder


### PR DESCRIPTION
By merging 2551, conflicts have been created with the large patch https://github.com/zcash/librustzcash/pull/2539.
We don't want to spend more time rebasing/merging main 2551. Therefore, we will revert any change that create conflicts from now.

This patch has been created using:
```
git checkout main
git fetch origin
git pull origin main
git checkout -b dw/revert-2555
# Current head of main
git revert -m 1 891541a2580ef29daf7bc200884810225fd2336e
```

A reviewer MUST check that they reach the same state.