### PR TITLE
Allow redacting Sapling anchors

### DIFF
--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -106,7 +106,7 @@ pub mod v1 {
     pub struct Pczt {
         global: common::Global,
         transparent: transparent::Bundle,
-        sapling: sapling::Bundle,
+        sapling: sapling::v1::Bundle,
         orchard: orchard::v1::Bundle,
     }
 
@@ -140,7 +140,7 @@ pub mod v1 {
             Ok(Self {
                 global: pczt.global,
                 transparent: pczt.transparent,
-                sapling: pczt.sapling,
+                sapling: sapling::v1::Bundle::try_from(pczt.sapling)?,
                 orchard: orchard::v1::Bundle::try_from(pczt.orchard)?,
             })
         }
@@ -151,7 +151,7 @@ pub mod v1 {
             Self {
                 global: pczt.global,
                 transparent: pczt.transparent,
-                sapling: pczt.sapling,
+                sapling: pczt.sapling.into(),
                 orchard: pczt.orchard.into(),
                 ironwood: orchard::EMPTY_IRONWOOD,
             }
@@ -234,7 +234,7 @@ pub mod v2 {
                 global: pczt.global,
                 transparent: (pczt.transparent != transparent::EMPTY_BUNDLE)
                     .then_some(pczt.transparent),
-                sapling: (pczt.sapling != sapling::EMPTY_BUNDLE).then_some(pczt.sapling),
+                sapling: sapling::v2::encode(pczt.sapling),
                 orchard: orchard::v2::encode(pczt.orchard, &orchard::EMPTY_ORCHARD)?,
                 ironwood: orchard::v2::encode(pczt.ironwood, &orchard::EMPTY_IRONWOOD)?,
             })
@@ -287,6 +287,7 @@ pub mod v2 {
             assert!(decoded.transparent.outputs.is_empty());
             assert!(decoded.sapling.spends.is_empty());
             assert!(decoded.sapling.outputs.is_empty());
+            assert!(decoded.sapling.anchor.is_none());
             assert!(decoded.orchard.actions.is_empty());
             assert_eq!(decoded.orchard.note_version, NoteVersion::V2);
             {
@@ -312,7 +313,7 @@ pub mod v2 {
 
             let decoded = crate::parse(&encoded.serialize()).unwrap();
 
-            assert_eq!(decoded.sapling.anchor, [1; 32]);
+            assert_eq!(decoded.sapling.anchor, Some([1; 32]));
             assert_eq!(decoded.orchard.anchor, Some([2; 32]));
         }
 

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -203,7 +203,10 @@ impl Creator {
     }
 
     pub fn build(self) -> Pczt {
-        let optional_anchor = |anchor| (anchor != crate::orchard::DEFAULT_ANCHOR).then_some(anchor);
+        let optional_sapling_anchor =
+            |anchor| (anchor != crate::sapling::DEFAULT_ANCHOR).then_some(anchor);
+        let optional_orchard_anchor =
+            |anchor| (anchor != crate::orchard::DEFAULT_ANCHOR).then_some(anchor);
 
         Pczt {
             global: crate::common::Global {
@@ -224,14 +227,14 @@ impl Creator {
                 spends: vec![],
                 outputs: vec![],
                 value_sum: 0,
-                anchor: self.sapling_anchor,
+                anchor: optional_sapling_anchor(self.sapling_anchor),
                 bsk: None,
             },
             orchard: OrchardBundle {
                 actions: vec![],
                 flags: self.orchard_flags,
                 value_sum: (0, false),
-                anchor: optional_anchor(self.orchard_anchor),
+                anchor: optional_orchard_anchor(self.orchard_anchor),
                 // The note-plaintext version is determined by the Orchard bundle version.
                 #[cfg(feature = "orchard")]
                 note_version: self
@@ -245,7 +248,7 @@ impl Creator {
             },
             ironwood: OrchardBundle {
                 flags: self.ironwood_flags,
-                anchor: optional_anchor(self.ironwood_anchor),
+                anchor: optional_orchard_anchor(self.ironwood_anchor),
                 ..crate::orchard::EMPTY_IRONWOOD
             },
         }

--- a/pczt/src/roles/io_finalizer/mod.rs
+++ b/pczt/src/roles/io_finalizer/mod.rs
@@ -31,8 +31,8 @@ impl IoFinalizer {
 
         let has_orchard_actions = !pczt.orchard.actions.is_empty();
         let has_ironwood_actions = !pczt.ironwood.actions.is_empty();
-        let has_shielded_spends =
-            !(pczt.sapling.spends.is_empty() && !has_orchard_actions && !has_ironwood_actions);
+        let has_sapling_spends = !pczt.sapling.spends.is_empty();
+        let has_shielded_spends = has_sapling_spends || has_orchard_actions || has_ironwood_actions;
         let has_shielded_outputs =
             !(pczt.sapling.outputs.is_empty() && !has_orchard_actions && !has_ironwood_actions);
 
@@ -47,6 +47,11 @@ impl IoFinalizer {
         if has_orchard_actions && pczt.orchard.anchor.is_none() {
             return Err(Error::Extract(ExtractError::OrchardParse(
                 ::orchard::pczt::ParseError::InvalidAnchor,
+            )));
+        }
+        if has_sapling_spends && pczt.sapling.anchor.is_none() {
+            return Err(Error::Extract(ExtractError::SaplingParse(
+                ::sapling::pczt::ParseError::InvalidAnchor,
             )));
         }
         if has_ironwood_actions && pczt.ironwood.anchor.is_none() {

--- a/pczt/src/roles/redactor/sapling.rs
+++ b/pczt/src/roles/redactor/sapling.rs
@@ -59,6 +59,14 @@ impl SaplingRedactor<'_> {
     pub fn clear_bsk(&mut self) {
         self.0.bsk = None;
     }
+
+    /// Removes the bundle anchor.
+    ///
+    /// Parsed roles require the real anchor for Sapling spends, so a receiver
+    /// must restore it before parsing a bundle that contains spends.
+    pub fn clear_anchor(&mut self) {
+        self.0.anchor = None;
+    }
 }
 
 /// A Redactor for Sapling spends.

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -36,7 +36,7 @@ pub struct Bundle {
     ///
     /// Set by the Creator.
     #[getset(get = "pub")]
-    pub(crate) anchor: [u8; 32],
+    pub(crate) anchor: Option<[u8; 32]>,
 
     /// The Sapling binding signature signing key.
     ///
@@ -51,9 +51,13 @@ pub(crate) const EMPTY_BUNDLE: Bundle = Bundle {
     spends: Vec::new(),
     outputs: Vec::new(),
     value_sum: 0,
-    anchor: [0; 32],
+    anchor: None,
     bsk: None,
 };
+
+/// The default anchor used as a parse-time placeholder for redacted empty
+/// Sapling bundles.
+pub(crate) const DEFAULT_ANCHOR: [u8; 32] = [0; 32];
 
 /// Information about a Sapling spend within a transaction.
 #[serde_as]
@@ -359,7 +363,7 @@ impl Bundle {
             }
         }
 
-        if self.anchor != anchor {
+        if !merge_optional(&mut self.anchor, anchor) {
             return None;
         }
 
@@ -454,9 +458,81 @@ impl Bundle {
     }
 }
 
+/// Types for the v1 Sapling PCZT encoding.
+pub(crate) mod v1 {
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Serialize};
+
+    /// PCZT fields that are specific to producing the transaction's Sapling
+    /// bundle.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Bundle {
+        spends: Vec<super::Spend>,
+        outputs: Vec<super::Output>,
+        value_sum: i128,
+        anchor: [u8; 32],
+        bsk: Option<[u8; 32]>,
+    }
+
+    impl TryFrom<super::Bundle> for Bundle {
+        type Error = crate::EncodingError;
+
+        fn try_from(bundle: super::Bundle) -> Result<Self, Self::Error> {
+            let anchor = match bundle.anchor {
+                Some(anchor) => anchor,
+                None if bundle.spends.is_empty() => super::DEFAULT_ANCHOR,
+                None => return Err(crate::EncodingError::RequiresV2),
+            };
+
+            Ok(Self {
+                spends: bundle.spends,
+                outputs: bundle.outputs,
+                value_sum: bundle.value_sum,
+                anchor,
+                bsk: bundle.bsk,
+            })
+        }
+    }
+
+    impl From<Bundle> for super::Bundle {
+        fn from(bundle: Bundle) -> Self {
+            Self {
+                spends: bundle.spends,
+                outputs: bundle.outputs,
+                value_sum: bundle.value_sum,
+                anchor: Some(bundle.anchor),
+                bsk: bundle.bsk,
+            }
+        }
+    }
+}
+
+/// Types and operations for the v2 Sapling PCZT encoding.
+pub(crate) mod v2 {
+    /// Encodes a logical Sapling bundle for the v2 PCZT format, owning the
+    /// decision of whether the bundle can be omitted. A bundle that is exactly
+    /// equal to [`super::EMPTY_BUNDLE`] serializes to `None` and is dropped from
+    /// the encoding. An otherwise-empty bundle carrying
+    /// [`super::DEFAULT_ANCHOR`] is treated as empty for this purpose.
+    pub(crate) fn encode(bundle: super::Bundle) -> Option<super::Bundle> {
+        (!is_default_empty(&bundle)).then_some(bundle)
+    }
+
+    fn is_default_empty(bundle: &super::Bundle) -> bool {
+        let mut bundle = bundle.clone();
+        if bundle.anchor == Some(super::DEFAULT_ANCHOR) {
+            bundle.anchor = None;
+        }
+
+        bundle == super::EMPTY_BUNDLE
+    }
+}
+
 #[cfg(feature = "sapling")]
 impl Bundle {
     pub(crate) fn into_parsed(self) -> Result<sapling::pczt::Bundle, sapling::pczt::ParseError> {
+        let has_spends = !self.spends.is_empty();
         let spends = self
             .spends
             .into_iter()
@@ -521,7 +597,13 @@ impl Bundle {
             })
             .collect::<Result<_, _>>()?;
 
-        sapling::pczt::Bundle::parse(spends, outputs, self.value_sum, self.anchor, self.bsk)
+        let anchor = match self.anchor {
+            Some(anchor) => anchor,
+            None if !has_spends => DEFAULT_ANCHOR,
+            None => return Err(sapling::pczt::ParseError::InvalidAnchor),
+        };
+
+        sapling::pczt::Bundle::parse(spends, outputs, self.value_sum, anchor, self.bsk)
     }
 
     pub(crate) fn serialize_from(bundle: sapling::pczt::Bundle) -> Self {
@@ -605,7 +687,8 @@ impl Bundle {
             spends,
             outputs,
             value_sum: bundle.value_sum().to_raw(),
-            anchor: bundle.anchor().to_bytes(),
+            anchor: (bundle.anchor().to_bytes() != DEFAULT_ANCHOR)
+                .then_some(bundle.anchor().to_bytes()),
             bsk: bundle.bsk().map(|bsk| bsk.into()),
         }
     }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -996,11 +996,24 @@ fn check_v2_round_trip(pczt: &Pczt) {
 
 #[derive(Clone, Copy)]
 enum ShieldedPool {
+    Sapling,
     Orchard,
     Ironwood,
 }
 
 fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
+    if matches!(pool, ShieldedPool::Sapling) {
+        return Creator::new(
+            zcash_protocol::consensus::BranchId::Nu6.into(),
+            10_000_000,
+            133,
+            [9; 32],
+            [0; 32],
+        )
+        .unwrap()
+        .build();
+    }
+
     if matches!(pool, ShieldedPool::Orchard) {
         return Creator::new(
             zcash_protocol::consensus::BranchId::Nu6_3.into(),
@@ -1072,6 +1085,9 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
 
 fn redact_anchor(pczt: Pczt, pool: ShieldedPool) -> Pczt {
     match pool {
+        ShieldedPool::Sapling => Redactor::new(pczt)
+            .redact_sapling_with(|mut r| r.clear_anchor())
+            .finish(),
         ShieldedPool::Orchard => Redactor::new(pczt)
             .redact_orchard_with(|mut r| r.clear_anchor())
             .finish(),
@@ -1083,6 +1099,7 @@ fn redact_anchor(pczt: Pczt, pool: ShieldedPool) -> Pczt {
 
 fn assert_anchor_redacted(pczt: &Pczt, pool: ShieldedPool) {
     match pool {
+        ShieldedPool::Sapling => assert!(pczt.sapling().anchor().is_none()),
         ShieldedPool::Orchard => assert!(pczt.orchard().anchor().is_none()),
         ShieldedPool::Ironwood => assert!(pczt.ironwood().anchor().is_none()),
     }
@@ -1095,6 +1112,14 @@ fn assert_redacted_anchor_v2_round_trip(pczt: Pczt, pool: ShieldedPool) {
 
     let reparsed = Pczt::parse(&redacted.serialize().unwrap()).unwrap();
     assert_anchor_redacted(&reparsed, pool);
+}
+
+#[test]
+fn redacted_sapling_anchor_round_trips_v2() {
+    assert_redacted_anchor_v2_round_trip(
+        pczt_with_anchor(ShieldedPool::Sapling),
+        ShieldedPool::Sapling,
+    );
 }
 
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.


### PR DESCRIPTION
## Summary

- represent the logical Sapling anchor as optional so v2 PCZT redaction can remove it
- preserve v1 behavior by filling the default anchor only for missing-anchor bundles with no Sapling spends
- add Sapling anchor redaction API and v2 round-trip coverage

## Validation

- cargo test -p pczt --all-features
- cargo check -p pczt --no-default-features