### PR TITLE
zcash_ironwood_migration_backend: add pure PCZT transfer builder

### DIFF
--- a/zcash_ironwood_migration_backend/CHANGELOG.md
+++ b/zcash_ironwood_migration_backend/CHANGELOG.md
@@ -38,7 +38,14 @@ and this library adheres to Rust's notion of
   mapping each output to its real Orchard action index. It is pure (no database or wallet-backend
   access) and takes the RNG as a parameter. `finalize_split_outputs` keeps each migration note at its
   exact planned value and reconciles the real ZIP-317 fee against the plan by adding a plain change
-  output (or, for a sub-action-fee leftover, folding it into the fee). Only the note split (Phase 1)
-  is built here; the value crossing is left for later, and the shared transaction-builder plumbing is
-  factored so that phase can reuse it. Adds optional `orchard` and `pczt` dependencies, enabled only
-  by the feature.
+  output (or, for a sub-action-fee leftover, folding it into the fee). The shared transaction-builder
+  plumbing (build config, PCZT finalization, action-index mapping, fees) is factored into the module
+  root so the transfer builder reuses it. Adds optional `orchard` and `pczt` dependencies, enabled
+  only by the feature.
+- The pure PCZT transfer builder (`build::build_transfer_pczt`, behind the `orchard` feature): spends
+  one self-funding note the split minted and outputs its crossing value into the Ironwood pool as an
+  unproven `pczt::Pczt`. It has no change output; the note's fee buffer funds the transfer's fee
+  exactly (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the
+  transfer is four logical actions, matching the buffer of `2 source + 2 destination` actions). It
+  runs post-NU6.3 (when the Ironwood pool is live), and like the split builder is pure (no database
+  or wallet-backend access) and takes the RNG as a parameter.

--- a/zcash_ironwood_migration_backend/src/build.rs
+++ b/zcash_ironwood_migration_backend/src/build.rs
@@ -23,7 +23,9 @@ use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::consensus::Parameters;
 
 mod split;
+mod transfer;
 pub use split::{SplitOutputs, build_split_pczt, build_split_pczt_for_plan};
+pub use transfer::build_transfer_pczt;
 
 /// An error building a migration PCZT.
 #[derive(Debug)]
@@ -86,4 +88,74 @@ pub(crate) fn output_action_index(
     meta.output_action_index(output)
         .map(|i| i as u32)
         .ok_or_else(|| BuildError::Build(format!("no action index for output {output}")))
+}
+
+/// Test helpers shared by the split and transfer builders: a deterministic account, regtest network
+/// params, and a single-leaf Orchard witness. Kept here so both submodules' tests reuse them.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use incrementalmerkletree::{Hashable, Level};
+    use orchard::Anchor;
+    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
+    use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
+    use orchard::tree::{MerkleHashOrchard, MerklePath};
+    use orchard::value::NoteValue;
+    use zcash_protocol::consensus::BlockHeight;
+    use zcash_protocol::local_consensus::LocalNetwork;
+
+    /// An account's Orchard full viewing key, deterministic across the tests.
+    pub(crate) fn account() -> FullViewingKey {
+        let sk = SpendingKey::from_bytes([7u8; 32]).unwrap();
+        FullViewingKey::from(&sk)
+    }
+
+    /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
+    /// The migration builds on a network where NU6.3 (the Ironwood pool) is live.
+    pub(crate) fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
+        let nu6_3 = if nu6_3_active {
+            Some(BlockHeight::from_u32(10))
+        } else {
+            None
+        };
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(2)),
+            blossom: Some(BlockHeight::from_u32(3)),
+            heartwood: Some(BlockHeight::from_u32(4)),
+            canopy: Some(BlockHeight::from_u32(5)),
+            nu5: Some(BlockHeight::from_u32(6)),
+            nu6: Some(BlockHeight::from_u32(7)),
+            nu6_1: Some(BlockHeight::from_u32(8)),
+            nu6_2: Some(BlockHeight::from_u32(9)),
+            nu6_3,
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: None,
+        }
+    }
+
+    /// An Orchard note owned by `fvk`, with a valid witness placing it as the sole leaf of an
+    /// otherwise-empty note-commitment tree, and the matching anchor. The authentication path uses
+    /// the empty-subtree roots for a single leaf at position 0, so `add_orchard_spend`'s anchor
+    /// check (`path.root(cmx) == anchor`) accepts it.
+    pub(crate) fn single_note_witness(
+        fvk: &FullViewingKey,
+        value: u64,
+    ) -> (Note, MerklePath, Anchor) {
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let note_value = NoteValue::from_raw(value);
+        let rho = Rho::from_bytes(&[1u8; 32]).unwrap();
+        let rseed = RandomSeed::from_bytes([2u8; 32], &rho).unwrap();
+        let note = Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2).unwrap();
+
+        let commitment = note.commitment();
+        let cmx = ExtractedNoteCommitment::from(commitment);
+        let auth_path = core::array::from_fn(|level| {
+            let level = Level::from(level as u8);
+            MerkleHashOrchard::empty_root(level)
+        });
+        let position = 0;
+        let path = MerklePath::from_parts(position, auth_path);
+        let anchor = path.root(cmx);
+        (note, path, anchor)
+    }
 }

--- a/zcash_ironwood_migration_backend/src/build/split.rs
+++ b/zcash_ironwood_migration_backend/src/build/split.rs
@@ -239,10 +239,10 @@ mod tests {
     use proptest::prelude::*;
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
-    use zcash_protocol::consensus::BlockHeight;
     use zcash_protocol::local_consensus::LocalNetwork;
     use zcash_protocol::value::COIN;
 
+    use crate::build::test_util::{account, regtest_network, single_note_witness};
     use crate::note_splitting::{
         CanonicalOneTwoFive, CanonicalPowerOfTen, DenominationStrategy, NoteSplitPlan,
         RESIDUAL_MIGRATION_MIN_ZATOSHI, RandomizedOneTwoFive,
@@ -352,72 +352,6 @@ mod tests {
         let result = build_split_pczt(&params, target_height, &fvk, anchor, spends, &outputs, rng);
         let err = result.unwrap_err();
         assert!(matches!(err, BuildError::Balance(_)));
-    }
-
-    /// An account's Orchard full viewing key, deterministic across the tests.
-    fn account() -> FullViewingKey {
-        let sk = orchard::keys::SpendingKey::from_bytes([7u8; 32]).unwrap();
-        FullViewingKey::from(&sk)
-    }
-
-    /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
-    /// The migration must build on a network where NU6.3 (the Ironwood pool) is live, so the tests
-    /// exercise both.
-    fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
-        let nu6_3 = if nu6_3_active {
-            Some(BlockHeight::from_u32(10))
-        } else {
-            None
-        };
-        LocalNetwork {
-            overwinter: Some(BlockHeight::from_u32(1)),
-            sapling: Some(BlockHeight::from_u32(2)),
-            blossom: Some(BlockHeight::from_u32(3)),
-            heartwood: Some(BlockHeight::from_u32(4)),
-            canopy: Some(BlockHeight::from_u32(5)),
-            nu5: Some(BlockHeight::from_u32(6)),
-            nu6: Some(BlockHeight::from_u32(7)),
-            nu6_1: Some(BlockHeight::from_u32(8)),
-            nu6_2: Some(BlockHeight::from_u32(9)),
-            nu6_3,
-            #[cfg(zcash_unstable = "nu7")]
-            nu7: None,
-        }
-    }
-
-    /// An Orchard note owned by `fvk`, with a valid witness placing it as the sole leaf of an
-    /// otherwise-empty note-commitment tree, and the matching anchor. The authentication path uses
-    /// the empty-subtree roots for a single leaf at position 0, so `add_orchard_spend`'s anchor
-    /// check (`path.root(cmx) == anchor`) accepts it.
-    fn single_note_witness(
-        fvk: &FullViewingKey,
-        value: u64,
-    ) -> (
-        orchard::note::Note,
-        orchard::tree::MerklePath,
-        orchard::Anchor,
-    ) {
-        use incrementalmerkletree::{Hashable, Level};
-        use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
-        use orchard::tree::{MerkleHashOrchard, MerklePath};
-        use orchard::value::NoteValue;
-
-        let recipient = fvk.address_at(0u32, Scope::External);
-        let note_value = NoteValue::from_raw(value);
-        let rho = Rho::from_bytes(&[1u8; 32]).unwrap();
-        let rseed = RandomSeed::from_bytes([2u8; 32], &rho).unwrap();
-        let note = Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2).unwrap();
-
-        let commitment = note.commitment();
-        let cmx = ExtractedNoteCommitment::from(commitment);
-        let auth_path = core::array::from_fn(|level| {
-            let level = Level::from(level as u8);
-            MerkleHashOrchard::empty_root(level)
-        });
-        let position = 0;
-        let path = MerklePath::from_parts(position, auth_path);
-        let anchor = path.root(cmx);
-        (note, path, anchor)
     }
 
     /// Plans a note split with one of the three note-splitting strategies (index `0..3`), the same

--- a/zcash_ironwood_migration_backend/src/build/transfer.rs
+++ b/zcash_ironwood_migration_backend/src/build/transfer.rs
@@ -1,0 +1,136 @@
+//! Building a migration transfer transaction: spending one self-funding note and crossing its value
+//! into the Ironwood pool.
+//!
+//! [`build_transfer_pczt`] spends a single self-funding note (one the note split minted, worth its
+//! crossing value plus a fee buffer) and outputs that crossing value into the destination Ironwood
+//! pool. It has no change output: the self-funding note's buffer funds the transfer's fee exactly
+//! (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the transfer is
+//! four logical actions, matching the buffer of `2 source + 2 destination` actions). The transfer
+//! only exists post-NU6.3, when the Ironwood pool is live.
+
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, RngCore};
+
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_primitives::transaction::builder::Builder;
+use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::value::Zatoshis;
+
+use super::{BuildError, build_config, finalize_pczt};
+
+/// Build a migration transfer as an unproven PCZT: spend the supplied self-funding `note` and output
+/// its `crossing_value` into the Ironwood pool (which is output-only here, so it is anchored against
+/// the empty tree). The transfer's fee is funded entirely by the note's buffer, so there is no change
+/// output; a build that balances proves the buffer matches the fee.
+///
+/// The ingredients (which the wallet backend resolves) are: the Orchard `anchor` and the note's
+/// `merkle_path`; the `note` itself (a self-funding note the split minted, worth
+/// `crossing_value` plus the fee buffer); the `orchard_fvk` (authorizes the spend and derives the
+/// output viewing key); and the destination-pool `recipient` (the account's own Ironwood receiver).
+/// `target_height` and `expiry_height` bound the transaction. It mirrors the note split's
+/// [`crossing_values`](crate::note_splitting::NoteSplitPlan::crossing_values): one transfer per
+/// self-funding note.
+///
+/// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
+/// pass a seeded one), keeping this builder pure.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Build`] if the builder or PCZT pipeline fails (including when the note's
+/// buffer does not cover the transfer fee, which unbalances the transaction).
+#[allow(clippy::too_many_arguments)]
+pub fn build_transfer_pczt<P, R>(
+    params: &P,
+    target_height: u32,
+    expiry_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    note: orchard::note::Note,
+    merkle_path: orchard::tree::MerklePath,
+    recipient: orchard::Address,
+    crossing_value: u64,
+    rng: R,
+) -> Result<pczt::Pczt, BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    let target = BlockHeight::from_u32(target_height);
+    let expiry = BlockHeight::from_u32(expiry_height);
+    // The Ironwood bundle is output-only (no spend to anchor against); the empty tree is the
+    // output-only anchor convention.
+    let config = build_config(anchor, Some(orchard::Anchor::empty_tree()));
+    let mut builder = Builder::new(params.clone(), target, config).with_expiry_height(expiry);
+
+    builder
+        .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
+        .map_err(|e| BuildError::Build(format!("transfer: add spend: {e:?}")))?;
+
+    let external_ovk = orchard_fvk.to_ovk(Scope::External);
+    let crossing = Zatoshis::const_from_u64(crossing_value);
+    let memo = MemoBytes::empty();
+    builder
+        .add_ironwood_output::<Infallible>(Some(external_ovk), recipient, crossing, memo)
+        .map_err(|e| BuildError::Build(format!("transfer: add ironwood output: {e:?}")))?;
+
+    let build_result = builder
+        .build_for_pczt(rng, &Zip317FeeRule::standard())
+        .map_err(|e| BuildError::Build(format!("transfer: build: {e:?}")))?;
+
+    finalize_pczt(build_result.pczt_parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::test_util::{account, regtest_network, single_note_witness};
+    use crate::note_splitting::{FeePolicy, RESIDUAL_MIGRATION_MIN_ZATOSHI, Zip317FeePolicy};
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// Every self-funding note the split can mint (a crossing value plus the fee buffer, from
+        /// sub-ZEC up) builds into a balanced transfer post-NU6.3. A build that succeeds proves the
+        /// buffer funds the transfer fee exactly, since the transfer has no change output.
+        #[test]
+        fn self_funding_notes_build_balanced_transfers(
+            crossing_value in RESIDUAL_MIGRATION_MIN_ZATOSHI..=(1_000 * COIN),
+        ) {
+            let fvk = account();
+            let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+            let note_value = crossing_value + buffer;
+            let (note, path, anchor) = single_note_witness(&fvk, note_value);
+            let recipient = fvk.address_at(0u32, Scope::External);
+
+            let params = regtest_network(true);
+            let target_height = 100;
+            let expiry_height = 140;
+            let rng = ChaCha8Rng::seed_from_u64(crossing_value);
+            let result = build_transfer_pczt(
+                &params,
+                target_height,
+                expiry_height,
+                &fvk,
+                anchor,
+                note,
+                path,
+                recipient,
+                crossing_value,
+                rng,
+            );
+
+            let pczt = result.expect("a self-funding note should build a balanced transfer");
+            let orchard_bundle = pczt.orchard();
+            let actions = orchard_bundle.actions();
+            prop_assert!(!actions.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #2647 (the note-split builder). Adds the second migration transaction: the **transfer** that crosses a self-funding note's value into the Ironwood pool.

## What

`build::build_transfer_pczt` spends one self-funding note the split minted and outputs its `crossing_value` into the Ironwood pool as an unproven `pczt::Pczt`. It mirrors the split builder: pure (no DB/wallet access), RNG injected, reusing the shared `build_config`/`finalize_pczt` plumbing. One transfer per self-funding note (consuming the plan's `crossing_values`, the counterpart to the split consuming `migration_outputs`).

## The fee invariant (now tested, not assumed)

The transfer has **no change output** - the self-funding note's fee buffer funds the fee exactly. The Orchard spend and the Ironwood output each pad to the two-action minimum, so the transfer is **four logical actions = `4 x MARGINAL` = the buffer** (`2 source + 2 destination` actions). This was the fragile coupling I flagged when we discussed Phase 2; a proptest over crossing values (sub-ZEC upward, post-NU6.3) now asserts every self-funding note builds a balanced transfer, turning the assumption into a checked invariant.

## Post-NU6.3

The transfer only exists post-NU6.3 (when Ironwood is live); the test builds against regtest params with NU6.3 active.

## Testing

A proptest (`self_funding_notes_build_balanced_transfers`) over crossing values from the dust floor up. The single-leaf witness and regtest-network helpers move to a shared `build::test_util` so both the split and transfer tests reuse them. 25 tests pass under `--features orchard`; fmt/clippy/`doc -D warnings` clean.

With this, the builder side of the migration is complete (plan -> split -> transfer); proving/signing/broadcast and the wallet ingredient-fetching remain (engine/zallet).