### PR TITLE
Return transparent change to originating P2SH address

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,43 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::fees::TransparentChangePolicy::ReturnToOriginatingAddress`
+  (behind the `transparent-inputs` feature flag): when the net flows of a
+  transaction are fully transparent, returns change to the transparent
+  address that originated the value being spent (selecting the address
+  controlling the largest total input value when the selected inputs are
+  controlled by more than one address), instead of an internal-scope P2PKH
+  address of the wallet. This is the appropriate policy when spending from a
+  P2SH (e.g. multisig) address, where change sent to an internal-scope P2PKH
+  address would not be spendable under the same multisig arrangement.
+- `zcash_client_backend::fees::TransparentChangeDestination` (behind
+  `transparent-inputs`): distinguishes the two possible destinations of a
+  non-ephemeral transparent change output, `InternalP2pkh` and
+  `OriginatingAddress`.
+- `zcash_client_backend::fees::ChangeValue::transparent_change_destination`
+  (behind `transparent-inputs`): returns the `TransparentChangeDestination`
+  for a non-ephemeral transparent change value.
+
+### Changed
+- `zcash_client_backend::fees::ChangeValue::transparent` (behind
+  `transparent-inputs`) now takes an additional
+  `TransparentChangeDestination` argument.
+- The proposal protobuf encoding of `ChangeValue` has a new optional
+  `transparentChangeAddress` field, used to encode the destination address
+  when non-ephemeral transparent change is proposed by
+  `TransparentChangePolicy::ReturnToOriginatingAddress`. Proposals encoded
+  by previous versions of this crate (in which the field is absent) continue
+  to decode as `TransparentChangeDestination::InternalP2pkh`.
+- `zcash_client_backend::proto::ProposalDecodingError` has a new
+  `TransparentChangeAddressInvalid` variant (behind `transparent-inputs`),
+  returned when the new `transparentChangeAddress` field is malformed or is
+  present on a change value other than non-ephemeral transparent change.
+- `create_proposed_transactions` now sends non-ephemeral transparent change
+  destined for a `TransparentChangeDestination::OriginatingAddress` directly
+  to that address, without reserving an internal-scope address via
+  `WalletWrite::reserve_next_n_internal_addresses`.
+
 ## [0.24.0-rc.1] - 2026-07-12
 
 ### Added

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -150,8 +150,12 @@ message TransactionBalance {
 // given a unique t-address.
 //
 // When the transparent value pool is selected and the `isEphemeral` field
-// is not set, the value represents transparent change, which will be sent
-// to an internal-scope (change) transparent address of the wallet.
+// is not set, the value represents transparent change. If
+// `transparentChangeAddress` is absent, the change will be sent to an
+// internal-scope (change) transparent address of the wallet; if present, the
+// change will be sent to that address instead (used to return change to the
+// address that originated the transparent value being spent, e.g. when
+// spending from a P2SH address).
 message ChangeValue {
     // The value of a change or ephemeral output to be created, in zatoshis.
     uint64 value = 1;
@@ -162,6 +166,12 @@ message ChangeValue {
     MemoBytes memo = 3;
     // Whether this is to be an ephemeral output.
     bool isEphemeral = 4;
+    // For non-ephemeral transparent change only: the encoded originating
+    // transparent address to which change should be returned, in place of an
+    // internal-scope (change) address of the wallet. Encoded as 21 bytes: a
+    // 1-byte script type (`0x00` for P2PKH, `0x01` for P2SH) followed by the
+    // 20-byte hash. Must be absent for shielded and ephemeral outputs.
+    optional bytes transparentChangeAddress = 5;
 }
 
 // An object wrapper for memo bytes, to facilitate representing the

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -2557,7 +2557,7 @@ where
     use std::convert::Infallible;
 
     use crate::{
-        fees::{ChangeValue, TransparentChangePolicy},
+        fees::{ChangeValue, TransparentChangeDestination, TransparentChangePolicy},
         wallet::{Exposure, OvkPolicy},
     };
 
@@ -2602,7 +2602,10 @@ where
     assert_eq!(step.balance().fee_required(), expected_fee);
     assert_eq!(
         step.balance().proposed_change(),
-        [ChangeValue::transparent(expected_change)],
+        [ChangeValue::transparent(
+            expected_change,
+            TransparentChangeDestination::InternalP2pkh,
+        )],
     );
     assert!(!step.balance().proposed_change()[0].is_ephemeral());
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -87,7 +87,7 @@ use orchard::builder::BundleType;
 use {
     super::CoinbaseFilter,
     crate::{
-        fees::ChangeValue,
+        fees::{ChangeValue, TransparentChangeDestination},
         proposal::StepOutput,
         wallet::{TransparentAddressMetadata, TransparentAddressSource},
     },
@@ -2046,9 +2046,11 @@ where
         }
     }
 
-    // Add any transparent change outputs, sending them to the next available internal-scope
-    // (change) transparent addresses of the account. As with ephemeral addresses above, this
-    // reserves the internal addresses even if transaction construction subsequently fails.
+    // Add any transparent change outputs. Non-ephemeral transparent change is sent either to
+    // the next available internal-scope (change) transparent address of the account, or
+    // directly to the originating address of the selected transparent inputs, depending on the
+    // destination proposed by the change strategy. As with ephemeral addresses above, internal
+    // addresses are reserved even if transaction construction subsequently fails.
     #[cfg(feature = "transparent-inputs")]
     {
         let transparent_change_outputs: Vec<(usize, &ChangeValue)> = proposal_step
@@ -2061,18 +2063,27 @@ where
             })
             .collect();
 
-        if !transparent_change_outputs.is_empty() {
-            let addresses_and_metadata = wallet_db
-                .reserve_next_n_internal_addresses(account_id, transparent_change_outputs.len())
-                .map_err(Error::DataSource)?;
-            assert_eq!(
-                addresses_and_metadata.len(),
-                transparent_change_outputs.len()
-            );
+        // Change destined for an internal-scope address must be assigned a freshly reserved
+        // address; change destined for the originating address of the selected inputs is sent
+        // there directly, without any reservation.
+        let (internal_change_outputs, originating_change_outputs): (Vec<_>, Vec<_>) =
+            transparent_change_outputs
+                .into_iter()
+                .partition(|(_, change_value)| {
+                    matches!(
+                        change_value.transparent_change_destination(),
+                        Some(TransparentChangeDestination::InternalP2pkh)
+                    )
+                });
 
-            for ((change_index, change_value), (change_address, _)) in transparent_change_outputs
-                .iter()
-                .zip(addresses_and_metadata)
+        if !internal_change_outputs.is_empty() {
+            let addresses_and_metadata = wallet_db
+                .reserve_next_n_internal_addresses(account_id, internal_change_outputs.len())
+                .map_err(Error::DataSource)?;
+            assert_eq!(addresses_and_metadata.len(), internal_change_outputs.len());
+
+            for ((change_index, change_value), (change_address, _)) in
+                internal_change_outputs.iter().zip(addresses_and_metadata)
             {
                 builder.add_transparent_output(&change_address, change_value.value())?;
                 transparent_output_meta.push((
@@ -2085,6 +2096,26 @@ where
                     StepOutputIndex::Change(*change_index),
                 ))
             }
+        }
+
+        for (change_index, change_value) in originating_change_outputs {
+            let change_address = match change_value.transparent_change_destination() {
+                Some(TransparentChangeDestination::OriginatingAddress(addr)) => *addr,
+                _ => unreachable!(
+                    "originating_change_outputs was partitioned to contain only \
+                     OriginatingAddress destinations"
+                ),
+            };
+            builder.add_transparent_output(&change_address, change_value.value())?;
+            transparent_output_meta.push((
+                TransparentBuildRecipient::InternalTransparent {
+                    receiving_account: account_id,
+                    recipient_address: change_address,
+                },
+                change_address,
+                change_value.value(),
+                StepOutputIndex::Change(change_index),
+            ))
         }
     }
 

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -4,6 +4,8 @@ use std::{
     num::{NonZeroU64, NonZeroUsize},
 };
 
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::TransparentAddress;
 use ::transparent::bundle::OutPoint;
 use zcash_primitives::transaction::fees::{
     FeeRule,
@@ -74,12 +76,6 @@ impl FeeRule for StandardFeeRule {
 /// transaction; returning the change to the transparent pool matches the behavior of
 /// transparent-only wallets (including `zcashd`) at the cost of the change remaining unshielded.
 ///
-/// Transparent change is currently always sent to a P2PKH address derived under the wallet
-/// account's internal scope; returning change to the originating address when spending from a
-/// P2SH (e.g. multisig) address is not yet supported. See [zcash/librustzcash#2570] for
-/// details.
-///
-/// [zcash/librustzcash#2570]: https://github.com/zcash/librustzcash/issues/2570
 #[cfg(feature = "transparent-inputs")]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum TransparentChangePolicy {
@@ -95,13 +91,42 @@ pub enum TransparentChangePolicy {
     ///
     /// [BIP 44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
     TransparentChangeAllowed,
+    /// When the net flows of the transaction are fully transparent, change is returned to the
+    /// transparent pool at the originating address of the selected transparent inputs, instead
+    /// of an internal-scope address of the wallet.
+    ///
+    /// This is the appropriate policy when spending from a P2SH (e.g. multisig) address: change
+    /// sent to an internal-scope P2PKH address would not be spendable under the same multisig
+    /// arrangement, so it must instead be returned to the address that funded the transaction.
+    ///
+    /// If the selected inputs are controlled by more than one transparent address, change is
+    /// returned to the single address controlling the largest total input value, with ties
+    /// broken deterministically. If no originating address can be determined (for example,
+    /// because the selected inputs do not use a standard script), change is instead shielded, as
+    /// with [`Self::ShieldChange`].
+    ReturnToOriginatingAddress,
+}
+
+/// The destination to which a non-ephemeral transparent change output should be sent.
+#[cfg(feature = "transparent-inputs")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransparentChangeDestination {
+    /// Change is to be sent to an internal-scope (change) transparent address of the wallet,
+    /// to be reserved at transaction-construction time. Produced by
+    /// [`TransparentChangePolicy::TransparentChangeAllowed`].
+    InternalP2pkh,
+    /// Change is to be sent to the given transparent address, which originated the transparent
+    /// value being spent by the transaction. Produced by
+    /// [`TransparentChangePolicy::ReturnToOriginatingAddress`].
+    OriginatingAddress(TransparentAddress),
 }
 
 /// `ChangeValue` represents either a proposed change output to a shielded pool
 /// (with an optional change memo), or if the "transparent-inputs" feature is
 /// enabled, an output to the transparent pool: either an ephemeral output as
-/// part of a [ZIP 320] transaction pair, or a change output to an
-/// internal-scope (change) transparent address of the wallet.
+/// part of a [ZIP 320] transaction pair, or a non-ephemeral change output to
+/// the transparent pool (see [`TransparentChangeDestination`] for the possible
+/// destinations of such an output).
 ///
 /// [ZIP 320]: https://zips.z.cash/zip-0320
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -117,7 +142,10 @@ enum ChangeValueInner {
     #[cfg(feature = "transparent-inputs")]
     EphemeralTransparent { value: Zatoshis },
     #[cfg(feature = "transparent-inputs")]
-    Transparent { value: Zatoshis },
+    Transparent {
+        value: Zatoshis,
+        destination: TransparentChangeDestination,
+    },
 }
 
 impl ChangeValue {
@@ -128,10 +156,10 @@ impl ChangeValue {
     }
 
     /// Constructs a new change value that will be created as a non-ephemeral transparent output
-    /// sent to an internal-scope (change) transparent address of the wallet.
+    /// sent to the given [`TransparentChangeDestination`].
     #[cfg(feature = "transparent-inputs")]
-    pub fn transparent(value: Zatoshis) -> Self {
-        Self(ChangeValueInner::Transparent { value })
+    pub fn transparent(value: Zatoshis, destination: TransparentChangeDestination) -> Self {
+        Self(ChangeValueInner::Transparent { value, destination })
     }
 
     /// Constructs a new change value that will be created as a shielded output.
@@ -178,7 +206,7 @@ impl ChangeValue {
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { value } => *value,
             #[cfg(feature = "transparent-inputs")]
-            ChangeValueInner::Transparent { value } => *value,
+            ChangeValueInner::Transparent { value, .. } => *value,
         }
     }
 
@@ -206,6 +234,16 @@ impl ChangeValue {
             ChangeValueInner::EphemeralTransparent { .. } => true,
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::Transparent { .. } => false,
+        }
+    }
+
+    /// Returns the destination for a non-ephemeral transparent change output, or `None` for any
+    /// other kind of change value.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn transparent_change_destination(&self) -> Option<&TransparentChangeDestination> {
+        match &self.0 {
+            ChangeValueInner::Transparent { destination, .. } => Some(destination),
+            _ => None,
         }
     }
 }
@@ -655,11 +693,17 @@ pub trait ChangeStrategy {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use ::transparent::address::TransparentAddress;
     use ::transparent::bundle::{OutPoint, TxOut};
     use zcash_primitives::transaction::fees::transparent;
     use zcash_protocol::value::Zatoshis;
 
     use super::sapling;
+
+    /// An arbitrary stand-in for the serialized size of a P2SH input with a known redeem
+    /// script, used so that tests can exercise P2SH inputs without the ZIP 317 fee rule
+    /// rejecting them as having an unknown size.
+    pub(crate) const TEST_P2SH_INPUT_SIZE: usize = 300;
 
     #[derive(Debug)]
     pub(crate) struct TestTransparentInput {
@@ -673,6 +717,17 @@ pub(crate) mod tests {
         }
         fn coin(&self) -> &TxOut {
             &self.coin
+        }
+        fn serialized_size(&self) -> transparent::InputSize {
+            match self.coin.recipient_address() {
+                Some(TransparentAddress::PublicKeyHash(_)) => {
+                    transparent::InputSize::STANDARD_P2PKH
+                }
+                Some(TransparentAddress::ScriptHash(_)) => {
+                    transparent::InputSize::Known(TEST_P2SH_INPUT_SIZE)
+                }
+                None => transparent::InputSize::Unknown(self.outpoint.clone()),
+            }
         }
     }
 

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -1,6 +1,12 @@
 use core::cmp::{Ordering, max, min};
+#[cfg(feature = "transparent-inputs")]
+use std::collections::BTreeMap;
 use std::num::{NonZeroU64, NonZeroUsize};
 
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::TransparentAddress;
+#[cfg(feature = "transparent-inputs")]
+use zcash_primitives::transaction::fees::zip317::P2SH_STANDARD_OUTPUT_SIZE;
 use zcash_primitives::transaction::fees::{
     FeeRule, transparent, zip317::MINIMUM_FEE, zip317::P2PKH_STANDARD_OUTPUT_SIZE,
 };
@@ -18,10 +24,10 @@ use super::{
     TransactionBalance, sapling as sapling_fees,
 };
 
-#[cfg(feature = "transparent-inputs")]
-use super::TransparentChangePolicy;
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
+#[cfg(feature = "transparent-inputs")]
+use super::{TransparentChangeDestination, TransparentChangePolicy};
 
 pub(crate) struct NetFlows {
     t_in: Zatoshis,
@@ -204,6 +210,59 @@ pub(crate) fn select_change_pool(
     ShieldedPool::Sapling
 }
 
+/// Determines the destination and standard output size of the transparent change output that
+/// should be produced for the given policy and selected transparent inputs, or `None` if no
+/// transparent change output should be produced (either because the policy does not permit
+/// transparent change, or because no suitable originating address could be determined).
+///
+/// When [`TransparentChangePolicy::ReturnToOriginatingAddress`] is in effect and the selected
+/// inputs are controlled by more than one transparent address, change is returned to the
+/// address controlling the largest total input value; ties are broken deterministically by
+/// address ordering.
+#[cfg(feature = "transparent-inputs")]
+fn resolve_transparent_change(
+    policy: TransparentChangePolicy,
+    transparent_inputs: &[impl transparent::InputView],
+) -> Option<(TransparentChangeDestination, usize)> {
+    match policy {
+        TransparentChangePolicy::ShieldChange => None,
+        TransparentChangePolicy::TransparentChangeAllowed => Some((
+            TransparentChangeDestination::InternalP2pkh,
+            P2PKH_STANDARD_OUTPUT_SIZE,
+        )),
+        TransparentChangePolicy::ReturnToOriginatingAddress => {
+            // Each per-address partial sum computed here is bounded by the total transparent
+            // input value, which the caller has already established does not overflow (via
+            // `calculate_net_flows`); the `unwrap_or` fallback here is unreachable in practice
+            // and simply preserves the running total rather than panicking.
+            let mut totals: BTreeMap<TransparentAddress, Zatoshis> = BTreeMap::new();
+            for input in transparent_inputs {
+                if let Some(addr) = input.coin().recipient_address() {
+                    let value = input.coin().value();
+                    totals
+                        .entry(addr)
+                        .and_modify(|total| *total = (*total + value).unwrap_or(*total))
+                        .or_insert(value);
+                }
+            }
+
+            totals
+                .into_iter()
+                .max_by_key(|(_, total)| *total)
+                .map(|(address, _)| {
+                    let output_size = match address {
+                        TransparentAddress::PublicKeyHash(_) => P2PKH_STANDARD_OUTPUT_SIZE,
+                        TransparentAddress::ScriptHash(_) => P2SH_STANDARD_OUTPUT_SIZE,
+                    };
+                    (
+                        TransparentChangeDestination::OriginatingAddress(address),
+                        output_size,
+                    )
+                })
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct OutputManifest {
     transparent: usize,
@@ -321,15 +380,22 @@ where
     // We don't create a fully-transparent transaction if a change memo is used.
     let fully_transparent = net_flows.is_transparent() && change_memo.is_none();
 
-    // Whether change should be returned to the transparent pool instead of being shielded.
-    // Transparent change is only ever produced when the flows of the transaction are fully
-    // transparent, so that shielded flows never leak change information to the transparent
-    // pool.
+    // The destination and standard output size of the transparent change output, if change
+    // should be returned to the transparent pool instead of being shielded. Transparent change
+    // is only ever produced when the flows of the transaction are fully transparent, so that
+    // shielded flows never leak change information to the transparent pool.
     #[cfg(feature = "transparent-inputs")]
-    let wants_transparent_change = fully_transparent
-        && cfg.transparent_change_policy == TransparentChangePolicy::TransparentChangeAllowed;
+    let transparent_change = fully_transparent
+        .then(|| resolve_transparent_change(cfg.transparent_change_policy, transparent_inputs))
+        .flatten();
+    #[cfg(feature = "transparent-inputs")]
+    let wants_transparent_change = transparent_change.is_some();
+    #[cfg(feature = "transparent-inputs")]
+    let transparent_change_output_size = transparent_change.as_ref().map(|(_, size)| *size);
     #[cfg(not(feature = "transparent-inputs"))]
     let wants_transparent_change = false;
+    #[cfg(not(feature = "transparent-inputs"))]
+    let transparent_change_output_size: Option<usize> = None;
 
     let total_in = net_flows
         .total_in()
@@ -565,9 +631,10 @@ where
                         transparent_input_sizes.clone(),
                         transparent_output_sizes
                             .clone()
-                            // Count the standard size of the P2PKH change output when change is
-                            // to be returned to the transparent pool.
-                            .chain(wants_transparent_change.then_some(P2PKH_STANDARD_OUTPUT_SIZE)),
+                            // Count the standard size of the transparent change output (P2PKH
+                            // or P2SH, depending on its destination) when change is to be
+                            // returned to the transparent pool.
+                            .chain(transparent_change_output_size),
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
                         orchard_action_count(target_change_counts.orchard())?,
@@ -639,7 +706,7 @@ where
             );
             let simple_case = || {
                 #[cfg(feature = "transparent-inputs")]
-                if wants_transparent_change {
+                if let Some((destination, _)) = transparent_change {
                     return (
                         if total_change.is_zero() {
                             // A zero-valued transparent output would be unspendable, so we omit
@@ -648,7 +715,7 @@ where
                             // are already publicly visible.
                             vec![]
                         } else {
-                            vec![ChangeValue::transparent(total_change)]
+                            vec![ChangeValue::transparent(total_change, destination)]
                         },
                         total_fee,
                     );
@@ -1134,6 +1201,138 @@ mod tests {
                 Zatoshis::const_from_u64(10_000)
             ),
             ShieldedPool::Ironwood
+        );
+    }
+}
+
+#[cfg(all(test, feature = "transparent-inputs"))]
+mod transparent_change_destination_tests {
+    use ::transparent::{
+        address::TransparentAddress,
+        bundle::{OutPoint, TxOut},
+    };
+    use zcash_protocol::value::Zatoshis;
+
+    use super::{
+        P2PKH_STANDARD_OUTPUT_SIZE, P2SH_STANDARD_OUTPUT_SIZE, TransparentChangeDestination,
+        TransparentChangePolicy, resolve_transparent_change,
+    };
+    use crate::fees::tests::TestTransparentInput;
+
+    fn input_from(value: u64, addr: TransparentAddress) -> TestTransparentInput {
+        TestTransparentInput {
+            outpoint: OutPoint::fake(),
+            coin: TxOut::new(Zatoshis::const_from_u64(value), addr.script().into()),
+        }
+    }
+
+    #[test]
+    fn shield_change_never_produces_transparent_change() {
+        let inputs = [input_from(
+            50_000,
+            TransparentAddress::PublicKeyHash([0u8; 20]),
+        )];
+
+        assert_eq!(
+            resolve_transparent_change(TransparentChangePolicy::ShieldChange, &inputs),
+            None
+        );
+    }
+
+    #[test]
+    fn transparent_change_allowed_always_targets_internal_p2pkh() {
+        // Even when the selected input is controlled by a P2SH address, the
+        // `TransparentChangeAllowed` policy (as opposed to `ReturnToOriginatingAddress`)
+        // always returns change to an internal-scope P2PKH address.
+        let inputs = [input_from(
+            50_000,
+            TransparentAddress::ScriptHash([7u8; 20]),
+        )];
+
+        assert_eq!(
+            resolve_transparent_change(TransparentChangePolicy::TransparentChangeAllowed, &inputs),
+            Some((
+                TransparentChangeDestination::InternalP2pkh,
+                P2PKH_STANDARD_OUTPUT_SIZE
+            ))
+        );
+    }
+
+    #[test]
+    fn originating_address_p2sh_input_sizes_p2sh_output() {
+        let addr = TransparentAddress::ScriptHash([9u8; 20]);
+        let inputs = [input_from(50_000, addr)];
+
+        assert_eq!(
+            resolve_transparent_change(
+                TransparentChangePolicy::ReturnToOriginatingAddress,
+                &inputs
+            ),
+            Some((
+                TransparentChangeDestination::OriginatingAddress(addr),
+                P2SH_STANDARD_OUTPUT_SIZE
+            ))
+        );
+    }
+
+    #[test]
+    fn originating_address_p2pkh_input_sizes_p2pkh_output() {
+        let addr = TransparentAddress::PublicKeyHash([3u8; 20]);
+        let inputs = [input_from(50_000, addr)];
+
+        assert_eq!(
+            resolve_transparent_change(
+                TransparentChangePolicy::ReturnToOriginatingAddress,
+                &inputs
+            ),
+            Some((
+                TransparentChangeDestination::OriginatingAddress(addr),
+                P2PKH_STANDARD_OUTPUT_SIZE
+            ))
+        );
+    }
+
+    #[test]
+    fn originating_address_picks_largest_total_value() {
+        let minority_addr = TransparentAddress::PublicKeyHash([1u8; 20]);
+        let majority_addr = TransparentAddress::ScriptHash([2u8; 20]);
+        let inputs = [
+            input_from(10_000, minority_addr),
+            input_from(5_000, majority_addr),
+            input_from(6_000, majority_addr),
+        ];
+
+        // majority_addr's total (11_000) exceeds minority_addr's total (10_000), even though
+        // no single input to majority_addr is as large as the single input to minority_addr.
+        assert_eq!(
+            resolve_transparent_change(
+                TransparentChangePolicy::ReturnToOriginatingAddress,
+                &inputs
+            ),
+            Some((
+                TransparentChangeDestination::OriginatingAddress(majority_addr),
+                P2SH_STANDARD_OUTPUT_SIZE
+            ))
+        );
+    }
+
+    #[test]
+    fn originating_address_falls_back_to_none_without_a_standard_address() {
+        use ::transparent::address::Script;
+
+        // A non-standard script does not correspond to any `TransparentAddress`, so no
+        // originating address can be determined.
+        let inputs = [TestTransparentInput {
+            outpoint: OutPoint::fake(),
+            coin: TxOut::new(Zatoshis::const_from_u64(50_000), Script::default()),
+        }];
+
+        assert_eq!(
+            resolve_transparent_change(
+                TransparentChangePolicy::ReturnToOriginatingAddress,
+                &inputs
+            ),
+            None
         );
     }
 }

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -1271,7 +1271,9 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn change_fully_transparent_with_transparent_change() {
-        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::fees::{
+            TransparentChangeDestination, TransparentChangePolicy, sapling as sapling_fees,
+        };
         use ::transparent::{address::TransparentAddress, bundle::OutPoint};
 
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
@@ -1315,7 +1317,69 @@ mod tests {
         assert_matches!(
             result,
             Ok(balance) if
-                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(13000))] &&
+                balance.proposed_change() == [ChangeValue::transparent(
+                    Zatoshis::const_from_u64(13000),
+                    TransparentChangeDestination::InternalP2pkh,
+                )] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_returns_p2sh_change_to_originating_address() {
+        use crate::fees::{
+            TransparentChangeDestination, TransparentChangePolicy, sapling as sapling_fees,
+        };
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::ReturnToOriginatingAddress);
+
+        let originating_address = TransparentAddress::ScriptHash([11u8; 20]);
+
+        // Spend a single P2SH UTXO (e.g. a multisig address) that is sufficient to pay the
+        // fee. Because the change strategy is configured to return change to the originating
+        // address rather than an internal-scope P2PKH address, the change output is sized and
+        // sent as a P2SH output (32 bytes) rather than a P2PKH output (34 bytes).
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &[TestTransparentInput {
+                outpoint: OutPoint::fake(),
+                coin: TxOut::new(
+                    Zatoshis::const_from_u64(100000),
+                    originating_address.script().into(),
+                ),
+            }],
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change() == [ChangeValue::transparent(
+                    Zatoshis::const_from_u64(50000),
+                    TransparentChangeDestination::OriginatingAddress(originating_address),
+                )] &&
                 balance.fee_required() == Zatoshis::const_from_u64(10000)
         );
     }
@@ -1420,7 +1484,9 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn transparent_change_is_not_split() {
-        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::fees::{
+            TransparentChangeDestination, TransparentChangePolicy, sapling as sapling_fees,
+        };
         use ::transparent::{address::TransparentAddress, bundle::OutPoint};
 
         let change_strategy = MultiOutputChangeStrategy::<_, MockWalletDb>::new(
@@ -1467,7 +1533,10 @@ mod tests {
         assert_matches!(
             result,
             Ok(balance) if
-                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(649_0000))] &&
+                balance.proposed_change() == [ChangeValue::transparent(
+                    Zatoshis::const_from_u64(649_0000),
+                    TransparentChangeDestination::InternalP2pkh,
+                )] &&
                 balance.fee_required() == Zatoshis::const_from_u64(10000)
         );
     }
@@ -1527,7 +1596,9 @@ mod tests {
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn transparent_change_allows_dust() {
-        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::fees::{
+            TransparentChangeDestination, TransparentChangePolicy, sapling as sapling_fees,
+        };
         use ::transparent::{address::TransparentAddress, bundle::OutPoint};
 
         let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
@@ -1573,7 +1644,10 @@ mod tests {
         assert_matches!(
             result,
             Ok(balance) if
-                balance.proposed_change() == [ChangeValue::transparent(Zatoshis::const_from_u64(100))] &&
+                balance.proposed_change() == [ChangeValue::transparent(
+                    Zatoshis::const_from_u64(100),
+                    TransparentChangeDestination::InternalP2pkh,
+                )] &&
                 balance.fee_required() == Zatoshis::const_from_u64(10000)
         );
     }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -26,6 +26,9 @@ use zcash_protocol::{
 };
 use zip321::{TransactionRequest, Zip321Error};
 
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::TransparentAddress;
+
 use crate::{
     data_api::{
         InputSource,
@@ -38,6 +41,9 @@ use crate::{
         produces_shielded_bundle,
     },
 };
+
+#[cfg(feature = "transparent-inputs")]
+use crate::fees::TransparentChangeDestination;
 
 #[cfg(feature = "transparent-inputs")]
 use transparent::bundle::OutPoint;
@@ -522,6 +528,10 @@ pub enum ProposalDecodingError<DbError> {
     /// The proposal specified an explicit transaction version header that the wallet does not
     /// recognize.
     ProposedVersionInvalid(u32),
+    /// The encoded transparent change address was malformed, or was present for a change value
+    /// that is not non-ephemeral transparent change.
+    #[cfg(feature = "transparent-inputs")]
+    TransparentChangeAddressInvalid,
 }
 
 impl<E> From<Zip321Error> for ProposalDecodingError<E> {
@@ -596,6 +606,12 @@ impl<E: Display> Display for ProposalDecodingError<E> {
                 f,
                 "The proposal specified an unrecognized transaction version header {header:#x}."
             ),
+            #[cfg(feature = "transparent-inputs")]
+            ProposalDecodingError::TransparentChangeAddressInvalid => write!(
+                f,
+                "The encoded transparent change address was malformed, or was present for a \
+                 change value other than non-ephemeral transparent change."
+            ),
         }
     }
 }
@@ -618,6 +634,37 @@ fn pool_type<T>(pool_id: i32) -> Result<PoolType, ProposalDecodingError<T>> {
         Ok(proposal::ValuePool::Orchard) => Ok(PoolType::ORCHARD),
         Ok(proposal::ValuePool::Ironwood) => Ok(PoolType::IRONWOOD),
         _ => Err(ProposalDecodingError::ValuePoolNotSupported(pool_id)),
+    }
+}
+
+/// Encodes a transparent change destination address as 21 bytes: a 1-byte script type
+/// (`0x00` for P2PKH, `0x01` for P2SH) followed by the 20-byte hash.
+#[cfg(feature = "transparent-inputs")]
+fn encode_transparent_change_address(addr: &TransparentAddress) -> Vec<u8> {
+    let (script_type, hash): (u8, &[u8; 20]) = match addr {
+        TransparentAddress::PublicKeyHash(hash) => (0x00, hash),
+        TransparentAddress::ScriptHash(hash) => (0x01, hash),
+    };
+    let mut bytes = Vec::with_capacity(21);
+    bytes.push(script_type);
+    bytes.extend_from_slice(hash);
+    bytes
+}
+
+/// Decodes a transparent change destination address from the 21-byte encoding produced by
+/// [`encode_transparent_change_address`].
+#[cfg(feature = "transparent-inputs")]
+fn decode_transparent_change_address<T>(
+    bytes: &[u8],
+) -> Result<TransparentAddress, ProposalDecodingError<T>> {
+    match bytes {
+        [0x00, hash @ ..] if hash.len() == 20 => Ok(TransparentAddress::PublicKeyHash(
+            hash.try_into().expect("length checked above"),
+        )),
+        [0x01, hash @ ..] if hash.len() == 20 => Ok(TransparentAddress::ScriptHash(
+            hash.try_into().expect("length checked above"),
+        )),
+        _ => Err(ProposalDecodingError::TransparentChangeAddressInvalid),
     }
 }
 
@@ -746,6 +793,17 @@ impl proposal::Proposal {
                                 value: memo_bytes.as_slice().to_vec(),
                             }),
                             is_ephemeral: change.is_ephemeral(),
+                            #[cfg(feature = "transparent-inputs")]
+                            transparent_change_address: match change
+                                .transparent_change_destination()
+                            {
+                                Some(TransparentChangeDestination::OriginatingAddress(addr)) => {
+                                    Some(encode_transparent_change_address(addr))
+                                }
+                                _ => None,
+                            },
+                            #[cfg(not(feature = "transparent-inputs"))]
+                            transparent_change_address: None,
                         })
                         .collect(),
                     fee_required: step.balance().fee_required().into(),
@@ -979,11 +1037,24 @@ impl proposal::Proposal {
                                     }
                                     #[cfg(feature = "transparent-inputs")]
                                     (PoolType::Transparent, true) => {
+                                        if cv.transparent_change_address.is_some() {
+                                            return Err(
+                                                ProposalDecodingError::TransparentChangeAddressInvalid,
+                                            );
+                                        }
                                         Ok(ChangeValue::ephemeral_transparent(value))
                                     }
                                     #[cfg(feature = "transparent-inputs")]
                                     (PoolType::Transparent, false) => {
-                                        Ok(ChangeValue::transparent(value))
+                                        let destination = match &cv.transparent_change_address {
+                                            None => TransparentChangeDestination::InternalP2pkh,
+                                            Some(bytes) => {
+                                                TransparentChangeDestination::OriginatingAddress(
+                                                    decode_transparent_change_address(bytes)?,
+                                                )
+                                            }
+                                        };
+                                        Ok(ChangeValue::transparent(value, destination))
                                     }
                                     // When all pool features are enabled, the explicit arms above
                                     // are exhaustive over the non-ephemeral cases; this fallback
@@ -1096,5 +1167,47 @@ impl service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transpo
     {
         let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
         Ok(Self::new(conn))
+    }
+}
+
+#[cfg(all(test, feature = "transparent-inputs"))]
+mod transparent_change_address_tests {
+    use ::transparent::address::TransparentAddress;
+
+    use super::{
+        ProposalDecodingError, decode_transparent_change_address, encode_transparent_change_address,
+    };
+
+    #[test]
+    fn round_trips_p2pkh() {
+        let addr = TransparentAddress::PublicKeyHash([7u8; 20]);
+        let encoded = encode_transparent_change_address(&addr);
+        assert_eq!(encoded.len(), 21);
+        assert_matches!(decode_transparent_change_address::<()>(&encoded), Ok(a) if a == addr);
+    }
+
+    #[test]
+    fn round_trips_p2sh() {
+        let addr = TransparentAddress::ScriptHash([9u8; 20]);
+        let encoded = encode_transparent_change_address(&addr);
+        assert_eq!(encoded.len(), 21);
+        assert_matches!(decode_transparent_change_address::<()>(&encoded), Ok(a) if a == addr);
+    }
+
+    #[test]
+    fn rejects_unrecognized_script_type() {
+        // `0x02` is not a recognized script type discriminant.
+        assert_matches!(
+            decode_transparent_change_address::<()>(&[0x02; 21]),
+            Err(ProposalDecodingError::TransparentChangeAddressInvalid)
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert_matches!(
+            decode_transparent_change_address::<()>(&[0x00; 5]),
+            Err(ProposalDecodingError::TransparentChangeAddressInvalid)
+        );
     }
 }

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -147,8 +147,12 @@ pub struct TransactionBalance {
 /// given a unique t-address.
 ///
 /// When the transparent value pool is selected and the `isEphemeral` field
-/// is not set, the value represents transparent change, which will be sent
-/// to an internal-scope (change) transparent address of the wallet.
+/// is not set, the value represents transparent change. If
+/// `transparentChangeAddress` is absent, the change will be sent to an
+/// internal-scope (change) transparent address of the wallet; if present, the
+/// change will be sent to that address instead (used to return change to the
+/// address that originated the transparent value being spent, e.g. when
+/// spending from a P2SH address).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChangeValue {
     /// The value of a change or ephemeral output to be created, in zatoshis.
@@ -164,6 +168,13 @@ pub struct ChangeValue {
     /// Whether this is to be an ephemeral output.
     #[prost(bool, tag = "4")]
     pub is_ephemeral: bool,
+    /// For non-ephemeral transparent change only: the encoded originating
+    /// transparent address to which change should be returned, in place of an
+    /// internal-scope (change) address of the wallet. Encoded as 21 bytes: a
+    /// 1-byte script type (`0x00` for P2PKH, `0x01` for P2SH) followed by the
+    /// 20-byte hash. Must be absent for shielded and ephemeral outputs.
+    #[prost(bytes = "vec", optional, tag = "5")]
+    pub transparent_change_address: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// An object wrapper for memo bytes, to facilitate representing the
 /// `change_memo == None` case.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_primitives::transaction::fees::zip317::P2SH_STANDARD_OUTPUT_SIZE`
+
 ## [0.29.0] - 2026-07-09
 
 ### Added

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -33,6 +33,13 @@ pub const P2PKH_STANDARD_INPUT_SIZE: usize = 150;
 /// [ZIP 317]: https//zips.z.cash/zip-0317
 pub const P2PKH_STANDARD_OUTPUT_SIZE: usize = 34;
 
+/// The standard size of a P2SH output, in bytes.
+///
+/// This is `8` bytes of value, plus `1` byte for the CompactSize length prefix of the
+/// `scriptPubKey`, plus `23` bytes for the `scriptPubKey` itself (`OP_HASH160
+/// <20-byte script hash> OP_EQUAL`), for a total of `32` bytes.
+pub const P2SH_STANDARD_OUTPUT_SIZE: usize = 32;
+
 /// The minimum conventional fee computed from the standard [ZIP 317] constants. Equivalent to
 /// `MARGINAL_FEE * GRACE_ACTIONS`.
 ///


### PR DESCRIPTION
## Summary

`TransparentChangePolicy::TransparentChangeAllowed` currently always returns transparent change to a BIP-44 internal-scope P2PKH address of the spending account, and the ZIP-317 fee computation in `single_pool_output_balance` counts the change output at `P2PKH_STANDARD_OUTPUT_SIZE`. When the inputs being spent are held at a P2SH (e.g. multisig) address, change sent to a wallet-internal P2PKH address would not be spendable under the same multisig arrangement.

This adds a new `TransparentChangePolicy::ReturnToOriginatingAddress` policy that, when the net flows of a transaction are fully transparent, returns change to the transparent address that originated the value being spent (selecting the address controlling the largest total input value when the selected inputs span more than one address), instead of an internal-scope address of the wallet.

- `fees::TransparentChangeDestination` represents the two possible non-ephemeral transparent change destinations (`InternalP2pkh` and `OriginatingAddress`), and is now carried by `ChangeValue::transparent` in place of the previous no-argument constructor.
- `fees::common::resolve_transparent_change` determines the destination and the correct standard output size (P2PKH or the newly added `P2SH_STANDARD_OUTPUT_SIZE`) for the transparent change output, and is used by `single_pool_output_balance` for both fee sizing and change emission.
- The proposal protobuf `ChangeValue` message gains an optional `transparentChangeAddress` field carrying the encoded destination address; its absence continues to mean `InternalP2pkh`, preserving compatibility with previously serialized proposals.
- `create_proposed_transactions` sends change destined for an `OriginatingAddress` directly to that address, skipping the internal-scope address reservation used for `InternalP2pkh` change.

Not currently needed for the `z_sendmany`/`z_sendfromaccount` support in `zallet`, which spends from derived P2PKH addresses.

Closes #2570

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-features --all-targets`
- `cargo check` for `--no-default-features`, `--features orchard`, `--features transparent-inputs` (both `zcash_client_backend` and `zcash_primitives`)
- `cargo test -p zcash_client_backend --all-features` (99 passed, including new unit and integration-style tests for the resolver, fee sizing, and proposal round trip)
- `cargo test -p zcash_client_sqlite --all-features propose_t2t_with_transparent_change` (confirms the existing `InternalP2pkh` path still works end-to-end)

Co-Authored-By: Claude <noreply@anthropic.com>