### PR TITLE
Update MSRV to 1.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -1166,12 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2628,11 +2627,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2832,12 +2831,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2869,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -3058,12 +3056,6 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3550,7 +3542,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3863,17 +3855,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3884,14 +3867,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4076,7 +4053,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -4099,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4934,30 +4911,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6057,7 +6033,7 @@ dependencies = [
  "paste",
  "pin-project",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.3",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -6202,14 +6178,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -7121,7 +7097,6 @@ dependencies = [
  "subtle",
  "tempfile",
  "time",
- "time-core",
  "tokio",
  "tokio-rustls",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.88"
 repository = "https://github.com/zcash/librustzcash"
 license = "MIT OR Apache-2.0"
 categories = ["cryptography::cryptocurrencies"]
@@ -184,9 +184,6 @@ zip32 = { version = "0.2", default-features = false }
 
 # ZeWIF wallet interchange
 zewif = "0.1.0"
-
-# Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
-time-core = "=0.1.2"
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/components/equihash/CHANGELOG.md
+++ b/components/equihash/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- MSRV is now 1.88
+
 ## [0.3.0] - 2026-04-23
 
 ### Changed

--- a/components/equihash/src/params.rs
+++ b/components/equihash/src/params.rs
@@ -12,7 +12,7 @@ impl Params {
         // - k >= 3 so the encoded solutions have an exact byte length.
         // - k < n, so the collision bit length is at least 1.
         // - n is a multiple of k + 1, so we have an integer collision bit length.
-        if (n % 8 == 0) && (k >= 3) && (k < n) && (n % (k + 1) == 0) {
+        if n.is_multiple_of(8) && (k >= 3) && (k < n) && n.is_multiple_of(k + 1) {
             Some(Params { n, k })
         } else {
             None

--- a/components/equihash/src/tromp.rs
+++ b/components/equihash/src/tromp.rs
@@ -222,7 +222,7 @@ mod tests {
 
         let solutions = solve_200_9(input, || {
             let variable_nonce = nonces.next()?;
-            println!("Using variable nonce [0..4] of {}", variable_nonce);
+            println!("Using variable nonce [0..4] of {variable_nonce}");
 
             let variable_nonce = variable_nonce.to_le_bytes();
             nonce[0] = variable_nonce[0];

--- a/components/zcash_address/CHANGELOG.md
+++ b/components/zcash_address/CHANGELOG.md
@@ -11,6 +11,7 @@ workspace.
 ## [0.13.0-pre.0] - 2026-06-30
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`.
 
 ## [0.12.0] - 2026-06-02

--- a/components/zcash_address/src/convert.rs
+++ b/components/zcash_address/src/convert.rs
@@ -40,11 +40,9 @@ impl<E> From<E> for ConversionError<E> {
 impl<E: fmt::Display> fmt::Display for ConversionError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::IncorrectNetwork { expected, actual } => write!(
-                f,
-                "Address is for {:?} but we expected {:?}",
-                actual, expected,
-            ),
+            Self::IncorrectNetwork { expected, actual } => {
+                write!(f, "Address is for {actual:?} but we expected {expected:?}",)
+            }
             Self::Unsupported(e) => e.fmt(f),
             Self::User(e) => e.fmt(f),
         }

--- a/components/zcash_address/src/encoding.rs
+++ b/components/zcash_address/src/encoding.rs
@@ -117,34 +117,34 @@ impl FromStr for ZcashAddress {
         }
 
         // The rest use Base58Check.
-        if let Ok(decoded) = bs58::decode(s).with_check(None).into_vec() {
-            if decoded.len() >= 2 {
-                let (prefix, net) = match decoded[..2].try_into().unwrap() {
-                    prefix @ (mainnet::B58_PUBKEY_ADDRESS_PREFIX
-                    | mainnet::B58_SCRIPT_ADDRESS_PREFIX
-                    | mainnet::B58_SPROUT_ADDRESS_PREFIX) => (prefix, NetworkType::Main),
-                    prefix @ (testnet::B58_PUBKEY_ADDRESS_PREFIX
-                    | testnet::B58_SCRIPT_ADDRESS_PREFIX
-                    | testnet::B58_SPROUT_ADDRESS_PREFIX) => (prefix, NetworkType::Test),
-                    // We will not define new Base58Check address encodings.
-                    _ => return Err(ParseError::NotZcash),
-                };
+        if let Ok(decoded) = bs58::decode(s).with_check(None).into_vec()
+            && decoded.len() >= 2
+        {
+            let (prefix, net) = match decoded[..2].try_into().unwrap() {
+                prefix @ (mainnet::B58_PUBKEY_ADDRESS_PREFIX
+                | mainnet::B58_SCRIPT_ADDRESS_PREFIX
+                | mainnet::B58_SPROUT_ADDRESS_PREFIX) => (prefix, NetworkType::Main),
+                prefix @ (testnet::B58_PUBKEY_ADDRESS_PREFIX
+                | testnet::B58_SCRIPT_ADDRESS_PREFIX
+                | testnet::B58_SPROUT_ADDRESS_PREFIX) => (prefix, NetworkType::Test),
+                // We will not define new Base58Check address encodings.
+                _ => return Err(ParseError::NotZcash),
+            };
 
-                return match prefix {
-                    mainnet::B58_SPROUT_ADDRESS_PREFIX | testnet::B58_SPROUT_ADDRESS_PREFIX => {
-                        decoded[2..].try_into().map(AddressKind::Sprout)
-                    }
-                    mainnet::B58_PUBKEY_ADDRESS_PREFIX | testnet::B58_PUBKEY_ADDRESS_PREFIX => {
-                        decoded[2..].try_into().map(AddressKind::P2pkh)
-                    }
-                    mainnet::B58_SCRIPT_ADDRESS_PREFIX | testnet::B58_SCRIPT_ADDRESS_PREFIX => {
-                        decoded[2..].try_into().map(AddressKind::P2sh)
-                    }
-                    _ => unreachable!(),
+            return match prefix {
+                mainnet::B58_SPROUT_ADDRESS_PREFIX | testnet::B58_SPROUT_ADDRESS_PREFIX => {
+                    decoded[2..].try_into().map(AddressKind::Sprout)
                 }
-                .map_err(|_| ParseError::InvalidEncoding)
-                .map(|kind| ZcashAddress { kind, net });
+                mainnet::B58_PUBKEY_ADDRESS_PREFIX | testnet::B58_PUBKEY_ADDRESS_PREFIX => {
+                    decoded[2..].try_into().map(AddressKind::P2pkh)
+                }
+                mainnet::B58_SCRIPT_ADDRESS_PREFIX | testnet::B58_SCRIPT_ADDRESS_PREFIX => {
+                    decoded[2..].try_into().map(AddressKind::P2sh)
+                }
+                _ => unreachable!(),
             }
+            .map_err(|_| ParseError::InvalidEncoding)
+            .map(|kind| ZcashAddress { kind, net });
         };
 
         // If it's not valid Bech32, Bech32m, or Base58Check, it's not a Zcash address.
@@ -175,7 +175,7 @@ impl fmt::Display for ZcashAddress {
             AddressKind::P2sh(data) => encode_b58(self.net.b58_script_address_prefix(), data),
             AddressKind::Tex(data) => encode_bech32::<Bech32m>(self.net.hrp_tex_address(), data),
         };
-        write!(f, "{}", encoded)
+        write!(f, "{encoded}")
     }
 }
 

--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -148,13 +148,13 @@ impl fmt::Display for ParseError {
         match self {
             ParseError::BothP2phkAndP2sh => write!(f, "UA contains both P2PKH and P2SH items"),
             ParseError::DuplicateTypecode(c) => write!(f, "Duplicate typecode {}", u32::from(*c)),
-            ParseError::InvalidTypecodeValue(v) => write!(f, "Typecode value out of range {}", v),
-            ParseError::InvalidEncoding(msg) => write!(f, "Invalid encoding: {}", msg),
+            ParseError::InvalidTypecodeValue(v) => write!(f, "Typecode value out of range {v}"),
+            ParseError::InvalidEncoding(msg) => write!(f, "Invalid encoding: {msg}"),
             ParseError::InvalidTypecodeOrder => write!(f, "Items are out of order."),
             ParseError::OnlyTransparent => write!(f, "UA only contains transparent items"),
             ParseError::NotUnified => write!(f, "Address is not Bech32m encoded"),
             ParseError::UnknownPrefix(s) => {
-                write!(f, "Unrecognized Bech32m human-readable prefix: {}", s)
+                write!(f, "Unrecognized Bech32m human-readable prefix: {s}")
             }
         }
     }
@@ -266,27 +266,23 @@ pub(crate) mod private {
                     .map(|v| u32::try_from(v).expect("CompactSize::read enforces MAX_SIZE limit"))
                     .map_err(|e| {
                         ParseError::InvalidEncoding(format!(
-                            "Failed to deserialize CompactSize-encoded typecode {}",
-                            e
+                            "Failed to deserialize CompactSize-encoded typecode {e}"
                         ))
                     })?;
                 let length = CompactSize::read(&mut cursor).map_err(|e| {
                     ParseError::InvalidEncoding(format!(
-                        "Failed to deserialize CompactSize-encoded length {}",
-                        e
+                        "Failed to deserialize CompactSize-encoded length {e}"
                     ))
                 })?;
                 let addr_end = cursor.position().checked_add(length).ok_or_else(|| {
                     ParseError::InvalidEncoding(format!(
-                        "Length value {} caused an overflow error",
-                        length
+                        "Length value {length} caused an overflow error"
                     ))
                 })?;
                 let buf = cursor.get_ref();
                 if (buf.len() as u64) < addr_end {
                     return Err(ParseError::InvalidEncoding(format!(
-                        "Truncated: unable to read {} bytes of item data",
-                        length
+                        "Truncated: unable to read {length} bytes of item data"
                     )));
                 }
                 let result = R::try_from((
@@ -300,7 +296,7 @@ pub(crate) mod private {
             // Here we allocate if necessary to get a mutable Vec<u8> to unjumble.
             let mut encoded = buf.into();
             f4jumble::f4jumble_inv_mut(&mut encoded[..]).map_err(|e| {
-                ParseError::InvalidEncoding(format!("F4Jumble decoding failed: {}", e))
+                ParseError::InvalidEncoding(format!("F4Jumble decoding failed: {e}"))
             })?;
 
             // Validate and strip trailing padding bytes.

--- a/components/zcash_address/src/kind/unified/address.rs
+++ b/components/zcash_address/src/kind/unified/address.rs
@@ -33,7 +33,7 @@ impl TryFrom<(u32, &[u8])> for Receiver {
             }),
         }
         .map_err(|e| {
-            ParseError::InvalidEncoding(format!("Invalid address for typecode {}: {}", typecode, e))
+            ParseError::InvalidEncoding(format!("Invalid address for typecode {typecode}: {e}"))
         })
     }
 }

--- a/components/zcash_address/src/kind/unified/fvk.rs
+++ b/components/zcash_address/src/kind/unified/fvk.rs
@@ -72,7 +72,7 @@ impl TryFrom<(u32, &[u8])> for Fvk {
             Typecode::Unknown(_) => Ok(Fvk::Unknown { typecode, data }),
         }
         .map_err(|e| {
-            ParseError::InvalidEncoding(format!("Invalid fvk for typecode {}: {:?}", typecode, e))
+            ParseError::InvalidEncoding(format!("Invalid fvk for typecode {typecode}: {e:?}"))
         })
     }
 }
@@ -434,7 +434,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            format!("{:?}", ufvk),
+            format!("{ufvk:?}"),
             "Ufvk([Fvk::P2pkh(\"...\"), Fvk::Unknown { typecode: 7, data: \"...\" }])"
         );
     }

--- a/components/zcash_address/src/kind/unified/ivk.rs
+++ b/components/zcash_address/src/kind/unified/ivk.rs
@@ -77,7 +77,7 @@ impl TryFrom<(u32, &[u8])> for Ivk {
             Typecode::Unknown(_) => Ok(Ivk::Unknown { typecode, data }),
         }
         .map_err(|e| {
-            ParseError::InvalidEncoding(format!("Invalid ivk for typecode {}: {:?}", typecode, e))
+            ParseError::InvalidEncoding(format!("Invalid ivk for typecode {typecode}: {e:?}"))
         })
     }
 }
@@ -412,7 +412,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            format!("{:?}", uivk),
+            format!("{uivk:?}"),
             "Uivk([Ivk::Sapling(\"...\"), Ivk::Unknown { typecode: 9, data: \"...\" }])"
         );
     }

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -183,7 +183,7 @@ impl ZcashAddress {
     /// [`Display` implementation]: core::fmt::Display
     /// [`address.to_string()`]: alloc::string::ToString
     pub fn encode(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     /// Attempts to parse the given string as a Zcash address.

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- MSRV is now 1.88
+
 ## [0.4.0] - 2026-04-23
 
 ### Added

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -14,6 +14,9 @@ workspace.
 - `zcash_protocol::consensus::OrchardProtocolRevision`
 - `zcash_protocol::consensus::BranchId::orchard_protocol_revision`
 
+### Changed
+- MSRV is now 1.88
+
 ## [0.10.0-pre.0] - 2026-06-30
 
 This release sets the NU6.3 activation height to 4134000 on testnet.

--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -11,6 +11,7 @@ workspace.
 ## [Unreleased]
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`.
 
 ## [0.8.0] - 2026-06-02

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,6 +11,7 @@ workspace.
 ## [0.8.0] - PLANNED
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_transparent 0.9.0-pre.0`,
   `zcash_primitives 0.29.0-pre.0`, `zcash_proofs 0.29.0-pre.0`.
 - The empty states of the transparent, Sapling, Orchard, and Ironwood bundles

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.88"
 components = [ "clippy", "rustfmt" ]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -494,6 +494,12 @@ criteria = "safe-to-deploy"
 delta = "0.4.4 -> 0.4.5"
 notes = "New uses of unsafe look reasonable."
 
+[[audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+
 [[audits.num_enum]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -992,6 +998,12 @@ delta = "1.0.60 -> 1.0.61"
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.0.61 -> 1.0.63"
+
+[[audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
 
 [[audits.tokio-stream]]
 who = "Daira-Emma Hopwood <daira@jacaranda.org>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -41,6 +41,7 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.orchard]
+audit-as-crates-io = true
 
 [policy.pczt]
 audit-as-crates-io = true
@@ -1082,15 +1083,7 @@ version = "1.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
-version = "0.1.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
 version = "0.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-syntax]]
-version = "0.6.26"
 criteria = "safe-to-deploy"
 
 [[exemptions.retry-error]]
@@ -1158,7 +1151,7 @@ version = "0.101.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
-version = "0.103.1"
+version = "0.103.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.rusty-fork]]
@@ -1338,7 +1331,11 @@ version = "2.0.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
-version = "0.3.23"
+version = "0.3.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.31"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinytemplate]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -71,13 +71,6 @@ user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
 
-[[publisher.orchard]]
-version = "0.15.0-pre.2"
-when = "2026-07-03"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.pczt]]
 version = "0.7.0"
 when = "2026-06-03"
@@ -871,6 +864,12 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Some unsafe code, but not more than before. Nothing awry."
+
 [[audits.bytecode-alliance.audits.miniz_oxide]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -891,11 +890,23 @@ criteria = "safe-to-deploy"
 version = "0.46.0"
 notes = "one use of unsafe to call windows specific api to get console handle."
 
-[[audits.bytecode-alliance.audits.overload]]
-who = "Pat Hickey <phickey@fastly.com>"
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.1.1"
-notes = "small crate, only defines macro-rules!, nicely documented as well"
+delta = "0.46.0 -> 0.50.1"
+notes = "Lots of stylistic/rust-related changes, plus new features, but nothing out of the ordrinary."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.50.1 -> 0.50.3"
+notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
 
 [[audits.bytecode-alliance.audits.pem-rfc7468]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -2660,6 +2671,19 @@ otherwise the unsafety is documented and left to the caller to verify.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.11 -> 0.4.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.8"
+notes = "New unsafe code is properly guarded"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.digest]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -2934,6 +2958,13 @@ side-effectful std functions, etc.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.num-integer]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"
@@ -3041,18 +3072,6 @@ criteria = "safe-to-deploy"
 delta = "1.5.3 -> 1.6.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.regex-syntax]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.26 -> 0.6.27"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.regex-syntax]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.27 -> 0.6.28"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.serde]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -3151,17 +3170,6 @@ version = "2.5.0"
 notes = "The goal is to provide some constant-time correctness for cryptographic implementations. The approach is reasonable, it is known to be insufficient but this is pointed out in the documentation."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.time]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.3.23 -> 0.3.36"
-notes = """
-There's a bit of new unsafe code that is self-imposed because they now assert
-that ordinals are non-zero. All unsafe code was checked to ensure that the
-invariants claimed were true.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.time-core]]
 who = "Kershaw Chang <kershaw@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3180,22 +3188,17 @@ criteria = "safe-to-deploy"
 delta = "0.1.1 -> 0.1.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.time-macros]]
-who = "Kershaw Chang <kershaw@mozilla.com>"
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
 criteria = "safe-to-deploy"
-version = "0.2.6"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.time-macros]]
-who = "Kershaw Chang <kershaw@mozilla.com>"
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
 criteria = "safe-to-deploy"
-delta = "0.2.6 -> 0.2.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.time-macros]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.10 -> 0.2.18"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.tinystr]]
@@ -3274,6 +3277,18 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
 delta = "0.1.30 -> 0.1.33"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-subscriber]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.3.17 -> 0.3.19"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-subscriber]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.3.19 -> 0.3.20"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.unicode-xid]]
@@ -3828,12 +3843,6 @@ criteria = "safe-to-deploy"
 delta = "0.4.3 -> 0.4.6"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.regex-syntax]]
-who = "Sean Bowe <ewillbefull@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.6.28 -> 0.6.29"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
 [[audits.zcash.audits.rustc-demangle]]
 who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
@@ -4033,12 +4042,6 @@ who = "Daira-Emma Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 delta = "1.35.1 -> 1.37.0"
 notes = "Cursory review, but new and changed uses of `unsafe` code look fine, as far as I can see."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.tracing-subscriber]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.3.17 -> 0.3.18"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.try-lock]]

--- a/zcash/CHANGELOG.md
+++ b/zcash/CHANGELOG.md
@@ -8,7 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- MSRV is now 1.85.1.
+- MSRV is now 1.88
 - Migrated to `zcash_primitives 0.29.0-pre.0`.
 
 ### Fixed

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -282,6 +282,7 @@ workspace.
   this option must be executed with a matching unpadded builder configuration.
 
 ### Changed
+- MSRV is now 1.88
 - `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes an
   `orchard_pool_bundle_type` argument (behind the `pczt` feature flag) selecting
   the transactional bundle type for the Orchard and Ironwood bundles; it must

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -136,9 +136,6 @@ serde = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 webpki-roots = { workspace = true, optional = true }
 
-# Workaround for https://anonticket.torproject.org/user/projects/arti/issues/pending/4028/
-time-core.workspace = true
-
 # Dependencies used internally:
 # (Breaking upgrades to these are usually backwards-compatible, but check MSRVs.)
 # - Boilerplate

--- a/zcash_client_backend/src/data_api/defaults.rs
+++ b/zcash_client_backend/src/data_api/defaults.rs
@@ -106,14 +106,13 @@ pub fn find_account_for_address<W: WalletRead, P: consensus::Parameters>(
             if stored == address {
                 return Ok(Some(acc_id));
             }
-            if let Address::Unified(stored_ua) = stored {
-                if stored_ua
+            if let Address::Unified(stored_ua) = stored
+                && stored_ua
                     .as_understood_receivers()
                     .iter()
                     .any(|r| r.corresponds(&zcash_address))
-                {
-                    return Ok(Some(acc_id));
-                }
+            {
+                return Ok(Some(acc_id));
             }
         }
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -2797,21 +2797,19 @@ fn fake_compact_block_spending<P: consensus::Parameters, Fvk: TestFvk>(
                 done = true;
             }
 
-            if !done {
-                if let Some(recipient) = ua.sapling() {
-                    ctx.outputs.push(
-                        compact_sapling_output(
-                            params,
-                            height,
-                            *recipient,
-                            value,
-                            Some(::sapling::keys::OutgoingViewingKey(ovk_bytes)),
-                            &mut rng,
-                        )
-                        .0,
-                    );
-                    done = true;
-                }
+            if !done && let Some(recipient) = ua.sapling() {
+                ctx.outputs.push(
+                    compact_sapling_output(
+                        params,
+                        height,
+                        *recipient,
+                        value,
+                        Some(::sapling::keys::OutgoingViewingKey(ovk_bytes)),
+                        &mut rng,
+                    )
+                    .0,
+                );
+                done = true;
             }
             if !done {
                 panic!("No supported shielded receiver to send funds to");

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2293,7 +2293,7 @@ pub fn spend_all_funds_single_step_proposed_transfer<T: ShieldedPoolTester>(
             Some(m) if m == &Memo::Empty => {
                 found_sent_empty_memo = true;
             }
-            Some(other) => panic!("Unexpected memo value: {:?}", other),
+            Some(other) => panic!("Unexpected memo value: {other:?}"),
             None => panic!("Memo should not be stored as NULL"),
         }
     }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -908,12 +908,12 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                             // transaction version was explicitly requested that cannot carry an
                             // Ironwood bundle, reject the proposal here rather than constructing one
                             // that could only fail at build time.
-                            if let Some(v) = proposed_version {
-                                if !v.has_ironwood() {
-                                    return Err(
-                                        ProposalError::OrchardReceiverRequiresIronwood(v).into()
-                                    );
-                                }
+                            if let Some(v) = proposed_version
+                                && !v.has_ironwood()
+                            {
+                                return Err(
+                                    ProposalError::OrchardReceiverRequiresIronwood(v).into()
+                                );
                             }
                             PoolType::IRONWOOD
                         } else {
@@ -1321,32 +1321,32 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     // defensive fallback. The common case (fee estimate was close) is
                     // a no-op.
                     #[cfg(feature = "transparent-inputs")]
-                    if let Some(transparent) = spend_policy.transparent() {
-                        if required > amount_at_transparent_gather {
-                            let address_allow_list = transparent.address_allow_list();
-                            transparent_inputs = wallet_db
-                                .select_spendable_transparent_outputs(
-                                    account,
-                                    target_height,
-                                    confirmations_policy,
-                                    transparent.coinbase().into(),
-                                    address_allow_list.as_deref(),
-                                    TargetValue::AtLeast(required),
-                                    shielding_max_inputs(self.shielding_block_space_percent),
-                                    &StandardFeeRule::Zip317,
-                                )
-                                .map_err(InputSelectorError::DataSource)?
-                                .into_iter()
-                                // Do not re-introduce outputs previously pruned as dust; the
-                                // value they would contribute is (approximately) consumed by
-                                // their own fee cost, so their absence does not meaningfully
-                                // reduce the gathered value.
-                                .filter(|utxo| !transparent_dust.contains(utxo.outpoint()))
-                                .map(|utxo| utxo.redact_account_data())
-                                .collect::<Vec<_>>();
-                            amount_at_transparent_gather = required;
-                            transparent_inputs_changed = true;
-                        }
+                    if let Some(transparent) = spend_policy.transparent()
+                        && required > amount_at_transparent_gather
+                    {
+                        let address_allow_list = transparent.address_allow_list();
+                        transparent_inputs = wallet_db
+                            .select_spendable_transparent_outputs(
+                                account,
+                                target_height,
+                                confirmations_policy,
+                                transparent.coinbase().into(),
+                                address_allow_list.as_deref(),
+                                TargetValue::AtLeast(required),
+                                shielding_max_inputs(self.shielding_block_space_percent),
+                                &StandardFeeRule::Zip317,
+                            )
+                            .map_err(InputSelectorError::DataSource)?
+                            .into_iter()
+                            // Do not re-introduce outputs previously pruned as dust; the
+                            // value they would contribute is (approximately) consumed by
+                            // their own fee cost, so their absence does not meaningfully
+                            // reduce the gathered value.
+                            .filter(|utxo| !transparent_dust.contains(utxo.outpoint()))
+                            .map(|utxo| utxo.redact_account_data())
+                            .collect::<Vec<_>>();
+                        amount_at_transparent_gather = required;
+                        transparent_inputs_changed = true;
                     }
                 }
                 Err(other) => return Err(InputSelectorError::Change(other)),

--- a/zcash_client_backend/src/tor/http/cryptex.rs
+++ b/zcash_client_backend/src/tor/http/cryptex.rs
@@ -221,13 +221,13 @@ impl Client {
         };
         match trusted_res {
             Ok(trusted) => {
-                if rates.len() % 2 != 0 {
+                if !rates.len().is_multiple_of(2) {
                     evict_random(&mut rates);
                 }
                 rates.push(trusted.exchange_rate());
             }
             Err(e) => {
-                if rates.len() % 2 == 0 {
+                if rates.len().is_multiple_of(2) {
                     evict_random(&mut rates);
                 }
                 errors.push(e);
@@ -240,7 +240,7 @@ impl Client {
             Err(errors.into_iter().next().expect("All requests failed"))
         } else {
             // We have an odd number of rates; take the median.
-            assert!(rates.len() % 2 != 0);
+            assert!(!rates.len().is_multiple_of(2));
             rates.sort();
             let median = rates.len() / 2;
             Ok(rates[median])

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -95,6 +95,7 @@ workspace.
   commitment tree shard tables.
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`,
   `zcash_transparent 0.9.0-pre.0`, `zcash_keys 0.15.0-pre.0`,
   `zcash_primitives 0.29.0-pre.0`, `zcash_proofs 0.29.0-pre.0`.

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -1242,10 +1242,10 @@ fn find_account_for_shielded_address<P: consensus::Parameters>(
                 "Not a valid Zcash recipient address".to_owned(),
             ))
         })?;
-        if let Address::Unified(stored_ua) = stored {
-            if address_receiver_matches_ua(address, &stored_ua, params) {
-                return Ok(Some(AccountUuid::from_uuid(row_uuid)));
-            }
+        if let Address::Unified(stored_ua) = stored
+            && address_receiver_matches_ua(address, &stored_ua, params)
+        {
+            return Ok(Some(AccountUuid::from_uuid(row_uuid)));
         }
     }
 
@@ -3437,35 +3437,34 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                 if _pool == &PoolType::Transparent {
                     let address = Address::try_from_zcash_address(params, _zaddr.clone())
                         .expect("recipient is an understood Zcash address.");
-                    if let Some(taddr) = address.to_transparent_address() {
-                        if transparent::find_account_uuid_for_transparent_address(
+                    if let Some(taddr) = address.to_transparent_address()
+                        && transparent::find_account_uuid_for_transparent_address(
                             conn, params, &taddr,
                         )?
                         .is_some()
-                        {
-                            transparent::put_transparent_output(
-                                conn,
-                                params,
-                                gap_limits,
-                                &WalletTransparentOutput::from_parts(
-                                    OutPoint::new(
-                                        sent_tx.tx().txid().into(),
-                                        u32::try_from(output.output_index())
-                                            .expect("output index fits into a u32")
-                                    ),
-                                    TxOut::new(output.value(), taddr.script().into()),
-                                    None,
-                                    None,
-                                    Some(TransparentKeyScope::EXTERNAL),
-                                    Some(*sent_tx.funding_account()),
-                                )
-                                .expect(
-                                    "can extract a recipient address from an internal address script",
+                    {
+                        transparent::put_transparent_output(
+                            conn,
+                            params,
+                            gap_limits,
+                            &WalletTransparentOutput::from_parts(
+                                OutPoint::new(
+                                    sent_tx.tx().txid().into(),
+                                    u32::try_from(output.output_index())
+                                        .expect("output index fits into a u32"),
                                 ),
-                                sent_tx.target_height().into(),
-                                true,
-                            )?;
-                        }
+                                TxOut::new(output.value(), taddr.script().into()),
+                                None,
+                                None,
+                                Some(TransparentKeyScope::EXTERNAL),
+                                Some(*sent_tx.funding_account()),
+                            )
+                            .expect(
+                                "can extract a recipient address from an internal address script",
+                            ),
+                            sent_tx.target_height().into(),
+                            true,
+                        )?;
                     }
                 }
             }
@@ -4149,55 +4148,54 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     if let Some(max_scanned_height) = block_max_scanned(conn, params)
         .map_err(RewindError::DataSource)?
         .map(|m| m.block_height())
+        && target_height < max_scanned_height
     {
-        if target_height < max_scanned_height {
-            // Compute the floor height of the pruning window.
-            let pruning_floor = max_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
-            let truncation_target = target_height.max(pruning_floor);
+        // Compute the floor height of the pruning window.
+        let pruning_floor = max_scanned_height.saturating_sub(PRUNING_DEPTH - 1);
+        let truncation_target = target_height.max(pruning_floor);
 
-            // Determine the minimum sapling and orchard checkpoints within the pruning window.
-            let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+        // Determine the minimum sapling and orchard checkpoints within the pruning window.
+        let sapling_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
+            conn,
+            crate::SAPLING_TABLES_PREFIX,
+            truncation_target,
+        )
+        .map_err(ShardTreeError::Storage)
+        .map_err(SqliteClientError::from)
+        .map_err(RewindError::DataSource)?;
+
+        #[cfg(feature = "orchard")]
+        {
+            // Check that Orchard checkpoint matches the Sapling checkpoint. These should
+            // always match unless the database is corrupted.
+            let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
                 conn,
-                crate::SAPLING_TABLES_PREFIX,
+                crate::ORCHARD_TABLES_PREFIX,
                 truncation_target,
             )
             .map_err(ShardTreeError::Storage)
             .map_err(SqliteClientError::from)
             .map_err(RewindError::DataSource)?;
-
-            #[cfg(feature = "orchard")]
-            {
-                // Check that Orchard checkpoint matches the Sapling checkpoint. These should
-                // always match unless the database is corrupted.
-                let orchard_window_floor = commitment_tree::min_checkpoint_id_at_or_above(
-                    conn,
-                    crate::ORCHARD_TABLES_PREFIX,
-                    truncation_target,
-                )
-                .map_err(ShardTreeError::Storage)
-                .map_err(SqliteClientError::from)
-                .map_err(RewindError::DataSource)?;
-                if orchard_window_floor != sapling_window_floor {
-                    return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
-                        "Sapling and Orchard should have the same checkpoints".into(),
-                    )));
-                }
+            if orchard_window_floor != sapling_window_floor {
+                return Err(RewindError::DataSource(SqliteClientError::CorruptedData(
+                    "Sapling and Orchard should have the same checkpoints".into(),
+                )));
             }
-
-            // Combine the per-pool floors by taking the shallower (larger height).
-            let truncation_height = sapling_window_floor.unwrap_or(pruning_floor);
-
-            // Use `truncate_to_height_internal` to perform full truncation of data within the
-            // pruning window.
-            truncate_to_height_internal(
-                conn,
-                params,
-                #[cfg(feature = "transparent-inputs")]
-                gap_limits,
-                truncation_height,
-            )
-            .map_err(RewindError::DataSource)?;
         }
+
+        // Combine the per-pool floors by taking the shallower (larger height).
+        let truncation_height = sapling_window_floor.unwrap_or(pruning_floor);
+
+        // Use `truncate_to_height_internal` to perform full truncation of data within the
+        // pruning window.
+        truncate_to_height_internal(
+            conn,
+            params,
+            #[cfg(feature = "transparent-inputs")]
+            gap_limits,
+            truncation_height,
+        )
+        .map_err(RewindError::DataSource)?;
     }
 
     // Overwrite the scan-queue range above the rewind target with a `Historic` rescan range,
@@ -4209,20 +4207,20 @@ pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     // those whose priority would dominate `Historic` even under a forced rescan
     // (`ChainTip`, `OpenAdjacent`, `FoundNote`, `Verify`); `Ignored` is the lowest priority
     // and cannot overwrite anything.
-    if let Some(t) = chain_tip {
-        if target_height < t {
-            let rescan_range = (target_height + 1)..(t + 1);
-            replace_queue_entries::<SqliteClientError>(
-                conn,
-                &rescan_range,
-                std::iter::once(ScanRange::from_parts(
-                    rescan_range.clone(),
-                    ScanPriority::Historic,
-                )),
-                true,
-            )
-            .map_err(RewindError::DataSource)?;
-        }
+    if let Some(t) = chain_tip
+        && target_height < t
+    {
+        let rescan_range = (target_height + 1)..(t + 1);
+        replace_queue_entries::<SqliteClientError>(
+            conn,
+            &rescan_range,
+            std::iter::once(ScanRange::from_parts(
+                rescan_range.clone(),
+                ScanPriority::Historic,
+            )),
+            true,
+        )
+        .map_err(RewindError::DataSource)?;
     }
 
     let new_sapling_tree_size: u64 = chain_state.final_sapling_tree().tree_size();
@@ -4641,15 +4639,15 @@ pub(crate) fn queue_transparent_input_retrieval<AccountId>(
     tx_ref: TxRef,
     d_tx: &DecryptedTransaction<Transaction, AccountId>,
 ) -> Result<(), SqliteClientError> {
-    if let Some(b) = d_tx.tx().transparent_bundle() {
-        if !b.is_coinbase() {
-            // queue the transparent inputs for enhancement
-            queue_tx_retrieval(
-                conn,
-                b.vin.iter().map(|txin| *txin.prevout().txid()),
-                Some(tx_ref),
-            )?;
-        }
+    if let Some(b) = d_tx.tx().transparent_bundle()
+        && !b.is_coinbase()
+    {
+        // queue the transparent inputs for enhancement
+        queue_tx_retrieval(
+            conn,
+            b.vin.iter().map(|txin| *txin.prevout().txid()),
+            Some(tx_ref),
+        )?;
     }
 
     Ok(())

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -641,20 +641,18 @@ fn init_wallet_db_internal<
     // but unfortunately `schemer` does not currently expose its DAG of migrations. As a
     // consequence, the caller has to choose whether or not this check should be performed
     // based upon which migrations they're asking to apply.
-    if verify_seed_relevance {
-        if let Some(seed) = seed {
-            match wdb
-                .seed_relevance_to_derived_accounts(&seed)
-                .map_err(sqlite_client_error_to_wallet_migration_error)?
-            {
-                SeedRelevance::Relevant { .. } => (),
-                // Every seed is relevant to a wallet with no accounts; this is most likely a
-                // new wallet database being initialized for the first time.
-                SeedRelevance::NoAccounts => (),
-                // No seed is relevant to a wallet that only has imported accounts.
-                SeedRelevance::NotRelevant | SeedRelevance::NoDerivedAccounts => {
-                    return Err(WalletMigrationError::SeedNotRelevant.into());
-                }
+    if verify_seed_relevance && let Some(seed) = seed {
+        match wdb
+            .seed_relevance_to_derived_accounts(&seed)
+            .map_err(sqlite_client_error_to_wallet_migration_error)?
+        {
+            SeedRelevance::Relevant { .. } => (),
+            // Every seed is relevant to a wallet with no accounts; this is most likely a
+            // new wallet database being initialized for the first time.
+            SeedRelevance::NoAccounts => (),
+            // No seed is relevant to a wallet that only has imported accounts.
+            SeedRelevance::NotRelevant | SeedRelevance::NoDerivedAccounts => {
+                return Err(WalletMigrationError::SeedNotRelevant.into());
             }
         }
     }

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -56,43 +56,42 @@ fn init_accounts<P: consensus::Parameters>(
     while let Some(row) = rows.next()? {
         let account_id = AccountRef(row.get(0)?);
         let ufvk_str: Option<String> = row.get(1)?;
-        if let Some(ufvk_str) = ufvk_str {
-            if let Some(tfvk) = UnifiedFullViewingKey::decode(params, &ufvk_str)
+        if let Some(ufvk_str) = ufvk_str
+            && let Some(tfvk) = UnifiedFullViewingKey::decode(params, &ufvk_str)
                 .map_err(SqliteClientError::CorruptedData)?
                 .transparent()
-            {
-                let ephemeral_ivk = tfvk.derive_ephemeral_ivk().map_err(|_| {
-                    SqliteClientError::CorruptedData(
-                        "Unexpected failure to derive ephemeral transparent IVK".to_owned(),
-                    )
-                })?;
+        {
+            let ephemeral_ivk = tfvk.derive_ephemeral_ivk().map_err(|_| {
+                SqliteClientError::CorruptedData(
+                    "Unexpected failure to derive ephemeral transparent IVK".to_owned(),
+                )
+            })?;
 
-                let mut ea_insert = transaction.prepare(
-                    "INSERT INTO ephemeral_addresses (account_id, address_index, address)
+            let mut ea_insert = transaction.prepare(
+                "INSERT INTO ephemeral_addresses (account_id, address_index, address)
                      VALUES (:account_id, :address_index, :address)",
-                )?;
+            )?;
 
-                // NB: we have reduced the initial space of generated ephemeral addresses
-                // from 20 addresses to 5, as ephemeral addresses should always be used in
-                // a transaction immediately after being reserved, and as a consequence
-                // there is no significant benefit in having a larger gap limit.
-                for i in 0..ephemeral_gap_limit {
-                    let address = ephemeral_ivk
-                        .derive_ephemeral_address(
-                            NonHardenedChildIndex::from_index(i).expect("index is valid"),
+            // NB: we have reduced the initial space of generated ephemeral addresses
+            // from 20 addresses to 5, as ephemeral addresses should always be used in
+            // a transaction immediately after being reserved, and as a consequence
+            // there is no significant benefit in having a larger gap limit.
+            for i in 0..ephemeral_gap_limit {
+                let address = ephemeral_ivk
+                    .derive_ephemeral_address(
+                        NonHardenedChildIndex::from_index(i).expect("index is valid"),
+                    )
+                    .map_err(|_| {
+                        AddressGenerationError::InvalidTransparentChildIndex(
+                            DiversifierIndex::from(i),
                         )
-                        .map_err(|_| {
-                            AddressGenerationError::InvalidTransparentChildIndex(
-                                DiversifierIndex::from(i),
-                            )
-                        })?;
-
-                    ea_insert.execute(named_params! {
-                        ":account_id": account_id.0,
-                        ":address_index": i,
-                        ":address": address.encode(params)
                     })?;
-                }
+
+                ea_insert.execute(named_params! {
+                    ":account_id": account_id.0,
+                    ":address_index": i,
+                    ":address": address.encode(params)
+                })?;
             }
         }
     }

--- a/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
@@ -60,8 +60,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
             let uivk = if let Some(ufvk_str) = ufvk_str {
                 let ufvk = UnifiedFullViewingKey::decode(&self.params, &ufvk_str).map_err(|e| {
                     WalletMigrationError::CorruptedData(format!(
-                        "Unable to parse UFVK for account {}: {}",
-                        account_id, e
+                        "Unable to parse UFVK for account {account_id}: {e}"
                     ))
                 })?;
                 ufvk.to_unified_incoming_viewing_key()
@@ -69,8 +68,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                 zcash_keys::keys::UnifiedIncomingViewingKey::decode(&self.params, &uivk_str)
                     .map_err(|e| {
                         WalletMigrationError::CorruptedData(format!(
-                            "Unable to parse UIVK for account {}: {}",
-                            account_id, e
+                            "Unable to parse UIVK for account {account_id}: {e}"
                         ))
                     })?
             };

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -134,7 +134,7 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                     )
                 })?;
 
-                if block_height % 1000 == 0 {
+                if block_height.is_multiple_of(1000) {
                     debug!(height = block_height, "Migrating tree data to shardtree");
                 }
                 trace!(

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -167,10 +167,9 @@ impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
                                                 &self._params,
                                                 &uivk_str,
                                             )?
+                                            && legacy_taddr == address
                                         {
-                                            if legacy_taddr == address {
-                                                return Ok(Some(account_id));
-                                            }
+                                            return Ok(Some(account_id));
                                         }
                                     }
 
@@ -254,15 +253,15 @@ fn queue_transparent_input_retrieval<AccountId>(
     tx_ref: TxRef,
     d_tx: &DecryptedTransaction<Transaction, AccountId>,
 ) -> Result<(), SqliteClientError> {
-    if let Some(b) = d_tx.tx().transparent_bundle() {
-        if !b.is_coinbase() {
-            // queue the transparent inputs for enhancement
-            queue_tx_retrieval(
-                conn,
-                b.vin.iter().map(|txin| *txin.prevout().txid()),
-                Some(tx_ref),
-            )?;
-        }
+    if let Some(b) = d_tx.tx().transparent_bundle()
+        && !b.is_coinbase()
+    {
+        // queue the transparent inputs for enhancement
+        queue_tx_retrieval(
+            conn,
+            b.vin.iter().map(|txin| *txin.prevout().txid()),
+            Some(tx_ref),
+        )?;
     }
 
     Ok(())

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -213,8 +213,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
             .map(|address_index| {
                 NonHardenedChildIndex::from_index(address_index).ok_or(
                     SqliteClientError::CorruptedData(format!(
-                        "{} is not a valid transparent child index",
-                        address_index
+                        "{address_index} is not a valid transparent child index"
                     )),
                 )
             })
@@ -277,7 +276,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
                                     })
                                 })?;
                         let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| {
-                            SqliteClientError::CorruptedData(format!("Invalid public key: {}", e))
+                            SqliteClientError::CorruptedData(format!("Invalid public key: {e}"))
                         })?;
                         Ok(TransparentAddressMetadata::standalone_p2pkh(
                             pubkey,
@@ -314,8 +313,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
                     let imported_transparent_receiver_script =
                         script::Redeem::parse(&Code(rs_bytes.clone())).map_err(|e| {
                             SqliteClientError::CorruptedData(format!(
-                                "Invalid redeem script: {:?}",
-                                e
+                                "Invalid redeem script: {e:?}"
                             ))
                         })?;
 
@@ -1470,14 +1468,10 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
         // estimation so that the ZIP 317 fee calculator can handle P2SH inputs.
         if let Ok(Some(rs_bytes)) =
             row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
+            && let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes))
+            && let Some(input_size) = transparent::builder::p2sh_input_serialized_len(&from_chain)
         {
-            if let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes)) {
-                if let Some(input_size) =
-                    transparent::builder::p2sh_input_serialized_len(&from_chain)
-                {
-                    output = output.with_known_input_size(input_size);
-                }
-            }
+            output = output.with_known_input_size(input_size);
         }
         utxos.push(output);
     }
@@ -2420,8 +2414,7 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
                                     let imported_transparent_receiver_script =
                                         script::Redeem::parse(&Code(rs_bytes.clone())).map_err(|e| {
                                             SqliteClientError::CorruptedData(format!(
-                                                "Invalid redeem script: {:?}",
-                                                e
+                                                "Invalid redeem script: {e:?}"
                                             ))
                                         })?;
 
@@ -2476,16 +2469,15 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
 
     if let Some((legacy_taddr, address_index)) =
         get_legacy_transparent_address(params, conn, account_uuid)?
+        && &legacy_taddr == address
     {
-        if &legacy_taddr == address {
-            let metadata = TransparentAddressMetadata::derived(
-                Scope::External.into(),
-                address_index,
-                Exposure::CannotKnow,
-                None,
-            );
-            return Ok(Some(metadata));
-        }
+        let metadata = TransparentAddressMetadata::derived(
+            Scope::External.into(),
+            address_index,
+            Exposure::CannotKnow,
+            None,
+        );
+        return Ok(Some(metadata));
     }
 
     Ok(None)
@@ -2531,10 +2523,10 @@ pub(crate) fn find_account_uuid_for_transparent_address<P: consensus::Parameters
     // look up the legacy address for each account in the wallet, and check whether it
     // matches the address for the received UTXO.
     for &account_id in account_ids.iter() {
-        if let Some((legacy_taddr, _)) = get_legacy_transparent_address(params, conn, account_id)? {
-            if &legacy_taddr == address {
-                return Ok(Some((account_id, KeyScope::EXTERNAL)));
-            }
+        if let Some((legacy_taddr, _)) = get_legacy_transparent_address(params, conn, account_id)?
+            && &legacy_taddr == address
+        {
+            return Ok(Some((account_id, KeyScope::EXTERNAL)));
         }
     }
 

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -7,7 +7,7 @@ and this library adheres to Rust's notion of
 
 ## [0.5.0-pre.0] - 2026-06-30
 ### Changed
-- MSRV is now 1.85.1.
+- MSRV is now 1.88
 - `zcash_history::MAX_NODE_DATA_SIZE` is now 317 bytes and the derived
   `zcash_history::MAX_ENTRY_SIZE` is now 326 bytes, to account for Ironwood
   history node metadata.

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -10,6 +10,7 @@ workspace.
 ## [0.15.0-pre.0] - 2026-06-30
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`,
   `zcash_transparent 0.9.0-pre.0`.
 

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -2430,7 +2430,7 @@ mod tests {
     fn usk_debug_redaction() {
         let seed = [0u8; 64];
         let usk = UnifiedSpendingKey::from_seed(&MAIN_NETWORK, &seed, AccountId::ZERO).unwrap();
-        assert!(format!("{:?}", usk).contains("\"...\""));
+        assert!(format!("{usk:?}").contains("\"...\""));
     }
 
     #[test]
@@ -2466,7 +2466,7 @@ mod tests {
         )
         .unwrap();
 
-        let debug_str = format!("{:?}", ufvk);
+        let debug_str = format!("{ufvk:?}");
         #[cfg(feature = "transparent-inputs")]
         assert!(debug_str.contains("transparent: Some(\"...\")"));
         #[cfg(feature = "sapling")]
@@ -2507,7 +2507,7 @@ mod tests {
             orchard,
         );
 
-        let debug_str = format!("{:?}", uivk);
+        let debug_str = format!("{uivk:?}");
         #[cfg(feature = "sapling")]
         assert!(debug_str.contains("sapling: Some(\"...\")"));
         #[cfg(feature = "orchard")]

--- a/zcash_keys/src/keys/transparent.rs
+++ b/zcash_keys/src/keys/transparent.rs
@@ -465,7 +465,7 @@ mod tests {
             secret,
             compressed: true,
         };
-        let debug_str = format!("{:?}", key);
+        let debug_str = format!("{key:?}");
         assert!(debug_str.contains("secret: \"...\""));
         assert!(debug_str.contains("compressed: true"));
     }

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -14,6 +14,7 @@ workspace.
 - `zcash_primitives::transaction::components::orchard::bundle_version_for_branch`
 
 ### Changed
+- MSRV is now 1.88
 - `zcash_primitives::transaction::components::orchard::read_v5_bundle` now takes
   the consensus branch ID under which the transaction was constructed instead of
   an `orchard::bundle::BundleVersion`; the Orchard bundle version is derived

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -995,10 +995,10 @@ impl Transaction {
             }
         }
 
-        if self.version.has_sapling() {
-            if let Some(bundle) = self.sapling_bundle.as_ref() {
-                writer.write_all(&<[u8; 64]>::from(bundle.authorization().binding_sig))?;
-            }
+        if self.version.has_sapling()
+            && let Some(bundle) = self.sapling_bundle.as_ref()
+        {
+            writer.write_all(&<[u8; 64]>::from(bundle.authorization().binding_sig))?;
         }
 
         Ok(())

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -291,10 +291,10 @@ fn test_sapling_bundle(
         crate::transaction::components::sapling::testing::arb_bundle_for_version(TxVersion::V6);
 
     for _ in 0..100 {
-        if let Some(bundle) = bundle_strategy.new_tree(runner).unwrap().current() {
-            if !bundle.shielded_spends().is_empty() {
-                return bundle;
-            }
+        if let Some(bundle) = bundle_strategy.new_tree(runner).unwrap().current()
+            && !bundle.shielded_spends().is_empty()
+        {
+            return bundle;
         }
     }
 
@@ -311,10 +311,11 @@ fn test_sapling_output_only_bundle(
         crate::transaction::components::sapling::testing::arb_bundle_for_version(TxVersion::V6);
 
     for _ in 0..1000 {
-        if let Some(bundle) = bundle_strategy.new_tree(runner).unwrap().current() {
-            if bundle.shielded_spends().is_empty() && !bundle.shielded_outputs().is_empty() {
-                return bundle;
-            }
+        if let Some(bundle) = bundle_strategy.new_tree(runner).unwrap().current()
+            && bundle.shielded_spends().is_empty()
+            && !bundle.shielded_outputs().is_empty()
+        {
+            return bundle;
         }
     }
 

--- a/zcash_proofs/CHANGELOG.md
+++ b/zcash_proofs/CHANGELOG.md
@@ -11,6 +11,7 @@ workspace.
 ## [0.29.0-pre.0] - 2026-06-30
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_primitives 0.29.0-pre.0`.
 
 ## [0.28.0] - 2026-06-02

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -14,6 +14,7 @@ workspace.
 - `transparent::bundle::OutPoint` now implements `std::hash::Hash`.
 
 ### Changed
+- MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0-pre.0`, `zcash_address 0.13.0-pre.0`.
 
 ### Changed

--- a/zcash_transparent/src/builder.rs
+++ b/zcash_transparent/src/builder.rs
@@ -87,8 +87,7 @@ impl fmt::Display for Error {
             Error::MissingSigningKey => write!(f, "Missing signing key"),
             Error::NullDataTooLong { actual, limit } => write!(
                 f,
-                "Provided null data is longer than the maximum supported length (actual: {}, limit: {})",
-                actual, limit
+                "Provided null data is longer than the maximum supported length (actual: {actual}, limit: {limit})"
             ),
             Error::InputCountMismatch => write!(
                 f,
@@ -96,8 +95,7 @@ impl fmt::Display for Error {
             ),
             Error::InvalidExternalSignature { sig_index } => write!(
                 f,
-                "A provided external signature at index {} was not valid for any transparent input",
-                sig_index
+                "A provided external signature at index {sig_index} was not valid for any transparent input"
             ),
             Error::DuplicateSignature => write!(
                 f,
@@ -822,18 +820,17 @@ impl TransparentSignatureContext<'_, secp256k1::VerifyOnly> {
             let sighash_msg = secp256k1::Message::from_digest(self.sighashes[input_idx]);
 
             // We only support external signatures for P2PKH inputs.
-            if let SpendInfo::P2pkh { pubkey } = &input_info.spend_info {
-                if self
+            if let SpendInfo::P2pkh { pubkey } = &input_info.spend_info
+                && self
                     .secp_ctx
                     .verify_ecdsa(&sighash_msg, signature, pubkey)
                     .is_ok()
-                {
-                    if matched_input_idx.is_some() {
-                        // This signature was already valid for a different input.
-                        return Err(Error::DuplicateSignature);
-                    }
-                    matched_input_idx = Some((input_idx, pubkey));
+            {
+                if matched_input_idx.is_some() {
+                    // This signature was already valid for a different input.
+                    return Err(Error::DuplicateSignature);
                 }
+                matched_input_idx = Some((input_idx, pubkey));
             }
         }
 
@@ -1086,8 +1083,7 @@ mod tests {
         let final_bundle_result = partially_signed_context.finalize_signatures();
         assert!(
             matches!(final_bundle_result, Err(Error::MissingSignatures)),
-            "Should fail with MissingSignatures, but got: {:?}",
-            final_bundle_result
+            "Should fail with MissingSignatures, but got: {final_bundle_result:?}"
         );
     }
 
@@ -1156,7 +1152,7 @@ mod tests {
         };
 
         let result = bundle.apply_signatures(calculate_sighash, &signing_set);
-        assert!(result.is_ok(), "P2SH apply_signatures failed: {:?}", result);
+        assert!(result.is_ok(), "P2SH apply_signatures failed: {result:?}");
     }
 
     #[test]

--- a/zcash_transparent/src/keys.rs
+++ b/zcash_transparent/src/keys.rs
@@ -880,7 +880,7 @@ mod tests {
     fn account_priv_key_debug_redaction() {
         let sk =
             AccountPrivKey::from_seed(&MAIN_NETWORK, &[0u8; 64], zip32::AccountId::ZERO).unwrap();
-        assert_eq!(format!("{:?}", sk), "AccountPrivKey(\"...\")");
+        assert_eq!(format!("{sk:?}"), "AccountPrivKey(\"...\")");
     }
 
     #[test]
@@ -890,19 +890,19 @@ mod tests {
         let account_sk =
             AccountPrivKey::from_seed(&MAIN_NETWORK, &seed, zip32::AccountId::ZERO).unwrap();
         let account_pubkey = account_sk.to_account_pubkey();
-        assert_eq!(format!("{:?}", account_pubkey), "AccountPubKey(\"...\")");
+        assert_eq!(format!("{account_pubkey:?}"), "AccountPubKey(\"...\")");
 
         let external_ivk = account_pubkey.derive_external_ivk().unwrap();
-        assert_eq!(format!("{:?}", external_ivk), "ExternalIvk(\"...\")");
+        assert_eq!(format!("{external_ivk:?}"), "ExternalIvk(\"...\")");
 
         let internal_ivk = account_pubkey.derive_internal_ivk().unwrap();
-        assert_eq!(format!("{:?}", internal_ivk), "InternalIvk(\"...\")");
+        assert_eq!(format!("{internal_ivk:?}"), "InternalIvk(\"...\")");
 
         let ephemeral_ivk = account_pubkey.derive_ephemeral_ivk().unwrap();
-        assert_eq!(format!("{:?}", ephemeral_ivk), "EphemeralIvk(\"...\")");
+        assert_eq!(format!("{ephemeral_ivk:?}"), "EphemeralIvk(\"...\")");
 
         let (internal_ovk, external_ovk) = account_pubkey.ovks_for_shielding();
-        assert_eq!(format!("{:?}", internal_ovk), "InternalOvk(\"...\")");
-        assert_eq!(format!("{:?}", external_ovk), "ExternalOvk(\"...\")");
+        assert_eq!(format!("{internal_ovk:?}"), "InternalOvk(\"...\")");
+        assert_eq!(format!("{external_ovk:?}"), "ExternalOvk(\"...\")");
     }
 }

--- a/zcash_transparent/src/pczt/verify.rs
+++ b/zcash_transparent/src/pczt/verify.rs
@@ -14,10 +14,10 @@ impl super::Input {
                 }
             }
             Some(TransparentAddress::ScriptHash(hash)) => {
-                if let Some(redeem_script) = self.redeem_script() {
-                    if hash[..] != crate::util::hash160::hash(&redeem_script.to_bytes())[..] {
-                        return Err(VerifyError::WrongRedeemScript);
-                    }
+                if let Some(redeem_script) = self.redeem_script()
+                    && hash[..] != crate::util::hash160::hash(&redeem_script.to_bytes())[..]
+                {
+                    return Err(VerifyError::WrongRedeemScript);
                 }
             }
             None => return Err(VerifyError::UnsupportedScriptPubkey),
@@ -39,10 +39,10 @@ impl super::Output {
                 }
             }
             Some(TransparentAddress::ScriptHash(hash)) => {
-                if let Some(redeem_script) = self.redeem_script() {
-                    if hash[..] != crate::util::hash160::hash(&redeem_script.to_bytes())[..] {
-                        return Err(VerifyError::WrongRedeemScript);
-                    }
+                if let Some(redeem_script) = self.redeem_script()
+                    && hash[..] != crate::util::hash160::hash(&redeem_script.to_bytes())[..]
+                {
+                    return Err(VerifyError::WrongRedeemScript);
                 }
             }
             None => return Err(VerifyError::UnsupportedScriptPubkey),


### PR DESCRIPTION
This allows us to update `time` to a version that passes `cargo deny` checks.