### PR TITLE
Add Ironwood historical witness generation

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -80,6 +80,9 @@ workspace.
 - `zcash_client_sqlite::error::SqliteClientError::FeeRuleError`, a new variant
   (behind the `transparent-inputs` feature flag) that wraps an error produced
   by a `FeeRule` during transparent input selection.
+- `WalletDb::generate_ironwood_witnesses_at_historical_height`, which mirrors
+  the existing Orchard historical witness helper over the wallet's Ironwood
+  commitment tree shard tables.
 
 ### Changed
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`,

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -149,19 +149,20 @@ pub enum SqliteClientError {
         error: ShardTreeError<commitment_tree::Error>,
     },
 
-    /// The caller-supplied frontier passed to
-    /// [`WalletDb::generate_orchard_witnesses_at_historical_height`] is
-    /// inconsistent with the shard data reconstructed from the wallet at the
-    /// requested height.
+    /// The caller-supplied frontier passed to an Orchard or Ironwood
+    /// historical witness generation helper is inconsistent with the shard
+    /// data reconstructed from the wallet at the requested height.
     ///
     /// [`WalletDb::generate_orchard_witnesses_at_historical_height`]:
     /// crate::WalletDb::generate_orchard_witnesses_at_historical_height
+    /// [`WalletDb::generate_ironwood_witnesses_at_historical_height`]:
+    /// crate::WalletDb::generate_ironwood_witnesses_at_historical_height
     #[cfg(feature = "orchard")]
     HistoricalFrontierInvalid(InsertionError),
 
     /// A witness could not be generated for the specified position at the
-    /// specified historical height in a call to
-    /// [`WalletDb::generate_orchard_witnesses_at_historical_height`].
+    /// specified historical height in a call to an Orchard or Ironwood
+    /// historical witness generation helper.
     ///
     /// The wallet most likely has not synced through `height`, the checkpoint
     /// at `height` has been pruned, or `position` does not belong to the
@@ -169,6 +170,8 @@ pub enum SqliteClientError {
     ///
     /// [`WalletDb::generate_orchard_witnesses_at_historical_height`]:
     /// crate::WalletDb::generate_orchard_witnesses_at_historical_height
+    /// [`WalletDb::generate_ironwood_witnesses_at_historical_height`]:
+    /// crate::WalletDb::generate_ironwood_witnesses_at_historical_height
     #[cfg(feature = "orchard")]
     HistoricalWitnessUnavailable {
         /// The note commitment tree position for which a witness was
@@ -367,7 +370,7 @@ impl fmt::Display for SqliteClientError {
             #[cfg(feature = "orchard")]
             SqliteClientError::HistoricalFrontierInvalid(err) => write!(
                 f,
-                "The frontier supplied to generate_orchard_witnesses_at_historical_height is inconsistent with the wallet's shard data: {err}"
+                "The frontier supplied to historical witness generation is inconsistent with the wallet's shard data: {err}"
             ),
             #[cfg(feature = "orchard")]
             SqliteClientError::HistoricalWitnessUnavailable { position, height } => write!(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2864,6 +2864,53 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
             height,
         )
     }
+
+    /// Generates Ironwood Merkle witnesses at a historical height.
+    ///
+    /// Loads the wallet's Ironwood shard data into an ephemeral in-memory
+    /// `ShardStore`, inserts the provided frontier at `height` as a checkpoint,
+    /// and generates a witness for each of the given note positions.
+    ///
+    /// The caller must provide the valid frontier at the given height. The wallet DB
+    /// is strictly read-only; shard data is read but not modified.
+    ///
+    /// # Errors
+    ///
+    /// Returns:
+    /// - [`SqliteClientError::CommitmentTree`] if reading the wallet's shard
+    ///   or cap data fails, or if the shard data reconstructed from the
+    ///   wallet is internally inconsistent at a node the computation
+    ///   requires.
+    /// - [`SqliteClientError::HistoricalFrontierInvalid`] if
+    ///   `frontier_at_height` is inconsistent with the shard data
+    ///   reconstructed from the wallet at `height`.
+    /// - [`SqliteClientError::HistoricalWitnessUnavailable`] if a witness
+    ///   cannot be generated for one of `note_positions` at `height` (most
+    ///   commonly because the wallet has not yet synced through that
+    ///   height).
+    pub fn generate_ironwood_witnesses_at_historical_height(
+        &self,
+        note_positions: &[Position],
+        frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+            orchard::tree::MerkleHashOrchard,
+        >,
+        height: BlockHeight,
+    ) -> Result<
+        Vec<
+            incrementalmerkletree::MerklePath<
+                orchard::tree::MerkleHashOrchard,
+                { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+            >,
+        >,
+        SqliteClientError,
+    > {
+        wallet::commitment_tree::generate_ironwood_witnesses_at_historical_height(
+            self.conn.borrow(),
+            note_positions,
+            frontier_at_height,
+            height,
+        )
+    }
 }
 
 /// A handle for the SQLite block source.

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -35,7 +35,7 @@ use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
 
 #[cfg(feature = "orchard")]
-use crate::{ORCHARD_TABLES_PREFIX, ironwood_tree, orchard_tree};
+use crate::{IRONWOOD_TABLES_PREFIX, ORCHARD_TABLES_PREFIX, ironwood_tree, orchard_tree};
 
 use super::common::{TableConstants, table_constants};
 
@@ -1361,23 +1361,80 @@ pub(crate) fn generate_orchard_witnesses_at_historical_height(
     >,
     SqliteClientError,
 > {
+    generate_orchard_like_witnesses_at_historical_height(
+        conn,
+        ORCHARD_TABLES_PREFIX,
+        note_positions,
+        frontier_at_height,
+        height,
+    )
+}
+
+/// Generates Ironwood Merkle witnesses at a historical height.
+///
+/// This is identical to [`generate_orchard_witnesses_at_historical_height`],
+/// except that it reconstructs witness paths from the Ironwood shard tables.
+#[cfg(feature = "orchard")]
+pub(crate) fn generate_ironwood_witnesses_at_historical_height(
+    conn: &rusqlite::Connection,
+    note_positions: &[Position],
+    frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+        orchard::tree::MerkleHashOrchard,
+    >,
+    height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
+    generate_orchard_like_witnesses_at_historical_height(
+        conn,
+        IRONWOOD_TABLES_PREFIX,
+        note_positions,
+        frontier_at_height,
+        height,
+    )
+}
+
+#[cfg(feature = "orchard")]
+fn generate_orchard_like_witnesses_at_historical_height(
+    conn: &rusqlite::Connection,
+    table_prefix: &'static str,
+    note_positions: &[Position],
+    frontier_at_height: incrementalmerkletree::frontier::NonEmptyFrontier<
+        orchard::tree::MerkleHashOrchard,
+    >,
+    height: BlockHeight,
+) -> Result<
+    Vec<
+        incrementalmerkletree::MerklePath<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    >,
+    SqliteClientError,
+> {
     // `get_shard_roots` returns addresses ordered by shard index, matching the
     // ascending insertion order required by `MemoryShardStore::put_shard`.
     // Storage errors flow through `From<ShardTreeError<commitment_tree::Error>>`
     // into `SqliteClientError::CommitmentTree`.
     let mut store = MemoryShardStore::<orchard::tree::MerkleHashOrchard, BlockHeight>::empty();
     let shard_root_level = Level::new(ORCHARD_SHARD_HEIGHT);
-    let shard_roots = get_shard_roots(conn, ORCHARD_TABLES_PREFIX, shard_root_level)
-        .map_err(ShardTreeError::Storage)?;
+    let shard_roots =
+        get_shard_roots(conn, table_prefix, shard_root_level).map_err(ShardTreeError::Storage)?;
     for shard_root in shard_roots {
         if let Some(shard) =
-            get_shard::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX, shard_root)
+            get_shard::<orchard::tree::MerkleHashOrchard>(conn, table_prefix, shard_root)
                 .map_err(ShardTreeError::Storage)?
         {
             store.put_shard(shard).expect("put_shard is infallible");
         }
     }
-    let cap = get_cap::<orchard::tree::MerkleHashOrchard>(conn, ORCHARD_TABLES_PREFIX)
+    let cap = get_cap::<orchard::tree::MerkleHashOrchard>(conn, table_prefix)
         .map_err(ShardTreeError::Storage)?;
     store.put_cap(cap).expect("put_cap is infallible");
 
@@ -1476,6 +1533,7 @@ mod tests {
     use super::SqliteShardStore;
     use crate::{
         WalletDb,
+        error::SqliteClientError,
         testing::{
             db::{test_clock, test_rng},
             pool::ShieldedPoolPersistence,
@@ -1573,6 +1631,11 @@ mod tests {
         #[test]
         fn witnesses_at_historical_height() {
             super::witnesses_at_historical_height()
+        }
+
+        #[test]
+        fn ironwood_witnesses_at_historical_height() {
+            super::ironwood_witnesses_at_historical_height()
         }
 
         #[test]
@@ -1796,6 +1859,45 @@ mod tests {
     /// witnesses when given a frontier extracted from an earlier tree state.
     #[cfg(feature = "orchard")]
     fn witnesses_at_historical_height() {
+        witnesses_at_historical_height_for_table(
+            crate::ORCHARD_TABLES_PREFIX,
+            super::generate_orchard_witnesses_at_historical_height,
+        )
+    }
+
+    /// Test that `generate_ironwood_witnesses_at_historical_height` uses the
+    /// Ironwood shard tables rather than the Orchard shard tables.
+    #[cfg(feature = "orchard")]
+    fn ironwood_witnesses_at_historical_height() {
+        witnesses_at_historical_height_for_table(
+            crate::IRONWOOD_TABLES_PREFIX,
+            super::generate_ironwood_witnesses_at_historical_height,
+        )
+    }
+
+    #[cfg(feature = "orchard")]
+    type OrchardFrontier =
+        incrementalmerkletree::frontier::NonEmptyFrontier<::orchard::tree::MerkleHashOrchard>;
+
+    #[cfg(feature = "orchard")]
+    type OrchardMerklePath = incrementalmerkletree::MerklePath<
+        ::orchard::tree::MerkleHashOrchard,
+        { ::orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+    >;
+
+    #[cfg(feature = "orchard")]
+    type HistoricalWitnessGenerator = fn(
+        &rusqlite::Connection,
+        &[Position],
+        OrchardFrontier,
+        BlockHeight,
+    ) -> Result<Vec<OrchardMerklePath>, SqliteClientError>;
+
+    #[cfg(feature = "orchard")]
+    fn witnesses_at_historical_height_for_table(
+        table_prefix: &'static str,
+        generate_witnesses: HistoricalWitnessGenerator,
+    ) {
         use ::orchard::tree::MerkleHashOrchard;
         use incrementalmerkletree::frontier::Frontier;
         use rand::SeedableRng;
@@ -1827,7 +1929,8 @@ mod tests {
             let tx = db_data.conn.transaction().unwrap();
             let store =
                 SqliteShardStore::<_, MerkleHashOrchard, ORCHARD_SHARD_HEIGHT>::from_connection(
-                    &tx, "orchard",
+                    &tx,
+                    table_prefix,
                 )
                 .unwrap();
             let mut tree = ShardTree::<
@@ -1867,13 +1970,9 @@ mod tests {
         let expected_root = frontier_tree.root();
         let frontier = frontier_tree.take().expect("frontier is non-empty");
 
-        let witnesses = super::generate_orchard_witnesses_at_historical_height(
-            &db_data.conn,
-            &[note_position],
-            frontier,
-            historical_height,
-        )
-        .expect("witness generation should succeed");
+        let witnesses =
+            generate_witnesses(&db_data.conn, &[note_position], frontier, historical_height)
+                .expect("witness generation should succeed");
 
         assert_eq!(witnesses.len(), 1);
         assert_eq!(witnesses[0].root(note_leaf), expected_root);


### PR DESCRIPTION
Adds an Ironwood variant of the SQLite historical witness helper, sharing the existing Orchard implementation over the tree table prefix.

Wallets need this to build Merkle paths for Ironwood notes at a historical snapshot height when preparing proofs against a saved round tree state.

Validation:
- cargo test -p zcash_client_sqlite --all-features witnesses_at_historical_height
- cargo check -p zcash_client_sqlite --all-features
