### PR TITLE
zcash_pool_migration_backend: note-split preparation planning and PCZT construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7261,6 +7261,9 @@ dependencies = [
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
 dependencies = [
+ "incrementalmerkletree",
+ "orchard",
+ "pczt",
  "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -27,3 +27,39 @@ and this library adheres to Rust's notion of
   strategy parameters. `plan_note_split` is a convenience wrapper over the recommended
   `CanonicalOneTwoFive`. The crate is `no_std` (it needs only `alloc`), depending on
   `zcash_protocol`, `zcash_primitives`, and `rand_core`.
+- The pure PCZT transfer builder (`build::build_transfer_pczt`, behind the `orchard` feature): spends
+  one self-funding note the note split minted and outputs its crossing value into the Ironwood pool as
+  an unproven `pczt::Pczt`, sent to the account's own internal Ironwood change address (derived inside
+  the builder, per ZIP 318). It has no change output; the note's fee buffer funds the transfer's fee
+  exactly (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the
+  transfer is four logical actions, matching the buffer of `2 source + 2 destination` actions). It
+  runs post-NU6.3 (when the Ironwood pool is live), is pure (no database or wallet-backend access),
+  and takes the RNG as a parameter. Adds optional `orchard` and `pczt` dependencies, enabled only by
+  the feature.
+- Pre-signing (`build::sign_pczt`, behind the `orchard` feature): adds the Orchard spend-authorization
+  signatures for a given `orchard::keys::SpendAuthorizingKey` to an assembled migration PCZT, leaving
+  the spends the key does not own (the builder's dummy spends, and any spend from another account)
+  unsigned. It signs a finalized but still UNPROVEN PCZT: the spend-authorization signature is over
+  the transaction's sighash, which is fixed independently of the zk proofs, so the migration signs up
+  front (capturing the account's authorization) and proves later, at scheduling time.
+- Note-preparation transaction planning (the `preparation` module): a pure planner that partitions the
+  work of minting a note-split plan's self-funding notes into note-preparation transactions of exactly
+  `PREP_TX_ACTIONS` (16) Orchard actions, per ZIP 318, organised into the fewest sequential layers
+  (with parallel transactions inside a layer). `plan_preparation` takes the wallet's spendable
+  source-pool note values, the target funding-note values, and a per-transaction fee reserve, and
+  returns a `PreparationPlan` of `PrepTransaction`s (each a same-pool send-to-self referencing wallet
+  notes or earlier layers' outputs). It uses a largest-first greedy: feed each output transaction from
+  the largest note, route every leftover forward as a feeder note, and consolidate dust; once the
+  funding notes are scheduled it consolidates the leftover feeders into a single residual note, per
+  ZIP 318's "one note per part plus at most one residual note". A typical wallet needs one layer, and
+  extra layers appear only for a lone large note fanning out into many funding notes or a dust-heavy
+  balance. It is pure (no cryptography or I/O) and `no_std`.
+- The pure PCZT note-preparation builder (`build::build_prep_tx`, behind the `orchard` feature): turns
+  one `preparation::PrepTransaction`'s resolved input notes and its outputs into an unproven
+  `pczt::Pczt` for a same-pool Orchard send-to-self. Every output (funding, feeder, or residual) is a
+  wallet-controlled internal change note, and the Orchard bundle is built with `pad_to_minimum` set to
+  `PREP_TX_ACTIONS` (16), so orchard fills it to exactly that many actions with fabricated dummies and
+  no preparation transaction is distinguishable by its action count (ZIP 318). It returns each
+  output's real post-shuffle action
+  index so the caller can locate the notes (and spend the feeders in a later layer). Like the other
+  builders it is pure (no database or wallet-backend access) and takes the RNG as a parameter.

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -23,9 +23,29 @@ rand_core.workspace = true
 zcash_primitives.workspace = true
 zcash_protocol.workspace = true
 
+# Enabled by the `orchard` feature.
+orchard = { workspace = true, optional = true }
+pczt = { workspace = true, optional = true, features = [
+    "io-finalizer",
+    "orchard",
+    "signer",
+    "zcp-builder",
+] }
+
 [dev-dependencies]
+incrementalmerkletree.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
+# The `local-consensus` feature exposes `LocalNetwork`, used to build the migration transactions
+# against regtest params with the relevant network upgrades (including NU6.3) active.
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
+
+[features]
+## Builds the pure PCZT transaction builder (the `build` module), which turns a note-split plan and
+## the cryptographic ingredients a wallet supplies into an unproven migration PCZT. Requires the
+## Orchard pool; pulls in `orchard` and `pczt`. The caller supplies the RNG, so no `rand` dependency
+## is added.
+orchard = ["dep:orchard", "dep:pczt"]
 
 [lints]
 workspace = true

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -1,0 +1,278 @@
+//! Constructing the migration transactions as unproven PCZTs, and pre-signing them.
+//!
+//! [`build_prep_tx`] builds a note-preparation transaction (restructuring the wallet's notes into the
+//! self-funding notes a migration run needs), [`build_transfer_pczt`] builds a value-crossing
+//! transfer, and [`sign_pczt`] adds the Orchard spend-authorization signatures up front. Each builder
+//! runs purely on the transaction [`Builder`](zcash_primitives::transaction::builder::Builder): no
+//! database or wallet-backend access. Selecting the notes to spend and resolving their witnesses and
+//! the anchor are the wallet backend's job, done separately; here they are inputs, and the returned
+//! PCZT is still to be proven and finalized.
+//!
+//! The shared transaction-builder plumbing (building the config, finishing the PCZT through the
+//! [`Creator`]/[`IoFinalizer`] roles, un-shuffling output positions) lives in this module root, so
+//! every builder reuses it.
+
+use alloc::string::String;
+
+use core::fmt;
+
+use pczt::roles::{creator::Creator, io_finalizer::IoFinalizer};
+use zcash_primitives::transaction::builder::{BuildConfig, PcztParts};
+use zcash_protocol::consensus::Parameters;
+
+mod prep;
+mod sign;
+mod transfer;
+pub use prep::build_prep_tx;
+pub use sign::sign_pczt;
+pub use transfer::build_transfer_pczt;
+
+#[cfg(test)]
+mod end_to_end;
+
+/// An error building a migration PCZT.
+#[derive(Debug)]
+pub enum BuildError {
+    /// The requested outputs cannot be balanced against the selected inputs (the real fee versus the
+    /// planned outputs).
+    Balance(String),
+    /// The transaction builder or the PCZT assembly pipeline failed.
+    Build(String),
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BuildError::Balance(m) => write!(f, "cannot balance the transaction: {m}"),
+            BuildError::Build(m) => write!(f, "pczt build failed: {m}"),
+        }
+    }
+}
+
+impl core::error::Error for BuildError {}
+
+/// The [`BuildConfig`] shared by the migration transactions: an Orchard-anchored bundle, with the
+/// destination-pool (Ironwood) bundle anchored only when that phase produces a crossing output
+/// (`None` for the same-pool note split).
+pub(crate) fn build_config(
+    orchard_anchor: orchard::Anchor,
+    ironwood_anchor: Option<orchard::Anchor>,
+) -> BuildConfig {
+    BuildConfig::Standard {
+        sapling_anchor: None,
+        orchard_anchor: Some(orchard_anchor),
+        ironwood_anchor,
+        orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
+        ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+    }
+}
+
+/// Finish an unproven PCZT from the transaction builder's parts: run the [`Creator`] and
+/// [`IoFinalizer`] roles.
+pub(crate) fn finalize_pczt<P: Parameters>(parts: PcztParts<P>) -> Result<pczt::Pczt, BuildError> {
+    let created = Creator::build_from_parts(parts)
+        .ok_or_else(|| BuildError::Build("pczt creation failed".into()))?;
+    IoFinalizer::new(created)
+        .finalize_io()
+        .map_err(|e| BuildError::Build(format!("io finalize: {e:?}")))
+}
+
+/// Map an output's request-order position to its real Orchard action index. The Orchard builder
+/// shuffles action positions, so the caller must look up where each requested output landed.
+pub(crate) fn output_action_index(
+    meta: &orchard::builder::BundleMetadata,
+    output: usize,
+) -> Result<u32, BuildError> {
+    meta.output_action_index(output)
+        .map(|i| i as u32)
+        .ok_or_else(|| BuildError::Build(format!("no action index for output {output}")))
+}
+
+/// Test helpers shared by the split and transfer builders: a deterministic account, regtest network
+/// params, and a single-leaf Orchard witness. Kept here so both submodules' tests reuse them.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use alloc::vec::Vec;
+
+    use incrementalmerkletree::{Hashable, Level};
+    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
+    use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
+    use orchard::tree::{MerkleHashOrchard, MerklePath};
+    use orchard::value::NoteValue;
+    use orchard::{Anchor, NOTE_COMMITMENT_TREE_DEPTH};
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::{RngCore, SeedableRng};
+    use zcash_protocol::consensus::BlockHeight;
+    use zcash_protocol::local_consensus::LocalNetwork;
+
+    /// 32 random bytes from a `seed`-derived RNG, keeping calls deterministic per case.
+    fn draw_bytes(rng: &mut ChaCha8Rng) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        bytes
+    }
+
+    /// A post-NU6.3 height (past the regtest NU6.3 activation) at which the migration transactions
+    /// are built and their fees computed.
+    pub(crate) const TARGET_HEIGHT: u32 = 100;
+
+    /// An account's Orchard spending key, derived from `seed` so tests can vary the account across
+    /// proptest cases. Draws bytes until they form a valid spending key.
+    pub(crate) fn spending_key(seed: u64) -> SpendingKey {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        loop {
+            let bytes = draw_bytes(&mut rng);
+            if let Some(sk) = SpendingKey::from_bytes(bytes).into_option() {
+                return sk;
+            }
+        }
+    }
+
+    /// An account's Orchard full viewing key (see [`spending_key`]).
+    pub(crate) fn account(seed: u64) -> FullViewingKey {
+        FullViewingKey::from(&spending_key(seed))
+    }
+
+    /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
+    /// The migration builds on a network where NU6.3 (the Ironwood pool) is live.
+    pub(crate) fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
+        let nu6_3 = if nu6_3_active {
+            Some(BlockHeight::from_u32(10))
+        } else {
+            None
+        };
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(2)),
+            blossom: Some(BlockHeight::from_u32(3)),
+            heartwood: Some(BlockHeight::from_u32(4)),
+            canopy: Some(BlockHeight::from_u32(5)),
+            nu5: Some(BlockHeight::from_u32(6)),
+            nu6: Some(BlockHeight::from_u32(7)),
+            nu6_1: Some(BlockHeight::from_u32(8)),
+            nu6_2: Some(BlockHeight::from_u32(9)),
+            nu6_3,
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: None,
+        }
+    }
+
+    /// An Orchard note of `value` owned by `fvk`, with its randomness drawn from `rng`.
+    fn orchard_note(fvk: &FullViewingKey, value: u64, rng: &mut ChaCha8Rng) -> Note {
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let note_value = NoteValue::from_raw(value);
+        let rho = loop {
+            let bytes = draw_bytes(rng);
+            if let Some(rho) = Rho::from_bytes(&bytes).into_option() {
+                break rho;
+            }
+        };
+        let rseed = loop {
+            let bytes = draw_bytes(rng);
+            if let Some(rseed) = RandomSeed::from_bytes(bytes, &rho).into_option() {
+                break rseed;
+            }
+        };
+        Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2)
+            .into_option()
+            .expect("valid note parts")
+    }
+
+    /// An Orchard note of `value` owned by `fvk`, with its randomness derived from `seed` (so
+    /// proptest varies the note across cases), placed as the sole leaf of an otherwise-empty
+    /// note-commitment tree, with the matching anchor. The authentication path uses the empty-subtree
+    /// roots for a single leaf at position 0, so `add_orchard_spend`'s anchor check
+    /// (`path.root(cmx) == anchor`) accepts it.
+    pub(crate) fn single_note_witness(
+        fvk: &FullViewingKey,
+        value: u64,
+        seed: u64,
+    ) -> (Note, MerklePath, Anchor) {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let note = orchard_note(fvk, value, &mut rng);
+        let cmx = ExtractedNoteCommitment::from(note.commitment());
+        let auth_path = core::array::from_fn(|level| {
+            let level = Level::from(level as u8);
+            MerkleHashOrchard::empty_root(level)
+        });
+        let path = MerklePath::from_parts(0, auth_path);
+        let anchor = path.root(cmx);
+        (note, path, anchor)
+    }
+
+    /// `values.len()` Orchard notes owned by `fvk`, placed as the first leaves of one note-commitment
+    /// tree, each paired with its authentication path against the single shared anchor. Randomness is
+    /// derived from `seed`. This lets a test build a multi-spend transaction whose spends all anchor to
+    /// the same root. Assumes `values` is non-empty.
+    pub(crate) fn shared_anchor_witnesses(
+        fvk: &FullViewingKey,
+        values: &[u64],
+        seed: u64,
+    ) -> (Vec<(Note, MerklePath)>, Anchor) {
+        // The notes and their leaf hashes.
+        let notes: Vec<Note> = values
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| {
+                let mut rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(i as u64));
+                orchard_note(fvk, v, &mut rng)
+            })
+            .collect();
+        let leaves: Vec<MerkleHashOrchard> = notes
+            .iter()
+            .map(|n| MerkleHashOrchard::from_cmx(&ExtractedNoteCommitment::from(n.commitment())))
+            .collect();
+
+        // Filled subtree roots per level: `levels[l][p]` is the root of the subtree at level `l`,
+        // position `p`. Level 0 is the leaves; each higher level combines pairs, using the
+        // empty-subtree root for a missing right sibling. Positions past `levels[l].len()` are empty.
+        let mut levels: Vec<Vec<MerkleHashOrchard>> =
+            Vec::with_capacity(NOTE_COMMITMENT_TREE_DEPTH + 1);
+        levels.push(leaves);
+        for l in 0..NOTE_COMMITMENT_TREE_DEPTH {
+            let level = Level::from(l as u8);
+            let cur = &levels[l];
+            let mut next = Vec::with_capacity(cur.len().div_ceil(2));
+            let mut p = 0;
+            while p < cur.len() {
+                let left = cur[p];
+                let right = cur
+                    .get(p + 1)
+                    .copied()
+                    .unwrap_or_else(|| MerkleHashOrchard::empty_root(level));
+                next.push(MerkleHashOrchard::combine(level, &left, &right));
+                p += 2;
+            }
+            levels.push(next);
+        }
+
+        // Each leaf's authentication path: the sibling subtree root at every level (its computed value
+        // when filled, else the empty-subtree root).
+        let witnesses: Vec<(Note, MerklePath)> = notes
+            .into_iter()
+            .enumerate()
+            .map(|(i, note)| {
+                let auth_path = core::array::from_fn(|l| {
+                    let level = Level::from(l as u8);
+                    let sibling = (i >> l) ^ 1;
+                    levels[l]
+                        .get(sibling)
+                        .copied()
+                        .unwrap_or_else(|| MerkleHashOrchard::empty_root(level))
+                });
+                (note, MerklePath::from_parts(i as u32, auth_path))
+            })
+            .collect();
+
+        // Every leaf's path yields the same root; assert it so a broken helper fails loudly rather
+        // than silently producing mismatched anchors.
+        let root_of = |(note, path): &(Note, MerklePath)| {
+            path.root(ExtractedNoteCommitment::from(note.commitment()))
+        };
+        let anchor = root_of(&witnesses[0]);
+        for w in &witnesses {
+            assert_eq!(root_of(w), anchor, "shared-anchor witnesses inconsistent");
+        }
+        (witnesses, anchor)
+    }
+}

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -1,0 +1,86 @@
+//! End-to-end test of the migration pipeline for a typical wallet, using only the crate's public API.
+//! It doubles as a usage example: plan the note split, plan the preparation transactions, build and
+//! pre-sign one, then build and pre-sign a pool-crossing transfer.
+
+use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use zcash_protocol::value::COIN;
+
+use super::test_util::{TARGET_HEIGHT, regtest_network, single_note_witness, spending_key};
+use super::{build_prep_tx, build_transfer_pczt, sign_pczt};
+use crate::note_splitting::{FeePolicy, Zip317FeePolicy, plan_note_split};
+use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
+
+/// note split -> preparation plan -> build + sign a preparation transaction -> build + sign a
+/// pool-crossing transfer, for a typical single-note wallet.
+#[test]
+fn migration_pipeline_end_to_end() {
+    let seed = 42u64;
+    let params = regtest_network(true);
+
+    // The account, and (conceptually) its single spendable Orchard note holding the whole balance.
+    let sk = spending_key(seed);
+    let fvk = FullViewingKey::from(&sk);
+    let ask = SpendAuthorizingKey::from(&sk);
+    let balance = 78 * COIN;
+
+    // 1. Note split: decompose the balance into canonical self-funding denominations.
+    let prep_fee = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
+    let split = {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        plan_note_split(balance, prep_fee, &mut rng)
+    };
+    let funding = split.migration_outputs();
+    assert!(!funding.is_empty(), "the balance yields funding notes");
+
+    // 2. Preparation: plan the send-to-self transactions that mint those funding notes. A typical
+    //    wallet (one note, a handful of funding notes) prepares in a single transaction.
+    let prep = plan_preparation(&[balance], funding, split.prep_fee_zatoshi())
+        .expect("the balance funds the preparation");
+    assert_eq!(prep.layer_count(), 1);
+    assert_eq!(prep.transaction_count(), 1);
+
+    // 3. Build + pre-sign the preparation transaction. The wallet backend resolves the transaction's
+    //    single input (PrepInput::Wallet(0)) to the account's note and its witness against the anchor.
+    let tx = &prep.layers()[0][0];
+    assert!(matches!(tx.inputs(), [PrepInput::Wallet(0)]));
+    let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+    let (prep_pczt, placed) = build_prep_tx(
+        &params,
+        TARGET_HEIGHT,
+        &fvk,
+        anchor,
+        vec![(note, path)],
+        tx.outputs(),
+        ChaCha8Rng::seed_from_u64(seed + 1),
+    )
+    .expect("the preparation transaction builds");
+    assert_eq!(
+        prep_pczt.orchard().actions().len(),
+        PREP_TX_ACTIONS,
+        "the preparation bundle is padded to exactly 16 actions"
+    );
+    assert_eq!(placed.len(), tx.outputs().len(), "every output is located");
+    sign_pczt(prep_pczt, &ask).expect("pre-signing the preparation transaction");
+
+    // 4. Build + pre-sign a pool-crossing transfer for one funding note (witnessed directly here, as
+    //    it would be once the preparation transaction is mined). It sends exactly the canonical
+    //    denomination into the Ironwood pool.
+    let crossing = split.crossing_values()[0];
+    let funding_value = funding[0];
+    let (fnote, fpath, fanchor) = single_note_witness(&fvk, funding_value, seed + 2);
+    let transfer_pczt = build_transfer_pczt(
+        &params,
+        TARGET_HEIGHT,
+        TARGET_HEIGHT + 40_000,
+        &fvk,
+        fanchor,
+        fnote,
+        fpath,
+        crossing,
+        ChaCha8Rng::seed_from_u64(seed + 3),
+    )
+    .expect("the transfer builds");
+    sign_pczt(transfer_pczt, &ask).expect("pre-signing the transfer");
+}

--- a/zcash_pool_migration_backend/src/build/prep.rs
+++ b/zcash_pool_migration_backend/src/build/prep.rs
@@ -1,0 +1,354 @@
+//! Building one note-preparation transaction as an unproven, exactly-16-action Orchard PCZT.
+//!
+//! # The mathematical problem
+//!
+//! Note preparation restructures a wallet's existing Orchard notes into the exact self-funding notes a
+//! migration needs (one per planned pool-crossing, each worth its denomination plus the transfer fee),
+//! using wallet-internal send-to-self transactions. Formally it is a degree-constrained
+//! *merge-and-split value flow*:
+//!
+//! - The *sources* are the wallet's spendable note values `W = {w_1, ..., w_m}` (in zatoshi); the
+//!   *sinks* are the funding-note values `F = {f_1, ..., f_l}` chosen by
+//!   [`note_splitting`](crate::note_splitting), plus at most one residual `r`.
+//! - A transaction `t = (I_t, O_t)` spends the notes `I_t` and creates the notes `O_t` subject to
+//!   three constraints:
+//!   - *budget*: `|I_t| + |O_t| <= A`, where `A` is [`PREP_TX_ACTIONS`], i.e. 16 Orchard actions;
+//!   - *balance*: `sum(I_t) = sum(O_t) + phi`, where `phi` is the ZIP-317 fee of a padded `A`-action
+//!     transaction (so every preparation transaction costs the same `phi`);
+//!   - *structure*: each note is spent by at most one transaction (Orchard notes are spent atomically),
+//!     and the spend graph is acyclic (a later layer may spend an earlier layer's outputs).
+//! - A *plan* is the resulting DAG of transactions whose final (unspent) notes are exactly `F` plus at
+//!   most one residual worth a fee. Value is conserved end to end:
+//!   `sum(W) = sum(F) + r + |T| * phi`, where `|T|` is the number of transactions.
+//!
+//! Because an output may take *any* value (internal change is free), exactness is never required, so
+//! this is NOT a subset-sum problem. It is a *fixed-charge network flow* (NP-hard in general) whose
+//! divisible-value, uniform-fee instance decomposes into two classic k-ary trees, a consolidation
+//! merge tree (many dust notes into one) and a split tree (one large note into many), and is solved by
+//! a greedy. The objective is lexicographic: feasibility first, then the fewest *layers* (each layer
+//! waits for a confirmation and a boundary, so layers dominate the wall-clock), then the fewest
+//! transactions (each a fixed fee `phi`).
+//!
+//! [`plan_preparation`](crate::preparation::plan_preparation) decides that DAG; THIS module realizes
+//! one of its transactions. See the [`preparation`](crate::preparation) module for the planner, its
+//! layering, and the k-ary lower bounds, and ZIP 318 for the constraints.
+//!
+//! # What this builder guarantees (per transaction)
+//!
+//! Given one [`PrepTransaction`](crate::preparation::PrepTransaction)'s resolved input notes (which the
+//! wallet backend witnesses against `anchor`) and its output values, [`build_prep_tx`] produces an
+//! unproven `pczt::Pczt` with these properties:
+//!
+//! - *value conservation*: `sum(spent notes) = sum(outputs) + phi`; an unbalanced request fails to
+//!   build.
+//! - *exactly `A` actions*: the Orchard bundle is padded to `A` with fabricated dummy actions
+//!   (`pad_to_minimum`), so no preparation transaction is distinguishable from another by its action
+//!   count (ZIP 318) and the real spend/output split is hidden.
+//! - *internal, same-pool send-to-self*: every output (a funding, feeder, or residual note) is a
+//!   wallet-controlled internal Orchard change note; there is no other pool and no external recipient.
+//! - *locatable outputs*: it returns each requested output's real post-shuffle action index, so the
+//!   caller can find the notes on-chain and spend the feeder notes in a later layer.
+//! - *pure*: no database, wallet-backend, or network access; the RNG is a parameter.
+
+use alloc::vec::Vec;
+
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, RngCore};
+
+use orchard::builder::BundleType;
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_primitives::transaction::builder::{BuildConfig, Builder};
+use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::value::Zatoshis;
+
+use super::{BuildError, finalize_pczt, output_action_index};
+use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
+
+/// The internal-scope diversifier index for the wallet's own preparation outputs.
+const INTERNAL_ADDRESS_INDEX: u32 = 0;
+
+/// Build one note-preparation transaction as an unproven PCZT: spend every note in `spends` and create
+/// one internal change note per output in `outputs` (a funding, feeder, or residual note), in an
+/// Orchard bundle padded to exactly [`PREP_TX_ACTIONS`] actions with fabricated dummies.
+///
+/// The caller (the wallet backend) resolves the transaction's inputs to the `(Note, MerklePath)`
+/// witnesses in `spends` against `anchor`, and supplies the `orchard_fvk` whose internal scope every
+/// output is derived from. The spent notes must total the outputs plus the ZIP-317 fee of a padded
+/// [`PREP_TX_ACTIONS`]-action transaction (the preparation planner reserves exactly this), or the
+/// build does not balance.
+///
+/// Returns the finalized PCZT and, for each requested output in order, its `(action_index, output)`
+/// so the caller can locate each note after the transaction is mined (and spend the feeder notes in a
+/// later layer). The fabricated dummy actions are not returned.
+///
+/// # Errors
+///
+/// Returns [`BuildError`] if there are no spends or outputs, if the logical action count
+/// (`spends + outputs`) exceeds [`PREP_TX_ACTIONS`], or if the builder/PCZT pipeline fails (including
+/// when the spent notes do not balance the outputs plus the fee).
+///
+/// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
+/// pass a seeded one), keeping this builder pure.
+pub fn build_prep_tx<P, R>(
+    params: &P,
+    target_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    spends: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
+    outputs: &[PrepOutput],
+    rng: R,
+) -> Result<(pczt::Pczt, Vec<(u32, PrepOutput)>), BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    if spends.is_empty() {
+        return Err(BuildError::Balance(
+            "preparation: no spendable notes".into(),
+        ));
+    }
+    if outputs.is_empty() {
+        return Err(BuildError::Balance("preparation: no outputs".into()));
+    }
+    let logical_actions = spends.len() + outputs.len();
+    if logical_actions > PREP_TX_ACTIONS {
+        return Err(BuildError::Balance(format!(
+            "preparation: {logical_actions} logical actions exceed the \
+             {PREP_TX_ACTIONS}-action budget"
+        )));
+    }
+
+    // An Orchard-only send-to-self whose bundle is padded to exactly PREP_TX_ACTIONS actions with
+    // orchard's fabricated dummies (`pad_to_minimum`).
+    let config = BuildConfig::Standard {
+        sapling_anchor: None,
+        orchard_anchor: Some(anchor),
+        ironwood_anchor: None,
+        orchard_bundle_type: BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(PREP_TX_ACTIONS as u8),
+        },
+        ironwood_bundle_type: BundleType::DEFAULT,
+    };
+    let mut builder = Builder::new(params.clone(), BlockHeight::from_u32(target_height), config);
+    for (note, merkle_path) in spends {
+        builder
+            .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
+            .map_err(|e| BuildError::Build(format!("preparation: add spend: {e:?}")))?;
+    }
+
+    let change_address = orchard_fvk.address_at(INTERNAL_ADDRESS_INDEX, Scope::Internal);
+    let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
+    for output in outputs {
+        builder
+            .add_orchard_change_output::<Infallible>(
+                orchard_fvk.clone(),
+                Some(internal_ovk.clone()),
+                change_address,
+                Zatoshis::const_from_u64(output.value()),
+                MemoBytes::empty(),
+            )
+            .map_err(|e| BuildError::Build(format!("preparation: add output: {e:?}")))?;
+    }
+
+    let build_result = builder
+        .build_for_pczt(rng, &Zip317FeeRule::standard())
+        .map_err(|e| BuildError::Build(format!("preparation: build: {e:?}")))?;
+
+    // Un-shuffle: map each requested output to its real action index (the fabricated dummies occupy
+    // the remaining actions) so the caller can store the right (action_index, output) references.
+    let placed: Vec<(u32, PrepOutput)> = outputs
+        .iter()
+        .enumerate()
+        .map(|(i, &out)| output_action_index(&build_result.orchard_meta, i).map(|ai| (ai, out)))
+        .collect::<Result<_, _>>()?;
+
+    let finalized = finalize_pczt(build_result.pczt_parts)?;
+    Ok((finalized, placed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::test_util::{
+        TARGET_HEIGHT, account, regtest_network, shared_anchor_witnesses, single_note_witness,
+    };
+    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+
+    /// The ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action preparation transaction (each action
+    /// costs one marginal fee), which the planner reserves per transaction.
+    fn prep_fee() -> u64 {
+        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
+    }
+
+    /// The number of Orchard actions in the built transaction.
+    fn action_count(pczt: &pczt::Pczt) -> usize {
+        pczt.orchard().actions().len()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(24))]
+
+        /// Every built preparation transaction has EXACTLY `PREP_TX_ACTIONS` Orchard actions, for any
+        /// mix of spends and outputs within the budget: `pad_to_minimum` always fills the bundle up to
+        /// the fixed count with dummies, so no transaction is distinguishable by its action count.
+        #[test]
+        fn always_exactly_prep_tx_actions(
+            out_zats in prop::collection::vec(1_000_000u64..(50 * COIN), 1..PREP_TX_ACTIONS),
+            n_spend in 1usize..PREP_TX_ACTIONS,
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let n_out = out_zats.len();
+            // Fit spends and outputs into the budget; at least one spend (n_out <= PREP_TX_ACTIONS-1).
+            let n_spend = n_spend.min(PREP_TX_ACTIONS - n_out);
+
+            // The spends must fund the outputs plus the padded fee; split that total across the spend
+            // notes (the remainder on the first), so the transaction balances exactly.
+            let total_in = out_zats.iter().sum::<u64>() + prep_fee();
+            let base = total_in / n_spend as u64;
+            let mut spend_values = vec![base; n_spend];
+            spend_values[0] += total_in % n_spend as u64;
+
+            let fvk = account(account_seed);
+            let (spends, anchor) = shared_anchor_witnesses(&fvk, &spend_values, note_seed);
+            let outputs: Vec<PrepOutput> =
+                out_zats.iter().map(|&v| PrepOutput::Funding(v)).collect();
+
+            let params = regtest_network(true);
+            let rng = ChaCha8Rng::seed_from_u64(note_seed);
+            let (pczt, placed) = build_prep_tx(
+                &params,
+                TARGET_HEIGHT,
+                &fvk,
+                anchor,
+                spends,
+                &outputs,
+                rng,
+            )
+            .expect("a balanced preparation transaction builds");
+
+            prop_assert_eq!(action_count(&pczt), PREP_TX_ACTIONS);
+            prop_assert_eq!(placed.len(), outputs.len());
+        }
+
+        /// A single funding note fanned into up to `FUNDING_OUTPUTS_PER_TX` outputs builds into a
+        /// padded transaction of exactly `PREP_TX_ACTIONS` actions, and each output is reported at its
+        /// real action index with its planned value.
+        #[test]
+        fn builds_a_padded_funding_prep_tx(
+            output_zats in prop::collection::vec(1u64..(50 * COIN), 1..14),
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let fvk = account(account_seed);
+            let outputs: Vec<PrepOutput> =
+                output_zats.iter().map(|&v| PrepOutput::Funding(v)).collect();
+            // One spend that funds every output plus the padded fee.
+            let spend_value = output_zats.iter().sum::<u64>() + prep_fee();
+            let (note, path, anchor) = single_note_witness(&fvk, spend_value, note_seed);
+
+            let params = regtest_network(true);
+            let rng = ChaCha8Rng::seed_from_u64(note_seed);
+            let (pczt, placed) = build_prep_tx(
+                &params,
+                100,
+                &fvk,
+                anchor,
+                vec![(note, path)],
+                &outputs,
+                rng,
+            )
+            .expect("a balanced preparation transaction should build");
+
+            prop_assert_eq!(action_count(&pczt), PREP_TX_ACTIONS);
+            prop_assert_eq!(placed.len(), outputs.len());
+            let placed_values: Vec<u64> = placed.iter().map(|(_, o)| o.value()).collect();
+            prop_assert_eq!(placed_values, output_zats);
+            // Every output maps to a distinct action index.
+            let mut indices: Vec<u32> = placed.iter().map(|&(i, _)| i).collect();
+            indices.sort_unstable();
+            indices.dedup();
+            prop_assert_eq!(indices.len(), outputs.len());
+        }
+    }
+
+    /// A minimal transaction (one spend, one output) is padded up to the full action budget.
+    #[test]
+    fn pads_a_minimal_prep_tx_to_the_action_budget() {
+        let fvk = account(1);
+        let outputs = [PrepOutput::Intermediate(10 * COIN)];
+        let spend_value = 10 * COIN + prep_fee();
+        let (note, path, anchor) = single_note_witness(&fvk, spend_value, 7);
+        let params = regtest_network(true);
+        let (pczt, placed) = build_prep_tx(
+            &params,
+            100,
+            &fvk,
+            anchor,
+            vec![(note, path)],
+            &outputs,
+            ChaCha8Rng::seed_from_u64(7),
+        )
+        .unwrap();
+        assert_eq!(action_count(&pczt), PREP_TX_ACTIONS);
+        assert_eq!(placed.len(), 1);
+    }
+
+    /// The builder rejects an empty spend set, an empty output set, and an over-budget action count
+    /// before touching cryptography.
+    #[test]
+    fn rejects_bad_inputs() {
+        let fvk = account(2);
+        let params = regtest_network(true);
+        let anchor = orchard::Anchor::empty_tree();
+        let one_output = [PrepOutput::Funding(COIN)];
+
+        let no_spends = build_prep_tx(
+            &params,
+            100,
+            &fvk,
+            anchor,
+            Vec::new(),
+            &one_output,
+            ChaCha8Rng::seed_from_u64(0),
+        );
+        assert!(matches!(no_spends, Err(BuildError::Balance(_))));
+
+        let (note, path, real_anchor) = single_note_witness(&fvk, COIN + prep_fee(), 3);
+        let no_outputs = build_prep_tx(
+            &params,
+            100,
+            &fvk,
+            real_anchor,
+            vec![(note, path)],
+            &[],
+            ChaCha8Rng::seed_from_u64(0),
+        );
+        assert!(matches!(no_outputs, Err(BuildError::Balance(_))));
+
+        // One spend plus more outputs than the remaining action budget.
+        let too_many: Vec<PrepOutput> = (0..PREP_TX_ACTIONS)
+            .map(|_| PrepOutput::Funding(COIN))
+            .collect();
+        let (note2, path2, anchor2) = single_note_witness(&fvk, 1_000 * COIN, 4);
+        let over_budget = build_prep_tx(
+            &params,
+            100,
+            &fvk,
+            anchor2,
+            vec![(note2, path2)],
+            &too_many,
+            ChaCha8Rng::seed_from_u64(0),
+        );
+        assert!(matches!(over_budget, Err(BuildError::Balance(_))));
+    }
+}

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -1,0 +1,116 @@
+//! Pre-signing a migration PCZT: adding the Orchard spend-authorization signatures.
+//!
+//! The migration signs UP FRONT (capturing the account's authorization in as few signing sessions
+//! as possible) and proves LATER, at scheduling time. This works because a spend-authorization
+//! signature is over the transaction's sighash, which is fixed once the effecting data is finalized,
+//! independent of the (still-absent) zk proofs: a finalized but unproven PCZT can be signed. The
+//! signed, unproven PCZT is safe to persist and schedule; it cannot be broadcast until it is also
+//! proven and extracted.
+
+use orchard::keys::SpendAuthorizingKey;
+use pczt::roles::signer::{Error as SignerError, Signer};
+
+use super::BuildError;
+
+/// Sign every Orchard spend in an assembled migration PCZT that `ask` authorizes, returning the
+/// signed (still unproven) PCZT. Spends the key does not own are left unsigned: the builder's
+/// fabricated zero-valued dummy spends, and any real spend belonging to another account.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Build`] if the signer cannot be initialized, or if a spend fails to sign
+/// for a reason other than the spend not being authorized by `ask`.
+pub fn sign_pczt(pczt: pczt::Pczt, ask: &SpendAuthorizingKey) -> Result<pczt::Pczt, BuildError> {
+    let mut signer =
+        Signer::new(pczt).map_err(|e| BuildError::Build(format!("signer init: {e:?}")))?;
+    for index in 0.. {
+        match signer.sign_orchard(index, ask) {
+            Ok(()) => {}
+            // Past the last Orchard spend.
+            Err(SignerError::InvalidIndex) => break,
+            // A dummy spend, or a real spend from another account: not ours to authorize.
+            Err(SignerError::OrchardSign(orchard::pczt::SignerError::WrongSpendAuthorizingKey)) => {
+            }
+            Err(e) => return Err(BuildError::Build(format!("sign orchard: {e:?}"))),
+        }
+    }
+    Ok(signer.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orchard::keys::FullViewingKey;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::build_prep_tx;
+    use crate::build::test_util::{
+        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
+    };
+    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+    use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
+
+    /// Builds a note-preparation PCZT spending one note owned by `fvk`. Deterministic in `note_seed`.
+    /// It uses one spend and `PREP_TX_ACTIONS - 1` outputs so the bundle fills the action budget
+    /// exactly, with no fabricated-only padding actions (which foreign-key signing would otherwise
+    /// touch, since a padding spend is not the account's).
+    fn build_prep(fvk: &FullViewingKey, note_seed: u64) -> pczt::Pczt {
+        let per = 4 * COIN;
+        let outputs = [PrepOutput::Funding(per); PREP_TX_ACTIONS - 1];
+        // The spent note funds the outputs plus the padded 16-action fee.
+        let fee = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
+        let note_value = (PREP_TX_ACTIONS as u64 - 1) * per + fee;
+        let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
+        let params = regtest_network(true);
+        let rng = ChaCha8Rng::seed_from_u64(note_seed);
+        let (pczt, _) = build_prep_tx(
+            &params,
+            TARGET_HEIGHT,
+            fvk,
+            anchor,
+            vec![(note, path)],
+            &outputs,
+            rng,
+        )
+        .expect("the preparation transaction builds");
+        pczt
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        /// Pre-signing a finalized (unproven) preparation PCZT adds the account's Orchard spend
+        /// authorization: the serialized PCZT changes when signed with the account's own key, and is
+        /// unchanged when signed with a foreign key, whose spends it does not own.
+        #[test]
+        fn pre_signing_authorizes_only_the_accounts_own_spend(
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let sk = spending_key(account_seed);
+            let fvk = FullViewingKey::from(&sk);
+            let ask = SpendAuthorizingKey::from(&sk);
+
+            // `Pczt::serialize` consumes the PCZT, and the build is deterministic in `note_seed`, so
+            // each comparison builds a fresh (identical) unsigned PCZT.
+            let unsigned = build_prep(&fvk, note_seed).serialize().expect("serialize");
+
+            let signed = sign_pczt(build_prep(&fvk, note_seed), &ask)
+                .expect("signing the account's own spend")
+                .serialize()
+                .expect("serialize");
+            prop_assert_ne!(signed, unsigned.clone());
+
+            // A foreign key authorizes nothing: the real spend is skipped as a key mismatch.
+            let foreign_ask = SpendAuthorizingKey::from(&spending_key(account_seed ^ 0x5a5a_5a5a));
+            let untouched = sign_pczt(build_prep(&fvk, note_seed), &foreign_ask)
+                .expect("a foreign key signs nothing")
+                .serialize()
+                .expect("serialize");
+            prop_assert_eq!(untouched, unsigned);
+        }
+    }
+}

--- a/zcash_pool_migration_backend/src/build/transfer.rs
+++ b/zcash_pool_migration_backend/src/build/transfer.rs
@@ -1,0 +1,141 @@
+//! Building a migration transfer transaction: spending one self-funding note and crossing its value
+//! into the Ironwood pool.
+//!
+//! [`build_transfer_pczt`] spends a single self-funding note (one the note split minted, worth its
+//! crossing value plus a fee buffer) and outputs that crossing value into the destination Ironwood
+//! pool, to the account's own internal (change) address as ZIP 318 requires. It has no change output:
+//! the self-funding note's buffer funds the transfer's fee exactly
+//! (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the transfer is
+//! four logical actions, matching the buffer of `2 source + 2 destination` actions). The transfer
+//! only exists post-NU6.3, when the Ironwood pool is live.
+
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, RngCore};
+
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_primitives::transaction::builder::Builder;
+use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::value::Zatoshis;
+
+use super::{BuildError, build_config, finalize_pczt};
+
+/// Build a migration transfer as an unproven PCZT: spend the supplied self-funding `note` and output
+/// its `crossing_value` into the Ironwood pool (which is output-only here, so it is anchored against
+/// the empty tree). The transfer's fee is funded entirely by the note's buffer, so there is no change
+/// output; a build that balances proves the buffer matches the fee.
+///
+/// The ingredients (which the wallet backend resolves) are: the Orchard `anchor` and the note's
+/// `merkle_path`; the `note` itself (a self-funding note the split minted, worth
+/// `crossing_value` plus the fee buffer); and the `orchard_fvk` (authorizes the spend, derives the
+/// output viewing key, and derives the destination: per ZIP 318 the crossing is sent to the account's
+/// own internal Ironwood change address). `target_height` and `expiry_height` bound the transaction.
+/// It mirrors the note split's
+/// [`crossing_values`](crate::note_splitting::NoteSplitPlan::crossing_values): one transfer per
+/// self-funding note.
+///
+/// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
+/// pass a seeded one), keeping this builder pure.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Build`] if the builder or PCZT pipeline fails (including when the note's
+/// buffer does not cover the transfer fee, which unbalances the transaction).
+#[allow(clippy::too_many_arguments)]
+pub fn build_transfer_pczt<P, R>(
+    params: &P,
+    target_height: u32,
+    expiry_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    note: orchard::note::Note,
+    merkle_path: orchard::tree::MerklePath,
+    crossing_value: u64,
+    rng: R,
+) -> Result<pczt::Pczt, BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    let target = BlockHeight::from_u32(target_height);
+    let expiry = BlockHeight::from_u32(expiry_height);
+    // The Ironwood bundle is output-only (no spend to anchor against); the empty tree is the
+    // output-only anchor convention.
+    let config = build_config(anchor, Some(orchard::Anchor::empty_tree()));
+    let mut builder = Builder::new(params.clone(), target, config).with_expiry_height(expiry);
+
+    builder
+        .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
+        .map_err(|e| BuildError::Build(format!("transfer: add spend: {e:?}")))?;
+
+    // ZIP 318: the destination MUST be the account's own internal (change) Ironwood address, sent with
+    // the internal outgoing viewing key so the wallet can recover the note. Derived here so a caller
+    // cannot misdirect the crossing.
+    let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
+    let recipient = orchard_fvk.address_at(0u32, Scope::Internal);
+    let crossing = Zatoshis::const_from_u64(crossing_value);
+    let memo = MemoBytes::empty();
+    builder
+        .add_ironwood_output::<Infallible>(Some(internal_ovk), recipient, crossing, memo)
+        .map_err(|e| BuildError::Build(format!("transfer: add ironwood output: {e:?}")))?;
+
+    let build_result = builder
+        .build_for_pczt(rng, &Zip317FeeRule::standard())
+        .map_err(|e| BuildError::Build(format!("transfer: build: {e:?}")))?;
+
+    finalize_pczt(build_result.pczt_parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::test_util::{account, regtest_network, single_note_witness};
+    use crate::note_splitting::{FeePolicy, RESIDUAL_MIGRATION_MIN_ZATOSHI, Zip317FeePolicy};
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// Every self-funding note the split can mint (a crossing value plus the fee buffer, from
+        /// sub-ZEC up) builds into a balanced transfer post-NU6.3. A build that succeeds proves the
+        /// buffer funds the transfer fee exactly, since the transfer has no change output.
+        #[test]
+        fn self_funding_notes_build_balanced_transfers(
+            crossing_value in RESIDUAL_MIGRATION_MIN_ZATOSHI..=(1_000 * COIN),
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let fvk = account(account_seed);
+            let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+            let note_value = crossing_value + buffer;
+            let (note, path, anchor) = single_note_witness(&fvk, note_value, note_seed);
+
+            let params = regtest_network(true);
+            let target_height = 100;
+            let expiry_height = 140;
+            let rng = ChaCha8Rng::seed_from_u64(crossing_value);
+            let result = build_transfer_pczt(
+                &params,
+                target_height,
+                expiry_height,
+                &fvk,
+                anchor,
+                note,
+                path,
+                crossing_value,
+                rng,
+            );
+
+            let pczt = result.expect("a self-funding note should build a balanced transfer");
+            let orchard_bundle = pczt.orchard();
+            let actions = orchard_bundle.actions();
+            prop_assert!(!actions.is_empty());
+        }
+    }
+}

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -12,11 +12,12 @@
 #![no_std]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-// The crate itself is `no_std` and needs only `alloc` (for `Vec`); `macro_use` under test brings the
-// `vec!` macro into scope, and the tests link `std` for `proptest`.
-#[cfg_attr(test, macro_use)]
+// The crate itself is `no_std` and needs only `alloc`; `macro_use` brings the `vec!` and `format!`
+// macros into scope (the `build` module uses `format!`), and the tests link `std` for `proptest`.
+#[macro_use]
 extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
 pub mod note_splitting;
+pub mod preparation;

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -19,5 +19,7 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
+#[cfg(feature = "orchard")]
+pub mod build;
 pub mod note_splitting;
 pub mod preparation;

--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -295,4 +295,274 @@ mod tests {
         let zec: Vec<u64> = crossings(45_000 * COIN).iter().map(|&c| c / COIN).collect();
         assert_eq!(zec, vec![10_000, 10_000, 10_000, 10_000, 5_000]);
     }
+
+    /// Plans a real migration preparation for one user's `balance_zatoshi` with the recommended
+    /// ZIP-317-fee strategy (no reserved prep fee), and asserts the WHOLE planned transaction set,
+    /// not just the crossing quantization:
+    ///
+    /// - the crossing values (what an observer sees cross the turnstile),
+    /// - the prepared self-funding notes actually created in the source pool, each
+    ///   `crossing + transfer buffer` (the output that funds one migration-transfer transaction),
+    /// - the source-pool change left behind.
+    ///
+    /// The transfer buffer is the ZIP-317 [`FeePolicy`] buffer, so this exercises the fee model the
+    /// fee-free [`crossings`] helper deliberately skips.
+    fn check_user_preparation(
+        balance_zatoshi: u64,
+        expected_crossings_zatoshi: &[u64],
+        expected_change_zatoshi: Option<u64>,
+    ) {
+        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let expected_notes: Vec<u64> = expected_crossings_zatoshi
+            .iter()
+            .map(|&c| c + buffer)
+            .collect();
+        let s = CanonicalOneTwoFive::recommended();
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let plan = s.plan(balance_zatoshi, 0, &mut rng);
+        assert_eq!(
+            plan.crossing_values(),
+            expected_crossings_zatoshi,
+            "unexpected crossings for balance {balance_zatoshi} zat",
+        );
+        assert_eq!(
+            plan.migration_outputs(),
+            expected_notes.as_slice(),
+            "unexpected prepared notes for balance {balance_zatoshi} zat",
+        );
+        assert_eq!(
+            plan.change(),
+            expected_change_zatoshi,
+            "unexpected change for balance {balance_zatoshi} zat",
+        );
+    }
+
+    /// Golden vectors for the full migration preparation (the planned transaction set, fees included)
+    /// of many different users' messy, non-round balances. Each note the plan creates is a real
+    /// transaction output holding `crossing + transfer buffer` (20,000 zat under ZIP-317), and the
+    /// leftover that cannot form a whole self-funding note stays as source-pool change.
+    ///
+    /// Every expected split is derived BY HAND from the canonical `{1, 2, 5} * 10^k` greedy rule
+    /// (digit expansion: 1->[1], 2->[2], 3->[2,1], 4->[2,2], 5->[5], 6->[5,1], 7->[5,2], 8->[5,2,1],
+    /// 9->[5,2,2] times each place value; balances above the 10,000 ZEC cap emit multiple cap-sized
+    /// parts). For the first group each balance is exactly `sum(crossings) + notes * buffer + change`,
+    /// so every crossing self-funds and the residual is the stated change; the last two are
+    /// independently chosen balances that exercise the fee model draining the smallest notes.
+    #[test]
+    fn messy_multi_user_preparations() {
+        // `(balance in zatoshi, expected crossings in zatoshi, expected source-pool change)`.
+        let cases: Vec<(u64, Vec<u64>, Option<u64>)> = vec![
+            // Ari, 3748.6174 ZEC: 3->[2,1] 7->[5,2] 4->[2,2] 8->[5,2,1] .6->[.5,.1] .01->[.01],
+            // 12 notes + 0.005 ZEC sub-floor dust change.
+            (
+                374_861_740_000,
+                vec![
+                    2_000 * COIN,
+                    1_000 * COIN,
+                    500 * COIN,
+                    200 * COIN,
+                    20 * COIN,
+                    20 * COIN,
+                    5 * COIN,
+                    2 * COIN,
+                    COIN,
+                    COIN / 2,
+                    COIN / 10,
+                    COIN / 100,
+                ],
+                Some(500_000),
+            ),
+            // Bo, 9631.8827 ZEC: 9->[5,2,2] 6->[5,1] 3->[2,1] 1->[1] .8->[.5,.2,.1] .07->[.05,.02],
+            // 13 notes + 0.0101 ZEC change (at/above the dust floor but too small to self-fund).
+            (
+                963_188_270_000,
+                vec![
+                    5_000 * COIN,
+                    2_000 * COIN,
+                    2_000 * COIN,
+                    500 * COIN,
+                    100 * COIN,
+                    20 * COIN,
+                    10 * COIN,
+                    COIN,
+                    COIN / 2,
+                    COIN / 5,
+                    COIN / 10,
+                    COIN / 20,
+                    COIN / 50,
+                ],
+                Some(1_010_000),
+            ),
+            // Cleo, 27853.4226 ZEC: above the cap -> two 10,000; then 7853.42 = 7->[5,2] 8->[5,2,1]
+            // 5->[5] 3->[2,1] .4->[.2,.2] .02->[.02]. 13 notes, no change.
+            (
+                2_785_342_260_000,
+                vec![
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    5_000 * COIN,
+                    2_000 * COIN,
+                    500 * COIN,
+                    200 * COIN,
+                    100 * COIN,
+                    50 * COIN,
+                    2 * COIN,
+                    COIN,
+                    COIN / 5,
+                    COIN / 5,
+                    COIN / 50,
+                ],
+                None,
+            ),
+            // Dex, 61337.5028 ZEC: above the cap -> six 10,000; then 1337.5 = 1->[1] 3->[2,1]
+            // 3->[2,1] 7->[5,2] .5->[.5]. 14 notes, no change.
+            (
+                6_133_750_280_000,
+                vec![
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    1_000 * COIN,
+                    200 * COIN,
+                    100 * COIN,
+                    20 * COIN,
+                    10 * COIN,
+                    5 * COIN,
+                    2 * COIN,
+                    COIN / 2,
+                ],
+                None,
+            ),
+            // Evie, 0.794 ZEC: .7->[.5,.2] .9->[.05,.02,.02], 5 notes + 0.003 ZEC sub-floor change.
+            (
+                79_400_000,
+                vec![COIN / 2, COIN / 5, COIN / 20, COIN / 50, COIN / 50],
+                Some(300_000),
+            ),
+            // Fin, 0.381 ZEC: .3->[.2,.1] .8->[.05,.02,.01] (down to the 0.01 dust floor), 5 notes,
+            // no change.
+            (
+                38_100_000,
+                vec![COIN / 5, COIN / 10, COIN / 20, COIN / 50, COIN / 100],
+                None,
+            ),
+            // Gwen, 0.0152 ZEC: a single 0.01 dust-floor note + 0.005 ZEC sub-floor change.
+            (1_520_000, vec![COIN / 100], Some(500_000)),
+            // Ivan, 142.5314 ZEC (typical wallet): 1->[1] 4->[2,2] 2->[2] .5->[.5] .03->[.02,.01],
+            // 7 notes, no change.
+            (
+                14_253_140_000,
+                vec![
+                    100 * COIN,
+                    20 * COIN,
+                    20 * COIN,
+                    2 * COIN,
+                    COIN / 2,
+                    COIN / 50,
+                    COIN / 100,
+                ],
+                None,
+            ),
+            // Jia, 76.1986 ZEC (typical wallet): 7->[5,2] 6->[5,1] .1->[.1] .09->[.05,.02,.02],
+            // 8 notes + 0.007 ZEC sub-floor change.
+            (
+                7_619_860_000,
+                vec![
+                    50 * COIN,
+                    20 * COIN,
+                    5 * COIN,
+                    COIN,
+                    COIN / 10,
+                    COIN / 20,
+                    COIN / 50,
+                    COIN / 50,
+                ],
+                Some(700_000),
+            ),
+            // Kai, 999.993 ZEC (every digit a 9 -> every place expands [5,2,2]): 999.99 =
+            // 9->[5,2,2] 9->[5,2,2] 9->[5,2,2] .9->[.5,.2,.2] .09->[.05,.02,.02]. 15 notes, no change.
+            (
+                99_999_300_000,
+                vec![
+                    500 * COIN,
+                    200 * COIN,
+                    200 * COIN,
+                    50 * COIN,
+                    20 * COIN,
+                    20 * COIN,
+                    5 * COIN,
+                    2 * COIN,
+                    2 * COIN,
+                    COIN / 2,
+                    COIN / 5,
+                    COIN / 5,
+                    COIN / 20,
+                    COIN / 50,
+                    COIN / 50,
+                ],
+                None,
+            ),
+            // Lex, 32222.2218 ZEC: above the cap -> three 10,000; then 2222.22 (every digit a 2 ->
+            // [2]): 2->[2] 2->[2] 2->[2] 2->[2] .2->[.2] .02->[.02]. 9 notes, no change.
+            (
+                3_222_222_180_000,
+                vec![
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    10_000 * COIN,
+                    2_000 * COIN,
+                    200 * COIN,
+                    20 * COIN,
+                    2 * COIN,
+                    COIN / 5,
+                    COIN / 50,
+                ],
+                None,
+            ),
+            // Mira, 4050.0735 ZEC (interior zero digits skipped): 4->[2,2] 0->[] 5->[5] 0->[] 0->[]
+            // .07->[.05,.02], 5 notes + 0.0025 ZEC sub-floor change.
+            (
+                405_007_350_000,
+                vec![2_000 * COIN, 2_000 * COIN, 50 * COIN, COIN / 20, COIN / 50],
+                Some(250_000),
+            ),
+            // Ozan, 88.884 ZEC (independently chosen): 88.88 = 8->[5,2,1] 8->[5,2,1] .8->[.5,.2,.1]
+            // .08->[.05,.02,.01]. The 0.004 ZEC fee-free residual exceeds the 12 notes' buffers
+            // (12 * 0.0002 = 0.0024 ZEC), so all 12 notes self-fund and 0.0016 ZEC stays as change.
+            (
+                8_888_400_000,
+                vec![
+                    50 * COIN,
+                    20 * COIN,
+                    10 * COIN,
+                    5 * COIN,
+                    2 * COIN,
+                    COIN,
+                    COIN / 2,
+                    COIN / 5,
+                    COIN / 10,
+                    COIN / 20,
+                    COIN / 50,
+                    COIN / 100,
+                ],
+                Some(160_000),
+            ),
+            // Priya, 7.1101 ZEC (independently chosen): the fee-free split is 7->[5,2] .1->[.1]
+            // .01->[.01], but only 0.0001 ZEC of residual is left for the buffers, so the 0.01
+            // crossing cannot self-fund (it needs 0.01 + 0.0002 ZEC). It is dropped: the plan is
+            // [5, 2, 0.1] and the unspent 0.0095 ZEC stays as change.
+            (
+                711_010_000,
+                vec![5 * COIN, 2 * COIN, COIN / 10],
+                Some(950_000),
+            ),
+        ];
+
+        for (balance, crossings, change) in &cases {
+            check_user_preparation(*balance, crossings, *change);
+        }
+    }
 }

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -1,0 +1,1300 @@
+//! Note-preparation transaction planning: how to restructure a wallet's spendable source-pool notes
+//! into the exact self-funding notes a migration run needs, using transactions that each stay within
+//! the [ZIP 318] action budget.
+//!
+//! # The problem
+//!
+//! The [`note_splitting`](super::note_splitting) planner decides the *values* of the self-funding
+//! notes to mint. This module decides the *transactions* that mint them. [ZIP 318] requires each
+//! note-preparation transaction to be padded to exactly [`PREP_TX_ACTIONS`] Orchard actions (a
+//! mobile-proving-time and on-chain-uniformity constraint). Under NU6.3 a bundle's action count is
+//! its spends plus its outputs, so one transaction can consume and produce at most
+//! [`PREP_TX_ACTIONS`] notes in total (for example 15 spends and one output when consolidating, or
+//! one spend and 15 outputs when splitting). A splitting transaction therefore mints MANY funding
+//! notes at once, one output per scheduled part (up to [`FUNDING_OUTPUTS_PER_TX`]); the number of
+//! funding notes in a preparation transaction is not one. The one-transaction-per-part shape belongs
+//! to the phase-2 crossing transfers (each spends a single funding note), not to preparation.
+//!
+//! A single transaction therefore cannot always turn the wallet's notes into every funding note: a
+//! note that must fan out into more outputs than one transaction holds, or a balance spread across
+//! more dust notes than one transaction can consume, needs **layers**. A layer is a set of
+//! transactions with no dependencies between them (buildable, provable, and broadcastable in
+//! parallel); a later layer may spend the outputs of an earlier one, but only after they are mined
+//! and a boundary passes, so each extra layer extends the preparation phase by roughly one anchor
+//! bucket. The planner therefore prefers fewer layers (which dominate the wall-clock) over fewer
+//! transactions.
+//!
+//! # The strategy
+//!
+//! The planner is a largest-first layered greedy. In each layer it feeds each output transaction from
+//! the largest available note it can (one big note funds up to [`FUNDING_OUTPUTS_PER_TX`] funding
+//! notes), routes every leftover forward as an intermediate ("feeder") note, and consolidates notes
+//! too small to fund anything on their own into feeder notes. Once all funding notes are scheduled it
+//! consolidates the feeders that no layer spent into a single residual note, matching ZIP 318's
+//! "one note per part plus at most one residual note". For a typical wallet (a few notes, a handful of
+//! funding notes) this is a single layer; extra layers appear only for a lone large note fanning out
+//! into many funding notes, or a dust-heavy balance.
+//!
+//! The single-residual goal is only reachable above the fee threshold. When several transactions each
+//! strand a remainder smaller than a transaction fee and those remainders together are still worth
+//! less than one fee, no consolidation can merge them (its output would be negative), so they remain
+//! as multiple sub-fee change notes. The planner therefore guarantees at most one residual note worth a
+//! fee; any further residue is sub-fee dust.
+//!
+//! When a single note can produce every funding note, the planner takes a fan-out fast path: it splits
+//! that note through a BALANCED tree (fanning out by [`FUNDING_OUTPUTS_PER_TX`] per layer), so the
+//! depth is logarithmic in the funding-note count rather than linear in it. The balanced tree uses more
+//! transactions, and so more fee, than a linear feeder chain would; it trades that for fewer layers,
+//! which dominate the wall-clock. Every other shape (many notes, mixed sizes, dust) uses the layered
+//! greedy above.
+//!
+//! This is a pure planner: it works in note *values* (in zatoshi) and does no cryptography or I/O. It
+//! reserves a fixed per-transaction fee (the caller passes the ZIP-317 fee of a padded
+//! [`PREP_TX_ACTIONS`]-action transaction) out of each transaction's inputs; the builder later
+//! absorbs the real fee into the change.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+
+use alloc::vec::Vec;
+
+use core::fmt;
+
+/// The exact number of Orchard actions in every note-preparation transaction ([ZIP 318]): each is
+/// padded up to this count, so no preparation transaction is distinguishable from another by its
+/// action count, and one transaction handles at most this many notes in total (spends plus outputs).
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const PREP_TX_ACTIONS: usize = 16;
+
+/// The most funding (or feeder) outputs one transaction produces from a single input: the action
+/// budget less that one input and one change/feeder slot (`16 - 1 - 1`).
+pub const FUNDING_OUTPUTS_PER_TX: usize = PREP_TX_ACTIONS - 2;
+
+/// The most notes one transaction consolidates: the action budget less the single output it produces
+/// (`16 - 1`).
+pub const CONSOLIDATION_INPUTS_PER_TX: usize = PREP_TX_ACTIONS - 1;
+
+/// A note a preparation transaction spends: either one of the wallet's original spendable notes, or a
+/// note an earlier layer produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepInput {
+    /// The wallet note at this index in the caller-supplied `available` slice.
+    Wallet(usize),
+    /// The `output`-th output of the `transaction`-th transaction of an earlier `layer`.
+    Prior {
+        layer: usize,
+        transaction: usize,
+        output: usize,
+    },
+}
+
+/// A note a preparation transaction produces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepOutput {
+    /// A final self-funding note: one of the requested funding values.
+    Funding(u64),
+    /// An intermediate ("feeder") note, spent by a later layer to route value forward.
+    Intermediate(u64),
+    /// Leftover value returned to the source pool.
+    Change(u64),
+}
+
+impl PrepOutput {
+    /// The note value this output carries.
+    pub fn value(&self) -> u64 {
+        match self {
+            PrepOutput::Funding(v) | PrepOutput::Intermediate(v) | PrepOutput::Change(v) => *v,
+        }
+    }
+}
+
+/// One note-preparation transaction: a same-pool send-to-self, padded at build time to
+/// [`PREP_TX_ACTIONS`] actions. Its logical action count (`inputs.len() + outputs.len()`) never
+/// exceeds that budget.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrepTransaction {
+    inputs: Vec<PrepInput>,
+    outputs: Vec<PrepOutput>,
+}
+
+impl PrepTransaction {
+    /// The notes this transaction spends.
+    pub fn inputs(&self) -> &[PrepInput] {
+        &self.inputs
+    }
+
+    /// The notes this transaction produces.
+    pub fn outputs(&self) -> &[PrepOutput] {
+        &self.outputs
+    }
+
+    /// The logical Orchard action count before padding (`inputs + outputs`).
+    pub fn action_count(&self) -> usize {
+        self.inputs.len() + self.outputs.len()
+    }
+}
+
+/// A schedule of note-preparation transactions grouped into sequential layers. Every transaction in a
+/// layer is independent of the others in that layer; a transaction may spend a [`PrepInput::Prior`]
+/// output only from a strictly earlier layer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreparationPlan {
+    layers: Vec<Vec<PrepTransaction>>,
+    /// Wallet notes (by their index in `available`) already equal to a funding value, used directly as
+    /// that funding note with no preparation transaction, paired with that value.
+    direct_funding: Vec<(usize, u64)>,
+}
+
+impl PreparationPlan {
+    /// The layers, in dependency order (later layers may spend earlier layers' outputs).
+    pub fn layers(&self) -> &[Vec<PrepTransaction>] {
+        &self.layers
+    }
+
+    /// The number of sequential layers (the depth that governs the preparation phase's duration).
+    pub fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// The total number of preparation transactions across all layers.
+    pub fn transaction_count(&self) -> usize {
+        self.layers.iter().map(Vec::len).sum()
+    }
+
+    /// The value an input carries, resolved against the wallet's `available` notes (for a
+    /// [`PrepInput::Wallet`]) or an earlier layer's output (for a [`PrepInput::Prior`]). Returns
+    /// `None` if the reference is out of range.
+    pub fn input_value(&self, input: &PrepInput, available: &[u64]) -> Option<u64> {
+        match input {
+            PrepInput::Wallet(i) => available.get(*i).copied(),
+            PrepInput::Prior {
+                layer,
+                transaction,
+                output,
+            } => self
+                .layers
+                .get(*layer)?
+                .get(*transaction)?
+                .outputs
+                .get(*output)
+                .map(PrepOutput::value),
+        }
+    }
+
+    /// An iterator over every output of every transaction, in plan (layer then transaction) order.
+    fn all_outputs(&self) -> impl Iterator<Item = &PrepOutput> {
+        self.layers
+            .iter()
+            .flatten()
+            .flat_map(PrepTransaction::outputs)
+    }
+
+    /// Wallet notes (by their index in the caller's `available` slice) already equal to a funding
+    /// value, used directly as that funding note with no preparation transaction, each paired with
+    /// that value. The caller must leave these notes unspent by preparation.
+    pub fn direct_funding_notes(&self) -> &[(usize, u64)] {
+        &self.direct_funding
+    }
+
+    /// The values of the self-funding notes this plan mints, both the [`PrepOutput::Funding`] outputs
+    /// its transactions create and the wallet notes used directly (see
+    /// [`direct_funding_notes`](Self::direct_funding_notes)): the notes the migration transfers will
+    /// each spend.
+    pub fn funding_notes(&self) -> Vec<u64> {
+        let mut out: Vec<u64> = self
+            .all_outputs()
+            .filter_map(|o| match o {
+                PrepOutput::Funding(v) => Some(*v),
+                _ => None,
+            })
+            .collect();
+        out.extend(self.direct_funding.iter().map(|&(_, v)| v));
+        out
+    }
+
+    /// The values of the residual notes this plan leaves in the source pool (its
+    /// [`PrepOutput::Change`] outputs): at most one worth a fee, plus any sub-fee dust.
+    pub fn residual_notes(&self) -> Vec<u64> {
+        self.all_outputs()
+            .filter_map(|o| match o {
+                PrepOutput::Change(v) => Some(*v),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The number of residual notes this plan leaves (see
+    /// [`residual_notes`](Self::residual_notes)).
+    pub fn residual_count(&self) -> usize {
+        self.residual_notes().len()
+    }
+}
+
+/// Why a preparation plan could not be produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepError {
+    /// The available notes cannot fund every requested funding note plus the per-transaction fees.
+    InsufficientFunds,
+}
+
+impl fmt::Display for PrepError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrepError::InsufficientFunds => {
+                f.write_str("available notes cannot fund the requested notes plus preparation fees")
+            }
+        }
+    }
+}
+
+impl core::error::Error for PrepError {}
+
+/// A note available to spend in the current layer: a reference and its value.
+type PoolNote = (PrepInput, u64);
+
+/// Plan the note-preparation transactions that mint `funding` (the self-funding note values, in
+/// zatoshi) from `available` (the wallet's spendable source-pool note values, in zatoshi), reserving
+/// `fee_per_tx` zatoshi for each transaction (the ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action
+/// transaction).
+///
+/// Returns an empty plan when `funding` is empty, and [`PrepError::InsufficientFunds`] when the
+/// available value cannot cover the funding notes plus the per-transaction fees.
+pub fn plan_preparation(
+    available: &[u64],
+    funding: &[u64],
+    fee_per_tx: u64,
+) -> Result<PreparationPlan, PrepError> {
+    // Funding values still to produce, largest first (so `last()` is the smallest).
+    let mut remaining: Vec<u64> = funding.iter().copied().filter(|&v| v > 0).collect();
+    remaining.sort_unstable_by(|a, b| b.cmp(a));
+
+    // Exact-match pass: a wallet note already equal to a funding value IS that funding note, so it is
+    // used directly, with no preparation transaction and no fee. The matched notes are removed from
+    // both the funding still to produce and the notes available to spend.
+    let mut used = vec![false; available.len()];
+    let mut direct_funding: Vec<(usize, u64)> = Vec::new();
+    remaining.retain(|&f| {
+        match available
+            .iter()
+            .enumerate()
+            .position(|(i, &v)| !used[i] && v == f)
+        {
+            Some(i) => {
+                used[i] = true;
+                direct_funding.push((i, f));
+                false
+            }
+            None => true,
+        }
+    });
+
+    let mut layers: Vec<Vec<PrepTransaction>> = Vec::new();
+    if remaining.is_empty() {
+        return Ok(PreparationPlan {
+            layers,
+            direct_funding,
+        });
+    }
+
+    // Fan-out fast path: when a single wallet note can produce every remaining funding note, split it
+    // through a balanced tree (depth logarithmic in the note count) rather than the linear feeder chain
+    // the layered loop below would build for a lone large note. Only that case takes this path;
+    // everything else (many notes, mixed sizes, dust) falls through to the layered greedy unchanged.
+    // Trade-off: the balanced tree uses more transactions (fees) than the chain, buying fewer layers.
+    if let Some((idx, big)) = available
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !used[*i])
+        .map(|(i, &v)| (i, v))
+        .max_by_key(|&(_, v)| v)
+    {
+        if big >= subtree_cost(&remaining, fee_per_tx).1 {
+            build_split(
+                PrepInput::Wallet(idx),
+                big,
+                &remaining,
+                fee_per_tx,
+                0,
+                &mut layers,
+            );
+            remaining.clear();
+        }
+    }
+
+    // The notes available to spend in the current layer (layer 0: the wallet's own notes not already
+    // used directly as funding notes).
+    let mut current: Vec<PoolNote> = available
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !used[*i])
+        .map(|(i, &v)| (PrepInput::Wallet(i), v))
+        .collect();
+
+    while !remaining.is_empty() {
+        if current.is_empty() {
+            return Err(PrepError::InsufficientFunds);
+        }
+        // Largest notes first.
+        current.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+
+        // Pass 1: assign funding to the notes that can fund at least the smallest remaining note.
+        // `partial` holds a note, the funding values it will mint, and its leftover budget; the rest
+        // go to `consolidatable` to be combined into feeder notes.
+        let mut partial: Vec<(PrepInput, Vec<u64>, u64)> = Vec::new();
+        let mut consolidatable: Vec<PoolNote> = Vec::new();
+
+        for (in_ref, value) in current.drain(..) {
+            if remaining.is_empty() {
+                // Everything is already scheduled; this note stays unspent in the wallet.
+                continue;
+            }
+            let smallest = *remaining.last().expect("remaining is non-empty");
+            if value <= fee_per_tx || value - fee_per_tx < smallest {
+                consolidatable.push((in_ref, value));
+                continue;
+            }
+            let budget = value - fee_per_tx;
+            let mut assigned = Vec::new();
+            let mut used = 0u64;
+            let mut i = 0;
+            while i < remaining.len() && assigned.len() < FUNDING_OUTPUTS_PER_TX {
+                if used + remaining[i] <= budget {
+                    used += remaining[i];
+                    assigned.push(remaining.remove(i));
+                } else {
+                    i += 1;
+                }
+            }
+            // `value - fee_per_tx >= smallest` guarantees at least the smallest note was assignable.
+            debug_assert!(!assigned.is_empty());
+            partial.push((in_ref, assigned, budget - used));
+        }
+
+        // Pass 2: mint the funding notes, routing every leftover forward as a feeder so a later layer
+        // reuses it rather than scattering change.
+        let mut txs: Vec<PrepTransaction> = Vec::new();
+        let mut next: Vec<PoolNote> = Vec::new();
+        for (in_ref, assigned, leftover) in partial {
+            let mut outputs: Vec<PrepOutput> =
+                assigned.into_iter().map(PrepOutput::Funding).collect();
+            if leftover > 0 {
+                next.push((
+                    PrepInput::Prior {
+                        layer: layers.len(),
+                        transaction: txs.len(),
+                        output: outputs.len(),
+                    },
+                    leftover,
+                ));
+                outputs.push(PrepOutput::Intermediate(leftover));
+            }
+            txs.push(PrepTransaction {
+                inputs: vec![in_ref],
+                outputs,
+            });
+        }
+
+        // Consolidate notes too small to fund anything into feeders for a later layer.
+        consolidate(
+            consolidatable,
+            layers.len(),
+            fee_per_tx,
+            &mut txs,
+            &mut next,
+        );
+
+        if txs.is_empty() {
+            // No note in this layer could fund or usefully consolidate: the balance is insufficient.
+            return Err(PrepError::InsufficientFunds);
+        }
+        layers.push(txs);
+        current = next;
+    }
+
+    // The funding notes are all scheduled. Consolidate every leftover feeder that no layer spends into
+    // a single residual note (ZIP 318 prepares one note per part plus at most one residual note), for
+    // as long as that is worth a transaction; a remainder too small to pay a fee is left as change.
+    loop {
+        let pool = unconsumed_feeders(&layers);
+        if pool.len() <= 1 {
+            break;
+        }
+        let mut txs: Vec<PrepTransaction> = Vec::new();
+        let mut next: Vec<PoolNote> = Vec::new();
+        consolidate(pool, layers.len(), fee_per_tx, &mut txs, &mut next);
+        if txs.is_empty() {
+            break; // the remainder is sub-fee dust; leave it as change
+        }
+        layers.push(txs);
+    }
+    let _ = current; // the residual pool is recomputed above, so the last `next` is unused
+
+    // Relabel any feeder note that no later layer ends up spending as source-pool change, so the plan
+    // has no dangling intermediates and value is conserved end to end.
+    let mut spent: Vec<(usize, usize, usize)> = Vec::new();
+    for layer in &layers {
+        for tx in layer {
+            for input in &tx.inputs {
+                if let PrepInput::Prior {
+                    layer,
+                    transaction,
+                    output,
+                } = input
+                {
+                    spent.push((*layer, *transaction, *output));
+                }
+            }
+        }
+    }
+    for (li, layer) in layers.iter_mut().enumerate() {
+        for (ti, tx) in layer.iter_mut().enumerate() {
+            for (oi, out) in tx.outputs.iter_mut().enumerate() {
+                if let PrepOutput::Intermediate(v) = *out {
+                    if !spent.contains(&(li, ti, oi)) {
+                        *out = PrepOutput::Change(v);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PreparationPlan {
+        layers,
+        direct_funding,
+    })
+}
+
+/// Split `n` notes into consolidation batches of at most [`CONSOLIDATION_INPUTS_PER_TX`], never
+/// leaving a batch of one (which would waste a fee without reducing the note count). Assumes `n >= 2`.
+fn consolidation_batch_sizes(mut n: usize) -> Vec<usize> {
+    let max = CONSOLIDATION_INPUTS_PER_TX;
+    let mut sizes = Vec::new();
+    while n > 0 {
+        let take = if n <= max {
+            n
+        } else if n - max == 1 {
+            max - 1 // leave 2 for the final batch rather than a lone note
+        } else {
+            max
+        };
+        sizes.push(take);
+        n -= take;
+    }
+    sizes
+}
+
+/// Consolidate `pool` into feeder notes: append one consolidation transaction per batch (of at most
+/// [`CONSOLIDATION_INPUTS_PER_TX`] inputs) to `txs` in layer `layer`, with its feeder pushed to
+/// `next`. Returns any notes whose batch could not cover the fee (too small to consolidate).
+fn consolidate(
+    mut pool: Vec<PoolNote>,
+    layer: usize,
+    fee: u64,
+    txs: &mut Vec<PrepTransaction>,
+    next: &mut Vec<PoolNote>,
+) -> Vec<PoolNote> {
+    if pool.len() < 2 {
+        return pool;
+    }
+    pool.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    let mut leftover = Vec::new();
+    for size in consolidation_batch_sizes(pool.len()) {
+        let batch: Vec<PoolNote> = pool.drain(..size).collect();
+        let sum: u64 = batch.iter().map(|&(_, v)| v).sum();
+        if sum <= fee {
+            leftover.extend(batch); // too small to pay a fee; leave unspent
+            continue;
+        }
+        let feeder = sum - fee;
+        next.push((
+            PrepInput::Prior {
+                layer,
+                transaction: txs.len(),
+                output: 0,
+            },
+            feeder,
+        ));
+        txs.push(PrepTransaction {
+            inputs: batch.into_iter().map(|(r, _)| r).collect(),
+            outputs: vec![PrepOutput::Intermediate(feeder)],
+        });
+    }
+    leftover
+}
+
+/// Every intermediate ("feeder") output that no transaction spends, as `(reference, value)` pairs.
+fn unconsumed_feeders(layers: &[Vec<PrepTransaction>]) -> Vec<PoolNote> {
+    let mut spent: Vec<(usize, usize, usize)> = Vec::new();
+    for layer in layers {
+        for tx in layer {
+            for input in &tx.inputs {
+                if let PrepInput::Prior {
+                    layer,
+                    transaction,
+                    output,
+                } = input
+                {
+                    spent.push((*layer, *transaction, *output));
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for (li, layer) in layers.iter().enumerate() {
+        for (ti, tx) in layer.iter().enumerate() {
+            for (oi, output) in tx.outputs.iter().enumerate() {
+                if let PrepOutput::Intermediate(v) = output {
+                    if !spent.contains(&(li, ti, oi)) {
+                        out.push((
+                            PrepInput::Prior {
+                                layer: li,
+                                transaction: ti,
+                                output: oi,
+                            },
+                            *v,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The most funding notes a balanced split subtree of the given `depth` can produce: each level fans
+/// out by [`FUNDING_OUTPUTS_PER_TX`] (one input, the rest outputs), so a depth-`d` subtree holds up to
+/// `FUNDING_OUTPUTS_PER_TX^d` funding notes (a depth-1 leaf holds one full transaction of them).
+fn subtree_capacity(depth: usize) -> usize {
+    FUNDING_OUTPUTS_PER_TX.pow(depth as u32)
+}
+
+/// The fewest balanced-split layers that produce `n` funding notes from one source note (the depth `d`
+/// with `subtree_capacity(d) >= n`). Zero for `n == 0`.
+fn split_depth(n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    let mut depth = 1;
+    while subtree_capacity(depth) < n {
+        depth += 1;
+    }
+    depth
+}
+
+/// Group sizes for splitting `len` targets into `g` contiguous groups as evenly as possible (the first
+/// `len % g` groups get one extra).
+fn even_group_sizes(len: usize, g: usize) -> Vec<usize> {
+    let base = len / g;
+    let extra = len % g;
+    (0..g).map(|i| base + usize::from(i < extra)).collect()
+}
+
+/// The transaction count and the value a single source note must carry to produce exactly `targets`
+/// (the funding notes) through a balanced split tree: each transaction costs one `fee`, and the tree
+/// fans out by [`FUNDING_OUTPUTS_PER_TX`] until each leaf holds at most that many funding notes.
+fn subtree_cost(targets: &[u64], fee: u64) -> (u64, u64) {
+    let depth = split_depth(targets.len());
+    if depth <= 1 {
+        return (1, targets.iter().sum::<u64>() + fee);
+    }
+    let child_cap = subtree_capacity(depth - 1);
+    let g = targets.len().div_ceil(child_cap);
+    let mut start = 0;
+    let mut txs = 1u64;
+    let mut value = fee;
+    for size in even_group_sizes(targets.len(), g) {
+        let (t, v) = subtree_cost(&targets[start..start + size], fee);
+        txs += t;
+        value += v;
+        start += size;
+    }
+    (txs, value)
+}
+
+/// Build a balanced split of `source` (a note reference worth `source_value`) into the funding notes
+/// `targets`, appending transactions to `layers` from `layer` downwards. Each transaction funds up to
+/// [`FUNDING_OUTPUTS_PER_TX`] notes directly at a leaf, or fans out into up to that many feeder notes
+/// (one per child subtree) at an internal node, so the depth is [`split_depth`] of the target count
+/// rather than linear in it. Only the top call (the whole source note) carries a leftover; it is
+/// emitted as an intermediate feeder so the residual pass merges it. The internal feeders are exact.
+fn build_split(
+    source: PrepInput,
+    source_value: u64,
+    targets: &[u64],
+    fee: u64,
+    layer: usize,
+    layers: &mut Vec<Vec<PrepTransaction>>,
+) {
+    while layers.len() <= layer {
+        layers.push(Vec::new());
+    }
+    let tx_index = layers[layer].len();
+    let depth = split_depth(targets.len());
+
+    if depth <= 1 {
+        // Leaf: fund every target directly, with any leftover as an intermediate (residual) note.
+        let mut outputs: Vec<PrepOutput> =
+            targets.iter().copied().map(PrepOutput::Funding).collect();
+        let spent: u64 = targets.iter().sum();
+        let leftover = source_value - fee - spent;
+        if leftover > 0 {
+            outputs.push(PrepOutput::Intermediate(leftover));
+        }
+        layers[layer].push(PrepTransaction {
+            inputs: vec![source],
+            outputs,
+        });
+        return;
+    }
+
+    // Internal node: fan out into one feeder per child subtree.
+    let child_cap = subtree_capacity(depth - 1);
+    let g = targets.len().div_ceil(child_cap);
+    let sizes = even_group_sizes(targets.len(), g);
+
+    let mut groups: Vec<(usize, usize)> = Vec::new(); // (start, size)
+    let mut child_values: Vec<u64> = Vec::new();
+    let mut start = 0;
+    for size in sizes {
+        child_values.push(subtree_cost(&targets[start..start + size], fee).1);
+        groups.push((start, size));
+        start += size;
+    }
+
+    let mut outputs: Vec<PrepOutput> = child_values
+        .iter()
+        .copied()
+        .map(PrepOutput::Intermediate)
+        .collect();
+    let spent: u64 = child_values.iter().sum();
+    let leftover = source_value - fee - spent;
+    if leftover > 0 {
+        outputs.push(PrepOutput::Intermediate(leftover));
+    }
+    layers[layer].push(PrepTransaction {
+        inputs: vec![source],
+        outputs,
+    });
+
+    for (output, ((gstart, gsize), &cv)) in groups.iter().zip(child_values.iter()).enumerate() {
+        let child = PrepInput::Prior {
+            layer,
+            transaction: tx_index,
+            output,
+        };
+        build_split(
+            child,
+            cv,
+            &targets[*gstart..*gstart + *gsize],
+            fee,
+            layer + 1,
+            layers,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+
+    /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
+    /// action costs one [`Zip317FeePolicy`] marginal fee). The planner treats it opaquely.
+    fn fee_per_tx() -> u64 {
+        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
+    }
+
+    /// The funding values a plan mints, sorted, for multiset comparison against the request.
+    fn sorted_funding(plan: &PreparationPlan) -> Vec<u64> {
+        let mut out = plan.funding_notes();
+        out.sort_unstable();
+        out
+    }
+
+    /// Assert every structural invariant of a plan against its inputs.
+    fn assert_plan_valid(plan: &PreparationPlan, available: &[u64], funding: &[u64], fee: u64) {
+        // Every requested funding note is minted exactly once.
+        let mut want: Vec<u64> = funding.iter().copied().filter(|&v| v > 0).collect();
+        want.sort_unstable();
+        assert_eq!(sorted_funding(plan), want, "funding multiset");
+
+        // A k-ary lower bound: a transaction has at least one spend, so it emits at most
+        // `PREP_TX_ACTIONS - 1` outputs and thus at most that many funding notes; minting `l` of them
+        // (the funding notes not used directly) needs at least `ceil(l / (A - 1))` transactions.
+        let minted = want.len() - plan.direct_funding_notes().len();
+        if minted > 0 {
+            let min_txs = minted.div_ceil(PREP_TX_ACTIONS - 1);
+            assert!(
+                plan.transaction_count() >= min_txs,
+                "transaction count {} below the k-ary lower bound {min_txs}",
+                plan.transaction_count()
+            );
+        }
+
+        let mut wallet_spent = 0u64;
+        let mut total_fees = 0u64;
+        let mut final_out = 0u64; // funding + change (intermediates are consumed downstream)
+        // Every input reference across the whole plan, to prove no note is spent twice.
+        let mut seen_inputs: Vec<PrepInput> = Vec::new();
+
+        for (li, layer) in plan.layers().iter().enumerate() {
+            for (ti, tx) in layer.iter().enumerate() {
+                // Action budget.
+                assert!(
+                    tx.action_count() <= PREP_TX_ACTIONS,
+                    "layer {li} tx {ti}: {} actions",
+                    tx.action_count()
+                );
+                assert!(!tx.inputs().is_empty(), "layer {li} tx {ti}: no inputs");
+                assert!(!tx.outputs().is_empty(), "layer {li} tx {ti}: no outputs");
+
+                let mut in_sum = 0u64;
+                for input in tx.inputs() {
+                    // Single-spend: an atomic Orchard note is spent by at most one transaction.
+                    assert!(
+                        !seen_inputs.contains(input),
+                        "layer {li} tx {ti}: note spent twice: {input:?}"
+                    );
+                    seen_inputs.push(*input);
+                    // Every reference resolves, and a Prior input points strictly backwards.
+                    if let PrepInput::Prior { layer, .. } = input {
+                        assert!(*layer < li, "layer {li} tx {ti}: forward/self reference");
+                    }
+                    let v = plan.input_value(input, available).expect("input resolves");
+                    in_sum += v;
+                    if let PrepInput::Wallet(_) = input {
+                        wallet_spent += v;
+                    }
+                }
+                let out_sum: u64 = tx.outputs().iter().map(PrepOutput::value).sum();
+                // Value conservation: inputs = outputs + the reserved fee.
+                assert_eq!(in_sum, out_sum + fee, "layer {li} tx {ti}: conservation");
+                total_fees += fee;
+                for o in tx.outputs() {
+                    match o {
+                        PrepOutput::Funding(v) | PrepOutput::Change(v) => final_out += v,
+                        PrepOutput::Intermediate(_) => {}
+                    }
+                }
+            }
+        }
+
+        // Global conservation: the wallet value spent equals what left as funding/change plus fees.
+        assert_eq!(wallet_spent, final_out + total_fees, "global conservation");
+
+        // Directly-used wallet notes are untouched: each carries the claimed value and is spent by no
+        // transaction (so it is not double-counted against the wallet balance).
+        for &(i, v) in plan.direct_funding_notes() {
+            assert_eq!(
+                available.get(i).copied(),
+                Some(v),
+                "direct funding note {i} value"
+            );
+            assert!(
+                !seen_inputs.contains(&PrepInput::Wallet(i)),
+                "direct funding note {i} also spent by a transaction"
+            );
+        }
+
+        // Residual: at most one Change note is worth a fee. ZIP 318's "at most one residual note" is
+        // only achievable above the fee threshold; when several spends each strand a sub-fee remainder
+        // whose total is itself below one transaction fee, no consolidation can merge them (its output
+        // would be negative), so they survive as multiple sub-fee Change notes. Two Change notes each
+        // >= fee could always be merged, so the planner never leaves more than one.
+        let changes = plan.residual_notes();
+        let fundable_residuals = changes.iter().filter(|&&v| v >= fee).count();
+        assert!(
+            fundable_residuals <= 1,
+            "at most one residual >= fee; got {fundable_residuals} of {changes:?}"
+        );
+        if changes.len() > 1 {
+            let total: u64 = changes.iter().sum();
+            assert!(
+                total < fee,
+                "multiple residuals only when their total is sub-fee; total {total} fee {fee}"
+            );
+        }
+    }
+
+    fn arb_input() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
+        (
+            prop::collection::vec(1u64..2_000_000, 0..12),
+            prop::collection::vec(1u64..500_000, 1..20),
+        )
+    }
+
+    /// Funding plus available notes that always include one note large enough to fund everything with
+    /// a generous fee budget, so the planner must succeed.
+    fn arb_sufficient() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
+        prop::collection::vec(1u64..500_000, 1..20).prop_flat_map(|funding| {
+            let need: u64 = funding.iter().sum();
+            let big = need + (funding.len() as u64 + 64) * fee_per_tx() + 1;
+            (prop::collection::vec(1u64..100_000, 0..8), Just(funding)).prop_map(
+                move |(mut extra, funding)| {
+                    extra.push(big);
+                    (extra, funding)
+                },
+            )
+        })
+    }
+
+    proptest! {
+        /// Whenever a plan is produced over arbitrary inputs, every structural invariant holds.
+        #[test]
+        fn valid_whenever_planned((available, funding) in arb_input()) {
+            if let Ok(plan) = plan_preparation(&available, &funding, fee_per_tx()) {
+                assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            }
+        }
+
+        /// With one note large enough to fund everything, the planner always succeeds with a valid
+        /// plan (the planner never gives up when the value is amply present).
+        #[test]
+        fn always_plans_when_amply_funded((available, funding) in arb_sufficient()) {
+            let plan = plan_preparation(&available, &funding, fee_per_tx())
+                .expect("ample funding must plan");
+            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            // The leftover is far larger than a fee, so it collapses to a single residual note.
+            prop_assert!(plan.residual_count() <= 1, "{} residual notes", plan.residual_count());
+        }
+    }
+
+    /// One well-funded note mints SEVERAL funding notes in a single preparation transaction: a
+    /// preparation transaction produces one output per scheduled part (up to `FUNDING_OUTPUTS_PER_TX`),
+    /// not one transaction per part (that is the phase-2 transfer). So this is one layer, one
+    /// transaction, with several funding outputs.
+    #[test]
+    fn common_case_is_one_layer_one_tx() {
+        let funding = [500u64, 200, 100, 20, 5];
+        let total: u64 = funding.iter().sum::<u64>() + fee_per_tx() + 10_000;
+        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        assert_eq!(plan.layer_count(), 1);
+        assert_eq!(plan.transaction_count(), 1);
+        assert_eq!(plan.residual_count(), 1, "one residual note");
+        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
+    }
+
+    /// One large note fanning out into more funding notes than a single transaction holds needs more
+    /// than one layer (the remainder feeds forward), yet every transaction stays within budget.
+    #[test]
+    fn whale_single_note_fans_out_across_layers() {
+        let funding: Vec<u64> = (0..40).map(|_| 100u64).collect();
+        let total: u64 = funding.iter().sum::<u64>() + 60 * fee_per_tx();
+        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        assert!(
+            plan.layer_count() >= 2,
+            "40 funding notes cannot fit one tx"
+        );
+        assert_eq!(plan.residual_count(), 1, "one residual note");
+        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
+    }
+
+    /// Dust smaller than a funding note is consolidated into a feeder before it can fund anything, and
+    /// the leftover collapses to a single residual note.
+    #[test]
+    fn dust_is_consolidated_first() {
+        // Twenty notes each far below the single 100-unit funding note (plus fees).
+        let per = fee_per_tx() + 20;
+        let available: Vec<u64> = core::iter::repeat_n(per, 20).collect();
+        let funding = [100u64];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert!(plan.layer_count() >= 2, "dust must consolidate first");
+        assert_eq!(plan.residual_count(), 1, "one residual note");
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+    }
+
+    /// When several notes each strand a sub-fee remainder whose total is below one transaction fee, the
+    /// remainders cannot be consolidated (the output would be negative), so they survive as multiple
+    /// sub-fee residual notes. ZIP 318's "at most one residual note" is only achievable above the fee
+    /// threshold; this documents the unavoidable corner case.
+    #[test]
+    fn sub_fee_remainders_leave_multiple_residuals() {
+        // Three notes, each funding one 100_000 note and stranding a 100-zatoshi remainder; the three
+        // remainders total 300 < fee_per_tx(), so no consolidation can merge them.
+        let f = 100_000u64;
+        let eps = 100u64;
+        let note = f + fee_per_tx() + eps;
+        let available = [note, note, note];
+        let funding = [f, f, f];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let changes = plan.residual_notes();
+        assert!(
+            changes.len() > 1,
+            "expected multiple sub-fee residuals: {changes:?}"
+        );
+        assert!(
+            changes.iter().all(|&v| v < fee_per_tx()),
+            "all residuals sub-fee"
+        );
+        assert!(
+            changes.iter().sum::<u64>() < fee_per_tx(),
+            "total residual sub-fee"
+        );
+    }
+
+    /// Empty funding yields an empty plan; value below the funding-plus-fee floor is insufficient.
+    #[test]
+    fn edge_cases() {
+        assert_eq!(
+            plan_preparation(&[1_000_000], &[], fee_per_tx())
+                .unwrap()
+                .layer_count(),
+            0
+        );
+        assert_eq!(
+            plan_preparation(&[10], &[100], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// The consolidation batching never leaves a lone note and never exceeds the input budget.
+    #[test]
+    fn consolidation_batches_avoid_singletons() {
+        for n in 2..200usize {
+            let sizes = consolidation_batch_sizes(n);
+            assert_eq!(sizes.iter().sum::<usize>(), n);
+            for s in sizes {
+                assert!(
+                    (2..=CONSOLIDATION_INPUTS_PER_TX).contains(&s),
+                    "n={n} size={s}"
+                );
+            }
+        }
+    }
+
+    /// When the total available value is below the funding note plus one transaction fee, no
+    /// arrangement of transactions can fund it, and the planner reports insufficiency rather than
+    /// emitting a broken plan.
+    #[test]
+    fn many_tiny_notes_insufficient() {
+        // 5 x 30_000 = 150_000 available. Funding one 100_000 note costs at least the note plus one
+        // fee: 100_000 + fee_per_tx() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
+        let available = vec![30_000u64; 5];
+        assert_eq!(
+            plan_preparation(&available, &[100_000], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// Dust that cannot fund on its own consolidates in batches of at most `CONSOLIDATION_INPUTS_PER_TX`,
+    /// never a singleton; the first layer's transactions have exactly the shape
+    /// `consolidation_batch_sizes` prescribes.
+    #[test]
+    fn dust_consolidation_batch_shapes() {
+        for n in [15usize, 16, 17, 30] {
+            // Each note is below the 100_000 funding note, so the whole first layer is consolidation.
+            let available = vec![50_000u64; n];
+            let funding = [100_000u64];
+            let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            let mut got: Vec<usize> = plan.layers()[0]
+                .iter()
+                .map(|tx| tx.inputs().len())
+                .collect();
+            got.sort_unstable();
+            let mut want = consolidation_batch_sizes(n);
+            want.sort_unstable();
+            assert_eq!(got, want, "n={n}");
+        }
+    }
+
+    /// A single layer can both split a large note directly into a funding note and consolidate a cloud
+    /// of dust that is needed to fund the rest. (Dust the plan does not need is left untouched, so the
+    /// large note must be too small to fund everything on its own.)
+    #[test]
+    fn mixes_split_and_consolidate_in_one_layer() {
+        let mut available = vec![40_000u64; 10]; // dust: needed to fund the 100_000 note
+        available.push(400_000); // funds the 300_000 note directly, but not also the 100_000 note
+        let funding = [300_000u64, 100_000];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let layer0 = &plan.layers()[0];
+        assert!(
+            layer0.iter().any(|tx| tx.inputs().len() == 1),
+            "a one-input split transaction"
+        );
+        assert!(
+            layer0.iter().any(|tx| tx.inputs().len() > 1),
+            "a multi-input consolidation transaction"
+        );
+    }
+
+    /// Fee-dominated dust (each note only just above the fee) cannot overcome the per-transaction fee to
+    /// reach a funding note, and the planner terminates with insufficient funds rather than looping.
+    #[test]
+    fn fee_dominated_dust_terminates_insufficient() {
+        // Two 90_000 notes: one consolidation nets 100_000, still short of 100_000 + a funding fee.
+        let available = vec![90_000u64; 2];
+        assert_eq!(
+            plan_preparation(&available, &[100_000], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// A single dust note cannot be batched (a lone consolidation only wastes a fee) and cannot fund a
+    /// larger note: insufficient when needed, and left untouched (empty plan) when not.
+    #[test]
+    fn lone_dust_note() {
+        assert_eq!(
+            plan_preparation(&[50_000], &[100_000], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+        assert_eq!(
+            plan_preparation(&[50_000], &[], fee_per_tx())
+                .unwrap()
+                .layer_count(),
+            0
+        );
+    }
+
+    /// A note worth exactly a funding value plus the fee funds it with no leftover, so it leaves no
+    /// residual; a note worth only the fee carries no spendable budget.
+    #[test]
+    fn threshold_notes() {
+        let f = 100_000u64;
+        let exact = f + fee_per_tx();
+        let plan = plan_preparation(&[exact], &[f], fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[exact], &[f], fee_per_tx());
+        assert_eq!(plan.transaction_count(), 1);
+        assert_eq!(plan.residual_count(), 0, "exact funding leaves no residual");
+
+        // A note worth only the fee has zero spendable budget; on its own it cannot fund anything.
+        assert_eq!(
+            plan_preparation(&[fee_per_tx()], &[f], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// Deep consolidation: 300 dust notes consolidate 15:1 per layer (300 -> 20 -> 2), then a funding
+    /// layer, then one residual-collapse layer: exactly four layers, one residual. The count grows only
+    /// logarithmically (base `CONSOLIDATION_INPUTS_PER_TX`) in the dust count.
+    #[test]
+    fn deep_consolidation_layer_count() {
+        let available = vec![50_000u64; 300];
+        let funding = [1_000_000u64];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(
+            plan.layer_count(),
+            4,
+            "300 dust -> 20 -> 2 -> fund -> residual"
+        );
+        assert_eq!(plan.residual_count(), 1);
+    }
+
+    /// A very large dust count still plans in a small, logarithmically-bounded number of layers:
+    /// 3000 -> 200 -> 14 -> 1 feeder, then a funding layer, exactly four layers. This is the "many
+    /// small notes" stress case (termination and performance).
+    #[test]
+    fn thousands_of_dust_notes_layer_count() {
+        let available = vec![50_000u64; 3_000];
+        let funding = [10_000_000u64];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(plan.layer_count(), 4, "3000 dust -> 200 -> 14 -> 1 -> fund");
+    }
+
+    /// A lone large note fanning out into many funding notes is split through a BALANCED tree, so the
+    /// layer count is `split_depth(p)` (logarithmic in `p`), not linear. This is the fan-out-first
+    /// path; the balanced tree uses more transactions than a linear chain in exchange for fewer layers.
+    /// The transitions are at 14 -> 15 (depth 1 -> 2) and 196 -> 197 (depth 2 -> 3).
+    #[test]
+    fn whale_fan_out_layer_counts() {
+        for p in [1usize, 14, 15, 28, 100, 196, 197, 500] {
+            let funding = vec![100u64; p];
+            // The balanced tree costs more than a linear chain; fund exactly that plus a small residual.
+            let whale = subtree_cost(&funding, fee_per_tx()).1 + 9_999;
+            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+            assert_eq!(plan.layer_count(), split_depth(p), "p={p} layers");
+        }
+    }
+
+    proptest! {
+        /// A lone note funding an arbitrary set of notes fans out into a balanced tree of exactly
+        /// `split_depth` layers, and the plan is valid for any values and count.
+        #[test]
+        fn whale_fan_out_is_balanced_and_valid(
+            funding in prop::collection::vec(1u64..10_000_000, 1..300),
+        ) {
+            let whale = subtree_cost(&funding, fee_per_tx()).1 + 12_345;
+            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+            prop_assert_eq!(plan.layer_count(), split_depth(funding.len()));
+        }
+    }
+
+    /// `split_depth` capacity thresholds and `subtree_cost` accounting.
+    #[test]
+    fn split_helpers() {
+        assert_eq!(split_depth(0), 0);
+        assert_eq!(split_depth(1), 1);
+        assert_eq!(split_depth(FUNDING_OUTPUTS_PER_TX), 1);
+        assert_eq!(split_depth(FUNDING_OUTPUTS_PER_TX + 1), 2);
+        assert_eq!(
+            split_depth(FUNDING_OUTPUTS_PER_TX * FUNDING_OUTPUTS_PER_TX),
+            2
+        );
+        assert_eq!(
+            split_depth(FUNDING_OUTPUTS_PER_TX * FUNDING_OUTPUTS_PER_TX + 1),
+            3
+        );
+        // A single leaf: one transaction, value = sum of the funding notes plus one fee.
+        assert_eq!(subtree_cost(&[100, 200], 7), (1, 307));
+    }
+
+    /// A whale worth exactly the balanced-tree cost leaves no residual: every transaction's value goes
+    /// to funding notes and fees, with nothing left over.
+    #[test]
+    fn exact_split_no_residual() {
+        let funding = vec![100u64; 15];
+        let whale = subtree_cost(&funding, fee_per_tx()).1; // exact cost, no leftover
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        assert_eq!(plan.layer_count(), split_depth(15));
+        assert_eq!(plan.residual_count(), 0, "exact split leaves no residual");
+    }
+
+    /// A hundred dust notes both consolidate and then split into thirty funding notes in a bounded
+    /// number of layers, minting every note with at most one residual.
+    #[test]
+    fn many_dust_fund_many_notes() {
+        let available = vec![50_000u64; 100];
+        let funding = vec![100_000u64; 30];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(
+            plan.layer_count(),
+            3,
+            "100 dust consolidate then fund 30 notes"
+        );
+        assert!(plan.residual_count() <= 1);
+    }
+
+    /// No available notes cannot fund anything.
+    #[test]
+    fn empty_available_insufficient() {
+        assert_eq!(
+            plan_preparation(&[], &[100_000], fee_per_tx()),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// Zero-value funding requests are ignored, yielding an empty plan.
+    #[test]
+    fn zero_value_funding_is_empty() {
+        assert_eq!(
+            plan_preparation(&[1_000_000], &[0], fee_per_tx())
+                .unwrap()
+                .layer_count(),
+            0
+        );
+        assert_eq!(
+            plan_preparation(&[1_000_000], &[0, 0], fee_per_tx())
+                .unwrap()
+                .layer_count(),
+            0
+        );
+    }
+
+    /// Repeated funding values (a multiset) are each minted as their own note.
+    #[test]
+    fn duplicate_funding_values() {
+        let funding = [100u64, 100, 100, 100];
+        let whale = 400 + 3 * fee_per_tx();
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        assert_eq!(sorted_funding(&plan), vec![100, 100, 100, 100]);
+    }
+
+    /// The planner is deterministic: identical inputs always produce an identical plan.
+    #[test]
+    fn deterministic() {
+        let available = vec![500_000u64, 300_000, 120_000, 60_000, 9_000];
+        let funding = vec![100_000u64, 50_000, 50_000, 20_000, 5_000];
+        let a = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let b = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// A wallet note worth exactly a funding value IS that funding note: it is used directly, with no
+    /// preparation transaction (re-minting it is impossible anyway, since the fee would leave the
+    /// budget below the funding value).
+    #[test]
+    fn note_equal_to_funding_value_is_used_directly() {
+        let f = 100_000u64;
+        let plan = plan_preparation(&[f], &[f], fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[f], &[f], fee_per_tx());
+        assert_eq!(plan.transaction_count(), 0, "no transaction needed");
+        assert_eq!(plan.direct_funding_notes(), &[(0, f)]);
+        assert_eq!(plan.funding_notes(), vec![f]);
+    }
+
+    /// A wallet holding some notes already equal to funding values uses those directly and mints only
+    /// the rest.
+    #[test]
+    fn exact_matches_are_used_directly_alongside_minting() {
+        let f = 100_000u64;
+        // Note 0 exactly matches a funding value; note 1 (large) mints the other two.
+        let available = vec![f, 10_000_000];
+        let funding = vec![f, 50_000, 20_000];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(
+            plan.direct_funding_notes(),
+            &[(0, f)],
+            "the exact note is used directly"
+        );
+        // Only the remaining two funding notes are minted, from the large note, in one transaction.
+        assert_eq!(plan.transaction_count(), 1);
+        assert_eq!(sorted_funding(&plan), vec![20_000, 50_000, 100_000]);
+    }
+
+    /// When wallet notes already equal every funding value, the plan has no transactions at all: each
+    /// note is used directly.
+    #[test]
+    fn all_exact_matches_need_no_transactions() {
+        let funding = vec![100_000u64, 50_000, 50_000];
+        let available = funding.clone();
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(plan.transaction_count(), 0);
+        assert_eq!(plan.layer_count(), 0);
+        assert_eq!(plan.direct_funding_notes().len(), 3);
+        assert_eq!(sorted_funding(&plan), vec![50_000, 50_000, 100_000]);
+    }
+
+    /// One whale funds funding notes of varied sizes in a single transaction, largest first, with the
+    /// remainder as the residual.
+    #[test]
+    fn varied_funding_from_one_whale() {
+        let funding = [500_000u64, 200_000, 100_000, 20_000, 5_000, 2_000];
+        let whale = funding.iter().sum::<u64>() + fee_per_tx() + 12_345;
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        assert_eq!(plan.layer_count(), 1);
+        assert_eq!(plan.transaction_count(), 1);
+    }
+
+    /// Many wallet notes, each exactly funding one note, are spent in parallel in a single layer (one
+    /// transaction per note) with no chaining, and the single-spend invariant holds across all of them.
+    #[test]
+    fn parallel_funding_across_notes() {
+        let f = 100_000u64;
+        let n = 20usize;
+        let available = vec![f + fee_per_tx(); n]; // each note funds exactly one f note
+        let funding = vec![f; n];
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_eq!(plan.layer_count(), 1, "independent notes fund in one layer");
+        assert_eq!(plan.transaction_count(), n, "one transaction per note");
+        assert_eq!(
+            plan.residual_count(),
+            0,
+            "each note funds exactly, no residual"
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #2645. This is the migration's transaction-construction layer, consolidated into one PR: it plans the note-preparation transactions, builds them (and the value-crossing transfer) as unproven PCZTs, and pre-signs them.

This PR supersedes the earlier three-way split (this branch plus #2656 and #2658, now folded in and closed). The obsolete single-transaction note-split builder `build_split_pczt` has been dropped in favour of the ZIP-318-compliant 16-action preparation pipeline below.

## What it adds (three commits: plan -> build -> sign)

### 1. Note-split preparation planning (the `preparation` module, pure, `no_std`)

`plan_preparation` partitions the work of minting a note-split plan's self-funding notes into note-preparation transactions of exactly `PREP_TX_ACTIONS` (16) Orchard actions (ZIP 318), organised into the fewest sequential layers with parallel transactions inside a layer. It returns a `PreparationPlan` of `PrepTransaction`s (each a same-pool send-to-self referencing wallet notes or earlier layers' outputs). A largest-first greedy feeds each output transaction from the largest note, routes every leftover forward as a feeder, and consolidates dust; once the funding notes are scheduled it consolidates the leftover feeders toward a single residual note (ZIP 318's "one note per part plus at most one residual note").

The single residual is only reachable above the fee threshold: because a note is spent atomically, several spends can each strand a sub-fee remainder whose total is below one transaction fee, and those cannot be merged (the consolidation output would be negative), so the planner guarantees at most one residual worth a fee. Property tests assert this invariant alongside value conservation, the 16-action budget, "each funding note minted once", and the ZIP-318 lower bound on the transaction count. Pure (no cryptography or I/O).

### 2. The PCZT builders and pre-signing (the `build` module, behind the `orchard` feature)

- `build_prep_tx` builds one `PrepTransaction` into a same-pool Orchard send-to-self; every output is a wallet-controlled internal change note, and the bundle is built with `pad_to_minimum` set to 16, so orchard fills it to exactly 16 actions with fabricated dummies (no preparation transaction is distinguishable by its action count).
- `build_transfer_pczt` builds a value-crossing transfer, spending one self-funding note and outputting its crossing value to the account's own internal Ironwood change address (a ZIP 318 MUST).
- `sign_pczt` adds the Orchard spend-authorization signatures up front, signing a finalized but still unproven PCZT (the sighash is fixed independent of the zk proofs), so the migration signs early and proves later at scheduling time.

The shared transaction-builder plumbing (build config, PCZT finalization, action-index mapping) lives in the module root. Each builder is pure (no database or wallet-backend access) and takes the RNG as a parameter. Adds optional `orchard` and `pczt` dependencies, enabled only by the feature.

## Notes for reviewers

- The crate is `no_std`; the `build` module is feature-gated on `orchard`.
- Residual semantics: ZIP 318's "at most one residual note" is only achievable above the fee threshold. When several spends each strand a sub-fee remainder whose total is below one transaction fee, those cannot be consolidated (the output would be negative) and remain as multiple sub-fee dust notes; the planner guarantees at most one residual worth a fee. Worth confirming with the ZIP authors whether "at most one residual" is meant strictly or as "at most one residual worth a fee".
- Padding to exactly 16 actions uses orchard 0.15.0's `BundleType::Transactional { pad_to_minimum }` (already resolved by the workspace), so no dependency change.
- Known test gap (tracked): a multi-spend consolidation-shaped `build_prep_tx` needs a multi-note shared-anchor witness helper; the single-spend paths are covered.
- The transfer's fee/action-count (currently 4 actions = 20,000 zatoshi; ZIP 318 allows leaving the Ironwood bundle unpadded, i.e. 3 actions = 15,000) is a follow-up reconciliation item.

## Tests

Proptest suites for the preparation planner (value conservation, <= 16 actions per transaction, each funding note minted once, at most one residual, acyclic layers) and each builder (exactly-16-action bundles, balanced transfers, pre-signing authorizes only the account's own spend), plus golden cases.

## Verification

- `cargo test -p zcash_pool_migration_backend` and `--features orchard`
- `cargo clippy -p zcash_pool_migration_backend --all-targets` and `--features orchard --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p zcash_pool_migration_backend --no-deps`
- `cargo fmt --check`
