### PR TITLE
zcash_client_backend: add bulk-flush methods to WalletCommitmentTrees

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -31,13 +31,13 @@ workspace.
   each pubkey individually.
 - `zcash_client_backend::data_api::WalletCommitmentTrees::put_sapling_shards`
   (and `put_orchard_shards` / `put_ironwood_shards` under the `orchard`
-  feature): provided methods that bulk-write previously accumulated note
-  commitment tree changes — shards, an optional tree cap, and a checkpoint
-  delta — to the backing store, for wallet stores that maintain their note
-  commitment trees outside the backing store (e.g. in memory) and periodically
-  flush. The default implementations apply the changes through the
-  corresponding `with_*_tree_mut` methods, so existing implementations of the
-  trait are unaffected.
+  feature): provided methods that bulk-write a batch of note commitment tree
+  changes — shards, an optional replacement tree cap, and a checkpoint delta —
+  to the backing store, for wallet stores that maintain their note commitment
+  trees outside the backing store (e.g. in memory) and flush in batches. The
+  default implementations apply the changes through the corresponding
+  `with_*_tree_mut` methods, so existing implementations of the trait are
+  unaffected.
 - `zcash_client_backend::proposal::Proposal::proposed_version` and
   `with_proposed_version`. The transaction version requested when a proposal is
   constructed is now recorded on the proposal (and preserved across

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -29,6 +29,15 @@ workspace.
   `import_standalone_transparent_pubkey` that lets implementations validate the
   target account once for the whole batch. The default implementation imports
   each pubkey individually.
+- `zcash_client_backend::data_api::WalletCommitmentTrees::put_sapling_shards`
+  (and `put_orchard_shards` / `put_ironwood_shards` under the `orchard`
+  feature): provided methods that bulk-write previously accumulated note
+  commitment tree changes — shards, an optional tree cap, and a checkpoint
+  delta — to the backing store, for wallet stores that maintain their note
+  commitment trees outside the backing store (e.g. in memory) and periodically
+  flush. The default implementations apply the changes through the
+  corresponding `with_*_tree_mut` methods, so existing implementations of the
+  trait are unaffected.
 - `zcash_client_backend::proposal::Proposal::proposed_version` and
   `with_proposed_version`. The transaction version requested when a proposal is
   constructed is now recorded on the proposal (and preserved across

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3866,6 +3866,138 @@ pub trait WalletCommitmentTrees {
         Ok(())
     }
 
+    /// Bulk-writes previously accumulated changes to the wallet's Sapling note commitment tree.
+    ///
+    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
+    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
+    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
+    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    ///
+    /// This is intended for wallet stores that accumulate note commitment tree updates outside
+    /// the backing store (for example, in an in-memory tree) and periodically flush the
+    /// accumulated changes. The default implementation applies the changes through
+    /// [`WalletCommitmentTrees::with_sapling_tree_mut`].
+    fn put_sapling_shards(
+        &mut self,
+        shards: &[shardtree::LocatedPrunableTree<sapling::Node>],
+        cap: Option<&shardtree::PrunableTree<sapling::Node>>,
+        checkpoints_remove: &[BlockHeight],
+        checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        self.with_sapling_tree_mut(|tree| {
+            for shard in shards {
+                tree.store_mut()
+                    .put_shard(shard.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            if let Some(cap) = cap {
+                tree.store_mut()
+                    .put_cap(cap.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for height in checkpoints_remove {
+                tree.store_mut()
+                    .remove_checkpoint(height)
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for (height, checkpoint) in checkpoints_add {
+                tree.store_mut()
+                    .add_checkpoint(*height, checkpoint.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            Ok::<_, ShardTreeError<Self::Error>>(())
+        })
+    }
+
+    /// Bulk-writes previously accumulated changes to the wallet's Orchard note commitment tree.
+    ///
+    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
+    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
+    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
+    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    ///
+    /// This is intended for wallet stores that accumulate note commitment tree updates outside
+    /// the backing store (for example, in an in-memory tree) and periodically flush the
+    /// accumulated changes. The default implementation applies the changes through
+    /// [`WalletCommitmentTrees::with_orchard_tree_mut`].
+    #[cfg(feature = "orchard")]
+    fn put_orchard_shards(
+        &mut self,
+        shards: &[shardtree::LocatedPrunableTree<orchard::tree::MerkleHashOrchard>],
+        cap: Option<&shardtree::PrunableTree<orchard::tree::MerkleHashOrchard>>,
+        checkpoints_remove: &[BlockHeight],
+        checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        self.with_orchard_tree_mut(|tree| {
+            for shard in shards {
+                tree.store_mut()
+                    .put_shard(shard.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            if let Some(cap) = cap {
+                tree.store_mut()
+                    .put_cap(cap.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for height in checkpoints_remove {
+                tree.store_mut()
+                    .remove_checkpoint(height)
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for (height, checkpoint) in checkpoints_add {
+                tree.store_mut()
+                    .add_checkpoint(*height, checkpoint.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            Ok::<_, ShardTreeError<Self::Error>>(())
+        })
+    }
+
+    /// Bulk-writes previously accumulated changes to the wallet's Ironwood note commitment tree,
+    /// if this backend tracks one.
+    ///
+    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
+    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
+    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
+    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    ///
+    /// The default implementation applies the changes through
+    /// [`WalletCommitmentTrees::with_ironwood_tree_mut`]; for backends that do not track an
+    /// Ironwood tree (see that method's documentation), the changes are ignored.
+    #[cfg(feature = "orchard")]
+    fn put_ironwood_shards(
+        &mut self,
+        shards: &[shardtree::LocatedPrunableTree<orchard::tree::MerkleHashOrchard>],
+        cap: Option<&shardtree::PrunableTree<orchard::tree::MerkleHashOrchard>>,
+        checkpoints_remove: &[BlockHeight],
+        checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
+    ) -> Result<(), ShardTreeError<Self::Error>> {
+        self.with_ironwood_tree_mut(|tree| {
+            for shard in shards {
+                tree.store_mut()
+                    .put_shard(shard.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            if let Some(cap) = cap {
+                tree.store_mut()
+                    .put_cap(cap.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for height in checkpoints_remove {
+                tree.store_mut()
+                    .remove_checkpoint(height)
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            for (height, checkpoint) in checkpoints_add {
+                tree.store_mut()
+                    .add_checkpoint(*height, checkpoint.clone())
+                    .map_err(ShardTreeError::Storage)?;
+            }
+            Ok::<_, ShardTreeError<Self::Error>>(())
+        })?;
+        Ok(())
+    }
+
     /// Releases all retained ("anchor") checkpoints with height strictly less than `max_height`
     /// from the wallet's note commitment trees, allowing them to be pruned normally.
     ///
@@ -3936,6 +4068,92 @@ mod tests {
     use transparent::address::TransparentAddress;
     use zcash_keys::address::{Address, UnifiedAddress};
     use zip32::DiversifierIndex;
+
+    #[test]
+    fn put_sapling_shards_flushes_through_the_interface() {
+        use incrementalmerkletree::{Address, Hashable, Level, Marking, Position};
+        use shardtree::store::Checkpoint;
+
+        let mut db = MockWalletDb::new(zcash_protocol::consensus::Network::TestNetwork);
+
+        // Build a shard-rooted subtree the same way `put_blocks` does, with a checkpoint on
+        // the final leaf.
+        let leaf = <sapling::Node as Hashable>::empty_leaf();
+        let checkpoint_height = BlockHeight::from(3);
+        let commitments = (0u64..4).map(|i| {
+            (
+                leaf,
+                if i == 3 {
+                    Retention::Checkpoint {
+                        id: checkpoint_height,
+                        marking: Marking::None,
+                    }
+                } else {
+                    Retention::Ephemeral
+                },
+            )
+        });
+        let built = shardtree::LocatedTree::from_iter(
+            Position::from(0)..Position::from(4),
+            Level::from(SAPLING_SHARD_HEIGHT),
+            commitments,
+        )
+        .expect("commitments produce a subtree");
+        let checkpoints_add = built
+            .checkpoints
+            .iter()
+            .map(|(height, position)| (*height, Checkpoint::at_position(*position)))
+            .collect::<Vec<_>>();
+
+        db.put_sapling_shards(&[built.subtree], None, &[], &checkpoints_add)
+            .expect("bulk flush succeeds");
+
+        // The shard and checkpoint are visible through the standard tree access path.
+        db.with_sapling_tree_mut(|tree| {
+            assert!(
+                tree.store()
+                    .get_shard(Address::from_parts(Level::from(SAPLING_SHARD_HEIGHT), 0))
+                    .map_err(ShardTreeError::Storage)?
+                    .is_some()
+            );
+            assert_eq!(
+                tree.store()
+                    .max_checkpoint_id()
+                    .map_err(ShardTreeError::Storage)?,
+                Some(checkpoint_height)
+            );
+            Ok::<_, ShardTreeError<_>>(())
+        })
+        .expect("tree reads succeed");
+
+        // Removals are applied before additions, so a checkpoint set can be replaced in a
+        // single call.
+        let new_height = BlockHeight::from(7);
+        db.put_sapling_shards(
+            &[],
+            None,
+            &[checkpoint_height],
+            &[(new_height, Checkpoint::tree_empty())],
+        )
+        .expect("checkpoint replacement succeeds");
+
+        db.with_sapling_tree_mut(|tree| {
+            assert_eq!(
+                tree.store()
+                    .max_checkpoint_id()
+                    .map_err(ShardTreeError::Storage)?,
+                Some(new_height)
+            );
+            assert_eq!(
+                tree.store()
+                    .checkpoint_count()
+                    .map_err(ShardTreeError::Storage)?,
+                1
+            );
+            Ok::<_, ShardTreeError<_>>(())
+        })
+        .expect("tree reads succeed");
+    }
 
     #[test]
     fn account_meta_totals_include_ironwood() {

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3762,6 +3762,49 @@ pub trait WalletWrite: WalletRead {
     }
 }
 
+/// Applies a batch of note commitment tree changes — shards, an optional replacement tree
+/// cap, and a checkpoint delta — directly to the given tree's backing [`ShardStore`].
+///
+/// `shards` must be in ascending shard-index order; stores may reject sequences that would
+/// leave gaps in the tree. Checkpoint removals are applied before additions, so that a
+/// checkpoint whose data has changed may appear in both lists.
+///
+/// This is the shared implementation of the [`WalletCommitmentTrees`] `put_*_shards`
+/// provided methods.
+fn apply_tree_changes<H, S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+    tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
+    shards: &[shardtree::LocatedPrunableTree<H>],
+    cap: Option<&shardtree::PrunableTree<H>>,
+    checkpoints_remove: &[BlockHeight],
+    checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
+) -> Result<(), ShardTreeError<S::Error>>
+where
+    H: incrementalmerkletree::Hashable + Clone + PartialEq,
+    S: ShardStore<H = H, CheckpointId = BlockHeight>,
+{
+    for shard in shards {
+        tree.store_mut()
+            .put_shard(shard.clone())
+            .map_err(ShardTreeError::Storage)?;
+    }
+    if let Some(cap) = cap {
+        tree.store_mut()
+            .put_cap(cap.clone())
+            .map_err(ShardTreeError::Storage)?;
+    }
+    for height in checkpoints_remove {
+        tree.store_mut()
+            .remove_checkpoint(height)
+            .map_err(ShardTreeError::Storage)?;
+    }
+    for (height, checkpoint) in checkpoints_add {
+        tree.store_mut()
+            .add_checkpoint(*height, checkpoint.clone())
+            .map_err(ShardTreeError::Storage)?;
+    }
+    Ok(())
+}
+
 /// This trait describes a capability for manipulating wallet note commitment trees.
 #[cfg_attr(feature = "test-dependencies", delegatable_trait)]
 pub trait WalletCommitmentTrees {
@@ -3866,16 +3909,16 @@ pub trait WalletCommitmentTrees {
         Ok(())
     }
 
-    /// Bulk-writes previously accumulated changes to the wallet's Sapling note commitment tree.
+    /// Applies a batch of changes — shards, an optional replacement tree cap, and a
+    /// checkpoint delta — to the wallet's Sapling note commitment tree.
     ///
-    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
-    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
-    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
-    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    /// `shards` must be in ascending shard-index order; stores may reject sequences that
+    /// would leave gaps in the tree. Checkpoint removals are applied before additions, so
+    /// that a checkpoint whose data has changed may appear in both lists.
     ///
-    /// This is intended for wallet stores that accumulate note commitment tree updates outside
-    /// the backing store (for example, in an in-memory tree) and periodically flush the
-    /// accumulated changes. The default implementation applies the changes through
+    /// This is intended for wallet stores that accumulate note commitment tree updates
+    /// outside the backing store (for example, in an in-memory tree) and flush them in
+    /// batches. The default implementation applies the changes through
     /// [`WalletCommitmentTrees::with_sapling_tree_mut`].
     fn put_sapling_shards(
         &mut self,
@@ -3885,40 +3928,20 @@ pub trait WalletCommitmentTrees {
         checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         self.with_sapling_tree_mut(|tree| {
-            for shard in shards {
-                tree.store_mut()
-                    .put_shard(shard.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            if let Some(cap) = cap {
-                tree.store_mut()
-                    .put_cap(cap.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for height in checkpoints_remove {
-                tree.store_mut()
-                    .remove_checkpoint(height)
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for (height, checkpoint) in checkpoints_add {
-                tree.store_mut()
-                    .add_checkpoint(*height, checkpoint.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            Ok::<_, ShardTreeError<Self::Error>>(())
+            apply_tree_changes(tree, shards, cap, checkpoints_remove, checkpoints_add)
         })
     }
 
-    /// Bulk-writes previously accumulated changes to the wallet's Orchard note commitment tree.
+    /// Applies a batch of changes — shards, an optional replacement tree cap, and a
+    /// checkpoint delta — to the wallet's Orchard note commitment tree.
     ///
-    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
-    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
-    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
-    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    /// `shards` must be in ascending shard-index order; stores may reject sequences that
+    /// would leave gaps in the tree. Checkpoint removals are applied before additions, so
+    /// that a checkpoint whose data has changed may appear in both lists.
     ///
-    /// This is intended for wallet stores that accumulate note commitment tree updates outside
-    /// the backing store (for example, in an in-memory tree) and periodically flush the
-    /// accumulated changes. The default implementation applies the changes through
+    /// This is intended for wallet stores that accumulate note commitment tree updates
+    /// outside the backing store (for example, in an in-memory tree) and flush them in
+    /// batches. The default implementation applies the changes through
     /// [`WalletCommitmentTrees::with_orchard_tree_mut`].
     #[cfg(feature = "orchard")]
     fn put_orchard_shards(
@@ -3929,37 +3952,17 @@ pub trait WalletCommitmentTrees {
         checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         self.with_orchard_tree_mut(|tree| {
-            for shard in shards {
-                tree.store_mut()
-                    .put_shard(shard.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            if let Some(cap) = cap {
-                tree.store_mut()
-                    .put_cap(cap.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for height in checkpoints_remove {
-                tree.store_mut()
-                    .remove_checkpoint(height)
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for (height, checkpoint) in checkpoints_add {
-                tree.store_mut()
-                    .add_checkpoint(*height, checkpoint.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            Ok::<_, ShardTreeError<Self::Error>>(())
+            apply_tree_changes(tree, shards, cap, checkpoints_remove, checkpoints_add)
         })
     }
 
-    /// Bulk-writes previously accumulated changes to the wallet's Ironwood note commitment tree,
-    /// if this backend tracks one.
+    /// Applies a batch of changes — shards, an optional replacement tree cap, and a
+    /// checkpoint delta — to the wallet's Ironwood note commitment tree, if this backend
+    /// tracks one.
     ///
-    /// Writes the provided shards to the backing [`ShardStore`] (`shards` must be in ascending
-    /// shard-index order; stores may reject sequences that would leave gaps in the tree),
-    /// replaces the tree cap if one is provided, and applies the checkpoint delta — removals
-    /// before additions, so that a checkpoint whose data has changed may appear in both lists.
+    /// `shards` must be in ascending shard-index order; stores may reject sequences that
+    /// would leave gaps in the tree. Checkpoint removals are applied before additions, so
+    /// that a checkpoint whose data has changed may appear in both lists.
     ///
     /// The default implementation applies the changes through
     /// [`WalletCommitmentTrees::with_ironwood_tree_mut`]; for backends that do not track an
@@ -3973,27 +3976,7 @@ pub trait WalletCommitmentTrees {
         checkpoints_add: &[(BlockHeight, shardtree::store::Checkpoint)],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         self.with_ironwood_tree_mut(|tree| {
-            for shard in shards {
-                tree.store_mut()
-                    .put_shard(shard.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            if let Some(cap) = cap {
-                tree.store_mut()
-                    .put_cap(cap.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for height in checkpoints_remove {
-                tree.store_mut()
-                    .remove_checkpoint(height)
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            for (height, checkpoint) in checkpoints_add {
-                tree.store_mut()
-                    .add_checkpoint(*height, checkpoint.clone())
-                    .map_err(ShardTreeError::Storage)?;
-            }
-            Ok::<_, ShardTreeError<Self::Error>>(())
+            apply_tree_changes(tree, shards, cap, checkpoints_remove, checkpoints_add)
         })?;
         Ok(())
     }
@@ -4153,6 +4136,120 @@ mod tests {
             Ok::<_, ShardTreeError<_>>(())
         })
         .expect("tree reads succeed");
+    }
+
+    /// Exercises [`apply_tree_changes`] — the shared implementation of the `put_*_shards`
+    /// provided methods — directly over a [`MemoryShardStore`] of the given node type.
+    ///
+    /// [`MemoryShardStore`]: shardtree::store::memory::MemoryShardStore
+    fn check_apply_tree_changes<H>()
+    where
+        H: incrementalmerkletree::Hashable + Clone + PartialEq + core::fmt::Debug,
+    {
+        use incrementalmerkletree::{Address, Level, Marking, Position};
+        use shardtree::store::{Checkpoint, memory::MemoryShardStore};
+
+        let mut tree: ShardTree<
+            MemoryShardStore<H, BlockHeight>,
+            { SAPLING_SHARD_HEIGHT * 2 },
+            SAPLING_SHARD_HEIGHT,
+        > = ShardTree::new(MemoryShardStore::empty(), 100);
+
+        // Build a shard-rooted subtree the same way `put_blocks` does, with a checkpoint on
+        // the final leaf.
+        let leaf = H::empty_leaf();
+        let checkpoint_height = BlockHeight::from(3);
+        let commitments = (0u64..4).map(|i| {
+            (
+                leaf.clone(),
+                if i == 3 {
+                    Retention::Checkpoint {
+                        id: checkpoint_height,
+                        marking: Marking::None,
+                    }
+                } else {
+                    Retention::Ephemeral
+                },
+            )
+        });
+        let built = shardtree::LocatedTree::from_iter(
+            Position::from(0)..Position::from(4),
+            Level::from(SAPLING_SHARD_HEIGHT),
+            commitments,
+        )
+        .expect("commitments produce a subtree");
+        let checkpoints_add = built
+            .checkpoints
+            .iter()
+            .map(|(height, position)| (*height, Checkpoint::at_position(*position)))
+            .collect::<Vec<_>>();
+
+        apply_tree_changes(&mut tree, &[built.subtree], None, &[], &checkpoints_add)
+            .expect("bulk flush succeeds");
+
+        assert!(
+            tree.store()
+                .get_shard(Address::from_parts(Level::from(SAPLING_SHARD_HEIGHT), 0))
+                .expect("shard read succeeds")
+                .is_some()
+        );
+        assert_eq!(
+            tree.store()
+                .max_checkpoint_id()
+                .expect("checkpoint read succeeds"),
+            Some(checkpoint_height)
+        );
+
+        // Removals are applied before additions, so a checkpoint set can be replaced in a
+        // single call.
+        let new_height = BlockHeight::from(7);
+        apply_tree_changes(
+            &mut tree,
+            &[],
+            None,
+            &[checkpoint_height],
+            &[(new_height, Checkpoint::tree_empty())],
+        )
+        .expect("checkpoint replacement succeeds");
+
+        assert_eq!(
+            tree.store()
+                .max_checkpoint_id()
+                .expect("checkpoint read succeeds"),
+            Some(new_height)
+        );
+        assert_eq!(
+            tree.store()
+                .checkpoint_count()
+                .expect("checkpoint read succeeds"),
+            1
+        );
+    }
+
+    #[test]
+    fn apply_tree_changes_supports_every_pool_node_type() {
+        check_apply_tree_changes::<sapling::Node>();
+        // Orchard and Ironwood both use `MerkleHashOrchard` trees of the same shape.
+        #[cfg(feature = "orchard")]
+        check_apply_tree_changes::<orchard::tree::MerkleHashOrchard>();
+    }
+
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn put_ironwood_shards_is_ignored_without_an_ironwood_tree() {
+        use shardtree::store::Checkpoint;
+
+        // `MockWalletDb` does not track an Ironwood tree, so the default
+        // `with_ironwood_tree_mut` reports no tree and the changes are ignored rather than
+        // returning an error.
+        let mut db = MockWalletDb::new(zcash_protocol::consensus::Network::TestNetwork);
+        db.put_ironwood_shards(
+            &[],
+            None,
+            &[],
+            &[(BlockHeight::from(1), Checkpoint::tree_empty())],
+        )
+        .expect("ignored on backends without an Ironwood tree");
     }
 
     #[test]

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3771,6 +3771,10 @@ pub trait WalletWrite: WalletRead {
 ///
 /// This is the shared implementation of the [`WalletCommitmentTrees`] `put_*_shards`
 /// provided methods.
+///
+/// NOTE: This procedure must be called only within a the context of a transaction, such as
+/// in the scope of a `with_*_tree_mut` call; otherwise, failure of an intermediate step could
+/// lead to data corruption.
 fn apply_tree_changes<H, S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
     shards: &[shardtree::LocatedPrunableTree<H>],


### PR DESCRIPTION
This is the second half of the discussion behind #2586: Slipstream implements the
`zcash_client_backend` wallet interfaces and maintains its note commitment trees in an
in-memory store during scanning, flushing the accumulated changes (dirty shards, the tree
cap, and the checkpoint delta) to the wallet database once per batch. Today that flush is
the one place it must reach into `zcash_client_sqlite` concretely; this PR lets it go
through the `WalletCommitmentTrees` interface instead — the "I'd prefer Slipstream didn't
deal with `zcash_client_sqlite` directly" ask.

## Changes

- **`WalletCommitmentTrees::put_sapling_shards`** (and `put_orchard_shards` /
  `put_ironwood_shards` under the `orchard` feature): provided methods that bulk-write
  previously accumulated tree changes — shards (ascending index order), an optional
  replacement tree cap, and a checkpoint delta (removals applied before additions) — to
  the backing [`ShardStore`].
- The **default implementations** apply the changes through the corresponding
  `with_*_tree_mut` methods (the same pattern as `remove_retained_checkpoints_below`), so
  **existing implementations of the trait are unaffected** and `zcash_client_sqlite`
  needs no changes — the default runs inside its usual tree-access transaction context.
  The Ironwood variant follows `with_ironwood_tree_mut`'s convention for backends that do
  not track an Ironwood tree.
- A unit test exercising the flush-and-read-back roundtrip (including
  remove-before-add checkpoint replacement) against the in-memory mock store.
- CHANGELOG entry under 0.24.0.

## Notes for review

- The signature types are written fully qualified (`shardtree::LocatedPrunableTree`,
  `shardtree::store::Checkpoint`, …) deliberately: `WalletCommitmentTrees` is an
  `ambassador`-delegatable trait, and delegation sites receive a textual copy of each
  method signature — unqualified names would force every existing
  `#[derive(Delegate)]` site (in-repo `TestDb`, and downstream users of the pattern)
  to add imports. Verified against the in-repo delegation site.
- Parameters are borrowed (`&[...]`) and cloned per store write, because
  `with_*_tree_mut` takes `FnMut` — and per-shard cloning is exactly what a consumer
  flushing from an accumulation store does today anyway. Happy to change the calling
  convention if you'd prefer owned inputs.
- Independent of #2586 (branched from current `main`); the two only touch adjacent
  CHANGELOG lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
