### PR TITLE
zcash_client_sqlite: resolve duplicate receiver on standalone transparent import

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -24,6 +24,11 @@ workspace.
   exact tree-update logic: `zcash_client_backend::data_api::ll::wallet::`
   `{build_subtrees, checkpoint_positions, ensure_checkpoints,
   cross_pool_ensure_heights, update_tree}`.
+- `zcash_client_backend::data_api::WalletWrite::import_standalone_transparent_pubkeys`
+  (behind the `transparent-key-import` feature flag), a batch variant of
+  `import_standalone_transparent_pubkey` that lets implementations validate the
+  target account once for the whole batch. The default implementation imports
+  each pubkey individually.
 - `zcash_client_backend::proposal::Proposal::proposed_version` and
   `with_proposed_version`. The transaction version requested when a proposal is
   constructed is now recorded on the proposal (and preserved across

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3398,6 +3398,28 @@ pub trait WalletWrite: WalletRead {
         )
     }
 
+    /// Imports a batch of standalone transparent pubkeys into the account, adding the associated
+    /// transparent p2pkh addresses. See [`import_standalone_transparent_pubkey`] for the semantics
+    /// and spending limitations that apply to each imported pubkey.
+    ///
+    /// This is equivalent to calling [`import_standalone_transparent_pubkey`] once per pubkey, but
+    /// implementations may validate the target account a single time for the whole batch. The
+    /// default implementation calls [`import_standalone_transparent_pubkey`] for each pubkey; a
+    /// pubkey whose receiver address is already known to the wallet is skipped.
+    ///
+    /// [`import_standalone_transparent_pubkey`]: Self::import_standalone_transparent_pubkey
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkeys(
+        &mut self,
+        account: Self::AccountId,
+        pubkeys: &[secp256k1::PublicKey],
+    ) -> Result<(), Self::Error> {
+        for pubkey in pubkeys {
+            self.import_standalone_transparent_pubkey(account, *pubkey)?;
+        }
+        Ok(())
+    }
+
     /// Imports the given redeem script into the account without key derivation information, and
     /// adds the associated transparent p2sh address.
     ///

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -129,6 +129,10 @@ workspace.
   received at the address — moves to the deriving account, since successful derivation
   establishes that account's ownership of the address. Funds received at such an address
   become spendable once the account derives it.
+- Importing a standalone transparent pubkey whose receiver address is already recorded (for
+  example because it was derived as an account receiver) is now a no-op instead of failing on
+  the transparent-receiver uniqueness invariant added in this release. This is the
+  import-direction counterpart of the derivation-side fix above.
 
 ## [0.21.1] - 2026-06-19
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,10 @@ workspace.
 ## Unreleased
 
 ### Added
+- `WalletDb` implements the new
+  `WalletWrite::import_standalone_transparent_pubkeys` batch method (behind the
+  `transparent-key-import` feature flag), resolving the target account a single
+  time for the whole batch.
 - `WalletDb` now implements the new
   `WalletWrite::reserve_next_n_internal_addresses` method (behind the
   `transparent-inputs` feature flag), reserving internal-scope (change)

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1686,6 +1686,7 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         pubkey: secp256k1::PublicKey,
     ) -> Result<(), Self::Error> {
         wallet::import_standalone_transparent_pubkey(self.conn.0, &self.params, account, pubkey)
+            .map(|_inserted| ())
     }
 
     #[cfg(feature = "transparent-key-import")]

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1391,6 +1391,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
     }
 
     #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkeys(
+        &mut self,
+        account: Self::AccountId,
+        pubkeys: &[secp256k1::PublicKey],
+    ) -> Result<(), Self::Error> {
+        self.transactionally(|wdb| wdb.import_standalone_transparent_pubkeys(account, pubkeys))
+    }
+
+    #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_script(
         &mut self,
         account: Self::AccountId,
@@ -1686,6 +1695,16 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         pubkey: secp256k1::PublicKey,
     ) -> Result<(), Self::Error> {
         wallet::import_standalone_transparent_pubkey(self.conn.0, &self.params, account, pubkey)
+            .map(|_inserted| ())
+    }
+
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkeys(
+        &mut self,
+        account: Self::AccountId,
+        pubkeys: &[secp256k1::PublicKey],
+    ) -> Result<(), Self::Error> {
+        wallet::import_standalone_transparent_pubkeys(self.conn.0, &self.params, account, pubkeys)
             .map(|_inserted| ())
     }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -803,6 +803,10 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
 ) -> Result<usize, SqliteClientError> {
     use ::transparent::address::TransparentAddress;
 
+    // Resolve the account up front so an unknown account is reported explicitly, rather than
+    // inferred from a zero-row INSERT below.
+    let account_id = get_account_ref(conn, account_uuid)?;
+
     let existing_import_account = conn
         .query_row(
             "SELECT accounts.uuid AS account_uuid
@@ -844,14 +848,13 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
           account_id, key_scope, address, cached_transparent_receiver_address,
           receiver_flags, imported_transparent_receiver_pubkey
         )
-        SELECT
-          id, :key_scope, :address, :address,
+        VALUES (
+          :account_id, :key_scope, :address, :address,
           :receiver_flags, :imported_transparent_receiver_pubkey
-          FROM accounts
-          WHERE accounts.uuid = :account_uuid
+        )
         "#,
         named_params![
-            ":account_uuid": account_uuid.0,
+            ":account_id": account_id.0,
             ":key_scope": KeyScope::Foreign.encode(),
             ":address": addr_str,
             ":receiver_flags": ReceiverFlags::P2PKH.bits(),
@@ -859,10 +862,8 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
         ],
     )?;
 
-    if rows_affected == 0 {
-        return Err(SqliteClientError::AccountUnknown);
-    }
-
+    // The account is known (resolved above) and the receiver is not already recorded (checked
+    // above), so exactly one row is inserted.
     Ok(rows_affected)
 }
 
@@ -876,6 +877,10 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
     use ::transparent::address::TransparentAddress;
     use zcash_script::descriptor::sh;
     use zcash_script::script::Evaluable;
+
+    // Resolve the account up front so an unknown account is reported explicitly, rather than
+    // inferred from a zero-row INSERT below.
+    let account_id = get_account_ref(conn, account_uuid)?;
 
     // This mirrors `zcash_script::opcode::push_value::LargeValue::MAX_SIZE`, which is
     // currently `pub(crate)`. Replace with a direct reference if it becomes public.
@@ -930,30 +935,25 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
     }
 
     let addr_str = Address::Transparent(addr).encode(params);
-    let rows_affected = conn.execute(
+    conn.execute(
         r#"
         INSERT INTO addresses (
           account_id, key_scope, address, cached_transparent_receiver_address,
           receiver_flags, imported_transparent_receiver_script
         )
-        SELECT
-          id, :key_scope, :address, :address,
+        VALUES (
+          :account_id, :key_scope, :address, :address,
           :receiver_flags, :imported_transparent_receiver_script
-          FROM accounts
-          WHERE accounts.uuid = :account_uuid
+        )
         "#,
         named_params![
-            ":account_uuid": account_uuid.0,
+            ":account_id": account_id.0,
             ":key_scope": KeyScope::Foreign.encode(),
             ":address": addr_str,
             ":receiver_flags": ReceiverFlags::P2SH.bits(),
             ":imported_transparent_receiver_script": &rs_bytes[..]
         ],
     )?;
-
-    if rows_affected == 0 {
-        return Err(SqliteClientError::AccountUnknown);
-    }
 
     Ok(())
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -768,13 +768,39 @@ pub(crate) fn delete_account(
     Ok(())
 }
 
+/// Returns `true` if `address` (an encoded transparent receiver address) is already recorded
+/// in the `addresses` table, whether as a derived account receiver or as a prior standalone
+/// import.
+///
+/// A transparent receiver appears at most once in `addresses`, enforced by the UNIQUE index on
+/// `cached_transparent_receiver_address`. Callers that would otherwise insert a fresh row for a
+/// receiver can use this to detect an existing row and avoid violating that constraint.
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn transparent_receiver_address_exists(
+    conn: &rusqlite::Connection,
+    address: &str,
+) -> Result<bool, SqliteClientError> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM addresses WHERE cached_transparent_receiver_address = :address",
+            named_params![":address": address],
+            |_row| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+/// Imports a standalone transparent P2PKH receiver by its pubkey into the given account.
+///
+/// Returns the number of address rows inserted: `1` when a new receiver row was added, or `0`
+/// when nothing was inserted because the receiver address was already present in the wallet.
 #[cfg(feature = "transparent-key-import")]
 pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
     account_uuid: AccountUuid,
     pubkey: secp256k1::PublicKey,
-) -> Result<(), SqliteClientError> {
+) -> Result<usize, SqliteClientError> {
     use ::transparent::address::TransparentAddress;
 
     let existing_import_account = conn
@@ -793,13 +819,25 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
     if let Some(current) = existing_import_account {
         if current == account_uuid.expose_uuid() {
             // The key has already been imported; nothing to do.
-            return Ok(());
+            return Ok(0);
         } else {
             return Err(SqliteClientError::StandaloneImportConflict(current));
         }
     }
 
     let addr_str = Address::Transparent(TransparentAddress::from_pubkey(&pubkey)).encode(params);
+
+    // If this transparent receiver is already recorded (for example it was derived as an
+    // account receiver, so its row carries a NULL `imported_transparent_receiver_pubkey` and is
+    // therefore not matched by the pubkey lookup above), do not insert a second row for the same
+    // `cached_transparent_receiver_address`: the UNIQUE index on that column forbids it, and the
+    // existing representation already covers the address. This is the import-direction
+    // counterpart of the resolution in `store_address_range`, which upgrades an imported receiver
+    // in place when the same address is later derived.
+    if transparent_receiver_address_exists(conn, &addr_str)? {
+        return Ok(0);
+    }
+
     let rows_affected = conn.execute(
         r#"
         INSERT INTO addresses (
@@ -825,7 +863,7 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
         return Err(SqliteClientError::AccountUnknown);
     }
 
-    Ok(())
+    Ok(rows_affected)
 }
 
 #[cfg(feature = "transparent-key-import")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -801,11 +801,50 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
     account_uuid: AccountUuid,
     pubkey: secp256k1::PublicKey,
 ) -> Result<usize, SqliteClientError> {
-    use ::transparent::address::TransparentAddress;
-
     // Resolve the account up front so an unknown account is reported explicitly, rather than
-    // inferred from a zero-row INSERT below.
+    // inferred from a zero-row INSERT.
     let account_id = get_account_ref(conn, account_uuid)?;
+    import_standalone_transparent_pubkey_inner(conn, params, account_uuid, account_id, pubkey)
+}
+
+/// Imports a batch of standalone transparent P2PKH receivers by their pubkeys into the given
+/// account, resolving the account a single time for the whole batch (rather than once per
+/// pubkey). Returns the total number of address rows inserted.
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn import_standalone_transparent_pubkeys<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_uuid: AccountUuid,
+    pubkeys: &[secp256k1::PublicKey],
+) -> Result<usize, SqliteClientError> {
+    let account_id = get_account_ref(conn, account_uuid)?;
+    let mut inserted = 0;
+    for pubkey in pubkeys {
+        inserted += import_standalone_transparent_pubkey_inner(
+            conn,
+            params,
+            account_uuid,
+            account_id,
+            *pubkey,
+        )?;
+    }
+    Ok(inserted)
+}
+
+/// Imports a single standalone transparent P2PKH receiver into the account identified by both
+/// `account_uuid` (for the cross-account conflict check) and its already-resolved `account_id`.
+///
+/// Returns the number of address rows inserted (`1` when a new receiver row was added, `0` when
+/// nothing was inserted because the receiver address was already present).
+#[cfg(feature = "transparent-key-import")]
+fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_uuid: AccountUuid,
+    account_id: AccountRef,
+    pubkey: secp256k1::PublicKey,
+) -> Result<usize, SqliteClientError> {
+    use ::transparent::address::TransparentAddress;
 
     let existing_import_account = conn
         .query_row(

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3273,6 +3273,147 @@ mod tests {
         tx.commit().unwrap();
     }
 
+    /// Importing a standalone (`Foreign`) receiver whose address is already present as a derived
+    /// account receiver inserts nothing (returns 0) rather than failing the transparent-receiver
+    /// uniqueness invariant. This is the import-direction counterpart of
+    /// `store_address_range_upgrades_imported_receiver`.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkey_noop_when_address_derived() {
+        use proptest::prelude::*;
+        use rusqlite::named_params;
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+        use transparent::address::TransparentAddress;
+        use zcash_keys::{address::Address, encoding::AddressCodec};
+
+        proptest!(
+            ProptestConfig::with_cases(16),
+            |(
+                sk in any::<[u8; 32]>()
+                    .prop_filter_map("valid secp256k1 secret key", |b| SecretKey::from_slice(&b).ok()),
+                // Above the account's default external gap (10) so store_address_range actually
+                // inserts our receiver rather than skipping an already-derived index.
+                child_index in 16u32..0x8000_0000u32,
+            )| {
+                let st = TestBuilder::new()
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account_uuid = st.test_account().unwrap().id();
+                let network = *st.network();
+
+                // A real pubkey and the transparent receiver it hashes to.
+                let pubkey = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+                let taddr = TransparentAddress::from_pubkey(&pubkey);
+                let taddr_enc = taddr.encode(&network);
+                let child = NonHardenedChildIndex::from_index(child_index).unwrap();
+
+                let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+                let account_id = get_account_ref(&tx, account_uuid).unwrap();
+
+                // Derive the receiver into `addresses` (as the account-import path would), so a
+                // row with a NULL `imported_transparent_receiver_pubkey` already holds this
+                // receiver address.
+                super::store_address_range(
+                    &tx,
+                    &network,
+                    account_id,
+                    TransparentKeyScope::EXTERNAL,
+                    vec![(Address::from(taddr), taddr, child)],
+                )
+                .unwrap();
+
+                // Importing the same receiver as a standalone pubkey inserts nothing: the pubkey
+                // lookup does not match the derived (NULL-pubkey) row, but the address-existence
+                // check does.
+                let inserted = crate::wallet::import_standalone_transparent_pubkey(
+                    &tx,
+                    &network,
+                    account_uuid,
+                    pubkey,
+                )
+                .unwrap();
+                prop_assert_eq!(inserted, 0);
+
+                // Exactly one row remains for the receiver.
+                let count: i64 = tx
+                    .query_row(
+                        "SELECT COUNT(*) FROM addresses \
+                         WHERE cached_transparent_receiver_address = :taddr",
+                        named_params! { ":taddr": &taddr_enc },
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                prop_assert_eq!(count, 1);
+            }
+        );
+    }
+
+    /// Importing a standalone receiver that is not yet recorded inserts exactly one row (returns
+    /// 1); importing the same pubkey again is a no-op (returns 0). Together with
+    /// `import_standalone_transparent_pubkey_noop_when_address_derived` this covers both return
+    /// values.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkey_returns_rows_inserted() {
+        use proptest::prelude::*;
+        use rusqlite::named_params;
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+        use transparent::address::TransparentAddress;
+        use zcash_keys::encoding::AddressCodec;
+
+        proptest!(
+            ProptestConfig::with_cases(16),
+            |(sk in any::<[u8; 32]>()
+                .prop_filter_map("valid secp256k1 secret key", |b| SecretKey::from_slice(&b).ok()))| {
+                let st = TestBuilder::new()
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account_uuid = st.test_account().unwrap().id();
+                let network = *st.network();
+
+                let pubkey = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+                let taddr_enc = TransparentAddress::from_pubkey(&pubkey).encode(&network);
+
+                let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+
+                // The receiver is not yet recorded: the first import inserts exactly one row.
+                let inserted = crate::wallet::import_standalone_transparent_pubkey(
+                    &tx,
+                    &network,
+                    account_uuid,
+                    pubkey,
+                )
+                .unwrap();
+                prop_assert_eq!(inserted, 1);
+
+                // Re-importing the same pubkey inserts nothing.
+                let reinserted = crate::wallet::import_standalone_transparent_pubkey(
+                    &tx,
+                    &network,
+                    account_uuid,
+                    pubkey,
+                )
+                .unwrap();
+                prop_assert_eq!(reinserted, 0);
+
+                // Exactly one row exists for the receiver.
+                let count: i64 = tx
+                    .query_row(
+                        "SELECT COUNT(*) FROM addresses \
+                         WHERE cached_transparent_receiver_address = :taddr",
+                        named_params! { ":taddr": &taddr_enc },
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                prop_assert_eq!(count, 1);
+            }
+        );
+    }
+
     #[test]
     #[cfg(feature = "transparent-key-import")]
     fn test_import_standalone_transparent_pubkey() {

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3444,6 +3444,108 @@ mod tests {
         ));
     }
 
+    /// The batch import resolves the account once and imports every pubkey: the returned count is
+    /// the number of distinct receivers inserted, all receivers are present, and re-importing the
+    /// same batch inserts nothing.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkeys_batch() {
+        use proptest::prelude::*;
+        use rusqlite::named_params;
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+        use std::collections::HashSet;
+        use transparent::address::TransparentAddress;
+        use zcash_keys::encoding::AddressCodec;
+
+        proptest!(
+            ProptestConfig::with_cases(12),
+            |(sks in proptest::collection::vec(
+                any::<[u8; 32]>()
+                    .prop_filter_map("valid secp256k1 secret key", |b| SecretKey::from_slice(&b).ok()),
+                1..8usize,
+            ))| {
+                let st = TestBuilder::new()
+                    .with_data_store_factory(TestDbFactory::default())
+                    .with_account_from_sapling_activation(BlockHash([0; 32]))
+                    .build();
+
+                let account_uuid = st.test_account().unwrap().id();
+                let network = *st.network();
+                let secp = Secp256k1::new();
+
+                let pubkeys: Vec<PublicKey> =
+                    sks.iter().map(|sk| PublicKey::from_secret_key(&secp, sk)).collect();
+                let distinct: HashSet<String> = pubkeys
+                    .iter()
+                    .map(|pk| TransparentAddress::from_pubkey(pk).encode(&network))
+                    .collect();
+
+                let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+
+                // Resolves the account once and inserts one row per distinct receiver.
+                let inserted = crate::wallet::import_standalone_transparent_pubkeys(
+                    &tx,
+                    &network,
+                    account_uuid,
+                    &pubkeys,
+                )
+                .unwrap();
+                prop_assert_eq!(inserted, distinct.len());
+
+                // Every receiver is present, exactly once.
+                for addr in &distinct {
+                    let count: i64 = tx
+                        .query_row(
+                            "SELECT COUNT(*) FROM addresses \
+                             WHERE cached_transparent_receiver_address = :a",
+                            named_params! { ":a": addr },
+                            |r| r.get(0),
+                        )
+                        .unwrap();
+                    prop_assert_eq!(count, 1);
+                }
+
+                // Re-importing the same batch inserts nothing.
+                let again = crate::wallet::import_standalone_transparent_pubkeys(
+                    &tx,
+                    &network,
+                    account_uuid,
+                    &pubkeys,
+                )
+                .unwrap();
+                prop_assert_eq!(again, 0);
+            }
+        );
+    }
+
+    /// The batch import resolves the account up front, so a batch targeting an account that does
+    /// not exist returns `AccountUnknown`.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkeys_unknown_account() {
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+        let st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let network = *st.network();
+        let pubkey = PublicKey::from_secret_key(
+            &Secp256k1::new(),
+            &SecretKey::from_slice(&[0x22; 32]).unwrap(),
+        );
+        let unknown = crate::AccountUuid::from_uuid(uuid::Uuid::from_bytes([0xfe; 16]));
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let result =
+            crate::wallet::import_standalone_transparent_pubkeys(&tx, &network, unknown, &[pubkey]);
+        assert!(matches!(
+            result,
+            Err(crate::error::SqliteClientError::AccountUnknown)
+        ));
+    }
+
     #[test]
     #[cfg(feature = "transparent-key-import")]
     fn test_import_standalone_transparent_pubkey() {

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3414,6 +3414,36 @@ mod tests {
         );
     }
 
+    /// Importing into an account that does not exist returns `AccountUnknown`, resolved
+    /// explicitly up front rather than inferred from a zero-row insert.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_pubkey_unknown_account() {
+        use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+        let st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let network = *st.network();
+        let pubkey = PublicKey::from_secret_key(
+            &Secp256k1::new(),
+            &SecretKey::from_slice(&[0x11; 32]).unwrap(),
+        );
+
+        // A uuid that matches no account in the wallet.
+        let unknown = crate::AccountUuid::from_uuid(uuid::Uuid::from_bytes([0xff; 16]));
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let result =
+            crate::wallet::import_standalone_transparent_pubkey(&tx, &network, unknown, pubkey);
+        assert!(matches!(
+            result,
+            Err(crate::error::SqliteClientError::AccountUnknown)
+        ));
+    }
+
     #[test]
     #[cfg(feature = "transparent-key-import")]
     fn test_import_standalone_transparent_pubkey() {


### PR DESCRIPTION
## Problem

Importing a standalone transparent pubkey whose receiver address is already recorded (for example because it was derived as an account receiver) fails with:

```
UNIQUE constraint failed: addresses.cached_transparent_receiver_address
```

This surfaced in Zallet's `migrate-zcashd-wallet`: the migration imports a wallet's unified accounts first (deriving and caching each account's transparent receivers), then imports the loose keystore keys as standalone transparent pubkeys. When a loose key's P2PKH address equals one already derived for an account, the standalone import inserts the same `cached_transparent_receiver_address` a second time and aborts.

## Root cause

The UNIQUE index on `addresses.cached_transparent_receiver_address` was added in ef6214bc5e, and the **derivation** path was taught to resolve the resulting duplicates in 3b6a45575c (deriving an address that was already imported upgrades the imported row in place). The **standalone-import** path never got the symmetric resolution: `import_standalone_transparent_pubkey`'s idempotency check keys only on `imported_transparent_receiver_pubkey`, so an address already present as a *derived* row (NULL pubkey) is not matched, and it falls through to a plain `INSERT` that violates the index.

## Fix

- Add an address-existence check before the `INSERT` in `import_standalone_transparent_pubkey`, so an already-recorded receiver is a no-op — the import-direction counterpart of `store_address_range`'s resolution.
- Extract that check into `transparent_receiver_address_exists`.
- `import_standalone_transparent_pubkey` now returns the number of address rows inserted: `1` when a new receiver row was added, `0` when nothing was inserted. The `WalletWrite` impl discards the count, so the public trait API is unchanged.

## Tests

Two proptest cases (random secret key and, for the derived case, a random non-hardened child index above the gap):
- `import_standalone_transparent_pubkey_noop_when_address_derived` — importing a receiver already present as a derived account receiver returns `0` and leaves exactly one row.
- `import_standalone_transparent_pubkey_returns_rows_inserted` — a fresh import returns `1`, and a repeat import of the same pubkey returns `0`.

Existing standalone-import tests, `cargo fmt --check`, and `cargo clippy --tests` all pass.


Generated with Claude.