### PR TITLE
zcash_protocol: add SECONDS_PER_BLOCK and BLOCKS_PER_HOUR constants

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,10 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::consensus::SECONDS_PER_BLOCK`
+- `zcash_protocol::consensus::BLOCKS_PER_HOUR`
+
 ## [0.10.0] - 2026-07-09
 
 This release sets the NU6.3 mainnet activation height to 3428143.

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -25,6 +25,12 @@ memuse::impl_no_dynamic_usage!(BlockHeight);
 /// The height of the genesis block on a network.
 pub const H0: BlockHeight = BlockHeight(0);
 
+/// The target time between blocks, in seconds (the post-Blossom target spacing).
+pub const SECONDS_PER_BLOCK: u32 = 75;
+
+/// The approximate number of blocks produced per hour at [`SECONDS_PER_BLOCK`].
+pub const BLOCKS_PER_HOUR: u32 = 3600 / SECONDS_PER_BLOCK;
+
 impl BlockHeight {
     pub const fn from_u32(v: u32) -> BlockHeight {
         BlockHeight(v)


### PR DESCRIPTION
Adds two block-time constants to `zcash_protocol::consensus`:

```rust
/// The target time between blocks, in seconds (the post-Blossom target spacing).
pub const SECONDS_PER_BLOCK: u32 = 75;
/// The approximate number of blocks produced per hour at `SECONDS_PER_BLOCK`.
pub const BLOCKS_PER_HOUR: u32 = 3600 / SECONDS_PER_BLOCK;
```

This gives consumers a single protocol-owned source for converting wall-clock durations to block counts, rather than hardcoding the block time. Extracted as a standalone change (independent of any consumer); an upcoming crate uses `BLOCKS_PER_HOUR` to express scheduling windows in hours and convert to blocks.

Two commits: the constants, then the CHANGELOG entry.

## Verification
- `cargo clippy -p zcash_protocol --all-features -- -D warnings`
- `cargo doc -p zcash_protocol --all-features` (with `-D warnings`)
- `cargo fmt --check`