### PR TITLE
Fix PCZT BuildConfig test initializer

### DIFF
--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -1058,6 +1058,7 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
             ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
                 .then(orchard::Anchor::empty_tree),
+            orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     );
     builder


### PR DESCRIPTION
Adds the missing Orchard bundle type field to a PCZT test BuildConfig initializer.

Current main fails workspace test and clippy jobs because this helper was not updated when BuildConfig::Standard gained orchard_pool_bundle_type.

Validation:
- cargo test --workspace --all-features --no-run
- cargo fmt --all -- --check
