### PR TITLE
Add Ironwood historical note selection

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,8 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `WalletDb::get_unspent_ironwood_notes_at_historical_height` returns all Ironwood
+  notes that existed and were unspent at a given height.
 - `WalletDb::transactionally_with_extension` performs wallet operations and writes to
   application-owned extension tables (created via
   `WalletMigrator::with_external_migrations`) atomically within a single database

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -3074,25 +3074,14 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
         )
     }
 
-    /// Returns all Ironwood notes received at or before `height`
-    /// and unspent as of that height, for the given account.
+    /// Returns every Ironwood note received by `height` that was unspent at that height.
     ///
-    /// Unlike [`InputSource::select_unspent_notes`] (which applies confirmation,
-    /// dust, and expiry filters for transaction construction), this returns every
-    /// note that existed and was unspent at the given height.
-    ///
-    /// This function does not verify that a Merkle witness can be constructed
-    /// for each returned note at `height`. Witness construction is a separate
-    /// concern intended to be handled by the caller. The companion
-    /// [`Self::generate_ironwood_witnesses_at_historical_height`] method returns an
-    /// actionable error for any position the wallet cannot witness at `height`
-    /// (for example, because the wallet has not synced through `height`, the
-    /// checkpoint was pruned, or the position does not belong to the wallet).
+    /// This does not apply transaction construction filters or check witness availability.
+    /// Use [`Self::generate_ironwood_witnesses_at_historical_height`] to check the latter.
     ///
     /// # Errors
     ///
-    /// Returns an error if the database query fails or a selected note cannot be
-    /// reconstructed from the stored data.
+    /// Returns an error if the query fails or a note cannot be reconstructed.
     pub fn get_unspent_ironwood_notes_at_historical_height(
         &self,
         account: AccountUuid,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -3074,6 +3074,38 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<
         )
     }
 
+    /// Returns all Ironwood notes received at or before `height`
+    /// and unspent as of that height, for the given account.
+    ///
+    /// Unlike [`InputSource::select_unspent_notes`] (which applies confirmation,
+    /// dust, and expiry filters for transaction construction), this returns every
+    /// note that existed and was unspent at the given height.
+    ///
+    /// This function does not verify that a Merkle witness can be constructed
+    /// for each returned note at `height`. Witness construction is a separate
+    /// concern intended to be handled by the caller. The companion
+    /// [`Self::generate_ironwood_witnesses_at_historical_height`] method returns an
+    /// actionable error for any position the wallet cannot witness at `height`
+    /// (for example, because the wallet has not synced through `height`, the
+    /// checkpoint was pruned, or the position does not belong to the wallet).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails or a selected note cannot be
+    /// reconstructed from the stored data.
+    pub fn get_unspent_ironwood_notes_at_historical_height(
+        &self,
+        account: AccountUuid,
+        height: BlockHeight,
+    ) -> Result<Vec<ReceivedNote<ReceivedNoteId, orchard::note::Note>>, SqliteClientError> {
+        wallet::orchard::get_unspent_ironwood_notes_at_historical_height(
+            self.conn.borrow(),
+            &self.params,
+            account,
+            height,
+        )
+    }
+
     /// Generates Orchard Merkle witnesses at a historical height.
     ///
     /// Loads the wallet's Orchard shard data into an ephemeral in-memory

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -2,6 +2,7 @@ use std::{collections::HashSet, rc::Rc};
 
 use incrementalmerkletree::Position;
 use orchard::{
+    ValuePool,
     keys::Diversifier,
     note::{Note, NoteVersion, Nullifier, RandomSeed, Rho},
 };
@@ -229,35 +230,64 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     )
 }
 
-/// Return all Orchard notes that were received at or before `height`
-/// and unspent as of `height`, for the given account.
-///
-/// Unlike `select_spendable_notes` (which applies confirmation, dust, and
-/// expiry filters for transaction construction), this returns every note
-/// that existed and was unspent at the given height.
-///
-/// Height filtering uses `transactions.mined_height`, not `transactions.block`.
-/// A transaction is considered to have occurred at its mined height as soon
-/// as the wallet learns of that height (for example, from transparent UTXO
-/// retrieval), even if the containing compact block has not been fully
-/// scanned. In practice the two columns are equivalent for the notes this
-/// query can return, because `nf IS NOT NULL` and
-/// `commitment_tree_position IS NOT NULL` already require a scan of the
-/// block that contains the receiving transaction.
-///
-/// This function does not verify that a Merkle witness can be constructed
-/// for each returned note at `height`. Witness construction is a separate
-/// concern intended to be handled by the callers. As an example, a companion
-/// `WalletDb::generate_orchard_witnesses_at_historical_height` returns an
-/// actionable error for any position the wallet cannot witness at `height`
-/// (for example, because the wallet has not synced through `height`, the checkpoint was pruned,
-/// or the position does not belong to the wallet).
 pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
     account: AccountUuid,
     height: BlockHeight,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    get_unspent_orchard_shaped_notes_at_historical_height(
+        conn,
+        params,
+        ValuePool::Orchard,
+        account,
+        height,
+    )
+}
+
+pub(crate) fn get_unspent_ironwood_notes_at_historical_height<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    height: BlockHeight,
+) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    get_unspent_orchard_shaped_notes_at_historical_height(
+        conn,
+        params,
+        ValuePool::Ironwood,
+        account,
+        height,
+    )
+}
+
+/// Returns all notes from the selected Orchard-shaped pool that were received at or before
+/// `height` and unspent as of `height`, for the given account.
+///
+/// Unlike `select_spendable_notes` (which applies confirmation, dust, and expiry filters for
+/// transaction construction), this returns every note that existed and was unspent at the given
+/// height.
+///
+/// Height filtering uses `transactions.mined_height`, not `transactions.block`. A transaction is
+/// considered to have occurred at its mined height as soon as the wallet learns of that height
+/// (for example, from transparent UTXO retrieval), even if the containing compact block has not
+/// been fully scanned. In practice the two columns are equivalent for the notes this query can
+/// return, because `nf IS NOT NULL` and `commitment_tree_position IS NOT NULL` already require a
+/// scan of the block that contains the receiving transaction.
+///
+/// This function does not verify that a Merkle witness can be constructed for each returned note
+/// at `height`. Witness construction is a separate concern intended to be handled by the caller.
+fn get_unspent_orchard_shaped_notes_at_historical_height<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    pool: ValuePool,
+    account: AccountUuid,
+    height: BlockHeight,
+) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    let shielded_pool = match pool {
+        ValuePool::Orchard => ShieldedPool::Orchard,
+        ValuePool::Ironwood => ShieldedPool::Ironwood,
+    };
+    let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(shielded_pool)?;
     let external_scope = KeyScope::EXTERNAL.encode();
     let internal_scope = KeyScope::INTERNAL.encode();
 
@@ -269,7 +299,7 @@ pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Param
              accounts.ufvk AS ufvk, rn.recipient_key_scope,
              t.mined_height,
              NULL AS max_shielding_input_height
-         FROM orchard_received_notes rn
+         FROM {table_prefix}_received_notes rn
          INNER JOIN accounts ON accounts.id = rn.account_id
          INNER JOIN transactions t ON t.id_tx = rn.transaction_id
          WHERE accounts.uuid = :account_uuid
@@ -279,8 +309,8 @@ pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Param
            AND rn.recipient_key_scope IN ({external_scope}, {internal_scope})
            AND accounts.ufvk IS NOT NULL
            AND rn.id NOT IN (
-               SELECT rns.orchard_received_note_id
-               FROM orchard_received_note_spends rns
+               SELECT rns.{table_prefix}_received_note_id
+               FROM {table_prefix}_received_note_spends rns
                JOIN transactions t_spend ON t_spend.id_tx = rns.transaction_id
                WHERE t_spend.mined_height <= :height
            )
@@ -292,7 +322,7 @@ pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Param
             ":account_uuid": account.0,
             ":height": u32::from(height),
         ],
-        |row| to_received_note(params, ShieldedPool::Orchard, row),
+        |row| to_received_note(params, shielded_pool, row),
     )?;
 
     rows.filter_map(|r| r.transpose()).collect()
@@ -1528,6 +1558,108 @@ pub(crate) mod tests {
             .sum::<Option<Zatoshis>>()
             .unwrap();
         assert_eq!(total, ((value - spend_value).unwrap() + value3).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn get_unspent_ironwood_notes_at_historical_height_boundary_heights() {
+        use orchard::note::NoteVersion;
+        use zcash_client_backend::data_api::{
+            Account,
+            testing::{
+                AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
+                pool::ShieldedPoolTester,
+            },
+        };
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{
+            ShieldedPool, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
+        };
+
+        use crate::testing::{BlockCache, db::TestDbFactory};
+
+        let activation = BlockHeight::from_u32(100_000);
+        let network = LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        };
+
+        let mut st = TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let dfvk = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
+
+        // Receive an Ironwood note at h1.
+        let value = Zatoshis::const_from_u64(50000);
+        let (h1, _, nf) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        assert_eq!(h1, activation);
+        st.scan_cached_blocks(h1, 1);
+
+        // Spend that note at h2, producing Ironwood change back to the account.
+        let not_our_key = SaplingPoolTester::sk_to_fvk(&SaplingPoolTester::sk(&[0xf5; 32]));
+        let to = SaplingPoolTester::fvk_default_address(&not_our_key);
+        let spend_value = Zatoshis::const_from_u64(20000);
+        let (h2, _) = st.generate_next_block_spending(&dfvk, (nf, value), to, spend_value);
+        st.scan_cached_blocks(h2, 1);
+
+        // Receive another Ironwood note at h3.
+        let value3 = Zatoshis::const_from_u64(70000);
+        let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value3);
+        st.scan_cached_blocks(h3, 1);
+
+        let db = st.wallet().db();
+
+        let notes = db
+            .get_unspent_ironwood_notes_at_historical_height(account.id(), h1 - 1)
+            .unwrap();
+        assert!(notes.is_empty());
+
+        let notes = db
+            .get_unspent_ironwood_notes_at_historical_height(account.id(), h1)
+            .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].note_value().unwrap(), value);
+        assert_eq!(notes[0].internal_note_id().0, ShieldedPool::Ironwood);
+        assert_eq!(notes[0].note().version(), NoteVersion::V3);
+
+        let notes = db
+            .get_unspent_ironwood_notes_at_historical_height(account.id(), h2)
+            .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(
+            notes[0].note_value().unwrap(),
+            (value - spend_value).unwrap()
+        );
+
+        let notes = db
+            .get_unspent_ironwood_notes_at_historical_height(account.id(), h3)
+            .unwrap();
+        assert_eq!(notes.len(), 2);
+        let total: Zatoshis = notes
+            .iter()
+            .map(|n| n.note_value().unwrap())
+            .sum::<Option<Zatoshis>>()
+            .unwrap();
+        assert_eq!(total, ((value - spend_value).unwrap() + value3).unwrap());
+        assert!(notes.iter().all(|note| {
+            note.internal_note_id().0 == ShieldedPool::Ironwood
+                && note.note().version() == NoteVersion::V3
+        }));
+
+        // The same account has no notes in the distinct Orchard pool.
+        assert!(
+            db.get_unspent_orchard_notes_at_historical_height(account.id(), h3)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// Property tests for the Orchard-turnstile behavior of input selection and transaction

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -230,6 +230,29 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     )
 }
 
+/// Return all Orchard notes that were received at or before `height`
+/// and unspent as of `height`, for the given account.
+///
+/// Unlike `select_spendable_notes` (which applies confirmation, dust, and
+/// expiry filters for transaction construction), this returns every note
+/// that existed and was unspent at the given height.
+///
+/// Height filtering uses `transactions.mined_height`, not `transactions.block`.
+/// A transaction is considered to have occurred at its mined height as soon
+/// as the wallet learns of that height (for example, from transparent UTXO
+/// retrieval), even if the containing compact block has not been fully
+/// scanned. In practice the two columns are equivalent for the notes this
+/// query can return, because `nf IS NOT NULL` and
+/// `commitment_tree_position IS NOT NULL` already require a scan of the
+/// block that contains the receiving transaction.
+///
+/// This function does not verify that a Merkle witness can be constructed
+/// for each returned note at `height`. Witness construction is a separate
+/// concern intended to be handled by the callers. As an example, a companion
+/// `WalletDb::generate_orchard_witnesses_at_historical_height` returns an
+/// actionable error for any position the wallet cannot witness at `height`
+/// (for example, because the wallet has not synced through `height`, the checkpoint was pruned,
+/// or the position does not belong to the wallet).
 pub(crate) fn get_unspent_orchard_notes_at_historical_height<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -260,22 +283,6 @@ pub(crate) fn get_unspent_ironwood_notes_at_historical_height<P: consensus::Para
     )
 }
 
-/// Returns all notes from the selected Orchard-shaped pool that were received at or before
-/// `height` and unspent as of `height`, for the given account.
-///
-/// Unlike `select_spendable_notes` (which applies confirmation, dust, and expiry filters for
-/// transaction construction), this returns every note that existed and was unspent at the given
-/// height.
-///
-/// Height filtering uses `transactions.mined_height`, not `transactions.block`. A transaction is
-/// considered to have occurred at its mined height as soon as the wallet learns of that height
-/// (for example, from transparent UTXO retrieval), even if the containing compact block has not
-/// been fully scanned. In practice the two columns are equivalent for the notes this query can
-/// return, because `nf IS NOT NULL` and `commitment_tree_position IS NOT NULL` already require a
-/// scan of the block that contains the receiving transaction.
-///
-/// This function does not verify that a Merkle witness can be constructed for each returned note
-/// at `height`. Witness construction is a separate concern intended to be handled by the caller.
 fn get_unspent_orchard_shaped_notes_at_historical_height<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -1597,20 +1604,18 @@ pub(crate) mod tests {
         let account = st.test_account().cloned().unwrap();
         let dfvk = IronwoodFvk(OrchardPoolTester::test_account_fvk(&st));
 
-        // Receive an Ironwood note at h1.
         let value = Zatoshis::const_from_u64(50000);
         let (h1, _, nf) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         assert_eq!(h1, activation);
         st.scan_cached_blocks(h1, 1);
 
-        // Spend that note at h2, producing Ironwood change back to the account.
+        // Use Sapling so the only wallet-owned output is Ironwood change.
         let not_our_key = SaplingPoolTester::sk_to_fvk(&SaplingPoolTester::sk(&[0xf5; 32]));
         let to = SaplingPoolTester::fvk_default_address(&not_our_key);
         let spend_value = Zatoshis::const_from_u64(20000);
         let (h2, _) = st.generate_next_block_spending(&dfvk, (nf, value), to, spend_value);
         st.scan_cached_blocks(h2, 1);
 
-        // Receive another Ironwood note at h3.
         let value3 = Zatoshis::const_from_u64(70000);
         let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value3);
         st.scan_cached_blocks(h3, 1);
@@ -1654,7 +1659,6 @@ pub(crate) mod tests {
                 && note.note().version() == NoteVersion::V3
         }));
 
-        // The same account has no notes in the distinct Orchard pool.
         assert!(
             db.get_unspent_orchard_notes_at_historical_height(account.id(), h3)
                 .unwrap()


### PR DESCRIPTION
Adds `WalletDb::get_unspent_ironwood_notes_at_historical_height` so callers can retrieve Ironwood notes that existed and were unspent at a requested height. The Orchard and Ironwood selectors share one query implementation while preserving their separate tables and pool identities.
