### PR TITLE
Split AccountBalance unshielded balance into regular and coinbase buckets

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -28,6 +28,30 @@ workspace.
   construction too — useful when a caller's view of the chain tip used to
   derive `min_target_height` may lag the real tip by more than the default
   expiry buffer covers.
+- `zcash_client_backend::data_api::AccountBalance` now tracks transparent funds
+  in two separate buckets: regular (non-coinbase) funds and funds in coinbase
+  outputs, replacing its single internal unshielded balance:
+  - New accessors `AccountBalance::unshielded_regular_balance` and
+    `AccountBalance::unshielded_coinbase_balance`, and new mutators
+    `AccountBalance::with_unshielded_regular_balance_mut` and
+    `AccountBalance::with_unshielded_coinbase_balance_mut`. Transparent outputs
+    whose transaction index within their block is unknown are classified as
+    regular (non-coinbase) funds.
+  - `AccountBalance::unshielded_balance` now returns a `Balance` by value,
+    computed as the sum of the regular and coinbase buckets, instead of a
+    `&Balance` reference.
+  - Value in immature transparent coinbase outputs is now expected to be
+    reported in the `value_pending_spendability` field of the coinbase bucket
+    rather than as spendable value; it becomes spendable only once the output
+    reaches coinbase maturity.
+- `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
+  `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
+  error type, so that `propose_send_max_transfer` can report
+  `GreedyInputSelectorError::UnsupportedTexAddress` — consistent with
+  `propose_transfer` — when a TEX recipient is requested and the
+  `transparent-inputs` feature is not enabled. Balance errors encountered
+  during send-max input selection are now wrapped in
+  `GreedyInputSelectorError::Balance`.
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
   `orchard::builder::BundleType` and `orchard::bundle::BundleVersion` that the
   transaction builder will be configured with, and returns a `Result`. It
@@ -37,14 +61,6 @@ workspace.
   transfers, and so requires `spends + outputs` actions. The method now also
   accounts for the bundle type's padding, and is gated on the `orchard`
   feature.
-- `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
-  `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
-  error type, so that `propose_send_max_transfer` can report
-  `GreedyInputSelectorError::UnsupportedTexAddress` — consistent with
-  `propose_transfer` — when a TEX recipient is requested and the
-  `transparent-inputs` feature is not enabled. Balance errors encountered
-  during send-max input selection are now wrapped in
-  `GreedyInputSelectorError::Balance`.
 
 ### Fixed
 - `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
@@ -77,6 +93,11 @@ workspace.
   returns `GreedyInputSelectorError::Balance` instead of panicking when a
   custom fee rule produces per-transaction fees whose sum exceeds the maximum
   monetary amount.
+
+### Removed
+- `zcash_client_backend::data_api::AccountBalance::`
+  - `with_unshielded_balance_mut`; use `with_unshielded_regular_balance_mut` or
+    `with_unshielded_coinbase_balance_mut` instead as appropriate.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -19,6 +19,10 @@ workspace.
   `pczt` feature.
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+- `zip-233` feature flag, forwarding to `zcash_primitives/zip-233`. It gates no
+  API of this crate; it exists so code in this crate that constructs
+  `zcash_primitives` transactions can pass the feature-gated ZIP 233 arguments
+  exactly when the underlying crate expects them.
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -166,6 +166,7 @@ zcash_protocol = { workspace = true, features = ["local-consensus", "test-depend
 
 [features]
 default = ["time/default"]
+zip-233 = ["zcash_primitives/zip-233"]
 
 ## Enables the `tonic` gRPC client bindings for connecting to a `lightwalletd` server.
 lightwalletd-tonic = ["dep:tonic", "dep:tonic-prost", "hyper-util?/tokio"]

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -326,7 +326,8 @@ pub struct AccountBalance {
     sapling_balance: Balance,
     orchard_balance: Balance,
     ironwood_balance: Balance,
-    unshielded_balance: Balance,
+    unshielded_regular_balance: Balance,
+    unshielded_coinbase_balance: Balance,
 }
 
 impl AccountBalance {
@@ -335,14 +336,16 @@ impl AccountBalance {
         sapling_balance: Balance::ZERO,
         orchard_balance: Balance::ZERO,
         ironwood_balance: Balance::ZERO,
-        unshielded_balance: Balance::ZERO,
+        unshielded_regular_balance: Balance::ZERO,
+        unshielded_coinbase_balance: Balance::ZERO,
     };
 
     fn check_total(&self) -> Result<Zatoshis, BalanceError> {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
             + self.ironwood_balance.total()
-            + self.unshielded_balance.total())
+            + self.unshielded_regular_balance.total()
+            + self.unshielded_coinbase_balance.total())
         .ok_or(BalanceError::Overflow)
     }
 
@@ -399,33 +402,80 @@ impl AccountBalance {
 
     /// Returns the total value of unspent transparent transaction outputs belonging to the wallet.
     #[deprecated(
-        note = "this function is deprecated. Please use [`AccountBalance::unshielded_balance`] instead."
+        note = "this function is deprecated. Please use [`AccountBalance::unshielded_regular_balance`] and [`AccountBalance::unshielded_coinbase_balance`] instead."
     )]
     pub fn unshielded(&self) -> Zatoshis {
-        self.unshielded_balance.total()
+        (self.unshielded_regular_balance.total() + self.unshielded_coinbase_balance.total())
+            .expect("Account balance cannot overflow MAX_MONEY")
     }
 
-    /// Returns the [`Balance`] of unshielded funds in the account.
+    /// Returns the combined [`Balance`] of unshielded funds in the account, computed as the sum
+    /// of the [`unshielded_regular_balance`] and the [`unshielded_coinbase_balance`].
     ///
-    /// Note that because transparent UTXOs may be shielded with zero confirmations and this crate
-    /// does not provide capabilities to directly spend transparent UTXOs in non-shielding
-    /// transactions, the [`change_pending_confirmation`] and [`value_pending_spendability`] fields
-    /// of the returned [`Balance`] will always be zero.
+    /// The [`spendable_value`] field of the returned [`Balance`] contains funds that may be spent
+    /// in a shielding transaction: transparent funds that satisfy the wallet's confirmation
+    /// policy, including coinbase funds that have reached maturity. The
+    /// [`value_pending_spendability`] field contains transparent funds that are not yet
+    /// spendable: funds that do not yet have the number of confirmations required by the
+    /// wallet's confirmation policy, and coinbase funds that have not yet reached maturity. The
+    /// [`change_pending_confirmation`] field is currently always zero, because this crate does
+    /// not yet distinguish transparent change from other transparent value awaiting
+    /// confirmation.
     ///
+    /// [`unshielded_regular_balance`]: AccountBalance::unshielded_regular_balance
+    /// [`unshielded_coinbase_balance`]: AccountBalance::unshielded_coinbase_balance
+    /// [`spendable_value`]: Balance::spendable_value
     /// [`change_pending_confirmation`]: Balance::change_pending_confirmation
     /// [`value_pending_spendability`]: Balance::value_pending_spendability
-    pub fn unshielded_balance(&self) -> &Balance {
-        &self.unshielded_balance
+    pub fn unshielded_balance(&self) -> Balance {
+        (self.unshielded_regular_balance + self.unshielded_coinbase_balance)
+            .expect("Account balance cannot overflow MAX_MONEY")
     }
 
-    /// Provides a mutable reference to the [`Balance`] of transparent funds in the account
-    /// to the specified callback, checking invariants after the callback's action has been
-    /// evaluated.
-    pub fn with_unshielded_balance_mut<A, E: From<BalanceError>>(
+    /// Returns the [`Balance`] of regular (non-coinbase) transparent funds in the account.
+    ///
+    /// Transparent outputs whose containing transaction's index within its block is unknown are
+    /// classified as regular (non-coinbase) funds, consistent with the treatment described for
+    /// `CoinbaseFilter`.
+    pub fn unshielded_regular_balance(&self) -> &Balance {
+        &self.unshielded_regular_balance
+    }
+
+    /// Provides a mutable reference to the [`Balance`] of regular (non-coinbase) transparent
+    /// funds in the account to the specified callback, checking invariants after the callback's
+    /// action has been evaluated.
+    pub fn with_unshielded_regular_balance_mut<A, E: From<BalanceError>>(
         &mut self,
         f: impl FnOnce(&mut Balance) -> Result<A, E>,
     ) -> Result<A, E> {
-        let result = f(&mut self.unshielded_balance)?;
+        let result = f(&mut self.unshielded_regular_balance)?;
+        self.check_total()?;
+        Ok(result)
+    }
+
+    /// Returns the [`Balance`] of funds in coinbase transparent outputs belonging to the
+    /// account.
+    ///
+    /// Coinbase outputs may only be spent by shielding them, and only once they have reached
+    /// coinbase maturity; immature coinbase funds are reported in the
+    /// [`value_pending_spendability`] field of the returned [`Balance`]. Outputs whose
+    /// containing transaction's index within its block is unknown are conservatively classified
+    /// as regular (non-coinbase) funds and do not contribute to this balance; see
+    /// `CoinbaseFilter`.
+    ///
+    /// [`value_pending_spendability`]: Balance::value_pending_spendability
+    pub fn unshielded_coinbase_balance(&self) -> &Balance {
+        &self.unshielded_coinbase_balance
+    }
+
+    /// Provides a mutable reference to the [`Balance`] of transparent coinbase funds in the
+    /// account to the specified callback, checking invariants after the callback's action has
+    /// been evaluated.
+    pub fn with_unshielded_coinbase_balance_mut<A, E: From<BalanceError>>(
+        &mut self,
+        f: impl FnOnce(&mut Balance) -> Result<A, E>,
+    ) -> Result<A, E> {
+        let result = f(&mut self.unshielded_coinbase_balance)?;
         self.check_total()?;
         Ok(result)
     }
@@ -435,7 +485,8 @@ impl AccountBalance {
         (self.sapling_balance.total()
             + self.orchard_balance.total()
             + self.ironwood_balance.total()
-            + self.unshielded_balance.total())
+            + self.unshielded_regular_balance.total()
+            + self.unshielded_coinbase_balance.total())
         .expect("Account balance cannot overflow MAX_MONEY")
     }
 
@@ -472,7 +523,8 @@ impl AccountBalance {
         (self.sapling_balance.uneconomic_value
             + self.orchard_balance.uneconomic_value
             + self.ironwood_balance.uneconomic_value
-            + self.unshielded_balance.uneconomic_value)
+            + self.unshielded_regular_balance.uneconomic_value
+            + self.unshielded_coinbase_balance.uneconomic_value)
             .expect("Account balance cannot overflow MAX_MONEY")
     }
 }
@@ -4547,5 +4599,143 @@ mod tests {
             result,
             Err(FindAccountForAddressError::UnifiedAddressConflict)
         ));
+    }
+
+    /// Each unshielded mutator updates only its own bucket, and transparent mutations leave the
+    /// shielded aggregates untouched.
+    #[test]
+    fn account_balance_unshielded_split_mutators() {
+        let mut balance = AccountBalance::ZERO;
+
+        let regular_value = Zatoshis::const_from_u64(100_000);
+        let coinbase_value = Zatoshis::const_from_u64(50_000);
+
+        balance
+            .with_unshielded_regular_balance_mut(|bal| bal.add_spendable_value(regular_value))
+            .unwrap();
+        balance
+            .with_unshielded_coinbase_balance_mut(|bal| {
+                bal.add_pending_spendable_value(coinbase_value)
+            })
+            .unwrap();
+
+        // The regular bucket contains only the regular value.
+        assert_eq!(
+            balance.unshielded_regular_balance().spendable_value(),
+            regular_value
+        );
+        assert_eq!(balance.unshielded_regular_balance().total(), regular_value);
+        assert_eq!(
+            balance
+                .unshielded_regular_balance()
+                .value_pending_spendability(),
+            Zatoshis::ZERO
+        );
+
+        // The coinbase bucket contains only the coinbase value, as pending.
+        assert_eq!(
+            balance.unshielded_coinbase_balance().spendable_value(),
+            Zatoshis::ZERO
+        );
+        assert_eq!(
+            balance
+                .unshielded_coinbase_balance()
+                .value_pending_spendability(),
+            coinbase_value
+        );
+        assert_eq!(
+            balance.unshielded_coinbase_balance().total(),
+            coinbase_value
+        );
+
+        // The shielded-only aggregates are unaffected by transparent mutations.
+        assert_eq!(balance.spendable_value(), Zatoshis::ZERO);
+        assert_eq!(balance.change_pending_confirmation(), Zatoshis::ZERO);
+        assert_eq!(balance.value_pending_spendability(), Zatoshis::ZERO);
+        assert_eq!(balance.sapling_balance(), &Balance::ZERO);
+        assert_eq!(balance.orchard_balance(), &Balance::ZERO);
+        assert_eq!(balance.ironwood_balance(), &Balance::ZERO);
+    }
+
+    /// `unshielded_balance` returns the sum of the regular and coinbase buckets, and the
+    /// account-level aggregates include both buckets.
+    #[test]
+    fn account_balance_unshielded_balance_is_sum() {
+        let mut balance = AccountBalance::ZERO;
+
+        let regular_spendable = Zatoshis::const_from_u64(100_000);
+        let regular_dust = Zatoshis::const_from_u64(100);
+        let coinbase_pending = Zatoshis::const_from_u64(625_000_000);
+        let coinbase_dust = Zatoshis::const_from_u64(42);
+
+        balance
+            .with_unshielded_regular_balance_mut(|bal| {
+                bal.add_spendable_value(regular_spendable)?;
+                bal.add_uneconomic_value(regular_dust)
+            })
+            .unwrap();
+        balance
+            .with_unshielded_coinbase_balance_mut(|bal| {
+                bal.add_pending_spendable_value(coinbase_pending)?;
+                bal.add_uneconomic_value(coinbase_dust)
+            })
+            .unwrap();
+
+        // The by-value combined balance is the field-wise sum of both buckets.
+        let combined = balance.unshielded_balance();
+        assert_eq!(
+            combined,
+            (*balance.unshielded_regular_balance() + *balance.unshielded_coinbase_balance())
+                .unwrap()
+        );
+        assert_eq!(combined.spendable_value(), regular_spendable);
+        assert_eq!(combined.value_pending_spendability(), coinbase_pending);
+        assert_eq!(
+            combined.uneconomic_value(),
+            (regular_dust + coinbase_dust).unwrap()
+        );
+
+        // The deprecated accessor reports the sum of both buckets' totals.
+        #[allow(deprecated)]
+        let unshielded = balance.unshielded();
+        assert_eq!(
+            unshielded,
+            (balance.unshielded_regular_balance().total()
+                + balance.unshielded_coinbase_balance().total())
+            .unwrap()
+        );
+
+        // The account total and uneconomic value include both buckets. (`Balance::total`
+        // excludes uneconomic value, so the dust does not appear in the account total.)
+        assert_eq!(
+            balance.total(),
+            (regular_spendable + coinbase_pending).unwrap()
+        );
+        assert_eq!(
+            balance.uneconomic_value(),
+            (regular_dust + coinbase_dust).unwrap()
+        );
+    }
+
+    /// The `check_total` invariant rejects mutations that would cause the sum of the regular and
+    /// coinbase transparent buckets to exceed `MAX_MONEY`.
+    #[test]
+    fn account_balance_unshielded_overflow_rejected() {
+        let max_money = Zatoshis::const_from_u64(zcash_protocol::value::MAX_MONEY);
+        let mut balance = AccountBalance::ZERO;
+
+        // Fill the regular bucket up to MAX_MONEY; this is fine on its own.
+        balance
+            .with_unshielded_regular_balance_mut(|bal| bal.add_spendable_value(max_money))
+            .unwrap();
+        assert_eq!(balance.total(), max_money);
+
+        // Any further value in the coinbase bucket must be rejected by the account-level
+        // invariant check, even though the coinbase bucket does not overflow on its own.
+        let result: Result<(), BalanceError> =
+            balance.with_unshielded_coinbase_balance_mut(|bal| {
+                bal.add_pending_spendable_value(Zatoshis::const_from_u64(1))
+            });
+        assert!(matches!(result, Err(BalanceError::Overflow)));
     }
 }

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -815,6 +815,9 @@ fn fake_transparent_coinbase_tx(
         lock_time,
         // Coinbase transactions do not expire.
         BlockHeight::from(0),
+        // Coinbase transactions burn nothing.
+        #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+        Zatoshis::ZERO,
         Some(coinbase_bundle),
         None,
         None,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -4,16 +4,23 @@ use assert_matches::assert_matches;
 
 use sapling::zip32::ExtendedSpendingKey;
 use transparent::{
-    address::TransparentAddress,
-    bundle::{OutPoint, TxOut},
+    address::{Script, TransparentAddress},
+    bundle::{Authorized, Bundle, OutPoint, TxIn, TxOut},
     keys::TransparentKeyScope,
 };
 use zcash_keys::{
     address::Address,
     keys::{UnifiedAddressRequest, transparent::gap_limits::GapLimits},
 };
-use zcash_primitives::block::BlockHash;
-use zcash_protocol::{local_consensus::LocalNetwork, value::Zatoshis};
+use zcash_primitives::{
+    block::BlockHash,
+    transaction::{Transaction, TransactionData, TxVersion, fees::zip317},
+};
+use zcash_protocol::{
+    consensus::{BlockHeight, BranchId, COINBASE_MATURITY_BLOCKS},
+    local_consensus::LocalNetwork,
+    value::Zatoshis,
+};
 use zip321::{Payment, TransactionRequest};
 
 #[cfg(feature = "transparent-key-import")]
@@ -25,8 +32,8 @@ use {
 use super::TestAccount;
 use crate::{
     data_api::{
-        Account as _, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode, TargetValue,
-        WalletRead as _, WalletTest as _, WalletWrite,
+        Account as _, AccountBalance, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode,
+        TargetValue, WalletRead as _, WalletTest as _, WalletWrite,
         testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
@@ -777,6 +784,272 @@ where
         taddr,
         ConfirmationsPolicy::new_symmetrical_unchecked(2, true),
         &zero_or_one_conf_value,
+    );
+}
+
+/// Constructs a fake transparent-only coinbase transaction paying `value` to `taddr`.
+///
+/// The result is a structurally valid coinbase transaction (a single input spending the null
+/// outpoint), which causes the receiving wallet to classify it as coinbase when it is stored
+/// via [`decrypt_and_store_transaction`]. The `lock_time` parameter has no consensus meaning
+/// here; distinct values may be used to give otherwise-identical coinbase transactions
+/// distinct txids.
+fn fake_transparent_coinbase_tx(
+    lock_time: u32,
+    value: Zatoshis,
+    taddr: &TransparentAddress,
+) -> Transaction {
+    let coinbase_bundle = Bundle {
+        vin: vec![TxIn::from_parts(
+            OutPoint::NULL,
+            Script::default(),
+            u32::MAX,
+        )],
+        vout: vec![TxOut::new(value, taddr.script().into())],
+        authorization: Authorized,
+    };
+
+    TransactionData::<zcash_primitives::transaction::Authorized>::from_parts(
+        TxVersion::V5,
+        BranchId::Nu5,
+        lock_time,
+        // Coinbase transactions do not expire.
+        BlockHeight::from(0),
+        Some(coinbase_bundle),
+        None,
+        None,
+        None,
+    )
+    .freeze()
+    .unwrap()
+}
+
+/// Retrieves the [`AccountBalance`] for the given test account from the wallet summary.
+fn get_account_balance<DSF>(
+    st: &TestState<impl TestCache, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+    account: &TestAccount<<DSF as DataStoreFactory>::Account>,
+    confirmations_policy: ConfirmationsPolicy,
+) -> AccountBalance
+where
+    DSF: DataStoreFactory,
+{
+    let summary = st
+        .wallet()
+        .get_wallet_summary(confirmations_policy)
+        .unwrap()
+        .unwrap();
+    *summary.account_balances().get(&account.id()).unwrap()
+}
+
+/// Verifies that transparent funds are reported in the correct `AccountBalance` bucket
+/// (regular vs. coinbase), that immature coinbase value is reported as pending rather than
+/// spendable, and that it becomes spendable upon reaching coinbase maturity.
+pub fn transparent_coinbase_balance_split<DSF>(ds_factory: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account.id(), UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    // Mine a coinbase output paying the wallet's transparent address at tx index 0.
+    let coinbase_value = Zatoshis::const_from_u64(625_000_000);
+    let coinbase_tx = fake_transparent_coinbase_tx(0, coinbase_value, taddr);
+    let (h, _) = st.generate_next_block_from_tx(0, &coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), &coinbase_tx, Some(h)).unwrap();
+
+    // Immature coinbase: the value is pending spendability in the coinbase bucket, not
+    // spendable; the regular bucket is untouched.
+    let balance = get_account_balance::<DSF>(&st, &account, ConfirmationsPolicy::MIN);
+    assert_eq!(
+        balance.unshielded_coinbase_balance().spendable_value(),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        balance
+            .unshielded_coinbase_balance()
+            .value_pending_spendability(),
+        coinbase_value
+    );
+    assert_eq!(balance.unshielded_regular_balance(), &Balance::ZERO);
+
+    // The same holds when the confirmations policy itself is not yet satisfied (the coinbase
+    // output has only one confirmation here), which exercises the pending-balance query.
+    let balance = get_account_balance::<DSF>(
+        &st,
+        &account,
+        ConfirmationsPolicy::new_symmetrical_unchecked(2, false),
+    );
+    assert_eq!(
+        balance.unshielded_coinbase_balance().spendable_value(),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        balance
+            .unshielded_coinbase_balance()
+            .value_pending_spendability(),
+        coinbase_value
+    );
+    assert_eq!(balance.unshielded_regular_balance(), &Balance::ZERO);
+
+    // Receive a regular (non-coinbase) UTXO. This output's transaction has no known tx_index,
+    // so it must be classified as regular (non-coinbase) funds.
+    let regular_value = Zatoshis::const_from_u64(100_000);
+    let utxo = WalletTransparentOutput::from_parts(
+        OutPoint::fake(),
+        TxOut::new(regular_value, taddr.script().into()),
+        Some(h),
+        Some(account.id()),
+        Some(TransparentKeyScope::EXTERNAL),
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    // Mixed state: the regular value is spendable, the coinbase value remains pending, and the
+    // combined accessors report the sums of the two buckets.
+    let balance = get_account_balance::<DSF>(&st, &account, ConfirmationsPolicy::MIN);
+    assert_eq!(
+        balance.unshielded_regular_balance().spendable_value(),
+        regular_value
+    );
+    assert_eq!(
+        balance
+            .unshielded_coinbase_balance()
+            .value_pending_spendability(),
+        coinbase_value
+    );
+    assert_eq!(
+        balance.unshielded_balance(),
+        (*balance.unshielded_regular_balance() + *balance.unshielded_coinbase_balance()).unwrap()
+    );
+    #[allow(deprecated)]
+    let unshielded = balance.unshielded();
+    assert_eq!(unshielded, (regular_value + coinbase_value).unwrap());
+    assert_eq!(balance.total(), (regular_value + coinbase_value).unwrap());
+
+    // Once the coinbase output reaches maturity, its value moves from pending to spendable.
+    for _ in 0..COINBASE_MATURITY_BLOCKS {
+        st.generate_empty_block();
+    }
+    st.scan_cached_blocks(h + 1, COINBASE_MATURITY_BLOCKS as usize);
+
+    let balance = get_account_balance::<DSF>(&st, &account, ConfirmationsPolicy::MIN);
+    assert_eq!(
+        balance.unshielded_coinbase_balance().spendable_value(),
+        coinbase_value
+    );
+    assert_eq!(
+        balance
+            .unshielded_coinbase_balance()
+            .value_pending_spendability(),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        balance.unshielded_regular_balance().spendable_value(),
+        regular_value
+    );
+    assert_eq!(balance.total(), (regular_value + coinbase_value).unwrap());
+}
+
+/// Verifies that dust-valued (uneconomic) transparent outputs are reported in the
+/// `uneconomic_value` field of the correct `AccountBalance` bucket (regular vs. coinbase).
+pub fn transparent_coinbase_balance_dust<DSF>(ds_factory: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    let dust_value = Zatoshis::const_from_u64(1000);
+    assert!(dust_value <= zip317::MARGINAL_FEE);
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account.id(), UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    // Mine a dust coinbase output paying the wallet's transparent address at tx index 0.
+    let coinbase_tx = fake_transparent_coinbase_tx(0, dust_value, taddr);
+    let (h, _) = st.generate_next_block_from_tx(0, &coinbase_tx);
+    st.scan_cached_blocks(h, 1);
+    let params = *st.network();
+    decrypt_and_store_transaction(&params, st.wallet_mut(), &coinbase_tx, Some(h)).unwrap();
+
+    // Receive a dust regular (non-coinbase) UTXO.
+    let utxo = WalletTransparentOutput::from_parts(
+        OutPoint::fake(),
+        TxOut::new(dust_value, taddr.script().into()),
+        Some(h),
+        Some(account.id()),
+        Some(TransparentKeyScope::EXTERNAL),
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    // Each dust output lands in the uneconomic value of its own bucket, and contributes to
+    // neither spendable nor pending value.
+    let balance = get_account_balance::<DSF>(&st, &account, ConfirmationsPolicy::MIN);
+    assert_eq!(
+        balance.unshielded_regular_balance().uneconomic_value(),
+        dust_value
+    );
+    assert_eq!(
+        balance.unshielded_coinbase_balance().uneconomic_value(),
+        dust_value
+    );
+    assert_eq!(
+        balance.uneconomic_value(),
+        (dust_value + dust_value).unwrap()
+    );
+    assert_eq!(
+        balance.unshielded_balance().spendable_value(),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        balance.unshielded_balance().value_pending_spendability(),
+        Zatoshis::ZERO
+    );
+    assert_eq!(balance.total(), Zatoshis::ZERO);
+
+    // Dust classification takes precedence over coinbase maturity: after the coinbase output
+    // matures, its value remains uneconomic rather than becoming spendable.
+    for _ in 0..COINBASE_MATURITY_BLOCKS {
+        st.generate_empty_block();
+    }
+    st.scan_cached_blocks(h + 1, COINBASE_MATURITY_BLOCKS as usize);
+
+    let balance = get_account_balance::<DSF>(&st, &account, ConfirmationsPolicy::MIN);
+    assert_eq!(
+        balance.unshielded_coinbase_balance().uneconomic_value(),
+        dust_value
+    );
+    assert_eq!(
+        balance.unshielded_coinbase_balance().spendable_value(),
+        Zatoshis::ZERO
     );
 }
 

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -59,7 +59,9 @@ fn check_balance<DSF>(
     #[allow(deprecated)]
     let old_unshielded_value = balance.unshielded();
     assert_eq!(old_unshielded_value, expected.total());
-    assert_eq!(balance.unshielded_balance(), expected);
+    assert_eq!(balance.unshielded_regular_balance(), expected);
+    assert_eq!(balance.unshielded_coinbase_balance(), &Balance::ZERO);
+    assert_eq!(balance.unshielded_balance(), *expected);
 
     // Check the older APIs for consistency.
     let target_height = TargetHeight::from(st.wallet().chain_height().unwrap().unwrap() + 1);

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -24,6 +24,11 @@ workspace.
   names begin with the `ext_` prefix reserved for external migrations, and denies
   everything else (DDL, `PRAGMA`, `ATTACH`/`DETACH`, and transaction control).
 
+### Changed
+- The `zip-233` feature flag now also enables `zcash_client_backend/zip-233`,
+  keeping the two crates' feature-gated `zcash_primitives` call signatures in
+  agreement when this crate is built with ZIP 233 support.
+
 ### Fixed
 - Value in immature transparent coinbase outputs is now reported as pending
   spendability (in the `value_pending_spendability` field of the coinbase

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -24,6 +24,13 @@ workspace.
   names begin with the `ext_` prefix reserved for external migrations, and denies
   everything else (DDL, `PRAGMA`, `ATTACH`/`DETACH`, and transaction control).
 
+### Fixed
+- Value in immature transparent coinbase outputs is now reported as pending
+  spendability (in the `value_pending_spendability` field of the coinbase
+  bucket) in wallet-summary account balances. Previously it was incorrectly
+  counted as spendable before the coinbase output reached maturity, even
+  though it could not be selected for shielding.
+
 ## [0.22.0-rc.1] - 2026-07-12
 
 ### Added

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -119,7 +119,7 @@ zip321 = { workspace = true }
 
 [features]
 default = ["multicore"]
-zip-233 = ["zcash_primitives/zip-233"]
+zip-233 = ["zcash_primitives/zip-233", "zcash_client_backend/zip-233"]
 
 ## Enables multithreading support for creating proofs and building subtrees.
 multicore = ["maybe-rayon/threads", "zcash_primitives/multicore"]

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1750,7 +1750,10 @@ pub(crate) fn add_transparent_account_balances(
     };
 
     let mut stmt_account_spendable_balances = conn.prepare(&format!(
-        "SELECT accounts.uuid, SUM(u.value_zat)
+        "SELECT accounts.uuid, SUM(u.value_zat),
+            (IFNULL(t.tx_index, 1) == 0) AS is_coinbase,
+            (t.mined_height IS NOT NULL
+             AND :target_height - t.mined_height >= {COINBASE_MATURITY_BLOCKS}) AS is_mature
          FROM transparent_received_outputs u
          JOIN accounts ON accounts.id = u.account_id
          JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1758,7 +1761,7 @@ pub(crate) fn add_transparent_account_balances(
          WHERE ({}) -- the transaction is mined or unexpired with minconf 0
          AND u.id NOT IN ({}) -- and the received txo is unspent
          AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-         GROUP BY accounts.uuid",
+         GROUP BY accounts.uuid, is_coinbase, is_mature",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
@@ -1775,17 +1778,33 @@ pub(crate) fn add_transparent_account_balances(
         let value = Zatoshis::from_nonnegative_i64(raw_value).map_err(|_| {
             SqliteClientError::CorruptedData(format!("Negative UTXO value {raw_value:?}"))
         })?;
+        let is_coinbase: bool = row.get("is_coinbase")?;
+        let is_mature: bool = row.get("is_mature")?;
 
-        account_balances
+        let balance = account_balances
             .entry(account)
-            .or_insert(AccountBalance::ZERO)
-            .with_unshielded_balance_mut(|bal| {
+            .or_insert(AccountBalance::ZERO);
+        if is_coinbase {
+            balance.with_unshielded_coinbase_balance_mut(|bal| {
+                if value <= zip317::MARGINAL_FEE {
+                    bal.add_uneconomic_value(value)
+                } else if is_mature {
+                    bal.add_spendable_value(value)
+                } else {
+                    // Immature coinbase value may not yet be spent (by shielding); report it
+                    // as pending until the coinbase output reaches maturity.
+                    bal.add_pending_spendable_value(value)
+                }
+            })?;
+        } else {
+            balance.with_unshielded_regular_balance_mut(|bal| {
                 if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
                 } else {
                     bal.add_spendable_value(value)
                 }
             })?;
+        }
     }
 
     // Pending spendable balance for transparent UTXOs is only relevant for min_confirmations > 0;
@@ -1794,7 +1813,8 @@ pub(crate) fn add_transparent_account_balances(
     // TODO (#1592): Ability to distinguish between Transparent pending change and pending non-change
     if min_confirmations > 0 {
         let mut stmt_account_unconfirmed_balances = conn.prepare(&format!(
-            "SELECT accounts.uuid, SUM(u.value_zat)
+            "SELECT accounts.uuid, SUM(u.value_zat),
+                (IFNULL(t.tx_index, 1) == 0) AS is_coinbase
              FROM transparent_received_outputs u
              JOIN accounts ON accounts.id = u.account_id
              JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1813,7 +1833,7 @@ pub(crate) fn add_transparent_account_balances(
              )
              AND u.id NOT IN ({}) -- and the received txo is unspent
              AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-             GROUP BY accounts.uuid",
+             GROUP BY accounts.uuid, is_coinbase",
             spent_utxos_clause(),
             excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
         ))?;
@@ -1829,17 +1849,23 @@ pub(crate) fn add_transparent_account_balances(
             let value = Zatoshis::from_nonnegative_i64(raw_value).map_err(|_| {
                 SqliteClientError::CorruptedData(format!("Negative UTXO value {raw_value:?}"))
             })?;
+            let is_coinbase: bool = row.get("is_coinbase")?;
 
-            account_balances
+            let add_pending = |bal: &mut Balance| {
+                if value <= zip317::MARGINAL_FEE {
+                    bal.add_uneconomic_value(value)
+                } else {
+                    bal.add_pending_spendable_value(value)
+                }
+            };
+            let balance = account_balances
                 .entry(account)
-                .or_insert(AccountBalance::ZERO)
-                .with_unshielded_balance_mut(|bal| {
-                    if value <= zip317::MARGINAL_FEE {
-                        bal.add_uneconomic_value(value)
-                    } else {
-                        bal.add_pending_spendable_value(value)
-                    }
-                })?;
+                .or_insert(AccountBalance::ZERO);
+            if is_coinbase {
+                balance.with_unshielded_coinbase_balance_mut(add_pending)?;
+            } else {
+                balance.with_unshielded_regular_balance_mut(add_pending)?;
+            }
         }
     }
     Ok(())
@@ -2985,6 +3011,22 @@ mod tests {
     #[test]
     fn transparent_balance_spendability() {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_spendability(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
+    fn transparent_coinbase_balance_split() {
+        zcash_client_backend::data_api::testing::transparent::transparent_coinbase_balance_split(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
+    #[test]
+    fn transparent_coinbase_balance_dust() {
+        zcash_client_backend::data_api::testing::transparent::transparent_coinbase_balance_dust(
             TestDbFactory::default(),
             BlockCache::new(),
         );


### PR DESCRIPTION
Fixes #2653.

## Summary

Splits `AccountBalance`'s single unshielded balance into **regular** (non-coinbase) and **coinbase** buckets, and classifies transparent coinbase correctly in the wallet-summary account balances.

Motivated by zcash/zallet#635: a mining pool found that no zallet RPC can answer "how much can I pay to a transparent recipient?", because `AccountBalance::unshielded_balance()` folds coinbase (which consensus requires to be shielded before further spending) into the only transparent number available, and the summary SQL applied no coinbase-maturity rule (immature coinbase was reported *spendable*).

## API changes (`zcash_client_backend`)

- `AccountBalance` now carries `unshielded_regular_balance` + `unshielded_coinbase_balance`, with accessors and `with_*_mut` mutators following the existing per-pool pattern (invariant-checked via `check_total`). Fields are deliberately **not** feature-gated, matching the existing pattern (only the sqlite population is gated on `transparent-inputs`).
- `unshielded_balance()` now returns the combined `Balance` **by value** (regular + coinbase).
- `with_unshielded_balance_mut` is removed (no single field remains for it to mutate).
- Deprecated `unshielded()` keeps returning the combined total, unchanged.
- `total()` / `uneconomic_value()` sum both buckets; `spendable_value()` & co. remain shielded-only as documented.

## Behavior changes (`zcash_client_sqlite`)

`add_transparent_account_balances` classifies each output by the existing conventions:
- coinbase = `IFNULL(t.tx_index, 1) == 0` (same predicate as `CoinbaseFilter`; unknown `tx_index` counts as regular, so light-client data degrades to today's behavior),
- **mature** coinbase (>= `COINBASE_MATURITY_BLOCKS` confirmations) -> coinbase `spendable`,
- **immature** coinbase -> coinbase `pending` (`value_pending_spendability`) — fixing the latent bug where it was counted spendable,
- dust routes to the matching bucket's `uneconomic_value`.

`get_transparent_balances` (the per-address map) is intentionally left unsplit — it feeds a different API surface and the per-address coinbase split is not needed for the motivating issue.

## Tests

- New shared test fns `transparent_coinbase_balance_split` and `transparent_coinbase_balance_dust` (run against the real SQLite store): immature->pending under both the minconf-0 and pending-pass routings, maturity transition after 100 blocks, NULL-`tx_index` -> regular, per-bucket dust routing.
- Pure unit tests for the new `AccountBalance` API surface (mutator routing, by-value sum, MAX_MONEY overflow rejection across the two fields).
- `check_balance` extended so all 15 existing call sites now also pin regular==expected / coinbase==ZERO / deprecated-total-unchanged.

`cargo test -p zcash_client_backend` and `-p zcash_client_sqlite` (with `transparent-inputs orchard test-dependencies`) pass; both crates also compile without `transparent-inputs` and with `--no-default-features`.

No version bumps are included (left to the release process). An end-to-end regtest proof (zebrad + zaino + zallet) of the full flow accompanies the zallet PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WB1TU6tyLmMa1n4SQ9XgK
