### PR TITLE
zcash_client_sqlite: Gate feature-conditional imports to fix clippy warnings

### DIFF
--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -123,11 +123,16 @@ use {
         fees::StandardFeeRule,
         wallet::TransparentAddressMetadata,
     },
-    zcash_keys::{
-        encoding::AddressCodec,
-        keys::transparent::gap_limits::{AddressStore, GapLimits},
-    },
+    zcash_keys::keys::transparent::gap_limits::{AddressStore, GapLimits},
 };
+
+// `AddressCodec` is used only by `find_account_for_ephemeral_address`, which is
+// part of the `WalletTest` surface.
+#[cfg(all(
+    any(test, feature = "test-dependencies"),
+    feature = "transparent-inputs"
+))]
+use zcash_keys::encoding::AddressCodec;
 
 #[cfg(any(test, feature = "test-dependencies"))]
 use {

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -1533,13 +1533,15 @@ mod tests {
     use super::SqliteShardStore;
     use crate::{
         WalletDb,
-        error::SqliteClientError,
         testing::{
             db::{test_clock, test_rng},
             pool::ShieldedPoolPersistence,
         },
         wallet::init::WalletMigrator,
     };
+    // Used only by the orchard-gated `HistoricalWitnessGenerator` type alias below.
+    #[cfg(feature = "orchard")]
+    use crate::error::SqliteClientError;
 
     fn new_tree<T: ShieldedPoolTester + ShieldedPoolPersistence>(
         m: usize,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -455,7 +455,10 @@ pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
 pub(crate) mod tests {
     use std::collections::HashSet;
 
+    // Used only by the orchard-gated note-generation strategies below.
+    #[cfg(feature = "orchard")]
     use proptest::prelude::any;
+    #[cfg(feature = "orchard")]
     use proptest::prop_compose;
     use rusqlite::Connection;
     use secrecy::Secret;

--- a/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
+++ b/zcash_client_sqlite/src/wallet/transparent/ephemeral.rs
@@ -1,21 +1,8 @@
 //! Functions for wallet support of ephemeral transparent addresses.
-use std::{ops::Range, time::SystemTime};
-
 use rand::{RngCore, seq::SliceRandom};
-use rusqlite::{OptionalExtension, named_params};
+use rusqlite::named_params;
 
-use ::transparent::{
-    address::TransparentAddress,
-    keys::{NonHardenedChildIndex, TransparentKeyScope},
-};
-use zcash_client_backend::wallet::{Exposure, TransparentAddressMetadata};
-use zcash_keys::encoding::AddressCodec;
-use zcash_protocol::consensus::{self, BlockHeight};
-
-#[cfg(any(test, feature = "test-dependencies"))]
-use crate::GapLimits;
 use crate::{
-    AccountRef, AccountUuid,
     error::SqliteClientError,
     util::Clock,
     wallet::{
@@ -24,10 +11,42 @@ use crate::{
     },
 };
 
+// Imports used only by the address-metadata helpers, which are compiled only
+// for tests and the `test-dependencies` feature.
+#[cfg(any(test, feature = "test-dependencies"))]
+use crate::{AccountRef, GapLimits};
+#[cfg(any(test, feature = "test-dependencies"))]
+use ::transparent::{
+    address::TransparentAddress,
+    keys::{NonHardenedChildIndex, TransparentKeyScope},
+};
+#[cfg(any(test, feature = "test-dependencies"))]
+use std::{ops::Range, time::SystemTime};
+#[cfg(any(test, feature = "test-dependencies"))]
+use zcash_client_backend::wallet::{Exposure, TransparentAddressMetadata};
+#[cfg(any(test, feature = "test-dependencies"))]
+use zcash_keys::encoding::AddressCodec;
+#[cfg(any(test, feature = "test-dependencies"))]
+use zcash_protocol::consensus::{self, BlockHeight};
+
+// Imports used only by `find_account_for_ephemeral_address_str`, which is
+// compiled only for the transparent-inputs test surface.
+#[cfg(all(
+    any(test, feature = "test-dependencies"),
+    feature = "transparent-inputs"
+))]
+use crate::AccountUuid;
+#[cfg(all(
+    any(test, feature = "test-dependencies"),
+    feature = "transparent-inputs"
+))]
+use rusqlite::OptionalExtension;
+
 use super::next_check_time;
 
 // Returns `TransparentAddressMetadata` in the ephemeral scope for the
 // given address index.
+#[cfg(any(test, feature = "test-dependencies"))]
 pub(crate) fn metadata(
     address_index: NonHardenedChildIndex,
     exposure: Exposure,
@@ -132,6 +151,10 @@ pub(crate) fn get_known_ephemeral_addresses<P: consensus::Parameters>(
 }
 
 /// If this is a known ephemeral address in any account, return its account id.
+#[cfg(all(
+    any(test, feature = "test-dependencies"),
+    feature = "transparent-inputs"
+))]
 pub(crate) fn find_account_for_ephemeral_address_str(
     conn: &rusqlite::Connection,
     address_str: &str,


### PR DESCRIPTION
## Summary

Several imports and helpers in `zcash_client_sqlite` were consumed only by
code compiled under narrower feature sets than the modules that declared them.
As a result, building certain feature combinations produced `unused_imports`
and `dead_code` warnings, for example:

- `cargo clippy -p zcash_client_sqlite --features zewif` (transparent-inputs on,
  test-dependencies off)
- `cargo clippy -p zcash_client_sqlite --all-targets` (default features, orchard
  off)

This gates each item with the exact `cfg` of the code that uses it. No
functional change.

## Changes

- `wallet::transparent::ephemeral`: `metadata` (and the imports it needs) is
  used only by the `test-dependencies`-gated `get_known_ephemeral_addresses`,
  and `find_account_for_ephemeral_address_str` only by the
  `transparent-inputs` test surface. Gated accordingly.
- `lib.rs`: `AddressCodec` is used only by the `WalletTest`-impl method
  `find_account_for_ephemeral_address`; gated to
  `all(any(test, test-dependencies), transparent-inputs)`.
- `wallet::commitment_tree` tests: `SqliteClientError` is used only by the
  `orchard`-gated `HistoricalWitnessGenerator` type alias.
- `wallet::init::migrations` tests: `proptest::prelude::any` and
  `proptest::prop_compose` are used only by the `orchard`-gated note-generation
  strategies.

## Verification

`cargo clippy -p zcash_client_sqlite` is warning-clean across all of:
default, `--features zewif`, `transparent-inputs`, `test-dependencies`,
`spend-index`, `orchard`, and `--all-features`, each also with `--all-targets`.
Affected tests pass under `--all-features`.