### PR TITLE
Add PCZT anchor updater APIs

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,9 +123,10 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
-- `pczt::roles::updater::OrchardAnchorUpdateError` and
-  `pczt::roles::updater::Updater::{set_v6_orchard_anchor, set_v6_ironwood_anchor}`
-  for wallets that need to restore v6 anchors after signing.
+- `pczt::roles::updater::AnchorUpdateError` and
+  `pczt::roles::updater::Updater::{set_sapling_anchor, set_orchard_anchor,
+  set_ironwood_anchor}` for wallets that need to restore shielded anchors after
+  signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,6 +123,9 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
+- `pczt::roles::updater::OrchardAnchorUpdateError` and
+  `pczt::roles::updater::Updater::{set_v6_orchard_anchor, set_v6_ironwood_anchor}`
+  for wallets that need to restore v6 anchors after signing.
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,9 +59,78 @@ impl Updater {
         }
     }
 
+    /// Sets the Orchard bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Orchard signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Orchard proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_orchard_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardAnchorUpdateError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        self.pczt.orchard.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
+    /// Sets the Ironwood bundle anchor for a version 6 PCZT on NU6.3 or later.
+    ///
+    /// Ironwood signatures in v6 do not commit to this anchor, so this may be
+    /// called after shielded signatures have been added. Ironwood proofs do
+    /// depend on the anchor, so this must be called before proof creation.
+    ///
+    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
+    /// Ironwood proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_v6_ironwood_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, OrchardAnchorUpdateError> {
+        ensure_v6_consensus_branch(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        self.pczt.ironwood.anchor = Some(anchor.to_bytes());
+        Ok(self)
+    }
+
     /// Finishes the Updater role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_no_orchard_proof(
+    bundle: &crate::orchard::Bundle,
+) -> Result<(), OrchardAnchorUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(OrchardAnchorUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardAnchorUpdateError> {
+    use zcash_protocol::{
+        consensus::BranchId,
+        constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
+    };
+
+    if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
+        return Err(OrchardAnchorUpdateError::RequiresV6);
+    }
+
+    match BranchId::try_from(global.consensus_branch_id) {
+        Ok(BranchId::Nu6_3) => Ok(()),
+        #[cfg(zcash_unstable = "nu7")]
+        Ok(BranchId::Nu7) => Ok(()),
+        Ok(_) => Err(OrchardAnchorUpdateError::UnsupportedConsensusBranchId),
+        Err(_) => Err(OrchardAnchorUpdateError::UnknownConsensusBranchId),
     }
 }
 
@@ -72,5 +141,46 @@ impl GlobalUpdater<'_> {
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);
+    }
+}
+
+/// Errors that can occur while setting Orchard or Ironwood anchors.
+#[cfg(feature = "orchard")]
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OrchardAnchorUpdateError {
+    /// The PCZT must use the version 6 transaction format for this update.
+    RequiresV6,
+    /// The PCZT's consensus branch ID is unrecognized.
+    UnknownConsensusBranchId,
+    /// The PCZT's consensus branch ID does not support version 6 PCZTs.
+    UnsupportedConsensusBranchId,
+    /// The bundle already contains a proof that depends on the current anchor.
+    ProofAlreadyPresent,
+}
+
+#[cfg(feature = "orchard")]
+impl core::fmt::Display for OrchardAnchorUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OrchardAnchorUpdateError::RequiresV6 => {
+                write!(
+                    f,
+                    "PCZT must be version 6 for this Orchard or Ironwood anchor update"
+                )
+            }
+            OrchardAnchorUpdateError::UnknownConsensusBranchId => {
+                write!(f, "unknown consensus branch ID")
+            }
+            OrchardAnchorUpdateError::UnsupportedConsensusBranchId => {
+                write!(
+                    f,
+                    "consensus branch ID does not support version 6 Orchard or Ironwood anchor updates"
+                )
+            }
+            OrchardAnchorUpdateError::ProofAlreadyPresent => {
+                write!(f, "Orchard or Ironwood proof is already present")
+            }
+        }
     }
 }

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,41 +59,66 @@ impl Updater {
         }
     }
 
-    /// Sets the Orchard bundle anchor for a version 6 PCZT on NU6.3 or later.
+    /// Sets the Sapling bundle anchor.
     ///
-    /// Orchard signatures in v6 do not commit to this anchor, so this may be
-    /// called after shielded signatures have been added. Orchard proofs do
-    /// depend on the anchor, so this must be called before proof creation.
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Sapling spend proofs depend on the anchor, so this must be called before
+    /// proof creation for Sapling spends.
     ///
-    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
-    /// Orchard proof is already present.
-    #[cfg(feature = "orchard")]
-    pub fn set_v6_orchard_anchor(
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if any Sapling spend proof is already present, or if the PCZT
+    /// already contains a different Sapling anchor.
+    #[cfg(feature = "sapling")]
+    pub fn set_sapling_anchor(
         mut self,
-        anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardAnchorUpdateError> {
-        ensure_v6_consensus_branch(&self.pczt.global)?;
-        ensure_no_orchard_proof(&self.pczt.orchard)?;
-        self.pczt.orchard.anchor = Some(anchor.to_bytes());
+        anchor: ::sapling::Anchor,
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
+        ensure_no_sapling_spend_proof(&self.pczt.sapling)?;
+        set_anchor(&mut self.pczt.sapling.anchor, anchor.to_bytes())?;
         Ok(self)
     }
 
-    /// Sets the Ironwood bundle anchor for a version 6 PCZT on NU6.3 or later.
+    /// Sets the Orchard bundle anchor.
     ///
-    /// Ironwood signatures in v6 do not commit to this anchor, so this may be
-    /// called after shielded signatures have been added. Ironwood proofs do
-    /// depend on the anchor, so this must be called before proof creation.
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Orchard proofs depend on the anchor, so this must be called before proof
+    /// creation.
     ///
-    /// Returns an error if the PCZT is not version 6 on NU6.3 or later, or if an
-    /// Ironwood proof is already present.
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if an Orchard proof is already present, or if the PCZT already
+    /// contains a different Orchard anchor.
     #[cfg(feature = "orchard")]
-    pub fn set_v6_ironwood_anchor(
+    pub fn set_orchard_anchor(
         mut self,
         anchor: ::orchard::Anchor,
-    ) -> Result<Self, OrchardAnchorUpdateError> {
-        ensure_v6_consensus_branch(&self.pczt.global)?;
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        set_anchor(&mut self.pczt.orchard.anchor, anchor.to_bytes())?;
+        Ok(self)
+    }
+
+    /// Sets the Ironwood bundle anchor.
+    ///
+    /// This may be called after shielded signatures have been added for
+    /// transaction formats that do not commit shielded signatures to anchors.
+    /// Ironwood proofs depend on the anchor, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if the PCZT's transaction format does not support this
+    /// update, if an Ironwood proof is already present, or if the PCZT already
+    /// contains a different Ironwood anchor.
+    #[cfg(feature = "orchard")]
+    pub fn set_ironwood_anchor(
+        mut self,
+        anchor: ::orchard::Anchor,
+    ) -> Result<Self, AnchorUpdateError> {
+        ensure_anchor_update_supported(&self.pczt.global)?;
         ensure_no_orchard_proof(&self.pczt.ironwood)?;
-        self.pczt.ironwood.anchor = Some(anchor.to_bytes());
+        set_anchor(&mut self.pczt.ironwood.anchor, anchor.to_bytes())?;
         Ok(self)
     }
 
@@ -103,34 +128,54 @@ impl Updater {
     }
 }
 
-#[cfg(feature = "orchard")]
-fn ensure_no_orchard_proof(
-    bundle: &crate::orchard::Bundle,
-) -> Result<(), OrchardAnchorUpdateError> {
-    if bundle.zkproof.is_some() {
-        Err(OrchardAnchorUpdateError::ProofAlreadyPresent)
+#[cfg(feature = "sapling")]
+fn ensure_no_sapling_spend_proof(bundle: &crate::sapling::Bundle) -> Result<(), AnchorUpdateError> {
+    if bundle.spends.iter().any(|spend| spend.zkproof.is_some()) {
+        Err(AnchorUpdateError::ProofAlreadyPresent)
     } else {
         Ok(())
     }
 }
 
 #[cfg(feature = "orchard")]
-fn ensure_v6_consensus_branch(global: &Global) -> Result<(), OrchardAnchorUpdateError> {
+fn ensure_no_orchard_proof(bundle: &crate::orchard::Bundle) -> Result<(), AnchorUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(AnchorUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+fn ensure_anchor_update_supported(global: &Global) -> Result<(), AnchorUpdateError> {
     use zcash_protocol::{
         consensus::BranchId,
         constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID},
     };
 
-    if global.tx_version != V6_TX_VERSION || global.version_group_id != V6_VERSION_GROUP_ID {
-        return Err(OrchardAnchorUpdateError::RequiresV6);
+    if global.tx_version < V6_TX_VERSION
+        || (global.tx_version == V6_TX_VERSION && global.version_group_id != V6_VERSION_GROUP_ID)
+    {
+        return Err(AnchorUpdateError::UnsupportedTransactionFormat);
     }
 
     match BranchId::try_from(global.consensus_branch_id) {
         Ok(BranchId::Nu6_3) => Ok(()),
         #[cfg(zcash_unstable = "nu7")]
         Ok(BranchId::Nu7) => Ok(()),
-        Ok(_) => Err(OrchardAnchorUpdateError::UnsupportedConsensusBranchId),
-        Err(_) => Err(OrchardAnchorUpdateError::UnknownConsensusBranchId),
+        Ok(_) => Err(AnchorUpdateError::UnsupportedConsensusBranchId),
+        Err(_) => Err(AnchorUpdateError::UnknownConsensusBranchId),
+    }
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+fn set_anchor(slot: &mut Option<[u8; 32]>, anchor: [u8; 32]) -> Result<(), AnchorUpdateError> {
+    match slot {
+        Some(existing) if *existing != anchor => Err(AnchorUpdateError::ConflictingAnchor),
+        _ => {
+            *slot = Some(anchor);
+            Ok(())
+        }
     }
 }
 
@@ -144,42 +189,50 @@ impl GlobalUpdater<'_> {
     }
 }
 
-/// Errors that can occur while setting Orchard or Ironwood anchors.
-#[cfg(feature = "orchard")]
+/// Errors that can occur while setting Sapling, Orchard, or Ironwood anchors.
+#[cfg(any(feature = "sapling", feature = "orchard"))]
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum OrchardAnchorUpdateError {
-    /// The PCZT must use the version 6 transaction format for this update.
-    RequiresV6,
+pub enum AnchorUpdateError {
+    /// The PCZT transaction format does not support this update.
+    UnsupportedTransactionFormat,
     /// The PCZT's consensus branch ID is unrecognized.
     UnknownConsensusBranchId,
-    /// The PCZT's consensus branch ID does not support version 6 PCZTs.
+    /// The PCZT's consensus branch ID does not support this update.
     UnsupportedConsensusBranchId,
     /// The bundle already contains a proof that depends on the current anchor.
     ProofAlreadyPresent,
+    /// The bundle already contains a different anchor.
+    ConflictingAnchor,
 }
 
-#[cfg(feature = "orchard")]
-impl core::fmt::Display for OrchardAnchorUpdateError {
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+impl core::fmt::Display for AnchorUpdateError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            OrchardAnchorUpdateError::RequiresV6 => {
+            AnchorUpdateError::UnsupportedTransactionFormat => {
                 write!(
                     f,
-                    "PCZT must be version 6 for this Orchard or Ironwood anchor update"
+                    "PCZT transaction format does not support shielded anchor updates"
                 )
             }
-            OrchardAnchorUpdateError::UnknownConsensusBranchId => {
+            AnchorUpdateError::UnknownConsensusBranchId => {
                 write!(f, "unknown consensus branch ID")
             }
-            OrchardAnchorUpdateError::UnsupportedConsensusBranchId => {
+            AnchorUpdateError::UnsupportedConsensusBranchId => {
                 write!(
                     f,
-                    "consensus branch ID does not support version 6 Orchard or Ironwood anchor updates"
+                    "consensus branch ID does not support shielded anchor updates"
                 )
             }
-            OrchardAnchorUpdateError::ProofAlreadyPresent => {
-                write!(f, "Orchard or Ironwood proof is already present")
+            AnchorUpdateError::ProofAlreadyPresent => {
+                write!(
+                    f,
+                    "shielded proof that depends on the anchor is already present"
+                )
+            }
+            AnchorUpdateError::ConflictingAnchor => {
+                write!(f, "bundle already contains a different anchor")
             }
         }
     }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1137,6 +1137,159 @@ fn redacted_sapling_anchor_round_trips_v2() {
     );
 }
 
+#[test]
+fn redacted_sapling_anchor_can_be_restored_after_signing() {
+    let mut rng = OsRng;
+
+    let sapling_extsk = sapling::zip32::ExtendedSpendingKey::master(&[1; 32]);
+    let sapling_dfvk = sapling_extsk.to_diversifiable_full_viewing_key();
+    let sapling_internal_dfvk = sapling_extsk
+        .derive_internal()
+        .to_diversifiable_full_viewing_key();
+    let sapling_recipient = sapling_dfvk.default_address().1;
+
+    let value = sapling::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut sapling_builder = sapling::builder::Builder::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+            sapling::builder::BundleType::DEFAULT,
+            sapling::Anchor::empty_tree(),
+        );
+        sapling_builder
+            .add_output(
+                None,
+                sapling_recipient,
+                value,
+                Memo::Empty.encode().into_bytes(),
+            )
+            .unwrap();
+        let (bundle, meta) = sapling_builder
+            .build::<LocalTxProver, LocalTxProver, _, i64>(&[], &mut rng)
+            .unwrap()
+            .unwrap();
+        let output = bundle
+            .shielded_outputs()
+            .get(meta.output_index(0).unwrap())
+            .unwrap();
+        let domain = sapling::note_encryption::SaplingDomain::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+        );
+        let (note, _, _) =
+            try_note_decryption(&domain, &sapling_dfvk.to_external_ivk().prepare(), output)
+                .unwrap();
+        note
+    };
+
+    let (anchor, merkle_path) = {
+        let cmu = note.cmu();
+        let leaf = sapling::Node::from_cmu(&cmu);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<sapling::Node, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path)
+    };
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: Some(anchor),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_sapling_spend::<zip317::FeeRule>(sapling_dfvk.fvk().clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_sapling_output::<zip317::FeeRule>(
+            Some(sapling_dfvk.to_ovk(zip32::Scope::Internal)),
+            sapling_internal_dfvk.find_address(0u32.into()).unwrap().1,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        sapling_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = sapling_meta.spend_index(0).unwrap();
+    let pczt = Updater::new(pczt)
+        .update_sapling_with(|mut updater| {
+            updater.update_spend_with(index, |mut spend_updater| {
+                spend_updater.set_proof_generation_key(sapling_extsk.expsk.proof_generation_key())
+            })
+        })
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&pczt);
+
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_sapling_anchor(sapling::Anchor::empty_tree()),
+        Err(pczt::roles::updater::AnchorUpdateError::ConflictingAnchor)
+    ));
+
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer
+        .sign_sapling(index, &sapling_extsk.expsk.ask)
+        .unwrap();
+    let signed = signer.finish();
+
+    let redacted = Redactor::new(signed)
+        .redact_sapling_with(|mut r| r.clear_anchor())
+        .finish();
+    assert!(redacted.sapling().anchor().is_none());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_sapling_proofs(&LocalTxProver::bundled(), &LocalTxProver::bundled())
+            .is_err()
+    );
+
+    let updated = Updater::new(redacted)
+        .set_sapling_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.sapling().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let sapling_prover = LocalTxProver::bundled();
+    let proved = Prover::new(updated)
+        .create_sapling_proofs(&sapling_prover, &sapling_prover)
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone()).set_sapling_anchor(anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::ProofAlreadyPresent)
+    ));
+
+    let (spend_vk, output_vk) = sapling_prover.verifying_keys();
+    let tx = TransactionExtractor::new(proved)
+        .with_sapling(&spend_vk, &output_vk)
+        .extract()
+        .unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
 fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
     use zcash_protocol::consensus::BlockHeight;
@@ -1166,7 +1319,7 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
-fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
+fn redacted_orchard_anchor_can_be_restored_after_signing() {
     let mut rng = OsRng;
 
     let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
@@ -1252,6 +1405,14 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     let index = orchard_meta.spend_action_index(0).unwrap();
     check_v2_round_trip(&pczt);
 
+    Updater::new(pczt.clone())
+        .set_orchard_anchor(anchor)
+        .unwrap();
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_orchard_anchor(orchard::Anchor::empty_tree()),
+        Err(pczt::roles::updater::AnchorUpdateError::ConflictingAnchor)
+    ));
+
     let redacted = Redactor::new(pczt)
         .redact_orchard_with(|mut r| r.clear_anchor())
         .finish();
@@ -1268,7 +1429,7 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     let signed = signer.finish();
 
     let updated = Updater::new(signed)
-        .set_v6_orchard_anchor(anchor)
+        .set_orchard_anchor(anchor)
         .unwrap()
         .finish();
     assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
@@ -1295,8 +1456,8 @@ fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
     check_v2_round_trip(&proved);
 
     assert!(matches!(
-        Updater::new(proved.clone()).set_v6_orchard_anchor(anchor),
-        Err(pczt::roles::updater::OrchardAnchorUpdateError::ProofAlreadyPresent)
+        Updater::new(proved.clone()).set_orchard_anchor(anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::ProofAlreadyPresent)
     ));
 
     let tx = TransactionExtractor::new(proved).extract().unwrap();
@@ -1328,7 +1489,7 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
 
     let updated = Updater::new(signed)
-        .set_v6_ironwood_anchor(anchor)
+        .set_ironwood_anchor(anchor)
         .unwrap()
         .finish();
     assert_eq!(updated.ironwood().anchor(), &Some(anchor.to_bytes()));
@@ -1336,22 +1497,31 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
 }
 
 #[test]
-fn v6_anchor_setters_reject_v5_pczts() {
-    let anchor = orchard::Anchor::empty_tree();
+fn anchor_setters_reject_unsupported_transaction_formats() {
+    let sapling_anchor = sapling::Anchor::empty_tree();
+    let orchard_anchor = orchard::Anchor::empty_tree();
     let pczt = Creator::new(
         zcash_protocol::consensus::BranchId::Nu6.into(),
         10_000_000,
         133,
-        Some([0; 32]),
-        Some(anchor.to_bytes()),
+        Some(sapling_anchor.to_bytes()),
+        Some(orchard_anchor.to_bytes()),
     )
     .unwrap()
     .build()
     .unwrap();
 
     assert!(matches!(
-        Updater::new(pczt).set_v6_orchard_anchor(anchor),
-        Err(pczt::roles::updater::OrchardAnchorUpdateError::RequiresV6)
+        Updater::new(pczt.clone()).set_sapling_anchor(sapling_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
+    ));
+    assert!(matches!(
+        Updater::new(pczt.clone()).set_orchard_anchor(orchard_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
+    ));
+    assert!(matches!(
+        Updater::new(pczt).set_ironwood_anchor(orchard_anchor),
+        Err(pczt::roles::updater::AnchorUpdateError::UnsupportedTransactionFormat)
     ));
 }
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -37,10 +37,17 @@ use zcash_protocol::{
 use zcash_script::script::{self, Evaluable};
 
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+static POST_NU6_3_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     ORCHARD_PROVING_KEY.get_or_init(|| {
         orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
+}
+
+fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
+    POST_NU6_3_ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3)
     })
 }
 
@@ -1159,6 +1166,144 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
+fn redacted_v6_orchard_anchor_can_be_restored_after_signing() {
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let orchard_bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V2);
+        note
+    };
+
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk, note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(980_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    check_v2_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_orchard_with(|mut r| r.clear_anchor())
+        .finish();
+    assert!(redacted.orchard().anchor().is_none());
+    assert!(
+        Prover::new(redacted.clone())
+            .create_orchard_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+
+    let updated = Updater::new(signed)
+        .set_v6_orchard_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let produced_sig = updated.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_valid_spend_auth_sig(
+        updated.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&proved);
+
+    assert!(matches!(
+        Updater::new(proved.clone()).set_v6_orchard_anchor(anchor),
+        Err(pczt::roles::updater::OrchardAnchorUpdateError::ProofAlreadyPresent)
+    ));
+
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
 fn redacted_ironwood_anchor_round_trips_v2() {
     assert_redacted_anchor_v2_round_trip(
         pczt_with_anchor(ShieldedPool::Ironwood),
@@ -1168,6 +1313,7 @@ fn redacted_ironwood_anchor_round_trips_v2() {
 
 #[test]
 fn redacted_ironwood_anchor_survives_signer_finish() {
+    let anchor = orchard::Anchor::empty_tree();
     let redacted = redact_anchor(
         pczt_with_anchor(ShieldedPool::Ironwood),
         ShieldedPool::Ironwood,
@@ -1178,8 +1324,35 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
     assert_anchor_redacted(&signed, ShieldedPool::Ironwood);
     check_v2_round_trip(&signed);
 
-    let reparsed = Pczt::parse(&signed.serialize().unwrap()).unwrap();
+    let reparsed = Pczt::parse(&signed.clone().serialize().unwrap()).unwrap();
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
+
+    let updated = Updater::new(signed)
+        .set_v6_ironwood_anchor(anchor)
+        .unwrap()
+        .finish();
+    assert_eq!(updated.ironwood().anchor(), &Some(anchor.to_bytes()));
+    check_v2_round_trip(&updated);
+}
+
+#[test]
+fn v6_anchor_setters_reject_v5_pczts() {
+    let anchor = orchard::Anchor::empty_tree();
+    let pczt = Creator::new(
+        zcash_protocol::consensus::BranchId::Nu6.into(),
+        10_000_000,
+        133,
+        Some([0; 32]),
+        Some(anchor.to_bytes()),
+    )
+    .unwrap()
+    .build()
+    .unwrap();
+
+    assert!(matches!(
+        Updater::new(pczt).set_v6_orchard_anchor(anchor),
+        Err(pczt::roles::updater::OrchardAnchorUpdateError::RequiresV6)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Adds `Updater` methods for restoring Sapling, Orchard, and Ironwood anchors before proof creation for transaction formats that do not commit shielded signatures to anchors. Existing matching anchors are accepted, while conflicting anchors and already-proved spends or bundles are rejected so callers must clear stale anchors before replacing them.

Tests cover signed PCZT copies whose Sapling or Orchard anchors are restored before proof generation, plus Ironwood anchor restoration across signer finish.

Validation:
- `cargo test -p pczt --all-features`
- `cargo fmt --all -- --check`
- `cargo check -p pczt --no-default-features`
- `cargo doc --no-deps -p pczt --all-features --document-private-items`
- `git diff --check`
