### PR TITLE
Make Orchard PCZT cmx optional

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -65,9 +65,11 @@ workspace.
 - PCZT version 2 serialization now omits empty Transparent, Sapling, and
   Orchard bundles.
 - The Orchard PCZT logical model now represents the bundle anchor and per-action
-  `cv_net` as optional fields, matching the version 2 encoding. Parsing resolves
-  absent `cv_net` values from the note values and `rcv`; absent anchors remain
-  absent until another PCZT copy or caller restores them.
+  `cv_net` as optional fields, matching the version 2 encoding. The logical
+  Orchard output model now similarly represents `cmx` as optional. Parsing
+  resolves absent `cv_net` values from the note values and `rcv`, and absent
+  `cmx` values from the output note fields and action spend nullifier; absent
+  anchors remain absent until another PCZT copy or caller restores them.
 - The logical Orchard output model now represents its encrypted note plaintext
   as `pczt::orchard::EncCiphertext`, allowing v2 serialization to carry either
   encrypted ciphertext or a trailing-zero-stripped
@@ -112,6 +114,7 @@ workspace.
   `pczt::roles::redactor::orchard::ActionRedactor::replace_enc_ciphertext_with_memo_plaintext`.
 - `pczt::roles::redactor::orchard::OrchardRedactor::clear_anchor` and
   `pczt::roles::redactor::orchard::ActionRedactor::clear_cv_net`.
+- `pczt::roles::redactor::orchard::ActionRedactor::clear_cmx`.
 - `pczt::v1`, a module providing the version 1 PCZT serialization format via
   `pczt::v1::Pczt`.
 - PCZT version 2 serialization, which encodes the Orchard note plaintext

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -286,12 +286,6 @@ fn recover_memo_plaintext_from_ciphertext_and_action(
         // we return None here to avoid excess sets or clone operations, as the caller need not do anything in this case.
         EncCiphertext::MemoPlaintext(_) => return None,
     };
-    let output = OutputRecoveryData {
-        cmx: action.output.cmx,
-        ephemeral_key: action.output.ephemeral_key,
-        enc_ciphertext,
-    };
-
     let recipient = Option::from(Address::from_raw_address_bytes(
         action.output.recipient.as_ref()?,
     ))?;
@@ -306,7 +300,15 @@ fn recover_memo_plaintext_from_ciphertext_and_action(
     ))?;
 
     let nullifier = Option::from(Nullifier::from_bytes(&action.spend.nullifier))?;
-    let cmx = Option::from(ExtractedNoteCommitment::from_bytes(&action.output.cmx))?;
+    // Memo recovery is best-effort and should not resolve redacted fields.
+    // Callers that want redacted `cmx` restored should use `resolve_fields`.
+    let cmx_bytes = action.output.cmx?;
+    let cmx = Option::from(ExtractedNoteCommitment::from_bytes(&cmx_bytes))?;
+    let output = OutputRecoveryData {
+        cmx: cmx_bytes,
+        ephemeral_key: action.output.ephemeral_key,
+        enc_ciphertext,
+    };
     let compact_action = CompactAction::from_parts(
         nullifier,
         cmx,
@@ -465,7 +467,7 @@ pub struct Output {
     // by the Constructor when adding an output.
     //
     #[getset(get = "pub")]
-    pub(crate) cmx: [u8; 32],
+    pub(crate) cmx: Option<[u8; 32]>,
     #[getset(get = "pub")]
     pub(crate) ephemeral_key: [u8; 32],
     /// The encrypted note plaintext for the output, or the memo plaintext
@@ -716,7 +718,7 @@ pub mod v1 {
                 .ok_or(crate::EncodingError::RequiresV2)?;
 
             Ok(Self {
-                cmx: output.cmx,
+                cmx: output.cmx.ok_or(crate::EncodingError::RequiresV2)?,
                 ephemeral_key: output.ephemeral_key,
                 enc_ciphertext,
                 out_ciphertext: output.out_ciphertext,
@@ -734,7 +736,7 @@ pub mod v1 {
     impl From<Output> for super::Output {
         fn from(output: Output) -> Self {
             Self {
-                cmx: output.cmx,
+                cmx: Some(output.cmx),
                 ephemeral_key: output.ephemeral_key,
                 enc_ciphertext: super::EncCiphertext::Encrypted(output.enc_ciphertext),
                 out_ciphertext: output.out_ciphertext,
@@ -834,7 +836,7 @@ pub(crate) mod v2 {
     #[serde_as]
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub(crate) struct Output {
-        cmx: [u8; 32],
+        cmx: Option<[u8; 32]>,
         ephemeral_key: [u8; 32],
         enc_ciphertext: super::EncCiphertext,
         out_ciphertext: Vec<u8>,
@@ -1025,7 +1027,7 @@ pub(crate) mod v2 {
             MemoPlaintext, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output, Spend,
         };
 
-        fn logical_action(cv_net: Option<[u8; 32]>) -> LogicalAction {
+        fn logical_action(cv_net: Option<[u8; 32]>, cmx: Option<[u8; 32]>) -> LogicalAction {
             LogicalAction {
                 cv_net,
                 spend: Spend {
@@ -1044,7 +1046,7 @@ pub(crate) mod v2 {
                     proprietary: BTreeMap::new(),
                 },
                 output: Output {
-                    cmx: [3; 32],
+                    cmx,
                     ephemeral_key: [4; 32],
                     enc_ciphertext: EncCiphertext::Encrypted(Vec::new()),
                     out_ciphertext: Vec::new(),
@@ -1061,8 +1063,16 @@ pub(crate) mod v2 {
         }
 
         fn logical_bundle(anchor: Option<[u8; 32]>, cv_net: Option<[u8; 32]>) -> LogicalBundle {
+            logical_bundle_with_cmx(anchor, cv_net, Some([3; 32]))
+        }
+
+        fn logical_bundle_with_cmx(
+            anchor: Option<[u8; 32]>,
+            cv_net: Option<[u8; 32]>,
+            cmx: Option<[u8; 32]>,
+        ) -> LogicalBundle {
             LogicalBundle {
-                actions: vec![logical_action(cv_net)],
+                actions: vec![logical_action(cv_net, cmx)],
                 flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
                 value_sum: (0, false),
                 anchor,
@@ -1073,13 +1083,17 @@ pub(crate) mod v2 {
         }
 
         #[test]
-        fn anchor_and_cv_net_round_trip_optional_encoding() {
-            for (anchor, cv_net) in [(None, None), (Some([5; 32]), Some([6; 32]))] {
-                let bundle = logical_bundle(anchor, cv_net);
+        fn anchor_cv_net_and_cmx_round_trip_optional_encoding() {
+            for (anchor, cv_net, cmx) in [
+                (None, None, None),
+                (Some([5; 32]), Some([6; 32]), Some([7; 32])),
+            ] {
+                let bundle = logical_bundle_with_cmx(anchor, cv_net, cmx);
 
                 let encoded = super::Bundle::try_from(bundle.clone()).unwrap();
                 assert_eq!(encoded.anchor, anchor);
                 assert_eq!(encoded.actions[0].cv_net, cv_net);
+                assert_eq!(encoded.actions[0].output.cmx, cmx);
 
                 let decoded = encoded.into_logical().unwrap();
                 assert_eq!(decoded, bundle);
@@ -1177,7 +1191,7 @@ pub(crate) mod v2 {
                     proprietary: BTreeMap::new(),
                 },
                 output: Output {
-                    cmx: ExtractedNoteCommitment::from(note.commitment()).to_bytes(),
+                    cmx: Some(ExtractedNoteCommitment::from(note.commitment()).to_bytes()),
                     ephemeral_key: OrchardDomain::epk_bytes(encryptor.epk()).0,
                     enc_ciphertext: EncCiphertext::Encrypted(
                         encryptor.encrypt_note_plaintext().to_vec(),
@@ -1255,6 +1269,27 @@ pub(crate) mod v2 {
 
         #[cfg(feature = "orchard")]
         #[test]
+        fn resolve_fields_recomputes_cmx() {
+            let action = decryptable_action_with_memo([0; MEMO_SIZE]);
+            let expected_cmx = action.output.cmx;
+            let mut bundle = LogicalBundle {
+                actions: vec![action],
+                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+                value_sum: (0, false),
+                anchor: None,
+                note_version: NoteVersion::V2,
+                zkproof: None,
+                bsk: None,
+            };
+            bundle.actions[0].output.cmx = None;
+
+            bundle.resolve_fields().unwrap();
+
+            assert_eq!(bundle.actions[0].output.cmx, expected_cmx);
+        }
+
+        #[cfg(feature = "orchard")]
+        #[test]
         fn decrypted_memo_plaintext_redaction_skips_decryption_failure() {
             let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
             let original_enc_ciphertext = match &mut action.output.enc_ciphertext {
@@ -1294,6 +1329,15 @@ pub(crate) mod v2 {
 
             assert!(matches!(
                 crate::orchard::v1::Bundle::try_from(logical_bundle(Some([5; 32]), None)),
+                Err(crate::EncodingError::RequiresV2)
+            ));
+
+            assert!(matches!(
+                crate::orchard::v1::Bundle::try_from(logical_bundle_with_cmx(
+                    Some([5; 32]),
+                    Some([6; 32]),
+                    None
+                )),
                 Err(crate::EncodingError::RequiresV2)
             ));
         }
@@ -1407,7 +1451,6 @@ impl Bundle {
 
             if lhs.spend.nullifier != nullifier
                 || lhs.spend.rk != rk
-                || lhs.output.cmx != cmx
                 || lhs.output.ephemeral_key != ephemeral_key
                 || lhs.output.enc_ciphertext != enc_ciphertext
                 || lhs.output.out_ciphertext != out_ciphertext
@@ -1427,6 +1470,7 @@ impl Bundle {
                 && merge_optional(&mut lhs.spend.zip32_derivation, spend_zip32_derivation)
                 && merge_optional(&mut lhs.spend.dummy_sk, dummy_sk)
                 && merge_map(&mut lhs.spend.proprietary, spend_proprietary)
+                && merge_optional(&mut lhs.output.cmx, cmx)
                 && merge_optional(&mut lhs.output.recipient, output_recipient)
                 && merge_optional(&mut lhs.output.value, output_value)
                 && merge_optional(&mut lhs.output.rseed, output_rseed)
@@ -1483,6 +1527,59 @@ pub(crate) fn orchard_bundle_version(global: &crate::common::Global) -> Option<B
 
 #[cfg(feature = "orchard")]
 impl Output {
+    /// Recomputes `cmx`, if this output carries it as an omitted field.
+    fn resolve_cmx(
+        &mut self,
+        note_version: NoteVersion,
+        spend_nullifier: [u8; 32],
+    ) -> Result<(), ::orchard::pczt::ParseError> {
+        use ::orchard::{
+            Address, Note,
+            note::{ExtractedNoteCommitment, RandomSeed, Rho},
+            pczt::ParseError,
+            value::NoteValue,
+        };
+
+        if self.cmx.is_some() {
+            return Ok(());
+        }
+
+        let recipient = Address::from_raw_address_bytes(
+            self.recipient
+                .as_ref()
+                .ok_or(ParseError::InvalidExtractedNoteCommitment)?,
+        )
+        .into_option()
+        .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
+        let rho = Rho::from_bytes(&spend_nullifier)
+            .into_option()
+            .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
+        let rseed = RandomSeed::from_bytes(
+            *self
+                .rseed
+                .as_ref()
+                .ok_or(ParseError::InvalidExtractedNoteCommitment)?,
+            &rho,
+        )
+        .into_option()
+        .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
+        let note = Note::from_parts(
+            recipient,
+            NoteValue::from_raw(
+                self.value
+                    .ok_or(ParseError::InvalidExtractedNoteCommitment)?,
+            ),
+            rho,
+            rseed,
+            note_version,
+        )
+        .into_option()
+        .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
+
+        self.cmx = Some(ExtractedNoteCommitment::from(note.commitment()).to_bytes());
+        Ok(())
+    }
+
     /// Recomputes [`Self::enc_ciphertext`] from memo plaintext, if present.
     ///
     /// If [`Self::enc_ciphertext`] is [`EncCiphertext::MemoPlaintext`], this
@@ -1603,6 +1700,7 @@ impl Bundle {
     ///
     /// This currently recomputes:
     /// - [`Action::cv_net`] if it is redacted.
+    /// - [`Output::cmx`] if it is redacted.
     /// - [`Output::enc_ciphertext`] if it is represented by memo plaintext.
     ///
     /// For improved efficiency, callers that will pass the same bundle through
@@ -1611,6 +1709,9 @@ impl Bundle {
     pub fn resolve_fields(&mut self) -> Result<(), ::orchard::pczt::ParseError> {
         for action in &mut self.actions {
             action.resolve_cv_net()?;
+            action
+                .output
+                .resolve_cmx(self.note_version, action.spend.nullifier)?;
             action
                 .output
                 .encrypt_ciphertext_from_memo(self.note_version, action.spend.nullifier)?;
@@ -1766,7 +1867,10 @@ impl Bundle {
 
             let output = orchard::pczt::Output::parse(
                 *spend.nullifier(),
-                action.output.cmx,
+                action
+                    .output
+                    .cmx
+                    .ok_or(orchard::pczt::ParseError::InvalidExtractedNoteCommitment)?,
                 action.output.ephemeral_key,
                 enc_ciphertext,
                 action.output.out_ciphertext,
@@ -1877,7 +1981,7 @@ impl Bundle {
                         proprietary: spend.proprietary().clone(),
                     },
                     output: Output {
-                        cmx: output.cmx().to_bytes(),
+                        cmx: Some(output.cmx().to_bytes()),
                         ephemeral_key: output.encrypted_note().epk_bytes,
                         enc_ciphertext: EncCiphertext::Encrypted(
                             output.encrypted_note().enc_ciphertext.to_vec(),

--- a/pczt/src/roles/low_level_signer/mod.rs
+++ b/pczt/src/roles/low_level_signer/mod.rs
@@ -285,7 +285,7 @@ mod tests {
                         proprietary: BTreeMap::new(),
                     },
                     output: Output {
-                        cmx: [0; 32],
+                        cmx: Some([0; 32]),
                         ephemeral_key: [0; 32],
                         enc_ciphertext: EncCiphertext::Encrypted(Vec::new()),
                         out_ciphertext: Vec::new(),

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -96,6 +96,16 @@ impl ActionRedactor<'_> {
         });
     }
 
+    /// Removes the output note commitment.
+    ///
+    /// The receiver recomputes `cmx` from the output note fields and the
+    /// action's spend nullifier.
+    pub fn clear_cmx(&mut self) {
+        self.redact(|action| {
+            action.output.cmx = None;
+        });
+    }
+
     /// Removes the spend authorizing signature.
     pub fn clear_spend_auth_sig(&mut self) {
         self.redact(|action| {


### PR DESCRIPTION
## Summary

- Allow v2 Orchard PCZTs to redact output note commitments by representing logical and v2 `cmx` as optional.
- Resolve redacted `cmx` before parsed conversion from the output note fields and action spend nullifier, while keeping memo recovery best-effort.
- Keep v1 encoding strict, add `ActionRedactor::clear_cmx`, and update focused tests and changelog entries.

## Validation

- `cargo test -p pczt --all-features`
- `cargo check -p pczt --no-default-features`