### PR TITLE
zcash_pool_migration_backend: add note-preparation transaction planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7261,6 +7261,9 @@ dependencies = [
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
 dependencies = [
+ "incrementalmerkletree",
+ "orchard",
+ "pczt",
  "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -53,3 +53,15 @@ and this library adheres to Rust's notion of
   unsigned. It signs a finalized but still UNPROVEN PCZT: the spend-authorization signature is over
   the transaction's sighash, which is fixed independently of the zk proofs, so the migration signs up
   front (capturing the account's authorization) and proves later, at scheduling time.
+- Note-preparation transaction planning (the `preparation` module): a pure planner that partitions the
+  work of minting a note-split plan's self-funding notes into note-preparation transactions of exactly
+  `PREP_TX_ACTIONS` (16) Orchard actions, per ZIP 318, organised into the fewest sequential layers
+  (with parallel transactions inside a layer). `plan_preparation` takes the wallet's spendable
+  source-pool note values, the target funding-note values, and a per-transaction fee reserve, and
+  returns a `PreparationPlan` of `PrepTransaction`s (each a same-pool send-to-self referencing wallet
+  notes or earlier layers' outputs). It uses a largest-first greedy: feed each output transaction from
+  the largest note, route every leftover forward as a feeder note, and consolidate dust; once the
+  funding notes are scheduled it consolidates the leftover feeders into a single residual note, per
+  ZIP 318's "one note per part plus at most one residual note". A typical wallet needs one layer, and
+  extra layers appear only for a lone large note fanning out into many funding notes or a dust-heavy
+  balance. It is pure (no cryptography or I/O) and `no_std`.

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -27,3 +27,29 @@ and this library adheres to Rust's notion of
   strategy parameters. `plan_note_split` is a convenience wrapper over the recommended
   `CanonicalOneTwoFive`. The crate is `no_std` (it needs only `alloc`), depending on
   `zcash_protocol`, `zcash_primitives`, and `rand_core`.
+- The pure PCZT split builder (the `build` module, behind the `orchard` feature):
+  `build_split_pczt` (and `build_split_pczt_for_plan`, which reads a `NoteSplitPlan`'s
+  `migration_outputs`) turn the split plan plus the cryptographic ingredients a wallet supplies (the
+  spendable Orchard notes and their witnesses, the anchor, the full viewing key) into an unproven
+  `pczt::Pczt` for the same-pool send-to-self that mints the self-funding notes, plus a `SplitOutputs`
+  mapping each output to its real Orchard action index. It is pure (no database or wallet-backend
+  access) and takes the RNG as a parameter. `finalize_split_outputs` keeps each migration note at its
+  exact planned value and reconciles the real ZIP-317 fee against the plan by adding a plain change
+  output (or, for a sub-action-fee leftover, folding it into the fee). The shared transaction-builder
+  plumbing (build config, PCZT finalization, action-index mapping, fees) is factored into the module
+  root so the transfer builder reuses it. Adds optional `orchard` and `pczt` dependencies, enabled
+  only by the feature.
+- The pure PCZT transfer builder (`build::build_transfer_pczt`, behind the `orchard` feature): spends
+  one self-funding note the split minted and outputs its crossing value into the Ironwood pool as an
+  unproven `pczt::Pczt`, sent to the account's own internal Ironwood change address (derived inside the
+  builder, per ZIP 318). It has no change output; the note's fee buffer funds the transfer's fee
+  exactly (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the
+  transfer is four logical actions, matching the buffer of `2 source + 2 destination` actions). It
+  runs post-NU6.3 (when the Ironwood pool is live), and like the split builder is pure (no database
+  or wallet-backend access) and takes the RNG as a parameter.
+- Pre-signing (`build::sign_pczt`, behind the `orchard` feature): adds the Orchard spend-authorization
+  signatures for a given `orchard::keys::SpendAuthorizingKey` to an assembled migration PCZT, leaving
+  the spends the key does not own (the builder's dummy spends, and any spend from another account)
+  unsigned. It signs a finalized but still UNPROVEN PCZT: the spend-authorization signature is over
+  the transaction's sighash, which is fixed independently of the zk proofs, so the migration signs up
+  front (capturing the account's authorization) and proves later, at scheduling time.

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -23,9 +23,29 @@ rand_core.workspace = true
 zcash_primitives.workspace = true
 zcash_protocol.workspace = true
 
+# Enabled by the `orchard` feature.
+orchard = { workspace = true, optional = true }
+pczt = { workspace = true, optional = true, features = [
+    "io-finalizer",
+    "orchard",
+    "signer",
+    "zcp-builder",
+] }
+
 [dev-dependencies]
+incrementalmerkletree.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
+# The `local-consensus` feature exposes `LocalNetwork`, used to build the migration transactions
+# against regtest params with the relevant network upgrades (including NU6.3) active.
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
+
+[features]
+## Builds the pure PCZT transaction builder (the `build` module), which turns a note-split plan and
+## the cryptographic ingredients a wallet supplies into an unproven migration PCZT. Requires the
+## Orchard pool; pulls in `orchard` and `pczt`. The caller supplies the RNG, so no `rand` dependency
+## is added.
+orchard = ["dep:orchard", "dep:pczt"]
 
 [lints]
 workspace = true

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -1,0 +1,198 @@
+//! Building the migration's note-split transaction as an unproven PCZT.
+//!
+//! [`build_split_pczt`] takes a note-split plan (the self-funding note values) plus the cryptographic
+//! ingredients a wallet backend supplies (the spendable Orchard notes and their witnesses, the
+//! anchor, the full viewing key) and assembles the same-pool Orchard send-to-self that mints one
+//! self-funding note per planned denomination (plus a plain change output for any leftover),
+//! returning the unproven [`pczt::Pczt`] and a [`SplitOutputs`] map from each output to its real
+//! Orchard action index. It runs purely on the transaction
+//! [`Builder`](zcash_primitives::transaction::builder::Builder): no database or wallet-backend
+//! access. Selecting the notes to spend and resolving their witnesses and the anchor are the wallet
+//! backend's job, done separately; here they are inputs, and the returned PCZT is still to be proven,
+//! signed, and finalized.
+//!
+//! The transaction-builder plumbing (building the config, finishing the PCZT through the
+//! [`Creator`]/[`IoFinalizer`] roles, un-shuffling output positions, the ZIP-317 marginal fee) lives
+//! in this module root, so the value-crossing transaction can reuse it when it is added.
+
+use alloc::string::String;
+
+use core::fmt;
+
+use pczt::roles::{creator::Creator, io_finalizer::IoFinalizer};
+use zcash_primitives::transaction::builder::{BuildConfig, PcztParts};
+use zcash_protocol::consensus::Parameters;
+
+mod sign;
+mod split;
+mod transfer;
+pub use sign::sign_pczt;
+pub use split::{SplitOutputs, build_split_pczt, build_split_pczt_for_plan};
+pub use transfer::build_transfer_pczt;
+
+/// An error building a migration PCZT.
+#[derive(Debug)]
+pub enum BuildError {
+    /// The requested outputs cannot be balanced against the selected inputs (the real fee versus the
+    /// planned outputs).
+    Balance(String),
+    /// The transaction builder or the PCZT assembly pipeline failed.
+    Build(String),
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BuildError::Balance(m) => write!(f, "cannot balance the transaction: {m}"),
+            BuildError::Build(m) => write!(f, "pczt build failed: {m}"),
+        }
+    }
+}
+
+impl core::error::Error for BuildError {}
+
+/// The [`BuildConfig`] shared by the migration transactions: an Orchard-anchored bundle, with the
+/// destination-pool (Ironwood) bundle anchored only when that phase produces a crossing output
+/// (`None` for the same-pool note split).
+pub(crate) fn build_config(
+    orchard_anchor: orchard::Anchor,
+    ironwood_anchor: Option<orchard::Anchor>,
+) -> BuildConfig {
+    BuildConfig::Standard {
+        sapling_anchor: None,
+        orchard_anchor: Some(orchard_anchor),
+        ironwood_anchor,
+        orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
+        ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+    }
+}
+
+/// Finish an unproven PCZT from the transaction builder's parts: run the [`Creator`] and
+/// [`IoFinalizer`] roles.
+pub(crate) fn finalize_pczt<P: Parameters>(parts: PcztParts<P>) -> Result<pczt::Pczt, BuildError> {
+    let created = Creator::build_from_parts(parts)
+        .ok_or_else(|| BuildError::Build("pczt creation failed".into()))?;
+    IoFinalizer::new(created)
+        .finalize_io()
+        .map_err(|e| BuildError::Build(format!("io finalize: {e:?}")))
+}
+
+/// Map an output's request-order position to its real Orchard action index. The Orchard builder
+/// shuffles action positions, so the caller must look up where each requested output landed.
+pub(crate) fn output_action_index(
+    meta: &orchard::builder::BundleMetadata,
+    output: usize,
+) -> Result<u32, BuildError> {
+    meta.output_action_index(output)
+        .map(|i| i as u32)
+        .ok_or_else(|| BuildError::Build(format!("no action index for output {output}")))
+}
+
+/// Test helpers shared by the split and transfer builders: a deterministic account, regtest network
+/// params, and a single-leaf Orchard witness. Kept here so both submodules' tests reuse them.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use incrementalmerkletree::{Hashable, Level};
+    use orchard::Anchor;
+    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
+    use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
+    use orchard::tree::{MerkleHashOrchard, MerklePath};
+    use orchard::value::NoteValue;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::{RngCore, SeedableRng};
+    use zcash_protocol::consensus::BlockHeight;
+    use zcash_protocol::local_consensus::LocalNetwork;
+
+    /// 32 random bytes from a `seed`-derived RNG, keeping calls deterministic per case.
+    fn draw_bytes(rng: &mut ChaCha8Rng) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        bytes
+    }
+
+    /// A post-NU6.3 height (past the regtest NU6.3 activation) at which the migration transactions
+    /// are built and their fees computed.
+    pub(crate) const TARGET_HEIGHT: u32 = 100;
+
+    /// An account's Orchard spending key, derived from `seed` so tests can vary the account across
+    /// proptest cases. Draws bytes until they form a valid spending key.
+    pub(crate) fn spending_key(seed: u64) -> SpendingKey {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        loop {
+            let bytes = draw_bytes(&mut rng);
+            if let Some(sk) = SpendingKey::from_bytes(bytes).into_option() {
+                return sk;
+            }
+        }
+    }
+
+    /// An account's Orchard full viewing key (see [`spending_key`]).
+    pub(crate) fn account(seed: u64) -> FullViewingKey {
+        FullViewingKey::from(&spending_key(seed))
+    }
+
+    /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
+    /// The migration builds on a network where NU6.3 (the Ironwood pool) is live.
+    pub(crate) fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
+        let nu6_3 = if nu6_3_active {
+            Some(BlockHeight::from_u32(10))
+        } else {
+            None
+        };
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(2)),
+            blossom: Some(BlockHeight::from_u32(3)),
+            heartwood: Some(BlockHeight::from_u32(4)),
+            canopy: Some(BlockHeight::from_u32(5)),
+            nu5: Some(BlockHeight::from_u32(6)),
+            nu6: Some(BlockHeight::from_u32(7)),
+            nu6_1: Some(BlockHeight::from_u32(8)),
+            nu6_2: Some(BlockHeight::from_u32(9)),
+            nu6_3,
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: None,
+        }
+    }
+
+    /// An Orchard note of `value` owned by `fvk`, with its randomness derived from `seed` (so
+    /// proptest varies the note across cases), placed as the sole leaf of an otherwise-empty
+    /// note-commitment tree, with the matching anchor. The authentication path uses the empty-subtree
+    /// roots for a single leaf at position 0, so `add_orchard_spend`'s anchor check
+    /// (`path.root(cmx) == anchor`) accepts it.
+    pub(crate) fn single_note_witness(
+        fvk: &FullViewingKey,
+        value: u64,
+        seed: u64,
+    ) -> (Note, MerklePath, Anchor) {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let note_value = NoteValue::from_raw(value);
+        let rho = loop {
+            let bytes = draw_bytes(&mut rng);
+            if let Some(rho) = Rho::from_bytes(&bytes).into_option() {
+                break rho;
+            }
+        };
+        let rseed = loop {
+            let bytes = draw_bytes(&mut rng);
+            if let Some(rseed) = RandomSeed::from_bytes(bytes, &rho).into_option() {
+                break rseed;
+            }
+        };
+        let note = Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2)
+            .into_option()
+            .expect("valid note parts");
+
+        let commitment = note.commitment();
+        let cmx = ExtractedNoteCommitment::from(commitment);
+        let auth_path = core::array::from_fn(|level| {
+            let level = Level::from(level as u8);
+            MerkleHashOrchard::empty_root(level)
+        });
+        let position = 0;
+        let path = MerklePath::from_parts(position, auth_path);
+        let anchor = path.root(cmx);
+        (note, path, anchor)
+    }
+}

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -1,0 +1,102 @@
+//! Pre-signing a migration PCZT: adding the Orchard spend-authorization signatures.
+//!
+//! The migration signs UP FRONT (capturing the account's authorization in as few signing sessions
+//! as possible) and proves LATER, at scheduling time. This works because a spend-authorization
+//! signature is over the transaction's sighash, which is fixed once the effecting data is finalized,
+//! independent of the (still-absent) zk proofs: a finalized but unproven PCZT can be signed. The
+//! signed, unproven PCZT is safe to persist and schedule; it cannot be broadcast until it is also
+//! proven and extracted.
+
+use orchard::keys::SpendAuthorizingKey;
+use pczt::roles::signer::{Error as SignerError, Signer};
+
+use super::BuildError;
+
+/// Sign every Orchard spend in an assembled migration PCZT that `ask` authorizes, returning the
+/// signed (still unproven) PCZT. Spends the key does not own are left unsigned: the builder's
+/// fabricated zero-valued dummy spends, and any real spend belonging to another account.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Build`] if the signer cannot be initialized, or if a spend fails to sign
+/// for a reason other than the spend not being authorized by `ask`.
+pub fn sign_pczt(pczt: pczt::Pczt, ask: &SpendAuthorizingKey) -> Result<pczt::Pczt, BuildError> {
+    let mut signer =
+        Signer::new(pczt).map_err(|e| BuildError::Build(format!("signer init: {e:?}")))?;
+    for index in 0.. {
+        match signer.sign_orchard(index, ask) {
+            Ok(()) => {}
+            // Past the last Orchard spend.
+            Err(SignerError::InvalidIndex) => break,
+            // A dummy spend, or a real spend from another account: not ours to authorize.
+            Err(SignerError::OrchardSign(orchard::pczt::SignerError::WrongSpendAuthorizingKey)) => {
+            }
+            Err(e) => return Err(BuildError::Build(format!("sign orchard: {e:?}"))),
+        }
+    }
+    Ok(signer.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orchard::keys::FullViewingKey;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::build_split_pczt;
+    use crate::build::test_util::{
+        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
+    };
+
+    /// Builds a two-output split PCZT spending one note owned by `fvk`. Deterministic in `note_seed`.
+    fn build_split(fvk: &FullViewingKey, note_seed: u64) -> pczt::Pczt {
+        let outputs = [40 * COIN, 40 * COIN];
+        let note_value = 100 * COIN;
+        let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
+        let params = regtest_network(true);
+        let spends = vec![(note, path)];
+        let rng = ChaCha8Rng::seed_from_u64(note_seed);
+        let (pczt, _split) =
+            build_split_pczt(&params, TARGET_HEIGHT, fvk, anchor, spends, &outputs, rng)
+                .expect("the split builds");
+        pczt
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        /// Pre-signing a finalized (unproven) split PCZT adds the account's Orchard spend
+        /// authorization: the serialized PCZT changes when signed with the account's own key, and is
+        /// unchanged when signed with a foreign key, whose spends it does not own.
+        #[test]
+        fn pre_signing_authorizes_only_the_accounts_own_spend(
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let sk = spending_key(account_seed);
+            let fvk = FullViewingKey::from(&sk);
+            let ask = SpendAuthorizingKey::from(&sk);
+
+            // `Pczt::serialize` consumes the PCZT, and the build is deterministic in `note_seed`, so
+            // each comparison builds a fresh (identical) unsigned PCZT.
+            let unsigned = build_split(&fvk, note_seed).serialize().expect("serialize");
+
+            let signed = sign_pczt(build_split(&fvk, note_seed), &ask)
+                .expect("signing the account's own spend")
+                .serialize()
+                .expect("serialize");
+            prop_assert_ne!(signed, unsigned.clone());
+
+            // A foreign key authorizes nothing: the real spend is skipped as a key mismatch.
+            let foreign_ask = SpendAuthorizingKey::from(&spending_key(account_seed ^ 0x5a5a_5a5a));
+            let untouched = sign_pczt(build_split(&fvk, note_seed), &foreign_ask)
+                .expect("a foreign key signs nothing")
+                .serialize()
+                .expect("serialize");
+            prop_assert_eq!(untouched, unsigned);
+        }
+    }
+}

--- a/zcash_pool_migration_backend/src/build/split.rs
+++ b/zcash_pool_migration_backend/src/build/split.rs
@@ -1,0 +1,501 @@
+//! Building the note-split transaction: a same-pool Orchard send-to-self that fans the spendable
+//! balance into one self-funding note per planned denomination (each holding a crossing value plus
+//! its fee buffer), plus a plain change output for any leftover. It produces no destination-pool
+//! output; the value crossing is built separately.
+
+use alloc::vec::Vec;
+
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, RngCore};
+
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_primitives::transaction::builder::Builder;
+use zcash_primitives::transaction::fees::FeeRule;
+use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::value::Zatoshis;
+
+use super::{BuildError, build_config, finalize_pczt, output_action_index};
+use crate::note_splitting::NoteSplitPlan;
+
+/// The internal-scope diversifier index used for the wallet's own split and change outputs.
+const INTERNAL_ADDRESS_INDEX: u32 = 0;
+
+/// The output notes a note-split transaction creates: the self-funding migration notes, and the
+/// leftover change output if the split produced one. Each entry is `(output_index, value)`, where
+/// `output_index` is the note's real position in the built transaction's Orchard actions (the
+/// builder shuffles them), so the wallet can locate each note after the transaction is mined.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SplitOutputs {
+    migration_notes: Vec<(u32, u64)>,
+    change: Option<(u32, u64)>,
+}
+
+impl SplitOutputs {
+    /// Constructs the split outputs from their parts.
+    pub fn from_parts(migration_notes: Vec<(u32, u64)>, change: Option<(u32, u64)>) -> Self {
+        SplitOutputs {
+            migration_notes,
+            change,
+        }
+    }
+
+    /// The `(output_index, value)` of each self-funding migration note the split creates.
+    pub fn migration_notes(&self) -> &[(u32, u64)] {
+        &self.migration_notes
+    }
+
+    /// The `(output_index, value)` of the Orchard change output, if the split produced one.
+    pub fn change(&self) -> Option<(u32, u64)> {
+        self.change
+    }
+}
+
+/// Exact ZIP-317 fee (in zatoshi) for a note-split transaction at `target_height`, delegating to the
+/// transaction's own [`Zip317FeeRule`] so the estimate cannot drift from the builder. The note split
+/// is an Orchard-only send-to-self with cross-address transfers disabled, so each spend and each
+/// output occupies its own action (paired with a fabricated zero-valued counterpart):
+/// `orchard_actions = n_spends + n_outputs`.
+fn split_fee<P: Parameters>(
+    params: &P,
+    target_height: u32,
+    n_spends: usize,
+    n_outputs: usize,
+) -> u64 {
+    let orchard_actions = n_spends + n_outputs;
+    Zip317FeeRule::standard()
+        .fee_required(
+            params,
+            BlockHeight::from_u32(target_height),
+            core::iter::empty(),
+            core::iter::empty(),
+            0,
+            0,
+            orchard_actions,
+            0,
+        )
+        .expect("a ZIP-317 fee for a note split never fails")
+        .into_u64()
+}
+
+/// Resolve the transaction's real balance against the planned migration-note values, deciding
+/// whether the split needs an extra plain change output for the leftover, and returning
+/// `(fee, change)`.
+///
+/// The migration notes always keep their exact planned values; drifting one to absorb the
+/// fee-estimate difference would leak that drift when the note is later spent. Any leftover
+/// (fee-estimate drift plus genuine dust) becomes its own plain change output, unless the leftover
+/// is smaller than one marginal action fee, in which case it is cheaper to pay it into the fee.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Balance`] if there are no outputs, if the real fee exceeds the selected
+/// total, or if the real fee exceeds the plan by more than the selected total (net of the planned
+/// outputs) can cover.
+fn finalize_split_outputs<P: Parameters>(
+    params: &P,
+    target_height: u32,
+    n_spends: usize,
+    selected_total: u64,
+    outputs: &[u64],
+) -> Result<(u64, Option<u64>), BuildError> {
+    if outputs.is_empty() {
+        return Err(BuildError::Balance(
+            "note split: no outputs to adjust".into(),
+        ));
+    }
+    let planned: u64 = outputs.iter().sum();
+    let fee_without_change = split_fee(params, target_height, n_spends, outputs.len());
+    let required = selected_total
+        .checked_sub(fee_without_change)
+        .ok_or_else(|| {
+            BuildError::Balance(format!(
+                "note split: fee {fee_without_change} exceeds selected total {selected_total}"
+            ))
+        })?;
+    let leftover = required.checked_sub(planned).ok_or_else(|| {
+        BuildError::Balance(format!(
+            "note split: real fee exceeds the plan by more than the selected total can cover \
+             (required {required} zatoshi, planned migration outputs {planned} zatoshi)"
+        ))
+    })?;
+    if leftover == 0 {
+        return Ok((fee_without_change, None));
+    }
+    let fee_with_change = split_fee(params, target_height, n_spends, outputs.len() + 1);
+    let extra_action_cost = fee_with_change - fee_without_change;
+    if leftover <= extra_action_cost {
+        return Ok((fee_without_change + leftover, None));
+    }
+    Ok((fee_with_change, Some(leftover - extra_action_cost)))
+}
+
+/// Build the note-split transaction as an unproven PCZT: spend every supplied Orchard note and fan
+/// the value into one same-address change output per planned denomination in `output_values`, plus
+/// one further plain change output if the real balance leaves anything over the plan.
+///
+/// The ingredients (which the wallet backend resolves from its note-commitment tree) are: the
+/// Orchard `anchor` and, per spent note, the `(Note, MerklePath)` witness in `spends`; plus the
+/// `orchard_fvk` (the split outputs are derived from its internal scope). `output_values` are the
+/// self-funding note values ([`NoteSplitPlan::migration_outputs`]).
+///
+/// Returns the finalized PCZT and the [`SplitOutputs`] mapping each requested output (migration
+/// notes first, then any change) to its real post-shuffle Orchard action index.
+///
+/// # Errors
+///
+/// Returns [`BuildError`] if there are no spends, if the outputs cannot be balanced against the
+/// selected total (fee versus planned outputs), or if the builder/PCZT pipeline fails.
+///
+/// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
+/// pass a seeded one), keeping this builder pure.
+pub fn build_split_pczt<P, R>(
+    params: &P,
+    target_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    spends: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
+    output_values: &[u64],
+    rng: R,
+) -> Result<(pczt::Pczt, SplitOutputs), BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    if spends.is_empty() {
+        return Err(BuildError::Balance("note split: no spendable notes".into()));
+    }
+    let selected_total: u64 = spends.iter().map(|(note, _)| note.value().inner()).sum();
+    let (_fee, change) = finalize_split_outputs(
+        params,
+        target_height,
+        spends.len(),
+        selected_total,
+        output_values,
+    )?;
+    let mut requested: Vec<u64> = output_values.to_vec();
+    if let Some(change_value) = change {
+        requested.push(change_value);
+    }
+
+    let mut builder = Builder::new(
+        params.clone(),
+        BlockHeight::from_u32(target_height),
+        build_config(anchor, None),
+    );
+    for (note, merkle_path) in spends {
+        builder
+            .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
+            .map_err(|e| BuildError::Build(format!("note split: add spend: {e:?}")))?;
+    }
+    let change_address = orchard_fvk.address_at(INTERNAL_ADDRESS_INDEX, Scope::Internal);
+    let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
+    for value in &requested {
+        builder
+            .add_orchard_change_output::<Infallible>(
+                orchard_fvk.clone(),
+                Some(internal_ovk.clone()),
+                change_address,
+                Zatoshis::const_from_u64(*value),
+                MemoBytes::empty(),
+            )
+            .map_err(|e| BuildError::Build(format!("note split: add change: {e:?}")))?;
+    }
+
+    let build_result = builder
+        .build_for_pczt(rng, &Zip317FeeRule::standard())
+        .map_err(|e| BuildError::Build(format!("note split: build: {e:?}")))?;
+
+    // Un-shuffle: map each requested output (request order) to its real action index so the caller
+    // stores the right (action_index, value) references.
+    let placed: Vec<(u32, u64)> = requested
+        .iter()
+        .enumerate()
+        .map(|(i, &value)| output_action_index(&build_result.orchard_meta, i).map(|ai| (ai, value)))
+        .collect::<Result<_, _>>()?;
+    let (migration_notes, change_out) = if change.is_some() {
+        let (notes, change_slice) = placed.split_at(output_values.len());
+        (notes.to_vec(), change_slice.first().copied())
+    } else {
+        (placed, None)
+    };
+
+    let finalized = finalize_pczt(build_result.pczt_parts)?;
+
+    Ok((
+        finalized,
+        SplitOutputs::from_parts(migration_notes, change_out),
+    ))
+}
+
+/// Build the note-split PCZT directly from a [`NoteSplitPlan`], using its
+/// [`migration_outputs`](NoteSplitPlan::migration_outputs) as the self-funding note values. A thin
+/// convenience over [`build_split_pczt`].
+///
+/// # Errors
+///
+/// See [`build_split_pczt`].
+pub fn build_split_pczt_for_plan<P, R>(
+    params: &P,
+    target_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    spends: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
+    plan: &NoteSplitPlan,
+    rng: R,
+) -> Result<(pczt::Pczt, SplitOutputs), BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    build_split_pczt(
+        params,
+        target_height,
+        orchard_fvk,
+        anchor,
+        spends,
+        plan.migration_outputs(),
+        rng,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::local_consensus::LocalNetwork;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::test_util::{TARGET_HEIGHT, account, regtest_network, single_note_witness};
+    use crate::note_splitting::{
+        CanonicalOneTwoFive, DenominationStrategy, MIGRATION_MAX_DENOMINATION_ZEC, NoteSplitPlan,
+        RESIDUAL_MIGRATION_MIN_ZATOSHI,
+    };
+
+    /// A `finalize_split_outputs` input guaranteed to balance: a spend count, a non-empty set of
+    /// planned output values, and a selected total at least large enough to cover the outputs plus
+    /// the no-change fee (plus an arbitrary extra leftover).
+    fn arb_finalize_input() -> impl Strategy<Value = (usize, Vec<u64>, u64)> {
+        (
+            1usize..10,
+            prop::collection::vec(1u64..1_000_000, 1..8),
+            0u64..80_000,
+        )
+            .prop_map(|(n_spends, outputs, extra)| {
+                let params = regtest_network(true);
+                let planned: u64 = outputs.iter().sum();
+                let fee = split_fee(&params, TARGET_HEIGHT, n_spends, outputs.len());
+                let selected_total = planned + fee + extra;
+                (n_spends, outputs, selected_total)
+            })
+    }
+
+    proptest! {
+        /// Whatever the split does with the leftover (own change output, or paid into the fee), value
+        /// is conserved: `planned outputs + change + fee == selected total`. The migration outputs
+        /// always keep their exact planned values, and any change is strictly positive.
+        #[test]
+        fn finalize_conserves_value((n_spends, outputs, selected_total) in arb_finalize_input()) {
+            let params = regtest_network(true);
+            let planned: u64 = outputs.iter().sum();
+            let (fee, change) =
+                finalize_split_outputs(&params, TARGET_HEIGHT, n_spends, selected_total, &outputs)
+                    .unwrap();
+            prop_assert_eq!(planned + change.unwrap_or(0) + fee, selected_total);
+            prop_assert!(fee >= split_fee(&params, TARGET_HEIGHT, n_spends, outputs.len()));
+            if let Some(c) = change {
+                prop_assert!(c > 0);
+            }
+        }
+    }
+
+    /// The leftover boundary: a leftover of at most one action's fee is paid into the fee (no change
+    /// output); one zatoshi more gets its own change output, net of that extra action's cost.
+    #[test]
+    fn leftover_at_or_below_one_action_is_paid_into_fee() {
+        // Two outputs, so adding a change output genuinely costs one more action (with a single
+        // output the action count is already floored at the grace count, and change is free).
+        let params = regtest_network(true);
+        let outputs = [100u64, 100];
+        let planned: u64 = outputs.iter().sum();
+        let n_spends = 1;
+        let fee_without_change = split_fee(&params, TARGET_HEIGHT, n_spends, outputs.len());
+        let extra_action_cost =
+            split_fee(&params, TARGET_HEIGHT, n_spends, outputs.len() + 1) - fee_without_change;
+        assert!(extra_action_cost > 0);
+
+        // Leftover exactly one action fee: folded into the fee, no change output.
+        let total = planned + fee_without_change + extra_action_cost;
+        assert_eq!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, n_spends, total, &outputs).unwrap(),
+            (fee_without_change + extra_action_cost, None)
+        );
+        // One zatoshi more: worth its own change output, of exactly that one zatoshi.
+        assert_eq!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, n_spends, total + 1, &outputs).unwrap(),
+            (fee_without_change + extra_action_cost, Some(1))
+        );
+    }
+
+    /// A leftover of exactly zero: the outputs plus the no-change fee consume the total exactly.
+    #[test]
+    fn exact_total_has_no_change() {
+        let params = regtest_network(true);
+        let outputs = [100u64, 250u64];
+        let n_spends = 2;
+        let fee = split_fee(&params, TARGET_HEIGHT, n_spends, outputs.len());
+        let total = 350 + fee;
+        assert_eq!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, n_spends, total, &outputs).unwrap(),
+            (fee, None)
+        );
+    }
+
+    #[test]
+    fn finalize_rejects_bad_inputs() {
+        let params = regtest_network(true);
+        // No outputs to size.
+        assert!(matches!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, 1, 1_000_000, &[]),
+            Err(BuildError::Balance(_))
+        ));
+        // Selected total cannot even cover the fee.
+        assert!(matches!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, 1, 1, &[100]),
+            Err(BuildError::Balance(_))
+        ));
+        // Fee is affordable but the planned outputs are not.
+        let fee = split_fee(&params, TARGET_HEIGHT, 1, 1);
+        assert!(matches!(
+            finalize_split_outputs(&params, TARGET_HEIGHT, 1, fee + 50, &[100]),
+            Err(BuildError::Balance(_))
+        ));
+    }
+
+    /// The builder rejects an empty spend set before touching any cryptography.
+    #[test]
+    fn build_rejects_no_spends() {
+        let sk = orchard::keys::SpendingKey::from_bytes([1; 32]).unwrap();
+        let fvk = FullViewingKey::from(&sk);
+        let params = zcash_protocol::consensus::MAIN_NETWORK;
+        let target_height = 1_000_000;
+        let anchor = orchard::Anchor::empty_tree();
+        let spends = Vec::new();
+        let outputs = [100u64];
+        let rng = ChaCha8Rng::seed_from_u64(0);
+        let result = build_split_pczt(&params, target_height, &fvk, anchor, spends, &outputs, rng);
+        let err = result.unwrap_err();
+        assert!(matches!(err, BuildError::Balance(_)));
+    }
+
+    /// Plans a note split with the canonical `{1, 2, 5} * 10^k` strategy, the same decomposition the
+    /// `note_splitting` tests exercise.
+    fn plan_for(balance: u64, rng: &mut ChaCha8Rng) -> NoteSplitPlan {
+        let strategy = CanonicalOneTwoFive::recommended();
+        strategy.plan(balance, 0, rng)
+    }
+
+    /// Builds a split for `plan`, funded by a single input note worth the plan total plus one ZEC of
+    /// headroom (which dwarfs the split fee, so a change output is always present), on `params` at a
+    /// height where Orchard is live. Asserts the migration notes reproduce the plan exactly, value is
+    /// conserved through the ZIP-317 fee (the build balancing already proves the estimate agreed with
+    /// the transaction builder), and every output maps to a distinct Orchard action index.
+    fn assert_builds_planned_split(
+        fvk: &FullViewingKey,
+        plan: &NoteSplitPlan,
+        params: &LocalNetwork,
+        note_seed: u64,
+    ) {
+        let outputs = plan.migration_outputs().to_vec();
+        let planned: u64 = outputs.iter().sum();
+        let change_headroom = COIN;
+        let note_value = planned + change_headroom;
+
+        let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
+        let spends = vec![(note, path)];
+        let build_rng = ChaCha8Rng::seed_from_u64(note_seed);
+        let result = build_split_pczt(
+            params,
+            TARGET_HEIGHT,
+            fvk,
+            anchor,
+            spends,
+            &outputs,
+            build_rng,
+        );
+        let (pczt, split) = result.expect("a planned split should build and balance");
+
+        let built_values: Vec<u64> = split.migration_notes().iter().map(|&(_, v)| v).collect();
+        assert_eq!(built_values, outputs);
+
+        let change = split
+            .change()
+            .expect("the one-ZEC headroom leaves a change output");
+        let (change_index, change_value) = change;
+        let implied_fee = note_value - planned - change_value;
+        let expected_fee = split_fee(params, TARGET_HEIGHT, 1, outputs.len() + 1);
+        assert_eq!(implied_fee, expected_fee);
+
+        let mut indices: Vec<u32> = split.migration_notes().iter().map(|&(i, _)| i).collect();
+        indices.push(change_index);
+        let output_count = indices.len();
+        indices.sort_unstable();
+        indices.dedup();
+        assert_eq!(
+            indices.len(),
+            output_count,
+            "action indices must be distinct"
+        );
+
+        let orchard_bundle = pczt.orchard();
+        let actions = orchard_bundle.actions();
+        assert!(!actions.is_empty());
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(48))]
+
+        /// The builder turns the note-splitting strategy's plans into balanced split PCZTs across a
+        /// range of balances (whole-ZEC and sub-ZEC), on a post-NU6.3 network (the Ironwood
+        /// migration's environment). This is the plan-to-PCZT integration over the same decompositions
+        /// the `note_splitting` tests cover.
+        #[test]
+        fn builds_planned_splits(
+            balance in RESIDUAL_MIGRATION_MIN_ZATOSHI..=(300 * COIN),
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+            seed in any::<u64>(),
+        ) {
+            let fvk = account(account_seed);
+            let mut plan_rng = ChaCha8Rng::seed_from_u64(seed);
+            let plan = plan_for(balance, &mut plan_rng);
+            // A balance below one self-funding note has nothing to split; that case is covered by
+            // `below_min_note_migrates_nothing` in `note_splitting`.
+            prop_assume!(!plan.migration_outputs().is_empty());
+
+            let params = regtest_network(true);
+            assert_builds_planned_split(&fvk, &plan, &params, note_seed);
+        }
+    }
+
+    /// A concrete near-maximum split (the canonical strategy of a large, above-cap balance yields tens
+    /// of cap-sized crossings): the whole many-output bundle builds into one balanced PCZT, post-NU6.3.
+    #[test]
+    fn builds_a_large_many_output_split() {
+        let fvk = account(0);
+        // Far above the per-note cap, so the plan fills with cap-sized (10,000 ZEC) crossings.
+        let balance = 40 * MIGRATION_MAX_DENOMINATION_ZEC * COIN;
+        let mut plan_rng = ChaCha8Rng::seed_from_u64(0);
+        let plan = plan_for(balance, &mut plan_rng);
+        assert!(
+            plan.migration_outputs().len() >= 30,
+            "a large balance should produce many crossings"
+        );
+        let params = regtest_network(true);
+        assert_builds_planned_split(&fvk, &plan, &params, 0);
+    }
+}

--- a/zcash_pool_migration_backend/src/build/transfer.rs
+++ b/zcash_pool_migration_backend/src/build/transfer.rs
@@ -1,0 +1,141 @@
+//! Building a migration transfer transaction: spending one self-funding note and crossing its value
+//! into the Ironwood pool.
+//!
+//! [`build_transfer_pczt`] spends a single self-funding note (one the note split minted, worth its
+//! crossing value plus a fee buffer) and outputs that crossing value into the destination Ironwood
+//! pool, to the account's own internal (change) address as ZIP 318 requires. It has no change output:
+//! the self-funding note's buffer funds the transfer's fee exactly
+//! (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the transfer is
+//! four logical actions, matching the buffer of `2 source + 2 destination` actions). The transfer
+//! only exists post-NU6.3, when the Ironwood pool is live.
+
+use core::convert::Infallible;
+
+use rand_core::{CryptoRng, RngCore};
+
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_primitives::transaction::builder::Builder;
+use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::value::Zatoshis;
+
+use super::{BuildError, build_config, finalize_pczt};
+
+/// Build a migration transfer as an unproven PCZT: spend the supplied self-funding `note` and output
+/// its `crossing_value` into the Ironwood pool (which is output-only here, so it is anchored against
+/// the empty tree). The transfer's fee is funded entirely by the note's buffer, so there is no change
+/// output; a build that balances proves the buffer matches the fee.
+///
+/// The ingredients (which the wallet backend resolves) are: the Orchard `anchor` and the note's
+/// `merkle_path`; the `note` itself (a self-funding note the split minted, worth
+/// `crossing_value` plus the fee buffer); and the `orchard_fvk` (authorizes the spend, derives the
+/// output viewing key, and derives the destination: per ZIP 318 the crossing is sent to the account's
+/// own internal Ironwood change address). `target_height` and `expiry_height` bound the transaction.
+/// It mirrors the note split's
+/// [`crossing_values`](crate::note_splitting::NoteSplitPlan::crossing_values): one transfer per
+/// self-funding note.
+///
+/// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
+/// pass a seeded one), keeping this builder pure.
+///
+/// # Errors
+///
+/// Returns [`BuildError::Build`] if the builder or PCZT pipeline fails (including when the note's
+/// buffer does not cover the transfer fee, which unbalances the transaction).
+#[allow(clippy::too_many_arguments)]
+pub fn build_transfer_pczt<P, R>(
+    params: &P,
+    target_height: u32,
+    expiry_height: u32,
+    orchard_fvk: &FullViewingKey,
+    anchor: orchard::Anchor,
+    note: orchard::note::Note,
+    merkle_path: orchard::tree::MerklePath,
+    crossing_value: u64,
+    rng: R,
+) -> Result<pczt::Pczt, BuildError>
+where
+    P: Parameters + Clone,
+    R: RngCore + CryptoRng,
+{
+    let target = BlockHeight::from_u32(target_height);
+    let expiry = BlockHeight::from_u32(expiry_height);
+    // The Ironwood bundle is output-only (no spend to anchor against); the empty tree is the
+    // output-only anchor convention.
+    let config = build_config(anchor, Some(orchard::Anchor::empty_tree()));
+    let mut builder = Builder::new(params.clone(), target, config).with_expiry_height(expiry);
+
+    builder
+        .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
+        .map_err(|e| BuildError::Build(format!("transfer: add spend: {e:?}")))?;
+
+    // ZIP 318: the destination MUST be the account's own internal (change) Ironwood address, sent with
+    // the internal outgoing viewing key so the wallet can recover the note. Derived here so a caller
+    // cannot misdirect the crossing.
+    let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
+    let recipient = orchard_fvk.address_at(0u32, Scope::Internal);
+    let crossing = Zatoshis::const_from_u64(crossing_value);
+    let memo = MemoBytes::empty();
+    builder
+        .add_ironwood_output::<Infallible>(Some(internal_ovk), recipient, crossing, memo)
+        .map_err(|e| BuildError::Build(format!("transfer: add ironwood output: {e:?}")))?;
+
+    let build_result = builder
+        .build_for_pczt(rng, &Zip317FeeRule::standard())
+        .map_err(|e| BuildError::Build(format!("transfer: build: {e:?}")))?;
+
+    finalize_pczt(build_result.pczt_parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::build::test_util::{account, regtest_network, single_note_witness};
+    use crate::note_splitting::{FeePolicy, RESIDUAL_MIGRATION_MIN_ZATOSHI, Zip317FeePolicy};
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// Every self-funding note the split can mint (a crossing value plus the fee buffer, from
+        /// sub-ZEC up) builds into a balanced transfer post-NU6.3. A build that succeeds proves the
+        /// buffer funds the transfer fee exactly, since the transfer has no change output.
+        #[test]
+        fn self_funding_notes_build_balanced_transfers(
+            crossing_value in RESIDUAL_MIGRATION_MIN_ZATOSHI..=(1_000 * COIN),
+            account_seed in any::<u64>(),
+            note_seed in any::<u64>(),
+        ) {
+            let fvk = account(account_seed);
+            let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+            let note_value = crossing_value + buffer;
+            let (note, path, anchor) = single_note_witness(&fvk, note_value, note_seed);
+
+            let params = regtest_network(true);
+            let target_height = 100;
+            let expiry_height = 140;
+            let rng = ChaCha8Rng::seed_from_u64(crossing_value);
+            let result = build_transfer_pczt(
+                &params,
+                target_height,
+                expiry_height,
+                &fvk,
+                anchor,
+                note,
+                path,
+                crossing_value,
+                rng,
+            );
+
+            let pczt = result.expect("a self-funding note should build a balanced transfer");
+            let orchard_bundle = pczt.orchard();
+            let actions = orchard_bundle.actions();
+            prop_assert!(!actions.is_empty());
+        }
+    }
+}

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -12,11 +12,13 @@
 #![no_std]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-// The crate itself is `no_std` and needs only `alloc` (for `Vec`); `macro_use` under test brings the
-// `vec!` macro into scope, and the tests link `std` for `proptest`.
-#[cfg_attr(test, macro_use)]
+// The crate itself is `no_std` and needs only `alloc`; `macro_use` brings the `vec!` and `format!`
+// macros into scope (the `build` module uses `format!`), and the tests link `std` for `proptest`.
+#[macro_use]
 extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
+#[cfg(feature = "orchard")]
+pub mod build;
 pub mod note_splitting;

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -22,3 +22,4 @@ extern crate std;
 #[cfg(feature = "orchard")]
 pub mod build;
 pub mod note_splitting;
+pub mod preparation;

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -1,0 +1,650 @@
+//! Note-preparation transaction planning: how to restructure a wallet's spendable source-pool notes
+//! into the exact self-funding notes a migration run needs, using transactions that each stay within
+//! the [ZIP 318] action budget.
+//!
+//! # The problem
+//!
+//! The [`note_splitting`](super::note_splitting) planner decides the *values* of the self-funding
+//! notes to mint. This module decides the *transactions* that mint them. [ZIP 318] requires each
+//! note-preparation transaction to be padded to exactly [`PREP_TX_ACTIONS`] Orchard actions (a
+//! mobile-proving-time and on-chain-uniformity constraint). Under NU6.3 a bundle's action count is
+//! its spends plus its outputs, so one transaction can consume and produce at most
+//! [`PREP_TX_ACTIONS`] notes in total (for example 15 spends and one output when consolidating, or
+//! one spend and 15 outputs when splitting).
+//!
+//! A single transaction therefore cannot always turn the wallet's notes into every funding note: a
+//! note that must fan out into more outputs than one transaction holds, or a balance spread across
+//! more dust notes than one transaction can consume, needs **layers**. A layer is a set of
+//! transactions with no dependencies between them (buildable, provable, and broadcastable in
+//! parallel); a later layer may spend the outputs of an earlier one, but only after they are mined
+//! and a boundary passes, so each extra layer extends the preparation phase by roughly one anchor
+//! bucket. The planner therefore prefers fewer layers (which dominate the wall-clock) over fewer
+//! transactions.
+//!
+//! # The strategy
+//!
+//! The planner is a largest-first layered greedy. In each layer it feeds each output transaction from
+//! the largest available note it can (one big note funds up to [`FUNDING_OUTPUTS_PER_TX`] funding
+//! notes), routes every leftover forward as an intermediate ("feeder") note, and consolidates notes
+//! too small to fund anything on their own into feeder notes. Once all funding notes are scheduled it
+//! consolidates the feeders that no layer spent into a single residual note, matching ZIP 318's
+//! "one note per part plus at most one residual note" (a remainder too small to pay a transaction fee
+//! is left as change instead). For a typical wallet (a few notes, a handful of funding notes) this is
+//! a single layer; extra layers appear only for a lone large note fanning out into many funding notes,
+//! or a dust-heavy balance.
+//!
+//! This greedy is a heuristic, not a layer-count optimiser. For a lone, very large note that must fan
+//! out into many funding notes it chains feeder notes linearly (one layer per
+//! [`FUNDING_OUTPUTS_PER_TX`] funding notes) rather than first fanning the note into several parallel
+//! feeders, so in that extreme it can use more layers than the minimum; the common cases above are
+//! already minimal. Fanning the lone-whale case out to parallel first is future work.
+//!
+//! This is a pure planner: it works in note *values* (in zatoshi) and does no cryptography or I/O. It
+//! reserves a fixed per-transaction fee (the caller passes the ZIP-317 fee of a padded
+//! [`PREP_TX_ACTIONS`]-action transaction) out of each transaction's inputs; the builder later
+//! absorbs the real fee into the change.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+
+use alloc::vec::Vec;
+
+use core::fmt;
+
+/// The exact number of Orchard actions in every note-preparation transaction ([ZIP 318]): each is
+/// padded up to this count, so no preparation transaction is distinguishable from another by its
+/// action count, and one transaction handles at most this many notes in total (spends plus outputs).
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const PREP_TX_ACTIONS: usize = 16;
+
+/// The most funding (or feeder) outputs one transaction produces from a single input: the action
+/// budget less that one input and one change/feeder slot (`16 - 1 - 1`).
+pub const FUNDING_OUTPUTS_PER_TX: usize = PREP_TX_ACTIONS - 2;
+
+/// The most notes one transaction consolidates: the action budget less the single output it produces
+/// (`16 - 1`).
+pub const CONSOLIDATION_INPUTS_PER_TX: usize = PREP_TX_ACTIONS - 1;
+
+/// A note a preparation transaction spends: either one of the wallet's original spendable notes, or a
+/// note an earlier layer produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepInput {
+    /// The wallet note at this index in the caller-supplied `available` slice.
+    Wallet(usize),
+    /// The `output`-th output of the `transaction`-th transaction of an earlier `layer`.
+    Prior {
+        layer: usize,
+        transaction: usize,
+        output: usize,
+    },
+}
+
+/// A note a preparation transaction produces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepOutput {
+    /// A final self-funding note: one of the requested funding values.
+    Funding(u64),
+    /// An intermediate ("feeder") note, spent by a later layer to route value forward.
+    Intermediate(u64),
+    /// Leftover value returned to the source pool.
+    Change(u64),
+}
+
+impl PrepOutput {
+    /// The note value this output carries.
+    pub fn value(&self) -> u64 {
+        match self {
+            PrepOutput::Funding(v) | PrepOutput::Intermediate(v) | PrepOutput::Change(v) => *v,
+        }
+    }
+}
+
+/// One note-preparation transaction: a same-pool send-to-self, padded at build time to
+/// [`PREP_TX_ACTIONS`] actions. Its logical action count (`inputs.len() + outputs.len()`) never
+/// exceeds that budget.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrepTransaction {
+    inputs: Vec<PrepInput>,
+    outputs: Vec<PrepOutput>,
+}
+
+impl PrepTransaction {
+    /// The notes this transaction spends.
+    pub fn inputs(&self) -> &[PrepInput] {
+        &self.inputs
+    }
+
+    /// The notes this transaction produces.
+    pub fn outputs(&self) -> &[PrepOutput] {
+        &self.outputs
+    }
+
+    /// The logical Orchard action count before padding (`inputs + outputs`).
+    pub fn action_count(&self) -> usize {
+        self.inputs.len() + self.outputs.len()
+    }
+}
+
+/// A schedule of note-preparation transactions grouped into sequential layers. Every transaction in a
+/// layer is independent of the others in that layer; a transaction may spend a [`PrepInput::Prior`]
+/// output only from a strictly earlier layer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreparationPlan {
+    layers: Vec<Vec<PrepTransaction>>,
+}
+
+impl PreparationPlan {
+    /// The layers, in dependency order (later layers may spend earlier layers' outputs).
+    pub fn layers(&self) -> &[Vec<PrepTransaction>] {
+        &self.layers
+    }
+
+    /// The number of sequential layers (the depth that governs the preparation phase's duration).
+    pub fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// The total number of preparation transactions across all layers.
+    pub fn transaction_count(&self) -> usize {
+        self.layers.iter().map(Vec::len).sum()
+    }
+
+    /// The value an input carries, resolved against the wallet's `available` notes (for a
+    /// [`PrepInput::Wallet`]) or an earlier layer's output (for a [`PrepInput::Prior`]). Returns
+    /// `None` if the reference is out of range.
+    pub fn input_value(&self, input: &PrepInput, available: &[u64]) -> Option<u64> {
+        match input {
+            PrepInput::Wallet(i) => available.get(*i).copied(),
+            PrepInput::Prior {
+                layer,
+                transaction,
+                output,
+            } => self
+                .layers
+                .get(*layer)?
+                .get(*transaction)?
+                .outputs
+                .get(*output)
+                .map(PrepOutput::value),
+        }
+    }
+}
+
+/// Why a preparation plan could not be produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepError {
+    /// The available notes cannot fund every requested funding note plus the per-transaction fees.
+    InsufficientFunds,
+}
+
+impl fmt::Display for PrepError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrepError::InsufficientFunds => {
+                f.write_str("available notes cannot fund the requested notes plus preparation fees")
+            }
+        }
+    }
+}
+
+impl core::error::Error for PrepError {}
+
+/// A note available to spend in the current layer: a reference and its value.
+type PoolNote = (PrepInput, u64);
+
+/// Plan the note-preparation transactions that mint `funding` (the self-funding note values, in
+/// zatoshi) from `available` (the wallet's spendable source-pool note values, in zatoshi), reserving
+/// `fee_per_tx` zatoshi for each transaction (the ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action
+/// transaction).
+///
+/// Returns an empty plan when `funding` is empty, and [`PrepError::InsufficientFunds`] when the
+/// available value cannot cover the funding notes plus the per-transaction fees.
+pub fn plan_preparation(
+    available: &[u64],
+    funding: &[u64],
+    fee_per_tx: u64,
+) -> Result<PreparationPlan, PrepError> {
+    // Funding values still to produce, largest first (so `last()` is the smallest).
+    let mut remaining: Vec<u64> = funding.iter().copied().filter(|&v| v > 0).collect();
+    remaining.sort_unstable_by(|a, b| b.cmp(a));
+
+    let mut layers: Vec<Vec<PrepTransaction>> = Vec::new();
+    if remaining.is_empty() {
+        return Ok(PreparationPlan { layers });
+    }
+
+    // The notes available to spend in the current layer (layer 0: the wallet's own notes).
+    let mut current: Vec<PoolNote> = available
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (PrepInput::Wallet(i), v))
+        .collect();
+
+    while !remaining.is_empty() {
+        if current.is_empty() {
+            return Err(PrepError::InsufficientFunds);
+        }
+        // Largest notes first.
+        current.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+
+        // Pass 1: assign funding to the notes that can fund at least the smallest remaining note.
+        // `partial` holds a note, the funding values it will mint, and its leftover budget; the rest
+        // go to `consolidatable` to be combined into feeder notes.
+        let mut partial: Vec<(PrepInput, Vec<u64>, u64)> = Vec::new();
+        let mut consolidatable: Vec<PoolNote> = Vec::new();
+
+        for (in_ref, value) in current.drain(..) {
+            if remaining.is_empty() {
+                // Everything is already scheduled; this note stays unspent in the wallet.
+                continue;
+            }
+            let smallest = *remaining.last().expect("remaining is non-empty");
+            if value <= fee_per_tx || value - fee_per_tx < smallest {
+                consolidatable.push((in_ref, value));
+                continue;
+            }
+            let budget = value - fee_per_tx;
+            let mut assigned = Vec::new();
+            let mut used = 0u64;
+            let mut i = 0;
+            while i < remaining.len() && assigned.len() < FUNDING_OUTPUTS_PER_TX {
+                if used + remaining[i] <= budget {
+                    used += remaining[i];
+                    assigned.push(remaining.remove(i));
+                } else {
+                    i += 1;
+                }
+            }
+            // `value - fee_per_tx >= smallest` guarantees at least the smallest note was assignable.
+            debug_assert!(!assigned.is_empty());
+            partial.push((in_ref, assigned, budget - used));
+        }
+
+        // Pass 2: mint the funding notes, routing every leftover forward as a feeder so a later layer
+        // reuses it rather than scattering change.
+        let mut txs: Vec<PrepTransaction> = Vec::new();
+        let mut next: Vec<PoolNote> = Vec::new();
+        for (in_ref, assigned, leftover) in partial {
+            let mut outputs: Vec<PrepOutput> =
+                assigned.into_iter().map(PrepOutput::Funding).collect();
+            if leftover > 0 {
+                next.push((
+                    PrepInput::Prior {
+                        layer: layers.len(),
+                        transaction: txs.len(),
+                        output: outputs.len(),
+                    },
+                    leftover,
+                ));
+                outputs.push(PrepOutput::Intermediate(leftover));
+            }
+            txs.push(PrepTransaction {
+                inputs: vec![in_ref],
+                outputs,
+            });
+        }
+
+        // Consolidate notes too small to fund anything into feeders for a later layer.
+        consolidate(
+            consolidatable,
+            layers.len(),
+            fee_per_tx,
+            &mut txs,
+            &mut next,
+        );
+
+        if txs.is_empty() {
+            // No note in this layer could fund or usefully consolidate: the balance is insufficient.
+            return Err(PrepError::InsufficientFunds);
+        }
+        layers.push(txs);
+        current = next;
+    }
+
+    // The funding notes are all scheduled. Consolidate every leftover feeder that no layer spends into
+    // a single residual note (ZIP 318 prepares one note per part plus at most one residual note), for
+    // as long as that is worth a transaction; a remainder too small to pay a fee is left as change.
+    loop {
+        let pool = unconsumed_feeders(&layers);
+        if pool.len() <= 1 {
+            break;
+        }
+        let mut txs: Vec<PrepTransaction> = Vec::new();
+        let mut next: Vec<PoolNote> = Vec::new();
+        consolidate(pool, layers.len(), fee_per_tx, &mut txs, &mut next);
+        if txs.is_empty() {
+            break; // the remainder is sub-fee dust; leave it as change
+        }
+        layers.push(txs);
+    }
+    let _ = current; // the residual pool is recomputed above, so the last `next` is unused
+
+    // Relabel any feeder note that no later layer ends up spending as source-pool change, so the plan
+    // has no dangling intermediates and value is conserved end to end.
+    let mut spent: Vec<(usize, usize, usize)> = Vec::new();
+    for layer in &layers {
+        for tx in layer {
+            for input in &tx.inputs {
+                if let PrepInput::Prior {
+                    layer,
+                    transaction,
+                    output,
+                } = input
+                {
+                    spent.push((*layer, *transaction, *output));
+                }
+            }
+        }
+    }
+    for (li, layer) in layers.iter_mut().enumerate() {
+        for (ti, tx) in layer.iter_mut().enumerate() {
+            for (oi, out) in tx.outputs.iter_mut().enumerate() {
+                if let PrepOutput::Intermediate(v) = *out {
+                    if !spent.contains(&(li, ti, oi)) {
+                        *out = PrepOutput::Change(v);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PreparationPlan { layers })
+}
+
+/// Split `n` notes into consolidation batches of at most [`CONSOLIDATION_INPUTS_PER_TX`], never
+/// leaving a batch of one (which would waste a fee without reducing the note count). Assumes `n >= 2`.
+fn consolidation_batch_sizes(mut n: usize) -> Vec<usize> {
+    let max = CONSOLIDATION_INPUTS_PER_TX;
+    let mut sizes = Vec::new();
+    while n > 0 {
+        let take = if n <= max {
+            n
+        } else if n - max == 1 {
+            max - 1 // leave 2 for the final batch rather than a lone note
+        } else {
+            max
+        };
+        sizes.push(take);
+        n -= take;
+    }
+    sizes
+}
+
+/// Consolidate `pool` into feeder notes: append one consolidation transaction per batch (of at most
+/// [`CONSOLIDATION_INPUTS_PER_TX`] inputs) to `txs` in layer `layer`, with its feeder pushed to
+/// `next`. Returns any notes whose batch could not cover the fee (too small to consolidate).
+fn consolidate(
+    mut pool: Vec<PoolNote>,
+    layer: usize,
+    fee: u64,
+    txs: &mut Vec<PrepTransaction>,
+    next: &mut Vec<PoolNote>,
+) -> Vec<PoolNote> {
+    if pool.len() < 2 {
+        return pool;
+    }
+    pool.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    let mut leftover = Vec::new();
+    for size in consolidation_batch_sizes(pool.len()) {
+        let batch: Vec<PoolNote> = pool.drain(..size).collect();
+        let sum: u64 = batch.iter().map(|&(_, v)| v).sum();
+        if sum <= fee {
+            leftover.extend(batch); // too small to pay a fee; leave unspent
+            continue;
+        }
+        let feeder = sum - fee;
+        next.push((
+            PrepInput::Prior {
+                layer,
+                transaction: txs.len(),
+                output: 0,
+            },
+            feeder,
+        ));
+        txs.push(PrepTransaction {
+            inputs: batch.into_iter().map(|(r, _)| r).collect(),
+            outputs: vec![PrepOutput::Intermediate(feeder)],
+        });
+    }
+    leftover
+}
+
+/// Every intermediate ("feeder") output that no transaction spends, as `(reference, value)` pairs.
+fn unconsumed_feeders(layers: &[Vec<PrepTransaction>]) -> Vec<PoolNote> {
+    let mut spent: Vec<(usize, usize, usize)> = Vec::new();
+    for layer in layers {
+        for tx in layer {
+            for input in &tx.inputs {
+                if let PrepInput::Prior {
+                    layer,
+                    transaction,
+                    output,
+                } = input
+                {
+                    spent.push((*layer, *transaction, *output));
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for (li, layer) in layers.iter().enumerate() {
+        for (ti, tx) in layer.iter().enumerate() {
+            for (oi, output) in tx.outputs.iter().enumerate() {
+                if let PrepOutput::Intermediate(v) = output {
+                    if !spent.contains(&(li, ti, oi)) {
+                        out.push((
+                            PrepInput::Prior {
+                                layer: li,
+                                transaction: ti,
+                                output: oi,
+                            },
+                            *v,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// A representative padded 16-action ZIP-317 fee reserve for the tests (16 * 5000-zatoshi marginal
+    /// fee). The planner treats it opaquely.
+    const FEE_PER_TX: u64 = PREP_TX_ACTIONS as u64 * 5_000;
+
+    /// The multiset of funding values a plan mints, sorted, for comparison against the request.
+    fn minted_funding(plan: &PreparationPlan) -> Vec<u64> {
+        let mut out: Vec<u64> = plan
+            .layers()
+            .iter()
+            .flatten()
+            .flat_map(PrepTransaction::outputs)
+            .filter_map(|o| match o {
+                PrepOutput::Funding(v) => Some(*v),
+                _ => None,
+            })
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    /// The number of final `Change` (residual) outputs across the whole plan.
+    fn change_count(plan: &PreparationPlan) -> usize {
+        plan.layers()
+            .iter()
+            .flatten()
+            .flat_map(PrepTransaction::outputs)
+            .filter(|o| matches!(o, PrepOutput::Change(_)))
+            .count()
+    }
+
+    /// Assert every structural invariant of a plan against its inputs.
+    fn assert_plan_valid(plan: &PreparationPlan, available: &[u64], funding: &[u64], fee: u64) {
+        // Every requested funding note is minted exactly once.
+        let mut want: Vec<u64> = funding.iter().copied().filter(|&v| v > 0).collect();
+        want.sort_unstable();
+        assert_eq!(minted_funding(plan), want, "funding multiset");
+
+        let mut wallet_spent = 0u64;
+        let mut total_fees = 0u64;
+        let mut final_out = 0u64; // funding + change (intermediates are consumed downstream)
+
+        for (li, layer) in plan.layers().iter().enumerate() {
+            for (ti, tx) in layer.iter().enumerate() {
+                // Action budget.
+                assert!(
+                    tx.action_count() <= PREP_TX_ACTIONS,
+                    "layer {li} tx {ti}: {} actions",
+                    tx.action_count()
+                );
+                assert!(!tx.inputs().is_empty(), "layer {li} tx {ti}: no inputs");
+                assert!(!tx.outputs().is_empty(), "layer {li} tx {ti}: no outputs");
+
+                let mut in_sum = 0u64;
+                for input in tx.inputs() {
+                    // Every reference resolves, and a Prior input points strictly backwards.
+                    if let PrepInput::Prior { layer, .. } = input {
+                        assert!(*layer < li, "layer {li} tx {ti}: forward/self reference");
+                    }
+                    let v = plan.input_value(input, available).expect("input resolves");
+                    in_sum += v;
+                    if let PrepInput::Wallet(_) = input {
+                        wallet_spent += v;
+                    }
+                }
+                let out_sum: u64 = tx.outputs().iter().map(PrepOutput::value).sum();
+                // Value conservation: inputs = outputs + the reserved fee.
+                assert_eq!(in_sum, out_sum + fee, "layer {li} tx {ti}: conservation");
+                total_fees += fee;
+                for o in tx.outputs() {
+                    match o {
+                        PrepOutput::Funding(v) | PrepOutput::Change(v) => final_out += v,
+                        PrepOutput::Intermediate(_) => {}
+                    }
+                }
+            }
+        }
+
+        // Global conservation: the wallet value spent equals what left as funding/change plus fees.
+        assert_eq!(wallet_spent, final_out + total_fees, "global conservation");
+    }
+
+    fn arb_input() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
+        (
+            prop::collection::vec(1u64..2_000_000, 0..12),
+            prop::collection::vec(1u64..500_000, 1..20),
+        )
+    }
+
+    /// Funding plus available notes that always include one note large enough to fund everything with
+    /// a generous fee budget, so the planner must succeed.
+    fn arb_sufficient() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
+        prop::collection::vec(1u64..500_000, 1..20).prop_flat_map(|funding| {
+            let need: u64 = funding.iter().sum();
+            let big = need + (funding.len() as u64 + 64) * FEE_PER_TX + 1;
+            (prop::collection::vec(1u64..100_000, 0..8), Just(funding)).prop_map(
+                move |(mut extra, funding)| {
+                    extra.push(big);
+                    (extra, funding)
+                },
+            )
+        })
+    }
+
+    proptest! {
+        /// Whenever a plan is produced over arbitrary inputs, every structural invariant holds.
+        #[test]
+        fn valid_whenever_planned((available, funding) in arb_input()) {
+            if let Ok(plan) = plan_preparation(&available, &funding, FEE_PER_TX) {
+                assert_plan_valid(&plan, &available, &funding, FEE_PER_TX);
+            }
+        }
+
+        /// With one note large enough to fund everything, the planner always succeeds with a valid
+        /// plan (the planner never gives up when the value is amply present).
+        #[test]
+        fn always_plans_when_amply_funded((available, funding) in arb_sufficient()) {
+            let plan = plan_preparation(&available, &funding, FEE_PER_TX)
+                .expect("ample funding must plan");
+            assert_plan_valid(&plan, &available, &funding, FEE_PER_TX);
+            // The leftover is far larger than a fee, so it collapses to a single residual note.
+            prop_assert!(change_count(&plan) <= 1, "{} residual notes", change_count(&plan));
+        }
+    }
+
+    /// A single well-funded note mints a handful of funding notes in one layer, one transaction.
+    #[test]
+    fn common_case_is_one_layer_one_tx() {
+        let funding = [500u64, 200, 100, 20, 5];
+        let total: u64 = funding.iter().sum::<u64>() + FEE_PER_TX + 10_000;
+        let plan = plan_preparation(&[total], &funding, FEE_PER_TX).unwrap();
+        assert_eq!(plan.layer_count(), 1);
+        assert_eq!(plan.transaction_count(), 1);
+        assert_eq!(change_count(&plan), 1, "one residual note");
+        assert_plan_valid(&plan, &[total], &funding, FEE_PER_TX);
+    }
+
+    /// One large note fanning out into more funding notes than a single transaction holds needs more
+    /// than one layer (the remainder feeds forward), yet every transaction stays within budget.
+    #[test]
+    fn whale_single_note_fans_out_across_layers() {
+        let funding: Vec<u64> = (0..40).map(|_| 100u64).collect();
+        let total: u64 = funding.iter().sum::<u64>() + 60 * FEE_PER_TX;
+        let plan = plan_preparation(&[total], &funding, FEE_PER_TX).unwrap();
+        assert!(
+            plan.layer_count() >= 2,
+            "40 funding notes cannot fit one tx"
+        );
+        assert_eq!(change_count(&plan), 1, "one residual note");
+        assert_plan_valid(&plan, &[total], &funding, FEE_PER_TX);
+    }
+
+    /// Dust smaller than a funding note is consolidated into a feeder before it can fund anything, and
+    /// the leftover collapses to a single residual note.
+    #[test]
+    fn dust_is_consolidated_first() {
+        // Twenty notes each far below the single 100-unit funding note (plus fees).
+        let per = FEE_PER_TX + 20;
+        let available: Vec<u64> = core::iter::repeat_n(per, 20).collect();
+        let funding = [100u64];
+        let plan = plan_preparation(&available, &funding, FEE_PER_TX).unwrap();
+        assert!(plan.layer_count() >= 2, "dust must consolidate first");
+        assert_eq!(change_count(&plan), 1, "one residual note");
+        assert_plan_valid(&plan, &available, &funding, FEE_PER_TX);
+    }
+
+    /// Empty funding yields an empty plan; value below the funding-plus-fee floor is insufficient.
+    #[test]
+    fn edge_cases() {
+        assert_eq!(
+            plan_preparation(&[1_000_000], &[], FEE_PER_TX)
+                .unwrap()
+                .layer_count(),
+            0
+        );
+        assert_eq!(
+            plan_preparation(&[10], &[100], FEE_PER_TX),
+            Err(PrepError::InsufficientFunds)
+        );
+    }
+
+    /// The consolidation batching never leaves a lone note and never exceeds the input budget.
+    #[test]
+    fn consolidation_batches_avoid_singletons() {
+        for n in 2..200usize {
+            let sizes = consolidation_batch_sizes(n);
+            assert_eq!(sizes.iter().sum::<usize>(), n);
+            for s in sizes {
+                assert!(
+                    (2..=CONSOLIDATION_INPUTS_PER_TX).contains(&s),
+                    "n={n} size={s}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #2647. Adds the note-preparation transaction planner: how a wallet's spendable source-pool notes are restructured into the exact self-funding notes a migration run needs, as transactions that each obey the [ZIP 318](https://zips.z.cash/zip-0318) action budget.

## Problem

[ZIP 318] requires every note-preparation transaction to be padded to **exactly 16 Orchard actions** (a mobile-proving-time and on-chain-uniformity constraint). Under NU6.3 a bundle's action count is its spends plus its outputs, so one transaction can consume and produce at most 16 notes in total (e.g. 15 spends + 1 output when consolidating, or 1 spend + 15 outputs when splitting).

A single transaction therefore cannot always turn the wallet's notes into every self-funding note: a note that must fan out into more outputs than one transaction holds, or a balance spread across more dust notes than one transaction can consume, needs several transactions organised into **layers**. A layer is a set of transactions with no dependencies between them (built, proved, and broadcast in parallel); a later layer may spend an earlier layer's outputs, but only after they are mined and a boundary passes, so each extra layer extends the preparation phase by roughly one anchor bucket. (The prior `build::build_split_pczt` fans up to 50 outputs into one transaction, which this planner replaces the shape of.)

## Solution

A **pure** `preparation` module (no cryptography, no I/O, `no_std`):

```rust
pub fn plan_preparation(available: &[u64], funding: &[u64], fee_per_tx: u64)
    -> Result<PreparationPlan, PrepError>
```

- `available`: the wallet's spendable source-pool note values (zatoshi).
- `funding`: the target self-funding note values from the note-split plan (each already `crossing + buffer`).
- `fee_per_tx`: the ZIP-317 fee reserved per padded 16-action transaction; the builder later absorbs the real fee into the change.

It returns a `PreparationPlan` of layers of `PrepTransaction`s. Each input is a `PrepInput::Wallet(i)` (an original note) or a `PrepInput::Prior { layer, transaction, output }` (an earlier layer's output); each output is a `PrepOutput::Funding` (a final self-funding note), `Intermediate` (a feeder routed to a later layer), or `Change`.

**Largest-first layered greedy**: in each layer, feed each output transaction from the largest note it can (1 input + up to `FUNDING_OUTPUTS_PER_TX = 14` funding notes + a feeder/change slot = 16 actions), route a large remainder forward as a feeder note, and consolidate notes too small to fund anything (15 inputs -> 1 feeder). Anything below a whole funding note is left as source-pool change. A final pass relabels any feeder that no later layer ends up spending as change, so value is conserved end to end. For a typical wallet (a few notes, a handful of funding notes) this is a single layer.

## Structure

- `preparation.rs` — the constants (`PREP_TX_ACTIONS`, `FUNDING_OUTPUTS_PER_TX`, `CONSOLIDATION_INPUTS_PER_TX`), the `PrepInput` / `PrepOutput` / `PrepTransaction` / `PreparationPlan` / `PrepError` types (with accessors and an `input_value` resolver), and `plan_preparation`.

## Notes for reviewers

- **Pure and `no_std`.** No crypto or I/O; a later slice wires the `build` module to emit one PCZT per `PrepTransaction`, and the engine drives the layers (build/sign a layer together, then prove + broadcast it only after the prior layer is mined and a boundary passes).
- **Fees.** The planner reserves `fee_per_tx` out of each transaction's inputs (the caller passes `16 * MARGINAL_FEE`, the fee of a padded 16-action tx); the real fee is smaller and the builder absorbs it into change.
- **Known limitation (documented in the module doc).** The greedy is a heuristic, not a layer-count optimiser: for a lone, very large note fanning out into many funding notes it chains feeders linearly (one layer per 14 funding notes) rather than fanning the note into several parallel feeders first, so in that extreme it can use more layers than the minimum (e.g. ~4 where 2 would do for 50 notes from one note). The common cases are already minimal; the lone-whale fan-out is flagged as future work.

## Tests

A proptest suite drives the structural contract over arbitrary inputs: every transaction stays within the 16-action budget, value is conserved per transaction (`inputs = outputs + fee`) and globally (`wallet spent = funding + change + fees`), every requested funding note is minted exactly once, and every `Prior` input references a strictly earlier layer (acyclic). A second generator that always includes one note large enough to fund everything asserts the planner never spuriously fails when the value is present. Golden tests cover the one-layer common case, a whale single note fanning across layers, dust consolidated before it can fund, an insufficient-value `Err`, and the consolidation batching (never a lone note, never over budget).

## Verification

- `cargo test -p zcash_pool_migration_backend` and `--features orchard`
- `cargo clippy -p zcash_pool_migration_backend --all-targets` and `--features orchard --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p zcash_pool_migration_backend --no-deps`
- `cargo fmt --check`
