### PR TITLE
zcash_client_backend: Fix `propose_send_max_transfer` transparent-recipient and edge-case handling

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -47,6 +47,10 @@ workspace.
   receiver that the build is able to pay is now rejected with
   `GreedyInputSelectorError::UnsupportedAddress` instead of the same misleading
   error.
+- `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  returns `GreedyInputSelectorError::Balance` instead of panicking when a
+  custom fee rule produces per-transaction fees whose sum exceeds the maximum
+  monetary amount.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,16 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
+  `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
+  error type, so that `propose_send_max_transfer` can report
+  `GreedyInputSelectorError::UnsupportedTexAddress` — consistent with
+  `propose_transfer` — when a TEX recipient is requested and the
+  `transparent-inputs` feature is not enabled. Balance errors encountered
+  during send-max input selection are now wrapped in
+  `GreedyInputSelectorError::Balance`.
+
 ### Fixed
 - `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
   correctly constructs proposals paying a transparent (non-TEX) recipient — a
@@ -17,6 +27,12 @@ workspace.
   Previously, such proposals failed validation with
   `ProposalError::PaymentPoolsMismatch` because no output pool was assigned to
   the payment.
+- When the `transparent-inputs` feature is not enabled,
+  `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  rejects TEX recipients up front with
+  `GreedyInputSelectorError::UnsupportedTexAddress` instead of constructing an
+  internally inconsistent proposal that failed validation with a misleading
+  error.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -39,6 +39,14 @@ workspace.
   zero value to a shielded recipient (spending the whole balance as fee), and
   reported `PaymentError::ZeroValuedTransparentOutput` for transparent
   recipients.
+- When the `orchard` feature is not enabled,
+  `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  delivers a payment to a unified address having both Sapling and Orchard
+  receivers via the Sapling receiver, instead of failing with
+  `ProposalError::PaymentPoolsMismatch`. A unified address containing no
+  receiver that the build is able to pay is now rejected with
+  `GreedyInputSelectorError::UnsupportedAddress` instead of the same misleading
+  error.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  correctly constructs proposals paying a transparent (non-TEX) recipient — a
+  bare transparent address, or a unified address having no shielded receiver.
+  Previously, such proposals failed validation with
+  `ProposalError::PaymentPoolsMismatch` because no output pool was assigned to
+  the payment.
+
 ## [0.24.0-rc.1] - 2026-07-12
 
 ### Added

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -33,6 +33,12 @@ workspace.
   `GreedyInputSelectorError::UnsupportedTexAddress` instead of constructing an
   internally inconsistent proposal that failed validation with a misleading
   error.
+- `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  returns `Error::InsufficientFunds` when the wallet's entire spendable balance
+  would be consumed by fees. Previously it proposed a transaction delivering
+  zero value to a shielded recipient (spending the whole balance as fee), and
+  reported `PaymentError::ZeroValuedTransparentOutput` for transparent
+  recipients.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1082,6 +1082,39 @@ pub fn send_max_to_tex_fails_without_transparent_inputs<T: ShieldedPoolTester>(
     );
 }
 
+/// Tests that a send-max proposal fails with `InsufficientFunds` when the entire wallet
+/// balance would be consumed by fees, rather than proposing a transaction that delivers
+/// nothing to the recipient.
+pub fn send_max_fails_when_balance_is_consumed_by_fees<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds equal to the exact fee of a send-max transaction spending a single note
+    // to a same-pool recipient (two logical actions under ZIP 317).
+    let value = MINIMUM_FEE;
+    st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let to: Address = T::sk_default_address(&T::sk(&[0xf5; 32]));
+    let fee_rule = StandardFeeRule::Zip317;
+
+    let addy = to.to_zcash_address(st.network());
+    assert_matches!(
+        st.propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        ),
+        Err(data_api::error::Error::InsufficientFunds { available, required })
+            if available == value && required > value
+    );
+}
+
 /// Tests that attempting to send all the spendable funds within the given shielded pool in a
 /// single transaction fail if there are funds that are not yet confirmed.
 ///

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1109,6 +1109,108 @@ pub fn send_max_fee_overflow_is_an_error<T: ShieldedPoolTester>(
     );
 }
 
+/// Tests that a send-max proposal spends notes from multiple shielded pools in a single
+/// transaction when the wallet's funds are split across pools.
+///
+/// The test:
+/// - Adds one note in each of the `P0` and `P1` pools.
+/// - Proposes a send-max transaction to an external `P1` recipient, so that the value of
+///   the `P0` note crosses pools.
+/// - Verifies that the proposal consists of a single step spending both notes and paying
+///   the whole balance, less the fee, to the recipient.
+/// - Builds the transaction, mines it, and verifies that the wallet is left empty.
+#[cfg(feature = "orchard")]
+pub fn send_max_spends_inputs_across_pools<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<P0>();
+    let account = st.test_account().cloned().unwrap();
+
+    // Add one note in each of the P0 and P1 pools.
+    let p0_fvk = P0::test_account_fvk(&st);
+    let p1_fvk = P1::test_account_fvk(&st);
+    let note_value = Zatoshis::const_from_u64(350000);
+    st.generate_next_block(&p0_fvk, AddressType::DefaultExternal, note_value);
+    st.generate_next_block(&p1_fvk, AddressType::DefaultExternal, note_value);
+    st.scan_cached_blocks(account.birthday().height(), 2);
+
+    let total = (note_value * 2u64).unwrap();
+    assert_eq!(
+        st.get_spendable_balance(account.id(), ConfirmationsPolicy::MIN),
+        total
+    );
+
+    let to: Address = P1::sk_default_address(&P1::sk(&[0xf5; 32]));
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // The proposed transaction spends one note in each pool and pays a single shielded
+    // output; under ZIP 317, each of the two shielded bundles is padded to two logical
+    // actions.
+    let expected_fee = (MARGINAL_FEE * 4u64).unwrap();
+    let expected_payment = (total - expected_fee).unwrap();
+
+    let addy = to.to_zcash_address(st.network());
+    let proposal = st
+        .propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap();
+
+    let steps: Vec<_> = proposal.steps().iter().cloned().collect();
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0].balance().fee_required(), expected_fee);
+    assert_eq!(steps[0].balance().proposed_change(), []);
+    assert_eq!(
+        steps[0].payment_pools(),
+        &BTreeMap::from([(0, PoolType::Shielded(P1::SHIELDED_PROTOCOL))])
+    );
+    assert_matches!(
+        steps[0].transaction_request().payments().get(&0),
+        Some(payment) if payment.amount() == Some(expected_payment)
+    );
+
+    // The proposal spends both notes, one from each pool.
+    let input_notes = steps[0]
+        .shielded_inputs()
+        .expect("the proposal has shielded inputs")
+        .notes();
+    assert_eq!(input_notes.len(), 2);
+    let input_pools = input_notes
+        .iter()
+        .map(|n| match n.note() {
+            Note::Sapling(_) => ShieldedPool::Sapling,
+            Note::Orchard { pool, .. } => match pool {
+                ::orchard::ValuePool::Orchard => ShieldedPool::Orchard,
+                ::orchard::ValuePool::Ironwood => ShieldedPool::Ironwood,
+            },
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        input_pools,
+        BTreeSet::from([P0::SHIELDED_PROTOCOL, P1::SHIELDED_PROTOCOL])
+    );
+
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+
+    // Mine the transaction and verify that the entire balance has been spent.
+    let (h, _) = st.generate_next_block_including(create_proposed_result.unwrap()[0]);
+    st.scan_cached_blocks(h, 1);
+    assert_eq!(st.get_total_balance(account.id()), Zatoshis::ZERO);
+}
+
 /// Tests that proposing a send-max transfer to a TEX recipient fails with a meaningful
 /// error when the `transparent-inputs` feature is not enabled.
 #[cfg(not(feature = "transparent-inputs"))]

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1048,6 +1048,67 @@ pub fn send_max_spendable_to_transparent<T: ShieldedPoolTester>(
     assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
 }
 
+/// Tests that a send-max proposal whose total required fee overflows the maximum
+/// monetary amount fails with a balance error rather than panicking.
+#[cfg(feature = "transparent-inputs")]
+pub fn send_max_fee_overflow_is_an_error<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use zcash_primitives::transaction::fees::{FeeRule, transparent::InputSize};
+    use zcash_protocol::value::{BalanceError, MAX_MONEY};
+
+    use crate::data_api::wallet::input_selection::GreedyInputSelectorError;
+
+    /// A fee rule that requires the maximum monetary amount for every transaction.
+    #[derive(Clone, Debug)]
+    struct MaxMoneyFeeRule;
+
+    impl FeeRule for MaxMoneyFeeRule {
+        type Error = Infallible;
+
+        fn fee_required<P: consensus::Parameters>(
+            &self,
+            _params: &P,
+            _target_height: BlockHeight,
+            _transparent_input_sizes: impl IntoIterator<Item = InputSize>,
+            _transparent_output_sizes: impl IntoIterator<Item = usize>,
+            _sapling_input_count: usize,
+            _sapling_output_count: usize,
+            _orchard_action_count: usize,
+            _ironwood_action_count: usize,
+        ) -> Result<Zatoshis, Self::Error> {
+            Ok(Zatoshis::const_from_u64(MAX_MONEY))
+        }
+    }
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60000));
+
+    let account = st.test_account().cloned().unwrap();
+
+    // A TEX recipient requires a second transaction, so the total required fee is the
+    // sum of two per-transaction fees, which overflows the maximum monetary amount.
+    let tex_addr = Address::Tex([0x4; 20]);
+    let addy = tex_addr.to_zcash_address(st.network());
+
+    assert_matches!(
+        st.propose_send_max_transfer(
+            account.id(),
+            &MaxMoneyFeeRule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        ),
+        Err(data_api::error::Error::NoteSelection(
+            GreedyInputSelectorError::Balance(BalanceError::Overflow)
+        ))
+    );
+}
+
 /// Tests that proposing a send-max transfer to a TEX recipient fails with a meaningful
 /// error when the `transparent-inputs` feature is not enabled.
 #[cfg(not(feature = "transparent-inputs"))]

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1082,6 +1082,123 @@ pub fn send_max_to_tex_fails_without_transparent_inputs<T: ShieldedPoolTester>(
     );
 }
 
+/// Tests that a send-max proposal to a unified address having both Sapling and Orchard
+/// receivers is delivered via the Sapling receiver when the `orchard` feature is not
+/// enabled, rather than failing.
+#[cfg(not(feature = "orchard"))]
+pub fn send_max_delivers_via_sapling_when_orchard_is_unavailable<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use zcash_address::{
+        ZcashAddress,
+        unified::{self, Encoding as _, Receiver},
+    };
+    use zcash_protocol::PoolType;
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(60000);
+    st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+
+    // Construct a unified address carrying both a Sapling receiver and an Orchard
+    // receiver. Without the `orchard` feature, the Orchard receiver's contents are
+    // not parsed, so arbitrary receiver bytes suffice.
+    let sapling_receiver = match T::sk_default_address(&T::sk(&[0xf5; 32])) {
+        Address::Sapling(addr) => addr.to_bytes(),
+        _ => panic!("expected a Sapling address"),
+    };
+    let ua = unified::Address::try_from_items(vec![
+        Receiver::Sapling(sapling_receiver),
+        Receiver::Orchard([0xab; 43]),
+    ])
+    .unwrap();
+    let addy = ZcashAddress::try_from_encoded(&ua.encode(&st.network().network_type())).unwrap();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // The proposed transaction carries one Sapling spend and one requested Sapling
+    // output (padded to two logical actions under ZIP 317).
+    let expected_fee = MINIMUM_FEE;
+    let expected_payment = (value - expected_fee).unwrap();
+
+    let proposal = st
+        .propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap();
+
+    let steps: Vec<_> = proposal.steps().iter().cloned().collect();
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0].balance().fee_required(), expected_fee);
+    assert_eq!(
+        steps[0].payment_pools(),
+        &std::collections::BTreeMap::from([(0, PoolType::SAPLING)])
+    );
+    assert_matches!(
+        steps[0].transaction_request().payments().get(&0),
+        Some(payment) if payment.amount() == Some(expected_payment)
+    );
+
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+}
+
+/// Tests that a send-max proposal to a unified address whose only receiver cannot be
+/// paid by this build (an Orchard-only address, without the `orchard` feature) fails
+/// with `GreedyInputSelectorError::UnsupportedAddress`.
+#[cfg(not(feature = "orchard"))]
+pub fn send_max_to_orchard_only_ua_fails_without_orchard<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use crate::data_api::wallet::input_selection::GreedyInputSelectorError;
+    use zcash_address::{
+        ZcashAddress,
+        unified::{self, Encoding as _, Receiver},
+    };
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60000));
+
+    let account = st.test_account().cloned().unwrap();
+
+    // Without the `orchard` feature, the Orchard receiver's contents are not parsed,
+    // so arbitrary receiver bytes suffice.
+    let ua = unified::Address::try_from_items(vec![Receiver::Orchard([0xab; 43])]).unwrap();
+    let addy = ZcashAddress::try_from_encoded(&ua.encode(&st.network().network_type())).unwrap();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    assert_matches!(
+        st.propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        ),
+        Err(data_api::error::Error::NoteSelection(
+            GreedyInputSelectorError::UnsupportedAddress(_)
+        ))
+    );
+}
+
 /// Tests that a send-max proposal fails with `InsufficientFunds` when the entire wallet
 /// balance would be consumed by fees, rather than proposing a transaction that delivers
 /// nothing to the recipient.

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -983,6 +983,71 @@ pub fn fails_to_send_max_spendable_to_transparent_with_memo<T: ShieldedPoolTeste
     );
 }
 
+/// Tests that sending all the spendable funds within the given shielded pool to a
+/// transparent (non-TEX) recipient succeeds.
+///
+/// The test:
+/// - Adds funds to the wallet in a single note.
+/// - Proposes a send-max transaction to a transparent address, without a memo.
+/// - Verifies that the proposal consists of a single step paying the whole balance,
+///   less the fee, to the transparent recipient.
+/// - Builds the transaction.
+#[cfg(feature = "transparent-inputs")]
+pub fn send_max_spendable_to_transparent<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use zcash_protocol::PoolType;
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(60000);
+    st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let to: Address = Address::Transparent(TransparentAddress::PublicKeyHash([0x7f; 20]));
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // The proposed transaction carries one shielded spend (padded to two shielded
+    // outputs) and one transparent output.
+    let expected_fee = (zip317::MARGINAL_FEE * 3u64).unwrap();
+    let expected_payment = (value - expected_fee).unwrap();
+
+    let addy = to.to_zcash_address(st.network());
+    let proposal = st
+        .propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap();
+
+    let steps: Vec<_> = proposal.steps().iter().cloned().collect();
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0].balance().fee_required(), expected_fee);
+    assert_eq!(steps[0].balance().proposed_change(), []);
+    assert_eq!(
+        steps[0].payment_pools(),
+        &std::collections::BTreeMap::from([(0, PoolType::TRANSPARENT)])
+    );
+    assert_matches!(
+        steps[0].transaction_request().payments().get(&0),
+        Some(payment) if payment.amount() == Some(expected_payment)
+    );
+
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+}
+
 /// Tests that attempting to send all the spendable funds within the given shielded pool in a
 /// single transaction fail if there are funds that are not yet confirmed.
 ///

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1048,6 +1048,40 @@ pub fn send_max_spendable_to_transparent<T: ShieldedPoolTester>(
     assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
 }
 
+/// Tests that proposing a send-max transfer to a TEX recipient fails with a meaningful
+/// error when the `transparent-inputs` feature is not enabled.
+#[cfg(not(feature = "transparent-inputs"))]
+pub fn send_max_to_tex_fails_without_transparent_inputs<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use crate::data_api::wallet::input_selection::GreedyInputSelectorError;
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60000));
+
+    let account = st.test_account().cloned().unwrap();
+    let tex_addr = Address::Tex([0x4; 20]);
+    let fee_rule = StandardFeeRule::Zip317;
+
+    let addy = tex_addr.to_zcash_address(st.network());
+    assert_matches!(
+        st.propose_send_max_transfer(
+            account.id(),
+            &fee_rule,
+            addy,
+            None,
+            MaxSpendMode::Everything,
+            ConfirmationsPolicy::MIN,
+        ),
+        Err(data_api::error::Error::NoteSelection(
+            GreedyInputSelectorError::UnsupportedTexAddress
+        ))
+    );
+}
+
 /// Tests that attempting to send all the spendable funds within the given shielded pool in a
 /// single transaction fail if there are funds that are not yet confirmed.
 ///

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -77,7 +77,7 @@ use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::{BalanceError, Zatoshis},
+    value::Zatoshis,
 };
 use zip32::Scope;
 use zip321::Payment;
@@ -116,13 +116,15 @@ use {
     serde::{Deserialize, Serialize},
     transparent::pczt::Bip32Derivation,
     zcash_note_encryption::try_output_recovery_with_pkd_esk,
-    zcash_protocol::consensus::NetworkConstants,
+    zcash_protocol::{consensus::NetworkConstants, value::BalanceError},
 };
 
 use zcash_primitives::transaction::TxVersion;
 
 pub mod input_selection;
-use input_selection::{GreedyInputSelector, InputSelector, InputSelectorError};
+use input_selection::{
+    GreedyInputSelector, GreedyInputSelectorError, InputSelector, InputSelectorError,
+};
 
 #[cfg(feature = "pczt")]
 const PROPRIETARY_PROPOSAL_INFO: &str = "zcash_client_backend:proposal_info";
@@ -281,7 +283,7 @@ pub type ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error<
 pub type ProposeSendMaxErrT<DbT, CommitmentTreeErrT, FeeRuleT> = Error<
     <DbT as WalletRead>::Error,
     CommitmentTreeErrT,
-    BalanceError,
+    GreedyInputSelectorError,
     <FeeRuleT as FeeRule>::Error,
     <FeeRuleT as FeeRule>::Error,
     <DbT as InputSource>::NoteRef,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1693,9 +1693,11 @@ where
     // the total fee required for the all the involved transactions. For the case
     // of TEX it means the fee requied to send the max value to the ephemeral
     // address + the fee to send the value in that ephemeral change address to
-    // the TEX address.
-    let total_fee_required = (tr0_fee + tr1_fee.unwrap_or(Zatoshis::ZERO))
-        .expect("fee value addition does not overflow");
+    // the TEX address. The sum can only exceed the maximum monetary amount for a
+    // fee rule that produces fees outside that amount's intended bounds.
+    let total_fee_required = (tr0_fee + tr1_fee.unwrap_or(Zatoshis::ZERO)).ok_or(
+        InputSelectorError::Selection(GreedyInputSelectorError::Balance(BalanceError::Overflow)),
+    )?;
 
     // the total amount involved in the "send max" operation. This is the total
     // spendable value present in the wallet minus the fees required to perform

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1565,13 +1565,13 @@ where
     let orchard_bundle_required = orchard_action_count > 0;
 
     #[cfg(feature = "orchard")]
-    let ironwood_action_count = orchard::builder::BundleType::DEFAULT
-        .num_actions(
-            orchard::bundle::Flags::ENABLED,
-            spendable_notes.ironwood.len(),
-            usize::from(orchard_receiver_payable && orchard_receivers_fill_ironwood),
-        )
-        .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?;
+    let ironwood_action_count = orchard_fees::transactional_action_count(
+        ::orchard::builder::BundleType::DEFAULT,
+        ironwood_bundle_version_for_height(params, target_height),
+        spendable_notes.ironwood.len(),
+        usize::from(orchard_receiver_payable && orchard_receivers_fill_ironwood),
+    )
+    .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?;
     #[cfg(not(feature = "orchard"))]
     let ironwood_action_count: usize = 0;
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1573,6 +1573,22 @@ where
         .clone()
         .convert_if_network(params.network_type())?;
 
+    // A recipient that can only receive funds via a transparent output — a bare
+    // transparent address, or a unified address with no shielded receiver — is paid
+    // directly from the proposed transaction. TEX recipients are excluded: their
+    // payment is delivered by the ephemeral second step, which carries its own
+    // payment pool assignment.
+    let pays_transparent_directly = match &recipient_address {
+        Address::Transparent(_) => true,
+        Address::Unified(addr) => {
+            addr.has_transparent() && !(addr.has_sapling() || addr.has_orchard())
+        }
+        _ => false,
+    };
+    if pays_transparent_directly {
+        payment_pools.insert(0, PoolType::Transparent);
+    }
+
     let (tr0_fee, tr1_fee) = match recipient_address {
         Address::Sapling(_) => fee_rule
             .fee_required(
@@ -1598,12 +1614,12 @@ where
                 ironwood_action_count,
             )
             .map(|fee| (fee, None)),
-        Address::Unified(addr) => fee_rule
+        Address::Unified(_) => fee_rule
             .fee_required(
                 params,
                 BlockHeight::from(target_height),
                 [],
-                if addr.has_transparent() && !(addr.has_sapling() || addr.has_orchard()) {
+                if pays_transparent_directly {
                     vec![P2PKH_STANDARD_OUTPUT_SIZE]
                 } else {
                     vec![]

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1504,17 +1504,25 @@ where
 
     let mut payment_pools = BTreeMap::new();
 
+    // An Orchard receiver takes delivery precedence over a Sapling receiver only when
+    // this build is able to produce Orchard-family outputs; without the `orchard`
+    // feature, a payment to a recipient having both receivers is delivered via the
+    // Sapling receiver.
+    #[cfg(feature = "orchard")]
+    let orchard_receiver_payable = recipient.can_receive_as(PoolType::ORCHARD);
+    #[cfg(not(feature = "orchard"))]
+    let orchard_receiver_payable = false;
+
     let sapling_output_count = {
-        // we require a sapling output if the recipient has a Sapling receiver but not an Orchard
-        // receiver.
-        let requested_sapling_outputs: usize = if recipient.can_receive_as(PoolType::SAPLING)
-            && !recipient.can_receive_as(PoolType::ORCHARD)
-        {
-            payment_pools.insert(0, PoolType::SAPLING);
-            1
-        } else {
-            0
-        };
+        // we require a sapling output if the recipient has a Sapling receiver and its
+        // payment is not deliverable via an Orchard receiver.
+        let requested_sapling_outputs: usize =
+            if recipient.can_receive_as(PoolType::SAPLING) && !orchard_receiver_payable {
+                payment_pools.insert(0, PoolType::SAPLING);
+                1
+            } else {
+                0
+            };
 
         ::sapling::builder::BundleType::DEFAULT
             .num_outputs(spendable_notes.sapling.len(), requested_sapling_outputs)
@@ -1527,11 +1535,9 @@ where
     // once Ironwood is active (delivered to the Orchard receiver via the Ironwood bundle), and as
     // an Orchard-pool output otherwise. The per-bundle action counts below reflect that split.
     #[cfg(feature = "orchard")]
-    let orchard_receiver_present = recipient.can_receive_as(PoolType::ORCHARD);
-    #[cfg(feature = "orchard")]
     let orchard_receivers_fill_ironwood = ironwood_active_at(params, target_height);
     #[cfg(feature = "orchard")]
-    if orchard_receiver_present {
+    if orchard_receiver_payable {
         payment_pools.insert(
             0,
             if orchard_receivers_fill_ironwood {
@@ -1549,7 +1555,7 @@ where
         ::orchard::builder::BundleType::DEFAULT,
         orchard_bundle_version_for_height(params, target_height),
         spendable_notes.orchard.len(),
-        usize::from(orchard_receiver_present && !orchard_receivers_fill_ironwood),
+        usize::from(orchard_receiver_payable && !orchard_receivers_fill_ironwood),
     )
     .map_err(|e| InputSelectorError::Change(ChangeError::BundleError(e)))?;
     #[cfg(not(feature = "orchard"))]
@@ -1563,7 +1569,7 @@ where
         .num_actions(
             orchard::bundle::Flags::ENABLED,
             spendable_notes.ironwood.len(),
-            usize::from(orchard_receiver_present && orchard_receivers_fill_ironwood),
+            usize::from(orchard_receiver_payable && orchard_receivers_fill_ironwood),
         )
         .map_err(|s| InputSelectorError::Change(ChangeError::BundleError(s)))?;
     #[cfg(not(feature = "orchard"))]
@@ -1590,6 +1596,19 @@ where
     };
     if pays_transparent_directly {
         payment_pools.insert(0, PoolType::Transparent);
+    }
+
+    // A unified address that has been assigned no payment pool by this point contains
+    // no receiver that this build is able to pay (for example, an address containing
+    // only an Orchard receiver, in a build made without the `orchard` feature). Other
+    // recipient kinds always receive an assignment above, except for TEX addresses,
+    // whose payment is delivered by the ephemeral second step.
+    if payment_pools.is_empty() {
+        if let Address::Unified(addr) = &recipient_address {
+            return Err(InputSelectorError::Selection(
+                GreedyInputSelectorError::UnsupportedAddress(Box::new(addr.clone())),
+            ));
+        }
     }
 
     let (tr0_fee, tr1_fee) = match recipient_address {

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -15,7 +15,7 @@ use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::{BalanceError, Zatoshis},
+    value::{BalanceError, MAX_MONEY, Zatoshis},
 };
 use zip321::TransactionRequest;
 
@@ -1680,11 +1680,16 @@ where
 
     // the total amount involved in the "send max" operation. This is the total
     // spendable value present in the wallet minus the fees required to perform
-    // the send max operation.
-    let total_to_recipient =
-        (input_total - total_fee_required).ok_or(InputSelectorError::InsufficientFunds {
+    // the send max operation. The proposal must deliver a nonzero amount to the
+    // recipient: a send-max operation on a wallet whose entire balance would be
+    // consumed by fees is reported as insufficient funds rather than proposed as
+    // a fee-only transaction.
+    let total_to_recipient = (input_total - total_fee_required)
+        .filter(|amount| *amount > Zatoshis::ZERO)
+        .ok_or(InputSelectorError::InsufficientFunds {
             available: input_total,
-            required: total_fee_required,
+            required: (total_fee_required + Zatoshis::const_from_u64(1))
+                .unwrap_or(Zatoshis::const_from_u64(MAX_MONEY)),
         })?;
 
     // when the recipient of the send max operation is a TEX address this is the

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -10,11 +10,7 @@ use std::{
 use transparent::bundle::TxOut;
 use zcash_address::{ConversionError, ZcashAddress};
 use zcash_keys::address::{Address, UnifiedAddress};
-use zcash_primitives::transaction::fees::{
-    FeeRule,
-    transparent::InputSize,
-    zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
-};
+use zcash_primitives::transaction::fees::{FeeRule, zip317::P2PKH_STANDARD_OUTPUT_SIZE};
 use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
@@ -44,7 +40,9 @@ use {
     },
     std::convert::Infallible,
     transparent::{address::TransparentAddress, bundle::OutPoint},
-    zcash_primitives::transaction::fees::transparent as transparent_fees,
+    zcash_primitives::transaction::fees::{
+        transparent as transparent_fees, transparent::InputSize, zip317::P2PKH_STANDARD_INPUT_SIZE,
+    },
     zip321::Payment,
 };
 
@@ -1477,7 +1475,12 @@ pub(crate) fn propose_send_max<ParamsT, InputSourceT, FeeRuleT>(
     memo: Option<MemoBytes>,
 ) -> Result<
     Proposal<FeeRuleT, InputSourceT::NoteRef>,
-    InputSelectorError<InputSourceT::Error, BalanceError, FeeRuleT::Error, InputSourceT::NoteRef>,
+    InputSelectorError<
+        InputSourceT::Error,
+        GreedyInputSelectorError,
+        FeeRuleT::Error,
+        InputSourceT::NoteRef,
+    >,
 >
 where
     ParamsT: consensus::Parameters,
@@ -1497,7 +1500,7 @@ where
 
     let input_total = spendable_notes
         .total_value()
-        .map_err(InputSelectorError::Selection)?;
+        .map_err(|e| InputSelectorError::Selection(GreedyInputSelectorError::Balance(e)))?;
 
     let mut payment_pools = BTreeMap::new();
 
@@ -1630,6 +1633,16 @@ where
                 ironwood_action_count,
             )
             .map(|fee| (fee, None)),
+        // Paying a TEX recipient requires a second, purely transparent transaction that
+        // spends an ephemeral output of the first; constructing that ZIP 320 pair is
+        // only supported when the `transparent-inputs` feature is enabled.
+        #[cfg(not(feature = "transparent-inputs"))]
+        Address::Tex(_) => {
+            return Err(InputSelectorError::Selection(
+                GreedyInputSelectorError::UnsupportedTexAddress,
+            ));
+        }
+        #[cfg(feature = "transparent-inputs")]
         Address::Tex(_) => fee_rule
             .fee_required(
                 params,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -57,6 +57,13 @@ pub(crate) fn spend_everything_single_step_proposed_transfer<T: ShieldedPoolTest
     )
 }
 
+#[cfg(not(feature = "transparent-inputs"))]
+pub(crate) fn send_max_to_tex_fails_without_transparent_inputs<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_to_tex_fails_without_transparent_inputs::<
+        T,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 #[cfg(feature = "transparent-inputs")]
 pub(crate) fn send_max_spendable_to_transparent<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::send_max_spendable_to_transparent::<T>(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -80,6 +80,20 @@ pub(crate) fn fails_to_send_max_to_transparent_with_memo<T: ShieldedPoolTester>(
     )
 }
 
+#[cfg(not(feature = "orchard"))]
+pub(crate) fn send_max_delivers_via_sapling_when_orchard_is_unavailable<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_delivers_via_sapling_when_orchard_is_unavailable::<
+        T,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
+#[cfg(not(feature = "orchard"))]
+pub(crate) fn send_max_to_orchard_only_ua_fails_without_orchard<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_to_orchard_only_ua_fails_without_orchard::<
+        T,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn send_max_fails_when_balance_is_consumed_by_fees<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<
         T,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -57,6 +57,14 @@ pub(crate) fn spend_everything_single_step_proposed_transfer<T: ShieldedPoolTest
     )
 }
 
+#[cfg(feature = "transparent-inputs")]
+pub(crate) fn send_max_fee_overflow_is_an_error<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_fee_overflow_is_an_error::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 #[cfg(not(feature = "transparent-inputs"))]
 pub(crate) fn send_max_to_tex_fails_without_transparent_inputs<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::send_max_to_tex_fails_without_transparent_inputs::<

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -57,6 +57,17 @@ pub(crate) fn spend_everything_single_step_proposed_transfer<T: ShieldedPoolTest
     )
 }
 
+#[cfg(feature = "orchard")]
+pub(crate) fn send_max_spends_inputs_across_pools<
+    P0: ShieldedPoolTester,
+    P1: ShieldedPoolTester,
+>() {
+    zcash_client_backend::data_api::testing::pool::send_max_spends_inputs_across_pools::<P0, P1>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 #[cfg(feature = "transparent-inputs")]
 pub(crate) fn send_max_fee_overflow_is_an_error<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::send_max_fee_overflow_is_an_error::<T>(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -80,6 +80,12 @@ pub(crate) fn fails_to_send_max_to_transparent_with_memo<T: ShieldedPoolTester>(
     )
 }
 
+pub(crate) fn send_max_fails_when_balance_is_consumed_by_fees<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<
+        T,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 pub(crate) fn send_max_proposal_fails_when_unconfirmed_funds_present<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::spend_everything_proposal_fails_when_unconfirmed_funds_present::<T>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -58,6 +58,14 @@ pub(crate) fn spend_everything_single_step_proposed_transfer<T: ShieldedPoolTest
 }
 
 #[cfg(feature = "transparent-inputs")]
+pub(crate) fn send_max_spendable_to_transparent<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_max_spendable_to_transparent::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+#[cfg(feature = "transparent-inputs")]
 pub(crate) fn fails_to_send_max_to_transparent_with_memo<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::fails_to_send_max_spendable_to_transparent_with_memo::<T>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -664,6 +664,12 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "transparent-inputs"))]
+    fn send_max_to_tex_fails_without_transparent_inputs() {
+        testing::pool::send_max_to_tex_fails_without_transparent_inputs::<OrchardPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<OrchardPoolTester>()

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -670,6 +670,12 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn send_max_fee_overflow_is_an_error() {
+        testing::pool::send_max_fee_overflow_is_an_error::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn send_max_fails_when_balance_is_consumed_by_fees() {
         testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -676,6 +676,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn send_max_spends_inputs_across_pools() {
+        testing::pool::send_max_spends_inputs_across_pools::<OrchardPoolTester, SaplingPoolTester>()
+    }
+
+    #[test]
     fn send_max_fails_when_balance_is_consumed_by_fees() {
         testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -659,6 +659,12 @@ pub(crate) mod tests {
 
     #[test]
     #[cfg(feature = "transparent-inputs")]
+    fn send_max_spendable_to_transparent() {
+        testing::pool::send_max_spendable_to_transparent::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -670,6 +670,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn send_max_fails_when_balance_is_consumed_by_fees() {
+        testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<OrchardPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<OrchardPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -451,6 +451,12 @@ pub(crate) mod tests {
 
     #[test]
     #[cfg(feature = "transparent-inputs")]
+    fn send_max_spendable_to_transparent() {
+        testing::pool::send_max_spendable_to_transparent::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -467,6 +467,19 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "orchard"))]
+    fn send_max_delivers_via_sapling_when_orchard_is_unavailable() {
+        testing::pool::send_max_delivers_via_sapling_when_orchard_is_unavailable::<SaplingPoolTester>(
+        )
+    }
+
+    #[test]
+    #[cfg(not(feature = "orchard"))]
+    fn send_max_to_orchard_only_ua_fails_without_orchard() {
+        testing::pool::send_max_to_orchard_only_ua_fails_without_orchard::<SaplingPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<SaplingPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -468,6 +468,12 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "orchard")]
+    fn send_max_spends_inputs_across_pools() {
+        testing::pool::send_max_spends_inputs_across_pools::<SaplingPoolTester, OrchardPoolTester>()
+    }
+
+    #[test]
     fn send_max_fails_when_balance_is_consumed_by_fees() {
         testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -462,6 +462,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn send_max_fails_when_balance_is_consumed_by_fees() {
+        testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<SaplingPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<SaplingPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -462,6 +462,12 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn send_max_fee_overflow_is_an_error() {
+        testing::pool::send_max_fee_overflow_is_an_error::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn send_max_fails_when_balance_is_consumed_by_fees() {
         testing::pool::send_max_fails_when_balance_is_consumed_by_fees::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -456,6 +456,12 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "transparent-inputs"))]
+    fn send_max_to_tex_fails_without_transparent_inputs() {
+        testing::pool::send_max_to_tex_fails_without_transparent_inputs::<SaplingPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn fails_to_send_max_to_transparent_with_memo() {
         testing::pool::fails_to_send_max_to_transparent_with_memo::<SaplingPoolTester>()


### PR DESCRIPTION
Closes #2614.

A review of `propose_send_max` found that send-max proposals to plain transparent recipients always failed, and that several edge cases were mishandled. Each fix is a separate commit, made test-first (the new pool tests were observed failing with the exact defect before each fix):

1. **Fix send-max proposals to transparent recipients.** No payment pool was ever assigned for a bare transparent address or a unified address with no shielded receiver, so every such proposal failed validation with `ProposalError::PaymentPoolsMismatch`. Such recipients are now assigned `PoolType::Transparent` (TEX recipients excluded — their payment belongs to the ephemeral second step), and the unified-address arm of the fee computation shares the same predicate so the transparent-output accounting and pool assignment cannot drift apart.

2. **Reject send-max to TEX recipients without `transparent-inputs`.** The `Address::Tex` fee arm was not feature-gated; without the feature, the second-step fee was deducted but no ephemeral step was constructed, and the proposal failed with a misleading error. TEX recipients are now rejected up front with `GreedyInputSelectorError::UnsupportedTexAddress`, consistent with `propose_transfer`. This required widening `ProposeSendMaxErrT`'s note-selection error type from `BalanceError` to `GreedyInputSelectorError` (balance errors are now wrapped in its `Balance` variant).

3. **Require send-max proposals to deliver nonzero value.** When the spendable balance exactly equaled the required fee, the proposal paid the recipient zero and consumed the entire balance as fees. This now reports `InsufficientFunds`, with `required` reflecting the minimum total needed to deliver a nonzero amount.

4. **Deliver via Sapling when Orchard is unavailable.** Orchard-receiver preemption of Sapling delivery was decided via `ZcashAddress::can_receive_as(ORCHARD)`, which reflects the address contents rather than the receivers the build can pay. In a no-`orchard` build, a payment to a UA with both receivers was assigned no pool at all. Orchard receivers now take precedence only when the feature is enabled, and a UA with no payable receiver is rejected with `GreedyInputSelectorError::UnsupportedAddress`. Verified end-to-end through transaction creation in a default-features build.

5. **Minor robustness/consistency:** the Ironwood action count now goes through `transactional_action_count` with the bundle version in effect at the target height (behavior-identical for all current versions), and the `tr0_fee + tr1_fee` sum reports `BalanceError::Overflow` instead of panicking when a caller-supplied fee rule produces fees near the maximum monetary amount.

Seven new pool tests cover the fixed behaviors, instantiated for the Sapling and (where applicable) Orchard pool testers, including `cfg(not(feature = ...))` variants for the feature-gated cases. The full `zcash_client_sqlite` suite passes with `orchard transparent-inputs` (313 tests) and with default features (166 tests), and `zcash_client_backend` compiles warning-free across the `orchard`/`transparent-inputs` feature matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
