### PR TITLE
DNM: DRAFT Add migration PCZT signer redaction

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,11 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `zcash_client_backend::data_api::wallet::redact_pczt_for_migration_signer`,
+  which creates a smaller signer contribution view for version 6 wallet
+  migration PCZTs when the signer derives the account viewing key and
+  reconstructs migration recipients itself, along with the
+  `MigrationSignerRedactionError` error type.
 - `zcash_client_backend::data_api::wallet::redact_pczt_for_signer`, which
   creates a compact signer view of a wallet-created PCZT while retaining the
   information a general-purpose external signer may need. This is available

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -81,7 +81,9 @@ use zcash_protocol::PoolType;
 
 #[cfg(feature = "pczt")]
 use {
-    crate::data_api::wallet::redact_pczt_for_signer,
+    crate::data_api::wallet::{
+        MigrationSignerRedactionError, redact_pczt_for_migration_signer, redact_pczt_for_signer,
+    },
     pczt::roles::{combiner::Combiner, prover::Prover, signer::Signer},
     rand_core::OsRng,
     transparent::builder::TransparentSigningSet,
@@ -6700,6 +6702,11 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     let original_sighash = Signer::new(pczt_proven.clone()).unwrap().shielded_sighash();
     let original_len = pczt_proven.clone().serialize().unwrap().len();
     let signer_view = redact_pczt_for_signer(&pczt_proven);
+    assert!(matches!(
+        redact_pczt_for_migration_signer(&pczt_proven, &[], &[]),
+        Err(MigrationSignerRedactionError::UnsupportedTransactionVersion(version))
+            if version == zcash_protocol::constants::V5_TX_VERSION
+    ));
     assert_eq!(
         *signer_view.global().tx_version(),
         zcash_protocol::constants::V5_TX_VERSION,
@@ -8091,31 +8098,214 @@ where
         + assert_redacted_bundle(pczt.ironwood(), signer_view.ironwood());
     assert!(memo_plaintexts > 0);
 
-    // Resolving the compact representation restores byte-identical effecting
-    // fields and therefore the same shielded signature digest.
-    let mut resolved = signer_view.clone();
-    resolved.resolve_fields().unwrap();
-    for (resolved_bundle, original_bundle) in [
-        (resolved.orchard(), pczt.orchard()),
-        (resolved.ironwood(), pczt.ironwood()),
-    ] {
-        for (resolved, original) in resolved_bundle
+    // The migration signer view has a narrower capability contract. Capture
+    // the IO-finalizer dummy actions from this controlled fixture, then verify
+    // that only those actions shed their spend randomizers.
+    let finalized_dummy_spend_action_indices = |bundle: &pczt::orchard::Bundle| {
+        bundle
             .actions()
             .iter()
-            .zip(original_bundle.actions())
-        {
-            assert_eq!(resolved.cv_net(), original.cv_net());
-            assert_eq!(resolved.output().cmx(), original.output().cmx());
-            assert_eq!(
-                resolved.output().enc_ciphertext(),
-                original.output().enc_ciphertext()
-            );
+            .enumerate()
+            .filter_map(|(index, action)| {
+                action.spend().spend_auth_sig().is_some().then_some(index)
+            })
+            .collect::<Vec<_>>()
+    };
+    let orchard_dummy_spends = finalized_dummy_spend_action_indices(pczt.orchard());
+    let ironwood_dummy_spends = finalized_dummy_spend_action_indices(pczt.ironwood());
+    assert!(!orchard_dummy_spends.is_empty() || !ironwood_dummy_spends.is_empty());
+
+    assert!(matches!(
+        redact_pczt_for_migration_signer(
+            &pczt,
+            &[pczt.orchard().actions().len()],
+            &ironwood_dummy_spends,
+        ),
+        Err(MigrationSignerRedactionError::OrchardDummySpendActionIndexOutOfRange { .. })
+    ));
+
+    let real_spend = (0..pczt.orchard().actions().len())
+        .find(|index| !orchard_dummy_spends.contains(index))
+        .expect("the migration fixture has a real Orchard spend");
+    assert!(matches!(
+        redact_pczt_for_migration_signer(&pczt, &[real_spend], &ironwood_dummy_spends),
+        Err(MigrationSignerRedactionError::OrchardDummySpendNotAuthorized(index))
+            if index == real_spend
+    ));
+
+    let migration_view =
+        redact_pczt_for_migration_signer(&pczt, &orchard_dummy_spends, &ironwood_dummy_spends)
+            .unwrap();
+    let migration_view_bytes = migration_view.clone().serialize().unwrap();
+    assert!(migration_view_bytes.len() < signer_view_bytes.len());
+    let migration_view = pczt::Pczt::parse(&migration_view_bytes).unwrap();
+
+    let clear_migration_fields =
+        |pczt: pczt::Pczt, orchard_dummy_spends: &[usize], ironwood_dummy_spends: &[usize]| {
+            let mut redactor =
+                pczt::roles::redactor::Redactor::new(pczt).redact_orchard_with(|mut redactor| {
+                    redactor.redact_actions(|mut action| {
+                        action.clear_spend_fvk();
+                        action.clear_spend_auth_sig();
+                        action.clear_output_ock();
+                        action.clear_output_zip32_derivation();
+                        action.clear_output_user_address();
+                    });
+                    for index in orchard_dummy_spends {
+                        redactor.redact_action(*index, |mut action| action.clear_spend_alpha());
+                    }
+                });
+            redactor = redactor.redact_ironwood_with(|mut redactor| {
+                redactor.redact_actions(|mut action| {
+                    action.clear_spend_fvk();
+                    action.clear_spend_auth_sig();
+                    action.clear_output_ock();
+                    action.clear_output_zip32_derivation();
+                    action.clear_output_user_address();
+                });
+                for index in ironwood_dummy_spends {
+                    redactor.redact_action(*index, |mut action| action.clear_spend_alpha());
+                }
+            });
+            redactor.finish().serialize().unwrap()
+        };
+    assert_eq!(
+        clear_migration_fields(
+            migration_view.clone(),
+            &orchard_dummy_spends,
+            &ironwood_dummy_spends,
+        ),
+        migration_view_bytes,
+    );
+    assert!(
+        migration_view
+            .orchard()
+            .actions()
+            .iter()
+            .chain(migration_view.ironwood().actions())
+            .all(|action| action.spend().spend_auth_sig().is_none()
+                && action.output().user_address().is_none())
+    );
+
+    // Re-clearing a real spend's alpha must change the migration view. The
+    // signer still needs that randomizer to create its contribution.
+    let mut signable_actions = 0;
+    for (bundle, dummy_spends, is_orchard) in [
+        (
+            migration_view.orchard(),
+            orchard_dummy_spends.as_slice(),
+            true,
+        ),
+        (
+            migration_view.ironwood(),
+            ironwood_dummy_spends.as_slice(),
+            false,
+        ),
+    ] {
+        for index in 0..bundle.actions().len() {
+            if !dummy_spends.contains(&index) {
+                signable_actions += 1;
+                let without_alpha = if is_orchard {
+                    pczt::roles::redactor::Redactor::new(migration_view.clone())
+                        .redact_orchard_with(|mut redactor| {
+                            redactor.redact_action(index, |mut action| action.clear_spend_alpha());
+                        })
+                        .finish()
+                } else {
+                    pczt::roles::redactor::Redactor::new(migration_view.clone())
+                        .redact_ironwood_with(|mut redactor| {
+                            redactor.redact_action(index, |mut action| action.clear_spend_alpha());
+                        })
+                        .finish()
+                };
+                assert_ne!(without_alpha.serialize().unwrap(), migration_view_bytes);
+            }
         }
     }
-    assert_eq!(
-        Signer::new(signer_view.clone()).unwrap().shielded_sighash(),
-        original_sighash,
+    assert!(signable_actions > 0);
+
+    // Resolving either compact representation restores byte-identical
+    // effecting fields and therefore the same shielded signature digest.
+    for compact_view in [&signer_view, &migration_view] {
+        let mut resolved = (*compact_view).clone();
+        resolved.resolve_fields().unwrap();
+        for (resolved_bundle, original_bundle) in [
+            (resolved.orchard(), pczt.orchard()),
+            (resolved.ironwood(), pczt.ironwood()),
+        ] {
+            for (resolved, original) in resolved_bundle
+                .actions()
+                .iter()
+                .zip(original_bundle.actions())
+            {
+                assert_eq!(resolved.cv_net(), original.cv_net());
+                assert_eq!(resolved.output().cmx(), original.output().cmx());
+                assert_eq!(
+                    resolved.output().enc_ciphertext(),
+                    original.output().enc_ciphertext()
+                );
+            }
+        }
+        assert_eq!(
+            Signer::new((*compact_view).clone())
+                .unwrap()
+                .shielded_sighash(),
+            original_sighash,
+        );
+    }
+
+    // The strict view can produce the real spend's signature contribution,
+    // which can be applied to the authoritative wallet PCZT.
+    let usk = st.get_account().usk().clone();
+    let ask = orchard::keys::SpendAuthorizingKey::from(OrchardPoolTester::usk_to_sk(&usk));
+    let signed_view = pczt::roles::low_level_signer::Signer::new(migration_view)
+        .sign_orchard_with::<pczt::roles::low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            bundle.actions_mut()[real_spend]
+                .sign(original_sighash, &ask, OsRng)
+                .unwrap();
+            Ok(())
+        })
+        .unwrap()
+        .finish();
+    let signatures = pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_view);
+    assert_eq!(signatures.len(), 1);
+    let mut signer = Signer::new(pczt.clone()).unwrap();
+    for signature in &signatures {
+        signer
+            .apply_orchard_spend_auth_signature(signature)
+            .unwrap();
+    }
+    let combined = signer.finish();
+    assert!(
+        combined.orchard().actions()[real_spend]
+            .spend()
+            .spend_auth_sig()
+            .is_some()
     );
+    for (combined, original) in combined
+        .orchard()
+        .actions()
+        .iter()
+        .zip(pczt.orchard().actions())
+        .chain(
+            combined
+                .ironwood()
+                .actions()
+                .iter()
+                .zip(pczt.ironwood().actions()),
+        )
+    {
+        assert_eq!(
+            combined.output().user_address(),
+            original.output().user_address()
+        );
+        assert_eq!(combined.cv_net(), original.cv_net());
+        assert_eq!(combined.output().cmx(), original.output().cmx());
+        assert_eq!(
+            combined.output().enc_ciphertext(),
+            original.output().enc_ciphertext()
+        );
+    }
 }
 
 /// The transaction version requested at proposal time is recorded on the proposal and preserved

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2392,6 +2392,8 @@ where
 ///
 /// Before sending the PCZT to an external Signer, create a signer view with
 /// [`redact_pczt_for_signer`] and retain the original for combination.
+/// Version 6 wallet migration flows whose Signer satisfies the narrower
+/// capability contract may instead use [`redact_pczt_for_migration_signer`].
 ///
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
@@ -2875,6 +2877,170 @@ pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
             redact_orchard_bundle(redactor, redact_v6_anchors);
         })
         .finish()
+}
+
+/// Errors that can occur while creating a migration Signer view.
+#[cfg(feature = "pczt")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MigrationSignerRedactionError {
+    /// Migration Signer redaction requires a version 6 transaction.
+    UnsupportedTransactionVersion(u32),
+    /// An Orchard dummy spend action index was out of range.
+    OrchardDummySpendActionIndexOutOfRange {
+        /// The invalid action index.
+        index: usize,
+        /// The number of actions in the Orchard bundle.
+        action_count: usize,
+    },
+    /// An Ironwood dummy spend action index was out of range.
+    IronwoodDummySpendActionIndexOutOfRange {
+        /// The invalid action index.
+        index: usize,
+        /// The number of actions in the Ironwood bundle.
+        action_count: usize,
+    },
+    /// The Orchard action identified as a dummy spend was not already authorized.
+    OrchardDummySpendNotAuthorized(usize),
+    /// The Ironwood action identified as a dummy spend was not already authorized.
+    IronwoodDummySpendNotAuthorized(usize),
+}
+
+#[cfg(feature = "pczt")]
+impl core::fmt::Display for MigrationSignerRedactionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnsupportedTransactionVersion(version) => write!(
+                f,
+                "migration Signer redaction requires transaction version 6, found {version}"
+            ),
+            Self::OrchardDummySpendActionIndexOutOfRange {
+                index,
+                action_count,
+            } => write!(
+                f,
+                "Orchard dummy spend action index {index} is out of range for {action_count} actions"
+            ),
+            Self::IronwoodDummySpendActionIndexOutOfRange {
+                index,
+                action_count,
+            } => write!(
+                f,
+                "Ironwood dummy spend action index {index} is out of range for {action_count} actions"
+            ),
+            Self::OrchardDummySpendNotAuthorized(index) => write!(
+                f,
+                "Orchard dummy spend action {index} is not already authorized"
+            ),
+            Self::IronwoodDummySpendNotAuthorized(index) => write!(
+                f,
+                "Ironwood dummy spend action {index} is not already authorized"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "pczt")]
+impl std::error::Error for MigrationSignerRedactionError {}
+
+/// Creates a compact signer contribution view for a wallet migration PCZT.
+///
+/// This starts with [`redact_pczt_for_signer`] and additionally removes each
+/// Orchard and Ironwood spend's full viewing key and existing authorization
+/// signature, and each output's outgoing cipher key (`ock`), ZIP 32 derivation,
+/// and user-facing address. It also removes `alpha` from the
+/// constructor-created dummy spends identified by the caller.
+///
+/// This narrower view is intended for version 6 migration PCZTs encoded with
+/// the v2 PCZT format. It is only suitable for a Signer that:
+///
+/// - derives the relevant full viewing key from trusted account data and uses
+///   it to check the spend rather than trusting a wire `fvk`;
+/// - reconstructs wallet migration output recipients from the retained note
+///   fields instead of using output recovery or address metadata;
+/// - recognizes already-authorized constructor dummy spends without their
+///   randomizers and does not mistake wallet-controlled zero-valued spends for
+///   dummies;
+/// - resolves the fields compacted by [`redact_pczt_for_signer`]; and
+/// - returns only the new Orchard-protocol spend authorization signatures it
+///   contributes.
+///
+/// The dummy spend action indices must be captured from the constructor's
+/// Orchard and Ironwood PCZT bundles before
+/// [`pczt::roles::io_finalizer::IoFinalizer`] consumes their `dummy_sk` values.
+/// Wallet-controlled zero-valued spends are not dummy spends and must not be
+/// included. Every identified action must be in range and carry the
+/// authorization signature produced by the IO Finalizer.
+///
+/// The caller must retain `pczt` and combine the Signer's contribution into
+/// that authoritative copy. Do not use this view with a general-purpose Signer
+/// that relies on any of the additionally omitted fields.
+///
+/// Returns an error if the PCZT is not for a version 6 transaction, a dummy
+/// action index is out of range, or an identified dummy action is not already
+/// authorized.
+#[cfg(feature = "pczt")]
+pub fn redact_pczt_for_migration_signer(
+    pczt: &pczt::Pczt,
+    orchard_dummy_spend_action_indices: &[usize],
+    ironwood_dummy_spend_action_indices: &[usize],
+) -> Result<pczt::Pczt, MigrationSignerRedactionError> {
+    if *pczt.global().tx_version() != zcash_protocol::constants::V6_TX_VERSION {
+        return Err(
+            MigrationSignerRedactionError::UnsupportedTransactionVersion(
+                *pczt.global().tx_version(),
+            ),
+        );
+    }
+
+    for index in orchard_dummy_spend_action_indices {
+        let action = pczt.orchard().actions().get(*index).ok_or(
+            MigrationSignerRedactionError::OrchardDummySpendActionIndexOutOfRange {
+                index: *index,
+                action_count: pczt.orchard().actions().len(),
+            },
+        )?;
+        if action.spend().spend_auth_sig().is_none() {
+            return Err(MigrationSignerRedactionError::OrchardDummySpendNotAuthorized(*index));
+        }
+    }
+    for index in ironwood_dummy_spend_action_indices {
+        let action = pczt.ironwood().actions().get(*index).ok_or(
+            MigrationSignerRedactionError::IronwoodDummySpendActionIndexOutOfRange {
+                index: *index,
+                action_count: pczt.ironwood().actions().len(),
+            },
+        )?;
+        if action.spend().spend_auth_sig().is_none() {
+            return Err(MigrationSignerRedactionError::IronwoodDummySpendNotAuthorized(*index));
+        }
+    }
+
+    fn redact_orchard_bundle(
+        mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>,
+        dummy_spend_action_indices: &[usize],
+    ) {
+        redactor.redact_actions(|mut action| {
+            action.clear_spend_fvk();
+            action.clear_spend_auth_sig();
+            action.clear_output_ock();
+            action.clear_output_zip32_derivation();
+            action.clear_output_user_address();
+        });
+        for index in dummy_spend_action_indices {
+            redactor.redact_action(*index, |mut action| action.clear_spend_alpha());
+        }
+    }
+
+    let signer_view = redact_pczt_for_signer(pczt);
+    Ok(Redactor::new(signer_view)
+        .redact_orchard_with(|redactor| {
+            redact_orchard_bundle(redactor, orchard_dummy_spend_action_indices);
+        })
+        .redact_ironwood_with(|redactor| {
+            redact_orchard_bundle(redactor, ironwood_dummy_spend_action_indices);
+        })
+        .finish())
 }
 
 /// Finalizes the given PCZT, and persists the transaction to the wallet database.


### PR DESCRIPTION
Adds a version 6 migration-specific signer view on top of the general external signer redaction helper. It validates constructor-captured dummy action indices, then removes fields that a signer with trusted account context reconstructs or does not consume, while preserving wallet-controlled spend randomizers and requiring the wallet to retain the authoritative PCZT.\n\nThe helper is intentionally narrower than the general signer path and returns a typed error for unsupported transaction versions or invalid dummy action metadata. Validated with the backend unit suite, the all-features version 6 PCZT construction and signature round trip, the version 5 rejection path, strict clippy, formatting, and rustdoc.