### PR TITLE
zcash_client_backend: Return transparent change to the originating P2SH address when spending P2SH inputs

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,14 @@ workspace.
 ### Added
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+- `zcash_client_backend::fees::ChangeValue::{transparent_to_address, transparent_recipient}`
+  (when the "transparent-inputs" feature is enabled)
+- `zcash_client_backend::fees::ChangeError::TransparentChangeDestinationAmbiguous`
+  (when the "transparent-inputs" feature is enabled)
+- `zcash_client_backend::proposal::ProposalError::TransparentChangeRecipientMismatch`
+  (when the "transparent-inputs" feature is enabled)
+- `zcash_client_backend::proto::ProposalDecodingError::TransparentChangeRecipientInvalid`
+  (when the "transparent-inputs" feature is enabled)
 
 ### Changed
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
@@ -32,6 +40,18 @@ workspace.
   `transparent-inputs` feature is not enabled. Balance errors encountered
   during send-max input selection are now wrapped in
   `GreedyInputSelectorError::Balance`.
+- When the "transparent-inputs" feature is enabled and a change strategy is
+  configured with `TransparentChangePolicy::TransparentChangeAllowed`, if the
+  transaction's transparent inputs were all funded via a single P2SH address,
+  transparent change is now returned to that originating address (fee-sized
+  using the actual change output script) instead of to a newly-derived
+  internal-scope P2PKH address of the account. Spends of P2SH-funded coins
+  that are not all funded by a single common address now fail with
+  `ChangeError::TransparentChangeDestinationAmbiguous` when nonzero
+  transparent change is required. Serialized proposals carry the explicit
+  change recipient in a new optional `transparentChangeRecipientScript`
+  field; proposals serialized by older versions are interpreted as before
+  (change is sent to an internal-scope address of the wallet).
 
 ### Fixed
 - `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now

--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -151,7 +151,8 @@ message TransactionBalance {
 //
 // When the transparent value pool is selected and the `isEphemeral` field
 // is not set, the value represents transparent change, which will be sent
-// to an internal-scope (change) transparent address of the wallet.
+// to an internal-scope (change) transparent address of the wallet, unless
+// `transparentChangeRecipientScript` is set.
 message ChangeValue {
     // The value of a change or ephemeral output to be created, in zatoshis.
     uint64 value = 1;
@@ -162,6 +163,14 @@ message ChangeValue {
     MemoBytes memo = 3;
     // Whether this is to be an ephemeral output.
     bool isEphemeral = 4;
+    // The scriptPubKey of the transparent address to which this change output is to be
+    // sent. This may only be set when `valuePool` is `Transparent` and `isEphemeral` is
+    // false, and it must be the scriptPubKey of an address that funds one or more of the
+    // transparent inputs of the same proposal step; it is used to return change to its
+    // originating address (e.g. when spending P2SH inputs). When this field is omitted,
+    // transparent change is sent to an internal-scope (change) transparent address of
+    // the wallet. Proposals serialized by older versions omit this field.
+    optional bytes transparentChangeRecipientScript = 5;
 }
 
 // An object wrapper for memo bytes, to facilitate representing the

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3435,16 +3435,15 @@ pub trait WalletWrite: WalletRead {
     /// # Spending limitations
     ///
     /// Addresses imported via this method may also be spent from via the PCZT flow:
-    /// [`create_pczt_from_proposal`] includes the redeem script in each such input, but does
-    /// not populate any key-derivation metadata for it (no derivation information is recorded
-    /// for standalone imports). Spending via PCZT therefore requires a subsequent updater to
-    /// add the appropriate derivation or key information to the PCZT before signing — for
-    /// example, by matching a multisig redeem script against ZIP 48 keys and setting the
-    /// corresponding BIP 32 derivation on the input. P2PKH-in-P2SH scripts are an exception:
-    /// no PCZT updater tooling currently exists for them, so the only way to spend from such
-    /// an address is to use the [`create_proposed_transactions`] signing path.
-    ///
-    /// [`create_pczt_from_proposal`]: crate::data_api::wallet::create_pczt_from_proposal
+    /// `create_pczt_from_proposal` (available under the `pczt` feature) includes the redeem
+    /// script in each such input, but does not populate any key-derivation metadata for it
+    /// (no derivation information is recorded for standalone imports). Spending via PCZT
+    /// therefore requires a subsequent updater to add the appropriate derivation or key
+    /// information to the PCZT before signing — for example, by matching a multisig redeem
+    /// script against ZIP 48 keys and setting the corresponding BIP 32 derivation on the
+    /// input. P2PKH-in-P2SH scripts are an exception: no PCZT updater tooling currently
+    /// exists for them, so the only way to spend from such an address is to use the
+    /// [`create_proposed_transactions`] signing path.
     #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_script(
         &mut self,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3434,8 +3434,17 @@ pub trait WalletWrite: WalletRead {
     ///
     /// # Spending limitations
     ///
-    /// P2PKH-in-P2SH scripts are unsupported by PCZT at this time, so the only way to spend
-    /// from such an address is to use the [`create_proposed_transactions`] signing path.
+    /// Addresses imported via this method may also be spent from via the PCZT flow:
+    /// [`create_pczt_from_proposal`] includes the redeem script in each such input, but does
+    /// not populate any key-derivation metadata for it (no derivation information is recorded
+    /// for standalone imports). Spending via PCZT therefore requires a subsequent updater to
+    /// add the appropriate derivation or key information to the PCZT before signing — for
+    /// example, by matching a multisig redeem script against ZIP 48 keys and setting the
+    /// corresponding BIP 32 derivation on the input. P2PKH-in-P2SH scripts are an exception:
+    /// no PCZT updater tooling currently exists for them, so the only way to spend from such
+    /// an address is to use the [`create_proposed_transactions`] signing path.
+    ///
+    /// [`create_pczt_from_proposal`]: crate::data_api::wallet::create_pczt_from_proposal
     #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_script(
         &mut self,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1620,7 +1620,7 @@ where
     use crate::{
         data_api::wallet::{self, SpendingKeys},
         fees::{ChangeValue, TransparentChangePolicy},
-        wallet::OvkPolicy,
+        wallet::{Exposure, OvkPolicy, TransparentAddressMetadata},
     };
 
     let mut st = TestBuilder::new()
@@ -1735,12 +1735,24 @@ where
     // A proposal carrying a P2SH change recipient must survive a serialization round trip.
     super::check_proposal_serialization_roundtrip(&network, st.wallet(), &proposal);
 
-    // Snapshot the account's internal-scope (change) receivers so we can prove that creating the
-    // transaction does not reserve a fresh internal change address.
-    let internal_before = st
-        .wallet()
-        .get_transparent_receivers(account_id, true, false)
-        .unwrap();
+    // Snapshot the account's EXPOSED (change-inclusive) receivers so we can prove that creating
+    // the transaction does not reserve a fresh internal change address. Reserving an internal
+    // address does not add rows to the receiver set (the gap-limit rows pre-exist); it marks a
+    // previously-unexposed address as exposed. The exposed subset is therefore the reservation-
+    // sensitive observable.
+    let exposed_receivers = |receivers: HashMap<TransparentAddress, TransparentAddressMetadata>|
+     -> std::collections::BTreeSet<TransparentAddress> {
+        receivers
+            .into_iter()
+            .filter(|(_, meta)| matches!(meta.exposure(), Exposure::Exposed { .. }))
+            .map(|(addr, _)| addr)
+            .collect()
+    };
+    let exposed_before = exposed_receivers(
+        st.wallet()
+            .get_transparent_receivers(account_id, true, false)
+            .unwrap(),
+    );
 
     // Build the transaction, signing the P2SH input with the standalone multisig key.
     let mut standalone_keys = HashMap::new();
@@ -1798,17 +1810,16 @@ where
                 && out.value() == transfer_amount),
     );
 
-    // No internal-scope change address was reserved: the set of change receivers is unchanged.
-    let internal_after = st
-        .wallet()
-        .get_transparent_receivers(account_id, true, false)
-        .unwrap();
-    assert_eq!(internal_before.len(), internal_after.len());
-    assert!(
-        internal_after
-            .keys()
-            .all(|addr| internal_before.contains_key(addr)),
-        "creating the transaction must not reserve a new internal change address",
+    // No internal-scope change address was reserved: the set of exposed receivers is unchanged.
+    // (A reservation would newly expose the next internal-scope gap address, growing this set.)
+    let exposed_after = exposed_receivers(
+        st.wallet()
+            .get_transparent_receivers(account_id, true, false)
+            .unwrap(),
+    );
+    assert_eq!(
+        exposed_before, exposed_after,
+        "creating the transaction must not reserve (newly expose) an internal change address",
     );
 
     // Mine and scan the transaction; the change output becomes spendable at the P2SH address.

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1596,6 +1596,251 @@ where
     );
 }
 
+/// End-to-end test that a fully-transparent spend of UTXOs funded by a single imported P2SH
+/// (multisig) address returns its change directly to that originating P2SH address, records the
+/// change as wallet-owned, and does so without reserving any internal-scope (change) address.
+///
+/// This is the observable behavior of a ZIP 317 change strategy configured with
+/// [`TransparentChangePolicy::TransparentChangeAllowed`] when all transparent inputs of a step are
+/// funded by one P2SH source: the proposed change is a
+/// [`ChangeValue::transparent_to_address`](crate::fees::ChangeValue::transparent_to_address)
+/// paying that P2SH address (rather than a
+/// [`ChangeValue::transparent`](crate::fees::ChangeValue::transparent) sent to a freshly-reserved
+/// internal P2PKH address).
+///
+/// [`TransparentChangePolicy::TransparentChangeAllowed`]: crate::fees::TransparentChangePolicy::TransparentChangeAllowed
+#[cfg(feature = "transparent-key-import")]
+pub fn transparent_change_returned_to_p2sh_source<DSF>(dsf: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+
+    use crate::{
+        data_api::wallet::{self, SpendingKeys},
+        fees::{ChangeValue, TransparentChangePolicy},
+        wallet::OvkPolicy,
+    };
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    // Import a standalone 1-of-1 multisig P2SH address and derive its address.
+    let (redeem_script, secret_key) = build_test_redeem_script();
+    st.wallet_mut()
+        .import_standalone_transparent_script(account_id, redeem_script.clone())
+        .unwrap();
+    let script_pubkey = sh(&redeem_script);
+    let p2sh_addr =
+        TransparentAddress::from_script_pubkey(&script_pubkey).expect("valid P2SH address");
+
+    // Seed the chain with notes that do not belong to us so that heights resolve while the
+    // account holds no shielded notes.
+    let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+    let not_our_value = Zatoshis::const_from_u64(10_000);
+    let (start_height, _, _) =
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    for _ in 1..10 {
+        st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+    }
+    st.scan_cached_blocks(start_height, 10);
+
+    // Fund the P2SH address with a single spendable UTXO.
+    let utxo_value = Zatoshis::const_from_u64(100_000);
+    let height = st.wallet().chain_height().unwrap().unwrap();
+    let outpoint = OutPoint::fake();
+    let utxo = WalletTransparentOutput::from_parts(
+        outpoint.clone(),
+        TxOut::new(utxo_value, p2sh_addr.script().into()),
+        Some(height),
+        Some(account_id),
+        None,
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    // Propose a fully-transparent payment to an external P2PKH recipient, spending only from the
+    // P2SH address, with transparent change allowed.
+    let transfer_amount = Zatoshis::const_from_u64(40_000);
+    let network = *st.network();
+    let request = t2t_request(&network, transfer_amount);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = standard::SingleOutputChangeStrategy::new(
+        StandardFeeRule::Zip317,
+        None,
+        ShieldedPool::Sapling,
+        DustOutputPolicy::default(),
+    )
+    .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+    let proposal = st
+        .propose_transfer_with_policy(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+            &SpendPolicy::default()
+                .with_transparent(TransparentSpendPolicy::from_one_address(p2sh_addr)),
+        )
+        .expect("t->t proposal from a P2SH source with transparent change must succeed");
+
+    // The transfer is a single step spending the single P2SH UTXO, with no shielded inputs.
+    assert_eq!(proposal.steps().len(), 1);
+    let step = &proposal.steps().head;
+    assert_eq!(step.transparent_inputs().len(), 1);
+    assert_eq!(step.transparent_inputs()[0].outpoint(), &outpoint);
+    assert!(step.shielded_inputs().is_none());
+
+    // ZIP 317 fee for this fully-transparent, single-step spend:
+    //   * One P2SH (1-of-1 multisig) input. Its serialized input size is 154 bytes:
+    //       PREVOUT (36)
+    //       + scriptSig [ CompactSize(113) = 1
+    //                     + Component{ OP_0 (1),
+    //                                  73-byte sig push (1 + 73 = 74),
+    //                                  37-byte redeem-script push (1 + 37 = 38) } = 113 ] (= 114)
+    //       + SEQUENCE (4)
+    //     => input actions = ceil(154 / 150) = 2.
+    //   * Two transparent TxOuts: the 34-byte P2PKH payment output and the 32-byte P2SH change
+    //     output (8-byte value + 1-byte CompactSize + 23-byte P2SH script pubkey).
+    //     => output actions = ceil((34 + 32) / 34) = ceil(66 / 34) = 2.
+    //   fee = MARGINAL_FEE (5_000) * max(GRACE_ACTIONS (2), max(2, 2)) = 10_000.
+    let expected_fee = Zatoshis::const_from_u64(10_000);
+    let expected_change = ((utxo_value - transfer_amount).unwrap() - expected_fee).unwrap();
+    assert_eq!(expected_change, Zatoshis::const_from_u64(50_000));
+    assert_eq!(step.balance().fee_required(), expected_fee);
+
+    // The single proposed change output must be a non-ephemeral transparent output returned to
+    // the originating P2SH address (not an internal-scope change address).
+    assert_eq!(
+        step.balance().proposed_change(),
+        [ChangeValue::transparent_to_address(
+            expected_change,
+            p2sh_addr
+        )],
+    );
+    assert!(!step.balance().proposed_change()[0].is_ephemeral());
+
+    // A proposal carrying a P2SH change recipient must survive a serialization round trip.
+    super::check_proposal_serialization_roundtrip(&network, st.wallet(), &proposal);
+
+    // Snapshot the account's internal-scope (change) receivers so we can prove that creating the
+    // transaction does not reserve a fresh internal change address.
+    let internal_before = st
+        .wallet()
+        .get_transparent_receivers(account_id, true, false)
+        .unwrap();
+
+    // Build the transaction, signing the P2SH input with the standalone multisig key.
+    let mut standalone_keys = HashMap::new();
+    standalone_keys.insert(p2sh_addr, vec![secret_key]);
+    let spending_keys = SpendingKeys::new(
+        account.usk().clone(),
+        #[cfg(feature = "transparent-key-import")]
+        standalone_keys,
+    );
+
+    let prover = ::zcash_proofs::prover::LocalTxProver::bundled();
+    let txids = wallet::create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+        st.wallet_mut(),
+        &network,
+        &prover,
+        &prover,
+        &spending_keys,
+        OvkPolicy::Sender,
+        &proposal,
+    )
+    .expect("transaction creation from a P2SH source must succeed");
+    assert_eq!(txids.len(), 1);
+    let txid = txids.head;
+
+    // The transaction is fully transparent with exactly the payment and change outputs.
+    let tx = st
+        .wallet()
+        .get_transaction(txid)
+        .unwrap()
+        .expect("the created transaction is retrievable");
+    assert!(tx.sapling_bundle().is_none());
+    #[cfg(feature = "orchard")]
+    assert!(tx.orchard_bundle().is_none());
+    let bundle = tx
+        .transparent_bundle()
+        .expect("the transaction has a transparent bundle");
+    assert_eq!(bundle.vin.len(), 1);
+    assert_eq!(bundle.vout.len(), 2);
+
+    // Exactly one output pays the originating P2SH address, carrying the expected change value.
+    let payment_recipient = TransparentAddress::PublicKeyHash([7u8; 20]);
+    let change_outputs: Vec<_> = bundle
+        .vout
+        .iter()
+        .filter(|out| out.recipient_address() == Some(p2sh_addr))
+        .collect();
+    assert_eq!(change_outputs.len(), 1);
+    assert_eq!(change_outputs[0].value(), expected_change);
+    // The external payment output is present.
+    assert!(
+        bundle
+            .vout
+            .iter()
+            .any(|out| out.recipient_address() == Some(payment_recipient)
+                && out.value() == transfer_amount),
+    );
+
+    // No internal-scope change address was reserved: the set of change receivers is unchanged.
+    let internal_after = st
+        .wallet()
+        .get_transparent_receivers(account_id, true, false)
+        .unwrap();
+    assert_eq!(internal_before.len(), internal_after.len());
+    assert!(
+        internal_after
+            .keys()
+            .all(|addr| internal_before.contains_key(addr)),
+        "creating the transaction must not reserve a new internal change address",
+    );
+
+    // Mine and scan the transaction; the change output becomes spendable at the P2SH address.
+    let (h, _) = st.generate_next_block_including(txid);
+    st.scan_cached_blocks(h, 1);
+
+    // The change UTXO is recorded at the P2SH address and is spendable.
+    let mut expected_balance = Balance::ZERO;
+    expected_balance
+        .add_spendable_value(expected_change)
+        .unwrap();
+    check_balance::<DSF>(
+        &st,
+        &account,
+        &p2sh_addr,
+        ConfirmationsPolicy::MIN,
+        &expected_balance,
+    );
+
+    // The account's total spendable transparent balance equals funding - payment - fee.
+    let summary = st
+        .wallet()
+        .get_wallet_summary(ConfirmationsPolicy::MIN)
+        .unwrap()
+        .unwrap();
+    let account_balance = summary.account_balances().get(&account_id).unwrap();
+    assert_eq!(
+        account_balance.unshielded_balance().spendable_value(),
+        expected_change,
+    );
+}
+
 /// Tests [`WalletWrite::mark_transparent_addresses_exposed`] by observing the effect on the
 /// address's exposure metadata via
 /// [`WalletRead::get_transparent_address_metadata`](crate::data_api::WalletRead::get_transparent_address_metadata).

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1198,6 +1198,9 @@ enum TransparentBuildRecipient<AccountId> {
         receiving_account: AccountId,
         ephemeral_address: TransparentAddress,
     },
+    /// Wallet-owned transparent change sent to a wallet-known transparent address: either an
+    /// internal-scope (change) address derived for the account, or the originating address of
+    /// the step's transparent inputs (to which returned-to-source change is sent).
     #[cfg(feature = "transparent-inputs")]
     InternalTransparent {
         receiving_account: AccountId,
@@ -2049,9 +2052,12 @@ where
         }
     }
 
-    // Add any transparent change outputs, sending them to the next available internal-scope
-    // (change) transparent addresses of the account. As with ephemeral addresses above, this
-    // reserves the internal addresses even if transaction construction subsequently fails.
+    // Add any transparent change outputs. Change that carries an explicit recipient is
+    // returned to that address (the originating address of the step's transparent inputs,
+    // validated by `Step::from_parts`); all other transparent change outputs are sent to the
+    // next available internal-scope (change) transparent addresses of the account. As with
+    // ephemeral addresses above, reserving an internal address reserves it even if transaction
+    // construction subsequently fails; returned-to-source change reserves nothing.
     #[cfg(feature = "transparent-inputs")]
     {
         let transparent_change_outputs: Vec<(usize, &ChangeValue)> = proposal_step
@@ -2064,18 +2070,37 @@ where
             })
             .collect();
 
-        if !transparent_change_outputs.is_empty() {
-            let addresses_and_metadata = wallet_db
-                .reserve_next_n_internal_addresses(account_id, transparent_change_outputs.len())
-                .map_err(Error::DataSource)?;
-            assert_eq!(
-                addresses_and_metadata.len(),
-                transparent_change_outputs.len()
-            );
+        let (sourced_change, derived_change): (Vec<_>, Vec<_>) = transparent_change_outputs
+            .into_iter()
+            .partition(|(_, change_value)| change_value.transparent_recipient().is_some());
 
-            for ((change_index, change_value), (change_address, _)) in transparent_change_outputs
-                .iter()
-                .zip(addresses_and_metadata)
+        // Change that carries an explicit recipient is returned directly to that address,
+        // without reserving an internal address.
+        for (change_index, change_value) in sourced_change {
+            let change_address = *change_value
+                .transparent_recipient()
+                .expect("partitioned on transparent_recipient().is_some()");
+            builder.add_transparent_output(&change_address, change_value.value())?;
+            transparent_output_meta.push((
+                TransparentBuildRecipient::InternalTransparent {
+                    receiving_account: account_id,
+                    recipient_address: change_address,
+                },
+                change_address,
+                change_value.value(),
+                StepOutputIndex::Change(change_index),
+            ))
+        }
+
+        // All remaining transparent change is sent to freshly reserved internal-scope addresses.
+        if !derived_change.is_empty() {
+            let addresses_and_metadata = wallet_db
+                .reserve_next_n_internal_addresses(account_id, derived_change.len())
+                .map_err(Error::DataSource)?;
+            assert_eq!(addresses_and_metadata.len(), derived_change.len());
+
+            for ((change_index, change_value), (change_address, _)) in
+                derived_change.iter().zip(addresses_and_metadata)
             {
                 builder.add_transparent_output(&change_address, change_value.value())?;
                 transparent_output_meta.push((

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1975,9 +1975,10 @@ where
                 }
             }
             PoolType::Transparent => {
-                // Transparent change outputs (both ephemeral outputs used in multi-step
-                // proposals and non-ephemeral change sent to internal-scope addresses)
-                // are added to the transaction below, after address reservation.
+                // Transparent change outputs (ephemeral outputs used in multi-step
+                // proposals, non-ephemeral change sent to freshly-reserved internal-scope
+                // addresses, and non-ephemeral change returned to an explicit recipient
+                // address) are added to the transaction below.
                 #[cfg(not(feature = "transparent-inputs"))]
                 return Err(Error::UnsupportedChangeType(output_pool));
             }

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -346,7 +346,8 @@ pub enum ChangeError<E, NoteRefT> {
     #[cfg(feature = "transparent-inputs")]
     TransparentChangeDestinationAmbiguous {
         /// The distinct addresses that funded the transparent inputs provided to change
-        /// selection.
+        /// selection. Inputs whose funding address could not be determined from their
+        /// script are not represented here.
         input_addresses: Vec<TransparentAddress>,
     },
     /// An error occurred that was specific to the change selection strategy in use.
@@ -395,8 +396,8 @@ impl<CE: fmt::Display, N: fmt::Display> fmt::Display for ChangeError<CE, N> {
                 write!(
                     f,
                     "Transparent change cannot be returned to a single originating address: \
-                     the transparent inputs were funded by {} distinct addresses ({input_addresses:?}).",
-                    input_addresses.len(),
+                     the transparent inputs were not all funded by a single common address. \
+                     Distinct resolvable funding addresses: {input_addresses:?}",
                 )
             }
             ChangeError::StrategyError(err) => {

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -4,6 +4,8 @@ use std::{
     num::{NonZeroU64, NonZeroUsize},
 };
 
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::TransparentAddress;
 use ::transparent::bundle::OutPoint;
 use zcash_primitives::transaction::fees::{
     FeeRule,
@@ -100,8 +102,11 @@ pub enum TransparentChangePolicy {
 /// `ChangeValue` represents either a proposed change output to a shielded pool
 /// (with an optional change memo), or if the "transparent-inputs" feature is
 /// enabled, an output to the transparent pool: either an ephemeral output as
-/// part of a [ZIP 320] transaction pair, or a change output to an
-/// internal-scope (change) transparent address of the wallet.
+/// part of a [ZIP 320] transaction pair, or a change output to the transparent
+/// pool. A transparent change output is ordinarily sent to an internal-scope
+/// (change) transparent address of the wallet, but it may instead carry an
+/// explicit recipient address, e.g. to return change to the P2SH address that
+/// funded the transaction's transparent inputs.
 ///
 /// [ZIP 320]: https://zips.z.cash/zip-0320
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -117,7 +122,10 @@ enum ChangeValueInner {
     #[cfg(feature = "transparent-inputs")]
     EphemeralTransparent { value: Zatoshis },
     #[cfg(feature = "transparent-inputs")]
-    Transparent { value: Zatoshis },
+    Transparent {
+        value: Zatoshis,
+        recipient: Option<TransparentAddress>,
+    },
 }
 
 impl ChangeValue {
@@ -131,7 +139,26 @@ impl ChangeValue {
     /// sent to an internal-scope (change) transparent address of the wallet.
     #[cfg(feature = "transparent-inputs")]
     pub fn transparent(value: Zatoshis) -> Self {
-        Self(ChangeValueInner::Transparent { value })
+        Self(ChangeValueInner::Transparent {
+            value,
+            recipient: None,
+        })
+    }
+
+    /// Constructs a new change value that will be created as a non-ephemeral transparent output
+    /// sent to the given transparent address.
+    ///
+    /// This is used to return change to the address that funded the transparent inputs of a
+    /// transaction (e.g. the originating P2SH address when spending P2SH inputs), instead of
+    /// sending it to an internal-scope (change) address of the wallet. Proposal validation
+    /// requires that the recipient address match the address of at least one of the transparent
+    /// inputs of the same proposal step.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn transparent_to_address(value: Zatoshis, recipient: TransparentAddress) -> Self {
+        Self(ChangeValueInner::Transparent {
+            value,
+            recipient: Some(recipient),
+        })
     }
 
     /// Constructs a new change value that will be created as a shielded output.
@@ -178,7 +205,19 @@ impl ChangeValue {
             #[cfg(feature = "transparent-inputs")]
             ChangeValueInner::EphemeralTransparent { value } => *value,
             #[cfg(feature = "transparent-inputs")]
-            ChangeValueInner::Transparent { value } => *value,
+            ChangeValueInner::Transparent { value, .. } => *value,
+        }
+    }
+
+    /// Returns the explicit transparent address to which this change output is to be sent, or
+    /// `None` if this is not a transparent change output with an explicit recipient (in which
+    /// case a non-ephemeral transparent change output is sent to an internal-scope (change)
+    /// address of the wallet).
+    #[cfg(feature = "transparent-inputs")]
+    pub fn transparent_recipient(&self) -> Option<&TransparentAddress> {
+        match &self.0 {
+            ChangeValueInner::Transparent { recipient, .. } => recipient.as_ref(),
+            _ => None,
         }
     }
 

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -76,12 +76,14 @@ impl FeeRule for StandardFeeRule {
 /// transaction; returning the change to the transparent pool matches the behavior of
 /// transparent-only wallets (including `zcashd`) at the cost of the change remaining unshielded.
 ///
-/// Transparent change is currently always sent to a P2PKH address derived under the wallet
-/// account's internal scope; returning change to the originating address when spending from a
-/// P2SH (e.g. multisig) address is not yet supported. See [zcash/librustzcash#2570] for
-/// details.
-///
-/// [zcash/librustzcash#2570]: https://github.com/zcash/librustzcash/issues/2570
+/// Under [`TransparentChangePolicy::TransparentChangeAllowed`], transparent change is ordinarily
+/// sent to a P2PKH address derived under the wallet account's internal scope. However, when the
+/// transparent inputs to the transaction include coins funded via a P2SH (e.g. multisig) address,
+/// change is instead returned to that originating address, provided that all of the transaction's
+/// transparent inputs were funded by that single common address. If the transparent inputs were
+/// funded by more than one such address, change computation will fail with
+/// [`ChangeError::TransparentChangeDestinationAmbiguous`] whenever the transaction requires
+/// nonzero transparent change.
 #[cfg(feature = "transparent-inputs")]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum TransparentChangePolicy {
@@ -92,8 +94,11 @@ pub enum TransparentChangePolicy {
     #[default]
     ShieldChange,
     /// When the net flows of the transaction are fully transparent, change is returned to the
-    /// transparent pool at an internal-scope (change) transparent address of the wallet, as
-    /// described in [BIP 44].
+    /// transparent pool. Ordinarily this change is sent to an internal-scope (change)
+    /// transparent address of the wallet, as described in [BIP 44]; however, when the
+    /// transaction's transparent inputs are all funded by a single P2SH (e.g. multisig) address,
+    /// change is instead returned to that originating address. See the documentation of
+    /// [`TransparentChangePolicy`] for details.
     ///
     /// [BIP 44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
     TransparentChangeAllowed,

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -339,6 +339,16 @@ pub enum ChangeError<E, NoteRefT> {
         #[cfg(feature = "orchard")]
         ironwood: Vec<NoteRefT>,
     },
+    /// The change strategy is configured to return transparent change to the transparent pool,
+    /// but the transparent inputs of the transaction include coins funded via P2SH and do not
+    /// all share a single originating address, so no unambiguous address exists to which the
+    /// change may be returned.
+    #[cfg(feature = "transparent-inputs")]
+    TransparentChangeDestinationAmbiguous {
+        /// The distinct addresses that funded the transparent inputs provided to change
+        /// selection.
+        input_addresses: Vec<TransparentAddress>,
+    },
     /// An error occurred that was specific to the change selection strategy in use.
     StrategyError(E),
     /// The proposed bundle structure would violate bundle type construction rules.
@@ -376,6 +386,17 @@ impl<CE: fmt::Display, N: fmt::Display> fmt::Display for ChangeError<CE, N> {
                     f,
                     "Insufficient funds: {} dust inputs were present, but would cost more to spend than they are worth.",
                     transparent.len() + sapling.len() + orchard_len,
+                )
+            }
+            #[cfg(feature = "transparent-inputs")]
+            ChangeError::TransparentChangeDestinationAmbiguous { input_addresses } => {
+                // We can't render the addresses to their string representations because we
+                // don't have network parameters here, so we use their `Debug` formatting.
+                write!(
+                    f,
+                    "Transparent change cannot be returned to a single originating address: \
+                     the transparent inputs were funded by {} distinct addresses ({input_addresses:?}).",
+                    input_addresses.len(),
                 )
             }
             ChangeError::StrategyError(err) => {

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -210,14 +210,16 @@ impl ChangeValue {
     }
 
     /// Returns the explicit transparent address to which this change output is to be sent, or
-    /// `None` if this is not a transparent change output with an explicit recipient (in which
-    /// case a non-ephemeral transparent change output is sent to an internal-scope (change)
-    /// address of the wallet).
+    /// `None` if this is not a transparent change output with an explicit recipient.
+    ///
+    /// A non-ephemeral transparent change output having no explicit recipient is sent to an
+    /// internal-scope (change) transparent address of the wallet.
     #[cfg(feature = "transparent-inputs")]
     pub fn transparent_recipient(&self) -> Option<&TransparentAddress> {
         match &self.0 {
+            ChangeValueInner::Shielded { .. } => None,
+            ChangeValueInner::EphemeralTransparent { .. } => None,
             ChangeValueInner::Transparent { recipient, .. } => recipient.as_ref(),
-            _ => None,
         }
     }
 

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -22,6 +22,10 @@ use super::{
 use super::TransparentChangePolicy;
 #[cfg(feature = "orchard")]
 use super::orchard as orchard_fees;
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::{Script, TransparentAddress};
+#[cfg(feature = "transparent-inputs")]
+use zcash_script::script;
 
 pub(crate) struct NetFlows {
     t_in: Zatoshis,
@@ -278,6 +282,42 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
     }
 }
 
+/// Determines the destination for transparent change, when transparent change is to be
+/// produced.
+///
+/// Returns `Ok(None)` if no transparent input was funded via P2SH (change should be sent to
+/// an internal-scope address of the wallet), `Ok(Some(addr))` if every transparent input was
+/// funded by the single P2SH address `addr` (change should be returned to that address), and
+/// `Err(input_addresses)` if P2SH-funded inputs are present but the inputs do not all share a
+/// single originating address.
+#[cfg(feature = "transparent-inputs")]
+fn transparent_change_destination(
+    transparent_inputs: &[impl transparent::InputView],
+) -> Result<Option<TransparentAddress>, Vec<TransparentAddress>> {
+    let mut input_addresses: Vec<Option<TransparentAddress>> = vec![];
+    for i in transparent_inputs {
+        let addr = script::PubKey::parse(&i.coin().script_pubkey().0)
+            .ok()
+            .as_ref()
+            .and_then(TransparentAddress::from_script_pubkey);
+        if !input_addresses.contains(&addr) {
+            input_addresses.push(addr);
+        }
+    }
+
+    let has_p2sh = input_addresses
+        .iter()
+        .any(|a| matches!(a, Some(TransparentAddress::ScriptHash(_))));
+    if !has_p2sh {
+        Ok(None)
+    } else {
+        match &input_addresses[..] {
+            [Some(addr)] => Ok(Some(*addr)),
+            _ => Err(input_addresses.iter().flatten().copied().collect()),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clone, F: FeeRule, E>(
     cfg: SinglePoolBalanceConfig<P, F>,
@@ -330,6 +370,17 @@ where
         && cfg.transparent_change_policy == TransparentChangePolicy::TransparentChangeAllowed;
     #[cfg(not(feature = "transparent-inputs"))]
     let wants_transparent_change = false;
+
+    // When transparent change is to be produced, determine the address to which it should be
+    // returned. Resolution failure (ambiguous P2SH sources) is deferred: it only matters if a
+    // non-zero change output actually has to be emitted, so the error is raised lazily at
+    // emission rather than here.
+    #[cfg(feature = "transparent-inputs")]
+    let change_destination = if wants_transparent_change {
+        transparent_change_destination(transparent_inputs)
+    } else {
+        Ok(None)
+    };
 
     let total_in = net_flows
         .total_in()
@@ -415,6 +466,21 @@ where
                 .and_then(|b| b.ephemeral_output_amount())
                 .map(|_| P2PKH_STANDARD_OUTPUT_SIZE),
         );
+
+    // The serialized size of the transparent change output, when change is to be returned to
+    // the transparent pool. When the change destination resolves to a single P2SH source
+    // address, the true `TxOut` size for that address's script is used; otherwise (an
+    // internal-scope P2PKH change address, or an unresolved/ambiguous destination) the
+    // standard P2PKH size is used. The P2PKH size is an upper bound on the size of any change
+    // output this function will produce, so the fee computed with it remains valid.
+    #[cfg(feature = "transparent-inputs")]
+    let transparent_change_output_size =
+        wants_transparent_change.then(|| match &change_destination {
+            Ok(Some(addr)) => 8 + Script::from(addr.script()).serialized_size(),
+            _ => P2PKH_STANDARD_OUTPUT_SIZE,
+        });
+    #[cfg(not(feature = "transparent-inputs"))]
+    let transparent_change_output_size: Option<usize> = None;
 
     // Once we calculate the balance with minimum fee (i.e. with no change),
     // there are three cases:
@@ -565,9 +631,9 @@ where
                         transparent_input_sizes.clone(),
                         transparent_output_sizes
                             .clone()
-                            // Count the standard size of the P2PKH change output when change is
-                            // to be returned to the transparent pool.
-                            .chain(wants_transparent_change.then_some(P2PKH_STANDARD_OUTPUT_SIZE)),
+                            // Count the size of the transparent change output when change is to
+                            // be returned to the transparent pool.
+                            .chain(transparent_change_output_size),
                         sapling_input_count,
                         sapling_output_count(target_change_counts.sapling())?,
                         orchard_action_count(target_change_counts.orchard())?,
@@ -640,7 +706,7 @@ where
             let simple_case = || {
                 #[cfg(feature = "transparent-inputs")]
                 if wants_transparent_change {
-                    return (
+                    return Ok((
                         if total_change.is_zero() {
                             // A zero-valued transparent output would be unspendable, so we omit
                             // it. Unlike the shielded change case, omitting the output does not
@@ -648,13 +714,30 @@ where
                             // are already publicly visible.
                             vec![]
                         } else {
-                            vec![ChangeValue::transparent(total_change)]
+                            // A non-zero transparent change output must be emitted; the change
+                            // destination must therefore be unambiguous. This is where a failure
+                            // to resolve a single originating address becomes an error, so that
+                            // exact-match (changeless) spends from ambiguous P2SH sources still
+                            // succeed.
+                            let recipient = change_destination.as_ref().map_err(|addrs| {
+                                ChangeError::TransparentChangeDestinationAmbiguous {
+                                    input_addresses: addrs.clone(),
+                                }
+                            })?;
+                            vec![match recipient {
+                                // Return the change to the originating P2SH address.
+                                Some(addr) => {
+                                    ChangeValue::transparent_to_address(total_change, *addr)
+                                }
+                                // Send the change to an internal-scope address of the wallet.
+                                None => ChangeValue::transparent(total_change),
+                            }]
                         },
                         total_fee,
-                    );
+                    ));
                 }
 
-                (
+                Ok((
                     (0usize..split_count)
                         .map(|i| {
                             ChangeValue::shielded(
@@ -673,7 +756,7 @@ where
                         })
                         .collect(),
                     total_fee,
-                )
+                ))
             };
 
             let change_dust_threshold = cfg
@@ -691,7 +774,7 @@ where
                         // * zero-valued notes do not require witness tracking;
                         // * the effect on trial decryption overhead is small.
                         if total_change.is_zero() {
-                            simple_case()
+                            simple_case()?
                         } else {
                             let shortfall =
                                 (change_dust_threshold - total_change).ok_or_else(underflow)?;
@@ -702,7 +785,7 @@ where
                             });
                         }
                     }
-                    DustAction::AllowDustChange => simple_case(),
+                    DustAction::AllowDustChange => simple_case()?,
                     DustAction::AddDustToFee => {
                         // Zero-valued change is also always allowed for this policy, but when
                         // no change memo is given, we might omit the change output instead.
@@ -714,7 +797,7 @@ where
                         if fee_with_dust > reasonable_fee {
                             // Defend against losing money by using AddDustToFee with a too-high
                             // dust threshold.
-                            simple_case()
+                            simple_case()?
                         } else if change_memo.is_some() {
                             (
                                 vec![ChangeValue::shielded(
@@ -730,7 +813,7 @@ where
                     }
                 }
             } else {
-                simple_case()
+                simple_case()?
             }
         }
     };

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -2,7 +2,8 @@ use core::cmp::{Ordering, max, min};
 use std::num::{NonZeroU64, NonZeroUsize};
 
 use zcash_primitives::transaction::fees::{
-    FeeRule, transparent, zip317::MINIMUM_FEE, zip317::P2PKH_STANDARD_OUTPUT_SIZE,
+    FeeRule, transparent,
+    zip317::{MINIMUM_FEE, P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
 };
 use zcash_protocol::{
     ShieldedPool,
@@ -861,9 +862,24 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
     let mut t_dust: Vec<_> = transparent_inputs
         .iter()
         .filter_map(|i| {
-            // For now, we're just assuming P2PKH inputs, so we don't check the
-            // size of the input script.
-            if i.coin().value() <= marginal_fee {
+            // A transparent input's marginal contribution to a ZIP 317-like fee is
+            // proportional to its serialized size: a P2SH input with a known size may
+            // amount to more than one logical action, so its economic threshold is
+            // correspondingly higher than a standard P2PKH input's. An input of unknown
+            // size is treated as having the standard P2PKH size; if it is in fact
+            // larger, fee computation will reject it as unsizeable in any case.
+            let input_actions = match i.serialized_size() {
+                transparent::InputSize::Known(size) => {
+                    size.div_ceil(P2PKH_STANDARD_INPUT_SIZE).max(1)
+                }
+                transparent::InputSize::Unknown(_) => 1,
+            };
+            // The multiplication can only overflow for absurd marginal fees or input
+            // sizes; saturating to `MAX_MONEY` treats any such input as dust.
+            let marginal_input_fee = (marginal_fee
+                * u64::try_from(input_actions).expect("input action count fits into a u64"))
+            .unwrap_or(Zatoshis::const_from_u64(zcash_protocol::value::MAX_MONEY));
+            if i.coin().value() <= marginal_input_fee {
                 Some(i.outpoint().clone())
             } else {
                 None
@@ -1016,8 +1032,12 @@ pub(crate) fn check_for_uneconomic_inputs<NoteRefT: Clone, E>(
             #[cfg(not(feature = "orchard"))]
             let i_action_count = 0;
 
-            // To calculate the number of unused actions, we assume that transparent inputs
-            // and outputs are P2PKH.
+            // This estimate treats each transparent input and output as a single logical
+            // action, which may under-count actions for P2SH inputs larger than the
+            // standard P2PKH input size. That can only make the grace-input allocation
+            // below more permissive (admitting a dust input whose spend is not actually
+            // free); the authoritative fee computation performed afterwards accounts for
+            // the actual serialized sizes.
             Ok(
                 max(t_req_inputs + t_extra, t_outputs_len + change.transparent)
                     + max(s_spend_count, s_output_count)

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -476,6 +476,8 @@ where
     #[cfg(feature = "transparent-inputs")]
     let transparent_change_output_size =
         wants_transparent_change.then(|| match &change_destination {
+            // The serialized size of a `TxOut` is the 8-byte value field plus the
+            // serialized size of the script pubkey.
             Ok(Some(addr)) => 8 + Script::from(addr.script()).serialized_size(),
             _ => P2PKH_STANDARD_OUTPUT_SIZE,
         });

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -1723,6 +1723,100 @@ mod tests {
         );
     }
 
+    /// Constructs two non-dust P2PKH inputs and one P2SH input with the given value and a
+    /// known 300-byte serialized size, paying a single 40_000-zat transparent output, and
+    /// returns the change computation result under the default (`ShieldChange`) policy.
+    #[cfg(feature = "transparent-inputs")]
+    fn compute_balance_with_p2sh_input_of_value(
+        p2sh_value: u64,
+    ) -> Result<
+        crate::fees::TransactionBalance,
+        ChangeError<zcash_primitives::transaction::fees::zip317::FeeError, Infallible>,
+    > {
+        use crate::fees::sapling as sapling_fees;
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        );
+
+        let p2pkh_input = |txid_byte: u8| {
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([txid_byte; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(100_000),
+                    TransparentAddress::PublicKeyHash([1u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2PKH output")
+        };
+        let inputs = [
+            p2pkh_input(1),
+            p2pkh_input(2),
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([3u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::from_u64(p2sh_value).unwrap(),
+                    TransparentAddress::ScriptHash([7u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2SH output")
+            .with_known_input_size(300),
+        ];
+
+        change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40_000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        )
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn p2sh_input_dust_threshold_scales_with_input_size() {
+        use ::transparent::bundle::OutPoint;
+
+        // A P2SH input with a known 300-byte serialized size contributes
+        // `ceil(300 / 150) = 2` logical actions to a ZIP 317 fee, so its economic
+        // threshold is `2 * 5_000 = 10_000` zats. A 9_000-zat input is uneconomic even
+        // though its value exceeds the 5_000-zat marginal fee that bounds the threshold
+        // for a standard P2PKH input.
+        assert_matches!(
+            compute_balance_with_p2sh_input_of_value(9_000),
+            Err(ChangeError::DustInputs { transparent, .. })
+                if transparent == vec![OutPoint::new([3u8; 32], 0)]
+        );
+
+        // A value just above the size-scaled threshold is economic to spend.
+        assert_matches!(compute_balance_with_p2sh_input_of_value(10_001), Ok(_));
+    }
+
     #[test]
     #[cfg(feature = "transparent-inputs")]
     fn transparent_change_policy_has_no_effect_on_shielded_flows() {

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -1373,6 +1373,358 @@ mod tests {
 
     #[test]
     #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_returned_to_p2sh_source() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        let p2sh_addr = TransparentAddress::ScriptHash([7u8; 20]);
+
+        // A single P2SH input (100_000 zats) funds four transparent payments (10_000 zats
+        // each). The change is returned to the originating P2SH address. Sizing the change
+        // output as a P2SH `TxOut` (32 bytes) yields a total transparent output size of 68
+        // bytes => 2 logical actions => a 10_000 zat fee; mis-sizing it as a P2PKH output
+        // (34 bytes) would tip the total to 70 bytes => 3 actions => a 15_000 zat fee.
+        let inputs = [WalletTransparentOutput::<()>::from_parts(
+            OutPoint::fake(),
+            TxOut::new(Zatoshis::const_from_u64(100_000), p2sh_addr.script().into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("valid P2SH output")
+        .with_known_input_size(150)];
+
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+            ],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change()
+                    == [ChangeValue::transparent_to_address(Zatoshis::const_from_u64(50_000), p2sh_addr)] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10_000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_returned_to_p2sh_source_multiple_inputs() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        let p2sh_addr = TransparentAddress::ScriptHash([7u8; 20]);
+
+        // Two P2SH inputs (50_000 zats each) funded by the *same* P2SH address still resolve
+        // to that single originating address; change is returned to it and sized as a P2SH
+        // output (32 bytes).
+        let p2sh_input = |n: u8| {
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([n; 32], 0),
+                TxOut::new(Zatoshis::const_from_u64(50_000), p2sh_addr.script().into()),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2SH output")
+            .with_known_input_size(150)
+        };
+        let inputs = [p2sh_input(1), p2sh_input(2)];
+
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+                TxOut::new(Zatoshis::const_from_u64(10_000), Script::default()),
+            ],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change()
+                    == [ChangeValue::transparent_to_address(Zatoshis::const_from_u64(50_000), p2sh_addr)] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10_000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_ambiguous_p2sh_sources() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // A P2SH input and a P2PKH input have distinct originating addresses, so no single
+        // address exists to which change may be returned. Because the payment is small
+        // enough that a non-zero change output must be emitted, resolution fails.
+        let inputs = [
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([1u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(60_000),
+                    TransparentAddress::ScriptHash([7u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2SH output")
+            .with_known_input_size(150),
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([2u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(60_000),
+                    TransparentAddress::PublicKeyHash([9u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2PKH output"),
+        ];
+
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[TxOut::new(
+                Zatoshis::const_from_u64(10_000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Err(ChangeError::TransparentChangeDestinationAmbiguous { input_addresses })
+                if input_addresses.len() == 2
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_distinct_p2pkh_sources_uses_internal_change() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // Two P2PKH inputs with distinct originating addresses: no P2SH source is present,
+        // so change is returned to an internal-scope address of the wallet (recipient
+        // `None`) with the standard P2PKH sizing, exactly as before.
+        let inputs = [
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([1u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(50_000),
+                    TransparentAddress::PublicKeyHash([1u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2PKH output"),
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([2u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(50_000),
+                    TransparentAddress::PublicKeyHash([2u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2PKH output"),
+        ];
+
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[TxOut::new(
+                Zatoshis::const_from_u64(40_000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change()
+                    == [ChangeValue::transparent(Zatoshis::const_from_u64(50_000))] &&
+                balance.fee_required() == Zatoshis::const_from_u64(10_000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn change_fully_transparent_exact_match_ambiguous_sources_ok() {
+        use crate::fees::{TransparentChangePolicy, sapling as sapling_fees};
+        use crate::wallet::WalletTransparentOutput;
+        use ::transparent::{address::TransparentAddress, bundle::OutPoint};
+
+        let change_strategy = SingleOutputChangeStrategy::<_, MockWalletDb>::new(
+            Zip317FeeRule::standard(),
+            None,
+            ShieldedPool::Sapling,
+            DustOutputPolicy::default(),
+        )
+        .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+
+        // The inputs have ambiguous (P2SH + P2PKH) sources, but their total exactly covers
+        // the payment plus the minimum (changeless) fee. No change output is emitted, so the
+        // ambiguity never has to be resolved and the transaction is built successfully. This
+        // is the reason the ambiguity error is raised lazily at change emission rather than
+        // eagerly at destination resolution.
+        let inputs = [
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([1u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(10_000),
+                    TransparentAddress::ScriptHash([7u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2SH output")
+            .with_known_input_size(150),
+            WalletTransparentOutput::<()>::from_parts(
+                OutPoint::new([2u8; 32], 0),
+                TxOut::new(
+                    Zatoshis::const_from_u64(10_000),
+                    TransparentAddress::PublicKeyHash([9u8; 20]).script().into(),
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("valid P2PKH output"),
+        ];
+
+        let result = change_strategy.compute_balance::<_, Infallible>(
+            &Network::TestNetwork,
+            Network::TestNetwork
+                .activation_height(NetworkUpgrade::Nu5)
+                .unwrap()
+                .into(),
+            &inputs,
+            &[TxOut::new(
+                Zatoshis::const_from_u64(10_000),
+                Script::default(),
+            )],
+            &sapling_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            #[cfg(feature = "orchard")]
+            &orchard_fees::EmptyBundleView,
+            None,
+            &(),
+        );
+
+        assert_matches!(
+            result,
+            Ok(balance) if
+                balance.proposed_change().is_empty() &&
+                balance.fee_required() == Zatoshis::const_from_u64(10_000)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
     fn transparent_change_policy_has_no_effect_on_shielded_flows() {
         use crate::fees::TransparentChangePolicy;
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -5,6 +5,8 @@ use std::{
     fmt::{self, Debug, Display},
 };
 
+#[cfg(feature = "transparent-inputs")]
+use ::transparent::address::TransparentAddress;
 use nonempty::NonEmpty;
 use zcash_primitives::transaction::{TxId, TxVersion};
 use zcash_protocol::{
@@ -79,6 +81,10 @@ pub enum ProposalError {
     /// receiver. Shielding requires the destination to be able to receive shielded value.
     #[cfg(feature = "transparent-inputs")]
     ShieldingRequiresShieldedRecipient,
+    /// A transparent change output carries an explicit recipient address that is not the
+    /// address of any of the transparent inputs of the same proposal step.
+    #[cfg(feature = "transparent-inputs")]
+    TransparentChangeRecipientMismatch(TransparentAddress),
     /// The transaction version requested is not compatible with the consensus branch for which the
     /// transaction is intended.
     IncompatibleTxVersion(BranchId),
@@ -186,6 +192,11 @@ impl Display for ProposalError {
             ProposalError::ShieldingRequiresShieldedRecipient => write!(
                 f,
                 "A shielding proposal's destination must have a shielded receiver."
+            ),
+            #[cfg(feature = "transparent-inputs")]
+            ProposalError::TransparentChangeRecipientMismatch(addr) => write!(
+                f,
+                "Transparent change may only be returned to an address that funds the transparent inputs of the same step (got {addr:?})."
             ),
             #[cfg(feature = "orchard")]
             ProposalError::OrchardPoolValueCreation {
@@ -647,6 +658,19 @@ impl<NoteRef> Step<NoteRef> {
                 || request_total > Zatoshis::ZERO)
         {
             return Err(ProposalError::ShieldingInvalid);
+        }
+
+        // Transparent change carrying an explicit recipient may only be returned to an
+        // address that funded the transparent inputs of this step.
+        #[cfg(feature = "transparent-inputs")]
+        for cv in balance.proposed_change() {
+            if let Some(addr) = cv.transparent_recipient()
+                && !transparent_inputs
+                    .iter()
+                    .any(|i| i.recipient_address() == addr)
+            {
+                return Err(ProposalError::TransparentChangeRecipientMismatch(*addr));
+            }
         }
 
         // After Ironwood activation, the Orchard turnstile only permits value to leave
@@ -1119,6 +1143,88 @@ mod tests {
                 false,
             ),
             Ok(step) if step.anchor_height().is_none()
+        );
+    }
+
+    /// A transparent change output carrying an explicit recipient address (e.g. to return
+    /// change to the P2SH address that funded a step's transparent inputs) may only name an
+    /// address that actually funds one of that step's transparent inputs. This is a safety
+    /// property: proposals may arrive via untrusted deserialization, and change must never be
+    /// redirected to an arbitrary address.
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_change_recipient_must_fund_step_inputs() {
+        use ::transparent::{
+            address::TransparentAddress,
+            bundle::{OutPoint, TxOut},
+        };
+
+        use crate::wallet::WalletTransparentOutput;
+
+        let funding_addr = TransparentAddress::ScriptHash([7u8; 20]);
+        let other_addr = TransparentAddress::ScriptHash([9u8; 20]);
+
+        let input = WalletTransparentOutput::<()>::from_parts(
+            OutPoint::fake(),
+            TxOut::new(
+                Zatoshis::const_from_u64(60_000),
+                funding_addr.script().into(),
+            ),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("valid P2SH output");
+
+        // Negative case: the change recipient does not match the funding address of any
+        // transparent input of the step.
+        assert_matches!(
+            Step::from_parts(
+                &[],
+                TransactionRequest::empty(),
+                BTreeMap::new(),
+                vec![input.clone()],
+                None::<ShieldedInputs<u32>>,
+                None,
+                vec![],
+                TransactionBalance::new(
+                    vec![ChangeValue::transparent_to_address(
+                        Zatoshis::const_from_u64(50_000),
+                        other_addr,
+                    )],
+                    Zatoshis::const_from_u64(10_000),
+                )
+                .unwrap(),
+                false,
+                false,
+            ),
+            Err(ProposalError::TransparentChangeRecipientMismatch(a)) if a == other_addr
+        );
+
+        // Positive case: the same setup, but the change recipient matches the funding
+        // address of the step's transparent input, so construction succeeds.
+        assert_matches!(
+            Step::from_parts(
+                &[],
+                TransactionRequest::empty(),
+                BTreeMap::new(),
+                vec![input],
+                None::<ShieldedInputs<u32>>,
+                None,
+                vec![],
+                TransactionBalance::new(
+                    vec![ChangeValue::transparent_to_address(
+                        Zatoshis::const_from_u64(50_000),
+                        funding_addr,
+                    )],
+                    Zatoshis::const_from_u64(10_000),
+                )
+                .unwrap(),
+                false,
+                false,
+            ),
+            Ok(_)
         );
     }
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -1146,88 +1146,6 @@ mod tests {
         );
     }
 
-    /// A transparent change output carrying an explicit recipient address (e.g. to return
-    /// change to the P2SH address that funded a step's transparent inputs) may only name an
-    /// address that actually funds one of that step's transparent inputs. This is a safety
-    /// property: proposals may arrive via untrusted deserialization, and change must never be
-    /// redirected to an arbitrary address.
-    #[test]
-    #[cfg(feature = "transparent-inputs")]
-    fn transparent_change_recipient_must_fund_step_inputs() {
-        use ::transparent::{
-            address::TransparentAddress,
-            bundle::{OutPoint, TxOut},
-        };
-
-        use crate::wallet::WalletTransparentOutput;
-
-        let funding_addr = TransparentAddress::ScriptHash([7u8; 20]);
-        let other_addr = TransparentAddress::ScriptHash([9u8; 20]);
-
-        let input = WalletTransparentOutput::<()>::from_parts(
-            OutPoint::fake(),
-            TxOut::new(
-                Zatoshis::const_from_u64(60_000),
-                funding_addr.script().into(),
-            ),
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("valid P2SH output");
-
-        // Negative case: the change recipient does not match the funding address of any
-        // transparent input of the step.
-        assert_matches!(
-            Step::from_parts(
-                &[],
-                TransactionRequest::empty(),
-                BTreeMap::new(),
-                vec![input.clone()],
-                None::<ShieldedInputs<u32>>,
-                None,
-                vec![],
-                TransactionBalance::new(
-                    vec![ChangeValue::transparent_to_address(
-                        Zatoshis::const_from_u64(50_000),
-                        other_addr,
-                    )],
-                    Zatoshis::const_from_u64(10_000),
-                )
-                .unwrap(),
-                false,
-                false,
-            ),
-            Err(ProposalError::TransparentChangeRecipientMismatch(a)) if a == other_addr
-        );
-
-        // Positive case: the same setup, but the change recipient matches the funding
-        // address of the step's transparent input, so construction succeeds.
-        assert_matches!(
-            Step::from_parts(
-                &[],
-                TransactionRequest::empty(),
-                BTreeMap::new(),
-                vec![input],
-                None::<ShieldedInputs<u32>>,
-                None,
-                vec![],
-                TransactionBalance::new(
-                    vec![ChangeValue::transparent_to_address(
-                        Zatoshis::const_from_u64(50_000),
-                        funding_addr,
-                    )],
-                    Zatoshis::const_from_u64(10_000),
-                )
-                .unwrap(),
-                false,
-                false,
-            ),
-            Ok(_)
-        );
-    }
-
     /// Proposal construction conserves value: the total output value of a step (payments +
     /// change + fee) may never exceed its total input value. A step whose outputs exceed its
     /// inputs is rejected with [`ProposalError::BalanceError`] rather than being constructed.
@@ -1909,5 +1827,99 @@ mod tests {
                 n_ironwood + m_ironwood
             );
         }
+    }
+}
+
+#[cfg(all(test, feature = "transparent-inputs"))]
+mod transparent_tests {
+    use std::collections::BTreeMap;
+
+    use ::transparent::{
+        address::TransparentAddress,
+        bundle::{OutPoint, TxOut},
+    };
+    use zcash_protocol::value::Zatoshis;
+    use zip321::TransactionRequest;
+
+    use super::{ProposalError, ShieldedInputs, Step};
+    use crate::{
+        fees::{ChangeValue, TransactionBalance},
+        wallet::WalletTransparentOutput,
+    };
+
+    /// A transparent change output carrying an explicit recipient address (e.g. to return
+    /// change to the P2SH address that funded a step's transparent inputs) may only name an
+    /// address that actually funds one of that step's transparent inputs. This is a safety
+    /// property: proposals may arrive via untrusted deserialization, and change must never be
+    /// redirected to an arbitrary address.
+    #[test]
+    fn transparent_change_recipient_must_fund_step_inputs() {
+        let funding_addr = TransparentAddress::ScriptHash([7u8; 20]);
+        let other_addr = TransparentAddress::ScriptHash([9u8; 20]);
+
+        let input = WalletTransparentOutput::<()>::from_parts(
+            OutPoint::fake(),
+            TxOut::new(
+                Zatoshis::const_from_u64(60_000),
+                funding_addr.script().into(),
+            ),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("valid P2SH output");
+
+        // Negative case: the change recipient does not match the funding address of any
+        // transparent input of the step.
+        assert_matches!(
+            Step::from_parts(
+                &[],
+                TransactionRequest::empty(),
+                BTreeMap::new(),
+                vec![input.clone()],
+                None::<ShieldedInputs<u32>>,
+                None,
+                vec![],
+                TransactionBalance::new(
+                    vec![ChangeValue::transparent_to_address(
+                        Zatoshis::const_from_u64(50_000),
+                        other_addr,
+                    )],
+                    Zatoshis::const_from_u64(10_000),
+                )
+                .unwrap(),
+                false,
+                #[cfg(feature = "orchard")]
+                false,
+            ),
+            Err(ProposalError::TransparentChangeRecipientMismatch(a)) if a == other_addr
+        );
+
+        // Positive case: the same setup, but the change recipient matches the funding
+        // address of the step's transparent input, so construction succeeds.
+        assert_matches!(
+            Step::from_parts(
+                &[],
+                TransactionRequest::empty(),
+                BTreeMap::new(),
+                vec![input],
+                None::<ShieldedInputs<u32>>,
+                None,
+                vec![],
+                TransactionBalance::new(
+                    vec![ChangeValue::transparent_to_address(
+                        Zatoshis::const_from_u64(50_000),
+                        funding_addr,
+                    )],
+                    Zatoshis::const_from_u64(10_000),
+                )
+                .unwrap(),
+                false,
+                #[cfg(feature = "orchard")]
+                false,
+            ),
+            Ok(_)
+        );
     }
 }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -40,13 +40,10 @@ use crate::{
 };
 
 #[cfg(feature = "transparent-inputs")]
-use transparent::{
-    address::{Script, TransparentAddress},
-    bundle::OutPoint,
-};
+use transparent::{address::TransparentAddress, bundle::OutPoint};
 
 #[cfg(feature = "transparent-inputs")]
-use zcash_script::script;
+use zcash_script::script::{self, Evaluable};
 
 #[cfg(feature = "orchard")]
 use orchard::tree::MerkleHashOrchard;
@@ -766,7 +763,7 @@ impl proposal::Proposal {
                             #[cfg(feature = "transparent-inputs")]
                             transparent_change_recipient_script: change
                                 .transparent_recipient()
-                                .map(|addr| Script::from(addr.script()).0.0),
+                                .map(|addr| addr.script().to_bytes()),
                             #[cfg(not(feature = "transparent-inputs"))]
                             transparent_change_recipient_script: None,
                         })
@@ -986,21 +983,22 @@ impl proposal::Proposal {
                                     })
                                     .transpose()?;
 
+                                let pool = cv.pool_type()?;
+
                                 // A `transparentChangeRecipientScript` may only be set on a
                                 // non-ephemeral transparent change value; reject it up front for
                                 // every other combination so that the match below only needs to
                                 // handle it for `(Transparent, false)`.
                                 #[cfg(feature = "transparent-inputs")]
                                 if cv.transparent_change_recipient_script.is_some()
-                                    && !(cv.pool_type()? == PoolType::Transparent
-                                        && !cv.is_ephemeral)
+                                    && (pool != PoolType::Transparent || cv.is_ephemeral)
                                 {
                                     return Err(
                                         ProposalDecodingError::TransparentChangeRecipientInvalid,
                                     );
                                 }
 
-                                match (cv.pool_type()?, cv.is_ephemeral) {
+                                match (pool, cv.is_ephemeral) {
                                     (PoolType::Shielded(ShieldedPool::Sapling), false) => {
                                         Ok(ChangeValue::sapling(value, memo))
                                     }
@@ -1383,6 +1381,26 @@ mod tests {
                 TransparentAddress::ScriptHash([7u8; 20]),
             ));
         proto.steps[0].balance.as_mut().unwrap().proposed_change[0].is_ephemeral = true;
+
+        assert_matches!(
+            proto.try_into_standard_proposal(&network, &wallet_data),
+            Err(ProposalDecodingError::TransparentChangeRecipientInvalid)
+        );
+    }
+
+    /// A `transparentChangeRecipientScript` set on a shielded change value is rejected: an
+    /// explicit transparent recipient is only meaningful for transparent change.
+    #[test]
+    fn transparent_change_recipient_script_with_shielded_pool_rejected() {
+        let (mut proto, _, network, wallet_data) =
+            proto_with_transparent_change(ChangeValue::transparent_to_address(
+                Zatoshis::const_from_u64(50_000),
+                TransparentAddress::ScriptHash([7u8; 20]),
+            ));
+        // Rewrite the change value's pool to Sapling while leaving the recipient script set;
+        // with no memo present, decoding reaches the recipient-script validity check.
+        proto.steps[0].balance.as_mut().unwrap().proposed_change[0].value_pool =
+            proposal::ValuePool::Sapling.into();
 
         assert_matches!(
             proto.try_into_standard_proposal(&network, &wallet_data),

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -40,7 +40,13 @@ use crate::{
 };
 
 #[cfg(feature = "transparent-inputs")]
-use transparent::bundle::OutPoint;
+use transparent::{
+    address::{Script, TransparentAddress},
+    bundle::OutPoint,
+};
+
+#[cfg(feature = "transparent-inputs")]
+use zcash_script::script;
 
 #[cfg(feature = "orchard")]
 use orchard::tree::MerkleHashOrchard;
@@ -522,6 +528,11 @@ pub enum ProposalDecodingError<DbError> {
     /// The proposal specified an explicit transaction version header that the wallet does not
     /// recognize.
     ProposedVersionInvalid(u32),
+    /// The `transparentChangeRecipientScript` field contained a script that is not the
+    /// scriptPubKey of a valid transparent address, or was set on a change value for which an
+    /// explicit transparent recipient is not permitted.
+    #[cfg(feature = "transparent-inputs")]
+    TransparentChangeRecipientInvalid,
 }
 
 impl<E> From<Zip321Error> for ProposalDecodingError<E> {
@@ -595,6 +606,12 @@ impl<E: Display> Display for ProposalDecodingError<E> {
             ProposalDecodingError::ProposedVersionInvalid(header) => write!(
                 f,
                 "The proposal specified an unrecognized transaction version header {header:#x}."
+            ),
+            #[cfg(feature = "transparent-inputs")]
+            ProposalDecodingError::TransparentChangeRecipientInvalid => write!(
+                f,
+                "The transparent change recipient script was invalid, or was set on a change \
+                 value that may not carry an explicit transparent recipient."
             ),
         }
     }
@@ -746,6 +763,12 @@ impl proposal::Proposal {
                                 value: memo_bytes.as_slice().to_vec(),
                             }),
                             is_ephemeral: change.is_ephemeral(),
+                            #[cfg(feature = "transparent-inputs")]
+                            transparent_change_recipient_script: change
+                                .transparent_recipient()
+                                .map(|addr| Script::from(addr.script()).0.0),
+                            #[cfg(not(feature = "transparent-inputs"))]
+                            transparent_change_recipient_script: None,
                         })
                         .collect(),
                     fee_required: step.balance().fee_required().into(),
@@ -962,6 +985,21 @@ impl proposal::Proposal {
                                             .map_err(ProposalDecodingError::MemoInvalid)
                                     })
                                     .transpose()?;
+
+                                // A `transparentChangeRecipientScript` may only be set on a
+                                // non-ephemeral transparent change value; reject it up front for
+                                // every other combination so that the match below only needs to
+                                // handle it for `(Transparent, false)`.
+                                #[cfg(feature = "transparent-inputs")]
+                                if cv.transparent_change_recipient_script.is_some()
+                                    && !(cv.pool_type()? == PoolType::Transparent
+                                        && !cv.is_ephemeral)
+                                {
+                                    return Err(
+                                        ProposalDecodingError::TransparentChangeRecipientInvalid,
+                                    );
+                                }
+
                                 match (cv.pool_type()?, cv.is_ephemeral) {
                                     (PoolType::Shielded(ShieldedPool::Sapling), false) => {
                                         Ok(ChangeValue::sapling(value, memo))
@@ -983,7 +1021,25 @@ impl proposal::Proposal {
                                     }
                                     #[cfg(feature = "transparent-inputs")]
                                     (PoolType::Transparent, false) => {
-                                        Ok(ChangeValue::transparent(value))
+                                        match cv.transparent_change_recipient_script.as_deref() {
+                                            None => Ok(ChangeValue::transparent(value)),
+                                            Some(script_bytes) => {
+                                                script::PubKey::parse(&script::Code(
+                                                    script_bytes.to_vec(),
+                                                ))
+                                                .ok()
+                                                .as_ref()
+                                                .and_then(TransparentAddress::from_script_pubkey)
+                                                .map(|addr| {
+                                                    ChangeValue::transparent_to_address(
+                                                        value, addr,
+                                                    )
+                                                })
+                                                .ok_or(
+                                                    ProposalDecodingError::TransparentChangeRecipientInvalid,
+                                                )
+                                            }
+                                        }
                                     }
                                     // When all pool features are enabled, the explicit arms above
                                     // are exhaustive over the non-ephemeral cases; this fallback
@@ -1096,5 +1152,241 @@ impl service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transpo
     {
         let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
         Ok(Self::new(conn))
+    }
+}
+
+// These tests exercise the serialization of `ChangeValue`'s explicit transparent change
+// recipient, which only exists when the `transparent-inputs` feature is enabled.
+#[cfg(all(test, feature = "transparent-inputs"))]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nonempty::NonEmpty;
+    use zcash_protocol::{consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis};
+    use zip321::TransactionRequest;
+
+    use super::{ProposalDecodingError, StandardFeeRule, proposal};
+    use crate::{
+        data_api::{
+            AccountMeta, InputSource, NoteFilter, ReceivedNotes, TargetValue,
+            wallet::{ConfirmationsPolicy, TargetHeight},
+        },
+        fees::{ChangeValue, TransactionBalance},
+        proposal::{Proposal, ShieldedInputs, Step},
+        wallet::{Note, ReceivedNote, WalletTransparentOutput},
+    };
+    use ::transparent::{
+        address::TransparentAddress,
+        bundle::{OutPoint, TxOut},
+    };
+
+    // A `LocalNetwork` value used to pin consensus state for these tests; Ironwood/NU6.3 is
+    // inactive, which is irrelevant to a purely transparent step.
+    fn test_network() -> LocalNetwork {
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(1)),
+            blossom: Some(BlockHeight::from_u32(1)),
+            heartwood: Some(BlockHeight::from_u32(1)),
+            canopy: Some(BlockHeight::from_u32(1)),
+            nu5: Some(BlockHeight::from_u32(1)),
+            nu6: None,
+            nu6_1: None,
+            nu6_2: None,
+            nu6_3: None,
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: None,
+        }
+    }
+
+    /// A minimal [`InputSource`] that resolves exactly one transparent UTXO, by outpoint; used to
+    /// decode a proposal whose only chain input is that UTXO.
+    struct FakeInputSource(WalletTransparentOutput<()>);
+
+    impl InputSource for FakeInputSource {
+        type Error = ();
+        type AccountId = ();
+        type NoteRef = u32;
+
+        fn get_spendable_note(
+            &self,
+            _txid: &zcash_primitives::transaction::TxId,
+            _protocol: zcash_protocol::ShieldedPool,
+            _index: u32,
+            _target_height: TargetHeight,
+        ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
+            Ok(None)
+        }
+
+        fn select_spendable_notes(
+            &self,
+            _account: Self::AccountId,
+            _target_value: TargetValue,
+            _sources: &[zcash_protocol::ShieldedPool],
+            _target_height: TargetHeight,
+            _confirmations_policy: ConfirmationsPolicy,
+            _exclude: &[Self::NoteRef],
+        ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
+            Ok(ReceivedNotes::empty())
+        }
+
+        fn select_unspent_notes(
+            &self,
+            _account: Self::AccountId,
+            _sources: &[zcash_protocol::ShieldedPool],
+            _target_height: TargetHeight,
+            _exclude: &[Self::NoteRef],
+        ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
+            Ok(ReceivedNotes::empty())
+        }
+
+        fn get_account_metadata(
+            &self,
+            _account: Self::AccountId,
+            _selector: &NoteFilter,
+            _target_height: TargetHeight,
+            _exclude: &[Self::NoteRef],
+        ) -> Result<AccountMeta, Self::Error> {
+            Err(())
+        }
+
+        fn get_unspent_transparent_output(
+            &self,
+            outpoint: &OutPoint,
+            _target_height: TargetHeight,
+        ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+            Ok((*outpoint == *self.0.outpoint()).then(|| self.0.clone()))
+        }
+    }
+
+    /// Builds a single-step proposal with one P2SH transparent input and a transparent change
+    /// output, encodes it to its protobuf representation, and returns everything needed to decode
+    /// it again.
+    fn proto_with_transparent_change(
+        change: ChangeValue,
+    ) -> (
+        proposal::Proposal,
+        Proposal<StandardFeeRule, u32>,
+        LocalNetwork,
+        FakeInputSource,
+    ) {
+        let funding_addr = TransparentAddress::ScriptHash([7u8; 20]);
+
+        let input = WalletTransparentOutput::<()>::from_parts(
+            OutPoint::fake(),
+            TxOut::new(
+                Zatoshis::const_from_u64(60_000),
+                funding_addr.script().into(),
+            ),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("valid P2SH output");
+
+        let balance =
+            TransactionBalance::new(vec![change], Zatoshis::const_from_u64(10_000)).unwrap();
+
+        let step = Step::from_parts(
+            &[],
+            TransactionRequest::empty(),
+            BTreeMap::new(),
+            vec![input.clone()],
+            None::<ShieldedInputs<u32>>,
+            None,
+            vec![],
+            balance,
+            false,
+            #[cfg(feature = "orchard")]
+            false,
+        )
+        .expect("valid step");
+
+        let proposal = Proposal::multi_step(
+            StandardFeeRule::Zip317,
+            TargetHeight::from(100u32),
+            ConfirmationsPolicy::default(),
+            NonEmpty::singleton(step),
+        )
+        .expect("valid proposal");
+
+        let proto = proposal::Proposal::from_standard_proposal(&proposal);
+        let network = test_network();
+        let wallet_data = FakeInputSource(input);
+
+        (proto, proposal, network, wallet_data)
+    }
+
+    /// A proposal whose transparent change carries an explicit recipient matching the P2SH input
+    /// of the same step round-trips through protobuf encoding and decoding unchanged.
+    #[test]
+    fn transparent_change_recipient_round_trips_through_proposal_proto() {
+        let (proto, proposal, network, wallet_data) =
+            proto_with_transparent_change(ChangeValue::transparent_to_address(
+                Zatoshis::const_from_u64(50_000),
+                TransparentAddress::ScriptHash([7u8; 20]),
+            ));
+
+        let decoded = proto
+            .try_into_standard_proposal(&network, &wallet_data)
+            .expect("decodes successfully");
+        assert_eq!(decoded, proposal);
+    }
+
+    /// A legacy transparent change value, with no explicit recipient, round-trips to
+    /// `ChangeValue::transparent` (the absent-field, wallet-change-address semantics).
+    #[test]
+    fn legacy_transparent_change_round_trips_through_proposal_proto() {
+        let (proto, proposal, network, wallet_data) = proto_with_transparent_change(
+            ChangeValue::transparent(Zatoshis::const_from_u64(50_000)),
+        );
+
+        // The wire representation omits the new field entirely for legacy change values.
+        assert_eq!(
+            proto.steps[0].balance.as_ref().unwrap().proposed_change[0]
+                .transparent_change_recipient_script,
+            None
+        );
+
+        let decoded = proto
+            .try_into_standard_proposal(&network, &wallet_data)
+            .expect("decodes successfully");
+        assert_eq!(decoded, proposal);
+    }
+
+    /// A `transparentChangeRecipientScript` that does not parse to the scriptPubKey of a valid
+    /// transparent address is rejected.
+    #[test]
+    fn transparent_change_recipient_script_invalid_bytes_rejected() {
+        let (mut proto, _, network, wallet_data) =
+            proto_with_transparent_change(ChangeValue::transparent_to_address(
+                Zatoshis::const_from_u64(50_000),
+                TransparentAddress::ScriptHash([7u8; 20]),
+            ));
+        proto.steps[0].balance.as_mut().unwrap().proposed_change[0]
+            .transparent_change_recipient_script = Some(vec![0xff, 0x00]);
+
+        assert_matches!(
+            proto.try_into_standard_proposal(&network, &wallet_data),
+            Err(ProposalDecodingError::TransparentChangeRecipientInvalid)
+        );
+    }
+
+    /// A `transparentChangeRecipientScript` set together with `isEphemeral` is rejected: an
+    /// explicit recipient is only meaningful for non-ephemeral transparent change.
+    #[test]
+    fn transparent_change_recipient_script_with_ephemeral_rejected() {
+        let (mut proto, _, network, wallet_data) =
+            proto_with_transparent_change(ChangeValue::transparent_to_address(
+                Zatoshis::const_from_u64(50_000),
+                TransparentAddress::ScriptHash([7u8; 20]),
+            ));
+        proto.steps[0].balance.as_mut().unwrap().proposed_change[0].is_ephemeral = true;
+
+        assert_matches!(
+            proto.try_into_standard_proposal(&network, &wallet_data),
+            Err(ProposalDecodingError::TransparentChangeRecipientInvalid)
+        );
     }
 }

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -148,7 +148,8 @@ pub struct TransactionBalance {
 ///
 /// When the transparent value pool is selected and the `isEphemeral` field
 /// is not set, the value represents transparent change, which will be sent
-/// to an internal-scope (change) transparent address of the wallet.
+/// to an internal-scope (change) transparent address of the wallet, unless
+/// `transparentChangeRecipientScript` is set.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChangeValue {
     /// The value of a change or ephemeral output to be created, in zatoshis.
@@ -164,6 +165,17 @@ pub struct ChangeValue {
     /// Whether this is to be an ephemeral output.
     #[prost(bool, tag = "4")]
     pub is_ephemeral: bool,
+    /// The scriptPubKey of the transparent address to which this change output is to be
+    /// sent. This may only be set when `valuePool` is `Transparent` and `isEphemeral` is
+    /// false, and it must be the scriptPubKey of an address that funds one or more of the
+    /// transparent inputs of the same proposal step; it is used to return change to its
+    /// originating address (e.g. when spending P2SH inputs). When this field is omitted,
+    /// transparent change is sent to an internal-scope (change) transparent address of
+    /// the wallet. Proposals serialized by older versions omit this field.
+    #[prost(bytes = "vec", optional, tag = "5")]
+    pub transparent_change_recipient_script: ::core::option::Option<
+        ::prost::alloc::vec::Vec<u8>,
+    >,
 }
 /// An object wrapper for memo bytes, to facilitate representing the
 /// `change_memo == None` case.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -24,6 +24,17 @@ workspace.
   names begin with the `ext_` prefix reserved for external migrations, and denies
   everything else (DDL, `PRAGMA`, `ATTACH`/`DETACH`, and transaction control).
 
+### Fixed
+- `select_spendable_transparent_outputs` and `get_wallet_transparent_output` now
+  attach the known input size to spendable outputs received at a P2SH address
+  imported via `WalletWrite::import_standalone_transparent_script` (behind the
+  `transparent-key-import` feature flag). Previously, only
+  `get_spendable_transparent_outputs` did so; the other two query paths left the
+  input size unknown, which could cause P2SH spend proposals to fail with
+  `zcash_primitives::transaction::fees::zip317::FeeError::UnknownP2shInputs` or,
+  when treated as an ordinary P2PKH-sized input, understate the required
+  ZIP 317 fee.
+
 ## [0.22.0-rc.1] - 2026-07-12
 
 ### Added

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1144,13 +1144,24 @@ fn to_unspent_transparent_output(
     // If the address has a recorded redeem script, compute the known input size so that the
     // ZIP 317 fee calculator can size P2SH inputs. The `imported_transparent_receiver_script`
     // column must be present in the caller's query for this to take effect; callers that do not
-    // select it (or rows without a redeem script) leave the size unknown, falling back to the
-    // standard P2PKH estimate.
+    // select it (an `Err` from `row.get`) or rows without a redeem script leave the size
+    // unknown, falling back to the standard P2PKH estimate. However, a recorded redeem script
+    // that cannot be parsed or sized indicates database corruption (import validation only
+    // permits standard, sizeable scripts to be stored): silently falling back would under-size
+    // the input and could produce an under-fee'd transaction, so it is an error instead.
     if let Ok(Some(rs_bytes)) =
         row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
-        && let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes))
-        && let Some(input_size) = transparent::builder::p2sh_input_serialized_len(&from_chain)
     {
+        let input_size = script::FromChain::parse(&script::Code(rs_bytes))
+            .ok()
+            .as_ref()
+            .and_then(transparent::builder::p2sh_input_serialized_len)
+            .ok_or_else(|| {
+                SqliteClientError::CorruptedData(
+                    "Recorded redeem script could not be parsed or sized as a standard P2SH input"
+                        .to_string(),
+                )
+            })?;
         output = output.with_known_input_size(input_size);
     }
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1141,17 +1141,28 @@ fn to_unspent_transparent_output(
         )
     })?;
 
-    // If the address has a recorded redeem script, compute the known input size so that the
-    // ZIP 317 fee calculator can size P2SH inputs. The `imported_transparent_receiver_script`
-    // column must be present in the caller's query for this to take effect; callers that do not
-    // select it (an `Err` from `row.get`) or rows without a redeem script leave the size
-    // unknown, falling back to the standard P2PKH estimate. However, a recorded redeem script
-    // that cannot be parsed or sized indicates database corruption (import validation only
-    // permits standard, sizeable scripts to be stored): silently falling back would under-size
-    // the input and could produce an under-fee'd transaction, so it is an error instead.
-    if let Ok(Some(rs_bytes)) =
-        row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
-    {
+    // ZIP 317 fee computation sizes each transparent input from its script: for an output
+    // held at a P2SH address, the input size is derived from the redeem script recorded when
+    // the address was imported, and treating such an input as P2PKH-sized would understate
+    // the fee. A P2SH output whose row provides no parseable, sizeable redeem script —
+    // whether because the recorded value is `NULL`, because the script is malformed, or
+    // because the caller's query does not select the `imported_transparent_receiver_script`
+    // column — is therefore reported as corrupted data. P2PKH outputs carry no redeem script
+    // and use the standard P2PKH size estimate.
+    if matches!(
+        output.recipient_address(),
+        TransparentAddress::ScriptHash(_)
+    ) {
+        let rs_bytes: Vec<u8> = row
+            .get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
+            .ok()
+            .flatten()
+            .ok_or_else(|| {
+                SqliteClientError::CorruptedData(
+                    "No redeem script is recorded for the P2SH address receiving this output"
+                        .to_string(),
+                )
+            })?;
         let input_size = script::FromChain::parse(&script::Code(rs_bytes))
             .ok()
             .as_ref()

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1127,7 +1127,7 @@ fn to_unspent_transparent_output(
         .map(|(account, _)| account);
 
     let outpoint = OutPoint::new(txid_bytes, index);
-    WalletTransparentOutput::from_parts(
+    let mut output = WalletTransparentOutput::from_parts(
         outpoint,
         TxOut::new(value, script_pubkey),
         height.map(BlockHeight::from),
@@ -1139,7 +1139,22 @@ fn to_unspent_transparent_output(
         SqliteClientError::CorruptedData(
             "Txout script_pubkey value did not correspond to a P2PKH or P2SH address".to_string(),
         )
-    })
+    })?;
+
+    // If the address has a recorded redeem script, compute the known input size so that the
+    // ZIP 317 fee calculator can size P2SH inputs. The `imported_transparent_receiver_script`
+    // column must be present in the caller's query for this to take effect; callers that do not
+    // select it (or rows without a redeem script) leave the size unknown, falling back to the
+    // standard P2PKH estimate.
+    if let Ok(Some(rs_bytes)) =
+        row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
+        && let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes))
+        && let Some(input_size) = transparent::builder::p2sh_input_serialized_len(&from_chain)
+    {
+        output = output.with_known_input_size(input_size);
+    }
+
+    Ok(output)
 }
 
 // Generates a SQL expression that returns the identifiers of all spent UTXOS in the wallet.
@@ -1282,6 +1297,7 @@ pub(crate) fn get_wallet_transparent_output(
                 u.value_zat, addresses.key_scope,
                 accounts.uuid AS account_uuid,
                 u.transaction_id AS creating_tx_id,
+                addresses.imported_transparent_receiver_script,
                 t.mined_height AS received_height
          FROM transparent_received_outputs u
          JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1463,17 +1479,7 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
 
     let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
     while let Some(row) = rows.next()? {
-        let mut output = to_unspent_transparent_output(conn, row)?;
-        // If the address has a redeem script, compute the known input size for fee
-        // estimation so that the ZIP 317 fee calculator can handle P2SH inputs.
-        if let Ok(Some(rs_bytes)) =
-            row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_script")
-            && let Ok(from_chain) = script::FromChain::parse(&script::Code(rs_bytes))
-            && let Some(input_size) = transparent::builder::p2sh_input_serialized_len(&from_chain)
-        {
-            output = output.with_known_input_size(input_size);
-        }
-        utxos.push(output);
+        utxos.push(to_unspent_transparent_output(conn, row)?);
     }
 
     Ok(utxos)
@@ -3623,6 +3629,15 @@ mod tests {
     #[cfg(feature = "transparent-key-import")]
     fn test_spend_from_standalone_p2sh() {
         zcash_client_backend::data_api::testing::transparent::spend_from_standalone_p2sh(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_transparent_change_returned_to_p2sh_source() {
+        zcash_client_backend::data_api::testing::transparent::transparent_change_returned_to_p2sh_source(
             TestDbFactory::default(),
             BlockCache::new(),
         );


### PR DESCRIPTION
## Summary

Under `TransparentChangePolicy::TransparentChangeAllowed`, when a transaction's transparent inputs are all funded by a single P2SH (e.g. multisig) address, ZIP 317 change selection now returns transparent change to that originating address — sized by its actual output script — instead of deriving a fresh internal-scope P2PKH change address that would not be spendable under the same multisig arrangement.

- `ChangeValue`'s non-ephemeral transparent variant carries an optional explicit recipient (`ChangeValue::transparent_to_address` / `ChangeValue::transparent_recipient`); the no-recipient form retains internal-scope-derivation semantics.
- `single_pool_output_balance` resolves the change destination from the transparent inputs' funding addresses. When P2SH-funded inputs do not all share a single originating address, change computation fails with the new `ChangeError::TransparentChangeDestinationAmbiguous` — lazily, only when a nonzero transparent change output must actually be emitted, so exact-match (changeless) spends from mixed sources still succeed. P2PKH-only flows are unaffected.
- `Step::from_parts` rejects a transparent change output whose explicit recipient is not the address of one of the same step's transparent inputs (`ProposalError::TransparentChangeRecipientMismatch`), on both trusted and untrusted (deserialized) construction paths, so a tampered proposal cannot redirect change.
- Serialized proposals carry the recipient in a new optional `transparentChangeRecipientScript` field (the destination scriptPubKey); absence preserves the legacy internal-scope semantics, so `PROPOSAL_SER_V1` is unchanged and proposals serialized by older versions decode as before. Malformed or misplaced scripts yield the new `ProposalDecodingError::TransparentChangeRecipientInvalid`.
- `create_proposed_transactions` sends explicit-recipient change directly to that address, skipping internal-scope address reservation (which observes a gap limit and cannot be undone). The PCZT construction path shares this code and records such change correctly (the address is recovered from the output script at extraction).
- `zcash_client_sqlite`: the end-to-end test exposed that `select_spendable_transparent_outputs` and `get_wallet_transparent_output` failed to attach the redeem-script-derived input size for imported P2SH addresses, causing P2SH spend proposals to fail with `UnknownP2shInputs` (or under-count fees). The size attachment is now centralized in the shared row converter, and a recorded redeem script that cannot be parsed or sized surfaces `CorruptedData` instead of silently falling back to the P2PKH size estimate.

Test coverage: ZIP-317 sizing/ambiguity unit tests (constructed so that incorrect P2PKH sizing of the change output produces a different fee), `Step::from_parts` validation tests (exercised in the transparent-inputs-only CI lane), proposal serialization round-trip plus rejection tests, and an end-to-end test that imports a multisig P2SH address, spends from it, verifies the change output pays the originating P2SH script with the exact ZIP-317 fee, verifies no internal-scope address was newly exposed, and confirms the returned change is recorded as spendable.

Closes #2570

## Testing

- `cargo test -p zcash_client_backend --all-features` (99 unit tests + doctests)
- `cargo test -p zcash_client_sqlite --all-features` (379 + 4 tests)
- `cargo check -p zcash_client_backend --no-default-features` (also `--features orchard`, `--features transparent-inputs`)
- `cargo clippy -p zcash_client_backend --all-features --tests` (no new warnings)
- `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
