### PR TITLE
Make Step::orchard_action_count NU6.3-aware

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -13,6 +13,8 @@ workspace.
 ### Added
 - `zcash_protocol::consensus::SECONDS_PER_BLOCK`
 - `zcash_protocol::consensus::BLOCKS_PER_HOUR`
+- `zcash_protocol::constants::MAX_BLOCK_BYTES`, the Zcash consensus maximum
+  block size and therefore the maximum size of any single transaction.
 
 ## [0.10.0] - 2026-07-09
 

--- a/components/zcash_protocol/src/constants.rs
+++ b/components/zcash_protocol/src/constants.rs
@@ -40,3 +40,12 @@ pub const V5_VERSION_GROUP_ID: u32 = 0x26A7270A;
 pub const V6_TX_VERSION: u32 = 6;
 /// The version group ID for Zcash v6 transactions.
 pub const V6_VERSION_GROUP_ID: u32 = 0xD884B698;
+
+/// The maximum size in bytes of a Zcash block, and therefore the maximum size of any single
+/// transaction within one.
+///
+/// It is specified as `MAX_BLOCK_SIZE` in
+/// [§ 7.6 Block Header Encoding and Consensus](https://zips.z.cash/protocol/protocol.pdf#blockheader).
+///
+/// This constant is called `MAX_BLOCK_SIZE` in the zcashd source.
+pub const MAX_BLOCK_BYTES: usize = 2_000_000;

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,7 +10,20 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
+  counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+
 ### Changed
+- `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
+  `orchard::builder::BundleType` and `orchard::bundle::BundleVersion` that the
+  transaction builder will be configured with, and returns a `Result`. It
+  previously hardcoded the pre-NU6.3 `max(spends, outputs)` formula, which
+  understates the action count for an Orchard-pool bundle constructed for a
+  target height at or after NU6.3: such a bundle disables cross-address
+  transfers, and so requires `spends + outputs` actions. The method now also
+  accounts for the bundle type's padding, and is gated on the `orchard`
+  feature.
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -423,10 +423,6 @@ impl orchard_fees::OutputView for OrchardPayment {
     }
 }
 
-/// The Zcash consensus maximum block size, in bytes.
-#[cfg(feature = "transparent-inputs")]
-const MAX_BLOCK_BYTES: usize = 2_000_000;
-
 /// The default maximum fraction of a block's space, as an integer percentage, that a single
 /// shielding transaction's transparent inputs may occupy.
 #[cfg(feature = "transparent-inputs")]
@@ -774,6 +770,8 @@ impl<DbT> GreedyInputSelector<DbT> {
 /// for general (non-shielding) transfers.
 #[cfg(feature = "transparent-inputs")]
 fn shielding_max_inputs(block_space_percent: u32) -> usize {
+    use zcash_protocol::constants::MAX_BLOCK_BYTES;
+
     (MAX_BLOCK_BYTES.saturating_mul(block_space_percent as usize) / 100) / P2PKH_STANDARD_INPUT_SIZE
 }
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -387,9 +387,7 @@ mod tests {
     use super::SingleOutputChangeStrategy;
     use crate::{
         data_api::{
-            AccountMeta, PoolMeta,
-            testing::MockWalletDb,
-            wallet::{TargetHeight, input_selection::SaplingPayment},
+            AccountMeta, PoolMeta, testing::MockWalletDb, wallet::input_selection::SaplingPayment,
         },
         fees::{
             ChangeError, ChangeStrategy, ChangeValue, DustAction, DustOutputPolicy, SplitPolicy,
@@ -403,6 +401,9 @@ mod tests {
         crate::data_api::wallet::input_selection::OrchardPayment,
         crate::fees::orchard as orchard_fees,
     };
+
+    #[cfg(all(feature = "orchard", feature = "transparent-inputs"))]
+    use crate::data_api::wallet::TargetHeight;
 
     #[test]
     fn change_without_dust() {

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -957,10 +957,14 @@ mod tests {
         value::NoteValue,
     };
     use proptest::prelude::*;
-    use zcash_primitives::transaction::{TxId, components::orchard::bundle_version_for_branch};
+    use zcash_primitives::transaction::{
+        TxId,
+        components::orchard::{ACTION_SIZE, bundle_version_for_branch},
+    };
     use zcash_protocol::{
         PoolType, ShieldedPool,
         consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters},
+        constants::MAX_BLOCK_BYTES,
         value::Zatoshis,
     };
     use zip321::TransactionRequest;
@@ -1068,7 +1072,7 @@ mod tests {
                 TransactionRequest::empty(),
                 BTreeMap::new(),
                 vec![],
-                shielded_inputs_for(orchard_and_ironwood_notes(1, 0)),
+                shielded_inputs_for(orchard_and_ironwood_notes((1, 10_000), (0, 0))),
                 None,
                 vec![],
                 TransactionBalance::new(vec![], Zatoshis::const_from_u64(10_000)).unwrap(),
@@ -1130,7 +1134,7 @@ mod tests {
         // not the turnstile, is what rejects this.)
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(1, 0),
+                orchard_and_ironwood_notes((1, 10_000), (0, 0)),
                 TransactionBalance::new(
                     vec![shielded_change(ShieldedPool::Orchard, 8_000)],
                     Zatoshis::const_from_u64(4_000),
@@ -1150,7 +1154,7 @@ mod tests {
         // constraint.
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(1, 0),
+                orchard_and_ironwood_notes((1, 10_000), (0, 0)),
                 TransactionBalance::new(
                     vec![shielded_change(ShieldedPool::Orchard, 6_000)],
                     Zatoshis::const_from_u64(4_000),
@@ -1168,7 +1172,7 @@ mod tests {
         // than the step's Orchard inputs remove: 6_000 change < 10_000 input.
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(1, 0),
+                orchard_and_ironwood_notes((1, 10_000), (0, 0)),
                 TransactionBalance::new(
                     vec![shielded_change(ShieldedPool::Orchard, 6_000)],
                     Zatoshis::const_from_u64(4_000),
@@ -1183,7 +1187,7 @@ mod tests {
         // pool balance unchanged, which the turnstile forbids.
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(1, 1),
+                orchard_and_ironwood_notes((1, 10_000), (1, 20_000)),
                 TransactionBalance::new(
                     vec![
                         shielded_change(ShieldedPool::Orchard, 10_000),
@@ -1205,7 +1209,7 @@ mod tests {
         // change at all.
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(0, 1),
+                orchard_and_ironwood_notes((0, 0), (1, 20_000)),
                 TransactionBalance::new(
                     vec![shielded_change(ShieldedPool::Orchard, 16_000)],
                     Zatoshis::const_from_u64(4_000),
@@ -1224,7 +1228,7 @@ mod tests {
         // valid.
         assert_matches!(
             validated_step(
-                orchard_and_ironwood_notes(0, 1),
+                orchard_and_ironwood_notes((0, 0), (1, 20_000)),
                 TransactionBalance::new(
                     vec![shielded_change(ShieldedPool::Orchard, 16_000)],
                     Zatoshis::const_from_u64(4_000),
@@ -1268,7 +1272,7 @@ mod tests {
             request,
             BTreeMap::from([(0usize, pool)]),
             vec![],
-            shielded_inputs_for(orchard_and_ironwood_notes(1, 0)),
+            shielded_inputs_for(orchard_and_ironwood_notes((1, 10_000), (0, 0))),
             Some(BlockHeight::from_u32(100)),
             vec![],
             TransactionBalance::new(vec![], Zatoshis::const_from_u64(4_000)).unwrap(),
@@ -1295,22 +1299,64 @@ mod tests {
         let _ = orchard_payment_step(PoolType::ORCHARD, true);
     }
 
-    // Builds `n` version-2 (Orchard) notes followed by `m` version-3 (Ironwood) notes.
-    fn orchard_and_ironwood_notes(n: usize, m: usize) -> Vec<Note> {
+    // Builds `orchard.0` version-2 (Orchard) notes of value `orchard.1`, followed by `ironwood.0`
+    // version-3 (Ironwood) notes of value `ironwood.1`.
+    //
+    // Every note of a given pool is identical, so each is derived once and cloned: deriving a full
+    // viewing key per note makes the large-transaction cases below cost seconds rather than
+    // milliseconds. Only the count and the pool of each note matter to an action count.
+    fn orchard_and_ironwood_notes(
+        (n, orchard_value): (usize, u64),
+        (m, ironwood_value): (usize, u64),
+    ) -> Vec<Note> {
         let mut notes = Vec::with_capacity(n + m);
-        for _ in 0..n {
-            notes.push(Note::Orchard {
-                note: orchard_note(10_000, NoteVersion::V2).unwrap(),
+        if n > 0 {
+            let note = Note::Orchard {
+                note: orchard_note(orchard_value, NoteVersion::V2).unwrap(),
                 pool: ValuePool::Orchard,
-            });
+            };
+            notes.extend(std::iter::repeat_n(note, n));
         }
-        for _ in 0..m {
-            notes.push(Note::Orchard {
-                note: orchard_note(20_000, NoteVersion::V3).unwrap(),
+        if m > 0 {
+            let note = Note::Orchard {
+                note: orchard_note(ironwood_value, NoteVersion::V3).unwrap(),
                 pool: ValuePool::Ironwood,
-            });
+            };
+            notes.extend(std::iter::repeat_n(note, m));
         }
         notes
+    }
+
+    // Note and change values, spanning a zero-valued note through a large one. An action count is a
+    // function of how many notes and outputs a step has in each pool, never of what they are worth,
+    // so every value here must give the same answer. The upper bound keeps the total value of even
+    // the largest generated step well inside `MAX_MONEY`, so that `TransactionBalance` construction
+    // cannot fail for a reason these tests are not about.
+    fn arb_note_value() -> impl Strategy<Value = u64> {
+        prop_oneof![
+            1 => Just(0u64),
+            8 => 1u64..1_000_000_000,
+        ]
+    }
+
+    // An upper bound on the actions a single bundle can contain on-chain: a transaction may not
+    // exceed a block, and each action costs at least its action description. The true ceiling is
+    // lower, since `ACTION_SIZE` excludes each action's spend authorization signature and the
+    // bundle's proof, but an over-estimate is what these tests want: it exercises counts at least
+    // as large as anything buildable.
+    const MAX_ACTIONS_PER_BUNDLE: usize = MAX_BLOCK_BYTES / ACTION_SIZE;
+
+    // Spend and output counts spanning what a wallet can actually produce: ordinary payments, large
+    // note-consolidation transactions, and bundles at the block ceiling. Each side is capped at
+    // half the ceiling, because from NU6.3 an Orchard spend and an output no longer share an
+    // action, so `spends + outputs` must itself fit. Small counts are weighted heavily: that is
+    // where the padding floor binds, and where real transactions live.
+    fn arb_note_count() -> impl Strategy<Value = usize> {
+        prop_oneof![
+            6 => 0usize..8,
+            2 => 8usize..100,
+            1 => 100usize..=MAX_ACTIONS_PER_BUNDLE / 2,
+        ]
     }
 
     // The network upgrades at which the Orchard pool exists but still permits cross-address
@@ -1374,6 +1420,27 @@ mod tests {
             step.orchard_action_count(required_unpadded, BundleVersion::orchard_v3()),
             Ok(1)
         );
+
+        // A zero floor cannot suppress a required bundle: a bundle must contain at least one
+        // action to exist at all, so the required-but-unpadded-to-zero case still yields one.
+        let required_zero_floor = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: Some(0),
+        };
+        assert_eq!(
+            step.orchard_action_count(required_zero_floor, BundleVersion::orchard_v3()),
+            Ok(1)
+        );
+
+        // Without `bundle_required`, a zero floor leaves an uninvolved pool with no bundle.
+        let zero_floor = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(0),
+        };
+        assert_eq!(
+            step.orchard_action_count(zero_floor, BundleVersion::orchard_v3()),
+            Ok(0)
+        );
     }
 
     // The documented error path. A coinbase bundle has spends disabled, so every spend in it must
@@ -1383,7 +1450,7 @@ mod tests {
     // enables both spends and outputs, so no transactional bundle type can reject a step's counts.
     #[test]
     fn spends_cannot_be_charged_to_a_coinbase_bundle() {
-        let step = step_with_notes(orchard_and_ironwood_notes(1, 1));
+        let step = step_with_notes(orchard_and_ironwood_notes((1, 10_000), (1, 20_000)));
         assert_matches!(
             step.orchard_action_count(BundleType::Coinbase, BundleVersion::orchard_v3()),
             Err(_)
@@ -1402,6 +1469,95 @@ mod tests {
         assert_eq!(
             step.ironwood_action_count(BundleType::Coinbase, BundleVersion::ironwood_v3()),
             Ok(1)
+        );
+    }
+
+    // What NU6.3 costs a large transaction depends on its shape, and a wallet estimating fees at
+    // scale has to get the difference right.
+    #[test]
+    fn nu6_3_action_growth_at_scale_depends_on_step_shape() {
+        let balanced = |n| {
+            step_with_notes_and_change(
+                orchard_and_ironwood_notes((n, 10_000), (0, 0)),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), n).collect(),
+            )
+        };
+
+        // A consolidation -- sweeping many notes into a single change output -- pays for that
+        // output's fabricated spend and nothing else: one extra action, however large it is.
+        let consolidation = step_with_notes_and_change(
+            orchard_and_ironwood_notes((MAX_ACTIONS_PER_BUNDLE, 10_000), (0, 0)),
+            vec![shielded_change(ShieldedPool::Orchard, 10_000)],
+        );
+        // 2439 actions: the change output rides along in a spend's action, exactly filling a block.
+        assert_eq!(
+            consolidation.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v2()),
+            Ok(MAX_ACTIONS_PER_BUNDLE)
+        );
+        // 2440 from NU6.3: one action over the ceiling, so the same sweep no longer fits.
+        assert_eq!(
+            consolidation.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+            Ok(MAX_ACTIONS_PER_BUNDLE + 1)
+        );
+
+        // A balanced step -- as many outputs as spends -- doubles instead, so the largest one that
+        // fits in a block halves at NU6.3: 2439 spends paired with 2439 outputs before, 1219 of
+        // each after. This is why `arb_note_count` caps each side at half the ceiling.
+        let half = MAX_ACTIONS_PER_BUNDLE / 2;
+        assert_eq!(
+            balanced(MAX_ACTIONS_PER_BUNDLE)
+                .orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v2()),
+            Ok(MAX_ACTIONS_PER_BUNDLE)
+        );
+        // 2438: the largest balanced step that still fits.
+        assert_eq!(
+            balanced(half).orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+            Ok(2 * half)
+        );
+        // 2440: one note more on each side and it does not.
+        assert_eq!(
+            balanced(half + 1)
+                .orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+            Ok(2 * half + 2)
+        );
+    }
+
+    // A `Step` does not necessarily come from this wallet's own input selection: a proposal crosses
+    // a trust boundary as a serialized message (see `proposal.proto` and
+    // `Proposal::try_into_standard_proposal`), so a step's output and change counts are
+    // attacker-influenced. A step claiming far more outputs than could ever fit on-chain must still
+    // be counted exactly, so that the fee rule is handed an unaffordable action count and rejects
+    // it, rather than a small wrapped-around one it would accept.
+    //
+    // The counts themselves cannot overflow `usize`: each is the length of an in-memory collection,
+    // so reaching `usize::MAX` would require more notes than could be addressed.
+    #[test]
+    fn counts_beyond_the_block_limit_are_counted_exactly() {
+        let spends = 4 * MAX_ACTIONS_PER_BUNDLE;
+        let change = 4 * MAX_ACTIONS_PER_BUNDLE;
+        let step = step_with_notes_and_change(
+            orchard_and_ironwood_notes((spends, 10_000), (0, 0)),
+            std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), change).collect(),
+        );
+
+        // Roughly eight times what a block can hold, reported exactly.
+        assert!(spends + change > 8 * MAX_ACTIONS_PER_BUNDLE - 1);
+        assert_eq!(
+            step.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+            Ok(spends + change)
+        );
+
+        // Pre-NU6.3 the same step pairs, so it is charged half as much -- still far past the
+        // ceiling, and still counted exactly.
+        assert_eq!(
+            step.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v2()),
+            Ok(spends.max(change))
+        );
+
+        // Padding a step this size cannot reduce it, and the ZIP 317 floor is irrelevant here.
+        assert_eq!(
+            step.orchard_action_count(BundleType::DEFAULT, BundleVersion::orchard_v3()),
+            Ok(spends + change)
         );
     }
 
@@ -1444,17 +1600,20 @@ mod tests {
         // permits cross-address transfers at every version, so it always pairs.
         #[test]
         fn action_count_pairs_spends_and_outputs_only_when_cross_address_is_permitted(
-            orchard_spends in 0usize..4,
-            ironwood_spends in 0usize..4,
-            orchard_change in 0usize..4,
-            ironwood_change in 0usize..4,
+            orchard_spends in arb_note_count(),
+            ironwood_spends in arb_note_count(),
+            orchard_change in arb_note_count(),
+            ironwood_change in arb_note_count(),
+            orchard_value in arb_note_value(),
+            ironwood_value in arb_note_value(),
+            change_value in arb_note_value(),
         ) {
             let change = std::iter::repeat_n(ShieldedPool::Orchard, orchard_change)
                 .chain(std::iter::repeat_n(ShieldedPool::Ironwood, ironwood_change))
-                .map(|pool| shielded_change(pool, 10_000))
+                .map(|pool| shielded_change(pool, change_value))
                 .collect();
             let step = step_with_notes_and_change(
-                orchard_and_ironwood_notes(orchard_spends, ironwood_spends),
+                orchard_and_ironwood_notes((orchard_spends, orchard_value), (ironwood_spends, ironwood_value)),
                 change,
             );
 
@@ -1496,14 +1655,16 @@ mod tests {
         // whenever a step had both spends and outputs, and so understated the ZIP 317 fee.
         #[test]
         fn orchard_action_count_grows_at_nu6_3_activation_height(
-            spends in 1usize..4,
-            change in 1usize..4,
+            spends in arb_note_count(),
+            change in arb_note_count(),
+            note_value in arb_note_value(),
+            change_value in arb_note_value(),
             pre_nu6_3 in arb_pre_nu6_3_upgrade(),
             nu6_3_or_later in arb_nu6_3_or_later_upgrade(),
         ) {
             let orchard_step = step_with_notes_and_change(
-                orchard_and_ironwood_notes(spends, 0),
-                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), change)
+                orchard_and_ironwood_notes((spends, note_value), (0, 0)),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, change_value), change)
                     .collect(),
             );
 
@@ -1531,8 +1692,8 @@ mod tests {
             // The Ironwood pool retains cross-address transfers, so an equivalent Ironwood step
             // still pairs at a post-NU6.3 height.
             let ironwood_step = step_with_notes_and_change(
-                orchard_and_ironwood_notes(0, spends),
-                std::iter::repeat_n(shielded_change(ShieldedPool::Ironwood, 10_000), change)
+                orchard_and_ironwood_notes((0, 0), (spends, note_value)),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Ironwood, change_value), change)
                     .collect(),
             );
             prop_assert_eq!(
@@ -1546,17 +1707,21 @@ mod tests {
 
         // A non-empty bundle is charged the greater of the actions it requests and the bundle
         // type's padding floor: padding never reduces the count, and the floor is never
-        // undershot. `DEFAULT` (floor 2) and `UNPADDED` (floor 1) are the two floors the
-        // wallet itself uses; this covers the range.
+        // undershot. A bundle that requests nothing is not produced at all, so it is charged
+        // nothing however high the floor. `DEFAULT` (floor 2) and `UNPADDED` (floor 1) are the
+        // floors the wallet itself uses; the whole `u8` range is covered here, including the
+        // degenerate zero floor, since the bundle type is the caller's to choose.
         #[test]
         fn action_count_is_never_below_the_bundle_types_padding_floor(
-            spends in 1usize..4,
-            change in 1usize..4,
-            pad_to_minimum in 1u8..8,
+            spends in arb_note_count(),
+            change in arb_note_count(),
+            note_value in arb_note_value(),
+            change_value in arb_note_value(),
+            pad_to_minimum in 0u8..=u8::MAX,
         ) {
             let step = step_with_notes_and_change(
-                orchard_and_ironwood_notes(spends, 0),
-                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), change)
+                orchard_and_ironwood_notes((spends, note_value), (0, 0)),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, change_value), change)
                     .collect(),
             );
             let bundle_type = BundleType::Transactional {
@@ -1564,9 +1729,16 @@ mod tests {
                 pad_to_minimum: Some(pad_to_minimum),
             };
 
+            // Post-NU6.3, so the requested count is `spends + change`.
+            let requested = spends + change;
+            let expected = if requested == 0 {
+                0
+            } else {
+                requested.max(usize::from(pad_to_minimum))
+            };
             prop_assert_eq!(
                 step.orchard_action_count(bundle_type, BundleVersion::orchard_v3()),
-                Ok((spends + change).max(usize::from(pad_to_minimum)))
+                Ok(expected)
             );
         }
 
@@ -1600,7 +1772,7 @@ mod tests {
             m_orchard in 0usize..5,
             m_ironwood in 0usize..5,
         ) {
-            let step1 = step_with_notes(orchard_and_ironwood_notes(n_orchard, n_ironwood));
+            let step1 = step_with_notes(orchard_and_ironwood_notes((n_orchard, 10_000), (n_ironwood, 20_000)));
             prop_assert_eq!(step1.input_count_in_pool(PoolType::SAPLING), 0);
             prop_assert_eq!(step1.input_count_in_pool(PoolType::ORCHARD), n_orchard);
             prop_assert_eq!(step1.input_count_in_pool(PoolType::IRONWOOD), n_ironwood);
@@ -1613,7 +1785,7 @@ mod tests {
                 );
             }
 
-            let step2 = step_with_notes(orchard_and_ironwood_notes(m_orchard, m_ironwood));
+            let step2 = step_with_notes(orchard_and_ironwood_notes((m_orchard, 10_000), (m_ironwood, 20_000)));
             let proposal = Proposal::<(), u32> {
                 fee_rule: (),
                 min_target_height: TargetHeight::from(100u32),

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -857,16 +857,71 @@ impl<NoteRef> Step<NoteRef> {
             .count()
     }
 
-    /// Returns the number of Orchard actions required by this step.
+    #[cfg(feature = "orchard")]
+    fn orchard_style_action_count(
+        &self,
+        pool_type: PoolType,
+        bundle_type: ::orchard::builder::BundleType,
+        bundle_version: ::orchard::bundle::BundleVersion,
+    ) -> Result<usize, &'static str> {
+        crate::fees::orchard::transactional_action_count(
+            bundle_type,
+            bundle_version,
+            self.input_count_in_pool(pool_type),
+            self.output_count_in_pool(pool_type) + self.change_count_in_pool(pool_type),
+        )
+    }
+
+    /// Returns the number of actions the transaction builder will produce for this step's
+    /// Orchard-pool bundle, given the bundle type and version it will be configured with.
     ///
-    /// Each Orchard action can carry both a spend and an output, so the number of actions is
-    /// the greater of the number of Orchard note spends and the number of Orchard outputs
-    /// (payments plus change) in this step.
-    pub fn orchard_action_count(&self) -> usize {
-        let spends = self.input_count_in_pool(PoolType::ORCHARD);
-        let outputs = self.output_count_in_pool(PoolType::ORCHARD)
-            + self.change_count_in_pool(PoolType::ORCHARD);
-        spends.max(outputs)
+    /// The count depends upon the bundle version: prior to NU6.3, an action may carry both a
+    /// spend and an output, so a bundle requires `max(spends, outputs)` actions; from NU6.3
+    /// onwards the Orchard pool disables cross-address transfers, and each requested spend and
+    /// output is instead paired with a fabricated zero-valued counterpart, so a bundle requires
+    /// `spends + outputs` actions. The bundle type determines the padding applied on top of
+    /// that count.
+    ///
+    /// The caller must pass the same bundle type and version the transaction builder will be
+    /// configured with, otherwise the count will not match the bundle that is built.
+    /// [`bundle_version_for_branch`] returns the version applicable to a given consensus branch
+    /// and pool; the bundle type is determined by the change strategy that produced the
+    /// proposal (see [`SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this step's Orchard spend and output counts are incompatible with
+    /// the given bundle type and version.
+    ///
+    /// [`bundle_version_for_branch`]: zcash_primitives::transaction::components::orchard::bundle_version_for_branch
+    /// [`SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles`]: crate::fees::zip317::SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles
+    #[cfg(feature = "orchard")]
+    pub fn orchard_action_count(
+        &self,
+        bundle_type: ::orchard::builder::BundleType,
+        bundle_version: ::orchard::bundle::BundleVersion,
+    ) -> Result<usize, &'static str> {
+        self.orchard_style_action_count(PoolType::ORCHARD, bundle_type, bundle_version)
+    }
+
+    /// Returns the number of actions the transaction builder will produce for this step's
+    /// Ironwood-pool bundle, given the bundle type and version it will be configured with.
+    ///
+    /// See [`Step::orchard_action_count`] for how the count is determined; the Ironwood pool
+    /// permits cross-address transfers, so an Ironwood bundle requires
+    /// `max(spends, outputs)` actions before padding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this step's Ironwood spend and output counts are incompatible with
+    /// the given bundle type and version.
+    #[cfg(feature = "orchard")]
+    pub fn ironwood_action_count(
+        &self,
+        bundle_type: ::orchard::builder::BundleType,
+        bundle_version: ::orchard::bundle::BundleVersion,
+    ) -> Result<usize, &'static str> {
+        self.orchard_style_action_count(PoolType::IRONWOOD, bundle_type, bundle_version)
     }
 }
 
@@ -895,13 +950,19 @@ mod tests {
     use nonempty::NonEmpty;
     use orchard::{
         ValuePool,
+        builder::BundleType,
+        bundle::BundleVersion,
         keys::{FullViewingKey, SpendingKey},
         note::{Note as OrchardNote, NoteVersion, RandomSeed, Rho},
         value::NoteValue,
     };
     use proptest::prelude::*;
-    use zcash_primitives::transaction::TxId;
-    use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
+    use zcash_primitives::transaction::{TxId, components::orchard::bundle_version_for_branch};
+    use zcash_protocol::{
+        PoolType, ShieldedPool,
+        consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters},
+        value::Zatoshis,
+    };
     use zip321::TransactionRequest;
 
     use super::{Proposal, ProposalError, ShieldedInputs, Step};
@@ -950,6 +1011,13 @@ mod tests {
 
     // Wraps a list of notes into a single `Step` whose only inputs are those shielded notes.
     fn step_with_notes(notes: Vec<Note>) -> Step<u32> {
+        step_with_notes_and_change(notes, vec![])
+    }
+
+    // Wraps a list of notes into a single `Step` spending those shielded notes and returning the
+    // given change outputs. The step is constructed directly rather than via `Step::from_parts`,
+    // so the change values need not be covered by the input values.
+    fn step_with_notes_and_change(notes: Vec<Note>, change: Vec<ChangeValue>) -> Step<u32> {
         let shielded_inputs = shielded_inputs_for(notes);
         Step {
             transaction_request: TransactionRequest::empty(),
@@ -958,7 +1026,7 @@ mod tests {
             shielded_inputs,
             anchor_height: Some(BlockHeight::from_u32(100)),
             prior_step_inputs: vec![],
-            balance: TransactionBalance::new(vec![], Zatoshis::ZERO).unwrap(),
+            balance: TransactionBalance::new(change, Zatoshis::ZERO).unwrap(),
             is_shielding: false,
         }
     }
@@ -1245,7 +1313,170 @@ mod tests {
         notes
     }
 
+    // The network upgrades at which the Orchard pool exists but still permits cross-address
+    // transfers, so that a requested spend and a requested output may share an action.
+    fn arb_pre_nu6_3_upgrade() -> impl Strategy<Value = NetworkUpgrade> {
+        prop::sample::select(vec![
+            NetworkUpgrade::Nu5,
+            NetworkUpgrade::Nu6,
+            NetworkUpgrade::Nu6_1,
+            NetworkUpgrade::Nu6_2,
+        ])
+    }
+
+    // The network upgrades from which the Orchard pool disables cross-address transfers. `Nu7` is
+    // excluded: it has no activation height on any network yet, so no bundle can be built for it.
+    fn arb_nu6_3_or_later_upgrade() -> impl Strategy<Value = NetworkUpgrade> {
+        prop::sample::select(vec![NetworkUpgrade::Nu6_3])
+    }
+
+    // Resolves the bundle version applicable to a pool at an upgrade's testnet activation height,
+    // the way the fee and builder paths do: height -> consensus branch -> `BundleVersion`.
+    fn bundle_version_at(upgrade: NetworkUpgrade, pool: ValuePool) -> BundleVersion {
+        let height = Network::TestNetwork.activation_height(upgrade).unwrap();
+        bundle_version_for_branch(BranchId::for_height(&Network::TestNetwork, height), pool)
+            .unwrap()
+    }
+
+    // A payment output counts towards the action count of the pool it is directed to, exactly as
+    // a change output does. `orchard_payment_step` spends one Orchard note to make one payment.
+    #[test]
+    fn action_count_includes_payment_outputs() {
+        // Pre-activation, the payment is an Orchard-pool output: one spend and one output share
+        // an action, because the pre-NU6.3 Orchard bundle version permits cross-address transfers.
+        let step = orchard_payment_step(PoolType::ORCHARD, false).unwrap();
+        assert_eq!(
+            step.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v2()),
+            Ok(1)
+        );
+        assert_eq!(
+            step.ironwood_action_count(BundleType::UNPADDED, BundleVersion::ironwood_v3()),
+            Ok(0)
+        );
+
+        // Post-activation, the payment is routed to the Ironwood pool: the Orchard note spend is
+        // charged to the Orchard bundle and the payment output to the Ironwood bundle, so neither
+        // pool can pair them into one action.
+        let step = orchard_payment_step(PoolType::IRONWOOD, true).unwrap();
+        assert_eq!(
+            step.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+            Ok(1)
+        );
+        assert_eq!(
+            step.ironwood_action_count(BundleType::UNPADDED, BundleVersion::ironwood_v3()),
+            Ok(1)
+        );
+    }
+
     proptest! {
+        // The number of actions a step's Orchard-pool bundle requires depends upon the bundle
+        // version: the pre-NU6.3 versions permit cross-address transfers, so a spend and an
+        // output may share an action (`max(spends, outputs)`), while from NU6.3 onwards the
+        // Orchard pool disables them, so each spend and output is paired with a fabricated
+        // counterpart and occupies its own action (`spends + outputs`). The Ironwood pool
+        // permits cross-address transfers at every version, so it always pairs.
+        #[test]
+        fn action_count_pairs_spends_and_outputs_only_when_cross_address_is_permitted(
+            orchard_spends in 0usize..4,
+            ironwood_spends in 0usize..4,
+            orchard_change in 0usize..4,
+            ironwood_change in 0usize..4,
+        ) {
+            let change = std::iter::repeat_n(ShieldedPool::Orchard, orchard_change)
+                .chain(std::iter::repeat_n(ShieldedPool::Ironwood, ironwood_change))
+                .map(|pool| shielded_change(pool, 10_000))
+                .collect();
+            let step = step_with_notes_and_change(
+                orchard_and_ironwood_notes(orchard_spends, ironwood_spends),
+                change,
+            );
+
+            // `UNPADDED` pads only to the one-action consensus minimum, so for a non-empty
+            // bundle its action count is exactly the number of requested actions.
+            for version in [BundleVersion::orchard_insecure_v1(), BundleVersion::orchard_v2()] {
+                prop_assert_eq!(
+                    step.orchard_action_count(BundleType::UNPADDED, version),
+                    Ok(orchard_spends.max(orchard_change))
+                );
+            }
+            prop_assert_eq!(
+                step.orchard_action_count(BundleType::UNPADDED, BundleVersion::orchard_v3()),
+                Ok(orchard_spends + orchard_change)
+            );
+            prop_assert_eq!(
+                step.ironwood_action_count(BundleType::UNPADDED, BundleVersion::ironwood_v3()),
+                Ok(ironwood_spends.max(ironwood_change))
+            );
+
+            // The bundle type governs padding on top of that count: `DEFAULT` pads a non-empty
+            // bundle up to the ZIP 317 two-action floor, and produces no bundle at all when the
+            // step requires no actions in that pool.
+            let pad = |requested: usize| if requested == 0 { 0 } else { requested.max(2) };
+            prop_assert_eq!(
+                step.orchard_action_count(BundleType::DEFAULT, BundleVersion::orchard_v3()),
+                Ok(pad(orchard_spends + orchard_change))
+            );
+            prop_assert_eq!(
+                step.ironwood_action_count(BundleType::DEFAULT, BundleVersion::ironwood_v3()),
+                Ok(pad(ironwood_spends.max(ironwood_change)))
+            );
+        }
+
+        // The action count a caller obtains for a real target height, resolving the bundle
+        // version the way the fee and builder paths do: height -> consensus branch ->
+        // `BundleVersion`. This is the scenario the legacy hardcoded `max(spends, outputs)`
+        // formula got wrong: at a post-NU6.3 height it understated the Orchard action count
+        // whenever a step had both spends and outputs, and so understated the ZIP 317 fee.
+        #[test]
+        fn orchard_action_count_grows_at_nu6_3_activation_height(
+            spends in 1usize..4,
+            change in 1usize..4,
+            pre_nu6_3 in arb_pre_nu6_3_upgrade(),
+            nu6_3_or_later in arb_nu6_3_or_later_upgrade(),
+        ) {
+            let orchard_step = step_with_notes_and_change(
+                orchard_and_ironwood_notes(spends, 0),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), change)
+                    .collect(),
+            );
+
+            // Pre-NU6.3, each change output shares an action with a spend: max(spends, change).
+            prop_assert_eq!(
+                orchard_step.orchard_action_count(
+                    BundleType::UNPADDED,
+                    bundle_version_at(pre_nu6_3, ValuePool::Orchard),
+                ),
+                Ok(spends.max(change))
+            );
+
+            // From NU6.3, the Orchard pool disables cross-address transfers: a change output's
+            // corresponding dummy input must be signed with the spending key for the internal
+            // IVK the change is sent to, so it cannot share an action with a spend of a note
+            // belonging to a different address. Hence spends + change actions.
+            prop_assert_eq!(
+                orchard_step.orchard_action_count(
+                    BundleType::UNPADDED,
+                    bundle_version_at(nu6_3_or_later, ValuePool::Orchard),
+                ),
+                Ok(spends + change)
+            );
+
+            // The Ironwood pool retains cross-address transfers, so an equivalent Ironwood step
+            // still pairs at a post-NU6.3 height.
+            let ironwood_step = step_with_notes_and_change(
+                orchard_and_ironwood_notes(0, spends),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Ironwood, 10_000), change)
+                    .collect(),
+            );
+            prop_assert_eq!(
+                ironwood_step.ironwood_action_count(
+                    BundleType::UNPADDED,
+                    bundle_version_at(nu6_3_or_later, ValuePool::Ironwood),
+                ),
+                Ok(spends.max(change))
+            );
+        }
+
         // `Note::pool` reports the `ValuePool` recorded alongside an Orchard note.
         #[test]
         fn note_pool_reports_stored_value_pool(

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -1385,7 +1385,7 @@ mod tests {
     }
 
     // A step that requires no actions in a pool produces no bundle in that pool, so it is charged
-    // nothing — no matter how much padding the bundle type would otherwise apply. The exception is
+    // nothing, no matter how much padding the bundle type would otherwise apply. The exception is
     // a bundle type that requires a bundle: the builder then produces one consisting entirely of
     // dummy actions, padded to the type's minimum.
     #[test]

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -1338,6 +1338,73 @@ mod tests {
             .unwrap()
     }
 
+    // A step that requires no actions in a pool produces no bundle in that pool, so it is charged
+    // nothing — no matter how much padding the bundle type would otherwise apply. The exception is
+    // a bundle type that requires a bundle: the builder then produces one consisting entirely of
+    // dummy actions, padded to the type's minimum.
+    #[test]
+    fn uninvolved_pool_is_charged_nothing_unless_a_bundle_is_required() {
+        let step = step_with_notes(vec![]);
+        for bundle_type in [BundleType::DEFAULT, BundleType::UNPADDED] {
+            assert_eq!(
+                step.orchard_action_count(bundle_type, BundleVersion::orchard_v3()),
+                Ok(0)
+            );
+            assert_eq!(
+                step.ironwood_action_count(bundle_type, BundleVersion::ironwood_v3()),
+                Ok(0)
+            );
+        }
+
+        // `bundle_required` guarantees a bundle exists, padded to the type's minimum: two
+        // all-dummy actions by default, or one when the type opts out of the default padding.
+        let required = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: None,
+        };
+        assert_eq!(
+            step.orchard_action_count(required, BundleVersion::orchard_v3()),
+            Ok(2)
+        );
+        let required_unpadded = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: Some(1),
+        };
+        assert_eq!(
+            step.orchard_action_count(required_unpadded, BundleVersion::orchard_v3()),
+            Ok(1)
+        );
+    }
+
+    // The documented error path. A coinbase bundle has spends disabled, so every spend in it must
+    // be a dummy; a step that spends notes in a pool therefore cannot be built as a coinbase
+    // bundle of that pool, and the count is reported as an error rather than as a wrong number.
+    // This is the only error a step can currently provoke: `BundleVersion::default_flags` always
+    // enables both spends and outputs, so no transactional bundle type can reject a step's counts.
+    #[test]
+    fn spends_cannot_be_charged_to_a_coinbase_bundle() {
+        let step = step_with_notes(orchard_and_ironwood_notes(1, 1));
+        assert_matches!(
+            step.orchard_action_count(BundleType::Coinbase, BundleVersion::orchard_v3()),
+            Err(_)
+        );
+        assert_matches!(
+            step.ironwood_action_count(BundleType::Coinbase, BundleVersion::ironwood_v3()),
+            Err(_)
+        );
+
+        // A step that spends nothing in the pool is accepted: coinbase bundles create outputs,
+        // and are never padded.
+        let step = step_with_notes_and_change(
+            vec![],
+            vec![shielded_change(ShieldedPool::Ironwood, 10_000)],
+        );
+        assert_eq!(
+            step.ironwood_action_count(BundleType::Coinbase, BundleVersion::ironwood_v3()),
+            Ok(1)
+        );
+    }
+
     // A payment output counts towards the action count of the pool it is directed to, exactly as
     // a change output does. `orchard_payment_step` spends one Orchard note to make one payment.
     #[test]
@@ -1474,6 +1541,32 @@ mod tests {
                     bundle_version_at(nu6_3_or_later, ValuePool::Ironwood),
                 ),
                 Ok(spends.max(change))
+            );
+        }
+
+        // A non-empty bundle is charged the greater of the actions it requests and the bundle
+        // type's padding floor: padding never reduces the count, and the floor is never
+        // undershot. `DEFAULT` (floor 2) and `UNPADDED` (floor 1) are the two floors the
+        // wallet itself uses; this covers the range.
+        #[test]
+        fn action_count_is_never_below_the_bundle_types_padding_floor(
+            spends in 1usize..4,
+            change in 1usize..4,
+            pad_to_minimum in 1u8..8,
+        ) {
+            let step = step_with_notes_and_change(
+                orchard_and_ironwood_notes(spends, 0),
+                std::iter::repeat_n(shielded_change(ShieldedPool::Orchard, 10_000), change)
+                    .collect(),
+            );
+            let bundle_type = BundleType::Transactional {
+                bundle_required: false,
+                pad_to_minimum: Some(pad_to_minimum),
+            };
+
+            prop_assert_eq!(
+                step.orchard_action_count(bundle_type, BundleVersion::orchard_v3()),
+                Ok((spends + change).max(usize::from(pad_to_minimum)))
             );
         }
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_primitives::transaction::components::orchard::ACTION_SIZE`, the size in
+  bytes of an Orchard action description as encoded in a transaction. It excludes
+  the action's spend authorization signature and its share of the bundle's proof,
+  which are encoded separately, so dividing a size budget by it yields an upper
+  bound on the number of actions that fit within that budget.
+
 ### Changed
 - `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries
   separate `orchard_bundle_type` and `ironwood_bundle_type` fields in place of

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -7,6 +7,7 @@ use corez::io::{self, Read, Write};
 
 use nonempty::NonEmpty;
 
+use core::mem::size_of;
 use orchard::{
     Action, Anchor, ValuePool,
     bundle::{Authorization, Authorized, BundleVersion, Flags},
@@ -15,6 +16,7 @@ use orchard::{
     value::ValueCommitment,
 };
 use zcash_encoding::{Array, CompactSize, Vector};
+use zcash_note_encryption::{ENC_CIPHERTEXT_SIZE, EphemeralKeyBytes, OUT_CIPHERTEXT_SIZE};
 use zcash_protocol::{
     consensus::{BranchId, OrchardProtocolRevision},
     value::ZatBalance,
@@ -25,6 +27,29 @@ use crate::transaction::Transaction;
 pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
+
+/// The size in bytes of the encoding of a Pallas group element or base field element.
+///
+/// Every such value in an Orchard action — the value commitment, nullifier, randomized
+/// verification key, note commitment, and ephemeral key — is encoded in this many bytes.
+/// [`EphemeralKeyBytes`] is the encoding of one of them (the ephemeral key, a group element),
+/// so its width is that of all of them; note that this is a property of the *encoding*, not of
+/// the in-memory representation, which differs between these types.
+const PALLAS_ENCODING_SIZE: usize = size_of::<EphemeralKeyBytes>();
+
+/// The number of Pallas encodings in an Orchard action description: the value commitment,
+/// nullifier, randomized verification key, note commitment, and ephemeral key.
+const PALLAS_ENCODINGS_PER_ACTION: usize = 5;
+
+/// The size in bytes of an Orchard action description, as written by
+/// [`write_action_without_auth`].
+///
+/// This does not include the action's spend authorization signature or its share of the bundle's
+/// proof, both of which are encoded separately from the action descriptions (see
+/// [`write_v5_bundle`]). Dividing a size budget by this constant therefore yields an upper bound
+/// on the number of actions that fit within it.
+pub const ACTION_SIZE: usize =
+    PALLAS_ENCODINGS_PER_ACTION * PALLAS_ENCODING_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
 
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
@@ -472,5 +497,63 @@ pub mod testing {
             bundle_version,
         )
         .expect("flags are representable under the target version")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use orchard::{bundle::testing::arb_action, note::NoteVersion, value::NoteValue};
+    use proptest::prelude::*;
+
+    use super::{
+        ACTION_SIZE, PALLAS_ENCODING_SIZE, io, write_action_without_auth, write_cmx,
+        write_note_ciphertext, write_nullifier, write_value_commitment, write_verification_key,
+    };
+
+    // Returns the number of bytes `write` emits.
+    fn encoded_len(write: impl FnOnce(&mut Vec<u8>) -> io::Result<()>) -> usize {
+        let mut buf = Vec::new();
+        write(&mut buf).expect("writing to a Vec cannot fail");
+        buf.len()
+    }
+
+    proptest! {
+        /// `ACTION_SIZE` is what callers divide a size budget by to bound an action count, and so
+        /// feeds fee estimation: it must equal what the encoder actually writes, not merely what
+        /// the constant's own arithmetic says. Measure a real action rather than restating the
+        /// composition, so that a change to any encoding it is built from fails here.
+        #[test]
+        fn action_size_matches_the_encoding(
+            action in arb_action(
+                NoteVersion::V2,
+                NoteValue::from_raw(1),
+                NoteValue::from_raw(1),
+            ),
+        ) {
+            prop_assert_eq!(
+                encoded_len(|w| write_action_without_auth(w, &action)),
+                ACTION_SIZE
+            );
+
+            // Every Pallas encoding in an action is the same width, which is what lets
+            // `ACTION_SIZE` count them rather than name each one's size separately.
+            for encoded in [
+                encoded_len(|w| write_value_commitment(w, action.cv_net())),
+                encoded_len(|w| write_nullifier(w, action.nullifier())),
+                encoded_len(|w| write_verification_key(w, action.rk())),
+                encoded_len(|w| write_cmx(w, action.cmx())),
+            ] {
+                prop_assert_eq!(encoded, PALLAS_ENCODING_SIZE);
+            }
+
+            // The remainder is the note ciphertext: the ephemeral key (a fifth Pallas encoding)
+            // followed by the two ciphertexts.
+            prop_assert_eq!(
+                encoded_len(|w| write_note_ciphertext(w, action.encrypted_note())),
+                ACTION_SIZE - 4 * PALLAS_ENCODING_SIZE
+            );
+        }
     }
 }

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -28,18 +28,27 @@ pub const FLAG_SPENDS_ENABLED: u8 = 0b0000_0001;
 pub const FLAG_OUTPUTS_ENABLED: u8 = 0b0000_0010;
 pub const FLAGS_EXPECTED_UNSET: u8 = !(FLAG_SPENDS_ENABLED | FLAG_OUTPUTS_ENABLED);
 
-/// The size in bytes of the encoding of a Pallas group element or base field element.
-///
-/// Every such value in an Orchard action — the value commitment, nullifier, randomized
-/// verification key, note commitment, and ephemeral key — is encoded in this many bytes.
-/// [`EphemeralKeyBytes`] is the encoding of one of them (the ephemeral key, a group element),
-/// so its width is that of all of them; note that this is a property of the *encoding*, not of
-/// the in-memory representation, which differs between these types.
-const PALLAS_ENCODING_SIZE: usize = size_of::<EphemeralKeyBytes>();
+// The encoded size of each element of an Orchard action. Each is a Pallas group element or base
+// field element, both of which encode to 32 bytes; note that this is a property of the *encoding*,
+// and unrelated to the in-memory representation, which differs between these types.
+//
+// These belong upstream in `orchard`, beside the types themselves: it defines each of these
+// elements but exposes no constant for the width of any of their encodings, so they are restated
+// here. Prefer upstream constants over these if `orchard` ever gains them. The
+// `action_size_matches_the_encoding` proptest holds each one to what the encoder actually writes.
 
-/// The number of Pallas encodings in an Orchard action description: the value commitment,
-/// nullifier, randomized verification key, note commitment, and ephemeral key.
-const PALLAS_ENCODINGS_PER_ACTION: usize = 5;
+/// The size in bytes of the encoding of an Orchard value commitment (a Pallas group element).
+const VALUE_COMMITMENT_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of an Orchard nullifier (a Pallas base field element).
+const NULLIFIER_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a randomized spend validating key (a Pallas group element).
+const VERIFICATION_KEY_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of an extracted note commitment (a Pallas base field element).
+const NOTE_COMMITMENT_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of an ephemeral key (a Pallas group element).
+///
+/// Unlike the others, this one the note encryption layer does give a name to.
+const EPHEMERAL_KEY_BYTE_SIZE: usize = size_of::<EphemeralKeyBytes>();
 
 /// The size in bytes of an Orchard action description, as written by
 /// [`write_action_without_auth`].
@@ -48,8 +57,13 @@ const PALLAS_ENCODINGS_PER_ACTION: usize = 5;
 /// proof, both of which are encoded separately from the action descriptions (see
 /// [`write_v5_bundle`]). Dividing a size budget by this constant therefore yields an upper bound
 /// on the number of actions that fit within it.
-pub const ACTION_SIZE: usize =
-    PALLAS_ENCODINGS_PER_ACTION * PALLAS_ENCODING_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+pub const ACTION_SIZE: usize = VALUE_COMMITMENT_BYTE_SIZE
+    + NULLIFIER_BYTE_SIZE
+    + VERIFICATION_KEY_BYTE_SIZE
+    + NOTE_COMMITMENT_BYTE_SIZE
+    + EPHEMERAL_KEY_BYTE_SIZE
+    + ENC_CIPHERTEXT_SIZE
+    + OUT_CIPHERTEXT_SIZE;
 
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
@@ -508,7 +522,9 @@ mod tests {
     use proptest::prelude::*;
 
     use super::{
-        ACTION_SIZE, PALLAS_ENCODING_SIZE, io, write_action_without_auth, write_cmx,
+        ACTION_SIZE, ENC_CIPHERTEXT_SIZE, EPHEMERAL_KEY_BYTE_SIZE, NOTE_COMMITMENT_BYTE_SIZE,
+        NULLIFIER_BYTE_SIZE, OUT_CIPHERTEXT_SIZE, VALUE_COMMITMENT_BYTE_SIZE,
+        VERIFICATION_KEY_BYTE_SIZE, io, write_action_without_auth, write_cmx,
         write_note_ciphertext, write_nullifier, write_value_commitment, write_verification_key,
     };
 
@@ -523,7 +539,10 @@ mod tests {
         /// `ACTION_SIZE` is what callers divide a size budget by to bound an action count, and so
         /// feeds fee estimation: it must equal what the encoder actually writes, not merely what
         /// the constant's own arithmetic says. Measure a real action rather than restating the
-        /// composition, so that a change to any encoding it is built from fails here.
+        /// composition, so that a change to any element's encoding fails here.
+        ///
+        /// This is also what keeps the per-element sizes honest while `orchard` exposes none of
+        /// them itself: each is checked against the encoding of the field it describes.
         #[test]
         fn action_size_matches_the_encoding(
             action in arb_action(
@@ -537,22 +556,29 @@ mod tests {
                 ACTION_SIZE
             );
 
-            // Every Pallas encoding in an action is the same width, which is what lets
-            // `ACTION_SIZE` count them rather than name each one's size separately.
-            for encoded in [
+            // Each element, against the constant that names it.
+            prop_assert_eq!(
                 encoded_len(|w| write_value_commitment(w, action.cv_net())),
+                VALUE_COMMITMENT_BYTE_SIZE
+            );
+            prop_assert_eq!(
                 encoded_len(|w| write_nullifier(w, action.nullifier())),
+                NULLIFIER_BYTE_SIZE
+            );
+            prop_assert_eq!(
                 encoded_len(|w| write_verification_key(w, action.rk())),
+                VERIFICATION_KEY_BYTE_SIZE
+            );
+            prop_assert_eq!(
                 encoded_len(|w| write_cmx(w, action.cmx())),
-            ] {
-                prop_assert_eq!(encoded, PALLAS_ENCODING_SIZE);
-            }
+                NOTE_COMMITMENT_BYTE_SIZE
+            );
 
-            // The remainder is the note ciphertext: the ephemeral key (a fifth Pallas encoding)
-            // followed by the two ciphertexts.
+            // The note ciphertext carries the remaining three: the ephemeral key, followed by the
+            // note and outgoing ciphertexts.
             prop_assert_eq!(
                 encoded_len(|w| write_note_ciphertext(w, action.encrypted_note())),
-                ACTION_SIZE - 4 * PALLAS_ENCODING_SIZE
+                EPHEMERAL_KEY_BYTE_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE
             );
         }
     }


### PR DESCRIPTION
Closes #2515. Closes #2618.

## Problem

`Step::orchard_action_count` hardcoded the legacy padded-bundle formula:

```rust
spends.max(outputs)
```

From NU6.3 the Orchard pool disables cross-address transfers: a change output's
corresponding dummy input must be signed with the spending key for the internal
IVK the change is sent to, so it cannot share an action with a spend of a note
belonging to a different address. The builder therefore pairs each requested
spend and output with a fabricated zero-valued counterpart, and the bundle
requires `spends + outputs` actions.

The method took no consensus-branch or bundle-version argument, so it
understated the action count for any post-NU6.3 Orchard-pool bundle, and had no
Ironwood counterpart. It has no callers in this repository, so this was stale
public API rather than a live bug, but an external consumer using it to estimate
post-NU6.3 fees would have underpaid.

## Approach

#2618 offered two resolutions: make the method version-aware, or deprecate and
remove it. This takes the first, matching #2515's framing, which resolves both
issues together.

`orchard_action_count` now takes the `BundleType` and `BundleVersion` the
transaction builder will be configured with, mirroring
`fees::orchard::transactional_action_count`, to which it delegates. The version
supplies the flags deciding whether spends and outputs pair; the bundle type
supplies the padding applied on top (`DEFAULT` pads to the ZIP 317 two-action
floor, `UNPADDED` does not). `ironwood_action_count` is added as the
counterpart. Both are gated on the `orchard` feature.

This is a breaking signature change, noted in the CHANGELOG; there are no
in-repo callers to update.

## Constants

The tests needed a realistic ceiling on a bundle's actions, which meant two
sizes that were magic numbers or absent:

- `zcash_protocol::constants::MAX_BLOCK_BYTES`, replacing a private copy in
  `input_selection`.
- `zcash_primitives::transaction::components::orchard::ACTION_SIZE`, which
  existed nowhere despite being what a caller must divide a size budget by to
  bound an action count. It is composed from the sizes of the parts
  `write_action_without_auth` writes, not stated as a literal: the ciphertext
  sizes come from `zcash_note_encryption`, and each Pallas element is named
  (`VALUE_COMMITMENT_BYTE_SIZE`, `NULLIFIER_BYTE_SIZE`, ...). Those per-element
  sizes belong upstream beside the types in `orchard`, which defines all of them
  but exposes no constant for any of their encodings; a comment says so.

`ACTION_SIZE` excludes each action's separately-encoded spend authorization
signature and its share of the bundle proof, so it bounds an action count from
above rather than exactly. That is documented on the constant.

## Tests

- `orchard_action_count_grows_at_nu6_3_activation_height` (proptest): resolves
  the bundle version the way the fee and builder paths do (height -> consensus
  branch -> `BundleVersion`) across the pre-NU6.3 upgrades and NU6.3, asserting
  `max(spends, change)` before and `spends + change` from NU6.3, and that
  Ironwood still pairs. Verified to fail against the old formula (minimal input
  `spends = 1, change = 1` at NU6.3).
- `nu6_3_action_growth_at_scale_depends_on_step_shape`: at the block ceiling the
  change costs a consolidation one extra action (2439 -> 2440), but doubles a
  balanced step, halving what one bundle can carry (2439 spends and outputs
  before, 1219 of each after).
- `counts_beyond_the_block_limit_are_counted_exactly`: a step can be rebuilt from
  a serialized proposal, so its output and change counts are attacker-influenced.
  One claiming roughly eight times a block's capacity must still be counted
  exactly, so the fee rule sees an unaffordable number rather than a wrapped-around
  affordable one.
- `spends_cannot_be_charged_to_a_coinbase_bundle`: the documented error path, and
  the only error a step can provoke, since `default_flags` always enables spends
  and outputs.
- Padding: the whole `u8` floor range including the degenerate zero floor, plus
  `bundle_required` on an empty step.
- Note and change values are generated rather than hardcoded: an action count is
  a function of how many notes and outputs a step has, never of what they are
  worth.
- `action_size_matches_the_encoding` (proptest, `zcash_primitives`): measures a
  real action and holds `ACTION_SIZE` and every per-element size to what the
  encoder actually writes, field by named field.

Also gates an unrelated `TargetHeight` test import in `fees::zip317` on both the
`orchard` and `transparent-inputs` features, matching its only consumer; it
previously warned as unused when building the tests with `orchard` alone. Clippy
is clean across all four combinations of those features, and the `zcash_primitives`
`no_std` build still passes.

Filed with Claude Code assistance.