### PR TITLE
Add PCZT spend witness updater APIs

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -123,6 +123,10 @@ workspace.
 - `pczt::roles::signer::Error::{IronwoodSign, IronwoodVerify}`
 - `pczt::roles::verifier::Verifier::with_ironwood`
 - `pczt::roles::updater::Updater::update_ironwood_with`
+- `pczt::roles::updater::Updater::{set_sapling_spend_witnesses,
+  set_orchard_spend_witnesses, set_ironwood_spend_witnesses}` for restoring
+  shielded spend witnesses before proof creation.
+- `pczt::roles::updater::SpendWitnessUpdateError`
 - `pczt::roles::creator::Error::IronwoodNotSupported`
 - `pczt::roles::low_level_signer::OrchardParseError`
 - `UnsupportedConsensusBranchId` variants of `pczt::roles::updater::OrchardError`,

--- a/pczt/src/roles/updater/mod.rs
+++ b/pczt/src/roles/updater/mod.rs
@@ -59,10 +59,125 @@ impl Updater {
         }
     }
 
+    /// Sets spend witnesses for Sapling spends by spend index.
+    ///
+    /// This may be called after shielded signatures have been added. Sapling
+    /// spend proofs depend on the witnesses, so this must be called before proof
+    /// creation for the updated spends.
+    ///
+    /// Returns an error if any witness references a spend index that does not
+    /// exist, or if a target spend proof is already present.
+    #[cfg(feature = "sapling")]
+    pub fn set_sapling_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::sapling::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        set_sapling_spend_witnesses(&mut self.pczt.sapling.spends, witnesses)?;
+
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Orchard actions by action index.
+    ///
+    /// This may be called after shielded signatures have been added. Orchard
+    /// proofs depend on the witnesses, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if any witness references an action index that does not
+    /// exist, if the Orchard bundle is not using Orchard note plaintexts, or if
+    /// an Orchard proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_orchard_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        if self.pczt.orchard.note_version != crate::orchard::NoteVersion::V2 {
+            return Err(SpendWitnessUpdateError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.orchard)?;
+        set_orchard_spend_witnesses(&mut self.pczt.orchard.actions, witnesses)?;
+
+        Ok(self)
+    }
+
+    /// Sets spend witnesses for Ironwood actions by action index.
+    ///
+    /// This may be called after shielded signatures have been added. Ironwood
+    /// proofs depend on the witnesses, so this must be called before proof
+    /// creation.
+    ///
+    /// Returns an error if any witness references an action index that does not
+    /// exist, if the Ironwood bundle is not using Ironwood note plaintexts, or if
+    /// an Ironwood proof is already present.
+    #[cfg(feature = "orchard")]
+    pub fn set_ironwood_spend_witnesses(
+        mut self,
+        witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+    ) -> Result<Self, SpendWitnessUpdateError> {
+        if self.pczt.ironwood.note_version != crate::orchard::NoteVersion::V3 {
+            return Err(SpendWitnessUpdateError::UnexpectedNoteVersion);
+        }
+        ensure_no_orchard_proof(&self.pczt.ironwood)?;
+        set_orchard_spend_witnesses(&mut self.pczt.ironwood.actions, witnesses)?;
+
+        Ok(self)
+    }
+
     /// Finishes the Updater role, returning the updated PCZT.
     pub fn finish(self) -> Pczt {
         self.pczt
     }
+}
+
+#[cfg(feature = "sapling")]
+fn set_sapling_spend_witnesses(
+    spends: &mut [crate::sapling::Spend],
+    witnesses: impl IntoIterator<Item = (usize, ::sapling::MerklePath)>,
+) -> Result<(), SpendWitnessUpdateError> {
+    for (spend_index, merkle_path) in witnesses {
+        let spend = spends
+            .get_mut(spend_index)
+            .ok_or(SpendWitnessUpdateError::InvalidSpendIndex(spend_index))?;
+        if spend.zkproof.is_some() {
+            return Err(SpendWitnessUpdateError::ProofAlreadyPresent);
+        }
+        let position = u32::try_from(u64::from(merkle_path.position()))
+            .map_err(|_| SpendWitnessUpdateError::PositionOutOfRange)?;
+        let mut auth_path = [[0; 32]; 32];
+        for (target, node) in auth_path.iter_mut().zip(merkle_path.path_elems()) {
+            *target = node.to_bytes();
+        }
+        spend.witness = Some((position, auth_path));
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "orchard")]
+fn ensure_no_orchard_proof(bundle: &crate::orchard::Bundle) -> Result<(), SpendWitnessUpdateError> {
+    if bundle.zkproof.is_some() {
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "orchard")]
+fn set_orchard_spend_witnesses(
+    actions: &mut [crate::orchard::Action],
+    witnesses: impl IntoIterator<Item = (usize, ::orchard::tree::MerklePath)>,
+) -> Result<(), SpendWitnessUpdateError> {
+    for (action_index, merkle_path) in witnesses {
+        let action = actions
+            .get_mut(action_index)
+            .ok_or(SpendWitnessUpdateError::InvalidSpendIndex(action_index))?;
+        action.spend.witness = Some((
+            merkle_path.position(),
+            merkle_path.auth_path().map(|node| node.to_bytes()),
+        ));
+    }
+
+    Ok(())
 }
 
 /// An updater for a transparent PCZT output.
@@ -72,5 +187,46 @@ impl GlobalUpdater<'_> {
     /// Stores the given proprietary value at the given key.
     pub fn set_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.proprietary.insert(key, value);
+    }
+}
+
+/// Errors that can occur while setting Sapling, Orchard, or Ironwood spend witnesses.
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SpendWitnessUpdateError {
+    /// The requested Sapling spend index or Orchard/Ironwood action index does not exist.
+    InvalidSpendIndex(usize),
+    /// The bundle already contains a proof that depends on the current witness.
+    ProofAlreadyPresent,
+    /// The witness position cannot be represented in the PCZT wire format.
+    PositionOutOfRange,
+    /// The bundle's note-plaintext version does not match the pool being updated.
+    UnexpectedNoteVersion,
+}
+
+#[cfg(any(feature = "sapling", feature = "orchard"))]
+impl core::fmt::Display for SpendWitnessUpdateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SpendWitnessUpdateError::InvalidSpendIndex(index) => {
+                write!(f, "spend index {index} does not exist")
+            }
+            SpendWitnessUpdateError::ProofAlreadyPresent => {
+                write!(f, "proof for target spend or bundle is already present")
+            }
+            SpendWitnessUpdateError::PositionOutOfRange => {
+                write!(
+                    f,
+                    "witness position cannot be represented in the PCZT wire format"
+                )
+            }
+            SpendWitnessUpdateError::UnexpectedNoteVersion => {
+                write!(
+                    f,
+                    "bundle note-plaintext version does not match the pool being updated"
+                )
+            }
+        }
     }
 }

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -11,9 +11,17 @@ use orchard::tree::MerkleHashOrchard;
 use pczt::{
     Pczt,
     roles::{
-        combiner::Combiner, creator::Creator, io_finalizer::IoFinalizer, low_level_signer,
-        prover::Prover, redactor::Redactor, signer::Signer, spend_finalizer::SpendFinalizer,
-        tx_extractor::TransactionExtractor, updater::Updater, verifier::Verifier,
+        combiner::Combiner,
+        creator::Creator,
+        io_finalizer::IoFinalizer,
+        low_level_signer,
+        prover::Prover,
+        redactor::Redactor,
+        signer::Signer,
+        spend_finalizer::SpendFinalizer,
+        tx_extractor::TransactionExtractor,
+        updater::{SpendWitnessUpdateError, Updater},
+        verifier::Verifier,
     },
     v1, v2,
 };
@@ -37,10 +45,17 @@ use zcash_protocol::{
 use zcash_script::script::{self, Evaluable};
 
 static ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
+static POST_NU6_3_ORCHARD_PROVING_KEY: OnceLock<orchard::circuit::ProvingKey> = OnceLock::new();
 
 fn orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
     ORCHARD_PROVING_KEY.get_or_init(|| {
         orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2)
+    })
+}
+
+fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
+    POST_NU6_3_ORCHARD_PROVING_KEY.get_or_init(|| {
+        orchard::circuit::ProvingKey::build(orchard::circuit::OrchardCircuitVersion::PostNu6_3)
     })
 }
 
@@ -1130,6 +1145,169 @@ fn redacted_sapling_anchor_round_trips_v2() {
     );
 }
 
+#[test]
+fn wallet_can_set_sapling_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create a Sapling account to spend from and send back to.
+    let sapling_extsk = sapling::zip32::ExtendedSpendingKey::master(&[1; 32]);
+    let sapling_dfvk = sapling_extsk.to_diversifiable_full_viewing_key();
+    let sapling_internal_dfvk = sapling_extsk
+        .derive_internal()
+        .to_diversifiable_full_viewing_key();
+    let sapling_recipient = sapling_dfvk.default_address().1;
+
+    // Pretend we already received a Sapling note.
+    let value = sapling::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut sapling_builder = sapling::builder::Builder::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+            sapling::builder::BundleType::DEFAULT,
+            sapling::Anchor::empty_tree(),
+        );
+        sapling_builder
+            .add_output(
+                None,
+                sapling_recipient,
+                value,
+                Memo::Empty.encode().into_bytes(),
+            )
+            .unwrap();
+        let (bundle, meta) = sapling_builder
+            .build::<LocalTxProver, LocalTxProver, _, i64>(&[], &mut rng)
+            .unwrap()
+            .unwrap();
+        let output = bundle
+            .shielded_outputs()
+            .get(meta.output_index(0).unwrap())
+            .unwrap();
+        let domain = sapling::note_encryption::SaplingDomain::new(
+            sapling::note_encryption::Zip212Enforcement::On,
+        );
+        let (note, _, _) =
+            try_note_decryption(&domain, &sapling_dfvk.to_external_ivk().prepare(), output)
+                .unwrap();
+        note
+    };
+
+    // Use the Sapling tree with a single leaf.
+    let (anchor, merkle_path) = {
+        let cmu = note.cmu();
+        let leaf = sapling::Node::from_cmu(&cmu);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<sapling::Node, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path)
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Sapling transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: Some(anchor),
+            orchard_anchor: Some(orchard::Anchor::empty_tree()),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_sapling_spend::<zip317::FeeRule>(sapling_dfvk.fvk().clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_sapling_output::<zip317::FeeRule>(
+            Some(sapling_dfvk.to_ovk(zip32::Scope::Internal)),
+            sapling_internal_dfvk.find_address(0u32.into()).unwrap().1,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        sapling_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = sapling_meta.spend_index(0).unwrap();
+    let pczt = Updater::new(pczt)
+        .update_sapling_with(|mut updater| {
+            updater.update_spend_with(index, |mut spend_updater| {
+                spend_updater.set_proof_generation_key(sapling_extsk.expsk.proof_generation_key())
+            })
+        })
+        .unwrap()
+        .finish();
+    check_round_trip(&pczt);
+
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer
+        .sign_sapling(index, &sapling_extsk.expsk.ask)
+        .unwrap();
+    let signed = signer.finish();
+
+    let redacted = Redactor::new(signed)
+        .redact_sapling_with(|mut r| {
+            r.redact_spend(index, |mut s| {
+                s.clear_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_sapling_proofs(&LocalTxProver::bundled(), &LocalTxProver::bundled())
+            .is_err()
+    );
+
+    assert_eq!(
+        Signer::new(redacted.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let invalid_index = redacted.sapling().spends().len();
+    assert!(matches!(
+        Updater::new(redacted.clone())
+            .set_sapling_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(redacted)
+        .set_sapling_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let sapling_prover = LocalTxProver::bundled();
+    let proved = Prover::new(updated)
+        .create_sapling_proofs(&sapling_prover, &sapling_prover)
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_sapling_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    check_round_trip(&proved);
+}
+
 /// A regtest network with NU6.3 activated, for exercising the Ironwood pool.
 fn nu6_3_test_network() -> zcash_protocol::local_consensus::LocalNetwork {
     use zcash_protocol::consensus::BlockHeight;
@@ -1159,6 +1337,144 @@ fn redacted_orchard_anchor_round_trips_v2() {
 }
 
 #[test]
+fn wallet_can_set_orchard_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to spend from and send back to.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Orchard note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard::bundle::BundleVersion::orchard_v2(),
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // Use the Orchard tree with a single leaf.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Orchard transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        MainNetwork,
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: Some(anchor),
+            ironwood_anchor: None,
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_orchard_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    check_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_orchard_with(|mut r| {
+            r.redact_action(index, |mut a| {
+                a.clear_spend_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_orchard_proof(orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted.clone()).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+    let invalid_index = signed.orchard().actions().len();
+    assert!(matches!(
+        Updater::new(signed.clone())
+            .set_orchard_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(signed)
+        .set_orchard_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(orchard_proving_key())
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_orchard_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
 fn redacted_ironwood_anchor_round_trips_v2() {
     assert_redacted_anchor_v2_round_trip(
         pczt_with_anchor(ShieldedPool::Ironwood),
@@ -1180,6 +1496,146 @@ fn redacted_ironwood_anchor_survives_signer_finish() {
 
     let reparsed = Pczt::parse(&signed.serialize().unwrap()).unwrap();
     assert_anchor_redacted(&reparsed, ShieldedPool::Ironwood);
+}
+
+#[test]
+fn wallet_can_set_ironwood_witness_after_signing() {
+    let mut rng = OsRng;
+
+    // Create an Orchard account to spend from and send back to through Ironwood.
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Ironwood note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::IronwoodDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        assert_eq!(note.version(), orchard::note::NoteVersion::V3);
+        note
+    };
+
+    // Use the Ironwood tree with a single leaf.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+    let merkle_path_for_update = merkle_path.clone();
+    let merkle_path_for_invalid_index = merkle_path.clone();
+    let merkle_path_after_proof = merkle_path.clone();
+
+    // Build the Ironwood transaction that a wallet will sign before proof creation.
+    let mut builder = Builder::new(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        BuildConfig::Standard {
+            sapling_anchor: None,
+            orchard_anchor: None,
+            ironwood_anchor: Some(anchor),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
+        },
+    );
+    builder
+        .add_ironwood_spend::<zip317::FeeRule>(orchard_fvk.clone(), note, merkle_path)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(990_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        ironwood_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+
+    let pczt = IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+        .finalize_io()
+        .unwrap();
+    let index = ironwood_meta.spend_action_index(0).unwrap();
+    check_v2_round_trip(&pczt);
+
+    let redacted = Redactor::new(pczt)
+        .redact_ironwood_with(|mut r| {
+            r.redact_action(index, |mut a| {
+                a.clear_spend_witness();
+            });
+        })
+        .finish();
+    assert!(
+        Prover::new(redacted.clone())
+            .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    let mut signer = Signer::new(redacted.clone()).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_ironwood(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+    let invalid_index = signed.ironwood().actions().len();
+    assert!(matches!(
+        Updater::new(signed.clone())
+            .set_ironwood_spend_witnesses([(invalid_index, merkle_path_for_invalid_index)]),
+        Err(SpendWitnessUpdateError::InvalidSpendIndex(_))
+    ));
+
+    let updated = Updater::new(signed)
+        .set_ironwood_spend_witnesses([(index, merkle_path_for_update)])
+        .unwrap()
+        .finish();
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+
+    let proved = Prover::new(updated)
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    assert!(matches!(
+        Updater::new(proved.clone())
+            .set_ironwood_spend_witnesses([(index, merkle_path_after_proof)]),
+        Err(SpendWitnessUpdateError::ProofAlreadyPresent)
+    ));
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
 }
 
 #[test]


### PR DESCRIPTION
Adds `Updater` methods for restoring Sapling, Orchard, and Ironwood spend witnesses from their native Merkle path types before proof creation. The setters reject invalid indices and already-proved spends or bundles, and Sapling returns a typed error if a witness position cannot fit the PCZT encoding.

Tests cover signed PCZT copies whose witnesses are restored before Sapling, Orchard, and Ironwood proof generation.

Validation:
- `cargo test -p pczt --all-features`
- `cargo check -p pczt --no-default-features`
- `cargo fmt --all -- --check`
- `cargo doc --no-deps -p pczt --all-features --document-private-items`
