### PR TITLE
Add PCZT anchor and witness updater APIs

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -115,6 +115,9 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
+- `pczt::roles::updater::{OrchardSpendWitness, OrchardSpendWitnessError}`
+  and Orchard or Ironwood anchor and spend witness setters for wallets that
+  need to restore v6 proof data after signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -115,9 +115,9 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
-- `pczt::roles::updater::{OrchardSpendWitness, OrchardSpendWitnessError}`
-  and Orchard or Ironwood anchor and spend witness setters for wallets that
-  need to restore v6 proof data after signing.
+- `pczt::roles::updater::OrchardProofDataError` and Orchard or Ironwood anchor
+  and spend witness setters for wallets that need to restore v6 proof data after
+  signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -8,6 +8,60 @@ use alloc::vec::Vec;
 
 use crate::{Pczt, common::Global};
 
+/// An Orchard-style spend witness to set on an Orchard or Ironwood PCZT action.
+#[cfg(feature = "orchard")]
+#[derive(Clone, Debug)]
+pub struct OrchardSpendWitness {
+    action_index: usize,
+    merkle_path: ::orchard::tree::MerklePath,
+}
+
+#[cfg(feature = "orchard")]
+impl OrchardSpendWitness {
+    /// Constructs a witness update from a typed Orchard-style Merkle path.
+    pub fn from_merkle_path(action_index: usize, merkle_path: ::orchard::tree::MerklePath) -> Self {
+        Self {
+            action_index,
+            merkle_path,
+        }
+    }
+
+    /// Parses and validates a witness update from serialized Orchard-style Merkle path data.
+    pub fn parse(
+        action_index: usize,
+        position: u32,
+        auth_path: [[u8; 32]; 32],
+    ) -> Result<Self, OrchardSpendWitnessError> {
+        let mut nodes = Vec::with_capacity(32);
+        for from in auth_path {
+            nodes.push(
+                ::orchard::tree::MerkleHashOrchard::from_bytes(&from)
+                    .into_option()
+                    .ok_or(OrchardSpendWitnessError::InvalidWitness)?,
+            );
+        }
+        let nodes = nodes
+            .try_into()
+            .map_err(|_| OrchardSpendWitnessError::InvalidWitness)?;
+
+        Ok(Self::from_merkle_path(
+            action_index,
+            ::orchard::tree::MerklePath::from_parts(position, nodes),
+        ))
+    }
+
+    fn action_index(&self) -> usize {
+        self.action_index
+    }
+
+    fn serialized_witness(&self) -> (u32, [[u8; 32]; 32]) {
+        (
+            self.merkle_path.position(),
+            self.merkle_path.auth_path().map(|node| node.to_bytes()),
+        )
+    }
+}
+
 #[cfg(feature = "orchard")]
 mod orchard;
 #[cfg(feature = "orchard")]
@@ -59,9 +113,136 @@ impl Updater {
         }
     }
 
+    /// Sets the Orchard bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Orchard signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Orchard proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_orchard_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardSpendWitnessError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        self.pczt.orchard.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Orchard actions by action index.
+    ///
+    /// Returns an error if any witness references an action index that does not exist,
+    /// or if an Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_orchard_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = OrchardSpendWitness>,
+    ) -> Result<Self, OrchardSpendWitnessError> {
+        if self.pczt.orchard.note_version != crate::orchard::NoteVersion::V2 {
+            return Err(OrchardSpendWitnessError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        for witness in witnesses {
+            let action = self
+                .pczt
+                .orchard
+                .actions
+                .get_mut(witness.action_index())
+                .ok_or(OrchardSpendWitnessError::InvalidActionIndex(
+                    witness.action_index(),
+                ))?;
+            action.spend.witness = Some(witness.serialized_witness());
+        }
+
+        Ok(self)
+    }
+
+    /// Sets the Ironwood bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Ironwood signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Ironwood proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Ironwood proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_ironwood_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardSpendWitnessError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        self.pczt.ironwood.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Ironwood actions by action index.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, if any
+    /// witness references an action index that does not exist, or if an Ironwood
+    /// proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_ironwood_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = OrchardSpendWitness>,
+    ) -> Result<Self, OrchardSpendWitnessError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        if self.pczt.ironwood.note_version != crate::orchard::NoteVersion::V3 {
+            return Err(OrchardSpendWitnessError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        for witness in witnesses {
+            let action = self
+                .pczt
+                .ironwood
+                .actions
+                .get_mut(witness.action_index())
+                .ok_or(OrchardSpendWitnessError::InvalidActionIndex(
+                    witness.action_index(),
+                ))?;
+            action.spend.witness = Some(witness.serialized_witness());
+        }
+
+        Ok(self)
+    }
+
     /// Finishes the Updater role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_no_orchard_proof(
+    bundle: &crate::orchard::Bundle,
+) -> Result<(), OrchardSpendWitnessError> {
+    if bundle.zkproof.is_some() {
+        Err(OrchardSpendWitnessError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardSpendWitnessError> {
+    use zcash_protocol::{
+        consensus::BranchId,
+        constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
+    };
+
+    if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
+        return Err(OrchardSpendWitnessError::RequiresV6);
+    }
+
+    match BranchId::try_from(global.consensus_branch_id) {
+        Ok(BranchId::Nu6_3) => Ok(()),
+        #[cfg(zcash_unstable = "nu7")]
+        Ok(BranchId::Nu7) => Ok(()),
+        Ok(_) => Err(OrchardSpendWitnessError::UnsupportedConsensusBranchId),
+        Err(_) => Err(OrchardSpendWitnessError::UnknownConsensusBranchId),
     }
 }
 
@@ -72,5 +253,62 @@ impl GlobalUpdater<'_> {
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);
+    }
+}
+
+/// Errors that can occur while setting Orchard or Ironwood anchor or spend witness data.
+#[cfg(feature = "orchard")]
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrchardSpendWitnessError {
+    /// The requested action index does not exist in the bundle.
+    InvalidActionIndex(usize),
+    /// The provided serialized witness contains an invalid Orchard-style Merkle node.
+    InvalidWitness,
+    /// The PCZT must use the version 6 transaction format for this update.
+    RequiresV6,
+    /// The PCZT's consensus branch ID is unrecognized.
+    UnknownConsensusBranchId,
+    /// The PCZT's consensus branch ID does not support version 6 PCZTs.
+    UnsupportedConsensusBranchId,
+    /// The bundle already contains a proof that depends on the current witness data.
+    ProofAlreadyPresent,
+    /// The bundle's note-plaintext version does not match the pool being updated.
+    UnexpectedNoteVersion,
+}
+
+#[cfg(feature = "orchard")]
+impl core::fmt::Display for OrchardSpendWitnessError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OrchardSpendWitnessError::InvalidActionIndex(index) => {
+                write!(f, "Orchard or Ironwood action index {index} does not exist")
+            }
+            OrchardSpendWitnessError::InvalidWitness => write!(f, "invalid Orchard-style witness"),
+            OrchardSpendWitnessError::RequiresV6 => {
+                write!(
+                    f,
+                    "PCZT must be version 6 for this Orchard or Ironwood update"
+                )
+            }
+            OrchardSpendWitnessError::UnknownConsensusBranchId => {
+                write!(f, "unknown consensus branch ID")
+            }
+            OrchardSpendWitnessError::UnsupportedConsensusBranchId => {
+                write!(
+                    f,
+                    "consensus branch ID does not support version 6 Orchard or Ironwood updates"
+                )
+            }
+            OrchardSpendWitnessError::ProofAlreadyPresent => {
+                write!(f, "Orchard or Ironwood proof is already present")
+            }
+            OrchardSpendWitnessError::UnexpectedNoteVersion => {
+                write!(
+                    f,
+                    "bundle note-plaintext version does not match the pool being updated"
+                )
+            }
+        }
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -8,60 +8,6 @@ use alloc::vec::Vec;
 
 use crate::{Pczt, common::Global};
 
-/// An Orchard-style spend witness to set on an Orchard or Ironwood PCZT action.
-#[cfg(feature = "orchard")]
-#[derive(Clone, Debug)]
-pub struct OrchardSpendWitness {
-    action_index: usize,
-    merkle_path: ::orchard::tree::MerklePath,
-}
-
-#[cfg(feature = "orchard")]
-impl OrchardSpendWitness {
-    /// Constructs a witness update from a typed Orchard-style Merkle path.
-    pub fn from_merkle_path(action_index: usize, merkle_path: ::orchard::tree::MerklePath) -> Self {
-        Self {
-            action_index,
-            merkle_path,
-        }
-    }
-
-    /// Parses and validates a witness update from serialized Orchard-style Merkle path data.
-    pub fn parse(
-        action_index: usize,
-        position: u32,
-        auth_path: [[u8; 32]; 32],
-    ) -> Result<Self, OrchardSpendWitnessError> {
-        let mut nodes = Vec::with_capacity(32);
-        for from in auth_path {
-            nodes.push(
-                ::orchard::tree::MerkleHashOrchard::from_bytes(&from)
-                    .into_option()
-                    .ok_or(OrchardSpendWitnessError::InvalidWitness)?,
-            );
-        }
-        let nodes = nodes
-            .try_into()
-            .map_err(|_| OrchardSpendWitnessError::InvalidWitness)?;
-
-        Ok(Self::from_merkle_path(
-            action_index,
-            ::orchard::tree::MerklePath::from_parts(position, nodes),
-        ))
-    }
-
-    fn action_index(&self) -> usize {
-        self.action_index
-    }
-
-    fn serialized_witness(&self) -> (u32, [[u8; 32]; 32]) {
-        (
-            self.merkle_path.position(),
-            self.merkle_path.auth_path().map(|node| node.to_bytes()),
-        )
-    }
-}
-
 #[cfg(feature = "orchard")]
 mod orchard;
 #[cfg(feature = "orchard")]
@@ -125,7 +71,7 @@ impl Updater {
     pub fn set_v6_orchard_anchor(
         mut self,
         anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardSpendWitnessError> {
+    ) -> Result<Self, OrchardProofDataError> {
         ensure_v6_consensus_branch(&self.pczt.global)?;
         ensure_no_orchard_proof(&self.pczt.orchard)?;
         self.pczt.orchard.anchor = Some(anchor.to_bytes());
@@ -139,23 +85,13 @@ impl Updater {
     #[cfg(feature = "orchard")]
     pub fn set_orchard_spend_witnesses(
         mut self,
-        witnesses: impl IntoIterator<Item = OrchardSpendWitness>,
-    ) -> Result<Self, OrchardSpendWitnessError> {
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, OrchardProofDataError> {
         if self.pczt.orchard.note_version != crate::orchard::NoteVersion::V2 {
-            return Err(OrchardSpendWitnessError::UnexpectedNoteVersion);
+            return Err(OrchardProofDataError::UnexpectedNoteVersion);
         }
         ensure_no_orchard_proof(&self.pczt.orchard)?;
-        for witness in witnesses {
-            let action = self
-                .pczt
-                .orchard
-                .actions
-                .get_mut(witness.action_index())
-                .ok_or(OrchardSpendWitnessError::InvalidActionIndex(
-                    witness.action_index(),
-                ))?;
-            action.spend.witness = Some(witness.serialized_witness());
-        }
+        set_spend_witnesses(&mut self.pczt.orchard.actions, witnesses)?;
 
         Ok(self)
     }
@@ -172,7 +108,7 @@ impl Updater {
     pub fn set_v6_ironwood_anchor(
         mut self,
         anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardSpendWitnessError> {
+    ) -> Result<Self, OrchardProofDataError> {
         ensure_v6_consensus_branch(&self.pczt.global)?;
         ensure_no_orchard_proof(&self.pczt.ironwood)?;
         self.pczt.ironwood.anchor = Some(anchor.to_bytes());
@@ -187,24 +123,14 @@ impl Updater {
     #[cfg(feature = "orchard")]
     pub fn set_ironwood_spend_witnesses(
         mut self,
-        witnesses: impl IntoIterator<Item = OrchardSpendWitness>,
-    ) -> Result<Self, OrchardSpendWitnessError> {
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, OrchardProofDataError> {
         ensure_v6_consensus_branch(&self.pczt.global)?;
         if self.pczt.ironwood.note_version != crate::orchard::NoteVersion::V3 {
-            return Err(OrchardSpendWitnessError::UnexpectedNoteVersion);
+            return Err(OrchardProofDataError::UnexpectedNoteVersion);
         }
         ensure_no_orchard_proof(&self.pczt.ironwood)?;
-        for witness in witnesses {
-            let action = self
-                .pczt
-                .ironwood
-                .actions
-                .get_mut(witness.action_index())
-                .ok_or(OrchardSpendWitnessError::InvalidActionIndex(
-                    witness.action_index(),
-                ))?;
-            action.spend.witness = Some(witness.serialized_witness());
-        }
+        set_spend_witnesses(&mut self.pczt.ironwood.actions, witnesses)?;
 
         Ok(self)
     }
@@ -216,34 +142,50 @@ impl Updater {
 }
 
 #[cfg(feature = "orchard")]
-fn ensure_no_orchard_proof(
-    bundle: &crate::orchard::Bundle,
-) -> Result<(), OrchardSpendWitnessError> {
+fn ensure_no_orchard_proof(bundle: &crate::orchard::Bundle) -> Result<(), OrchardProofDataError> {
     if bundle.zkproof.is_some() {
-        Err(OrchardSpendWitnessError::ProofAlreadyPresent)
+        Err(OrchardProofDataError::ProofAlreadyPresent)
     } else {
         Ok(())
     }
 }
 
 #[cfg(feature = "orchard")]
-fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardSpendWitnessError> {
+fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardProofDataError> {
     use zcash_protocol::{
         consensus::BranchId,
         constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
     };
 
     if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
-        return Err(OrchardSpendWitnessError::RequiresV6);
+        return Err(OrchardProofDataError::RequiresV6);
     }
 
     match BranchId::try_from(global.consensus_branch_id) {
         Ok(BranchId::Nu6_3) => Ok(()),
         #[cfg(zcash_unstable = "nu7")]
         Ok(BranchId::Nu7) => Ok(()),
-        Ok(_) => Err(OrchardSpendWitnessError::UnsupportedConsensusBranchId),
-        Err(_) => Err(OrchardSpendWitnessError::UnknownConsensusBranchId),
+        Ok(_) => Err(OrchardProofDataError::UnsupportedConsensusBranchId),
+        Err(_) => Err(OrchardProofDataError::UnknownConsensusBranchId),
     }
+}
+
+#[cfg(feature = "orchard")]
+fn set_spend_witnesses(
+    actions: &mut [crate::orchard::Action],
+    witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+) -> Result<(), OrchardProofDataError> {
+    for (action_index, merkle_path) in witnesses {
+        let action = actions
+            .get_mut(action_index)
+            .ok_or(OrchardProofDataError::InvalidActionIndex(action_index))?;
+        action.spend.witness = Some((
+            merkle_path.position(),
+            merkle_path.auth_path().map(|node| node.to_bytes()),
+        ));
+    }
+
+    Ok(())
 }
 
 /// An updater for a transparent PCZT output.
@@ -256,54 +198,51 @@ impl GlobalUpdater<'_> {
     }
 }
 
-/// Errors that can occur while setting Orchard or Ironwood anchor or spend witness data.
+/// Errors that can occur while setting Orchard or Ironwood proof data.
 #[cfg(feature = "orchard")]
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum OrchardSpendWitnessError {
+pub enum OrchardProofDataError {
     /// The requested action index does not exist in the bundle.
     InvalidActionIndex(usize),
-    /// The provided serialized witness contains an invalid Orchard-style Merkle node.
-    InvalidWitness,
     /// The PCZT must use the version 6 transaction format for this update.
     RequiresV6,
     /// The PCZT's consensus branch ID is unrecognized.
     UnknownConsensusBranchId,
     /// The PCZT's consensus branch ID does not support version 6 PCZTs.
     UnsupportedConsensusBranchId,
-    /// The bundle already contains a proof that depends on the current witness data.
+    /// The bundle already contains a proof that depends on the current proof data.
     ProofAlreadyPresent,
     /// The bundle's note-plaintext version does not match the pool being updated.
     UnexpectedNoteVersion,
 }
 
 #[cfg(feature = "orchard")]
-impl core::fmt::Display for OrchardSpendWitnessError {
+impl core::fmt::Display for OrchardProofDataError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            OrchardSpendWitnessError::InvalidActionIndex(index) => {
+            OrchardProofDataError::InvalidActionIndex(index) => {
                 write!(f, "Orchard or Ironwood action index {index} does not exist")
             }
-            OrchardSpendWitnessError::InvalidWitness => write!(f, "invalid Orchard-style witness"),
-            OrchardSpendWitnessError::RequiresV6 => {
+            OrchardProofDataError::RequiresV6 => {
                 write!(
                     f,
                     "PCZT must be version 6 for this Orchard or Ironwood update"
                 )
             }
-            OrchardSpendWitnessError::UnknownConsensusBranchId => {
+            OrchardProofDataError::UnknownConsensusBranchId => {
                 write!(f, "unknown consensus branch ID")
             }
-            OrchardSpendWitnessError::UnsupportedConsensusBranchId => {
+            OrchardProofDataError::UnsupportedConsensusBranchId => {
                 write!(
                     f,
                     "consensus branch ID does not support version 6 Orchard or Ironwood updates"
                 )
             }
-            OrchardSpendWitnessError::ProofAlreadyPresent => {
+            OrchardProofDataError::ProofAlreadyPresent => {
                 write!(f, "Orchard or Ironwood proof is already present")
             }
-            OrchardSpendWitnessError::UnexpectedNoteVersion => {
+            OrchardProofDataError::UnexpectedNoteVersion => {
                 write!(
                     f,
                     "bundle note-plaintext version does not match the pool being updated"

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -12,17 +12,9 @@ use orchard::tree::MerkleHashOrchard;
 use pczt::{
     Pczt,
     roles::{
-        combiner::Combiner,
-        creator::Creator,
-        io_finalizer::IoFinalizer,
-        low_level_signer,
-        prover::Prover,
-        redactor::Redactor,
-        signer::Signer,
-        spend_finalizer::SpendFinalizer,
-        tx_extractor::TransactionExtractor,
-        updater::{OrchardSpendWitness, Updater},
-        verifier::Verifier,
+        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
+        prover::Prover, redactor::Redactor, signer::Signer, spend_finalizer::SpendFinalizer,
+        tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
     },
     v1, v2,
 };
@@ -1286,10 +1278,7 @@ fn wallet_can_set_v6_orchard_anchor_and_witness_after_signing() {
     let updated = Updater::new(signed)
         .set_v6_orchard_anchor(anchor)
         .unwrap()
-        .set_orchard_spend_witnesses([OrchardSpendWitness::from_merkle_path(
-            index,
-            merkle_path_for_update,
-        )])
+        .set_orchard_spend_witnesses([(index, merkle_path_for_update)])
         .unwrap()
         .finish();
     assert_eq!(

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -12,9 +12,17 @@ use orchard::tree::MerkleHashOrchard;
 use pczt::{
     Pczt,
     roles::{
-        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
-        prover::Prover, redactor::Redactor, signer::Signer, spend_finalizer::SpendFinalizer,
-        tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
+        combiner::Combiner,
+        creator::Creator,
+        io_finalizer::IoFinalizer,
+        low_level_signer,
+        prover::Prover,
+        redactor::Redactor,
+        signer::Signer,
+        spend_finalizer::SpendFinalizer,
+        tx_extractor::TransactionExtractor,
+        updater::{OrchardSpendWitness, Updater},
+        verifier::Verifier,
     },
     v1, v2,
 };
@@ -38,10 +46,17 @@ use zcash_protocol::{
 use zcash_script::script::{self, Evaluable};
 
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+static POST_NU6_3_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     ORCHARD_PROVING_KEY.get_or_init(|| {
         orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
+}
+
+fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
+    POST_NU6_3_ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3)
     })
 }
 
@@ -1058,6 +1073,7 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
             ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
                 .then(orchard::Anchor::empty_tree),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder
@@ -1154,6 +1170,152 @@ fn redacted_orchard_anchor_round_trips_v2() {
         pczt_with_anchor(ShieldedPool::Orchard),
         ShieldedPool::Orchard,
     );
+}
+
+#[test]
+fn wallet_can_set_v6_orchard_anchor_and_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to spend from and send back to.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Orchard note that will be spent by a v6 transaction.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let orchard_bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V2);
+        note
+    };
+
+    // Use the Orchard tree with a single leaf.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+    let merkle_path_for_update = merkle_path.clone();
+
+    // Build the v6 Orchard transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(980_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    check_v2_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt.clone())
+        .redact_orchard_with(|mut r| {
+            r.clear_anchor();
+            r.redact_action(index, |mut a| {
+                a.clear_spend_witness();
+            });
+        })
+        .finish();
+    assert!(redacted.orchard().anchor().is_none());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_orchard_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+
+    let updated = Updater::new(signed)
+        .set_v6_orchard_anchor(anchor)
+        .unwrap()
+        .set_orchard_spend_witnesses([OrchardSpendWitness::from_merkle_path(
+            index,
+            merkle_path_for_update,
+        )])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let produced_sig = updated.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_valid_spend_auth_sig(
+        updated.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&proved);
+
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
 }
 
 #[test]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -90,6 +90,10 @@ workspace.
   Ironwood note commitment tree from a subtree-root source. It defaults to a
   no-op for backends that do not track an Ironwood tree, mirroring
   `with_ironwood_tree_mut`.
+- `zcash_client_backend::data_api::WalletSummary::next_ironwood_subtree_index`,
+  the Ironwood counterpart of `next_orchard_subtree_index`. `WalletSummary::new`
+  now also takes the next Ironwood subtree index when the `orchard` feature is
+  enabled.
 - `zcash_client_backend::data_api::IRONWOOD_SHARD_HEIGHT`, the shard height of
   the Ironwood note commitment tree (equal to the Orchard shard height).
 - `zcash_client_backend::data_api::NoteCommitmentTree`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -847,6 +847,8 @@ pub struct WalletSummary<AccountId: Eq + Hash> {
     next_sapling_subtree_index: u64,
     #[cfg(feature = "orchard")]
     next_orchard_subtree_index: u64,
+    #[cfg(feature = "orchard")]
+    next_ironwood_subtree_index: u64,
 }
 
 impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
@@ -858,6 +860,7 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
         progress: Progress,
         next_sapling_subtree_index: u64,
         #[cfg(feature = "orchard")] next_orchard_subtree_index: u64,
+        #[cfg(feature = "orchard")] next_ironwood_subtree_index: u64,
     ) -> Self {
         Self {
             account_balances,
@@ -867,6 +870,8 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
             next_sapling_subtree_index,
             #[cfg(feature = "orchard")]
             next_orchard_subtree_index,
+            #[cfg(feature = "orchard")]
+            next_ironwood_subtree_index,
         }
     }
 
@@ -916,6 +921,13 @@ impl<AccountId: Eq + Hash> WalletSummary<AccountId> {
     #[cfg(feature = "orchard")]
     pub fn next_orchard_subtree_index(&self) -> u64 {
         self.next_orchard_subtree_index
+    }
+
+    /// Returns the Ironwood subtree index that should start the next range of subtree
+    /// roots passed to [`WalletCommitmentTrees::put_ironwood_subtree_roots`].
+    #[cfg(feature = "orchard")]
+    pub fn next_ironwood_subtree_index(&self) -> u64 {
+        self.next_ironwood_subtree_index
     }
 
     /// Returns whether or not wallet scanning is complete.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -80,6 +80,9 @@ workspace.
 - `zcash_client_sqlite::error::SqliteClientError::FeeRuleError`, a new variant
   (behind the `transparent-inputs` feature flag) that wraps an error produced
   by a `FeeRule` during transparent input selection.
+- `WalletDb::generate_ironwood_witnesses_at_historical_height`, which mirrors
+  the existing Orchard historical witness helper over the wallet's Ironwood
+  commitment tree shard tables.
 
 ### Changed
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`,

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -149,19 +149,20 @@ pub enum SqliteClientError {
         error: ShardTreeError<commitment_tree::Error>,
     },
 
-    /// The caller-supplied frontier passed to
-    /// [`WalletDb::generate_orchard_witnesses_at_historical_height`] is
-    /// inconsistent with the shard data reconstructed from the wallet at the
-    /// requested height.
+    /// The caller-supplied frontier passed to an Orchard or Ironwood
+    /// historical witness generation helper is inconsistent with the shard
+    /// data reconstructed from the wallet at the requested height.
     ///
     /// [`WalletDb::generate_orchard_witnesses_at_historical_height`]:
     /// crate::WalletDb::generate_orchard_witnesses_at_historical_height
+    /// [`WalletDb::generate_ironwood_witnesses_at_historical_height`]:
+    /// crate::WalletDb::generate_ironwood_witnesses_at_historical_height
     #[cfg(feature = "orchard")]
     HistoricalFrontierInvalid(InsertionError),
 
     /// A witness could not be generated for the specified position at the
-    /// specified historical height in a call to
-    /// [`WalletDb::generate_orchard_witnesses_at_historical_height`].
+    /// specified historical height in a call to an Orchard or Ironwood
+    /// historical witness generation helper.
     ///
     /// The wallet most likely has not synced through `height`, the checkpoint
     /// at `height` has been pruned, or `position` does not belong to the
@@ -169,6 +170,8 @@ pub enum SqliteClientError {
     ///
     /// [`WalletDb::generate_orchard_witnesses_at_historical_height`]:
     /// crate::WalletDb::generate_orchard_witnesses_at_historical_height
+    /// [`WalletDb::generate_ironwood_witnesses_at_historical_height`]:
+    /// crate::WalletDb::generate_ironwood_witnesses_at_historical_height
     #[cfg(feature = "orchard")]
     HistoricalWitnessUnavailable {
         /// The note commitment tree position for which a witness was
@@ -367,7 +370,7 @@ impl fmt::Display for SqliteClientError {
             #[cfg(feature = "orchard")]
             SqliteClientError::HistoricalFrontierInvalid(err) => write!(
                 f,
-                "The frontier supplied to generate_orchard_witnesses_at_historical_height is inconsistent with the wallet's shard data: {err}"
+                "The frontier supplied to historical witness generation is inconsistent with the wallet's shard data: {err}"
             ),
             #[cfg(feature = "orchard")]
             SqliteClientError::HistoricalWitnessUnavailable { position, height } => write!(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2864,6 +2864,53 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
             height,
         )
     }
+
+    /// Generates Ironwood Merkle witnesses at a historical height.
+    ///
+    /// Loads the wallet's Ironwood shard data into an ephemeral in-memory
+    /// `ShardStore`, inserts the provided frontier at `height` as a checkpoint,
+    /// and generates a witness for each of the given note positions.
+    ///
+    /// The caller must provide the valid frontier at the given height. The wallet DB
+    /// is strictly read-only; shard data is read but not modified.
+    ///
+    /// # Errors
+    ///
+    /// Returns:
+    /// - [`SqliteClientError::CommitmentTree`] if reading the wallet's shard
+    ///   or cap data fails, or if the shard data reconstructed from the
+    ///   wallet is internally inconsistent at a node the computation
+    ///   requires.
+    /// - [`SqliteClientError::HistoricalFrontierInvalid`] if
+    ///   `frontier_at_height` is inconsistent with the shard data
+    ///   reconstructed from the wallet at `height`.
+    /// - [`SqliteClientError::HistoricalWitnessUnavailable`] if a witness
+    ///   cannot be generated for one of `note_positions` at `height` (most
+    ///   commonly because the wallet has not yet synced through that
+    ///   height).
+    pub fn generate_ironwood_witnesses_at_historical_height(
+        &self,
+        note_positions: &[Position],
+        frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+            orchard::tree::MerkleHashOrchard,
+        >,
+        height: BlockHeight,
+    ) -> Result<
+        Vec<
+            incrementalmerkletree::MerklePath<
+                orchard::tree::MerkleHashOrchard,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >,
+        >,
+        SqliteClientError,
+    > {
+        wallet::commitment_tree::generate_ironwood_witnesses_at_historical_height(
+            self.conn.borrow(),
+            note_positions,
+            frontier_at_height,
+            height,
+        )
+    }
 }
 
 /// A handle for the SQLite block source.

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -110,7 +110,7 @@ use zcash_keys::{
 };
 use zcash_primitives::{
     block::BlockHash,
-    merkle_tree::read_commitment_tree,
+    merkle_tree::{HashSer, read_commitment_tree},
     transaction::{Transaction, TransactionData, builder::DEFAULT_TX_EXPIRY_DELTA, fees::zip317},
 };
 use zcash_protocol::{
@@ -2403,6 +2403,25 @@ impl ProgressEstimator for SubtreeProgressEstimator {
     }
 }
 
+fn next_subtree_index<H: HashSer, const SHARD_HEIGHT: u8>(
+    tx: &rusqlite::Transaction,
+    table_prefix: &'static str,
+) -> Result<u64, SqliteClientError> {
+    let shard_store = SqliteShardStore::<_, H, SHARD_HEIGHT>::from_connection(tx, table_prefix)?;
+
+    // The last shard will be incomplete, and we want the next range to overlap with
+    // the last complete shard, so return the index of the second-to-last shard root.
+    let roots = shard_store
+        .get_shard_roots()
+        .map_err(ShardTreeError::Storage)?;
+    Ok(roots
+        .iter()
+        .rev()
+        .nth(1)
+        .map(|addr| addr.index())
+        .unwrap_or(0))
+}
+
 /// Returns the spendable balance for the account at the specified height.
 ///
 /// This may be used to obtain a balance that ignores notes that have been detected so recently
@@ -2757,47 +2776,25 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         &mut account_balances,
     )?;
 
-    // The approach used here for Sapling and Orchard subtree indexing was a quick hack
+    // The approach used here for shielded subtree indexing was a quick hack
     // that has not yet been replaced. TODO: Make less hacky.
     // https://github.com/zcash/librustzcash/issues/1249
-    let next_sapling_subtree_index = {
-        let shard_store =
-            SqliteShardStore::<_, ::sapling::Node, SAPLING_SHARD_HEIGHT>::from_connection(
-                tx,
-                crate::SAPLING_TABLES_PREFIX,
-            )?;
-
-        // The last shard will be incomplete, and we want the next range to overlap with
-        // the last complete shard, so return the index of the second-to-last shard root.
-        shard_store
-            .get_shard_roots()
-            .map_err(ShardTreeError::Storage)?
-            .iter()
-            .rev()
-            .nth(1)
-            .map(|addr| addr.index())
-            .unwrap_or(0)
-    };
+    let next_sapling_subtree_index = next_subtree_index::<::sapling::Node, SAPLING_SHARD_HEIGHT>(
+        tx,
+        crate::SAPLING_TABLES_PREFIX,
+    )?;
 
     #[cfg(feature = "orchard")]
-    let next_orchard_subtree_index = {
-        let shard_store = SqliteShardStore::<
-            _,
-            ::orchard::tree::MerkleHashOrchard,
-            ORCHARD_SHARD_HEIGHT,
-        >::from_connection(tx, crate::ORCHARD_TABLES_PREFIX)?;
+    let next_orchard_subtree_index = next_subtree_index::<
+        ::orchard::tree::MerkleHashOrchard,
+        ORCHARD_SHARD_HEIGHT,
+    >(tx, crate::ORCHARD_TABLES_PREFIX)?;
 
-        // The last shard will be incomplete, and we want the next range to overlap with
-        // the last complete shard, so return the index of the second-to-last shard root.
-        shard_store
-            .get_shard_roots()
-            .map_err(ShardTreeError::Storage)?
-            .iter()
-            .rev()
-            .nth(1)
-            .map(|addr| addr.index())
-            .unwrap_or(0)
-    };
+    #[cfg(feature = "orchard")]
+    let next_ironwood_subtree_index = next_subtree_index::<
+        ::orchard::tree::MerkleHashOrchard,
+        ORCHARD_SHARD_HEIGHT,
+    >(tx, crate::IRONWOOD_TABLES_PREFIX)?;
 
     let summary = WalletSummary::new(
         account_balances,
@@ -2807,6 +2804,8 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         next_sapling_subtree_index,
         #[cfg(feature = "orchard")]
         next_orchard_subtree_index,
+        #[cfg(feature = "orchard")]
+        next_ironwood_subtree_index,
     );
 
     Ok(Some(summary))

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -35,7 +35,7 @@ use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
 #[cfg(feature = "orchard")]
-use crate::{ORCHARD_TABLES_PREFIX, ironwood_tree, orchard_tree};
+use crate::{IRONWOOD_TABLES_PREFIX, ORCHARD_TABLES_PREFIX, ironwood_tree, orchard_tree};
 
 use super::common::{TableConstants, table_constants};
 
@@ -1361,23 +1361,80 @@ pub(crate) fn generate_orchard_witnesses_at_historical_height(
     >,
     SqliteClientError,
 > {
+    generate_orchard_like_witnesses_at_historical_height(
+        conn,
+        ORCHARD_TABLES_PREFIX,
+        note_positions,
+        frontier_at_height,
+        height,
+    )
+}
+
+/// Generates Ironwood Merkle witnesses at a historical height.
+///
+/// This is identical to [`generate_orchard_witnesses_at_historical_height`],
+/// except that it reconstructs witness paths from the Ironwood shard tables.
+#[cfg(feature = "orchard")]
+pub(crate) fn generate_ironwood_witnesses_at_historical_height(
+    conn: &rusqlite::Connection,
+    note_positions: &[Position],
+    frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+        orchard::tree::MerkleHashOrchard,
+    >,
+    height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
+    generate_orchard_like_witnesses_at_historical_height(
+        conn,
+        IRONWOOD_TABLES_PREFIX,
+        note_positions,
+        frontier_at_height,
+        height,
+    )
+}
+
+#[cfg(feature = "orchard")]
+fn generate_orchard_like_witnesses_at_historical_height(
+    conn: &rusqlite::Connection,
+    table_prefix: &'static str,
+    note_positions: &[Position],
+    frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+        orchard::tree::MerkleHashOrchard,
+    >,
+    height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
     // `get_shard_roots` returns addresses ordered by shard index, matching the
     // ascending insertion order required by `MemoryShardStore::put_shard`.
     // Storage errors flow through `From<ShardTreeError<commitment_tree::Error>>`
     // into `SqliteClientError::CommitmentTree`.
     let mut store = MemoryShardStore::<orchard::tree::MerkleHashOrchard, BlockHeight>::empty();
     let shard_root_level = Level::new(ORCHARD_SHARD_HEIGHT);
-    let shard_roots = get_shard_roots(conn, ORCHARD_TABLES_PREFIX, shard_root_level)
-        .map_err(ShardTreeError::Storage)?;
+    let shard_roots =
+        get_shard_roots(conn, table_prefix, shard_root_level).map_err(ShardTreeError::Storage)?;
     for shard_root in shard_roots {
         if let Some(shard) =
-            get_shard::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX, shard_root)
+            get_shard::<orchard::tree::MerkleHashOrchard>(conn, table_prefix, shard_root)
                 .map_err(ShardTreeError::Storage)?
         {
             store.put_shard(shard).expect("put_shard is infallible");
         }
     }
-    let cap = get_cap::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX)
+    let cap = get_cap::<orchard::tree::MerkleHashOrchard>(conn, table_prefix)
         .map_err(ShardTreeError::Storage)?;
     store.put_cap(cap).expect("put_cap is infallible");
 
@@ -1476,6 +1533,7 @@ mod tests {
     use super::SqliteShardStore;
     use crate::{
         WalletDb,
+        error::SqliteClientError,
         testing::{
             db::{test_clock, test_rng},
             pool::ShieldedPoolPersistence,
@@ -1573,6 +1631,11 @@ mod tests {
         #[test]
         fn witnesses_at_historical_height() {
             super::witnesses_at_historical_height()
+        }
+
+        #[test]
+        fn ironwood_witnesses_at_historical_height() {
+            super::ironwood_witnesses_at_historical_height()
         }
 
         #[test]
@@ -1796,6 +1859,45 @@ mod tests {
     /// witnesses when given a frontier extracted from an earlier tree state.
     #[cfg(feature = "orchard")]
     fn witnesses_at_historical_height() {
+        witnesses_at_historical_height_for_table(
+            crate::ORCHARD_TABLES_PREFIX,
+            super::generate_orchard_witnesses_at_historical_height,
+        )
+    }
+
+    /// Test that `generate_ironwood_witnesses_at_historical_height` uses the
+    /// Ironwood shard tables rather than the Orchard shard tables.
+    #[cfg(feature = "orchard")]
+    fn ironwood_witnesses_at_historical_height() {
+        witnesses_at_historical_height_for_table(
+            crate::IRONWOOD_TABLES_PREFIX,
+            super::generate_ironwood_witnesses_at_historical_height,
+        )
+    }
+
+    #[cfg(feature = "orchard")]
+    type OrchardFrontier =
+        incrementalmerkletree::frontier::NonEmptyFrontier<::orchard::tree::MerkleHashOrchard>;
+
+    #[cfg(feature = "orchard")]
+    type OrchardMerklePath = incrementalmerkletree::MerklePath<
+        ::orchard::tree::MerkleHashOrchard,
+        { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+    >;
+
+    #[cfg(feature = "orchard")]
+    type HistoricalWitnessGenerator = fn(
+        &rusqlite::Connection,
+        &[Position],
+        OrchardFrontier,
+        BlockHeight,
+    ) -> Result<Vec<OrchardMerklePath>, SqliteClientError>;
+
+    #[cfg(feature = "orchard")]
+    fn witnesses_at_historical_height_for_table(
+        table_prefix: &'static str,
+        generate_witnesses: HistoricalWitnessGenerator,
+    ) {
         use ::orchard::tree::MerkleHashOrchard;
         use incrementalmerkletree::frontier::Frontier;
         use rand::SeedableRng;
@@ -1827,7 +1929,8 @@ mod tests {
             let tx = db_data.conn.transaction().unwrap();
             let store =
                 SqliteShardStore::<_, MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>::from_connection(
-                    &tx, "orchard",
+                    &tx,
+                    table_prefix,
                 )
                 .unwrap();
             let mut tree = ShardTree::<
@@ -1867,13 +1970,9 @@ mod tests {
         let expected_root = frontier_tree.root();
         let frontier = frontier_tree.take().expect("frontier is non-empty");
 
-        let witnesses = super::generate_orchard_witnesses_at_historical_height(
-            &db_data.conn,
-            &[note_position],
-            frontier,
-            historical_height,
-        )
-        .expect("witness generation should succeed");
+        let witnesses =
+            generate_witnesses(&db_data.conn, &[note_position], frontier, historical_height)
+                .expect("witness generation should succeed");
 
         assert_eq!(witnesses.len(), 1);
         assert_eq!(witnesses[0].root(note_leaf), expected_root);


### PR DESCRIPTION
Adds a narrow PCZT updater API for wallets to restore Orchard or Ironwood anchors and spend witnesses before proof creation. Anchor setters are v6-only and validate the PCZT global branch/version fields; witness setters reject already proved bundles and wrong Orchard/Ironwood note versions.

The regression covers the current upstream format with an Orchard spend, Ironwood output, signing while the Orchard anchor and real spend witness are redacted, then restoring them, proving, and extracting.

Validation:
- cargo test -p pczt --all-features
- cargo fmt --all -- --check
- cargo check -p pczt --no-default-features
- git diff --check
