### PR TITLE
Support optional PCZT anchors and updater APIs

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,6 +123,10 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
+- `pczt::roles::updater::Updater::{set_sapling_spend_witnesses,
+  set_orchard_spend_witnesses, set_ironwood_spend_witnesses}` for restoring
+  shielded spend witnesses before proof creation.
+- `pczt::roles::updater::SpendWitnessUpdateError`
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,9 +123,10 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
-- `pczt::roles::updater::OrchardAnchorUpdateError` and
-  `pczt::roles::updater::Updater::{set_v6_orchard_anchor, set_v6_ironwood_anchor}`
-  for wallets that need to restore v6 anchors after signing.
+- `pczt::roles::updater::AnchorUpdateError` and
+  `pczt::roles::updater::Updater::{set_sapling_anchor, set_orchard_anchor,
+  set_ironwood_anchor}` for wallets that need to restore shielded anchors after
+  signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,6 +123,9 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
+- `pczt::roles::updater::OrchardAnchorUpdateError` and
+  `pczt::roles::updater::Updater::{set_v6_orchard_anchor, set_v6_ironwood_anchor}`
+  for wallets that need to restore v6 anchors after signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -46,6 +46,12 @@ workspace.
 - `pczt::roles::creator::Creator::new` is now fallible, returning
   `Result<Self, pczt::roles::creator::Error>`; it rejects unrecognized consensus
   branch IDs and upgrades that predate the v5 transaction format.
+- `pczt::roles::creator::Creator::new` now takes optional Sapling and Orchard
+  anchors. These may be [`None`] for v6 transactions, but v5 transactions still
+  require an anchor for each corresponding non-empty shielded bundle when the
+  PCZT is built.
+- `pczt::roles::creator::Creator::build` is now fallible, returning
+  `Result<Pczt, pczt::roles::creator::Error>`.
 - `pczt::roles::creator::Creator::with_orchard_flags` is now fallible, returning
   `Result<Self, pczt::roles::creator::Error>`. The Orchard bundle version (and
   hence the note-plaintext version and flag-byte encoding) is now derived from the
@@ -83,6 +89,8 @@ workspace.
 ### Added
 - `pczt::roles::creator::Error`, the error type returned by the now-fallible
   `Creator` methods.
+- `pczt::roles::creator::Error::AnchorRequiredForV5`, returned when building a
+  v5 PCZT with a non-empty shielded bundle whose anchor is missing.
 - `pczt::parse`, a free function for parsing PCZT encodings.
 - `pczt::EncodingError`, for errors that can occur during PCZT encoding.
 - `pczt::EncodingError::UnsupportedOrchardNoteVersion`, returned when an

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -168,9 +168,16 @@ pub mod v1 {
         fn v1_refuses_v6_pczts_and_non_canonical_ironwood_bundles() {
             // A v6 tx cannot be encoded as a v1 PCZT, even when its Ironwood bundle is
             // canonically empty.
-            let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
-                .unwrap()
-                .build();
+            let pczt = Creator::new(
+                BranchId::Nu6_3.into(),
+                10_000_000,
+                133,
+                Some([0; 32]),
+                Some([0; 32]),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
             assert!(matches!(
                 super::Pczt::try_from(pczt),
                 Err(crate::EncodingError::UnsupportedTxVersion)
@@ -178,9 +185,16 @@ pub mod v1 {
 
             // A v5 tx carrying non-canonical Ironwood bundle data cannot be encoded
             // as a v1 PCZT, because the data would be dropped.
-            let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-                .unwrap()
-                .build();
+            let mut pczt = Creator::new(
+                BranchId::Nu6.into(),
+                10_000_000,
+                133,
+                Some([0; 32]),
+                Some([0; 32]),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
             pczt.ironwood.bsk = Some([1; 32]);
             assert!(matches!(
                 super::Pczt::try_from(pczt),
@@ -268,11 +282,12 @@ pub mod v2 {
 
         #[test]
         fn empty_bundles_encode_as_none_and_decode_as_empty() {
-            // Zero anchors: the shielded bundles carry no anchor and no
+            // Absent anchors: the shielded bundles carry no anchor and no
             // spends/actions, so they are fully empty and omitted.
-            let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
+            let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, None, None)
                 .unwrap()
-                .build();
+                .build()
+                .unwrap();
 
             let encoded = Pczt::try_from(pczt).unwrap();
 
@@ -301,9 +316,16 @@ pub mod v2 {
             // A Sapling/Orchard bundle with a non-empty anchor differs from its
             // empty form, so it must not be omitted even with no spends/actions,
             // and the anchor must survive the v2 round-trip.
-            let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [1; 32], [2; 32])
-                .unwrap()
-                .build();
+            let pczt = Creator::new(
+                BranchId::Nu6.into(),
+                10_000_000,
+                133,
+                Some([1; 32]),
+                Some([2; 32]),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
 
             let encoded = Pczt::try_from(pczt).unwrap();
 
@@ -319,9 +341,16 @@ pub mod v2 {
 
         #[test]
         fn non_canonical_orchard_flags_and_note_version_prevent_omission() {
-            let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-                .unwrap()
-                .build();
+            let mut pczt = Creator::new(
+                BranchId::Nu6.into(),
+                10_000_000,
+                133,
+                Some([0; 32]),
+                Some([0; 32]),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
             pczt.orchard.flags = 0;
             pczt.orchard.note_version = NoteVersion::V3;
 
@@ -646,9 +675,16 @@ mod extraction_tests {
 
     #[test]
     fn v5_pczt_with_ironwood_data_does_not_extract() {
-        let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let mut pczt = Creator::new(
+            BranchId::Nu6.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
         pczt.ironwood.bsk = Some([1; 32]);
         assert!(matches!(
             pczt.into_effects(),
@@ -658,9 +694,16 @@ mod extraction_tests {
 
     #[test]
     fn v6_pczt_with_pre_nu6_3_branch_does_not_extract() {
-        let mut pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let mut pczt = Creator::new(
+            BranchId::Nu6_3.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
         pczt.global.consensus_branch_id = BranchId::Nu6_2.into();
         assert!(matches!(
             pczt.into_effects(),

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -1114,9 +1114,16 @@ pub(crate) mod v2 {
             let mut memo = [0; MEMO_SIZE];
             memo[..5].copy_from_slice(b"hello");
 
-            let mut pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-                .unwrap()
-                .build();
+            let mut pczt = Creator::new(
+                BranchId::Nu6.into(),
+                10_000_000,
+                133,
+                Some([0; 32]),
+                Some([0; 32]),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
             pczt.orchard
                 .actions
                 .push(decryptable_action_with_memo(memo));

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -47,9 +47,16 @@ mod tests {
             tx_extractor::{self, TransactionExtractor},
         };
 
-        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let pczt = Creator::new(
+            BranchId::Nu6.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
 
         // Extraction fails because we haven't run the IO Finalizer.
         // Extraction fails in Sapling because we happen to extract it before Orchard.
@@ -71,9 +78,16 @@ mod tests {
             io_finalizer::{self, IoFinalizer},
         };
 
-        let pczt = Creator::new(BranchId::Nu6.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let pczt = Creator::new(
+            BranchId::Nu6.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
 
         // IO finalization fails on spends because we happen to check them first.
         assert!(matches!(

--- a/pczt/src/roles/creator/mod.rs
+++ b/pczt/src/roles/creator/mod.rs
@@ -29,6 +29,10 @@ const INITIAL_TX_MODIFIABLE: u8 = FLAG_TRANSPARENT_INPUTS_MODIFIABLE
 /// Errors that can occur when creating a PCZT.
 #[derive(Debug)]
 pub enum Error {
+    /// A v5 transaction's shielded bundle anchors must be set by the Creator,
+    /// because they are transaction effecting data and cannot subsequently
+    /// change.
+    AnchorRequiredForV5,
     /// The transaction version implied by the consensus branch ID does not carry an
     /// Ironwood bundle.
     IronwoodNotSupported,
@@ -66,9 +70,9 @@ pub struct Creator {
     coin_type: u32,
     orchard_flags: u8,
     ironwood_flags: u8,
-    sapling_anchor: [u8; 32],
-    orchard_anchor: [u8; 32],
-    ironwood_anchor: [u8; 32],
+    sapling_anchor: Option<[u8; 32]>,
+    orchard_anchor: Option<[u8; 32]>,
+    ironwood_anchor: Option<[u8; 32]>,
 }
 
 impl Creator {
@@ -76,6 +80,9 @@ impl Creator {
     ///
     /// The transaction version is implied by the consensus branch ID: the v6
     /// transaction format from NU6.3 onward, and the v5 format for earlier upgrades.
+    /// For v5 transactions, `sapling_anchor` and `orchard_anchor` must both be
+    /// [`Option::Some`]. For v6 transactions, either anchor may be
+    /// [`Option::None`] and restored later.
     ///
     /// # Errors
     ///
@@ -86,8 +93,8 @@ impl Creator {
         consensus_branch_id: u32,
         expiry_height: u32,
         coin_type: u32,
-        sapling_anchor: [u8; 32],
-        orchard_anchor: [u8; 32],
+        sapling_anchor: Option<[u8; 32]>,
+        orchard_anchor: Option<[u8; 32]>,
     ) -> Result<Self, Error> {
         let branch_id = consensus_branch_id_for_pczt(consensus_branch_id)?;
 
@@ -120,7 +127,7 @@ impl Creator {
             ironwood_flags: crate::orchard::IRONWOOD_SPENDS_OUTPUTS_AND_CROSS_ADDRESS_ENABLED,
             sapling_anchor,
             orchard_anchor,
-            ironwood_anchor: [0; 32],
+            ironwood_anchor: None,
         })
     }
 
@@ -176,7 +183,7 @@ impl Creator {
         if self.tx_version != V6_TX_VERSION {
             return Err(Error::IronwoodNotSupported);
         }
-        self.ironwood_anchor = ironwood_anchor;
+        self.ironwood_anchor = Some(ironwood_anchor);
         Ok(self)
     }
 
@@ -202,13 +209,46 @@ impl Creator {
         Ok(self)
     }
 
-    pub fn build(self) -> Pczt {
-        let optional_sapling_anchor =
-            |anchor| (anchor != crate::sapling::DEFAULT_ANCHOR).then_some(anchor);
-        let optional_orchard_anchor =
-            |anchor| (anchor != crate::orchard::DEFAULT_ANCHOR).then_some(anchor);
+    /// Builds the initial PCZT.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AnchorRequiredForV5`] if this Creator describes a v5
+    /// transaction and either the Sapling anchor is missing from a bundle with
+    /// spends, or the Orchard anchor is missing from a bundle with actions.
+    pub fn build(self) -> Result<Pczt, Error> {
+        let sapling = crate::sapling::Bundle {
+            spends: vec![],
+            outputs: vec![],
+            value_sum: 0,
+            anchor: self.sapling_anchor,
+            bsk: None,
+        };
+        let orchard = OrchardBundle {
+            actions: vec![],
+            flags: self.orchard_flags,
+            value_sum: (0, false),
+            anchor: self.orchard_anchor,
+            // The note-plaintext version is determined by the Orchard bundle version.
+            #[cfg(feature = "orchard")]
+            note_version: self
+                .bundle_version(orchard::ValuePool::Orchard)
+                .expect("`Creator::new` rejects branches that predate NU5")
+                .note_version(),
+            #[cfg(not(feature = "orchard"))]
+            note_version: crate::orchard::NoteVersion::V2,
+            zkproof: None,
+            bsk: None,
+        };
 
-        Pczt {
+        if self.tx_version == V5_TX_VERSION
+            && ((sapling.anchor.is_none() && !sapling.spends.is_empty())
+                || (orchard.anchor.is_none() && !orchard.actions.is_empty()))
+        {
+            return Err(Error::AnchorRequiredForV5);
+        }
+
+        Ok(Pczt {
             global: crate::common::Global {
                 tx_version: self.tx_version,
                 version_group_id: self.version_group_id,
@@ -223,35 +263,14 @@ impl Creator {
                 inputs: vec![],
                 outputs: vec![],
             },
-            sapling: crate::sapling::Bundle {
-                spends: vec![],
-                outputs: vec![],
-                value_sum: 0,
-                anchor: optional_sapling_anchor(self.sapling_anchor),
-                bsk: None,
-            },
-            orchard: OrchardBundle {
-                actions: vec![],
-                flags: self.orchard_flags,
-                value_sum: (0, false),
-                anchor: optional_orchard_anchor(self.orchard_anchor),
-                // The note-plaintext version is determined by the Orchard bundle version.
-                #[cfg(feature = "orchard")]
-                note_version: self
-                    .bundle_version(orchard::ValuePool::Orchard)
-                    .expect("`Creator::new` rejects branches that predate NU5")
-                    .note_version(),
-                #[cfg(not(feature = "orchard"))]
-                note_version: crate::orchard::NoteVersion::V2,
-                zkproof: None,
-                bsk: None,
-            },
+            sapling,
+            orchard,
             ironwood: OrchardBundle {
                 flags: self.ironwood_flags,
-                anchor: optional_orchard_anchor(self.ironwood_anchor),
+                anchor: self.ironwood_anchor,
                 ..crate::orchard::EMPTY_IRONWOOD
             },
-        }
+        })
     }
 
     /// Builds a PCZT from the output of a [`Builder`].
@@ -329,33 +348,85 @@ mod tests {
 
     #[test]
     fn tx_version_follows_branch() {
-        let pczt = Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let pczt = Creator::new(
+            BranchId::Nu6_2.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
         assert_eq!(pczt.global.tx_version, V5_TX_VERSION);
         assert_eq!(pczt.global.version_group_id, V5_VERSION_GROUP_ID);
 
-        let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .build();
+        let pczt = Creator::new(
+            BranchId::Nu6_3.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
         assert_eq!(pczt.global.tx_version, V6_TX_VERSION);
         assert_eq!(pczt.global.version_group_id, V6_VERSION_GROUP_ID);
     }
 
     #[test]
+    fn optional_anchors_are_supported_for_empty_bundles() {
+        let pczt = Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, None, Some([0; 32]))
+            .unwrap()
+            .build()
+            .unwrap();
+        assert!(pczt.sapling.anchor.is_none());
+        assert_eq!(pczt.orchard.anchor, Some([0; 32]));
+
+        let pczt = Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, Some([0; 32]), None)
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(pczt.sapling.anchor, Some([0; 32]));
+        assert!(pczt.orchard.anchor.is_none());
+
+        let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, None, None)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert!(pczt.sapling.anchor.is_none());
+        assert!(pczt.orchard.anchor.is_none());
+    }
+
+    #[test]
     fn ironwood_anchor_requires_v6() {
         assert!(matches!(
-            Creator::new(BranchId::Nu6_2.into(), 10_000_000, 133, [0; 32], [0; 32])
-                .unwrap()
-                .with_ironwood_anchor([1; 32]),
+            Creator::new(
+                BranchId::Nu6_2.into(),
+                10_000_000,
+                133,
+                Some([0; 32]),
+                Some([0; 32])
+            )
+            .unwrap()
+            .with_ironwood_anchor([1; 32]),
             Err(Error::IronwoodNotSupported)
         ));
 
-        let pczt = Creator::new(BranchId::Nu6_3.into(), 10_000_000, 133, [0; 32], [0; 32])
-            .unwrap()
-            .with_ironwood_anchor([1; 32])
-            .unwrap()
-            .build();
+        let pczt = Creator::new(
+            BranchId::Nu6_3.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .with_ironwood_anchor([1; 32])
+        .unwrap()
+        .build()
+        .unwrap();
         assert_eq!(pczt.ironwood.anchor, Some([1; 32]));
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,10 +59,125 @@ impl Updater {
         }
     }
 
+    /// Sets spend witnesses for Sapling spends by spend index.
+    ///
+    /// This may be called after shielded signatures have been added. Sapling
+    /// spend proofs depend on the witnesses, so this must be called before proof
+    /// creation for the updated spends.
+    ///
+    /// Returns an error if any witness references a spend index that does not
+    /// exist, or if a target spend proof is already present.
+    #[cfg(feature = "sapling")]
+    pub fn set_sapling_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::sapling::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        set_sapling_spend_witnesses(&mut self.pczt.sapling.spends, witnesses)?;
+
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Orchard actions by action index.
+    ///
+    /// This may be called after shielded signatures have been added. Orchard
+    /// proofs depend on the witnesses, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if any witness references an action index that does not
+    /// exist, if the Orchard bundle is not using Orchard note plaintexts, or if
+    /// an Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_orchard_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        if self.pczt.orchard.note_version != crate::orchard::NoteVersion::V2 {
+            return Err(SpendWitnessUpdateError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        set_orchard_spend_witnesses(&mut self.pczt.orchard.actions, witnesses)?;
+
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Ironwood actions by action index.
+    ///
+    /// This may be called after shielded signatures have been added. Ironwood
+    /// proofs depend on the witnesses, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if any witness references an action index that does not
+    /// exist, if the Ironwood bundle is not using Ironwood note plaintexts, or if
+    /// an Ironwood proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_ironwood_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        if self.pczt.ironwood.note_version != crate::orchard::NoteVersion::V3 {
+            return Err(SpendWitnessUpdateError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        set_orchard_spend_witnesses(&mut self.pczt.ironwood.actions, witnesses)?;
+
+        Ok(self)
+    }
+
     /// Finishes the Updater role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
     }
+}
+
+#[cfg(feature = "sapling")]
+fn set_sapling_spend_witnesses(
+    spends: &mut [crate::sapling::Spend],
+    witnesses: impl IntoIterator<Item = (usize, ::sapling::MerklePath)>,
+) -> Result<(), SpendWitnessUpdateError> {
+    for (spend_index, merkle_path) in witnesses {
+        let spend = spends
+            .get_mut(spend_index)
+            .ok_or(SpendWitnessUpdateError::InvalidSpendIndex(spend_index))?;
+        if spend.zkproof.is_some() {
+            return Err(SpendWitnessUpdateError::ProofAlreadyPresent);
+        }
+        let position = u32::try_from(u64::from(merkle_path.position()))
+            .map_err(|_| SpendWitnessUpdateError::PositionOutOfRange)?;
+        let mut auth_path = [[0; 32]; 32];
+        for (target, node) in auth_path.iter_mut().zip(merkle_path.path_elems()) {
+            *target = node.to_bytes();
+        }
+        spend.witness = Some((position, auth_path));
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_no_orchard_proof(bundle: &crate::orchard::Bundle) -> Result<(), SpendWitnessUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn set_orchard_spend_witnesses(
+    actions: &mut [crate::orchard::Action],
+    witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+) -> Result<(), SpendWitnessUpdateError> {
+    for (action_index, merkle_path) in witnesses {
+        let action = actions
+            .get_mut(action_index)
+            .ok_or(SpendWitnessUpdateError::InvalidSpendIndex(action_index))?;
+        action.spend.witness = Some((
+            merkle_path.position(),
+            merkle_path.auth_path().map(|node| node.to_bytes()),
+        ));
+    }
+
+    Ok(())
 }
 
 /// An updater for a transparent PCZT output.
@@ -72,5 +187,46 @@ impl GlobalUpdater<'_> {
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);
+    }
+}
+
+/// Errors that can occur while setting Sapling, Orchard, or Ironwood spend witnesses.
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SpendWitnessUpdateError {
+    /// The requested Sapling spend index or Orchard/Ironwood action index does not exist.
+    InvalidSpendIndex(usize),
+    /// The bundle already contains a proof that depends on the current witness.
+    ProofAlreadyPresent,
+    /// The witness position cannot be represented in the PCZT wire format.
+    PositionOutOfRange,
+    /// The bundle's note-plaintext version does not match the pool being updated.
+    UnexpectedNoteVersion,
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+impl core::fmt::Display for SpendWitnessUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SpendWitnessUpdateError::InvalidSpendIndex(index) => {
+                write!(f, "spend index {index} does not exist")
+            }
+            SpendWitnessUpdateError::ProofAlreadyPresent => {
+                write!(f, "proof for target spend or bundle is already present")
+            }
+            SpendWitnessUpdateError::PositionOutOfRange => {
+                write!(
+                    f,
+                    "witness position cannot be represented in the PCZT wire format"
+                )
+            }
+            SpendWitnessUpdateError::UnexpectedNoteVersion => {
+                write!(
+                    f,
+                    "bundle note-plaintext version does not match the pool being updated"
+                )
+            }
+        }
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,9 +59,78 @@ impl Updater {
         }
     }
 
+    /// Sets the Orchard bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Orchard signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Orchard proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_orchard_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardAnchorUpdateError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        self.pczt.orchard.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
+    /// Sets the Ironwood bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Ironwood signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Ironwood proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Ironwood proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_ironwood_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardAnchorUpdateError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        self.pczt.ironwood.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
     /// Finishes the Updater role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_no_orchard_proof(
+    bundle: &crate::orchard::Bundle,
+) -> Result<(), OrchardAnchorUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(OrchardAnchorUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardAnchorUpdateError> {
+    use zcash_protocol::{
+        consensus::BranchId,
+        constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
+    };
+
+    if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
+        return Err(OrchardAnchorUpdateError::RequiresV6);
+    }
+
+    match BranchId::try_from(global.consensus_branch_id) {
+        Ok(BranchId::Nu6_3) => Ok(()),
+        #[cfg(zcash_unstable = "nu7")]
+        Ok(BranchId::Nu7) => Ok(()),
+        Ok(_) => Err(OrchardAnchorUpdateError::UnsupportedConsensusBranchId),
+        Err(_) => Err(OrchardAnchorUpdateError::UnknownConsensusBranchId),
     }
 }
 
@@ -72,5 +141,46 @@ impl GlobalUpdater<'_> {
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);
+    }
+}
+
+/// Errors that can occur while setting Orchard or Ironwood anchors.
+#[cfg(feature = "orchard")]
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrchardAnchorUpdateError {
+    /// The PCZT must use the version 6 transaction format for this update.
+    RequiresV6,
+    /// The PCZT's consensus branch ID is unrecognized.
+    UnknownConsensusBranchId,
+    /// The PCZT's consensus branch ID does not support version 6 PCZTs.
+    UnsupportedConsensusBranchId,
+    /// The bundle already contains a proof that depends on the current anchor.
+    ProofAlreadyPresent,
+}
+
+#[cfg(feature = "orchard")]
+impl core::fmt::Display for OrchardAnchorUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OrchardAnchorUpdateError::RequiresV6 => {
+                write!(
+                    f,
+                    "PCZT must be version 6 for this Orchard or Ironwood anchor update"
+                )
+            }
+            OrchardAnchorUpdateError::UnknownConsensusBranchId => {
+                write!(f, "unknown consensus branch ID")
+            }
+            OrchardAnchorUpdateError::UnsupportedConsensusBranchId => {
+                write!(
+                    f,
+                    "consensus branch ID does not support version 6 Orchard or Ironwood anchor updates"
+                )
+            }
+            OrchardAnchorUpdateError::ProofAlreadyPresent => {
+                write!(f, "Orchard or Ironwood proof is already present")
+            }
+        }
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,41 +59,66 @@ impl Updater {
         }
     }
 
-    /// Sets the Orchard bundle anchor for a version 6 PCZT on NU6.3 or later.
+    /// Sets the Sapling bundle anchor.
     ///
-    /// Orchard signatures in v6 do not commit to this anchor, so this may be
-    /// called after shielded signatures have been added. Orchard proofs do
-    /// depend on the anchor, so this must be called before proof creation.
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Sapling spend proofs depend on the anchor, so this must be called before
+    /// proof creation for Sapling spends.
     ///
-    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
-    /// Orchard proof is already present.
-    #[cfg(feature = "orchard")]
-    pub fn set_v6_orchard_anchor(
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if any Sapling spend proof is already present, or if the PCZT
+    /// already contains a different Sapling anchor.
+    #[cfg(feature = "sapling")]
+    pub fn set_sapling_anchor(
         mut self,
-        anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardAnchorUpdateError> {
-        ensure_v6_consensus_branch(&self.pczt.global)?;
-        ensure_no_orchard_proof(&self.pczt.orchard)?;
-        self.pczt.orchard.anchor = Some(anchor.to_bytes());
+        anchor: ::sapling::Anchor,
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
+        ensure_no_sapling_spend_proof(&self.pczt.sapling)?;
+        set_anchor(&mut self.pczt.sapling.anchor, anchor.to_bytes())?;
         Ok(self)
     }
 
-    /// Sets the Ironwood bundle anchor for a version 6 PCZT on NU6.3 or later.
+    /// Sets the Orchard bundle anchor.
     ///
-    /// Ironwood signatures in v6 do not commit to this anchor, so this may be
-    /// called after shielded signatures have been added. Ironwood proofs do
-    /// depend on the anchor, so this must be called before proof creation.
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Orchard proofs depend on the anchor, so this must be called before proof
+    /// creation.
     ///
-    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
-    /// Ironwood proof is already present.
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if an Orchard proof is already present, or if the PCZT already
+    /// contains a different Orchard anchor.
     #[cfg(feature = "orchard")]
-    pub fn set_v6_ironwood_anchor(
+    pub fn set_orchard_anchor(
         mut self,
         anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardAnchorUpdateError> {
-        ensure_v6_consensus_branch(&self.pczt.global)?;
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        set_anchor(&mut self.pczt.orchard.anchor, anchor.to_bytes())?;
+        Ok(self)
+    }
+
+    /// Sets the Ironwood bundle anchor.
+    ///
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Ironwood proofs depend on the anchor, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if an Ironwood proof is already present, or if the PCZT already
+    /// contains a different Ironwood anchor.
+    #[cfg(feature = "orchard")]
+    pub fn set_ironwood_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
         ensure_no_orchard_proof(&self.pczt.ironwood)?;
-        self.pczt.ironwood.anchor = Some(anchor.to_bytes());
+        set_anchor(&mut self.pczt.ironwood.anchor, anchor.to_bytes())?;
         Ok(self)
     }
 
@@ -103,34 +128,54 @@ impl Updater {
     }
 }
 
-#[cfg(feature = "orchard")]
-fn ensure_no_orchard_proof(
-    bundle: &crate::orchard::Bundle,
-) -> Result<(), OrchardAnchorUpdateError> {
-    if bundle.zkproof.is_some() {
-        Err(OrchardAnchorUpdateError::ProofAlreadyPresent)
+#[cfg(feature = "sapling")]
+fn ensure_no_sapling_spend_proof(bundle: &crate::sapling::Bundle) -> Result<(), AnchorUpdateError> {
+    if bundle.spends.iter().any(|spend| spend.zkproof.is_some()) {
+        Err(AnchorUpdateError::ProofAlreadyPresent)
     } else {
         Ok(())
     }
 }
 
 #[cfg(feature = "orchard")]
-fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardAnchorUpdateError> {
+fn ensure_no_orchard_proof(bundle: &crate::orchard::Bundle) -> Result<(), AnchorUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(AnchorUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+fn ensure_anchor_update_supported(global: &Global) -> Result<(), AnchorUpdateError> {
     use zcash_protocol::{
         consensus::BranchId,
         constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
     };
 
-    if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
-        return Err(OrchardAnchorUpdateError::RequiresV6);
+    if global.tx_version < V6_TX_VERSION
+        || (global.tx_version == V6_TX_VERSION && global.version_group_id != V6_VERSION_GROUP_ID)
+    {
+        return Err(AnchorUpdateError::UnsupportedTransactionFormat);
     }
 
     match BranchId::try_from(global.consensus_branch_id) {
         Ok(BranchId::Nu6_3) => Ok(()),
         #[cfg(zcash_unstable = "nu7")]
         Ok(BranchId::Nu7) => Ok(()),
-        Ok(_) => Err(OrchardAnchorUpdateError::UnsupportedConsensusBranchId),
-        Err(_) => Err(OrchardAnchorUpdateError::UnknownConsensusBranchId),
+        Ok(_) => Err(AnchorUpdateError::UnsupportedConsensusBranchId),
+        Err(_) => Err(AnchorUpdateError::UnknownConsensusBranchId),
+    }
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+fn set_anchor(slot: &mut Option<[u8; 32]>, anchor: [u8; 32]) -> Result<(), AnchorUpdateError> {
+    match slot {
+        Some(existing) if *existing != anchor => Err(AnchorUpdateError::ConflictingAnchor),
+        _ => {
+            *slot = Some(anchor);
+            Ok(())
+        }
     }
 }
 
@@ -144,42 +189,50 @@ impl GlobalUpdater<'_> {
     }
 }
 
-/// Errors that can occur while setting Orchard or Ironwood anchors.
-#[cfg(feature = "orchard")]
+/// Errors that can occur while setting Sapling, Orchard, or Ironwood anchors.
+#[cfg(any(feature = "sapling", feature = "orchard"))]
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum OrchardAnchorUpdateError {
-    /// The PCZT must use the version 6 transaction format for this update.
-    RequiresV6,
+pub enum AnchorUpdateError {
+    /// The PCZT transaction format does not support this update.
+    UnsupportedTransactionFormat,
     /// The PCZT's consensus branch ID is unrecognized.
     UnknownConsensusBranchId,
-    /// The PCZT's consensus branch ID does not support version 6 PCZTs.
+    /// The PCZT's consensus branch ID does not support this update.
     UnsupportedConsensusBranchId,
     /// The bundle already contains a proof that depends on the current anchor.
     ProofAlreadyPresent,
+    /// The bundle already contains a different anchor.
+    ConflictingAnchor,
 }
 
-#[cfg(feature = "orchard")]
-impl core::fmt::Display for OrchardAnchorUpdateError {
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+impl core::fmt::Display for AnchorUpdateError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            OrchardAnchorUpdateError::RequiresV6 => {
+            AnchorUpdateError::UnsupportedTransactionFormat => {
                 write!(
                     f,
-                    "PCZT must be version 6 for this Orchard or Ironwood anchor update"
+                    "PCZT transaction format does not support shielded anchor updates"
                 )
             }
-            OrchardAnchorUpdateError::UnknownConsensusBranchId => {
+            AnchorUpdateError::UnknownConsensusBranchId => {
                 write!(f, "unknown consensus branch ID")
             }
-            OrchardAnchorUpdateError::UnsupportedConsensusBranchId => {
+            AnchorUpdateError::UnsupportedConsensusBranchId => {
                 write!(
                     f,
-                    "consensus branch ID does not support version 6 Orchard or Ironwood anchor updates"
+                    "consensus branch ID does not support shielded anchor updates"
                 )
             }
-            OrchardAnchorUpdateError::ProofAlreadyPresent => {
-                write!(f, "Orchard or Ironwood proof is already present")
+            AnchorUpdateError::ProofAlreadyPresent => {
+                write!(
+                    f,
+                    "shielded proof that depends on the anchor is already present"
+                )
+            }
+            AnchorUpdateError::ConflictingAnchor => {
+                write!(f, "bundle already contains a different anchor")
             }
         }
     }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1137,6 +1137,159 @@ fn redacted_sapling_anchor_round_trips_v2() {
     );
 }
 
+#[test]
+fn redacted_sapling_anchor_can_be_restored_after_signing() {
+    let mut rng = OsRng;
+
+    let sapling_extsk = sapling::zip32::ExtendedSpendingKey::master(&[1; 32]);
+    let sapling_dfvk = sapling_extsk.to_diversifiable_full_viewing_key();
+    let sapling_internal_dfvk = sapling_extsk
+        .derive_internal()
+        .to_diversifiable_full_viewing_key();
+    let sapling_recipient = sapling_dfvk.default_address().1;
+
+    let value = sapling::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut sapling_builder = sapling::builder::Builder::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+            sapling::builder::BundleType::DEFAULT,
+            sapling::Anchor::empty_tree(),
+        );
+        sapling_builder
+            .add_output(
+                None,
+                sapling_recipient,
+                value,
+                Memo::Empty.encode().into_bytes(),
+            )
+            .unwrap();
+        let (bundle, meta) = sapling_builder
+            .build::<LocalTxProver, LocalTxProver, _, i64>(&[], &mut rng)
+            .unwrap()
+            .unwrap();
+        let output = bundle
+            .shielded_outputs()
+            .get(meta.output_index(0).unwrap())
+            .unwrap();
+        let domain = sapling::note_encryption::SaplingDomain::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+        );
+        let (note, _, _) =
+            try_note_decryption(&domain, &sapling_dfvk.to_external_ivk().prepare(), output)
+                .unwrap();
+        note
+    };
+
+    let (anchor, merkle_path) = {
+        let cmu = note.cmu();
+        let leaf = sapling::Node::from_cmu(&cmu);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<sapling::Node, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path)
+    };
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: Some(anchor),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_sapling_spend::<zip317::FeeRule>(sapling_dfvk.fvk().clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_sapling_output::<zip317::FeeRule>(
+            Some(sapling_dfvk.to_ovk(zip32::Scope::Internal)),
+            sapling_internal_dfvk.find_address(0u32.into()).unwrap().1,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        sapling_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = sapling_meta.spend_index(0).unwrap();
+    let pczt = Updater::new(pczt)
+        .update_sapling_with(|mut updater| {
+            updater.update_spend_with(index, |mut spend_updater| {
+                spend_updater.set_proof_generation_key(sapling_extsk.expsk.proof_generation_key())
+            })
+        })
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&pczt);
+
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_sapling_anchor(sapling::Anchor::empty_tree()),
+        Err(pczt::roles::updater::AnchorUpdateError::ConflictingAnchor)
+    ));
+
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer
+        .sign_sapling(index, &sapling_extsk.expsk.ask)
+        .unwrap();
+    let signed = signer.finish();
+
+    let redacted = Redactor::new(signed)
+        .redact_sapling_with(|mut r| r.clear_anchor())
+        .finish();
+    assert!(redacted.sapling().anchor().is_none());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_sapling_proofs(&LocalTxProver::bundled(), &LocalTxProver::bundled())
+            .is_err()
+    );
+
+    let updated = Updater::new(redacted)
+        .set_sapling_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.sapling().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let sapling_prover = LocalTxProver::bundled();
+    let proved = Prover::new(updated)
+        .create_sapling_proofs(&sapling_prover, &sapling_prover)
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone()).set_sapling_anchor(anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::ProofAlreadyPresent)
+    ));
+
+    let (spend_vk, output_vk) = sapling_prover.verifying_keys();
+    let tx = TransactionExtractor::new(proved)
+        .with_sapling(&spend_vk, &output_vk)
+        .extract()
+        .unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
 fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
     use zcash_protocol::consensus::BlockHeight;
@@ -1166,7 +1319,7 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
-fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
+fn redacted_orchard_anchor_can_be_restored_after_signing() {
     let mut rng = OsRng;
 
     let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
@@ -1252,6 +1405,14 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     let index = orchard_meta.spend_action_index(0).unwrap();
     check_v2_round_trip(&pczt);
 
+    Updater::new(pczt.clone())
+        .set_orchard_anchor(anchor)
+        .unwrap();
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_orchard_anchor(orchard::Anchor::empty_tree()),
+        Err(pczt::roles::updater::AnchorUpdateError::ConflictingAnchor)
+    ));
+
     let redacted = Redactor::new(pczt)
         .redact_orchard_with(|mut r| r.clear_anchor())
         .finish();
@@ -1268,7 +1429,7 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     let signed = signer.finish();
 
     let updated = Updater::new(signed)
-        .set_v6_orchard_anchor(anchor)
+        .set_orchard_anchor(anchor)
         .unwrap()
         .finish();
     assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
@@ -1295,8 +1456,8 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     check_v2_round_trip(&proved);
 
     assert!(matches!(
-        Updater::new(proved.clone()).set_v6_orchard_anchor(anchor),
-        Err(pczt::roles::updater::OrchardAnchorUpdateError::ProofAlreadyPresent)
+        Updater::new(proved.clone()).set_orchard_anchor(anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::ProofAlreadyPresent)
     ));
 
     let tx = TransactionExtractor::new(proved).extract().unwrap();
@@ -1328,7 +1489,7 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
 
     let updated = Updater::new(signed)
-        .set_v6_ironwood_anchor(anchor)
+        .set_ironwood_anchor(anchor)
         .unwrap()
         .finish();
     assert_eq!(updated.ironwood().anchor(), &Some(anchor.to_bytes()));
@@ -1336,22 +1497,31 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
 }
 
 #[test]
-fn v6_anchor_setters_reject_v5_pczts() {
-    let anchor = orchard::Anchor::empty_tree();
+fn anchor_setters_reject_unsupported_transaction_formats() {
+    let sapling_anchor = sapling::Anchor::empty_tree();
+    let orchard_anchor = orchard::Anchor::empty_tree();
     let pczt = Creator::new(
         zcash_protocol::consensus::BranchId::Nu6.into(),
         10_000_000,
         133,
-        Some([0; 32]),
-        Some(anchor.to_bytes()),
+        Some(sapling_anchor.to_bytes()),
+        Some(orchard_anchor.to_bytes()),
     )
     .unwrap()
     .build()
     .unwrap();
 
     assert!(matches!(
-        Updater::new(pczt).set_v6_orchard_anchor(anchor),
-        Err(pczt::roles::updater::OrchardAnchorUpdateError::RequiresV6)
+        Updater::new(pczt.clone()).set_sapling_anchor(sapling_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
+    ));
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_orchard_anchor(orchard_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
+    ));
+    assert!(matches!(
+        Updater::new(pczt).set_ironwood_anchor(orchard_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
     ));
 }
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -37,10 +37,17 @@ use zcash_protocol::{
 use zcash_script::script::{self, Evaluable};
 
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+static POST_NU6_3_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     ORCHARD_PROVING_KEY.get_or_init(|| {
         orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
+}
+
+fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
+    POST_NU6_3_ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3)
     })
 }
 
@@ -1159,6 +1166,144 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
+fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let orchard_bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V2);
+        note
+    };
+
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk, note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(980_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    check_v2_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_orchard_with(|mut r| r.clear_anchor())
+        .finish();
+    assert!(redacted.orchard().anchor().is_none());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_orchard_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+
+    let updated = Updater::new(signed)
+        .set_v6_orchard_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let produced_sig = updated.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_valid_spend_auth_sig(
+        updated.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&proved);
+
+    assert!(matches!(
+        Updater::new(proved.clone()).set_v6_orchard_anchor(anchor),
+        Err(pczt::roles::updater::OrchardAnchorUpdateError::ProofAlreadyPresent)
+    ));
+
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
 fn redacted_ironwood_anchor_round_trips_v2() {
     assert_redacted_anchor_v2_round_trip(
         pczt_with_anchor(ShieldedPool::Ironwood),
@@ -1168,6 +1313,7 @@ fn redacted_ironwood_anchor_round_trips_v2() {
 
 #[test]
 fn redacted_ironwood_anchor_survives_signer_finish() {
+    let anchor = orchard::Anchor::empty_tree();
     let redacted = redact_anchor(
         pczt_with_anchor(ShieldedPool::Ironwood),
         ShieldedPool::Ironwood,
@@ -1178,8 +1324,35 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
     assert_anchor_redacted(&signed, ShieldedPool::Ironwood);
     check_v2_round_trip(&signed);
 
-    let reparsed = Pczt::parse(&signed.serialize().unwrap()).unwrap();
+    let reparsed = Pczt::parse(&signed.clone().serialize().unwrap()).unwrap();
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
+
+    let updated = Updater::new(signed)
+        .set_v6_ironwood_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.ironwood().anchor(), &Some(anchor.to_bytes()));
+    check_v2_round_trip(&updated);
+}
+
+#[test]
+fn v6_anchor_setters_reject_v5_pczts() {
+    let anchor = orchard::Anchor::empty_tree();
+    let pczt = Creator::new(
+        zcash_protocol::consensus::BranchId::Nu6.into(),
+        10_000_000,
+        133,
+        Some([0; 32]),
+        Some(anchor.to_bytes()),
+    )
+    .unwrap()
+    .build()
+    .unwrap();
+
+    assert!(matches!(
+        Updater::new(pczt).set_v6_orchard_anchor(anchor),
+        Err(pczt::roles::updater::OrchardAnchorUpdateError::RequiresV6)
+    ));
 }
 
 #[test]

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1012,11 +1012,12 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             zcash_protocol::consensus::BranchId::Nu6.into(),
             10_000_000,
             133,
-            [9; 32],
-            [0; 32],
+            Some([9; 32]),
+            Some([0; 32]),
         )
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
     }
 
     if matches!(pool, ShieldedPool::Orchard) {
@@ -1024,11 +1025,12 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             zcash_protocol::consensus::BranchId::Nu6_3.into(),
             10_000_000,
             133,
-            [0; 32],
-            [9; 32],
+            Some([0; 32]),
+            Some([9; 32]),
         )
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
     }
 
     let transparent_account_sk =
@@ -1057,6 +1059,7 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
             ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
                 .then(orchard::Anchor::empty_tree),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -1410,11 +1413,12 @@ fn redacted_anchor_is_not_resolved() {
         zcash_protocol::consensus::BranchId::Nu6.into(),
         10_000_000,
         133,
-        [0; 32],
-        [9; 32],
+        Some([0; 32]),
+        Some([9; 32]),
     )
     .unwrap()
-    .build();
+    .build()
+    .unwrap();
 
     let mut redacted = Redactor::new(pczt)
         .redact_orchard_with(|mut r| {

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -11,9 +11,17 @@ use orchard::tree::MerkleHashOrchard;
 use pczt::{
     Pczt,
     roles::{
-        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
-        prover::Prover, redactor::Redactor, signer::Signer, spend_finalizer::SpendFinalizer,
-        tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
+        combiner::Combiner,
+        creator::Creator,
+        io_finalizer::IoFinalizer,
+        low_level_signer,
+        prover::Prover,
+        redactor::Redactor,
+        signer::Signer,
+        spend_finalizer::SpendFinalizer,
+        tx_extractor::TransactionExtractor,
+        updater::{SpendWitnessUpdateError, Updater},
+        verifier::Verifier,
     },
     v1, v2,
 };
@@ -37,10 +45,17 @@ use zcash_protocol::{
 use zcash_script::script::{self, Evaluable};
 
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+static POST_NU6_3_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     ORCHARD_PROVING_KEY.get_or_init(|| {
         orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
+}
+
+fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
+    POST_NU6_3_ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3)
     })
 }
 
@@ -1130,6 +1145,169 @@ fn redacted_sapling_anchor_round_trips_v2() {
     );
 }
 
+#[test]
+fn wallet_can_set_sapling_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create a Sapling account to spend from and send back to.
+    let sapling_extsk = sapling::zip32::ExtendedSpendingKey::master(&[1; 32]);
+    let sapling_dfvk = sapling_extsk.to_diversifiable_full_viewing_key();
+    let sapling_internal_dfvk = sapling_extsk
+        .derive_internal()
+        .to_diversifiable_full_viewing_key();
+    let sapling_recipient = sapling_dfvk.default_address().1;
+
+    // Pretend we already received a Sapling note.
+    let value = sapling::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut sapling_builder = sapling::builder::Builder::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+            sapling::builder::BundleType::DEFAULT,
+            sapling::Anchor::empty_tree(),
+        );
+        sapling_builder
+            .add_output(
+                None,
+                sapling_recipient,
+                value,
+                Memo::Empty.encode().into_bytes(),
+            )
+            .unwrap();
+        let (bundle, meta) = sapling_builder
+            .build::<LocalTxProver, LocalTxProver, _, i64>(&[], &mut rng)
+            .unwrap()
+            .unwrap();
+        let output = bundle
+            .shielded_outputs()
+            .get(meta.output_index(0).unwrap())
+            .unwrap();
+        let domain = sapling::note_encryption::SaplingDomain::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+        );
+        let (note, _, _) =
+            try_note_decryption(&domain, &sapling_dfvk.to_external_ivk().prepare(), output)
+                .unwrap();
+        note
+    };
+
+    // Use the Sapling tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmu = note.cmu();
+        let leaf = sapling::Node::from_cmu(&cmu);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<sapling::Node, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path)
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Sapling transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: Some(anchor),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_sapling_spend::<zip317::FeeRule>(sapling_dfvk.fvk().clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_sapling_output::<zip317::FeeRule>(
+            Some(sapling_dfvk.to_ovk(zip32::Scope::Internal)),
+            sapling_internal_dfvk.find_address(0u32.into()).unwrap().1,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        sapling_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = sapling_meta.spend_index(0).unwrap();
+    let pczt = Updater::new(pczt)
+        .update_sapling_with(|mut updater| {
+            updater.update_spend_with(index, |mut spend_updater| {
+                spend_updater.set_proof_generation_key(sapling_extsk.expsk.proof_generation_key())
+            })
+        })
+        .unwrap()
+        .finish();
+    check_round_trip(&pczt);
+
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer
+        .sign_sapling(index, &sapling_extsk.expsk.ask)
+        .unwrap();
+    let signed = signer.finish();
+
+    let redacted = Redactor::new(signed)
+        .redact_sapling_with(|mut r| {
+            r.redact_spend(index, |mut s| {
+                s.clear_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_sapling_proofs(&LocalTxProver::bundled(), &LocalTxProver::bundled())
+            .is_err()
+    );
+
+    assert_eq!(
+        Signer::new(redacted.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let invalid_index = redacted.sapling().spends().len();
+    assert!(matches!(
+        Updater::new(redacted.clone())
+            .set_sapling_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(redacted)
+        .set_sapling_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let sapling_prover = LocalTxProver::bundled();
+    let proved = Prover::new(updated)
+        .create_sapling_proofs(&sapling_prover, &sapling_prover)
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_sapling_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    check_round_trip(&proved);
+}
+
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
 fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
     use zcash_protocol::consensus::BlockHeight;
@@ -1159,6 +1337,144 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
+fn wallet_can_set_orchard_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to spend from and send back to.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Orchard note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // Use the Orchard tree with a single leaf.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Orchard transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    check_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_orchard_with(|mut r| {
+            r.redact_action(index, |mut a| {
+                a.clear_spend_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_orchard_proof(orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted.clone()).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+    let invalid_index = signed.orchard().actions().len();
+    assert!(matches!(
+        Updater::new(signed.clone())
+            .set_orchard_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(signed)
+        .set_orchard_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(orchard_proving_key())
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_orchard_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
 fn redacted_ironwood_anchor_round_trips_v2() {
     assert_redacted_anchor_v2_round_trip(
         pczt_with_anchor(ShieldedPool::Ironwood),
@@ -1180,6 +1496,146 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
 
     let reparsed = Pczt::parse(&signed.serialize().unwrap()).unwrap();
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
+}
+
+#[test]
+fn wallet_can_set_ironwood_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to spend from and send back to through Ironwood.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Ironwood note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::IronwoodDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V3);
+        note
+    };
+
+    // Use the Ironwood tree with a single leaf.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Ironwood transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: None,
+            ironwood_anchor: Some(anchor),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_ironwood_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        ironwood_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = ironwood_meta.spend_action_index(0).unwrap();
+    check_v2_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_ironwood_with(|mut r| {
+            r.redact_action(index, |mut a| {
+                a.clear_spend_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted.clone()).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_ironwood(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+    let invalid_index = signed.ironwood().actions().len();
+    assert!(matches!(
+        Updater::new(signed.clone())
+            .set_ironwood_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(signed)
+        .set_ironwood_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let proved = Prover::new(updated)
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_ironwood_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- allow PCZT Creator to accept optional Sapling and Orchard anchors, requiring anchors only for non-empty v5 shielded bundles
- add updater APIs for restoring Sapling, Orchard, and Ironwood anchors after signing and before proof creation
- add updater APIs for restoring Sapling, Orchard, and Ironwood spend witnesses before proof creation
- extend PCZT roundtrip and end-to-end tests for redacted anchors and witnesses

## Validation

- cargo fmt --all -- --check
- cargo test -p pczt --all-features
- cargo check -p pczt --no-default-features
- cargo doc --no-deps -p pczt --all-features --document-private-items
- git diff --check