### PR TITLE
Release zip321 0.9.0-rc.1, pczt 0.8.0-rc.1, zcash_client_backend 0.24.0-rc.1, zcash_client_sqlite 0.22.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7127,7 +7127,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.1"
+version = "0.22.0-rc.1"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
+version = "0.24.0-rc.1"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.7.0"
+version = "0.8.0-rc.1"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ zcash_client_backend = { version = "0.23", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.4", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.15.0", path = "zcash_keys", default-features = false  }
 zcash_protocol = { version = "0.10.0", path = "components/zcash_protocol", default-features = false }
-zip321 = { version = "0.8", path = "components/zip321" }
+zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.29.0", path = "zcash_primitives", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.23", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.1", path = "zcash_client_backend" }
 zcash_encoding = { version = "0.4", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.15.0", path = "zcash_keys", default-features = false  }
 zcash_protocol = { version = "0.10.0", path = "components/zcash_protocol", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.29.0", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.29.0", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.7", path = "pczt" }
+pczt = { version = "0.8.0-rc.1", path = "pczt" }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/components/zip321/CHANGELOG.md
+++ b/components/zip321/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.9.0-rc.1] - 2026-07-12
+
 ### Changed
 - MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0`, `zcash_address 0.13.0`.

--- a/components/zip321/Cargo.toml
+++ b/components/zip321/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zip321"
 description = "Parsing functions and data types for Zcash ZIP 321 Payment Request URIs"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 authors = [
     "Kris Nuttycombe <kris@electriccoin.co>"
 ]

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -8,12 +8,14 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## [0.8.0] - PLANNED
+## [Unreleased]
+
+## [0.8.0-rc.1] - 2026-07-12
 
 ### Changed
 - MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0`, `zcash_transparent 0.9.0`,
-  `zcash_primitives 0.29.0`, `zcash_proofs 0.29.0`
+  `zcash_primitives 0.29.0`, `zcash_proofs 0.29.0`,
   `orchard 0.15`, `shardtree 0.7`.
 - The empty states of the transparent, Sapling, Orchard, and Ironwood bundles
   now have a single canonical representation, produced consistently by the
@@ -61,10 +63,6 @@ workspace.
   and the flags are validated against it.
 - PCZT version 1 is now treated as a serialization format for the logical
   `pczt::Pczt` type.
-- The Orchard PCZT logical model now tracks the Orchard bundle's note plaintext
-  version separately from the version 1 serialization format.
-- PCZT version 2 serialization now omits empty Transparent, Sapling, and
-  Orchard bundles.
 - The Orchard PCZT logical model now represents the bundle anchor and per-action
   `cv_net` as optional fields, matching the version 2 encoding. The logical
   Orchard output model now similarly represents `cmx` as optional. Parsing
@@ -75,9 +73,6 @@ workspace.
   as `pczt::orchard::EncCiphertext`, allowing v2 serialization to carry either
   encrypted ciphertext or a trailing-zero-stripped
   `pczt::orchard::MemoPlaintext`.
-- PCZT version 2 Orchard action serialization now represents spend nullifiers
-  and `rk` values as optional fields, while parsing rejects encodings that omit
-  either field until the logical Orchard spend model supports their absence.
 - Direct `serde` serialization implementations have been removed from the
   logical `pczt::orchard::{Bundle, Action, Spend, Output}` types.
 - `pczt::Pczt::serialize` now consumes `self` and returns
@@ -85,8 +80,7 @@ workspace.
   returning `Vec<u8>`.
 - The low-level Signer's `sign_orchard_with` and `sign_ironwood_with` now parse
   the bundle with a preverified signing parse that skips deriving each spend's
-  full viewing key, driven by a bounded loop that keeps parsing stack usage flat
-  on constrained devices. These methods no longer validate the wire `fvk` bytes
+  full viewing key. These methods no longer validate the wire `fvk` bytes
   (callers must first run the full Verifier checks over the identical PCZT bytes)
   but preserve them unchanged in the returned PCZT. The signing closure must not
   add, remove, or reorder actions; doing so now returns the new
@@ -116,19 +110,20 @@ workspace.
   represent v2-only logical PCZT data.
 - `pczt::ParseError::MissingRequiredField`, returned when the PCZT encoding
   omits a field that the logical PCZT type still requires.
-- `pczt::orchard::{EncCiphertext, MEMO_SIZE, MemoPlaintext,
-  MemoPlaintextError}` for representing encrypted note plaintext data in the
-  logical Orchard output model.
+- `pczt::orchard::{EncCiphertext, MemoPlaintext}` for representing encrypted note
+  plaintext data in the logical Orchard output model.
 - `pczt::Pczt::resolve_fields`,
   `pczt::orchard::Bundle::{resolve_fields, resolve_memo_plaintexts}`, and
-  `pczt::roles::redactor::orchard::ActionRedactor::replace_enc_ciphertext_with_memo_plaintext`.
-- `pczt::roles::redactor::orchard::OrchardRedactor::clear_anchor` and
+  `pczt::roles::redactor::orchard::ActionRedactor::{replace_enc_ciphertext_with_memo_plaintext, replace_enc_ciphertext_with_decrypted_memo_plaintext}`.
+- `pczt::roles::redactor::orchard::OrchardRedactor::clear_anchor`,
+  `pczt::roles::redactor::sapling::SaplingRedactor::clear_anchor`, and
   `pczt::roles::redactor::orchard::ActionRedactor::clear_cv_net`.
 - `pczt::roles::redactor::orchard::ActionRedactor::clear_cmx`.
 - `pczt::v1`, a module providing the version 1 PCZT serialization format via
   `pczt::v1::Pczt`.
-- PCZT version 2 serialization, which encodes the Orchard note plaintext
-  version at the Orchard bundle level.
+- `pczt::v2`, a module providing the version 2 PCZT serialization format via
+  `pczt::v2::Pczt`, which encodes the Orchard note plaintext version at the
+  Orchard bundle level and omits empty Transparent, Sapling, and Orchard bundles.
 - `PartialEq` is now derived for the logical `pczt::transparent::{Bundle, Input,
   Output}`, `pczt::sapling::{Bundle, Spend, Output}`, and
   `pczt::orchard::{Bundle, Action, Spend, Output}` types (used to detect empty

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.7.0"
+version = "0.8.0-rc.1"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -995,10 +995,6 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.proc-macro2]]
-version = "1.0.103"
-criteria = "safe-to-deploy"
-
 [[exemptions.proptest]]
 version = "1.3.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zip321]]
+version = "0.9.0-rc.1"
+audited_as = "0.8.0"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.8.0-rc.1"
 audited_as = "0.7.0"
 
+[[unpublished.zcash_client_backend]]
+version = "0.24.0-rc.1"
+audited_as = "0.23.0"
+
 [[unpublished.zip321]]
 version = "0.9.0-rc.1"
 audited_as = "0.8.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,34 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_address]]
-version = "0.13.0"
-audited_as = "0.13.0-pre.0"
-
-[[unpublished.zcash_history]]
-version = "0.5.0"
-audited_as = "0.5.0-pre.0"
-
-[[unpublished.zcash_keys]]
-version = "0.15.0"
-audited_as = "0.15.0-pre.0"
-
-[[unpublished.zcash_primitives]]
-version = "0.29.0"
-audited_as = "0.29.0-pre.0"
-
-[[unpublished.zcash_proofs]]
-version = "0.29.0"
-audited_as = "0.29.0-pre.0"
-
-[[unpublished.zcash_protocol]]
-version = "0.10.0"
-audited_as = "0.10.0-pre.0"
-
-[[unpublished.zcash_transparent]]
-version = "0.9.0"
-audited_as = "0.9.0-pre.0"
-
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -470,8 +442,8 @@ user-login = "str4d"
 user-name = "Jack Grigg"
 
 [[publisher.zcash_address]]
-version = "0.13.0-pre.0"
-when = "2026-07-01"
+version = "0.13.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -498,36 +470,36 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_history]]
-version = "0.5.0-pre.0"
-when = "2026-07-01"
+version = "0.5.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_keys]]
-version = "0.15.0-pre.0"
-when = "2026-07-01"
+version = "0.15.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_primitives]]
-version = "0.29.0-pre.0"
-when = "2026-07-01"
+version = "0.29.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_proofs]]
-version = "0.29.0-pre.0"
-when = "2026-07-01"
+version = "0.29.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.10.0-pre.0"
-when = "2026-07-01"
+version = "0.10.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -547,8 +519,8 @@ user-login = "daira"
 user-name = "Daira-Emma Hopwood"
 
 [[publisher.zcash_transparent]]
-version = "0.9.0-pre.0"
-when = "2026-07-01"
+version = "0.9.0"
+when = "2026-07-09"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,21 +1,9 @@
 
 # cargo-vet imports lock
 
-[[unpublished.pczt]]
-version = "0.8.0-rc.1"
-audited_as = "0.7.0"
-
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.1"
-audited_as = "0.23.0"
-
 [[unpublished.zcash_client_sqlite]]
 version = "0.22.0-rc.1"
 audited_as = "0.21.1"
-
-[[unpublished.zip321]]
-version = "0.9.0-rc.1"
-audited_as = "0.8.0"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -109,8 +97,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.pczt]]
-version = "0.7.0"
-when = "2026-06-03"
+version = "0.8.0-rc.1"
+when = "2026-07-12"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -465,8 +453,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.23.0"
-when = "2026-06-03"
+version = "0.24.0-rc.1"
+when = "2026-07-12"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -556,8 +544,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zip321]]
-version = "0.8.0"
-when = "2026-06-03"
+version = "0.9.0-rc.1"
+when = "2026-07-12"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.7.0"
 version = "0.24.0-rc.1"
 audited_as = "0.23.0"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.1"
+audited_as = "0.21.1"
+
 [[unpublished.zip321]]
 version = "0.9.0-rc.1"
 audited_as = "0.8.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.pczt]]
+version = "0.8.0-rc.1"
+audited_as = "0.7.0"
+
 [[unpublished.zip321]]
 version = "0.9.0-rc.1"
 audited_as = "0.8.0"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -306,7 +306,7 @@ workspace.
 - Migrated to `lightwallet-protocol v0.5.0`, `zcash_protocol 0.10.0`,
   `zcash_address 0.13.0`, `zcash_transparent 0.9.0`, `zip321 0.9.0-rc.1`,
   `zcash_keys 0.15.0`, `orchard 0.15`, `zcash_primitives 0.29.0`,
-  `zcash_proofs 0.29.0`, `shardtree 0.7`. 
+  `zcash_proofs 0.29.0`, `zip321 0.9.0-rc.1`, `pczt 0.8.0-rc.1`, `shardtree 0.7`. 
 - `zcash_client_backend::data_api::ll::LowLevelWalletRead` has an added
   `block_fully_scanned_height` method, returning the height to which the wallet
   has been fully scanned.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -8,12 +8,9 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## [0.24.0] - PLANNED
+## [Unreleased]
 
-### Fixed
-- Transparent-to-shielded proposals now preserve the wallet checkpoint selected during proposal
-  construction. This prevents output-only Orchard and Ironwood bundles from attempting to use an
-  unrecorded anchor when a wallet has no shielded inputs.
+## [0.24.0-rc.1] - 2026-07-12
 
 ### Added
 - `zcash_client_backend::data_api::ll::wallet::put_blocks_rows` (with the
@@ -26,19 +23,6 @@ workspace.
 - `zcash_client_backend::data_api::ll::wallet::NULLIFIER_MAP_RETENTION_BLOCKS`, the
   trailing window of blocks whose nullifier-map entries `put_blocks_rows` always
   inserts.
-
-### Changed
-- `zcash_client_backend::data_api::ll::LowLevelWalletRead` has an added
-  `block_fully_scanned_height` method, returning the height to which the wallet
-  has been fully scanned.
-- `zcash_client_backend::data_api::ll::wallet::put_blocks_rows` (and therefore
-  `put_blocks`) now skips nullifier-map insertion for entries it can prove are
-  unobservable: when a batch extends the wallet's contiguous fully-scanned
-  frontier, only the trailing `NULLIFIER_MAP_RETENTION_BLOCKS` blocks' nullifiers
-  are inserted. The nullifier map exists to detect spends observed before the
-  corresponding note's block has been scanned, which cannot occur below a
-  contiguous frontier; out-of-order scan ranges are unaffected and continue to
-  track the nullifiers of every block.
 - The helper functions used by the note commitment tree stage of `put_blocks`
   are now `pub`, so that alternative `ShardStore`-backed stores can reuse the
   exact tree-update logic: `zcash_client_backend::data_api::ll::wallet::`
@@ -93,8 +77,8 @@ workspace.
   the total number of inputs from a given pool across all steps of the proposal.
 - `zcash_client_backend::data_api::wallet::ConfirmationsPolicy::anchor_height`,
   which returns the shielded anchor height for a given target height under the
-  policy. It is used to resolve the anchor of a proposal step that spends no
-  shielded notes and therefore defers its anchor choice.
+  policy. It is used to resolve the anchor of a purely transparent proposal step,
+  which produces no shielded bundle and therefore defers its anchor choice.
 - `zcash_client_backend::data_api::AccountBalance::ironwood_balance` and
   `AccountBalance::with_ironwood_balance_mut`, exposing the balance of Ironwood
   funds in an account. Received Ironwood notes are now included in the account's
@@ -319,6 +303,19 @@ workspace.
   this option must be executed with a matching unpadded builder configuration.
 
 ### Changed
+- Migrated to `lightwallet-protocol v0.5.0`, `zcash_protocol 0.10.0`,
+  `zcash_address 0.13.0`, `zcash_transparent 0.9.0`, `zip321 0.9.0-rc.1`,
+  `zcash_keys 0.15.0`, `orchard 0.15`, `zcash_primitives 0.29.0`,
+  `zcash_proofs 0.29.0`, `shardtree 0.7`. 
+- `zcash_client_backend::data_api::ll::LowLevelWalletRead` has an added
+  `block_fully_scanned_height` method, returning the height to which the wallet
+  has been fully scanned.
+- `zcash_client_backend::data_api::ll::wallet::put_blocks_rows` (and therefore
+  `put_blocks`) now skips nullifier-map insertion for entries it can prove are
+  unobservable: when a batch extends the wallet's contiguous fully-scanned
+  frontier, only the trailing `NULLIFIER_MAP_RETENTION_BLOCKS` blocks' nullifiers
+  are inserted. Out-of-order scan ranges are unaffected and continue to track
+  the nullifiers of every block.
 - `zcash_client_backend::proposal::Step::from_parts` now takes its `anchor_height`
   as `Option<BlockHeight>` instead of `BlockHeight`. Any step that produces a
   shielded bundle — it spends shielded notes, pays to a shielded pool, or returns
@@ -342,26 +339,13 @@ workspace.
   `orchard::builder::BundleType::DEFAULT` for the previous (padded) behavior.
 - The `proposed_version: Option<TxVersion>` parameter of
   `zcash_client_backend::data_api::wallet::propose_transfer`,
-  `propose_standard_transfer_to_address`, and `create_proposed_transactions`, along
-  with `input_selection::InputSelector::propose_transaction` and the
-  `ProposalError::IncompatibleTxVersion` variant, are no longer gated behind the
+  `propose_standard_transfer_to_address`, and
+  `input_selection::InputSelector::propose_transaction`, along with the
+  `ProposalError::IncompatibleTxVersion` variant, is no longer gated behind the
   `unstable` feature flag. Callers that did not previously enable `unstable` must now
   pass this argument explicitly; pass `None` to retain the previous behavior of
   selecting the transaction version from the target height.
-- When a transaction spends Orchard notes once the Ironwood pool is active, its
-  Orchard-pool change now stays in the Orchard pool instead of being routed into
-  the Ironwood bundle. The change is returned to a spent note's own address,
-  which the Orchard V3 cross-address restriction permits (via the builder's
-  dedicated change entry point), so only the payment crosses the turnstile into
-  Ironwood. Orchard-pool change is still routed into the Ironwood bundle when the
-  transaction spends no Orchard notes (e.g. an Orchard-receiver payment funded
-  from the Sapling and Ironwood pools).
-- Migrated to `orchard 0.15`, `shardtree 0.7`.
-- Migrated to `lightwallet-protocol v0.5.0`, `zcash_protocol 0.10.0`,
-  `zcash_address 0.13.0`, `zcash_transparent 0.9.0`,
-  `zcash_keys 0.15.0`, `zcash_primitives 0.29.0`,
-  `zcash_proofs 0.29.0`. The `lightwallet-protocol v0.5.0` migration
-  changes `zcash_client_backend::proto`:
+- The migration to `lightwallet-protocol v0.5.0` changes `zcash_client_backend::proto`:
   - Adds the `service::PoolType::Ironwood` and `service::ShieldedProtocol::Ironwood`
     variants.
   - Adds the `compact_formats::ChainMetadata::ironwood_commitment_tree_size` and
@@ -452,8 +436,7 @@ workspace.
   both behind the `orchard` feature flag.
 - `zcash_client_backend::proposal`:
   - `Proposal::single_step` and `Step::from_parts` now take transparent inputs
-    as `Vec<WalletTransparentOutput<()>>` (explicitly with no account ID), and
-    take the step's anchor height as an explicit `BlockHeight` argument.
+    as `Vec<WalletTransparentOutput<()>>` (explicitly with no account ID).
   - `Proposal::single_step` and `Step::from_parts` also take an
     `ironwood_active` flag (behind the `orchard` feature flag) indicating
     whether the Ironwood pool is active at the target height; when set, the
@@ -465,10 +448,11 @@ workspace.
     anchor of a step that defers its anchor choice (see `Step::anchor_height`).
   - The shielded anchor height has moved from `ShieldedInputs` to `Step`:
     `Step::anchor_height` is new and returns `Option<BlockHeight>`. It is `Some`
-    only for a step that spends shielded notes; a step with no shielded inputs
-    returns `None`, deferring its anchor to interpretation time where it is
-    resolved from the proposal's confirmations policy and target height.
-    `ShieldedInputs::from_parts` no longer takes an anchor height, and
+    for any step that produces a shielded bundle (one that spends shielded notes,
+    pays to a shielded pool, or returns shielded change); only a purely
+    transparent step returns `None`, deferring its anchor to interpretation time
+    where it is resolved from the proposal's confirmations policy and target
+    height. `ShieldedInputs::from_parts` no longer takes an anchor height, and
     `ShieldedInputs::anchor_height` has been removed.
 - `zcash_client_backend::proto::proposal::Proposal::try_into_standard_proposal`
   now takes the network parameters as an additional argument, in order to

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.23.0"
+version = "0.24.0-rc.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -8,7 +8,9 @@ indicated by the `PLANNED` status in order to make it possible to correctly
 represent the transitive `semver` implications of changes within the enclosing
 workspace.
 
-## Unreleased
+## [Unreleased]
+
+## [0.22.0-rc.1] - 2026-07-12
 
 ### Added
 - `WalletDb` implements the new
@@ -97,13 +99,21 @@ workspace.
 - `WalletDb::generate_ironwood_witnesses_at_historical_height`, which mirrors
   the existing Orchard historical witness helper over the wallet's Ironwood
   commitment tree shard tables.
+- A new `zewif` feature flag adds the `zcash_client_sqlite::zewif` module for
+  importing wallets from the Zcash Wallet Interchange Format (ZeWIF).
+  `zewif::import_wallet` ingests a ZeWIF document into an already-initialized
+  `WalletDb` within a single transaction, delivering any encountered spending-key
+  material to a caller-supplied `zewif::SecretSink` (use `zewif::DiscardSecrets`
+  to drop it, e.g. for a view-only import) and returning a
+  `zewif::ZewifImportReport` describing the imported and skipped items. Import
+  failures are reported via `zewif::ZewifImportError`.
 
 ### Changed
 - MSRV is now 1.88
 - Migrated to `zcash_protocol 0.10.0`, `zcash_address 0.13.0`,
-  `zcash_transparent 0.9.0`, `zcash_keys 0.15.0`,
+  `zcash_transparent 0.9.0`, `zip321 0.9.0-rc.1`, `zcash_keys 0.15.0`,
   `zcash_primitives 0.29.0`, `zcash_proofs 0.29.0`,
-  `orchard 0.15`, `shardtree 0.7`.
+  `orchard 0.15`, `shardtree 0.7`, `zcash_client_backend-0.24.0-rc.1`.
 - (behind the new `spend-index` feature) `WalletRead::transaction_data_requests`
   emits `TransactionDataRequest::GetSpendingTx` for transparent spend
   detection instead of `TransactionDataRequest::TransactionsInvolvingAddress`.
@@ -125,19 +135,6 @@ workspace.
   including under the ZIP 32 account index 0x7FFFFFFF used for the `zcashd` legacy account).
   A cross-account duplicate for which no unique record can be verified by derivation causes
   the migration to abort.
-
-### Fixed
-- Deriving a transparent address that was previously imported as a standalone receiver now
-  upgrades the existing address record in place to its derived form, instead of failing on the
-  transparent-receiver uniqueness invariant added in this release. If the import was recorded
-  under a different account, the record's account attribution — and that of any outputs
-  received at the address — moves to the deriving account, since successful derivation
-  establishes that account's ownership of the address. Funds received at such an address
-  become spendable once the account derives it.
-- Importing a standalone transparent pubkey whose receiver address is already recorded (for
-  example because it was derived as an account receiver) is now a no-op instead of failing on
-  the transparent-receiver uniqueness invariant added in this release. This is the
-  import-direction counterpart of the derivation-side fix above.
 
 ## [0.21.1] - 2026-06-19
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.21.1"
+version = "0.22.0-rc.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"


### PR DESCRIPTION
Prepares release candidates for the `zcash_client_sqlite` dependency stack.

## Releases (in dependency order)

- **zip321 0.9.0-rc.1**
- **pczt 0.8.0-rc.1**
- **zcash_client_backend 0.24.0-rc.1**
- **zcash_client_sqlite 0.22.0-rc.1**

Each release commit bumps the crate version and its `[workspace.dependencies]` requirement (full pre-release form, so the RC resolves), refreshes `Cargo.lock`, dates the CHANGELOG header, and adds a self-audited `cargo vet` `unpublished` entry mapping the RC to the previous release.

A preceding **Update `cargo vet` metadata** commit prunes the `unpublished` entries for crates that have since been published to crates.io (`zcash_protocol`, `zcash_address`, `zcash_keys`, `zcash_primitives`, `zcash_proofs`, `zcash_transparent`, `zcash_history`) and refreshes their publisher records.

## CHANGELOG review pass

Beyond dating the headers, each pending section was reconciled against the crate's last release tag: deduplicated, focused on API changes and how to adapt to them, and stripped of `Fixed`/`Changed` items for bugs or states that did not exist at the previous release. Notably:

- **pczt** — dropped in-cycle `Changed` items describing the brand-new v2 serialization format and a non-public field; corrected an `Added` entry that named non-public items; added two genuinely-public omissions (`SaplingRedactor::clear_anchor`, `ActionRedactor::replace_enc_ciphertext_with_decrypted_memo_plaintext`).
- **zcash_client_backend** — dropped the in-cycle `Fixed` item (anchor/checkpoint fix for machinery introduced this cycle); repaired a stray `### Changed` heading that had re-parented ~46 `Added` bullets; fixed a `proposed_version` contradiction; corrected two `Step` anchor descriptions to match the shipped source.
- **zcash_client_sqlite** — dropped the two in-cycle `Fixed` items (fixes for the transparent-receiver uniqueness invariant added this release); documented the new feature-gated ZeWIF wallet import.

`cargo vet --locked` passes and the workspace resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
