### PR TITLE
zcash_ironwood_migration_backend: add migration Phase

### DIFF
--- a/zcash_ironwood_migration_backend/CHANGELOG.md
+++ b/zcash_ironwood_migration_backend/CHANGELOG.md
@@ -40,3 +40,5 @@ and this library adheres to Rust's notion of
   operations; the engine performs the pure PCZT steps itself. Note references cross the boundary as
   `NoteRef` pairs and builds return an unproven `pczt::Pczt`, so no backend-specific type appears in
   the interface.
+- `state::Phase`, a migration run's fine-grained 14-value phase, with its stable persisted string
+  form (`Phase::as_str` / `Phase::parse`).

--- a/zcash_ironwood_migration_backend/src/lib.rs
+++ b/zcash_ironwood_migration_backend/src/lib.rs
@@ -24,10 +24,12 @@ mod scheduling;
 mod pipeline;
 
 pub mod error;
+pub mod state;
 pub mod types;
 pub mod wallet;
 
 pub use error::{InvalidStateError, MigrationError};
+pub use state::Phase;
 pub use types::{
     AttentionReason, MigrationProgress, MigrationSchedule, MigrationState, NoteSplitProposal,
     PreparedTransfer, Signed, SignedTransferPczt, TransferId, TransferPczt, TransferProposal,

--- a/zcash_ironwood_migration_backend/src/state.rs
+++ b/zcash_ironwood_migration_backend/src/state.rs
@@ -1,0 +1,84 @@
+//! A migration run's fine-grained phase.
+//!
+//! A run advances through the 14 phases below; the store persists each as its string form
+//! ([`Phase::as_str`]), and the 6-value public `MigrationState` is derived from it. The string
+//! values are a stable persisted format.
+
+/// A migration run's fine-grained phase.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Phase {
+    /// No spendable Orchard funds to migrate.
+    NoOrchardFunds,
+    /// Orchard funds exist but are not yet spendable (awaiting confirmations).
+    WaitingForSpendableOrchard,
+    /// Ready to prepare the note split.
+    ReadyToPrepare,
+    /// The note-split transaction is being prepared.
+    PreparingDenominations,
+    /// The note-split transaction is awaiting on-chain confirmation.
+    WaitingDenomConfirmations,
+    /// The split is confirmed; ready to propose transfers.
+    ReadyToMigrate,
+    /// Transfers are scheduled and awaiting broadcast.
+    BroadcastScheduled,
+    /// Transfers are being broadcast.
+    Broadcasting,
+    /// Broadcast transfers are awaiting on-chain confirmation.
+    WaitingMigrationConfirmations,
+    /// Every transfer is confirmed and the Orchard balance is fully migrated.
+    Complete,
+    /// The run is paused.
+    Paused,
+    /// The run failed in a recoverable way.
+    FailedRecoverable,
+    /// The run failed terminally.
+    FailedTerminal,
+    /// The run was abandoned.
+    Abandoned,
+}
+
+impl Phase {
+    /// The persisted string form of this phase.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Phase::NoOrchardFunds => "no_orchard_funds",
+            Phase::WaitingForSpendableOrchard => "waiting_for_spendable_orchard",
+            Phase::ReadyToPrepare => "ready_to_prepare",
+            Phase::PreparingDenominations => "preparing_denominations",
+            Phase::WaitingDenomConfirmations => "waiting_denom_confirmations",
+            Phase::ReadyToMigrate => "ready_to_migrate",
+            Phase::BroadcastScheduled => "broadcast_scheduled",
+            Phase::Broadcasting => "broadcasting",
+            Phase::WaitingMigrationConfirmations => "waiting_migration_confirmations",
+            Phase::Complete => "complete",
+            Phase::Paused => "paused",
+            Phase::FailedRecoverable => "failed_recoverable",
+            Phase::FailedTerminal => "failed_terminal",
+            Phase::Abandoned => "abandoned",
+        }
+    }
+
+    /// Parses a persisted phase string, returning `None` if it is unrecognised.
+    ///
+    /// An unrecognised value indicates the wallet database was written by a newer (or otherwise
+    /// incompatible) version of this engine.
+    pub fn parse(s: &str) -> Option<Phase> {
+        Some(match s {
+            "no_orchard_funds" => Phase::NoOrchardFunds,
+            "waiting_for_spendable_orchard" => Phase::WaitingForSpendableOrchard,
+            "ready_to_prepare" => Phase::ReadyToPrepare,
+            "preparing_denominations" => Phase::PreparingDenominations,
+            "waiting_denom_confirmations" => Phase::WaitingDenomConfirmations,
+            "ready_to_migrate" => Phase::ReadyToMigrate,
+            "broadcast_scheduled" => Phase::BroadcastScheduled,
+            "broadcasting" => Phase::Broadcasting,
+            "waiting_migration_confirmations" => Phase::WaitingMigrationConfirmations,
+            "complete" => Phase::Complete,
+            "paused" => Phase::Paused,
+            "failed_recoverable" => Phase::FailedRecoverable,
+            "failed_terminal" => Phase::FailedTerminal,
+            "abandoned" => Phase::Abandoned,
+            _ => return None,
+        })
+    }
+}


### PR DESCRIPTION
Part of the two-crate split of #2625. **Draft. Stacked on #2634** (base `feat/pool-migration-wallet-trait`).

Adds `state::Phase`, a migration run's fine-grained 14-value phase, with its stable persisted string form (`as_str` / `parse`). This is the prerequisite for the `MigrationStore` trait (its row types carry `Phase`).

Backend-agnostic: `Phase` names only the phases; it references no wallet or storage type. The `Phase -> MigrationState` mapping is engine logic and lands with the generic `MigrationContext`.

Notes:
- Factual module doc (dropped the "vizor's internal phase / Ported from" phrasing; crate-level attribution lives in `lib.rs`).
- No tests; the fixed-value phase tests were dropped.

## Verification
- `cargo clippy -p zcash_ironwood_migration_backend --all-features --all-targets -- -D warnings`
- `cargo doc --all-features` (with `-D warnings`)
- `cargo fmt --check`