### PR TITLE
zcash_ironwood_migration_backend: add height-based transfer scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7210,6 +7210,8 @@ name = "zcash_ironwood_migration_backend"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "rand 0.8.5",
+ "rand_distr",
  "zcash_protocol",
 ]
 

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,10 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::consensus::SECONDS_PER_BLOCK`
+- `zcash_protocol::consensus::BLOCKS_PER_HOUR`
+
 ## [0.10.0] - 2026-07-09
 
 This release sets the NU6.3 mainnet activation height to 3428143.

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -25,6 +25,12 @@ memuse::impl_no_dynamic_usage!(BlockHeight);
 /// The height of the genesis block on a network.
 pub const H0: BlockHeight = BlockHeight(0);
 
+/// The target time between blocks, in seconds (the post-Blossom target spacing).
+pub const SECONDS_PER_BLOCK: u32 = 75;
+
+/// The approximate number of blocks produced per hour at [`SECONDS_PER_BLOCK`].
+pub const BLOCKS_PER_HOUR: u32 = 3600 / SECONDS_PER_BLOCK;
+
 impl BlockHeight {
     pub const fn from_u32(v: u32) -> BlockHeight {
         BlockHeight(v)

--- a/zcash_ironwood_migration_backend/CHANGELOG.md
+++ b/zcash_ironwood_migration_backend/CHANGELOG.md
@@ -27,3 +27,6 @@ and this library adheres to Rust's notion of
   into notes whose crossing values follow the `{1, 2, 5} * 10^k` ZEC series (1, 2, 5, 10, ... ZEC),
   each note holding its crossing value plus a fixed fee buffer, leaving any residual (including
   dust) as Orchard change rather than folding it into a fee.
+- Height-based transfer scheduling (`build_schedule`): assigns each crossing value a send window
+  and expiry, sharing the wallet's natural anchor across a schedule and sampling the gap between
+  successive transfers from an exponential distribution (floored at one block).

--- a/zcash_ironwood_migration_backend/Cargo.toml
+++ b/zcash_ironwood_migration_backend/Cargo.toml
@@ -21,6 +21,9 @@ all-features = true
 [dependencies]
 zcash_protocol.workspace = true
 
+rand.workspace = true
+rand_distr.workspace = true
+
 proptest = { workspace = true, optional = true }
 
 [features]

--- a/zcash_ironwood_migration_backend/src/lib.rs
+++ b/zcash_ironwood_migration_backend/src/lib.rs
@@ -16,6 +16,9 @@
 // Remove the `allow` once a consumer is added.
 #[allow(dead_code)]
 mod denominations;
+// Internal transfer scheduler, consumed by the context module in a later slice.
+#[allow(dead_code)]
+mod scheduling;
 
 pub mod error;
 pub mod types;

--- a/zcash_ironwood_migration_backend/src/scheduling.rs
+++ b/zcash_ironwood_migration_backend/src/scheduling.rs
@@ -1,0 +1,106 @@
+//! Migration-transfer scheduling: give each crossing amount a send window and expiry.
+//!
+//! All transfers in a schedule share one anchor: the wallet's natural anchor from
+//! `get_target_and_anchor_heights`. De-correlation between a wallet's own transfers comes from
+//! staggered send heights and distinct expiry heights, not from the anchor (see the note below on
+//! why the anchor is not bucketed). Each transfer's send height is independently sampled from an
+//! exponential distribution around a target cadence (see [`sample_cadence_blocks`]) rather than a
+//! fixed offset, so the gaps between a wallet's own transfers are not a predictable, uniform
+//! pattern. The first transfer is executable immediately (`first_delay_blocks = 0` on both paths):
+//! de-correlation from user activity is the send-time machinery's job (background delivery, and a
+//! future rule of no send earlier than ~10 minutes after the last sync), not the schedule's. Sends
+//! do not correlate with the confirm tap because nothing broadcasts in the foreground.
+//!
+//! NOTE: an earlier design floored the anchor to a shared network-wide 288-block bucket
+//! (`floor(natural_anchor / 288) * 288`) to hide the wallet's last sync time. That cannot work
+//! against the SDK as-is: `create_pczt` requires a note-commitment-tree checkpoint at the *exact*
+//! anchor height, but the wallet only checkpoints at ~100-block scan-batch boundaries, so an
+//! arbitrary 288-aligned height is essentially never witnessable (giving `AnchorNotFound`).
+//! Reinstating the shared bucket requires the SDK to persist a checkpoint at every 288-boundary
+//! during scan.
+
+use rand::RngCore;
+use rand_distr::{Distribution, Exp};
+
+use crate::types::{MigrationSchedule, TransferId, TransferProposal};
+use zcash_protocol::consensus::{BLOCKS_PER_HOUR, BlockHeight};
+use zcash_protocol::value::Zatoshis;
+
+/// Target average time, in hours, between successive transfers' send windows.
+const TARGET_CADENCE_HOURS: u32 = 6;
+/// Hard cap, in hours, on the time any single sampled gap between transfers can represent.
+const MAX_CADENCE_HOURS: u32 = 24;
+/// Time, in hours, after its send window during which a transfer remains valid.
+const TRANSFER_EXPIRY_WINDOW_HOURS: u32 = 6;
+
+/// Expected value of the gap between successive transfers' send windows, in blocks.
+pub(crate) const TARGET_CADENCE_BLOCKS: u32 = TARGET_CADENCE_HOURS * BLOCKS_PER_HOUR;
+/// Hard cap on any single sampled gap between transfers, in blocks. The exponential distribution is
+/// unbounded, so this bounds the worst case a single draw can produce.
+pub(crate) const MAX_CADENCE_BLOCKS: u32 = MAX_CADENCE_HOURS * BLOCKS_PER_HOUR;
+/// Blocks after its send window during which a transfer remains valid.
+pub(crate) const TRANSFER_EXPIRY_WINDOW_BLOCKS: u32 =
+    TRANSFER_EXPIRY_WINDOW_HOURS * BLOCKS_PER_HOUR;
+
+/// Sample the block-count gap to the next transfer's send window from an exponential
+/// distribution with expected value [`TARGET_CADENCE_BLOCKS`], clamped to `[1,
+/// MAX_CADENCE_BLOCKS]`.
+///
+/// Uses inverse-transform sampling with rate `1 / mean` (which gives that expected value). Each
+/// transfer's gap is an independent draw, chained onto the previous transfer's send height, so
+/// gaps are neither uniform nor correlated with each other, unlike a fixed per-index offset. The
+/// exponential distribution's support is the positive reals, so a raw draw below 0.5 would round
+/// to 0; it is floored to 1 so two consecutive transfers never land on the exact same send/expiry
+/// height (rare, well under 1% per gap, but not negligible over a full multi-transfer schedule).
+fn sample_cadence_blocks<R: RngCore>(rng: &mut R) -> u32 {
+    let dist = Exp::new(1.0 / f64::from(TARGET_CADENCE_BLOCKS)).expect("rate is positive");
+    (dist.sample(rng).round() as u32).clamp(1, MAX_CADENCE_BLOCKS)
+}
+
+/// Build a migration schedule mapping each output amount (zatoshi) to a `TransferProposal`.
+///
+/// All transfers share `natural_anchor`, a real, witnessable note-commitment-tree checkpoint (see
+/// the module note on why this is not bucketed). The first transfer's send height is
+/// `target_height + first_delay_blocks` (both paths pass `first_delay_blocks = 0` today, so the
+/// first transfer is executable immediately; send-time machinery owns de-correlation). Every
+/// subsequent transfer's send height is the previous transfer's plus an independently sampled gap
+/// (see [`sample_cadence_blocks`]); each transfer expires [`TRANSFER_EXPIRY_WINDOW_BLOCKS`] after
+/// its own send window.
+pub(crate) fn build_schedule<R: RngCore>(
+    rng: &mut R,
+    run_id: &str,
+    crossing_values: &[u64],
+    target_height: u32,
+    natural_anchor: u32,
+    first_delay_blocks: u32,
+) -> MigrationSchedule {
+    let anchor_height = BlockHeight::from_u32(natural_anchor);
+    let mut next = target_height.saturating_add(first_delay_blocks);
+    let mut transfers = Vec::with_capacity(crossing_values.len());
+    for (i, &amount) in crossing_values.iter().enumerate() {
+        if i > 0 {
+            next = next.saturating_add(sample_cadence_blocks(rng));
+        }
+        transfers.push(TransferProposal::from_parts(
+            TransferId::for_transfer(run_id, i as u32),
+            Zatoshis::const_from_u64(amount),
+            anchor_height,
+            BlockHeight::from_u32(next),
+            BlockHeight::from_u32(next.saturating_add(TRANSFER_EXPIRY_WINDOW_BLOCKS)),
+        ));
+    }
+
+    let duration_hours = estimated_duration_hours(&transfers);
+    MigrationSchedule::from_parts(transfers, duration_hours)
+}
+
+/// Hours spanned by the schedule, from the first transfer's send window to the last's, rounded
+/// up. Zero for an empty or single-transfer schedule.
+fn estimated_duration_hours(transfers: &[TransferProposal]) -> u32 {
+    match (transfers.first(), transfers.last()) {
+        (Some(first), Some(last)) => u32::from(last.next_executable_after_height())
+            .saturating_sub(u32::from(first.next_executable_after_height()))
+            .div_ceil(BLOCKS_PER_HOUR),
+        _ => 0,
+    }
+}


### PR DESCRIPTION
Part of the two-crate split of #2625. **Draft. Stacked on #2629** (base `feat/pool-migration-denominations`).

Adds the internal transfer scheduler (`build_schedule`): assigns each crossing value a send window and expiry, shares the wallet's natural anchor, and samples the gap between transfers from an exponential distribution. Also adds `zcash_protocol::consensus::{SECONDS_PER_BLOCK, BLOCKS_PER_HOUR}` so cadence/expiry are expressed in hours and converted to blocks from a protocol-owned source. Deps: `rand` + `rand_distr`. Internal module -> temporary `#[allow(dead_code)]`.

Verified: clippy `-D warnings` (both crates), doc `-D warnings`, fmt.