### PR TITLE
zcash_client_backend: rename and restructure Recipient::InternalAccount / BuildRecipient

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -282,6 +282,11 @@ workspace.
   this option must be executed with a matching unpadded builder configuration.
 
 ### Changed
+- `zcash_client_backend::wallet::Recipient::InternalAccount` has been renamed
+  to `Recipient::InternalShielded`, for symmetry with `Recipient::InternalTransparent`
+  and to clarify that the distinguishing feature of this variant is that its
+  payload is a shielded note, not that it is somehow more "the account" than the
+  other internal variant.
 - MSRV is now 1.88
 - `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes an
   `orchard_pool_bundle_type` argument (behind the `pczt` feature flag) selecting

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1264,7 +1264,7 @@ where
                 let note = output.to_wallet_note();
                 let value = note.value();
 
-                let recipient = Recipient::InternalAccount {
+                let recipient = Recipient::InternalShielded {
                     receiving_account: output.account_id(),
                     external_address: None,
                     note: Box::new(note),
@@ -1282,7 +1282,7 @@ where
                     let value = note.value();
 
                     // Even if the recipient address is external, record the send as internal.
-                    let recipient = Recipient::InternalAccount {
+                    let recipient = Recipient::InternalShielded {
                         receiving_account: output.account_id(),
                         external_address: Some(external_address(
                             wallet_db,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -196,31 +196,43 @@ enum PcztRecipient<AccountId> {
 
 #[cfg(feature = "pczt")]
 impl<AccountId: Copy> PcztRecipient<AccountId> {
-    fn from_recipient(recipient: BuildRecipient<AccountId>) -> (Self, Option<ZcashAddress>) {
+    fn from_shielded_recipient(
+        recipient: ShieldedBuildRecipient<AccountId>,
+    ) -> (Self, Option<ZcashAddress>) {
         match recipient {
-            BuildRecipient::External {
+            ShieldedBuildRecipient::External {
+                recipient_address, ..
+            } => (PcztRecipient::External, Some(recipient_address)),
+            ShieldedBuildRecipient::InternalShielded {
+                receiving_account,
+                external_address,
+            } => (
+                PcztRecipient::InternalShielded { receiving_account },
+                external_address,
+            ),
+        }
+    }
+
+    fn from_transparent_recipient(
+        recipient: TransparentBuildRecipient<AccountId>,
+    ) -> (Self, Option<ZcashAddress>) {
+        match recipient {
+            TransparentBuildRecipient::External {
                 recipient_address, ..
             } => (PcztRecipient::External, Some(recipient_address)),
             #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::EphemeralTransparent {
+            TransparentBuildRecipient::EphemeralTransparent {
                 receiving_account, ..
             } => (
                 PcztRecipient::EphemeralTransparent { receiving_account },
                 None,
             ),
             #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::InternalTransparent {
+            TransparentBuildRecipient::InternalTransparent {
                 receiving_account, ..
             } => (
                 PcztRecipient::InternalTransparent { receiving_account },
                 None,
-            ),
-            BuildRecipient::InternalShielded {
-                receiving_account,
-                external_address,
-            } => (
-                PcztRecipient::InternalShielded { receiving_account },
-                external_address,
             ),
         }
     }
@@ -1135,8 +1147,47 @@ where
     Ok(NonEmpty::from_vec(txids).expect("proposal.steps is NonEmpty"))
 }
 
+/// A recipient of a shielded output under construction, awaiting the decrypted [`Note`]
+/// that [`ShieldedBuildRecipient::into_recipient`] will attach to produce a [`Recipient`].
 #[derive(Debug, Clone)]
-enum BuildRecipient<AccountId> {
+enum ShieldedBuildRecipient<AccountId> {
+    External {
+        recipient_address: ZcashAddress,
+        output_pool: PoolType,
+    },
+    InternalShielded {
+        receiving_account: AccountId,
+        external_address: Option<ZcashAddress>,
+    },
+}
+
+impl<AccountId> ShieldedBuildRecipient<AccountId> {
+    fn into_recipient(self, note: impl FnOnce() -> Note) -> Recipient<AccountId> {
+        match self {
+            ShieldedBuildRecipient::External {
+                recipient_address,
+                output_pool,
+            } => Recipient::External {
+                recipient_address,
+                output_pool,
+            },
+            ShieldedBuildRecipient::InternalShielded {
+                receiving_account,
+                external_address,
+            } => Recipient::InternalShielded {
+                receiving_account,
+                external_address,
+                note: Box::new(note()),
+            },
+        }
+    }
+}
+
+/// A recipient of a transparent output under construction, awaiting the [`OutPoint`] (for
+/// ephemeral outputs only) that [`TransparentBuildRecipient::into_recipient`] will attach
+/// to produce a [`Recipient`].
+#[derive(Debug, Clone)]
+enum TransparentBuildRecipient<AccountId> {
     External {
         recipient_address: ZcashAddress,
         output_pool: PoolType,
@@ -1151,43 +1202,27 @@ enum BuildRecipient<AccountId> {
         receiving_account: AccountId,
         recipient_address: TransparentAddress,
     },
-    InternalShielded {
-        receiving_account: AccountId,
-        external_address: Option<ZcashAddress>,
-    },
+    /// Never constructed. Present only so that `AccountId` remains a used type parameter
+    /// when `transparent-inputs` is disabled, in which case the two variants above (the
+    /// only ones that otherwise reference it) do not exist. The uninhabited
+    /// [`core::convert::Infallible`] field lets every match on this type prove, rather than
+    /// assert, that this arm is unreachable.
+    #[cfg(not(feature = "transparent-inputs"))]
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    Unconstructible(
+        core::marker::PhantomData<AccountId>,
+        core::convert::Infallible,
+    ),
 }
 
-impl<AccountId> BuildRecipient<AccountId> {
-    fn into_recipient_with_note(self, note: impl FnOnce() -> Note) -> Recipient<AccountId> {
-        match self {
-            BuildRecipient::External {
-                recipient_address,
-                output_pool,
-            } => Recipient::External {
-                recipient_address,
-                output_pool,
-            },
-            #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::EphemeralTransparent { .. } => unreachable!(),
-            #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::InternalTransparent { .. } => unreachable!(),
-            BuildRecipient::InternalShielded {
-                receiving_account,
-                external_address,
-            } => Recipient::InternalShielded {
-                receiving_account,
-                external_address,
-                note: Box::new(note()),
-            },
-        }
-    }
-
-    fn into_recipient_with_outpoint(
+impl<AccountId> TransparentBuildRecipient<AccountId> {
+    fn into_recipient(
         self,
         #[cfg(feature = "transparent-inputs")] outpoint: OutPoint,
     ) -> Recipient<AccountId> {
         match self {
-            BuildRecipient::External {
+            TransparentBuildRecipient::External {
                 recipient_address,
                 output_pool,
             } => Recipient::External {
@@ -1195,7 +1230,7 @@ impl<AccountId> BuildRecipient<AccountId> {
                 output_pool,
             },
             #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::EphemeralTransparent {
+            TransparentBuildRecipient::EphemeralTransparent {
                 receiving_account,
                 ephemeral_address,
             } => Recipient::EphemeralTransparent {
@@ -1204,14 +1239,15 @@ impl<AccountId> BuildRecipient<AccountId> {
                 outpoint,
             },
             #[cfg(feature = "transparent-inputs")]
-            BuildRecipient::InternalTransparent {
+            TransparentBuildRecipient::InternalTransparent {
                 receiving_account,
                 recipient_address,
             } => Recipient::InternalTransparent {
                 receiving_account,
                 recipient_address,
             },
-            BuildRecipient::InternalShielded { .. } => unreachable!(),
+            #[cfg(not(feature = "transparent-inputs"))]
+            TransparentBuildRecipient::Unconstructible(_, absurd) => match absurd {},
         }
     }
 }
@@ -1224,12 +1260,24 @@ struct BuildState<P, AccountId> {
     #[cfg(feature = "transparent-inputs")]
     transparent_input_addresses: HashMap<TransparentAddress, TransparentAddressMetadata>,
     #[cfg(feature = "orchard")]
-    orchard_output_meta: Vec<(BuildRecipient<AccountId>, Zatoshis, Option<MemoBytes>)>,
+    orchard_output_meta: Vec<(
+        ShieldedBuildRecipient<AccountId>,
+        Zatoshis,
+        Option<MemoBytes>,
+    )>,
     #[cfg(feature = "orchard")]
-    ironwood_output_meta: Vec<(BuildRecipient<AccountId>, Zatoshis, Option<MemoBytes>)>,
-    sapling_output_meta: Vec<(BuildRecipient<AccountId>, Zatoshis, Option<MemoBytes>)>,
+    ironwood_output_meta: Vec<(
+        ShieldedBuildRecipient<AccountId>,
+        Zatoshis,
+        Option<MemoBytes>,
+    )>,
+    sapling_output_meta: Vec<(
+        ShieldedBuildRecipient<AccountId>,
+        Zatoshis,
+        Option<MemoBytes>,
+    )>,
     transparent_output_meta: Vec<(
-        BuildRecipient<AccountId>,
+        TransparentBuildRecipient<AccountId>,
         TransparentAddress,
         Zatoshis,
         StepOutputIndex,
@@ -1662,12 +1710,18 @@ where
     };
 
     #[cfg(feature = "orchard")]
-    let mut orchard_output_meta: Vec<(BuildRecipient<_>, Zatoshis, Option<MemoBytes>)> = vec![];
+    let mut orchard_output_meta: Vec<(ShieldedBuildRecipient<_>, Zatoshis, Option<MemoBytes>)> =
+        vec![];
     #[cfg(feature = "orchard")]
-    let mut ironwood_output_meta: Vec<(BuildRecipient<_>, Zatoshis, Option<MemoBytes>)> = vec![];
-    let mut sapling_output_meta: Vec<(BuildRecipient<_>, Zatoshis, Option<MemoBytes>)> = vec![];
+    let mut ironwood_output_meta: Vec<(
+        ShieldedBuildRecipient<_>,
+        Zatoshis,
+        Option<MemoBytes>,
+    )> = vec![];
+    let mut sapling_output_meta: Vec<(ShieldedBuildRecipient<_>, Zatoshis, Option<MemoBytes>)> =
+        vec![];
     let mut transparent_output_meta: Vec<(
-        BuildRecipient<_>,
+        TransparentBuildRecipient<_>,
         TransparentAddress,
         Zatoshis,
         StepOutputIndex,
@@ -1699,7 +1753,7 @@ where
                     memo.clone(),
                 )?;
                 sapling_output_meta.push((
-                    BuildRecipient::External {
+                    ShieldedBuildRecipient::External {
                         recipient_address: recipient_address.clone(),
                         output_pool: PoolType::SAPLING,
                     },
@@ -1723,7 +1777,7 @@ where
                     memo.clone(),
                 )?;
                 orchard_output_meta.push((
-                    BuildRecipient::External {
+                    ShieldedBuildRecipient::External {
                         recipient_address: recipient_address.clone(),
                         output_pool: PoolType::ORCHARD,
                     },
@@ -1747,7 +1801,7 @@ where
                     memo.clone(),
                 )?;
                 ironwood_output_meta.push((
-                    BuildRecipient::External {
+                    ShieldedBuildRecipient::External {
                         recipient_address: recipient_address.clone(),
                         // The payment is built into the Ironwood bundle, so its sent-note record
                         // belongs to the Ironwood pool. (Post-NU6.3 an Orchard-pool payment output
@@ -1770,7 +1824,7 @@ where
                 }
                 builder.add_transparent_output(&to, payment_amount)?;
                 transparent_output_meta.push((
-                    BuildRecipient::External {
+                    TransparentBuildRecipient::External {
                         recipient_address: recipient_address.clone(),
                         output_pool: PoolType::TRANSPARENT,
                     },
@@ -1856,7 +1910,7 @@ where
                     memo.clone(),
                 )?;
                 sapling_output_meta.push((
-                    BuildRecipient::InternalShielded {
+                    ShieldedBuildRecipient::InternalShielded {
                         receiving_account: account_id,
                         external_address: None,
                     },
@@ -1891,7 +1945,7 @@ where
                             memo.clone(),
                         )?;
                         orchard_output_meta.push((
-                            BuildRecipient::InternalShielded {
+                            ShieldedBuildRecipient::InternalShielded {
                                 receiving_account: account_id,
                                 external_address: None,
                             },
@@ -1906,7 +1960,7 @@ where
                             memo.clone(),
                         )?;
                         orchard_output_meta.push((
-                            BuildRecipient::InternalShielded {
+                            ShieldedBuildRecipient::InternalShielded {
                                 receiving_account: account_id,
                                 external_address: None,
                             },
@@ -1943,7 +1997,7 @@ where
                         memo.clone(),
                     )?;
                     ironwood_output_meta.push((
-                        BuildRecipient::InternalShielded {
+                        ShieldedBuildRecipient::InternalShielded {
                             receiving_account: account_id,
                             external_address: None,
                         },
@@ -1983,7 +2037,7 @@ where
             // if a later step does not consume it.
             builder.add_transparent_output(&ephemeral_address, change_value.value())?;
             transparent_output_meta.push((
-                BuildRecipient::EphemeralTransparent {
+                TransparentBuildRecipient::EphemeralTransparent {
                     receiving_account: account_id,
                     ephemeral_address,
                 },
@@ -2024,7 +2078,7 @@ where
             {
                 builder.add_transparent_output(&change_address, change_value.value())?;
                 transparent_output_meta.push((
-                    BuildRecipient::InternalTransparent {
+                    TransparentBuildRecipient::InternalTransparent {
                         receiving_account: account_id,
                         recipient_address: change_address,
                     },
@@ -2168,7 +2222,7 @@ where
                 .output_action_index(i)
                 .expect("An action should exist in the transaction for each Orchard output.");
 
-            let recipient = recipient.into_recipient_with_note(|| {
+            let recipient = recipient.into_recipient(|| {
                 build_result
                     .transaction()
                     .orchard_bundle()
@@ -2207,7 +2261,7 @@ where
                 .output_action_index(i)
                 .expect("An action should exist in the transaction for each Ironwood output.");
 
-            let recipient = recipient.into_recipient_with_note(|| {
+            let recipient = recipient.into_recipient(|| {
                 build_result
                     .transaction()
                     .ironwood_bundle()
@@ -2247,7 +2301,7 @@ where
                 .output_index(i)
                 .expect("An output should exist in the transaction for each Sapling payment.");
 
-            let recipient = recipient.into_recipient_with_note(|| {
+            let recipient = recipient.into_recipient(|| {
                 build_result
                     .transaction()
                     .sapling_bundle()
@@ -2293,7 +2347,7 @@ where
             // would not usefully improve privacy.
             let outpoint = OutPoint::new(txid, n as u32);
 
-            let recipient = recipient.into_recipient_with_outpoint(
+            let recipient = recipient.into_recipient(
                 #[cfg(feature = "transparent-inputs")]
                 outpoint.clone(),
             );
@@ -2443,7 +2497,10 @@ where
                 .output_action_index(i)
                 .expect("An action should exist in the transaction for each Orchard output.");
 
-            (output_index, PcztRecipient::from_recipient(recipient))
+            (
+                output_index,
+                PcztRecipient::from_shielded_recipient(recipient),
+            )
         })
         .collect::<HashMap<_, _>>();
 
@@ -2465,7 +2522,10 @@ where
                 .output_action_index(i)
                 .expect("An action should exist in the transaction for each Ironwood output.");
 
-            (output_index, PcztRecipient::from_recipient(recipient))
+            (
+                output_index,
+                PcztRecipient::from_shielded_recipient(recipient),
+            )
         })
         .collect::<HashMap<_, _>>();
 
@@ -2486,7 +2546,10 @@ where
                 .output_index(i)
                 .expect("An output should exist in the transaction for each Sapling output.");
 
-            (output_index, PcztRecipient::from_recipient(recipient))
+            (
+                output_index,
+                PcztRecipient::from_shielded_recipient(recipient),
+            )
         })
         .collect::<HashMap<_, _>>();
 
@@ -2716,7 +2779,7 @@ where
             {
                 updater.update_output_with(index, |mut output_updater| {
                     let (pczt_recipient, external_address) =
-                        PcztRecipient::from_recipient(recipient);
+                        PcztRecipient::from_transparent_recipient(recipient);
                     if let Some(user_address) = external_address {
                         output_updater.set_user_address(user_address.encode());
                     }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -183,7 +183,7 @@ enum PcztRecipient<AccountId> {
     EphemeralTransparent {
         receiving_account: AccountId,
     },
-    InternalAccount {
+    InternalShielded {
         receiving_account: AccountId,
     },
     // This variant is placed at the end of the enum in order to preserve the encoded
@@ -215,11 +215,11 @@ impl<AccountId: Copy> PcztRecipient<AccountId> {
                 PcztRecipient::InternalTransparent { receiving_account },
                 None,
             ),
-            BuildRecipient::InternalAccount {
+            BuildRecipient::InternalShielded {
                 receiving_account,
                 external_address,
             } => (
-                PcztRecipient::InternalAccount { receiving_account },
+                PcztRecipient::InternalShielded { receiving_account },
                 external_address,
             ),
         }
@@ -1151,7 +1151,7 @@ enum BuildRecipient<AccountId> {
         receiving_account: AccountId,
         recipient_address: TransparentAddress,
     },
-    InternalAccount {
+    InternalShielded {
         receiving_account: AccountId,
         external_address: Option<ZcashAddress>,
     },
@@ -1171,10 +1171,10 @@ impl<AccountId> BuildRecipient<AccountId> {
             BuildRecipient::EphemeralTransparent { .. } => unreachable!(),
             #[cfg(feature = "transparent-inputs")]
             BuildRecipient::InternalTransparent { .. } => unreachable!(),
-            BuildRecipient::InternalAccount {
+            BuildRecipient::InternalShielded {
                 receiving_account,
                 external_address,
-            } => Recipient::InternalAccount {
+            } => Recipient::InternalShielded {
                 receiving_account,
                 external_address,
                 note: Box::new(note()),
@@ -1211,7 +1211,7 @@ impl<AccountId> BuildRecipient<AccountId> {
                 receiving_account,
                 recipient_address,
             },
-            BuildRecipient::InternalAccount { .. } => unreachable!(),
+            BuildRecipient::InternalShielded { .. } => unreachable!(),
         }
     }
 }
@@ -1856,7 +1856,7 @@ where
                     memo.clone(),
                 )?;
                 sapling_output_meta.push((
-                    BuildRecipient::InternalAccount {
+                    BuildRecipient::InternalShielded {
                         receiving_account: account_id,
                         external_address: None,
                     },
@@ -1891,7 +1891,7 @@ where
                             memo.clone(),
                         )?;
                         orchard_output_meta.push((
-                            BuildRecipient::InternalAccount {
+                            BuildRecipient::InternalShielded {
                                 receiving_account: account_id,
                                 external_address: None,
                             },
@@ -1906,7 +1906,7 @@ where
                             memo.clone(),
                         )?;
                         orchard_output_meta.push((
-                            BuildRecipient::InternalAccount {
+                            BuildRecipient::InternalShielded {
                                 receiving_account: account_id,
                                 external_address: None,
                             },
@@ -1943,7 +1943,7 @@ where
                         memo.clone(),
                     )?;
                     ironwood_output_meta.push((
-                        BuildRecipient::InternalAccount {
+                        BuildRecipient::InternalShielded {
                             receiving_account: account_id,
                             external_address: None,
                         },
@@ -2979,8 +2979,8 @@ where
             (PcztRecipient::InternalTransparent { .. }, _) => Err(PcztError::Invalid(
                 "shielded output cannot be InternalTransparent".into(),
             )),
-            (PcztRecipient::InternalAccount { receiving_account }, external_address) => {
-                Ok(Recipient::InternalAccount {
+            (PcztRecipient::InternalShielded { receiving_account }, external_address) => {
+                Ok(Recipient::InternalShielded {
                     receiving_account,
                     external_address,
                     note: Box::new(wallet_note(note)),
@@ -3113,12 +3113,12 @@ where
                                     recipient_address,
                                 }),
                             (
-                                PcztRecipient::InternalAccount {
+                                PcztRecipient::InternalShielded {
                                     receiving_account,
                                 },
                                 _,
                             ) => Err(PcztError::Invalid(
-                                "Transparent output cannot be InternalAccount".into(),
+                                "Transparent output cannot be InternalShielded".into(),
                             )),
                         }?;
 

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -65,13 +65,19 @@ impl NoteId {
     }
 }
 
-/// A type that represents the recipient of a transaction output:
+/// A type that represents the recipient of a transaction output.
 ///
-/// * a recipient address;
-/// * for external unified addresses, the pool to which the payment is sent;
-/// * for wallet-internal outputs, the internal account ID and metadata about the note.
-/// * if the `transparent-inputs` feature is enabled, for ephemeral transparent outputs, the
-///   internal account ID and metadata about the outpoint;
+/// Variants vary along two independent axes:
+///
+/// * **Relationship to the wallet**: whether the recipient address is [`Self::External`] to
+///   the wallet, an [`Self::EphemeralTransparent`] address of a wallet account (used
+///   transiently as a middle hop), or otherwise internal to a wallet account (recorded as
+///   [`Self::InternalShielded`] or [`Self::InternalTransparent`], depending on payload
+///   domain).
+/// * **Payload domain**: whether the output is shielded (in which case what is recorded is
+///   the decrypted [`Note`], since the recipient address is not itself externally
+///   meaningful) or transparent (in which case what is recorded is the on-chain-observable
+///   recipient address, since transparent outputs carry no analogous decryptable payload).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Recipient<AccountId> {
     /// An output sent to a recipient external to the wallet.
@@ -93,7 +99,7 @@ pub enum Recipient<AccountId> {
     /// a wallet account. Used to record the send side of a transparent output that
     /// the wallet both funded and received.
     ///
-    /// Distinct from [`Self::InternalAccount`] because for transparent outputs
+    /// Distinct from [`Self::InternalShielded`] because for transparent outputs
     /// the recipient address is observable on chain and must be recorded;
     /// additionally, the receiving account may not be known at the point the
     /// send is recorded. For shielded outputs the recipient address is not
@@ -108,7 +114,7 @@ pub enum Recipient<AccountId> {
     /// same-account outputs such as change (`external_address` is `None`) and
     /// for outputs received via an external IVK but funded by another wallet
     /// account, in which case `external_address` is the address that was paid.
-    InternalAccount {
+    InternalShielded {
         receiving_account: AccountId,
         external_address: Option<ZcashAddress>,
         note: Box<Note>,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3468,7 +3468,7 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                     }
                 }
             }
-            Recipient::InternalAccount {
+            Recipient::InternalShielded {
                 receiving_account,
                 note,
                 ..
@@ -4811,7 +4811,7 @@ fn recipient_params<P: consensus::Parameters>(
                 PoolType::TRANSPARENT,
             ))
         }
-        Recipient::InternalAccount {
+        Recipient::InternalShielded {
             receiving_account,
             external_address,
             note,


### PR DESCRIPTION
Resolves #2595.

Two commits:

1. Renames `zcash_client_backend::wallet::Recipient::InternalAccount` (and its
   `BuildRecipient`/`PcztRecipient` mirrors) to `InternalShielded`, for symmetry with
   `Recipient::InternalTransparent`. The prior name did not communicate the actual
   distinction between the two internal variants — payload domain (shielded note vs.
   transparent address), not some special relationship to "the account". The
   `Recipient` enum doc comments are expanded to spell out the two independent axes the
   variants vary along. This is a public, semver-breaking rename; a `Changed` entry is
   added to the unreleased section of `zcash_client_backend/CHANGELOG.md`.
   `PcztRecipient`'s variant order (and thus its postcard encoding within a PCZT) is
   unchanged.

2. Splits the private `BuildRecipient` type into `ShieldedBuildRecipient` and
   `TransparentBuildRecipient`, matching the two functions that previously consumed a
   single `BuildRecipient` with two `unreachable!()` arms apiece
   (`into_recipient_with_note`, used only for shielded outputs where a decrypted `Note`
   is available; `into_recipient_with_outpoint`, used only for transparent outputs
   where an `OutPoint` is available). Each split type carries only the variants
   relevant to its domain, and each has a single `into_recipient` method that is a
   total function. `PcztRecipient::from_recipient` is likewise split. This is a
   private, internal-only change with no effect on the public API.

Both follow from review discussion on #2550:
https://github.com/zcash/librustzcash/pull/2550#discussion_r3549071493

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings` (workspace)
- `cargo check -p zcash_client_backend` with `--all-features`, `--no-default-features`,
  `--features transparent-inputs`, `--features orchard`
- `cargo test --workspace --all-features` (all green, no failures)
- `cargo doc --no-deps --workspace --all-features --document-private-items` (nightly):
  no new warnings (4 pre-existing warnings, unrelated to this change)
- Verified commit 1 builds standalone

Co-Authored-By: Claude <noreply@anthropic.com>