### PR TITLE
Patch zewif to the CBOR tag container framing revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7438,9 +7438,9 @@ dependencies = [
 
 [[package]]
 name = "zewif"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abbade0d83234bfef4eeff61e115c667871dc164895209f30815bf301e5389b"
+checksum = "9b300001aff0db0e844ea42359640b6abe648776b055d7861fb7075782abb715"
 dependencies = [
  "hex",
  "minicbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ fpe = { version = "0.6", default-features = false, features = ["alloc"] }
 zip32 = { version = "0.2", default-features = false }
 
 # ZeWIF wallet interchange
-zewif = "1.0.0-rc.2"
+zewif = "1.0.0-rc.3"
 
 [workspace.metadata.release]
 consolidate-commits = false

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -80,6 +80,8 @@ audit-as-crates-io = true
 [policy.zcash_transparent]
 audit-as-crates-io = true
 
+[policy.zewif]
+
 [policy.zip321]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,10 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.1"
-audited_as = "0.21.1"
-
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -460,8 +456,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.21.1"
-when = "2026-06-20"
+version = "0.22.0-rc.1"
+when = "2026-07-12"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -530,8 +526,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zewif]]
-version = "1.0.0-rc.2"
-when = "2026-07-11"
+version = "1.0.0-rc.3"
+when = "2026-07-17"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"


### PR DESCRIPTION
Update to zewif 0.1.0-rc.3

zewif 0.1.0-rc.3 frames ZeWIF documents as self-described CBOR
(55799(133133([version, payload]))) in place of the ASCII magic +
version header. No code changes are needed: the zewif import module
consumes an in-memory ::zewif::Zewif document, and the container framing
is fully encapsulated by the zewif crate's serialize/deserialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
