### PR TITLE
zcash_client_backend: Add a backend-agnostic network-privacy layer

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,25 @@ workspace.
 ### Added
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
+- `zcash_client_backend::privacy` (behind the new `lightwalletd-privacy` feature):
+  a backend-agnostic network-privacy layer generalizing the Tor transport.
+  - `privacy::PrivateNetwork`: a trait abstracting a connection-level privacy
+    transport (opening byte streams to a `host:port`).
+  - `privacy::DynPrivateNetwork` and `privacy::BoxedStream`: an object-safe
+    mirror of `PrivateNetwork` (with a blanket implementation for every
+    `PrivateNetwork`) for use behind a pointer, e.g. `Arc<dyn DynPrivateNetwork>`
+    (which itself implements `PrivateNetwork`).
+  - `privacy::DormantMode` and `privacy::Error`.
+  - `privacy::grpc::connect_to_lightwalletd` (feature-gated on
+    `lightwalletd-tonic-tls-webpki-roots`) and `privacy::http`
+    (`http_get`/`http_post`/`http_get_json`, `Retry`, `HttpError`, and the
+    `cryptex` exchange-rate machinery), each generalized over `PrivateNetwork`.
+- `zcash_client_backend::privacy::blocking` (behind the new
+  `lightwalletd-blocking` feature, which does not require the `tor` feature):
+  - `privacy::blocking::PrivacyRuntime`: a synchronous facade bundling a Tokio
+    runtime with a `PrivateNetwork` backend, with a `tor`-gated `create_tor`
+    convenience constructor.
+  - `privacy::blocking::LwdConn`: a blocking `lightwalletd` gRPC client.
 
 ### Changed
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
@@ -24,6 +43,19 @@ workspace.
   transfers, and so requires `spends + outputs` actions. The method now also
   accounts for the bundle type's padding, and is gated on the `orchard`
   feature.
+- `zcash_client_backend::tor::DormantMode` is now a re-export of the crate-owned
+  `zcash_client_backend::privacy::DormantMode` (with the same `Normal` and `Soft`
+  variants) rather than a re-export of `arti_client::DormantMode`. `From`
+  conversions to and from `arti_client::DormantMode` are provided under the `tor`
+  feature. Code that constructs or matches `Normal`/`Soft` is unaffected.
+- `zcash_client_backend::tor::http::{HttpError, Retry}` and
+  `zcash_client_backend::tor::http::cryptex` are now re-exports of the
+  corresponding items in `zcash_client_backend::privacy::http`. The existing
+  `tor::http::*` paths continue to resolve unchanged.
+- `zcash_client_backend::tor::Error` has a new `Backend` variant, carrying
+  privacy-layer transport errors that originate from a source other than
+  `arti_client`.
+- The `tor` feature now enables the `lightwalletd-privacy` feature.
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report
@@ -64,6 +96,14 @@ workspace.
   returns `GreedyInputSelectorError::Balance` instead of panicking when a
   custom fee rule produces per-transaction fees whose sum exceeds the maximum
   monetary amount.
+
+### Removed
+- `zcash_client_backend::tor::http::HttpError::Spawn` (also reachable as
+  `zcash_client_backend::privacy::http::HttpError`). HTTP connection tasks are
+  now spawned on the ambient Tokio runtime, which does not produce the
+  `futures`-based spawn error that this variant represented; the absence of an
+  ambient Tokio runtime is instead reported via the new `HttpError::Runtime`
+  variant.
 
 ## [0.24.0-rc.1] - 2026-07-12
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -270,6 +270,18 @@ lightwalletd-privacy = [
     "dep:webpki-roots",
 ]
 
+## Exposes a blocking (synchronous) facade over the network-privacy layer
+## (`zcash_client_backend::privacy::blocking`): a `PrivacyRuntime` bundling a Tokio runtime
+## with a backend, and an `LwdConn` blocking `lightwalletd` client. Does not require the
+## `tor` feature; construct a runtime from any `PrivateNetwork` backend.
+lightwalletd-blocking = [
+    "lightwalletd-privacy",
+    "lightwalletd-tonic-tls-webpki-roots",
+    "tokio?/net",
+    "tokio?/rt-multi-thread",
+    "tokio?/time",
+]
+
 ## Exposes a Tor client for hiding a wallet's IP address while performing certain wallet
 ## operations.
 tor = [

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -247,26 +247,37 @@ sync-decryptor = [
     "tokio?/tracing",
 ]
 
-## Exposes a Tor client for hiding a wallet's IP address while performing certain wallet
-## operations.
-tor = [
-    "dep:arti-client",
+## Exposes the backend-agnostic network-privacy layer (`zcash_client_backend::privacy`):
+## the `PrivateNetwork` trait, its object-safe `DynPrivateNetwork` mirror, and the HTTP,
+## gRPC, and exchange-rate helpers generalized over it. Backends (such as the `tor`
+## feature, or an out-of-tree dVPN or mixnet backend) build on this layer.
+lightwalletd-privacy = [
     "dep:dynosaur",
-    "dep:fs-mistrust",
     "dep:futures-util",
     "dep:http-body-util",
     "dep:hyper",
     "dep:hyper-util",
+    "hyper-util?/tokio",
     "dep:rand",
     "dep:rust_decimal",
     "dep:serde",
     "dep:serde_json",
     "dep:tokio",
+    "tokio?/rt",
     "dep:tokio-rustls",
-    "dep:tor-rtcompat",
-    "dep:trait-variant",
     "dep:tower",
+    "dep:trait-variant",
     "dep:webpki-roots",
+]
+
+## Exposes a Tor client for hiding a wallet's IP address while performing certain wallet
+## operations.
+tor = [
+    "lightwalletd-privacy",
+    "dep:arti-client",
+    "dep:fs-mistrust",
+    "dep:tor-rtcompat",
+    "tokio?/fs",
 ]
 
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -77,6 +77,9 @@ pub mod serialization;
 #[cfg(feature = "sync-decryptor")]
 mod task;
 
+#[cfg(feature = "lightwalletd-privacy")]
+pub mod privacy;
+
 #[cfg(feature = "tor")]
 pub mod tor;
 

--- a/zcash_client_backend/src/privacy.rs
+++ b/zcash_client_backend/src/privacy.rs
@@ -1,0 +1,215 @@
+//! Backend-agnostic network privacy for lightwallet clients.
+//!
+//! Wallets frequently need to hide the network-level metadata (in particular their IP
+//! address) that they would otherwise reveal to a `lightwalletd` server or to an exchange
+//! rate provider. This module abstracts over the transport that provides this privacy so
+//! that the same gRPC, HTTP, and exchange-rate machinery can run over any such transport.
+//!
+//! The central abstraction is the [`PrivateNetwork`] trait, which exposes the single
+//! capability the higher layers require: opening a byte stream to a remote `host:port`.
+//! The [`crate::tor`] module provides the reference implementation (Tor, via `arti`);
+//! other backends (for example a dVPN tunnel or a mixnet proxy) can be implemented in
+//! separate crates without depending on `arti`.
+//!
+//! Because [`PrivateNetwork`] uses return-position `impl Trait` and an associated stream
+//! type, it is not object-safe. FFI layers that need to store a backend behind a pointer
+//! can instead use the object-safe [`DynPrivateNetwork`] mirror, for which a blanket
+//! implementation is provided for every [`PrivateNetwork`]. `Arc<dyn DynPrivateNetwork>`
+//! itself implements [`PrivateNetwork`], so the generic helpers in this module accept
+//! either a concrete backend or its erased form.
+
+use std::{fmt, future::Future, pin::Pin, sync::Arc};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// The level of background activity a [`PrivateNetwork`] should maintain.
+///
+/// This is a crate-owned generalization of `arti_client::DormantMode`; the [`crate::tor`]
+/// backend maps between the two. Backends without a native notion of dormancy may treat a
+/// [`DormantMode::Soft`] request as a hint to tear down idle resources and rebuild them
+/// lazily on next use.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DormantMode {
+    /// The backend functions as normal, and background tasks run periodically.
+    #[default]
+    Normal,
+    /// Background tasks are suspended, conserving CPU usage. Attempts to use the backend
+    /// will wake it back up again.
+    Soft,
+}
+
+#[cfg(feature = "tor")]
+impl From<DormantMode> for arti_client::DormantMode {
+    fn from(mode: DormantMode) -> Self {
+        match mode {
+            DormantMode::Normal => arti_client::DormantMode::Normal,
+            DormantMode::Soft => arti_client::DormantMode::Soft,
+        }
+    }
+}
+
+#[cfg(feature = "tor")]
+impl From<arti_client::DormantMode> for DormantMode {
+    fn from(mode: arti_client::DormantMode) -> Self {
+        match mode {
+            arti_client::DormantMode::Soft => DormantMode::Soft,
+            // `arti_client::DormantMode` is `#[non_exhaustive]`; treat anything we don't
+            // specifically recognise as the fully-awake mode.
+            _ => DormantMode::Normal,
+        }
+    }
+}
+
+/// A byte stream produced by a [`PrivateNetwork`], type-erased for use behind a pointer.
+///
+/// This is the stream type carried by [`DynPrivateNetwork`] and by the blanket
+/// `PrivateNetwork` implementation for `Arc<dyn DynPrivateNetwork>`.
+pub trait NetworkStream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> NetworkStream for T {}
+
+/// A boxed [`NetworkStream`].
+pub type BoxedStream = Box<dyn NetworkStream + 'static>;
+
+/// A network transport that provides connection-level privacy for wallet traffic.
+///
+/// Implementations open byte streams to arbitrary `host:port` endpoints while concealing
+/// network metadata (at minimum, the client's IP address) to the degree the backend
+/// supports. Name resolution happens remotely wherever the backend supports it, so `host`
+/// is passed through as a string rather than a resolved address.
+pub trait PrivateNetwork: Send + Sync {
+    /// The byte stream produced by [`PrivateNetwork::connect`].
+    type Stream: AsyncRead + AsyncWrite + Unpin + Send + 'static;
+
+    /// Opens a byte stream to the given `host` and `port`.
+    fn connect(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> impl Future<Output = Result<Self::Stream, Error>> + Send;
+
+    /// Returns a new handle whose traffic is unlinkable to this handle's, to the degree
+    /// the backend supports.
+    ///
+    /// For example, the Tor backend returns a handle that uses fresh circuits, while a
+    /// dVPN backend that shares a single tunnel may return an equivalent handle (and
+    /// should document that its isolation is best-effort).
+    fn isolated_handle(&self) -> Self
+    where
+        Self: Sized;
+
+    /// Best-effort reduction of the backend's background activity.
+    ///
+    /// See [`DormantMode`] for the semantics backends should provide.
+    fn set_dormant(&self, mode: DormantMode);
+}
+
+/// An object-safe mirror of [`PrivateNetwork`], suitable for storage behind a pointer
+/// (for example `Arc<dyn DynPrivateNetwork>` in an FFI layer).
+///
+/// A blanket implementation is provided for every `PrivateNetwork + 'static`, boxing the
+/// backend's stream into a [`BoxedStream`] and its futures into [`Pin<Box<...>>`]. In turn,
+/// `Arc<dyn DynPrivateNetwork>` implements [`PrivateNetwork`], so the two forms are freely
+/// interchangeable at the boundaries of this module's generic helpers.
+///
+/// Note that the blanket implementation therefore also applies to
+/// `Arc<dyn DynPrivateNetwork>` itself. When holding such an `Arc`, call the
+/// [`PrivateNetwork`] methods (or explicitly deref to `&dyn DynPrivateNetwork`) rather
+/// than invoking `dyn_*` methods on the `Arc` directly: method resolution would select
+/// the blanket implementation on the `Arc`, adding a layer of boxing per call — and for
+/// [`DynPrivateNetwork::dyn_isolated_handle`], an additional permanent `Arc` layer per
+/// handle.
+pub trait DynPrivateNetwork: Send + Sync {
+    /// Opens a byte stream to the given `host` and `port`, erased to a [`BoxedStream`].
+    fn dyn_connect<'a>(
+        &'a self,
+        host: &'a str,
+        port: u16,
+    ) -> Pin<Box<dyn Future<Output = Result<BoxedStream, Error>> + Send + 'a>>;
+
+    /// Returns a new isolated handle; see [`PrivateNetwork::isolated_handle`].
+    fn dyn_isolated_handle(&self) -> Arc<dyn DynPrivateNetwork>;
+
+    /// See [`PrivateNetwork::set_dormant`].
+    fn dyn_set_dormant(&self, mode: DormantMode);
+}
+
+impl<P: PrivateNetwork + 'static> DynPrivateNetwork for P {
+    fn dyn_connect<'a>(
+        &'a self,
+        host: &'a str,
+        port: u16,
+    ) -> Pin<Box<dyn Future<Output = Result<BoxedStream, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let stream = self.connect(host, port).await?;
+            Ok(Box::new(stream) as BoxedStream)
+        })
+    }
+
+    fn dyn_isolated_handle(&self) -> Arc<dyn DynPrivateNetwork> {
+        Arc::new(self.isolated_handle())
+    }
+
+    fn dyn_set_dormant(&self, mode: DormantMode) {
+        self.set_dormant(mode);
+    }
+}
+
+impl PrivateNetwork for Arc<dyn DynPrivateNetwork> {
+    type Stream = BoxedStream;
+
+    fn connect(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> impl Future<Output = Result<Self::Stream, Error>> + Send {
+        async move { self.dyn_connect(host, port).await }
+    }
+
+    fn isolated_handle(&self) -> Self {
+        self.dyn_isolated_handle()
+    }
+
+    fn set_dormant(&self, mode: DormantMode) {
+        self.dyn_set_dormant(mode);
+    }
+}
+
+/// Errors that can occur while connecting or transferring data over a [`PrivateNetwork`].
+#[derive(Debug)]
+pub enum Error {
+    /// The backend cannot route to the requested `host:port`.
+    ///
+    /// This is returned by backends (such as a mixnet proxy) that can only reach a fixed
+    /// set of pre-configured endpoints.
+    NoRoute {
+        /// The host that could not be routed to.
+        host: String,
+        /// The port that could not be routed to.
+        port: u16,
+    },
+    /// A backend-specific error occurred while connecting or transferring data.
+    ///
+    /// This nests the native error of whichever [`PrivateNetwork`] backend produced it
+    /// (for example an `arti_client::Error` from the Tor backend).
+    Backend(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::NoRoute { host, port } => {
+                write!(f, "No route to {host}:{port} via this network backend")
+            }
+            Error::Backend(e) => write!(f, "Network backend error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::NoRoute { .. } => None,
+            Error::Backend(e) => Some(e.as_ref()),
+        }
+    }
+}

--- a/zcash_client_backend/src/privacy.rs
+++ b/zcash_client_backend/src/privacy.rs
@@ -22,6 +22,10 @@ use std::{fmt, future::Future, pin::Pin, sync::Arc};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
+#[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+pub mod grpc;
+pub mod http;
+
 /// The level of background activity a [`PrivateNetwork`] should maintain.
 ///
 /// This is a crate-owned generalization of `arti_client::DormantMode`; the [`crate::tor`]
@@ -157,12 +161,8 @@ impl<P: PrivateNetwork + 'static> DynPrivateNetwork for P {
 impl PrivateNetwork for Arc<dyn DynPrivateNetwork> {
     type Stream = BoxedStream;
 
-    fn connect(
-        &self,
-        host: &str,
-        port: u16,
-    ) -> impl Future<Output = Result<Self::Stream, Error>> + Send {
-        async move { self.dyn_connect(host, port).await }
+    async fn connect(&self, host: &str, port: u16) -> Result<Self::Stream, Error> {
+        self.dyn_connect(host, port).await
     }
 
     fn isolated_handle(&self) -> Self {
@@ -177,6 +177,11 @@ impl PrivateNetwork for Arc<dyn DynPrivateNetwork> {
 /// Errors that can occur while connecting or transferring data over a [`PrivateNetwork`].
 #[derive(Debug)]
 pub enum Error {
+    /// An error occurred while using gRPC over a [`PrivateNetwork`].
+    #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+    Grpc(self::grpc::GrpcError),
+    /// An error occurred while using HTTP over a [`PrivateNetwork`].
+    Http(self::http::HttpError),
     /// The backend cannot route to the requested `host:port`.
     ///
     /// This is returned by backends (such as a mixnet proxy) that can only reach a fixed
@@ -197,6 +202,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+            Error::Grpc(e) => write!(f, "gRPC-over-privacy error: {e}"),
+            Error::Http(e) => write!(f, "HTTP-over-privacy error: {e}"),
             Error::NoRoute { host, port } => {
                 write!(f, "No route to {host}:{port} via this network backend")
             }
@@ -208,8 +216,24 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+            Error::Grpc(e) => Some(e),
+            Error::Http(e) => Some(e),
             Error::NoRoute { .. } => None,
             Error::Backend(e) => Some(e.as_ref()),
         }
+    }
+}
+
+impl From<self::http::HttpError> for Error {
+    fn from(e: self::http::HttpError) -> Self {
+        Error::Http(e)
+    }
+}
+
+#[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+impl From<self::grpc::GrpcError> for Error {
+    fn from(e: self::grpc::GrpcError) -> Self {
+        Error::Grpc(e)
     }
 }

--- a/zcash_client_backend/src/privacy.rs
+++ b/zcash_client_backend/src/privacy.rs
@@ -22,6 +22,8 @@ use std::{fmt, future::Future, pin::Pin, sync::Arc};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
+#[cfg(feature = "lightwalletd-blocking")]
+pub mod blocking;
 #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
 pub mod grpc;
 pub mod http;
@@ -162,15 +164,17 @@ impl PrivateNetwork for Arc<dyn DynPrivateNetwork> {
     type Stream = BoxedStream;
 
     async fn connect(&self, host: &str, port: u16) -> Result<Self::Stream, Error> {
-        self.dyn_connect(host, port).await
+        // Dispatch to the inner trait object rather than back through this impl, which
+        // would otherwise recurse via the blanket `DynPrivateNetwork` implementation.
+        DynPrivateNetwork::dyn_connect(&**self, host, port).await
     }
 
     fn isolated_handle(&self) -> Self {
-        self.dyn_isolated_handle()
+        DynPrivateNetwork::dyn_isolated_handle(&**self)
     }
 
     fn set_dormant(&self, mode: DormantMode) {
-        self.dyn_set_dormant(mode);
+        DynPrivateNetwork::dyn_set_dormant(&**self, mode);
     }
 }
 

--- a/zcash_client_backend/src/privacy/blocking.rs
+++ b/zcash_client_backend/src/privacy/blocking.rs
@@ -1,0 +1,622 @@
+//! A blocking (synchronous) facade over the network-privacy layer.
+//!
+//! [`PrivacyRuntime`] bundles a Tokio runtime with a [`PrivateNetwork`] backend (held in
+//! its erased [`DynPrivateNetwork`] form), exposing synchronous entry points that FFI
+//! layers can call without managing async themselves. [`LwdConn`] is a blocking facade
+//! over a `lightwalletd` gRPC connection carrying the point queries wallets make over the
+//! privacy layer.
+//!
+//! This module does not require the `tor` feature: construct a [`PrivacyRuntime`] from any
+//! [`PrivateNetwork`] via [`PrivacyRuntime::new`]. The [`PrivacyRuntime::create_tor`]
+//! convenience constructor is additionally available under the `tor` feature.
+
+use std::sync::Arc;
+
+use tokio::runtime::Runtime;
+use tonic::transport::{Channel, Uri};
+
+use transparent::{
+    address::{Script, TransparentAddress},
+    bundle::{OutPoint, TxOut},
+};
+use zcash_keys::encoding::AddressCodec;
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::{
+    TxId,
+    consensus::{self, BlockHeight},
+    value::Zatoshis,
+};
+use zcash_script::script;
+
+use super::{DormantMode, DynPrivateNetwork, Error as PrivacyError, PrivateNetwork};
+use crate::proto::service::{self, compact_tx_streamer_client::CompactTxStreamerClient};
+use crate::wallet::WalletTransparentOutput;
+
+/// A synchronous runtime that drives a [`PrivateNetwork`] backend.
+///
+/// It owns a Tokio runtime and an erased handle to the backend, so it can be stored behind
+/// an FFI pointer and used from synchronous code.
+pub struct PrivacyRuntime {
+    runtime: Arc<Runtime>,
+    net: Arc<dyn DynPrivateNetwork>,
+}
+
+fn build_runtime() -> Result<Arc<Runtime>, Error> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map(Arc::new)
+        .map_err(Error::Runtime)
+}
+
+impl PrivacyRuntime {
+    /// Builds a blocking runtime around the given [`PrivateNetwork`] backend.
+    pub fn new(net: impl PrivateNetwork + 'static) -> Result<Self, Error> {
+        Ok(Self {
+            runtime: build_runtime()?,
+            net: Arc::new(net),
+        })
+    }
+
+    /// Builds a blocking runtime backed by a freshly-bootstrapped Tor client.
+    ///
+    /// The client's persistent data and cache are stored in `tor_dir`. If
+    /// `dangerously_trust_everyone` is set, Tor's filesystem permission checks are
+    /// disabled; do this only where the platform already sandboxes the app's data.
+    #[cfg(feature = "tor")]
+    pub fn create_tor(
+        tor_dir: &std::path::Path,
+        dangerously_trust_everyone: bool,
+    ) -> Result<Self, Error> {
+        let runtime = build_runtime()?;
+        let client = runtime
+            .block_on(async {
+                crate::tor::Client::create(
+                    tor_dir,
+                    |permissions: &mut fs_mistrust::MistrustBuilder| {
+                        if dangerously_trust_everyone {
+                            permissions.dangerously_trust_everyone();
+                        }
+                    },
+                )
+                .await
+            })
+            .map_err(Error::TorSetup)?;
+
+        Ok(Self {
+            runtime,
+            net: Arc::new(client),
+        })
+    }
+
+    /// Returns a new runtime handle whose backend is isolated from this one's, sharing the
+    /// same Tokio runtime.
+    ///
+    /// See [`PrivateNetwork::isolated_handle`] for the isolation semantics.
+    #[must_use]
+    pub fn isolated_client(&self) -> Self {
+        Self {
+            runtime: self.runtime.clone(),
+            // Go through `PrivateNetwork::isolated_handle`: calling `dyn_isolated_handle`
+            // on the `Arc` itself would resolve to the blanket `DynPrivateNetwork` impl
+            // for `Arc<dyn DynPrivateNetwork>` and wrap the handle in an additional layer
+            // on every call.
+            net: self.net.isolated_handle(),
+        }
+    }
+
+    /// Changes the backend's current dormant mode. See [`DormantMode`].
+    pub fn set_dormant(&self, mode: DormantMode) {
+        self.net.dyn_set_dormant(mode);
+    }
+
+    /// Connects to the `lightwalletd` server at the given endpoint.
+    ///
+    /// Each connection returned by this method is isolated from any other usage of the
+    /// backend.
+    pub fn connect_to_lightwalletd(&self, endpoint: Uri) -> Result<LwdConn, Error> {
+        // See `isolated_client` for why this is not `dyn_isolated_handle`.
+        let net = self.net.isolated_handle();
+        let conn = self
+            .runtime
+            .block_on(async { super::grpc::connect_to_lightwalletd(&net, endpoint).await })?;
+
+        Ok(LwdConn {
+            runtime: self.runtime.clone(),
+            _net: net,
+            conn,
+        })
+    }
+
+    /// Makes an HTTP GET request over the backend. See [`super::http::http_get`].
+    pub fn http_get<T, F>(
+        &self,
+        url: Uri,
+        request: impl Fn(hyper::http::request::Builder) -> hyper::http::request::Builder,
+        parse_response: impl FnOnce(hyper::body::Incoming) -> F,
+        retry_limit: u8,
+        retry_filter: impl Fn(Result<hyper::StatusCode, &PrivacyError>) -> Option<super::http::Retry>,
+    ) -> Result<hyper::Response<T>, PrivacyError>
+    where
+        F: std::future::Future<Output = Result<T, PrivacyError>>,
+    {
+        self.runtime.block_on(super::http::http_get(
+            &self.net,
+            url,
+            request,
+            parse_response,
+            retry_limit,
+            retry_filter,
+        ))
+    }
+
+    /// Makes an HTTP POST request over the backend. See [`super::http::http_post`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn http_post<B, T, F>(
+        &self,
+        url: Uri,
+        request: impl Fn(hyper::http::request::Builder) -> hyper::http::request::Builder,
+        body: B,
+        parse_response: impl FnOnce(hyper::body::Incoming) -> F,
+        retry_limit: u8,
+        retry_filter: impl Fn(Result<hyper::StatusCode, &PrivacyError>) -> Option<super::http::Retry>,
+    ) -> Result<hyper::Response<T>, PrivacyError>
+    where
+        B: hyper::body::Body + Clone + Send + 'static,
+        B::Data: Send,
+        B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        F: std::future::Future<Output = Result<T, PrivacyError>>,
+    {
+        self.runtime.block_on(super::http::http_post(
+            &self.net,
+            url,
+            request,
+            body,
+            parse_response,
+            retry_limit,
+            retry_filter,
+        ))
+    }
+
+    /// Fetches the latest USD/ZEC exchange rate over the backend, derived from the given
+    /// exchanges. See [`super::http::cryptex::get_latest_zec_to_usd_rate`].
+    pub fn get_latest_zec_to_usd_rate(
+        &self,
+        exchanges: &super::http::cryptex::Exchanges,
+    ) -> Result<rust_decimal::Decimal, PrivacyError> {
+        self.runtime
+            .block_on(super::http::cryptex::get_latest_zec_to_usd_rate(
+                &self.net, exchanges,
+            ))
+    }
+}
+
+/// A blocking facade over a `lightwalletd` gRPC connection established through a
+/// [`PrivacyRuntime`].
+pub struct LwdConn {
+    conn: CompactTxStreamerClient<Channel>,
+    _net: Arc<dyn DynPrivateNetwork>,
+    runtime: Arc<Runtime>,
+}
+
+impl LwdConn {
+    /// Returns information about this `lightwalletd` instance and the blockchain.
+    pub fn get_lightd_info(&mut self) -> Result<service::LightdInfo, Error> {
+        Ok(self
+            .runtime
+            .clone()
+            .block_on(self.conn.get_lightd_info(service::Empty {}))?
+            .into_inner())
+    }
+
+    /// Fetches the height and hash of the block at the tip of the best chain.
+    pub fn get_latest_block(&mut self) -> Result<(BlockHeight, BlockHash), Error> {
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.conn.get_latest_block(service::ChainSpec {}))?
+            .into_inner();
+
+        Ok((
+            BlockHeight::from_u32(response.height.try_into()?),
+            BlockHash::try_from_slice(&response.hash).ok_or(Error::InvalidBlockHash {
+                length: response.hash.len(),
+            })?,
+        ))
+    }
+
+    /// Fetches the raw [`service::BlockId`] of the block at the tip of the best chain.
+    pub fn get_latest_block_id(&mut self) -> Result<service::BlockId, Error> {
+        Ok(self
+            .runtime
+            .clone()
+            .block_on(self.conn.get_latest_block(service::ChainSpec {}))?
+            .into_inner())
+    }
+
+    /// Fetches the transaction with the given ID, returning its raw bytes and the height of
+    /// the block it was mined in (0 if unmined).
+    pub fn get_transaction(&mut self, txid: TxId) -> Result<(Vec<u8>, u64), Error> {
+        let request = service::TxFilter {
+            hash: txid.as_ref().to_vec(),
+            ..Default::default()
+        };
+
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.conn.get_transaction(request))?
+            .into_inner();
+
+        Ok((response.data, response.height))
+    }
+
+    /// Submits a transaction to the Zcash network.
+    pub fn send_transaction(&mut self, tx_bytes: Vec<u8>) -> Result<(), Error> {
+        let request = service::RawTransaction {
+            data: tx_bytes,
+            ..Default::default()
+        };
+
+        let response = self
+            .runtime
+            .clone()
+            .block_on(self.conn.send_transaction(request))?
+            .into_inner();
+
+        if response.error_code == 0 {
+            Ok(())
+        } else {
+            Err(Error::TransactionRejected {
+                code: response.error_code,
+                message: response.error_message,
+            })
+        }
+    }
+
+    /// Fetches the note commitment tree state corresponding to the given block.
+    pub fn get_tree_state(&mut self, height: BlockHeight) -> Result<service::TreeState, Error> {
+        let request = service::BlockId {
+            height: u32::from(height).into(),
+            ..Default::default()
+        };
+
+        Ok(self
+            .runtime
+            .clone()
+            .block_on(self.conn.get_tree_state(request))?
+            .into_inner())
+    }
+
+    /// Discovers UTXOs received by the given transparent address in the provided block
+    /// range, invoking `f` with each corresponding [`WalletTransparentOutput`].
+    pub fn with_taddress_utxos<E: From<Error>>(
+        &mut self,
+        params: &impl consensus::Parameters,
+        address: TransparentAddress,
+        start: Option<BlockHeight>,
+        limit: Option<u32>,
+        mut f: impl FnMut(WalletTransparentOutput<()>) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let request = service::GetAddressUtxosArg {
+            addresses: vec![address.encode(params)],
+            start_height: start.map_or(0, u64::from),
+            max_entries: match limit {
+                None => 0,
+                Some(0) => return Err(Error::InvalidLimit.into()),
+                Some(n) => n,
+            },
+        };
+
+        self.runtime.clone().block_on(async {
+            let mut utxos = self
+                .conn
+                .get_address_utxos_stream(request)
+                .await
+                .map_err(Error::from)
+                .map_err(E::from)?
+                .into_inner();
+
+            while let Some(result) = utxos
+                .message()
+                .await
+                .map_err(Error::from)
+                .map_err(E::from)?
+            {
+                let output = WalletTransparentOutput::<()>::from_parts(
+                    OutPoint::new(
+                        result.txid[..]
+                            .try_into()
+                            .map_err(Error::from)
+                            .map_err(E::from)?,
+                        result
+                            .index
+                            .try_into()
+                            .map_err(Error::from)
+                            .map_err(E::from)?,
+                    ),
+                    TxOut::new(
+                        Zatoshis::from_nonnegative_i64(result.value_zat)
+                            .map_err(Error::from)
+                            .map_err(E::from)?,
+                        Script(script::Code(result.script)),
+                    ),
+                    Some(BlockHeight::from(
+                        u32::try_from(result.height)
+                            .map_err(Error::from)
+                            .map_err(E::from)?,
+                    )),
+                    None,
+                    None,
+                    None,
+                )
+                .ok_or(Error::InvalidUtxo)
+                .map_err(E::from)?;
+
+                f(output)?;
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Invokes `f` with the transactions corresponding to the given t-address within the
+    /// given block range, and the height of the main-chain block they are mined in (if
+    /// any).
+    pub fn with_taddress_transactions<E: From<Error>>(
+        &mut self,
+        params: &impl consensus::Parameters,
+        address: TransparentAddress,
+        start: BlockHeight,
+        end: Option<BlockHeight>,
+        mut f: impl FnMut(Vec<u8>, Option<BlockHeight>) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let request = service::TransparentAddressBlockFilter {
+            address: address.encode(params),
+            range: Some(service::BlockRange {
+                start: Some(service::BlockId {
+                    height: u32::from(start).into(),
+                    ..Default::default()
+                }),
+                end: end.map(|height| service::BlockId {
+                    height: u32::from(height).into(),
+                    ..Default::default()
+                }),
+                pool_types: vec![],
+            }),
+        };
+
+        self.runtime.clone().block_on(async {
+            let mut txs = self
+                .conn
+                .get_taddress_txids(request)
+                .await
+                .map_err(Error::from)
+                .map_err(E::from)?
+                .into_inner();
+
+            while let Some(tx) = txs.message().await.map_err(Error::from).map_err(E::from)? {
+                let mined_height = match tx.height {
+                    0 => None,
+                    // TODO: [#1447] Represent "not in main chain".
+                    0xffff_ffff_ffff_ffff => None,
+                    h => Some(BlockHeight::from_u32(
+                        h.try_into().map_err(Error::from).map_err(E::from)?,
+                    )),
+                };
+
+                f(tx.data, mined_height)?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+/// Errors that can occur while using the blocking network-privacy facade.
+#[derive(Debug)]
+pub enum Error {
+    /// The internal Tokio runtime could not be built.
+    Runtime(std::io::Error),
+    /// A network-privacy layer error occurred (connecting or transferring data).
+    Network(PrivacyError),
+    /// Bootstrapping the Tor backend failed.
+    #[cfg(feature = "tor")]
+    TorSetup(crate::tor::Error),
+    /// The `lightwalletd` server returned a gRPC status error.
+    Grpc(tonic::Status),
+    /// The server returned a block hash whose length was not 32 bytes.
+    InvalidBlockHash {
+        /// The length of the returned hash.
+        length: usize,
+    },
+    /// A numeric field from the server was out of the supported range.
+    IntegerOverflow(std::num::TryFromIntError),
+    /// A fixed-width field from the server had an unexpected length.
+    InvalidSlice(std::array::TryFromSliceError),
+    /// A value field from the server was not a valid amount of zatoshis.
+    InvalidAmount(zcash_protocol::value::BalanceError),
+    /// A returned UTXO did not correspond to a P2PKH or P2SH address.
+    InvalidUtxo,
+    /// A zero `limit` was supplied to a bounded query.
+    InvalidLimit,
+    /// The server rejected a submitted transaction.
+    TransactionRejected {
+        /// The error code returned by the server.
+        code: i32,
+        /// The error message returned by the server.
+        message: String,
+    },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Runtime(e) => write!(f, "Failed to build Tokio runtime: {e}"),
+            Error::Network(e) => write!(f, "Network privacy error: {e}"),
+            #[cfg(feature = "tor")]
+            Error::TorSetup(e) => write!(f, "Failed to set up Tor: {e}"),
+            Error::Grpc(e) => write!(f, "lightwalletd gRPC error: {e}"),
+            Error::InvalidBlockHash { length } => {
+                write!(f, "Returned block hash has invalid length {length}")
+            }
+            Error::IntegerOverflow(e) => write!(f, "Numeric field out of range: {e}"),
+            Error::InvalidSlice(e) => write!(f, "Fixed-width field had wrong length: {e}"),
+            Error::InvalidAmount(e) => write!(f, "Invalid amount: {e}"),
+            Error::InvalidUtxo => write!(
+                f,
+                "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"
+            ),
+            Error::InvalidLimit => write!(f, "Invalid limit"),
+            Error::TransactionRejected { code, message } => {
+                write!(f, "Failed to submit transaction ({code}): {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Runtime(e) => Some(e),
+            Error::Network(e) => Some(e),
+            #[cfg(feature = "tor")]
+            Error::TorSetup(e) => Some(e),
+            Error::Grpc(e) => Some(e),
+            Error::IntegerOverflow(e) => Some(e),
+            Error::InvalidSlice(e) => Some(e),
+            Error::InvalidAmount(e) => Some(e),
+            Error::InvalidBlockHash { .. }
+            | Error::InvalidUtxo
+            | Error::InvalidLimit
+            | Error::TransactionRejected { .. } => None,
+        }
+    }
+}
+
+impl From<PrivacyError> for Error {
+    fn from(e: PrivacyError) -> Self {
+        Error::Network(e)
+    }
+}
+
+impl From<tonic::Status> for Error {
+    fn from(e: tonic::Status) -> Self {
+        Error::Grpc(e)
+    }
+}
+
+impl From<std::num::TryFromIntError> for Error {
+    fn from(e: std::num::TryFromIntError) -> Self {
+        Error::IntegerOverflow(e)
+    }
+}
+
+impl From<std::array::TryFromSliceError> for Error {
+    fn from(e: std::array::TryFromSliceError) -> Self {
+        Error::InvalidSlice(e)
+    }
+}
+
+impl From<zcash_protocol::value::BalanceError> for Error {
+    fn from(e: zcash_protocol::value::BalanceError) -> Self {
+        Error::InvalidAmount(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde::Deserialize;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::PrivacyRuntime;
+    use crate::privacy::{DormantMode, DynPrivateNetwork, Error as PrivacyError, PrivateNetwork};
+
+    /// A [`PrivateNetwork`] whose connections are served by an in-process HTTP responder
+    /// over Tokio duplex streams, for exercising the privacy plumbing without a network.
+    struct MockNetwork;
+
+    impl PrivateNetwork for MockNetwork {
+        type Stream = tokio::io::DuplexStream;
+
+        async fn connect(&self, _host: &str, _port: u16) -> Result<Self::Stream, PrivacyError> {
+            let (client_side, server_side) = tokio::io::duplex(4096);
+            tokio::spawn(serve_http(server_side));
+            Ok(client_side)
+        }
+
+        fn isolated_handle(&self) -> Self {
+            MockNetwork
+        }
+
+        fn set_dormant(&self, _mode: DormantMode) {}
+    }
+
+    async fn serve_http(mut stream: tokio::io::DuplexStream) {
+        // Read (and discard) the request; a small GET fits in one read.
+        let mut buf = [0u8; 1024];
+        let _ = stream.read(&mut buf).await;
+
+        let body = br#"{"price":"1.23"}"#;
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len(),
+        );
+        let _ = stream.write_all(head.as_bytes()).await;
+        let _ = stream.write_all(body).await;
+        let _ = stream.flush().await;
+        let _ = stream.shutdown().await;
+    }
+
+    #[derive(Deserialize)]
+    struct Body {
+        price: String,
+    }
+
+    #[test]
+    fn http_round_trips_over_concrete_and_erased_backends() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let url: hyper::Uri = "http://example.com/".parse().unwrap();
+
+            // Over the concrete backend.
+            let net = MockNetwork;
+            let res = crate::privacy::http::http_get_json::<MockNetwork, Body>(
+                &net,
+                url.clone(),
+                0,
+                |_| None,
+            )
+            .await
+            .unwrap();
+            assert_eq!(res.into_body().price, "1.23");
+
+            // Over the erased backend, proving `Arc<dyn DynPrivateNetwork>` plumbs through.
+            let erased: Arc<dyn DynPrivateNetwork> = Arc::new(MockNetwork);
+            let res = crate::privacy::http::http_get_json::<Arc<dyn DynPrivateNetwork>, Body>(
+                &erased,
+                url,
+                0,
+                |_| None,
+            )
+            .await
+            .unwrap();
+            assert_eq!(res.into_body().price, "1.23");
+        });
+    }
+
+    #[test]
+    fn privacy_runtime_wraps_a_backend() {
+        let runtime = PrivacyRuntime::new(MockNetwork).unwrap();
+        let _isolated = runtime.isolated_client();
+        runtime.set_dormant(DormantMode::Soft);
+    }
+
+    // Confirms the gRPC helper instantiates over the erased backend (compile-time check).
+    #[allow(dead_code)]
+    async fn grpc_plumbing_typechecks(net: Arc<dyn DynPrivateNetwork>, uri: tonic::transport::Uri) {
+        let _ = crate::privacy::grpc::connect_to_lightwalletd(&net, uri).await;
+    }
+}

--- a/zcash_client_backend/src/privacy/grpc.rs
+++ b/zcash_client_backend/src/privacy/grpc.rs
@@ -1,3 +1,5 @@
+//! gRPC to a `lightwalletd` server over a [`PrivateNetwork`].
+
 use std::{
     error::Error as _,
     fmt,
@@ -6,55 +8,48 @@ use std::{
     task::{Context, Poll},
 };
 
-use arti_client::DataStream;
 use hyper_util::rt::TokioIo;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 use tower::Service;
 use tracing::debug;
 
-use super::{Client, Error, http};
+use super::{Error, PrivateNetwork, http};
 use crate::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 
-impl Client {
-    /// Connects to the `lightwalletd` server at the given endpoint.
-    pub async fn connect_to_lightwalletd(
-        &self,
-        endpoint: Uri,
-    ) -> Result<CompactTxStreamerClient<Channel>, Error> {
-        self.ensure_bootstrapped().await?;
+/// Connects to the `lightwalletd` server at the given endpoint over the provided
+/// [`PrivateNetwork`].
+pub async fn connect_to_lightwalletd<N>(
+    net: &N,
+    endpoint: Uri,
+) -> Result<CompactTxStreamerClient<Channel>, Error>
+where
+    N: PrivateNetwork + Clone + 'static,
+{
+    let is_https = http::url_is_https(&endpoint)?;
 
-        let is_https = http::url_is_https(&endpoint)?;
+    let channel = Endpoint::from(endpoint);
+    let channel = if is_https {
+        channel
+            .tls_config(ClientTlsConfig::new().with_webpki_roots())
+            .map_err(GrpcError::Tonic)?
+    } else {
+        channel
+    };
 
-        let channel = Endpoint::from(endpoint);
-        let channel = if is_https {
-            channel
-                .tls_config(ClientTlsConfig::new().with_webpki_roots())
-                .map_err(GrpcError::Tonic)?
-        } else {
-            channel
-        };
+    let conn = channel
+        .connect_with_connector(PrivateNetworkConnector { net: net.clone() })
+        .await
+        .map_err(GrpcError::Tonic)?;
 
-        let conn = channel
-            .connect_with_connector(self.http_tcp_connector())
-            .await
-            .map_err(GrpcError::Tonic)?;
-
-        Ok(CompactTxStreamerClient::new(conn))
-    }
-
-    fn http_tcp_connector(&self) -> HttpTcpConnector {
-        HttpTcpConnector {
-            client: self.clone(),
-        }
-    }
+    Ok(CompactTxStreamerClient::new(conn))
 }
 
-struct HttpTcpConnector {
-    client: Client,
+struct PrivateNetworkConnector<N> {
+    net: N,
 }
 
-impl Service<Uri> for HttpTcpConnector {
-    type Response = TokioIo<DataStream>;
+impl<N: PrivateNetwork + Clone + 'static> Service<Uri> for PrivateNetworkConnector<N> {
+    type Response = TokioIo<N::Stream>;
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -63,23 +58,20 @@ impl Service<Uri> for HttpTcpConnector {
     }
 
     fn call(&mut self, endpoint: Uri) -> Self::Future {
-        let parsed = http::parse_url(&endpoint);
-        let client = self.client.clone();
+        let net = self.net.clone();
 
-        let fut = async move {
-            let (_, host, port) = parsed?;
+        Box::pin(async move {
+            let (_, host, port) = http::parse_url(&endpoint)?;
 
-            debug!("Connecting through Tor to {}:{}", host, port);
-            let stream = client.inner.connect((host.as_str(), port)).await?;
+            debug!("Connecting through privacy backend to {}:{}", host, port);
+            let stream = net.connect(&host, port).await?;
 
             Ok(TokioIo::new(stream))
-        };
-
-        Box::pin(fut)
+        })
     }
 }
 
-/// Errors that can occurr while using HTTP-over-Tor.
+/// Errors that can occur while using gRPC over a [`PrivateNetwork`].
 #[derive(Debug)]
 pub enum GrpcError {
     /// A [`tonic`] error.

--- a/zcash_client_backend/src/privacy/http.rs
+++ b/zcash_client_backend/src/privacy/http.rs
@@ -1,0 +1,407 @@
+//! HTTP requests over a [`PrivateNetwork`].
+
+use std::{fmt, future::Future, io, sync::Arc};
+
+use http_body_util::{BodyExt, Empty};
+use hyper::{
+    Request, Response, StatusCode, Uri,
+    body::{Body, Buf, Bytes, Incoming},
+    client::conn,
+    http::{request::Builder, uri::Scheme},
+};
+use hyper_util::rt::TokioIo;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_rustls::{
+    TlsConnector,
+    rustls::{ClientConfig, RootCertStore, pki_types::ServerName},
+};
+use tracing::{debug, error};
+
+use super::{DynPrivateNetwork, Error, PrivateNetwork};
+
+pub mod cryptex;
+
+/// How a particular connection failure should be retried.
+pub enum Retry {
+    /// Retry using the same network handle that resulted in this error.
+    Same,
+    /// Retry using a fresh handle that is isolated from any other usage.
+    Isolated,
+}
+
+pub(crate) fn url_is_https(url: &Uri) -> Result<bool, HttpError> {
+    Ok(url.scheme().ok_or(HttpError::NonHttpUrl)? == &Scheme::HTTPS)
+}
+
+pub(crate) fn parse_url(url: &Uri) -> Result<(bool, String, u16), HttpError> {
+    let is_https = url_is_https(url)?;
+
+    let host = url.host().ok_or(HttpError::NonHttpUrl)?.to_string();
+
+    let port = match url.port_u16() {
+        Some(port) => port,
+        None if is_https => 443,
+        None => 80,
+    };
+
+    Ok((is_https, host, port))
+}
+
+/// Makes an HTTP GET request over the given [`PrivateNetwork`].
+///
+/// The `request` closure can be used to modify or append HTTP request headers. You
+/// must not call the following [`Builder`] methods within it:
+/// - [`Builder::method`] (this is internally set to `GET`).
+/// - [`Builder::uri`] (this is internally set to `url`).
+/// - [`Builder::header`] with header name `"Host"` (this is internally set based on
+///   `url`).
+///
+/// Returns `Ok(response)` if an HTTP response is received, even if the HTTP status
+/// code is not in the 200-299 success range (i.e. [`HttpError::Unsuccessful`] is
+/// never returned).
+///
+/// There are two arguments for controlling retry behaviour:
+/// - `retry_limit` is the maximum number of times that a failed request should be
+///   retried. You can disable retries by setting this to 0.
+/// - `retry_filter` can be used to only retry requests that fail in specific ways,
+///   and control how the retry is performed. You can disable retries by setting this
+///   to `|_| None`, and you can ensure the same handle is reused by setting this to
+///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
+///   network identity across queries).
+#[tracing::instrument(skip(net, request, parse_response, retry_filter))]
+pub async fn http_get<N, T, F>(
+    net: &N,
+    url: Uri,
+    request: impl Fn(Builder) -> Builder,
+    parse_response: impl FnOnce(Incoming) -> F,
+    retry_limit: u8,
+    retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
+) -> Result<Response<T>, Error>
+where
+    N: PrivateNetwork + 'static,
+    F: Future<Output = Result<T, Error>>,
+{
+    http_request_over::<Error, Empty<Bytes>, T, F>(
+        net,
+        url,
+        |builder| request(builder).method("GET"),
+        Empty::<Bytes>::new(),
+        parse_response,
+        retry_limit,
+        retry_filter,
+    )
+    .await
+}
+
+/// Makes an HTTP POST request over the given [`PrivateNetwork`].
+///
+/// The `request` closure can be used to modify or append HTTP request headers. You
+/// must not call the following [`Builder`] methods within it:
+/// - [`Builder::method`] (this is internally set to `POST`).
+/// - [`Builder::uri`] (this is internally set to `url`).
+/// - [`Builder::header`] with header name `"Host"` (this is internally set based on
+///   `url`).
+///
+/// Returns `Ok(response)` if an HTTP response is received, even if the HTTP status
+/// code is not in the 200-299 success range (i.e. [`HttpError::Unsuccessful`] is
+/// never returned).
+///
+/// See [`http_get`] for a description of the retry arguments.
+#[tracing::instrument(skip(net, request, body, parse_response, retry_filter))]
+pub async fn http_post<N, B, T, F>(
+    net: &N,
+    url: Uri,
+    request: impl Fn(Builder) -> Builder,
+    body: B,
+    parse_response: impl FnOnce(Incoming) -> F,
+    retry_limit: u8,
+    retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
+) -> Result<Response<T>, Error>
+where
+    N: PrivateNetwork + 'static,
+    B: Body + Clone + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    F: Future<Output = Result<T, Error>>,
+{
+    http_request_over::<Error, B, T, F>(
+        net,
+        url,
+        |builder| request(builder).method("POST"),
+        body,
+        parse_response,
+        retry_limit,
+        retry_filter,
+    )
+    .await
+}
+
+/// Makes an HTTP GET request over the given [`PrivateNetwork`], parsing the response as
+/// JSON.
+///
+/// This is a simple wrapper around [`http_get`]. Use that function if you need more
+/// control over the request headers or response parsing.
+///
+/// See [`http_get`] for a description of the retry arguments.
+pub async fn http_get_json<N, T>(
+    net: &N,
+    url: Uri,
+    retry_limit: u8,
+    retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
+) -> Result<Response<T>, Error>
+where
+    N: PrivateNetwork + 'static,
+    T: DeserializeOwned,
+{
+    http_get_json_over(net, url, retry_limit, retry_filter).await
+}
+
+/// Makes an HTTP GET request that parses its response as JSON, over an erased network
+/// handle.
+pub(crate) async fn http_get_json_over<T: DeserializeOwned>(
+    net: &dyn DynPrivateNetwork,
+    url: Uri,
+    retry_limit: u8,
+    retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
+) -> Result<Response<T>, Error> {
+    http_request_over::<Error, Empty<Bytes>, T, _>(
+        net,
+        url,
+        |builder| {
+            builder
+                .method("GET")
+                .header(hyper::header::ACCEPT, "application/json")
+        },
+        Empty::<Bytes>::new(),
+        |body| async {
+            Ok(serde_json::from_reader(
+                body.collect()
+                    .await
+                    .map_err(HttpError::from)?
+                    .aggregate()
+                    .reader(),
+            )
+            .map_err(HttpError::from)?)
+        },
+        retry_limit,
+        retry_filter,
+    )
+    .await
+}
+
+/// Makes an HTTP request over an erased network handle, with retry handling.
+///
+/// This is the engine shared by every HTTP helper in the crate. It is generic over the
+/// error type `E` so that callers (such as [`crate::tor::Client`]) can surface a
+/// backend-specific error type, provided transport and HTTP errors convert into it.
+pub(crate) async fn http_request_over<E, B, T, F>(
+    net: &dyn DynPrivateNetwork,
+    url: Uri,
+    request: impl Fn(Builder) -> Builder,
+    body: B,
+    parse_response: impl FnOnce(Incoming) -> F,
+    retry_limit: u8,
+    retry_filter: impl Fn(Result<StatusCode, &E>) -> Option<Retry>,
+) -> Result<Response<T>, E>
+where
+    E: From<HttpError> + From<Error>,
+    B: Body + Clone + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    F: Future<Output = Result<T, E>>,
+{
+    let mut retries_remaining = retry_limit;
+    let mut isolated: Option<Arc<dyn DynPrivateNetwork>> = None;
+
+    let (parts, body) = loop {
+        let current: &dyn DynPrivateNetwork = isolated.as_ref().map_or(net, |c| c.as_ref());
+        let response = one_http_request::<E, _>(current, url.clone(), &request, body.clone()).await;
+
+        match (
+            retries_remaining.checked_sub(1),
+            retry_filter(response.as_ref().map(|response| response.status())),
+        ) {
+            (Some(retries), Some(retry)) => {
+                debug!("Retrying due to filter match");
+                retries_remaining = retries;
+
+                match retry {
+                    Retry::Same => (),
+                    Retry::Isolated => {
+                        debug!("Switching to isolated handle for retry");
+                        isolated = Some(net.dyn_isolated_handle());
+                    }
+                }
+            }
+            (None, _) | (_, None) => break response,
+        }
+    }?
+    .into_parts();
+
+    Ok(Response::from_parts(parts, parse_response(body).await?))
+}
+
+async fn one_http_request<E, B>(
+    net: &dyn DynPrivateNetwork,
+    url: Uri,
+    request: impl FnOnce(Builder) -> Builder,
+    body: B,
+) -> Result<Response<Incoming>, E>
+where
+    E: From<HttpError> + From<Error>,
+    B: Body + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    let (is_https, host, port) = parse_url(&url)?;
+
+    // Connect to the server.
+    debug!("Connecting through privacy backend to {}:{}", host, port);
+    let stream = net.dyn_connect(&host, port).await?;
+
+    if is_https {
+        // On apple-darwin targets there's an issue with the native TLS implementation
+        // when used over Tor circuits. We use Rustls instead.
+        //
+        // https://gitlab.torproject.org/tpo/core/arti/-/issues/715
+        let root_store = RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+        let config = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        let connector = TlsConnector::from(Arc::new(config));
+        let dnsname = ServerName::try_from(host).expect("Already checked");
+        let stream = connector
+            .connect(dnsname, stream)
+            .await
+            .map_err(HttpError::Tls)?;
+        make_http_request(stream, url, request, body).await
+    } else {
+        make_http_request(stream, url, request, body).await
+    }
+}
+
+async fn make_http_request<E, B>(
+    stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    url: Uri,
+    request: impl FnOnce(Builder) -> Builder,
+    body: B,
+) -> Result<Response<Incoming>, E>
+where
+    E: From<HttpError>,
+    B: Body + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    debug!("Making request");
+    let (mut sender, connection) = conn::http1::handshake(TokioIo::new(stream))
+        .await
+        .map_err(HttpError::from)?;
+
+    // Spawn a task to poll the connection and drive the HTTP state. The connection must
+    // continue to be driven while the caller consumes the response body, so it cannot be
+    // awaited inline. A missing ambient Tokio runtime surfaces as a recoverable
+    // [`HttpError::Runtime`] rather than the panic `tokio::spawn` would produce.
+    let runtime = tokio::runtime::Handle::try_current().map_err(HttpError::from)?;
+    runtime.spawn(async move {
+        if let Err(e) = connection.await {
+            error!("Connection failed: {}", e);
+        }
+    });
+
+    // Build the request. We let the caller make whatever request modifications they need,
+    // and then set the Host and URI afterwards so that they are guaranteed to match the
+    // connection.
+    let req = request(Request::builder())
+        .header(
+            hyper::header::HOST,
+            url.authority().expect("Already checked").as_str(),
+        )
+        .uri(url)
+        .body(body)
+        .map_err(HttpError::from)?;
+    let response = sender.send_request(req).await.map_err(HttpError::from)?;
+    debug!("Response status code: {}", response.status());
+
+    Ok(response)
+}
+
+/// Errors that can occur while using HTTP over a [`PrivateNetwork`].
+#[derive(Debug)]
+pub enum HttpError {
+    /// A non-HTTP URL was encountered.
+    NonHttpUrl,
+    /// An HTTP error.
+    Http(hyper::http::Error),
+    /// A [`hyper`] error.
+    Hyper(hyper::Error),
+    /// A JSON parsing error.
+    Json(serde_json::Error),
+    /// A TLS-specific IO error.
+    Tls(io::Error),
+    /// The status code indicated that the request was unsuccessful.
+    ///
+    /// This is only returned by APIs that make specific queries, such as the
+    /// exchange-rate helpers. Generic APIs like [`http_get`] will not return this error
+    /// variant.
+    Unsuccessful(hyper::http::StatusCode),
+    /// No Tokio runtime was available to drive the HTTP connection.
+    Runtime(tokio::runtime::TryCurrentError),
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HttpError::NonHttpUrl => write!(f, "Only HTTP or HTTPS URLs are supported"),
+            HttpError::Http(e) => write!(f, "HTTP error: {e}"),
+            HttpError::Hyper(e) => write!(f, "Hyper error: {e}"),
+            HttpError::Json(e) => write!(f, "Failed to parse JSON: {e}"),
+            HttpError::Tls(e) => write!(f, "TLS error: {e}"),
+            HttpError::Unsuccessful(status) => write!(f, "Request was unsuccessful ({status:?})"),
+            HttpError::Runtime(e) => write!(
+                f,
+                "No Tokio runtime available to drive the HTTP connection: {e}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HttpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            HttpError::NonHttpUrl => None,
+            HttpError::Http(e) => Some(e),
+            HttpError::Hyper(e) => Some(e),
+            HttpError::Json(e) => Some(e),
+            HttpError::Tls(e) => Some(e),
+            HttpError::Unsuccessful(_) => None,
+            HttpError::Runtime(e) => Some(e),
+        }
+    }
+}
+
+impl From<tokio::runtime::TryCurrentError> for HttpError {
+    fn from(e: tokio::runtime::TryCurrentError) -> Self {
+        HttpError::Runtime(e)
+    }
+}
+
+impl From<hyper::http::Error> for HttpError {
+    fn from(e: hyper::http::Error) -> Self {
+        HttpError::Http(e)
+    }
+}
+
+impl From<hyper::Error> for HttpError {
+    fn from(e: hyper::Error) -> Self {
+        HttpError::Hyper(e)
+    }
+}
+
+impl From<serde_json::Error> for HttpError {
+    fn from(e: serde_json::Error) -> Self {
+        HttpError::Json(e)
+    }
+}

--- a/zcash_client_backend/src/privacy/http/cryptex.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex.rs
@@ -6,7 +6,7 @@ use rand::{seq::IteratorRandom, thread_rng};
 use rust_decimal::Decimal;
 use tracing::{error, trace};
 
-use crate::tor::{Client, Error};
+use crate::privacy::{DynPrivateNetwork, Error, PrivateNetwork};
 
 use super::Retry;
 
@@ -74,7 +74,7 @@ pub trait LocalExchange {
     ///
     /// The returned bid and ask data must be denominated in USD, i.e. the latest bid and
     /// ask for 1 ZEC.
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error>;
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error>;
 }
 
 /// Data queried from an [`Exchange`].
@@ -169,81 +169,80 @@ impl ExchangesBuilder {
     }
 }
 
-impl Client {
-    /// Fetches the latest USD/ZEC exchange rate, derived from the given exchanges.
-    ///
-    /// Returns:
-    /// - `Ok(rate)` if at least one exchange request succeeds.
-    /// - `Err(_)` if none of the exchange queries succeed.
-    pub async fn get_latest_zec_to_usd_rate(
-        &self,
-        exchanges: &Exchanges,
-    ) -> Result<Decimal, Error> {
-        self.ensure_bootstrapped().await?;
+/// Fetches the latest USD/ZEC exchange rate over the given [`PrivateNetwork`], derived
+/// from the given exchanges.
+///
+/// Returns:
+/// - `Ok(rate)` if at least one exchange request succeeds.
+/// - `Err(_)` if none of the exchange queries succeed.
+pub async fn get_latest_zec_to_usd_rate<N: PrivateNetwork + 'static>(
+    net: &N,
+    exchanges: &Exchanges,
+) -> Result<Decimal, Error> {
+    let net: &dyn DynPrivateNetwork = net;
 
-        // Fetch the data in parallel.
-        let res = join!(
-            DynExchange::query_zec_to_usd(&exchanges.trusted, self),
-            join_all(
-                exchanges
-                    .others
-                    .iter()
-                    .map(|e| DynExchange::query_zec_to_usd(e, self))
-            )
-        );
-        trace!(?res, "Data results");
-        let (trusted_res, other_res) = res;
+    // Fetch the data in parallel.
+    let res = join!(
+        DynExchange::query_zec_to_usd(&exchanges.trusted, net),
+        join_all(
+            exchanges
+                .others
+                .iter()
+                .map(|e| DynExchange::query_zec_to_usd(e, net))
+        )
+    );
+    trace!(?res, "Data results");
+    let (trusted_res, other_res) = res;
 
-        // Split into successful queries and errors.
-        let mut rates: Vec<Decimal> = vec![];
-        let mut errors = vec![];
-        for res in other_res {
-            match res {
-                Ok(d) => rates.push(d.exchange_rate()),
-                Err(e) => errors.push(e),
-            }
+    // Split into successful queries and errors.
+    let mut rates: Vec<Decimal> = vec![];
+    let mut errors = vec![];
+    for res in other_res {
+        match res {
+            Ok(d) => rates.push(d.exchange_rate()),
+            Err(e) => errors.push(e),
         }
+    }
 
-        // "Never go to sea with two chronometers; take one or three."
-        // Randomly drop one rate if necessary to have an odd number of rates, as long as
-        // we have either at least three rates, or fewer than three sources.
-        if exchanges.others.len() >= 2 && rates.len() + usize::from(trusted_res.is_ok()) < 3 {
-            error!("Too many exchange requests failed");
-            return Err(errors
-                .into_iter()
-                .next()
-                .expect("At least one request failed"));
+    // "Never go to sea with two chronometers; take one or three."
+    // Randomly drop one rate if necessary to have an odd number of rates, as long as
+    // we have either at least three rates, or fewer than three sources.
+    if exchanges.others.len() >= 2 && rates.len() + usize::from(trusted_res.is_ok()) < 3 {
+        error!("Too many exchange requests failed");
+        return Err(errors
+            .into_iter()
+            .next()
+            .expect("At least one request failed"));
+    }
+    let evict_random = |s: &mut Vec<Decimal>| {
+        if let Some(index) = (0..s.len()).choose(&mut thread_rng()) {
+            s.remove(index);
         }
-        let evict_random = |s: &mut Vec<Decimal>| {
-            if let Some(index) = (0..s.len()).choose(&mut thread_rng()) {
-                s.remove(index);
+    };
+    match trusted_res {
+        Ok(trusted) => {
+            if !rates.len().is_multiple_of(2) {
+                evict_random(&mut rates);
             }
-        };
-        match trusted_res {
-            Ok(trusted) => {
-                if !rates.len().is_multiple_of(2) {
-                    evict_random(&mut rates);
-                }
-                rates.push(trusted.exchange_rate());
-            }
-            Err(e) => {
-                if rates.len().is_multiple_of(2) {
-                    evict_random(&mut rates);
-                }
-                errors.push(e);
-            }
+            rates.push(trusted.exchange_rate());
         }
+        Err(e) => {
+            if rates.len().is_multiple_of(2) {
+                evict_random(&mut rates);
+            }
+            errors.push(e);
+        }
+    }
 
-        // If all of the requests failed, log all errors and return one of them.
-        if rates.is_empty() {
-            error!("All exchange requests failed");
-            Err(errors.into_iter().next().expect("All requests failed"))
-        } else {
-            // We have an odd number of rates; take the median.
-            assert!(!rates.len().is_multiple_of(2));
-            rates.sort();
-            let median = rates.len() / 2;
-            Ok(rates[median])
-        }
+    // If all of the requests failed, log all errors and return one of them.
+    if rates.is_empty() {
+        error!("All exchange requests failed");
+        Err(errors.into_iter().next().expect("All requests failed"))
+    } else {
+        // We have an odd number of rates; take the median.
+        assert!(!rates.len().is_multiple_of(2));
+        rates.sort();
+        let median = rates.len() / 2;
+        Ok(rates[median])
     }
 }

--- a/zcash_client_backend/src/privacy/http/cryptex/binance.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/binance.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the Binance exchange.
 pub struct Binance {
@@ -44,18 +45,18 @@ struct BinanceData {
 }
 
 impl Exchange for Binance {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://binance-docs.github.io/apidocs/spot/en/#24hr-ticker-price-change-statistics
-        let res = client
-            .http_get_json::<BinanceData>(
-                "https://api.binance.com/api/v3/ticker/24hr?symbol=ZECUSDT"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<BinanceData>(
+            net,
+            "https://api.binance.com/api/v3/ticker/24hr?symbol=ZECUSDT"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body();
         Ok(ExchangeData {
             bid: data.bidPrice,

--- a/zcash_client_backend/src/privacy/http/cryptex/coin_ex.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/coin_ex.rs
@@ -3,7 +3,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error, http::HttpError};
+use crate::privacy::http::{HttpError, http_get_json_over};
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the CoinEx exchange.
 pub struct CoinEx {
@@ -44,18 +45,18 @@ struct CoinExResponse {
 }
 
 impl Exchange for CoinEx {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://docs.coinex.com/api/v2/spot/market/http/list-market-depth
-        let res = client
-            .http_get_json::<CoinExResponse>(
-                "https://api.coinex.com/v2/spot/depth?market=ZECUSDT&limit=5&interval=0"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<CoinExResponse>(
+            net,
+            "https://api.coinex.com/v2/spot/depth?market=ZECUSDT&limit=5&interval=0"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body().data.depth;
         Ok(ExchangeData {
             bid: data

--- a/zcash_client_backend/src/privacy/http/cryptex/coinbase.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/coinbase.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the Coinbase exchange.
 pub struct Coinbase {
@@ -32,18 +33,18 @@ struct CoinbaseData {
 
 impl Exchange for Coinbase {
     #[allow(dead_code)]
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://docs.cdp.coinbase.com/exchange/reference/exchangerestapi_getproductticker
-        let res = client
-            .http_get_json::<CoinbaseData>(
-                "https://api.exchange.coinbase.com/products/ZEC-USD/ticker"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<CoinbaseData>(
+            net,
+            "https://api.exchange.coinbase.com/products/ZEC-USD/ticker"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body();
         Ok(ExchangeData {
             bid: data.bid,

--- a/zcash_client_backend/src/privacy/http/cryptex/digi_finex.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/digi_finex.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the DigiFinex exchange.
 pub struct DigiFinex {
@@ -39,18 +40,18 @@ struct DigiFinexResponse {
 }
 
 impl Exchange for DigiFinex {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://docs.digifinex.com/en-ww/spot/v3/rest.html#ticker-price
-        let res = client
-            .http_get_json::<DigiFinexResponse>(
-                "https://openapi.digifinex.com/v3/ticker?symbol=zec_usdt"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<DigiFinexResponse>(
+            net,
+            "https://openapi.digifinex.com/v3/ticker?symbol=zec_usdt"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body().ticker.0;
         Ok(ExchangeData {
             bid: data.buy,

--- a/zcash_client_backend/src/privacy/http/cryptex/gemini.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/gemini.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the Gemini exchange.
 pub struct Gemini {
@@ -30,16 +31,16 @@ struct GeminiData {
 }
 
 impl Exchange for Gemini {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://docs.gemini.com/rest-api/#ticker-v2
-        let res = client
-            .http_get_json::<GeminiData>(
-                "https://api.gemini.com/v2/ticker/zecusd".parse().unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<GeminiData>(
+            net,
+            "https://api.gemini.com/v2/ticker/zecusd".parse().unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body();
         Ok(ExchangeData {
             bid: data.bid,

--- a/zcash_client_backend/src/privacy/http/cryptex/kraken.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/kraken.rs
@@ -4,7 +4,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the Kraken exchange.
 pub struct Kraken {
@@ -35,20 +36,20 @@ struct KrakenData {
 type KrakenResponse = Result<KrakenData, Vec<String>>;
 
 impl Exchange for Kraken {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://docs.kraken.com/api/docs/rest-api/get-ticker-information
-        let res = client
-            .http_get_json::<KrakenResponse>(
-                "https://api.kraken.com/0/public/Ticker?pair=XZECZUSD"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<KrakenResponse>(
+            net,
+            "https://api.kraken.com/0/public/Ticker?pair=XZECZUSD"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body().map_err(|e| {
-            Error::Io(io::Error::other(
+            Error::Backend(Box::new(io::Error::other(
                 e.into_iter()
                     .reduce(|mut acc, e| {
                         acc.push_str("; ");
@@ -56,7 +57,7 @@ impl Exchange for Kraken {
                         acc
                     })
                     .unwrap_or_default(),
-            ))
+            )))
         })?;
         Ok(ExchangeData {
             bid: data.b.0,

--- a/zcash_client_backend/src/privacy/http/cryptex/ku_coin.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/ku_coin.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the KuCoin exchange.
 pub struct KuCoin {
@@ -46,18 +47,18 @@ struct KuCoinResponse {
 }
 
 impl Exchange for KuCoin {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://www.kucoin.com/docs/rest/spot-trading/market-data/get-24hr-stats
-        let res = client
-            .http_get_json::<KuCoinResponse>(
-                "https://api.kucoin.com/api/v1/market/stats?symbol=ZEC-USDT"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<KuCoinResponse>(
+            net,
+            "https://api.kucoin.com/api/v1/market/stats?symbol=ZEC-USDT"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body().data;
         Ok(ExchangeData {
             bid: data.buy,

--- a/zcash_client_backend/src/privacy/http/cryptex/mexc.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/mexc.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the MEXC exchange.
 pub struct Mexc {
@@ -39,18 +40,18 @@ struct MexcData {
 }
 
 impl Exchange for Mexc {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://mexcdevelop.github.io/apidocs/spot_v3_en/#24hr-ticker-price-change-statistics
-        let res = client
-            .http_get_json::<MexcData>(
-                "https://api.mexc.com/api/v3/ticker/24hr?symbol=ZECUSDT"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<MexcData>(
+            net,
+            "https://api.mexc.com/api/v3/ticker/24hr?symbol=ZECUSDT"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body();
         Ok(ExchangeData {
             bid: data.bidPrice,

--- a/zcash_client_backend/src/privacy/http/cryptex/xt.rs
+++ b/zcash_client_backend/src/privacy/http/cryptex/xt.rs
@@ -2,7 +2,8 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 
 use super::{Exchange, ExchangeData, RETRY_LIMIT, retry_filter};
-use crate::tor::{Client, Error};
+use crate::privacy::http::http_get_json_over;
+use crate::privacy::{DynPrivateNetwork, Error};
 
 /// Querier for the XT exchange.
 pub struct Xt {
@@ -37,18 +38,18 @@ struct XtResponse {
 }
 
 impl Exchange for Xt {
-    async fn query_zec_to_usd(&self, client: &Client) -> Result<ExchangeData, Error> {
+    async fn query_zec_to_usd(&self, net: &dyn DynPrivateNetwork) -> Result<ExchangeData, Error> {
         // API documentation:
         // https://doc.xt.com/docs/spot/Market/GetBestPendingOrderTicker
-        let res = client
-            .http_get_json::<XtResponse>(
-                "https://sapi.xt.com/v4/public/ticker/book?symbol=zec_usdt"
-                    .parse()
-                    .unwrap(),
-                RETRY_LIMIT,
-                retry_filter,
-            )
-            .await?;
+        let res = http_get_json_over::<XtResponse>(
+            net,
+            "https://sapi.xt.com/v4/public/ticker/book?symbol=zec_usdt"
+                .parse()
+                .unwrap(),
+            RETRY_LIMIT,
+            retry_filter,
+        )
+        .await?;
         let data = res.into_body().result.0;
         Ok(ExchangeData {
             bid: data.bp,

--- a/zcash_client_backend/src/tor.rs
+++ b/zcash_client_backend/src/tor.rs
@@ -1,19 +1,23 @@
 //! Tor support for Zcash wallets.
+//!
+//! This module provides the Tor (via `arti`) implementation of the crate's
+//! backend-agnostic [`crate::privacy`] network-privacy layer. [`Client`] implements
+//! [`PrivateNetwork`], and its gRPC, HTTP, and exchange-rate methods delegate to the
+//! generic helpers in [`crate::privacy`].
 
 use std::{fmt, io, path::Path};
 
-use arti_client::{TorClient, config::TorClientConfigBuilder};
+use arti_client::{DataStream, TorClient, config::TorClientConfigBuilder};
 use tor_rtcompat::PreferredRuntime;
 use tracing::debug;
 
-#[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
-mod grpc;
+use crate::privacy::{Error as PrivacyError, PrivateNetwork};
 
 pub mod http;
 
-// Re-exported as this is currently the only `arti_client` type users would need to use
-// our minimal client API.
-pub use arti_client::DormantMode;
+// Re-exported so that `tor::DormantMode` continues to resolve for downstream users; it is
+// now the crate-owned [`crate::privacy::DormantMode`] rather than `arti_client`'s.
+pub use crate::privacy::DormantMode;
 
 /// A Tor client that exposes capabilities designed for Zcash wallets.
 #[derive(Clone)]
@@ -112,7 +116,50 @@ impl Client {
     ///
     /// See the [`DormantMode`] documentation for more details.
     pub fn set_dormant(&self, mode: DormantMode) {
-        self.inner.set_dormant(mode);
+        self.inner.set_dormant(mode.into());
+    }
+
+    /// Connects to the `lightwalletd` server at the given endpoint.
+    #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+    pub async fn connect_to_lightwalletd(
+        &self,
+        endpoint: tonic::transport::Uri,
+    ) -> Result<
+        crate::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<
+            tonic::transport::Channel,
+        >,
+        Error,
+    > {
+        self.ensure_bootstrapped().await?;
+        Ok(crate::privacy::grpc::connect_to_lightwalletd(self, endpoint).await?)
+    }
+}
+
+impl PrivateNetwork for Client {
+    type Stream = DataStream;
+
+    async fn connect(&self, host: &str, port: u16) -> Result<Self::Stream, PrivacyError> {
+        // Ensure the Tor client is bootstrapped before attempting to connect.
+        if !self.inner.bootstrap_status().ready_for_traffic() {
+            debug!("Re-bootstrapping Tor");
+            self.inner
+                .bootstrap()
+                .await
+                .map_err(|e| PrivacyError::Backend(Box::new(e)))?;
+            debug!("Tor re-bootstrapped");
+        }
+        self.inner
+            .connect((host, port))
+            .await
+            .map_err(|e| PrivacyError::Backend(Box::new(e)))
+    }
+
+    fn isolated_handle(&self) -> Self {
+        self.isolated_client()
+    }
+
+    fn set_dormant(&self, mode: DormantMode) {
+        self.inner.set_dormant(mode.into());
     }
 }
 
@@ -123,13 +170,15 @@ pub enum Error {
     MissingTorDirectory,
     #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
     /// An error occurred while using gRPC-over-Tor.
-    Grpc(self::grpc::GrpcError),
+    Grpc(crate::privacy::grpc::GrpcError),
     /// An error occurred while using HTTP-over-Tor.
-    Http(self::http::HttpError),
+    Http(crate::privacy::http::HttpError),
     /// An IO error occurred while interacting with the filesystem.
     Io(io::Error),
     /// A Tor-specific error.
     Tor(arti_client::Error),
+    /// A network-privacy backend error not covered by the more specific variants.
+    Backend(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl fmt::Display for Error {
@@ -141,6 +190,7 @@ impl fmt::Display for Error {
             Error::Http(e) => write!(f, "HTTP-over-Tor error: {e}"),
             Error::Io(e) => write!(f, "IO error: {e}"),
             Error::Tor(e) => write!(f, "Tor error: {e}"),
+            Error::Backend(e) => write!(f, "Network backend error: {e}"),
         }
     }
 }
@@ -154,19 +204,20 @@ impl std::error::Error for Error {
             Error::Http(e) => Some(e),
             Error::Io(e) => Some(e),
             Error::Tor(e) => Some(e),
+            Error::Backend(e) => Some(e.as_ref()),
         }
     }
 }
 
 #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
-impl From<self::grpc::GrpcError> for Error {
-    fn from(e: self::grpc::GrpcError) -> Self {
+impl From<crate::privacy::grpc::GrpcError> for Error {
+    fn from(e: crate::privacy::grpc::GrpcError) -> Self {
         Error::Grpc(e)
     }
 }
 
-impl From<self::http::HttpError> for Error {
-    fn from(e: self::http::HttpError) -> Self {
+impl From<crate::privacy::http::HttpError> for Error {
+    fn from(e: crate::privacy::http::HttpError) -> Self {
         Error::Http(e)
     }
 }
@@ -180,5 +231,24 @@ impl From<io::Error> for Error {
 impl From<arti_client::Error> for Error {
     fn from(e: arti_client::Error) -> Self {
         Error::Tor(e)
+    }
+}
+
+impl From<PrivacyError> for Error {
+    fn from(e: PrivacyError) -> Self {
+        match e {
+            #[cfg(feature = "lightwalletd-tonic-tls-webpki-roots")]
+            PrivacyError::Grpc(e) => Error::Grpc(e),
+            PrivacyError::Http(e) => Error::Http(e),
+            PrivacyError::NoRoute { host, port } => {
+                Error::Backend(Box::new(PrivacyError::NoRoute { host, port }))
+            }
+            // The Tor backend nests its native errors as `arti_client::Error`; recover
+            // that specific type where possible for a more precise error.
+            PrivacyError::Backend(b) => match b.downcast::<arti_client::Error>() {
+                Ok(e) => Error::Tor(*e),
+                Err(b) => Error::Backend(b),
+            },
+        }
     }
 }

--- a/zcash_client_backend/src/tor/http.rs
+++ b/zcash_client_backend/src/tor/http.rs
@@ -1,55 +1,24 @@
 //! HTTP requests over Tor.
+//!
+//! The generic machinery lives in [`crate::privacy::http`]; the methods here are thin
+//! Tor-specific wrappers that surface [`super::Error`]. The [`HttpError`], [`Retry`], and
+//! [`cryptex`] items are re-exported from [`crate::privacy::http`] so that existing
+//! `tor::http::*` paths continue to resolve.
 
-use std::{fmt, future::Future, io, sync::Arc};
-
-use arti_client::TorClient;
-use futures_util::task::SpawnExt;
 use http_body_util::{BodyExt, Empty};
 use hyper::{
-    Request, Response, StatusCode, Uri,
+    Response, StatusCode, Uri,
     body::{Body, Buf, Bytes, Incoming},
-    client::conn,
-    http::{request::Builder, uri::Scheme},
+    http::request::Builder,
 };
-use hyper_util::rt::TokioIo;
+use rust_decimal::Decimal;
 use serde::de::DeserializeOwned;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_rustls::{
-    TlsConnector,
-    rustls::{ClientConfig, RootCertStore, pki_types::ServerName},
-};
-use tor_rtcompat::PreferredRuntime;
-use tracing::{debug, error};
+use std::future::Future;
+
+pub use crate::privacy::http::{HttpError, Retry, cryptex};
 
 use super::{Client, Error};
-
-pub mod cryptex;
-
-/// How a particular connection failure should be retried.
-pub enum Retry {
-    /// Retry using the same Tor circuits that resulted in this error.
-    Same,
-    /// Retry using separate Tor circuits isolated from any other Tor usage.
-    Isolated,
-}
-
-pub(super) fn url_is_https(url: &Uri) -> Result<bool, HttpError> {
-    Ok(url.scheme().ok_or_else(|| HttpError::NonHttpUrl)? == &Scheme::HTTPS)
-}
-
-pub(super) fn parse_url(url: &Uri) -> Result<(bool, String, u16), Error> {
-    let is_https = url_is_https(url)?;
-
-    let host = url.host().ok_or_else(|| HttpError::NonHttpUrl)?.to_string();
-
-    let port = match url.port_u16() {
-        Some(port) => port,
-        None if is_https => 443,
-        None => 80,
-    };
-
-    Ok((is_https, host, port))
-}
+use crate::privacy::http::http_request_over;
 
 impl Client {
     /// Makes an HTTP GET request over Tor.
@@ -82,7 +51,8 @@ impl Client {
         retry_limit: u8,
         retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
     ) -> Result<Response<T>, Error> {
-        self.http_request(
+        http_request_over::<Error, Empty<Bytes>, T, F>(
+            self,
             url,
             |builder| request(builder).method("GET"),
             Empty::<Bytes>::new(),
@@ -106,14 +76,7 @@ impl Client {
     /// code is not in the 200-299 success range (i.e. [`HttpError::Unsuccessful`] is
     /// never returned).
     ///
-    /// There are two arguments for controlling retry behaviour:
-    /// - `retry_limit` is the maximum number of times that a failed request should be
-    ///   retried. You can disable retries by setting this to 0.
-    /// - `retry_filter` can be used to only retry requests that fail in specific ways,
-    ///   and control how the retry is performed. You can disable retries by setting this
-    ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
-    ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
-    ///   Tor client identity across queries).
+    /// See [`Client::http_get`] for a description of the retry arguments.
     #[tracing::instrument(skip(self, request, body, parse_response, retry_filter))]
     pub async fn http_post<B, T, F>(
         &self,
@@ -130,7 +93,8 @@ impl Client {
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         F: Future<Output = Result<T, Error>>,
     {
-        self.http_request(
+        http_request_over::<Error, B, T, F>(
+            self,
             url,
             |builder| request(builder).method("POST"),
             body,
@@ -141,93 +105,27 @@ impl Client {
         .await
     }
 
-    /// Makes an HTTP request over Tor.
-    ///
-    /// There are two arguments for controlling retry behaviour:
-    /// - `retry_limit` is the maximum number of times that a failed request should be
-    ///   retried. You can disable retries by setting this to 0.
-    /// - `retry_filter` can be used to only retry requests that fail in specific ways,
-    ///   and control how the retry is performed. You can disable retries by setting this
-    ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
-    ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
-    ///   Tor client identity across queries).
-    async fn http_request<B, T, F>(
-        &self,
-        url: Uri,
-        request: impl Fn(Builder) -> Builder,
-        body: B,
-        parse_response: impl FnOnce(Incoming) -> F,
-        retry_limit: u8,
-        retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
-    ) -> Result<Response<T>, Error>
-    where
-        B: Body + Clone + Send + 'static,
-        B::Data: Send,
-        B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-        F: Future<Output = Result<T, Error>>,
-    {
-        let mut retries_remaining = retry_limit;
-        let mut client = None;
-
-        let (parts, body) = loop {
-            let response = one_http_request(
-                &client.as_ref().unwrap_or(self).inner,
-                url.clone(),
-                &request,
-                body.clone(),
-            )
-            .await;
-
-            match (
-                retries_remaining.checked_sub(1),
-                retry_filter(response.as_ref().map(|response| response.status())),
-            ) {
-                (Some(retries), Some(retry)) => {
-                    debug!("Retrying due to filter match");
-                    retries_remaining = retries;
-
-                    match retry {
-                        Retry::Same => (),
-                        Retry::Isolated => {
-                            debug!("Switching to isolated Tor circuit for retry");
-                            client = Some(self.isolated_client());
-                        }
-                    }
-                }
-                (None, _) | (_, None) => break response,
-            }
-        }?
-        .into_parts();
-
-        Ok(Response::from_parts(parts, parse_response(body).await?))
-    }
-
     /// Makes an HTTP GET request over Tor, parsing the response as JSON.
     ///
-    /// This is a simple wapper around [`Self::http_get`]. Use that method if you need
+    /// This is a simple wrapper around [`Client::http_get`]. Use that method if you need
     /// more control over the request headers or response parsing.
     ///
-    /// Returns `Ok(response)` if an HTTP response is received, even if the HTTP status
-    /// code is not in the 200-299 success range (i.e. [`HttpError::Unsuccessful`] is
-    /// never returned).
-    ///
-    /// There are two arguments for controlling retry behaviour:
-    /// - `retry_limit` is the maximum number of times that a failed request should be
-    ///   retried. You can disable retries by setting this to 0.
-    /// - `retry_filter` can be used to only retry requests that fail in specific ways,
-    ///   and control how the retry is performed. You can disable retries by setting this
-    ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
-    ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
-    ///   Tor client identity across queries).
+    /// See [`Client::http_get`] for a description of the retry arguments.
     pub async fn http_get_json<T: DeserializeOwned>(
         &self,
         url: Uri,
         retry_limit: u8,
         retry_filter: impl Fn(Result<StatusCode, &Error>) -> Option<Retry>,
     ) -> Result<Response<T>, Error> {
-        self.http_get(
+        http_request_over::<Error, Empty<Bytes>, T, _>(
+            self,
             url,
-            |builder| builder.header(hyper::header::ACCEPT, "application/json"),
+            |builder| {
+                builder
+                    .method("GET")
+                    .header(hyper::header::ACCEPT, "application/json")
+            },
+            Empty::<Bytes>::new(),
             |body| async {
                 Ok(serde_json::from_reader(
                     body.collect()
@@ -243,163 +141,19 @@ impl Client {
         )
         .await
     }
-}
 
-async fn one_http_request<B>(
-    tor_client: &TorClient<PreferredRuntime>,
-    url: Uri,
-    request: impl FnOnce(Builder) -> Builder,
-    body: B,
-) -> Result<Response<Incoming>, Error>
-where
-    B: Body + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-{
-    let (is_https, host, port) = parse_url(&url)?;
-
-    // Connect to the server.
-    debug!("Connecting through Tor to {}:{}", host, port);
-    let stream = tor_client.connect((host.as_str(), port)).await?;
-
-    if is_https {
-        // On apple-darwin targets there's an issue with the native TLS implementation
-        // when used over Tor circuits. We use Rustls instead.
-        //
-        // https://gitlab.torproject.org/tpo/core/arti/-/issues/715
-        let root_store = RootCertStore {
-            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-        };
-        let config = ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        let connector = TlsConnector::from(Arc::new(config));
-        let dnsname = ServerName::try_from(host).expect("Already checked");
-        let stream = connector
-            .connect(dnsname, stream)
-            .await
-            .map_err(HttpError::Tls)?;
-        make_http_request(stream, url, request, body).await
-    } else {
-        make_http_request(stream, url, request, body).await
-    }
-}
-
-async fn make_http_request<B>(
-    stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    url: Uri,
-    request: impl FnOnce(Builder) -> Builder,
-    body: B,
-) -> Result<Response<Incoming>, Error>
-where
-    B: Body + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-{
-    debug!("Making request");
-    let (mut sender, connection) = conn::http1::handshake(TokioIo::new(stream))
-        .await
-        .map_err(HttpError::from)?;
-
-    // Spawn a task to poll the connection and drive the HTTP state.
-    PreferredRuntime::current()?
-        .spawn(async move {
-            if let Err(e) = connection.await {
-                error!("Connection failed: {}", e);
-            }
-        })
-        .map_err(HttpError::from)?;
-
-    // Build the request. We let the caller make whatever request modifications they need,
-    // and then set the Host and URI afterwards so that they are guaranteed to match the
-    // circuit and TLS connection.
-    let req = request(Request::builder())
-        .header(
-            hyper::header::HOST,
-            url.authority().expect("Already checked").as_str(),
-        )
-        .uri(url)
-        .body(body)
-        .map_err(HttpError::from)?;
-    let response = sender.send_request(req).await.map_err(HttpError::from)?;
-    debug!("Response status code: {}", response.status());
-
-    Ok(response)
-}
-
-/// Errors that can occurr while using HTTP-over-Tor.
-#[derive(Debug)]
-pub enum HttpError {
-    /// A non-HTTP URL was encountered.
-    NonHttpUrl,
-    /// An HTTP error.
-    Http(hyper::http::Error),
-    /// A [`hyper`] error.
-    Hyper(hyper::Error),
-    /// A JSON parsing error.
-    Json(serde_json::Error),
-    /// An error occurred while spawning a background worker task for driving the HTTP
-    /// connection.
-    Spawn(futures_util::task::SpawnError),
-    /// A TLS-specific IO error.
-    Tls(io::Error),
-    /// The status code indicated that the request was unsuccessful.
+    /// Fetches the latest USD/ZEC exchange rate over Tor, derived from the given
+    /// exchanges.
     ///
-    /// This is only returned by APIs that make specific queries, such as
-    /// [`Client::get_latest_zec_to_usd_rate`]. Generic APIs like [`Client::http_get`]
-    /// will not return this error variant.
-    Unsuccessful(hyper::http::StatusCode),
-}
-
-impl fmt::Display for HttpError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            HttpError::NonHttpUrl => write!(f, "Only HTTP or HTTPS URLs are supported"),
-            HttpError::Http(e) => write!(f, "HTTP error: {e}"),
-            HttpError::Hyper(e) => write!(f, "Hyper error: {e}"),
-            HttpError::Json(e) => write!(f, "Failed to parse JSON: {e}"),
-            HttpError::Spawn(e) => write!(f, "Failed to spawn task: {e}"),
-            HttpError::Tls(e) => write!(f, "TLS error: {e}"),
-            HttpError::Unsuccessful(status) => write!(f, "Request was unsuccessful ({status:?})"),
-        }
-    }
-}
-
-impl std::error::Error for HttpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            HttpError::NonHttpUrl => None,
-            HttpError::Http(e) => Some(e),
-            HttpError::Hyper(e) => Some(e),
-            HttpError::Json(e) => Some(e),
-            HttpError::Spawn(e) => Some(e),
-            HttpError::Tls(e) => Some(e),
-            HttpError::Unsuccessful(_) => None,
-        }
-    }
-}
-
-impl From<hyper::http::Error> for HttpError {
-    fn from(e: hyper::http::Error) -> Self {
-        HttpError::Http(e)
-    }
-}
-
-impl From<hyper::Error> for HttpError {
-    fn from(e: hyper::Error) -> Self {
-        HttpError::Hyper(e)
-    }
-}
-
-impl From<serde_json::Error> for HttpError {
-    fn from(e: serde_json::Error) -> Self {
-        HttpError::Json(e)
-    }
-}
-
-impl From<futures_util::task::SpawnError> for HttpError {
-    fn from(e: futures_util::task::SpawnError) -> Self {
-        HttpError::Spawn(e)
+    /// Returns:
+    /// - `Ok(rate)` if at least one exchange request succeeds.
+    /// - `Err(_)` if none of the exchange queries succeed.
+    pub async fn get_latest_zec_to_usd_rate(
+        &self,
+        exchanges: &cryptex::Exchanges,
+    ) -> Result<Decimal, Error> {
+        self.ensure_bootstrapped().await?;
+        Ok(cryptex::get_latest_zec_to_usd_rate(self, exchanges).await?)
     }
 }
 


### PR DESCRIPTION
This PR generalizes `zcash_client_backend::tor` into a backend-agnostic network-privacy layer, so that the privacy transport used for lightwalletd point queries, HTTP requests, and exchange-rate fetches can be selected at runtime — Tor today, with alternative backends (e.g. the Nym mixnet) pluggable without further changes to this crate.

## Motivation

Both mobile SDKs (zcash-swift-wallet-sdk and zcash-android-wallet-sdk) carry near-identical ~290-line hand-rolled blocking wrappers (`TorRuntime` + `LwdConn`) over `zcash_client_backend::tor`, and both already select their transport at runtime above the FFI (`ServiceMode`). Meanwhile, the only Tor-specific capability the gRPC and HTTP machinery in this crate actually uses is "open a byte stream to `host:port`" — a single `connect()` call in each of `tor/grpc.rs` and `tor/http.rs`. This PR makes that seam explicit and moves the duplicated blocking wrapper here so both SDKs can share it.

## What's included

- **`zcash_client_backend::privacy`** (new `lightwalletd-privacy` feature):
  - `PrivateNetwork` — the core trait: `connect(&self, host, port) -> impl Future<Output = Result<Stream, Error>>` (RPITIT), `isolated_handle()`, `set_dormant(DormantMode)`.
  - `DynPrivateNetwork` / `BoxedStream` — an object-safe mirror with a blanket impl, so FFI layers can hold `Arc<dyn DynPrivateNetwork>`; the `Arc<dyn>` form itself implements `PrivateNetwork`.
  - A crate-owned `DormantMode` (re-exported at `tor::DormantMode`; `From` conversions with `arti_client::DormantMode` under the `tor` feature).
- **`privacy::grpc` / `privacy::http` / `privacy::http::cryptex`** — the existing gRPC-over-Tor, HTTP-over-Tor, and exchange-rate modules, moved and parameterized over `PrivateNetwork`. The old `tor::http::*` paths (`HttpError`, `Retry`, `cryptex`) remain as re-exports, and `tor::Client`'s methods delegate, so the module's public API stays source-compatible.
- **`privacy::blocking`** (new `lightwalletd-blocking` feature, independent of `tor`): `PrivacyRuntime` (owns a Tokio runtime + an erased backend; `create_tor(tor_dir, dangerously_trust_everyone)` convenience under the `tor` feature) and `LwdConn` (a blocking lightwalletd client carrying the union of the two mobile SDKs' wrapper methods). This is the deduplication target: both SDKs' FFI layers delegate to these types unchanged in their corresponding integration branches.
- `tor::Client` implements `PrivateNetwork`; `tor::Error` gains a `Backend` variant. `HttpError::Spawn` is removed (connection tasks now spawn on the ambient Tokio runtime).

## Verification

- `cargo test -p zcash_client_backend --all-features` passes; two new unit tests exercise the erased layer end-to-end over in-memory duplex streams (HTTP round-trip through both a concrete and an `Arc<dyn>` backend, gRPC helper instantiation over the erased form).
- Feature independence: `--no-default-features` plus each of `tor`, `lightwalletd-blocking`, `tor,lightwalletd-blocking`, `lightwalletd-privacy` compile.
- `cargo check --workspace --all-features` clean; clippy clean and rustfmt applied on touched code.

## Downstream consumers

Integration branches exist for both mobile SDKs (stacked on their `maint/ironwood-2.5.x` branches) that delete the hand-rolled wrappers and delegate the existing Tor FFI symbols to `privacy::blocking` with unchanged FFI surfaces, pinning the librustzcash family to this branch's tip via `[patch.crates-io]` until it lands in a published release (zcash/zcash-swift-wallet-sdk#1809, zcash/zcash-android-wallet-sdk#2014). A stacked draft PR (#2660) adds experimental Nym backends implementing `PrivateNetwork`, useful as a cross-reference for reviewing the abstraction.

Resolves MOB-1492 and MOB-1491

---

This PR was prepared with Claude Code assistance.