### PR TITLE
zcash_client_sqlite: Order add_transparent_value_index after account_delete_cascade

### DIFF
--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -131,8 +131,8 @@ pub(super) fn all_migrations<
     //                        \      ensure_default_transparent_address    /                                 \
     //                         \                     |                    /                                   \
     //                          `---- fix_transparent_received_outputs --'                                     \
-    //                                    /         /           \    \                                         |
-    //                                   /         /             \   add_transparent_value_index               |
+    //                                    /         /           \                                              |
+    //                                   /         /             \                                             |
     //                                  /         /               \                                            |
     //           support_zcashd_wallet_import    /             fix_v_transactions_expired_unmined              |
     //                \                         /                    /        |         \                      |
@@ -143,8 +143,8 @@ pub(super) fn all_migrations<
     //                     \                       \         v_received_output_spends_account      /        /
     //                      \                       \               /                             /        /
     //                       `------------------- account_delete_cascade ---------------------------------'
-    //                                        /               |              \
-    //                       v_tx_outputs_key_scopes    standalone_p2sh    witness_stabilized_notes
+    //                              /               /                  |              \
+    //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
     //                                                    /          \         \
     //                                                   /            \      orchard_note_version
     //                                                  /              \         \

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
@@ -20,18 +20,20 @@ use rusqlite::params;
 use schemerz_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 
-use super::fix_transparent_received_outputs;
+use super::account_delete_cascade;
 use crate::wallet::init::WalletMigrationError;
 
 pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x47c0e9c2_2eda_4b9c_be15_63c636c0e1c7);
 
-// `fix_transparent_received_outputs` drops and recreates the `transparent_received_outputs`
-// table (via `DROP TABLE` + `ALTER TABLE ... RENAME TO`), which destroys any index that was
-// created on the old table. Depending on it here (rather than on `utxos_to_txos`, which only
-// creates the table initially) guarantees this migration always runs after that rebuild, so
-// the index is created on the table that will actually persist. `utxos_to_txos` does not need
-// to be listed explicitly: `fix_transparent_received_outputs` transitively depends on it.
-const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
+// `account_delete_cascade` is the topologically-latest migration that rebuilds the
+// `transparent_received_outputs` table (via `CREATE TABLE` + `INSERT INTO ... SELECT` +
+// `DROP TABLE` + `ALTER TABLE ... RENAME TO`), which destroys any index that was created
+// on the old table. Depending on it here guarantees this migration always runs after that
+// rebuild, so the index is created on the table that will actually persist. The earlier
+// rebuilds (`fix_transparent_received_outputs`, and `utxos_to_txos` which creates the
+// table initially) do not need to be listed explicitly: `account_delete_cascade`
+// transitively depends on both.
+const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 pub(super) struct Migration;
 


### PR DESCRIPTION
Closes #2632.

`account_delete_cascade` rebuilds the `transparent_received_outputs` table
without recreating `idx_transparent_received_outputs_value_zat`, but nothing
ordered it before `add_transparent_value_index`: the two migrations were
incomparable in the migration DAG, so whether the index survived a full
migration run depended on the migrator's topological tie-breaking. Current
`main` happens to run them in the safe order, but adding any new migration can
perturb the tie-break, silently drop the index, and fail
`wallet::init::tests::verify_schema` (this surfaced while rebasing a feature
branch that adds a new migration).

This changes `add_transparent_value_index` to depend on
`account_delete_cascade` — the topologically-latest rebuild of the table —
following the same pattern used by `add_transparent_receiver_address_index`
for the `addresses` table. The earlier rebuilds
(`fix_transparent_received_outputs`, `utxos_to_txos`) are reachable
transitively and no longer need to be listed. The migration DAG comment in
`migrations.rs` is updated to match.

Both migrations already ship in published releases, but adding an edge between
them is safe for existing wallets: any wallet that has applied
`add_transparent_value_index` has also applied `account_delete_cascade` (or
will, before the migrator considers the DAG satisfied), and reordering only
affects fresh migration runs.

---
Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
