### PR TITLE
zcash_client_backend: accept expiry_height in create_proposed_transactions

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,8 @@ workspace.
 ### Added
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+
+### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
   takes an `expiry_height: Option<BlockHeight>` parameter, mirroring the
   one already accepted by `create_pczt_from_proposal`. This lets callers
@@ -20,8 +22,6 @@ workspace.
   construction too — useful when a caller's view of the chain tip used to
   derive `min_target_height` may lag the real tip by more than the default
   expiry buffer covers.
-
-### Changed
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
   `orchard::builder::BundleType` and `orchard::bundle::BundleVersion` that the
   transaction builder will be configured with, and returns a `Result`. It

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,13 @@ workspace.
 ### Added
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+- `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
+  takes an `expiry_height: Option<BlockHeight>` parameter, mirroring the
+  one already accepted by `create_pczt_from_proposal`. This lets callers
+  override the builder-derived expiry height for non-PCZT transaction
+  construction too — useful when a caller's view of the chain tip used to
+  derive `min_target_height` may lag the real tip by more than the default
+  expiry buffer covers.
 
 ### Changed
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -104,9 +104,8 @@ pub enum Error<DataSourceError, CommitmentTreeError, SelectionError, FeeError, C
     #[cfg(feature = "transparent-inputs")]
     AddressNotRecognized(TransparentAddress),
 
-    /// The caller requested a nonzero PCZT expiry height below the proposal's
+    /// The caller requested a nonzero target expiry height below the proposal's
     /// minimum target height. Zero remains valid because it disables expiry.
-    #[cfg(feature = "pczt")]
     ExpiryHeightBelowTargetHeight {
         expiry_height: BlockHeight,
         min_target_height: BlockHeight,
@@ -315,13 +314,12 @@ where
                     "The specified transparent address was not recognized as belonging to the wallet."
                 )
             }
-            #[cfg(feature = "pczt")]
             Error::ExpiryHeightBelowTargetHeight {
                 expiry_height,
                 min_target_height,
             } => write!(
                 f,
-                "The requested PCZT expiry height {expiry_height} is below the proposal's \
+                "The requested expiry height {expiry_height} is below the proposal's \
                  minimum target height {min_target_height}; the transaction would already be \
                  expired at the earliest height at which it could be mined."
             ),

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1071,6 +1071,7 @@ where
             &SpendingKeys::from_unified_spending_key(usk.clone()),
             ovk_policy,
             &proposal,
+            None,
         )
     }
 
@@ -1319,6 +1320,7 @@ where
             &SpendingKeys::from_unified_spending_key(usk.clone()),
             ovk_policy,
             proposal,
+            None,
         )
     }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1334,7 +1334,7 @@ where
         spend_from_account: <DbT as InputSource>::AccountId,
         ovk_policy: OvkPolicy,
         proposal: &Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
-        target_expiry_height: Option<BlockHeight>,
+        expiry_height: Option<BlockHeight>,
     ) -> Result<
         pczt::Pczt,
         super::wallet::CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, DbT::NoteRef>,
@@ -1353,7 +1353,7 @@ where
             spend_from_account,
             ovk_policy,
             proposal,
-            target_expiry_height,
+            expiry_height,
             ::orchard::builder::BundleType::DEFAULT,
         )
     }

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6633,10 +6633,10 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     let min_target_height = proposal0.min_target_height();
     assert_eq!(proposal0.steps().len(), 1);
 
-    let target_expiry_height =
+    let expiry_height =
         pin_expiry_above_target.map(|delta| BlockHeight::from(min_target_height) + delta);
 
-    if target_expiry_height.is_some() {
+    if expiry_height.is_some() {
         // This is rejected before transaction building, so the successful call below
         // can reuse the same proposal.
         assert_matches!(
@@ -6654,7 +6654,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         account.id(),
         OvkPolicy::Sender,
         &proposal0,
-        target_expiry_height,
+        expiry_height,
     );
     assert_matches!(&create_proposed_result, Ok(_));
     let pczt_created = create_proposed_result.unwrap();
@@ -6702,7 +6702,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     assert_matches!(&extract_and_store_result, Ok(_));
     let txid = extract_and_store_result.unwrap();
 
-    if let Some(expiry_height) = target_expiry_height {
+    if let Some(expiry_height) = expiry_height {
         let tx = st.wallet().get_transaction(txid).unwrap().unwrap();
         assert_eq!(tx.expiry_height(), expiry_height);
     }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -1052,6 +1052,14 @@ impl SpendingKeys {
 /// step is not supported, because the ultimate positions of those notes in the global note
 /// commitment tree cannot be known until the transaction that produces those notes is mined,
 /// and therefore the required spend proofs for such notes cannot be constructed.
+///
+/// `expiry_height`, when set, replaces the builder-derived expiry for every step's
+/// transaction before it is built and signed.
+///
+/// A nonzero `expiry_height` below the proposal's
+/// [`min_target_height`](Proposal::min_target_height) is rejected with
+/// [`Error::ExpiryHeightBelowTargetHeight`]. An `expiry_height` of zero,
+/// which disables expiry, is exempt from this check.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn create_proposed_transactions<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>(
@@ -1062,6 +1070,7 @@ pub fn create_proposed_transactions<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeEr
     spending_keys: &SpendingKeys,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
+    expiry_height: Option<BlockHeight>,
 ) -> Result<NonEmpty<TxId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -1071,6 +1080,16 @@ where
     // The transaction version is carried on the proposal, chosen when the proposal was
     // constructed; `None` builds at the version implied by the target height.
     let proposed_version = proposal.proposed_version();
+
+    if let Some(expiry_height) = expiry_height {
+        let min_target_height = BlockHeight::from(proposal.min_target_height());
+        if expiry_height != consensus::H0 && expiry_height < min_target_height {
+            return Err(Error::ExpiryHeightBelowTargetHeight {
+                expiry_height,
+                min_target_height,
+            });
+        }
+    }
 
     // The set of transparent `StepOutput`s available and unused from prior steps.
     // When a transparent `StepOutput` is created, it is added to the map. When it
@@ -1102,6 +1121,7 @@ where
             #[cfg(feature = "transparent-inputs")]
             &mut unused_transparent_outputs,
             proposed_version,
+            expiry_height,
         )?;
         step_results.push((step, step_result));
     }
@@ -1310,6 +1330,9 @@ fn build_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>
     // The transactional bundle type for the Orchard and Ironwood bundles; the PCZT path
     // threads the proposal's configured type here, other callers pass `BundleType::DEFAULT`.
     orchard_pool_bundle_type: BundleType,
+    // Overrides the builder-derived expiry height, when set. Applied immediately after
+    // `Builder::new` below, before any inputs are added or signatures/proofs are produced.
+    expiry_height: Option<BlockHeight>,
 ) -> Result<BuildState<ParamsT, DbT::AccountId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -1518,6 +1541,9 @@ where
             ironwood_bundle_type: orchard_pool_bundle_type,
         },
     );
+    if let Some(expiry_height) = expiry_height {
+        builder = builder.with_expiry_height(expiry_height);
+    }
 
     if let Some(version) = proposed_version {
         builder.propose_version(version)?;
@@ -2131,6 +2157,7 @@ fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N
         (TransparentAddress, OutPoint),
     >,
     proposed_version: Option<TxVersion>,
+    expiry_height: Option<BlockHeight>,
 ) -> Result<
     StepResult<<DbT as WalletRead>::AccountId>,
     CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>,
@@ -2155,6 +2182,7 @@ where
         proposed_version,
         // The non-PCZT path always builds padded Orchard-pool bundles.
         BundleType::DEFAULT,
+        expiry_height,
     )?;
 
     // Build the transaction with the specified fee rule
@@ -2474,6 +2502,9 @@ where
         unused_transparent_outputs,
         proposed_version,
         orchard_pool_bundle_type,
+        // This path applies `target_expiry_height` after the PCZT is built instead (below),
+        // since overriding it via the builder would be redundant with that existing mechanism.
+        None,
     )?;
 
     // Build the transaction with the specified fee rule
@@ -3308,5 +3339,6 @@ where
         spending_keys,
         OvkPolicy::Sender,
         &proposal,
+        None,
     )
 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2421,13 +2421,13 @@ where
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
 ///
-/// `target_expiry_height`, when set, replaces the builder-derived expiry before
+/// `expiry_height`, when set, replaces the builder-derived expiry before
 /// the PCZT is finalized. Applying this override after finalization can invalidate
 /// dummy spend signatures.
 ///
-/// A nonzero `target_expiry_height` below the proposal's
+/// A nonzero `expiry_height` below the proposal's
 /// [`min_target_height`](Proposal::min_target_height) is rejected with
-/// [`Error::ExpiryHeightBelowTargetHeight`]. A `target_expiry_height` of zero,
+/// [`Error::ExpiryHeightBelowTargetHeight`]. An `expiry_height` of zero,
 /// which disables expiry, is exempt from this check.
 ///
 /// `orchard_pool_bundle_type` selects the transactional bundle type for the Orchard
@@ -2444,7 +2444,7 @@ pub fn create_pczt_from_proposal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT,
     account_id: <DbT as WalletRead>::AccountId,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
-    target_expiry_height: Option<BlockHeight>,
+    expiry_height: Option<BlockHeight>,
     orchard_pool_bundle_type: BundleType,
 ) -> Result<pczt::Pczt, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
@@ -2469,7 +2469,7 @@ where
     let fee_rule = proposal.fee_rule();
     let min_target_height = proposal.min_target_height();
 
-    if let Some(expiry_height) = target_expiry_height {
+    if let Some(expiry_height) = expiry_height {
         let min_target_height = BlockHeight::from(min_target_height);
         if expiry_height != consensus::H0 && expiry_height < min_target_height {
             return Err(Error::ExpiryHeightBelowTargetHeight {
@@ -2502,7 +2502,7 @@ where
         unused_transparent_outputs,
         proposed_version,
         orchard_pool_bundle_type,
-        // This path applies `target_expiry_height` after the PCZT is built instead (below),
+        // This path applies `expiry_height` after the PCZT is built instead (below),
         // since overriding it via the builder would be redundant with that existing mechanism.
         None,
     )?;
@@ -2510,8 +2510,8 @@ where
     // Build the transaction with the specified fee rule
     let mut build_result = build_state.builder.build_for_pczt(OsRng, fee_rule)?;
 
-    if let Some(target) = target_expiry_height {
-        build_result.pczt_parts.expiry_height = target;
+    if let Some(expiry_height) = expiry_height {
+        build_result.pczt_parts.expiry_height = expiry_height;
     }
 
     let created = Creator::build_from_parts(build_result.pczt_parts).ok_or(PcztError::Build)?;


### PR DESCRIPTION
## Summary

`create_pczt_from_proposal` already accepts an `expiry_height: Option<BlockHeight>` override, letting a caller replace the builder-derived expiry height before finalization. The non-PCZT sibling `create_proposed_transactions` (used directly by, e.g., zallet's `z_sendmany`) had no equivalent — the expiry was always derived purely from the proposal's `min_target_height`, with no way for a caller to widen or override it.

This PR adds the same `expiry_height` parameter to `create_proposed_transactions` (and the private `create_proposed_transaction` / `build_proposed_transaction` helpers it shares with the PCZT path), applying it via the existing, already-tested `Builder::with_expiry_height` immediately after `Builder::new` — before any inputs are added or anything is signed. Same validation as the PCZT sibling: a nonzero override below the proposal's target height is rejected with `Error::ExpiryHeightBelowTargetHeight`; a zero override (disable expiry) is exempt.

The PCZT call site is left behaviorally unchanged — it continues to apply its override post-build via `pczt_parts.expiry_height` as before; this PR just threads `None` through the now-shared parameter list for that path so both callers of `build_proposed_transaction` compile against one signature.

Per review, the parameter is named `expiry_height` rather than `target_expiry_height` — it literally just sets the expiry, with the default computed from the target height as before. The final commit also renames the pre-existing `create_pczt_from_proposal` parameter to match (parameter names are not part of the Rust API surface, so this is not a breaking change).

## Motivation — updated

This was originally motivated by zcash/zallet#634, where `z_sendmany` built already-expired transactions on a live chain because zallet's cached view of the chain tip had fallen ~1000 blocks behind reality. **That specific bug turned out to have a different, simpler root cause**: zallet's `zebra` backend was pinned to `zebra-rpc` 11.0.0, which had a since-fixed non-finalized-block-syncer bug (ZcashFoundation/zebra#10841, merged and released in `zebra-rpc` 11.1.0). Bumping that dependency alone fully resolves the reproduced issue — no zallet-side code change is needed after all, and no zallet PR is forthcoming on top of this one.

So this PR is no longer a "prerequisite fix" for an active bug. What remains is a smaller, standalone case for it: `create_proposed_transactions` has no way to defend itself if a caller's cached tip view goes stale again for some other reason in the future (a slow restart, a different regression, network hiccups during catch-up) — it simply trusts `min_target_height` and a fixed ~40-block buffer. Adding the same override the PCZT path already has closes that gap and keeps the two builders consistent, but I want to be upfront that it isn't fixing a currently-active defect.

## Test plan

- [x] `cargo test -p zcash_client_backend --features "pczt,transparent-inputs,orchard" --lib` — 74/74 passing
- [x] `cargo fmt -p zcash_client_backend -- --check` — clean
- [x] `cargo clippy -p zcash_client_backend --features "pczt,transparent-inputs,orchard" --all-targets -- -D warnings` — one pre-existing unrelated warning at `wallet.rs:2758` (`bind_instead_of_map`), confirmed present on `main` before this change too
- [x] CHANGELOG entry added under `[Unreleased] / Changed` (breaking signature change)

Used Claude for the investigation, implementation, and this description; scope and correctness reviewed by me.