### PR TITLE
Add PCZT signer redaction helper

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::roles::redactor::orchard::OrchardRedactor::redact_recomputable_fields`,
+  behind the `orchard` feature, which removes the Orchard-protocol (Orchard and
+  Ironwood) action fields that `pczt::orchard::Bundle::resolve_fields` can restore.
+
 ## [0.8.0-rc.1] - 2026-07-12
 
 ### Changed

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -443,6 +443,41 @@ impl Action {
             self.output.enc_ciphertext = EncCiphertext::MemoPlaintext(memo);
         }
     }
+
+    pub(crate) fn redact_recomputable_fields(&mut self, note_version: NoteVersion) {
+        let original_enc_ciphertext = self.output.enc_ciphertext.clone();
+        self.replace_enc_ciphertext_with_decrypted_memo_plaintext(note_version);
+        if self.output.enc_ciphertext != original_enc_ciphertext {
+            let mut resolved = self.output.clone();
+            if resolved
+                .encrypt_ciphertext_from_memo(note_version, self.spend.nullifier)
+                .is_err()
+                || resolved.enc_ciphertext != original_enc_ciphertext
+            {
+                self.output.enc_ciphertext = original_enc_ciphertext;
+            }
+        }
+
+        if let Some(original_cv_net) = self.cv_net {
+            let mut resolved = self.clone();
+            resolved.cv_net = None;
+            if resolved.resolve_cv_net().is_ok() && resolved.cv_net == Some(original_cv_net) {
+                self.cv_net = None;
+            }
+        }
+
+        if let Some(original_cmx) = self.output.cmx {
+            let mut resolved = self.output.clone();
+            resolved.cmx = None;
+            if resolved
+                .resolve_cmx(note_version, self.spend.nullifier)
+                .is_ok()
+                && resolved.cmx == Some(original_cmx)
+            {
+                self.output.cmx = None;
+            }
+        }
+    }
 }
 
 /// Information about an Orchard action within a transaction.
@@ -1409,6 +1444,61 @@ pub(crate) mod v2 {
                 action.output.enc_ciphertext,
                 EncCiphertext::Encrypted(original_enc_ciphertext)
             );
+        }
+
+        #[cfg(feature = "orchard")]
+        #[test]
+        fn recomputable_field_redaction_checks_derived_values() {
+            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+            action.spend.value = Some(200_000);
+            action.rcv = Some([3; 32]);
+            action.cv_net = Some(super::super::testing::value_commitment(100_000, [3; 32]));
+
+            action.redact_recomputable_fields(NoteVersion::V2);
+
+            assert_eq!(action.cv_net, None);
+            assert_eq!(action.output.cmx, None);
+            assert!(matches!(
+                action.output.enc_ciphertext,
+                EncCiphertext::MemoPlaintext(_)
+            ));
+        }
+
+        #[cfg(feature = "orchard")]
+        #[test]
+        fn recomputable_field_redaction_retains_unverifiable_values() {
+            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+            let original_cv_net = action.cv_net;
+            let original_cmx = action.output.cmx;
+            let original_enc_ciphertext = action.output.enc_ciphertext.clone();
+            action.output.recipient = None;
+
+            action.redact_recomputable_fields(NoteVersion::V2);
+
+            assert_eq!(action.cv_net, original_cv_net);
+            assert_eq!(action.output.cmx, original_cmx);
+            assert_eq!(action.output.enc_ciphertext, original_enc_ciphertext);
+        }
+
+        #[cfg(feature = "orchard")]
+        #[test]
+        fn recomputable_field_redaction_retains_mismatched_values() {
+            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+            action.spend.value = Some(200_000);
+            action.rcv = Some([3; 32]);
+            let mut cv_net = super::super::testing::value_commitment(100_000, [3; 32]);
+            cv_net[0] ^= 1;
+            action.cv_net = Some(cv_net);
+            let mut cmx = action.output.cmx.unwrap();
+            cmx[0] ^= 1;
+            action.output.cmx = Some(cmx);
+            let original_enc_ciphertext = action.output.enc_ciphertext.clone();
+
+            action.redact_recomputable_fields(NoteVersion::V2);
+
+            assert_eq!(action.cv_net, Some(cv_net));
+            assert_eq!(action.output.cmx, Some(cmx));
+            assert_eq!(action.output.enc_ciphertext, original_enc_ciphertext);
         }
 
         #[test]

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -23,6 +23,26 @@ impl super::Redactor {
 pub struct OrchardRedactor<'a>(&'a mut Bundle);
 
 impl OrchardRedactor<'_> {
+    /// Redacts fields that can be recomputed from the remaining action data.
+    ///
+    /// For every action, this removes `cv_net` and `cmx` when the remaining
+    /// fields derive the same values, and replaces a decryptable encrypted note
+    /// plaintext with its stripped memo plaintext when re-encryption reproduces
+    /// the original ciphertext. The receiver can restore these fields with
+    /// [`Bundle::resolve_fields`](crate::orchard::Bundle::resolve_fields).
+    ///
+    /// Encrypted note plaintexts that cannot be decrypted from the remaining
+    /// action data are left unchanged. Memo recovery runs before `cmx` is
+    /// removed because it needs the original note commitment. A bundle with
+    /// these fields redacted requires the v2 PCZT encoding.
+    #[cfg(feature = "orchard")]
+    pub fn redact_recomputable_fields(&mut self) {
+        let note_version = self.0.note_version;
+        self.redact_actions(|mut action| {
+            action.redact(|action| action.redact_recomputable_fields(note_version));
+        });
+    }
+
     /// Redacts all actions in the same way.
     pub fn redact_actions<F>(&mut self, f: F)
     where

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -2175,9 +2175,7 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
     let redacted = Redactor::new(pczt.clone())
         .redact_ironwood_with(|mut r| {
             r.clear_anchor();
-            r.redact_actions(|mut a| {
-                a.clear_cv_net();
-            });
+            r.redact_recomputable_fields();
         })
         .finish();
     assert!(redacted.ironwood().anchor().is_none());
@@ -2188,53 +2186,66 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
             .iter()
             .all(|action| action.cv_net().is_none())
     );
-    let verified = Verifier::new(redacted.clone())
+    assert!(
+        redacted
+            .ironwood()
+            .actions()
+            .iter()
+            .all(|action| action.output().cmx().is_none())
+    );
+    assert!(redacted.ironwood().actions().iter().any(|action| {
+        matches!(
+            action.output().enc_ciphertext(),
+            pczt::orchard::EncCiphertext::MemoPlaintext(_)
+        )
+    }));
+    let transported = Pczt::parse(&redacted.clone().serialize().unwrap()).unwrap();
+    let verified = Verifier::new(transported.clone())
         .with_ironwood::<std::convert::Infallible, _>(|_| {
             Ok::<(), pczt::roles::verifier::OrchardError<std::convert::Infallible>>(())
         })
         .unwrap()
         .finish();
     assert!(verified.ironwood().anchor().is_none());
-    let updated = Updater::new(redacted.clone())
+    let updated = Updater::new(transported.clone())
         .update_ironwood_with(|_| Ok(()))
         .unwrap()
         .finish();
     assert!(updated.ironwood().anchor().is_none());
 
-    let mut resolved = redacted.clone();
+    let mut resolved = transported.clone();
     resolved.resolve_fields().unwrap();
     assert!(resolved.ironwood().anchor().is_none());
     assert_eq!(
         resolved.ironwood().actions()[index].cv_net(),
         pczt.ironwood().actions()[index].cv_net()
     );
-    let finalized = IoFinalizer::new(redacted.clone()).finalize_io().unwrap();
+    for (resolved, original) in resolved
+        .ironwood()
+        .actions()
+        .iter()
+        .zip(pczt.ironwood().actions())
+    {
+        assert_eq!(resolved.cv_net(), original.cv_net());
+        assert_eq!(resolved.output().cmx(), original.output().cmx());
+        assert_eq!(
+            resolved.output().enc_ciphertext(),
+            original.output().enc_ciphertext()
+        );
+    }
+    let finalized = IoFinalizer::new(transported.clone()).finalize_io().unwrap();
     assert!(finalized.ironwood().anchor().is_none());
     assert!(
-        Prover::new(redacted.clone())
+        Prover::new(transported.clone())
             .create_ironwood_proof(orchard_proving_key())
             .is_err()
     );
     assert_eq!(
-        Signer::new(redacted.clone()).unwrap().shielded_sighash(),
+        Signer::new(transported.clone()).unwrap().shielded_sighash(),
         sighash
     );
 
-    let cv_net_redacted = Redactor::new(pczt.clone())
-        .redact_ironwood_with(|mut r| {
-            r.redact_actions(|mut a| {
-                a.clear_cv_net();
-            });
-        })
-        .finish();
-    assert_eq!(
-        Signer::new(cv_net_redacted.clone())
-            .unwrap()
-            .shielded_sighash(),
-        sighash
-    );
-
-    let signed_redacted = low_level_signer::Signer::new(cv_net_redacted)
+    let signed_redacted = low_level_signer::Signer::new(transported)
         .sign_ironwood_with::<low_level_signer::OrchardParseError, _>(|_, bundle, _| {
             bundle.actions_mut()[index]
                 .sign(sighash, &orchard_ask, ChaCha20Rng::from_seed(seed))
@@ -2251,6 +2262,31 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
         expected_sig
     );
     check_v2_round_trip(&signed_redacted);
+
+    let combined = Combiner::new(vec![pczt.clone(), signed_redacted])
+        .combine()
+        .unwrap();
+    assert_eq!(combined.ironwood().anchor(), pczt.ironwood().anchor());
+    for (combined, original) in combined
+        .ironwood()
+        .actions()
+        .iter()
+        .zip(pczt.ironwood().actions())
+    {
+        assert_eq!(combined.cv_net(), original.cv_net());
+        assert_eq!(combined.output().cmx(), original.output().cmx());
+        assert_eq!(
+            combined.output().enc_ciphertext(),
+            original.output().enc_ciphertext()
+        );
+    }
+    assert_eq!(
+        combined.ironwood().actions()[index]
+            .spend()
+            .spend_auth_sig()
+            .expect("combined action carries the Signer's contribution"),
+        expected_sig
+    );
 
     // Sign through the low-level Signer's preverified path with the same seed.
     let signed = low_level_signer::Signer::new(pczt.clone())

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,12 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::wallet::redact_pczt_for_signer`, which
+  creates a compact signer view of a wallet-created PCZT while retaining the
+  information a general-purpose external signer may need. This is available
+  behind the `pczt` feature.
+
 ### Changed
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -81,7 +81,8 @@ use zcash_protocol::PoolType;
 
 #[cfg(feature = "pczt")]
 use {
-    pczt::roles::{prover::Prover, signer::Signer},
+    crate::data_api::wallet::redact_pczt_for_signer,
+    pczt::roles::{combiner::Combiner, prover::Prover, signer::Signer},
     rand_core::OsRng,
     transparent::builder::TransparentSigningSet,
     zcash_primitives::transaction::builder::{BuildConfig, Builder},
@@ -6692,10 +6693,51 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         .unwrap()
         .finish();
 
-    // Apply signatures.
-    let mut signer = Signer::new(pczt_proven).unwrap();
+    // The signer view of a v5 PCZT commits to the same transaction effects. V5
+    // anchors are retained, while Orchard effecting fields are compacted using
+    // the v2 PCZT encoding. Passing the proof-bearing authoritative copy also
+    // exercises redaction of data that the external Signer does not need.
+    let original_sighash = Signer::new(pczt_proven.clone()).unwrap().shielded_sighash();
+    let original_len = pczt_proven.clone().serialize().unwrap().len();
+    let signer_view = redact_pczt_for_signer(&pczt_proven);
+    assert_eq!(
+        *signer_view.global().tx_version(),
+        zcash_protocol::constants::V5_TX_VERSION,
+    );
+    assert_eq!(
+        signer_view.sapling().anchor(),
+        pczt_proven.sapling().anchor()
+    );
+    assert_eq!(
+        signer_view.orchard().anchor(),
+        pczt_proven.orchard().anchor()
+    );
+    if !signer_view.orchard().actions().is_empty() {
+        assert!(pczt::v1::Pczt::try_from(signer_view.clone()).is_err());
+        assert!(
+            signer_view
+                .orchard()
+                .actions()
+                .iter()
+                .all(|action| action.cv_net().is_none() && action.output().cmx().is_none())
+        );
+    }
+
+    let signer_view_bytes = signer_view.serialize().unwrap();
+    assert!(signer_view_bytes.len() < original_len);
+    let signer_view = pczt::Pczt::parse(&signer_view_bytes).unwrap();
+    assert_eq!(
+        Signer::new(signer_view.clone()).unwrap().shielded_sighash(),
+        original_sighash,
+    );
+
+    // Apply signatures to the transported signer view, then combine the
+    // contribution with the proof-bearing authoritative copy.
+    let mut signer = Signer::new(signer_view).unwrap();
     P0::apply_signatures_to_pczt(&mut signer, account.usk()).unwrap();
-    let pczt_authorized = signer.finish();
+    let pczt_authorized = Combiner::new(vec![pczt_proven, signer.finish()])
+        .combine()
+        .unwrap();
 
     // Now we can extract the transaction.
     let extract_and_store_result = st.extract_and_store_transaction_from_pczt(pczt_authorized);
@@ -7973,6 +8015,106 @@ where
             .iter()
             .any(|action| !action.output().proprietary().is_empty()),
         "the Ironwood output carries recipient metadata",
+    );
+
+    let original_sighash = Signer::new(pczt.clone()).unwrap().shielded_sighash();
+    let original_len = pczt.clone().serialize().unwrap().len();
+    let signer_view = redact_pczt_for_signer(&pczt);
+    let signer_view_bytes = signer_view.serialize().unwrap();
+    assert!(signer_view_bytes.len() < original_len);
+    let signer_view = pczt::Pczt::parse(&signer_view_bytes).unwrap();
+
+    // The backend metadata belongs to the authoritative wallet copy, not the
+    // external Signer.
+    assert!(
+        signer_view
+            .global()
+            .proprietary()
+            .get("zcash_client_backend:proposal_info")
+            .is_none()
+    );
+    assert!(
+        pczt.global()
+            .proprietary()
+            .contains_key("zcash_client_backend:proposal_info")
+    );
+
+    // V6 signatures do not commit to shielded anchors. Orchard action fields
+    // that resolve_fields can restore are omitted from the signer view.
+    assert!(signer_view.sapling().anchor().is_none());
+    assert!(signer_view.orchard().anchor().is_none());
+    assert!(signer_view.ironwood().anchor().is_none());
+
+    let assert_redacted_bundle =
+        |original: &pczt::orchard::Bundle, redacted: &pczt::orchard::Bundle| {
+            assert_eq!(redacted.actions().len(), original.actions().len());
+            let mut memo_plaintexts = 0;
+            for (redacted, original) in redacted.actions().iter().zip(original.actions()) {
+                assert!(redacted.cv_net().is_none());
+                assert!(redacted.output().cmx().is_none());
+                assert_eq!(redacted.spend().nullifier(), original.spend().nullifier());
+                assert_eq!(redacted.spend().rk(), original.spend().rk());
+                assert_eq!(
+                    redacted.spend().spend_auth_sig(),
+                    original.spend().spend_auth_sig()
+                );
+                assert_eq!(
+                    redacted.output().ephemeral_key(),
+                    original.output().ephemeral_key()
+                );
+                assert_eq!(
+                    redacted.output().out_ciphertext(),
+                    original.output().out_ciphertext()
+                );
+                assert_eq!(
+                    redacted.output().user_address(),
+                    original.output().user_address()
+                );
+                assert!(
+                    redacted
+                        .output()
+                        .proprietary()
+                        .get("zcash_client_backend:output_info")
+                        .is_none()
+                );
+                if matches!(
+                    redacted.output().enc_ciphertext(),
+                    pczt::orchard::EncCiphertext::MemoPlaintext(_)
+                ) {
+                    memo_plaintexts += 1;
+                }
+            }
+            memo_plaintexts
+        };
+
+    let memo_plaintexts = assert_redacted_bundle(pczt.orchard(), signer_view.orchard())
+        + assert_redacted_bundle(pczt.ironwood(), signer_view.ironwood());
+    assert!(memo_plaintexts > 0);
+
+    // Resolving the compact representation restores byte-identical effecting
+    // fields and therefore the same shielded signature digest.
+    let mut resolved = signer_view.clone();
+    resolved.resolve_fields().unwrap();
+    for (resolved_bundle, original_bundle) in [
+        (resolved.orchard(), pczt.orchard()),
+        (resolved.ironwood(), pczt.ironwood()),
+    ] {
+        for (resolved, original) in resolved_bundle
+            .actions()
+            .iter()
+            .zip(original_bundle.actions())
+        {
+            assert_eq!(resolved.cv_net(), original.cv_net());
+            assert_eq!(resolved.output().cmx(), original.output().cmx());
+            assert_eq!(
+                resolved.output().enc_ciphertext(),
+                original.output().enc_ciphertext()
+            );
+        }
+    }
+    assert_eq!(
+        Signer::new(signer_view.clone()).unwrap().shielded_sighash(),
+        original_sighash,
     );
 }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -109,8 +109,8 @@ use {
     bip32::ChildNumber,
     orchard::note_encryption::OrchardDomain,
     pczt::roles::{
-        creator::Creator, io_finalizer::IoFinalizer, spend_finalizer::SpendFinalizer,
-        tx_extractor::TransactionExtractor, updater::Updater,
+        creator::Creator, io_finalizer::IoFinalizer, redactor::Redactor,
+        spend_finalizer::SpendFinalizer, tx_extractor::TransactionExtractor, updater::Updater,
     },
     sapling::note_encryption::SaplingDomain,
     serde::{Deserialize, Serialize},
@@ -2390,6 +2390,9 @@ where
 /// - [`pczt::roles::combiner::Combiner`] (if you create proofs and apply signatures in
 ///   parallel)
 ///
+/// Before sending the PCZT to an external Signer, create a signer view with
+/// [`redact_pczt_for_signer`] and retain the original for combination.
+///
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
 ///
@@ -2798,6 +2801,80 @@ where
         .finish();
 
     Ok(pczt)
+}
+
+/// Creates a redacted copy of a wallet PCZT for an external Signer.
+///
+/// This is intended for PCZTs returned by [`create_pczt_from_proposal`]. It removes
+/// wallet metadata, proof data, binding and dummy signing keys, and Orchard-protocol
+/// spend witnesses that a Signer does not need. Sapling spend witnesses are retained
+/// because a Signer may use them to verify nullifiers. It also compacts Orchard and
+/// Ironwood fields that the receiver can restore with [`pczt::Pczt::resolve_fields`].
+/// For v6 transactions, it removes shielded anchors; v5 anchors are retained because
+/// signatures commit to them. The compact signer view requires the v2 PCZT encoding
+/// whenever it contains Orchard or Ironwood actions whose fields could be compacted.
+///
+/// The returned PCZT retains information that a general-purpose Signer may need,
+/// including full viewing keys, spend authorization randomizers, key derivation
+/// paths, output recovery keys, and user-facing addresses. Applications may apply
+/// additional redaction when they know their Signer's capabilities.
+///
+/// The caller must retain `pczt` and combine the Signer's contribution into that
+/// authoritative copy. The returned signer view omits wallet metadata and other
+/// fields that [`extract_and_store_transaction_from_pczt`] requires.
+#[cfg(feature = "pczt")]
+pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
+    let redact_v6_anchors = *pczt.global().tx_version() == zcash_protocol::constants::V6_TX_VERSION;
+
+    fn redact_orchard_bundle(
+        mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>,
+        redact_v6_anchor: bool,
+    ) {
+        redactor.clear_zkproof();
+        redactor.clear_bsk();
+        redactor.redact_actions(|mut action| {
+            action.clear_spend_witness();
+            action.clear_spend_dummy_sk();
+            action.redact_output_proprietary(PROPRIETARY_OUTPUT_INFO);
+        });
+
+        redactor.redact_recomputable_fields();
+
+        if redact_v6_anchor {
+            redactor.clear_anchor();
+        }
+    }
+
+    Redactor::new(pczt.clone())
+        .redact_global_with(|mut redactor| {
+            redactor.redact_proprietary(PROPRIETARY_PROPOSAL_INFO);
+        })
+        .redact_transparent_with(|mut redactor| {
+            redactor.redact_outputs(|mut output| {
+                output.redact_proprietary(PROPRIETARY_OUTPUT_INFO);
+            });
+        })
+        .redact_sapling_with(|mut redactor| {
+            redactor.clear_bsk();
+            redactor.redact_spends(|mut spend| {
+                spend.clear_zkproof();
+                spend.clear_dummy_ask();
+            });
+            redactor.redact_outputs(|mut output| {
+                output.clear_zkproof();
+                output.redact_proprietary(PROPRIETARY_OUTPUT_INFO);
+            });
+            if redact_v6_anchors {
+                redactor.clear_anchor();
+            }
+        })
+        .redact_orchard_with(|redactor| {
+            redact_orchard_bundle(redactor, redact_v6_anchors);
+        })
+        .redact_ironwood_with(|redactor| {
+            redact_orchard_bundle(redactor, redact_v6_anchors);
+        })
+        .finish()
 }
 
 /// Finalizes the given PCZT, and persists the transaction to the wallet database.


### PR DESCRIPTION
Adds a wallet helper that creates a smaller PCZT for an external signer by removing wallet-only data and fields that can be regenerated. The wallet keeps the original PCZT and combines the signer’s contribution back into it, while the signer view retains the information needed to verify what is being signed.