### PR TITLE
Reconcile AGENTS.md and the README dependency diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 ## Crate Architecture
 
-See `README.md` for the full dependency graph (Mermaid diagram). Below is a text summary
-since LLMs cannot render diagrams.
+See `README.md` for the full dependency graph (Mermaid diagram). Below is a text summary,
+since Mermaid layout is hard to reason about in plain text.
 
 ### Zcash Protocol
 
@@ -124,7 +124,9 @@ since LLMs cannot render diagrams.
 
 - Dependencies flow **downward**: higher-level crates depend on lower-level ones, never
   the reverse.
-- `zcash_protocol` is the lowest layer in this repo — most crates depend on it.
+- `zcash_protocol` is the lowest layer with Zcash-domain semantics — most crates depend
+  on it. The standalone utility crates (`zcash_encoding`, `equihash`, `f4jumble`) sit
+  below it, and `eip681` stands alone with no in-repo dependencies.
 - `zcash_client_sqlite` sits at the top, depending on `zcash_client_backend`.
 
 ## Build & Test Commands

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ graph TB
         end
 
         subgraph standalone_components
+            eip681
             equihash
             f4jumble
             zcash_encoding


### PR DESCRIPTION
Closes #2316.

Reconciles `AGENTS.md` with the README's Mermaid dependency diagram. Each item verified against current `main` before changing anything (details in my comment on the issue):

- **`eip681` added to the diagram** as a bare node under `standalone_components` — its `Cargo.toml` has no in-repo dependencies and nothing in the workspace depends on it, so no edges are warranted. `.github/helpers/check-dep-graph.py` passes with the change.
- **"lowest layer" claim qualified** — `zcash_protocol` is now described as the lowest layer *with Zcash-domain semantics*, since `zcash_encoding`, `equihash`, and `f4jumble` sit strictly below it in the graph (and `eip681` stands alone).
- **Diagram preamble reworded** per the suggestion in the issue — the barrier is Mermaid layout comprehension in plain text, not rendering.
- **`zcash_extensions` (item 1 of the issue): no change needed** — the crate no longer appears in the diagram or the workspace members, so that checkbox appears to have resolved itself since April.

**AI disclosure:** prepared with Claude (research, drafting, and verification runs); I reviewed every line, and the commit carries the `Co-Authored-By` trailer per `AGENTS.md`.
