### PR TITLE
Make Orchard v2 spend fields (nullifier, rk) options

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -65,6 +65,9 @@ workspace.
   as `pczt::orchard::EncCiphertext`, allowing v2 serialization to carry either
   encrypted ciphertext or a trailing-zero-stripped
   `pczt::orchard::MemoPlaintext`.
+- PCZT version 2 Orchard action serialization now represents spend nullifiers
+  and `rk` values as optional fields, while parsing rejects encodings that omit
+  either field until the logical Orchard spend model supports their absence.
 - Direct `serde` serialization implementations have been removed from the
   logical `pczt::orchard::{Bundle, Action, Spend, Output}` types.
 - `pczt::Pczt::serialize` now consumes `self` and returns
@@ -90,6 +93,8 @@ workspace.
   encoding.
 - `pczt::EncodingError::RequiresV2`, returned when v1 serialization cannot
   represent v2-only logical PCZT data.
+- `pczt::ParseError::MissingRequiredField`, returned when the PCZT encoding
+  omits a field that the logical PCZT type still requires.
 - `pczt::orchard::{EncCiphertext, MEMO_SIZE, MemoPlaintext,
   MemoPlaintextError}` for representing encrypted note plaintext data in the
   logical Orchard output model.

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -241,21 +241,23 @@ pub mod v2 {
         }
     }
 
-    impl From<Pczt> for super::Pczt {
-        fn from(pczt: Pczt) -> Self {
-            Self {
-                global: pczt.global,
-                transparent: pczt.transparent.unwrap_or(transparent::EMPTY_BUNDLE),
-                sapling: pczt.sapling.unwrap_or(sapling::EMPTY_BUNDLE),
-                orchard: pczt
+    impl Pczt {
+        pub(super) fn into_logical(self) -> Result<super::Pczt, super::ParseError> {
+            Ok(super::Pczt {
+                global: self.global,
+                transparent: self.transparent.unwrap_or(transparent::EMPTY_BUNDLE),
+                sapling: self.sapling.unwrap_or(sapling::EMPTY_BUNDLE),
+                orchard: self
                     .orchard
-                    .map(orchard::Bundle::from)
+                    .map(orchard::v2::Bundle::into_logical)
+                    .transpose()?
                     .unwrap_or(orchard::EMPTY_ORCHARD),
-                ironwood: pczt
+                ironwood: self
                     .ironwood
-                    .map(orchard::Bundle::from)
+                    .map(orchard::v2::Bundle::into_logical)
+                    .transpose()?
                     .unwrap_or(orchard::EMPTY_IRONWOOD),
-            }
+            })
         }
     }
 
@@ -329,7 +331,7 @@ pub mod v2 {
             let encoded = Pczt::try_from(pczt.clone()).unwrap();
             assert!(encoded.orchard.is_some());
 
-            let decoded = crate::Pczt::from(encoded);
+            let decoded = encoded.into_logical().unwrap();
             assert_eq!(decoded.orchard, pczt.orchard);
             assert_eq!(decoded.orchard.flags, 0);
             assert_eq!(decoded.orchard.note_version, NoteVersion::V3);
@@ -366,8 +368,8 @@ impl Pczt {
                 .map(Pczt::from)
                 .map_err(ParseError::Invalid),
             PCZT_VERSION_2 => postcard::from_bytes::<v2::Pczt>(&bytes[8..])
-                .map(Pczt::from)
-                .map_err(ParseError::Invalid),
+                .map_err(ParseError::Invalid)
+                .and_then(v2::Pczt::into_logical),
             _ => Err(ParseError::UnknownVersion(version)),
         }
     }
@@ -631,6 +633,9 @@ pub enum ParseError {
     NotPczt,
     /// The PCZT encoding was invalid.
     Invalid(postcard::Error),
+    /// The PCZT encoding omitted a field that is required by the logical PCZT
+    /// type.
+    MissingRequiredField(&'static str),
     /// The bytes are too short to contain a PCZT.
     TooShort,
     /// The PCZT has an unknown version.

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -764,7 +764,7 @@ pub(crate) mod v2 {
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
 
-    use super::{NoteVersion, v1};
+    use super::NoteVersion;
 
     /// A serializable representation of Orchard note plaintext versions.
     #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -807,9 +807,33 @@ pub(crate) mod v2 {
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub(crate) struct Action {
         cv_net: Option<[u8; 32]>,
-        spend: v1::Spend,
+        spend: Spend,
         output: Output,
         rcv: Option<[u8; 32]>,
+    }
+
+    /// Information about the spend part of an Orchard action.
+    #[serde_as]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub(crate) struct Spend {
+        #[serde_as(as = "Option<[_; 32]>")]
+        nullifier: Option<[u8; 32]>,
+        #[serde_as(as = "Option<[_; 32]>")]
+        rk: Option<[u8; 32]>,
+        #[serde_as(as = "Option<[_; 64]>")]
+        spend_auth_sig: Option<[u8; 64]>,
+        #[serde_as(as = "Option<[_; 43]>")]
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rho: Option<[u8; 32]>,
+        rseed: Option<[u8; 32]>,
+        #[serde_as(as = "Option<[_; 96]>")]
+        fvk: Option<[u8; 96]>,
+        witness: Option<(u32, [[u8; 32]; 32])>,
+        alpha: Option<[u8; 32]>,
+        zip32_derivation: Option<crate::common::Zip32Derivation>,
+        dummy_sk: Option<[u8; 32]>,
+        proprietary: BTreeMap<String, Vec<u8>>,
     }
 
     /// Information about the output part of an Orchard action.
@@ -850,21 +874,21 @@ pub(crate) mod v2 {
         }
     }
 
-    impl From<Bundle> for super::Bundle {
-        fn from(bundle: Bundle) -> Self {
-            Self {
-                actions: bundle
+    impl Bundle {
+        pub(crate) fn into_logical(self) -> Result<super::Bundle, crate::ParseError> {
+            Ok(super::Bundle {
+                actions: self
                     .actions
                     .into_iter()
-                    .map(super::Action::from)
-                    .collect(),
-                flags: bundle.flags,
-                value_sum: bundle.value_sum,
-                anchor: bundle.anchor,
-                note_version: bundle.note_version.into(),
-                zkproof: bundle.zkproof,
-                bsk: bundle.bsk,
-            }
+                    .map(Action::into_logical)
+                    .collect::<Result<Vec<_>, _>>()?,
+                flags: self.flags,
+                value_sum: self.value_sum,
+                anchor: self.anchor,
+                note_version: self.note_version.into(),
+                zkproof: self.zkproof,
+                bsk: self.bsk,
+            })
         }
     }
 
@@ -872,21 +896,67 @@ pub(crate) mod v2 {
         fn from(action: super::Action) -> Self {
             Self {
                 cv_net: action.cv_net,
-                spend: v1::Spend::from(action.spend),
+                spend: Spend::from(action.spend),
                 output: Output::from(action.output),
                 rcv: action.rcv,
             }
         }
     }
 
-    impl From<Action> for super::Action {
-        fn from(action: Action) -> Self {
+    impl Action {
+        fn into_logical(self) -> Result<super::Action, crate::ParseError> {
+            Ok(super::Action {
+                cv_net: self.cv_net,
+                spend: self.spend.into_logical()?,
+                output: super::Output::from(self.output),
+                rcv: self.rcv,
+            })
+        }
+    }
+
+    impl From<super::Spend> for Spend {
+        fn from(spend: super::Spend) -> Self {
             Self {
-                cv_net: action.cv_net,
-                spend: super::Spend::from(action.spend),
-                output: super::Output::from(action.output),
-                rcv: action.rcv,
+                nullifier: Some(spend.nullifier),
+                rk: Some(spend.rk),
+                spend_auth_sig: spend.spend_auth_sig,
+                recipient: spend.recipient,
+                value: spend.value,
+                rho: spend.rho,
+                rseed: spend.rseed,
+                fvk: spend.fvk,
+                witness: spend.witness,
+                alpha: spend.alpha,
+                zip32_derivation: spend.zip32_derivation,
+                dummy_sk: spend.dummy_sk,
+                proprietary: spend.proprietary,
             }
+        }
+    }
+
+    impl Spend {
+        fn into_logical(self) -> Result<super::Spend, crate::ParseError> {
+            Ok(super::Spend {
+                nullifier: self
+                    .nullifier
+                    .ok_or(crate::ParseError::MissingRequiredField(
+                        "orchard.actions[].spend.nullifier",
+                    ))?,
+                rk: self.rk.ok_or(crate::ParseError::MissingRequiredField(
+                    "orchard.actions[].spend.rk",
+                ))?,
+                spend_auth_sig: self.spend_auth_sig,
+                recipient: self.recipient,
+                value: self.value,
+                rho: self.rho,
+                rseed: self.rseed,
+                fvk: self.fvk,
+                witness: self.witness,
+                alpha: self.alpha,
+                zip32_derivation: self.zip32_derivation,
+                dummy_sk: self.dummy_sk,
+                proprietary: self.proprietary,
+            })
         }
     }
 
@@ -1017,8 +1087,35 @@ pub(crate) mod v2 {
                 assert_eq!(encoded.anchor, anchor);
                 assert_eq!(encoded.actions[0].cv_net, cv_net);
 
-                let decoded = LogicalBundle::from(encoded);
+                let decoded = encoded.into_logical().unwrap();
                 assert_eq!(decoded, bundle);
+            }
+        }
+
+        #[test]
+        fn missing_spend_nullifier_or_rk_is_rejected() {
+            let bundle = logical_bundle(Some([5; 32]), Some([6; 32]));
+
+            for (clear_field, missing_field) in [
+                (
+                    (|spend: &mut super::Spend| spend.nullifier = None) as fn(&mut super::Spend),
+                    "orchard.actions[].spend.nullifier",
+                ),
+                (
+                    |spend: &mut super::Spend| spend.rk = None,
+                    "orchard.actions[].spend.rk",
+                ),
+            ] {
+                let mut encoded = super::Bundle::try_from(bundle.clone()).unwrap();
+                assert_eq!(encoded.actions[0].spend.nullifier, Some([1; 32]));
+                assert_eq!(encoded.actions[0].spend.rk, Some([2; 32]));
+
+                clear_field(&mut encoded.actions[0].spend);
+
+                assert!(matches!(
+                    encoded.into_logical(),
+                    Err(crate::ParseError::MissingRequiredField(field)) if field == missing_field
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

- add an Orchard v2 serialization-specific spend type
- encode spend nullifiers and rk values as optional fields in v2
- reject v2 encodings that omit either field until the logical Orchard spend type can represent their absence
- add coverage for missing nullifier and missing rk parse failures

## Validation

- cargo test -p pczt --all-features
- cargo check -p pczt --no-default-features
- git diff --check