### PR TITLE
Add PCZT batch signer redaction helper

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,8 +11,8 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- `pczt::roles::redactor::orchard::OrchardRedactor::redact_recomputable_fields`,
-  behind the `orchard` feature, which removes the Orchard-protocol (Orchard and
+- `pczt::roles::redactor::orchard::OrchardRedactor::compact_resolvable_fields`,
+  behind the `orchard` feature, which compacts the Orchard-protocol (Orchard and
   Ironwood) action fields that `pczt::orchard::Bundle::resolve_fields` can restore.
 
 ## [0.8.0-rc.1] - 2026-07-12

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -444,7 +444,7 @@ impl Action {
         }
     }
 
-    pub(crate) fn redact_recomputable_fields(&mut self, note_version: NoteVersion) {
+    pub(crate) fn compact_resolvable_fields(&mut self, note_version: NoteVersion) {
         let original_enc_ciphertext = self.output.enc_ciphertext.clone();
         self.replace_enc_ciphertext_with_decrypted_memo_plaintext(note_version);
         if self.output.enc_ciphertext != original_enc_ciphertext {
@@ -1428,7 +1428,7 @@ pub(crate) mod v2 {
 
         #[cfg(feature = "orchard")]
         #[test]
-        fn decrypted_memo_plaintext_redaction_skips_decryption_failure() {
+        fn decrypted_memo_plaintext_compaction_skips_decryption_failure() {
             let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
             let original_enc_ciphertext = match &mut action.output.enc_ciphertext {
                 EncCiphertext::Encrypted(enc_ciphertext) => {
@@ -1448,32 +1448,36 @@ pub(crate) mod v2 {
 
         #[cfg(feature = "orchard")]
         #[test]
-        fn recomputable_field_redaction_checks_derived_values() {
-            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+        fn resolvable_field_compaction_checks_derived_values() {
+            let mut memo = [0; MEMO_SIZE];
+            memo[..5].copy_from_slice(b"hello");
+            let mut action = decryptable_action_with_memo(memo);
             action.spend.value = Some(200_000);
             action.rcv = Some([3; 32]);
             action.cv_net = Some(super::super::testing::value_commitment(100_000, [3; 32]));
 
-            action.redact_recomputable_fields(NoteVersion::V2);
+            action.compact_resolvable_fields(NoteVersion::V2);
 
             assert_eq!(action.cv_net, None);
             assert_eq!(action.output.cmx, None);
-            assert!(matches!(
+            assert_eq!(
                 action.output.enc_ciphertext,
-                EncCiphertext::MemoPlaintext(_)
-            ));
+                EncCiphertext::MemoPlaintext(MemoPlaintext::from_memo(memo))
+            );
         }
 
         #[cfg(feature = "orchard")]
         #[test]
-        fn recomputable_field_redaction_retains_unverifiable_values() {
-            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+        fn resolvable_field_compaction_retains_unverifiable_values() {
+            let mut memo = [0; MEMO_SIZE];
+            memo[..5].copy_from_slice(b"hello");
+            let mut action = decryptable_action_with_memo(memo);
             let original_cv_net = action.cv_net;
             let original_cmx = action.output.cmx;
             let original_enc_ciphertext = action.output.enc_ciphertext.clone();
             action.output.recipient = None;
 
-            action.redact_recomputable_fields(NoteVersion::V2);
+            action.compact_resolvable_fields(NoteVersion::V2);
 
             assert_eq!(action.cv_net, original_cv_net);
             assert_eq!(action.output.cmx, original_cmx);
@@ -1482,8 +1486,10 @@ pub(crate) mod v2 {
 
         #[cfg(feature = "orchard")]
         #[test]
-        fn recomputable_field_redaction_retains_mismatched_values() {
-            let mut action = decryptable_action_with_memo([0; MEMO_SIZE]);
+        fn resolvable_field_compaction_retains_mismatched_values() {
+            let mut memo = [0; MEMO_SIZE];
+            memo[..5].copy_from_slice(b"hello");
+            let mut action = decryptable_action_with_memo(memo);
             action.spend.value = Some(200_000);
             action.rcv = Some([3; 32]);
             let mut cv_net = super::super::testing::value_commitment(100_000, [3; 32]);
@@ -1494,7 +1500,7 @@ pub(crate) mod v2 {
             action.output.cmx = Some(cmx);
             let original_enc_ciphertext = action.output.enc_ciphertext.clone();
 
-            action.redact_recomputable_fields(NoteVersion::V2);
+            action.compact_resolvable_fields(NoteVersion::V2);
 
             assert_eq!(action.cv_net, Some(cv_net));
             assert_eq!(action.output.cmx, Some(cmx));

--- a/pczt/src/roles/redactor/orchard.rs
+++ b/pczt/src/roles/redactor/orchard.rs
@@ -23,7 +23,7 @@ impl super::Redactor {
 pub struct OrchardRedactor<'a>(&'a mut Bundle);
 
 impl OrchardRedactor<'_> {
-    /// Redacts fields that can be recomputed from the remaining action data.
+    /// Compacts fields that can be resolved from the remaining action data.
     ///
     /// For every action, this removes `cv_net` and `cmx` when the remaining
     /// fields derive the same values, and replaces a decryptable encrypted note
@@ -34,12 +34,12 @@ impl OrchardRedactor<'_> {
     /// Encrypted note plaintexts that cannot be decrypted from the remaining
     /// action data are left unchanged. Memo recovery runs before `cmx` is
     /// removed because it needs the original note commitment. A bundle with
-    /// these fields redacted requires the v2 PCZT encoding.
+    /// these fields compacted requires the v2 PCZT encoding.
     #[cfg(feature = "orchard")]
-    pub fn redact_recomputable_fields(&mut self) {
+    pub fn compact_resolvable_fields(&mut self) {
         let note_version = self.0.note_version;
         self.redact_actions(|mut action| {
-            action.redact(|action| action.redact_recomputable_fields(note_version));
+            action.redact(|action| action.compact_resolvable_fields(note_version));
         });
     }
 

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -2175,7 +2175,7 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
     let redacted = Redactor::new(pczt.clone())
         .redact_ironwood_with(|mut r| {
             r.clear_anchor();
-            r.redact_recomputable_fields();
+            r.compact_resolvable_fields();
         })
         .finish();
     assert!(redacted.ironwood().anchor().is_none());

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,10 +11,12 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- `zcash_client_backend::data_api::wallet::redact_pczt_for_signer`, which
-  creates a compact signer view of a wallet-created PCZT while retaining the
-  information a general-purpose external signer may need. This is available
-  behind the `pczt` feature.
+- `zcash_client_backend::data_api::wallet::{redact_pczt_for_signer,
+  redact_pczt_for_batch_signer}`, which create compact signer views of a
+  wallet-created PCZT. The batch variant additionally removes fields that a
+  Signer that obtains its full viewing key independently and returns only new
+  Orchard-protocol signatures does not need. These are available behind the
+  `pczt` feature.
 - `zcash_client_backend::proposal::Step::ironwood_action_count`, the Ironwood-pool
   counterpart to `Step::orchard_action_count`. Requires the `orchard` feature.
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -81,7 +81,7 @@ use zcash_protocol::PoolType;
 
 #[cfg(feature = "pczt")]
 use {
-    crate::data_api::wallet::redact_pczt_for_signer,
+    crate::data_api::wallet::{redact_pczt_for_batch_signer, redact_pczt_for_signer},
     pczt::roles::{combiner::Combiner, prover::Prover, signer::Signer},
     rand_core::OsRng,
     transparent::builder::TransparentSigningSet,
@@ -8017,12 +8017,52 @@ where
         "the Ironwood output carries recipient metadata",
     );
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct SpendState {
+        has_fvk: bool,
+        has_signature: bool,
+        has_alpha: bool,
+        value: Option<u64>,
+    }
+
+    fn spend_states(pczt: pczt::Pczt) -> (Vec<SpendState>, Vec<SpendState>) {
+        fn for_bundle(bundle: &orchard::pczt::Bundle) -> Vec<SpendState> {
+            bundle
+                .actions()
+                .iter()
+                .map(|action| SpendState {
+                    has_fvk: action.spend().fvk().is_some(),
+                    has_signature: action.spend().spend_auth_sig().is_some(),
+                    has_alpha: action.spend().alpha().is_some(),
+                    value: action.spend().value().as_ref().map(|value| value.inner()),
+                })
+                .collect()
+        }
+
+        let mut orchard = vec![];
+        let mut ironwood = vec![];
+        pczt::roles::verifier::Verifier::new(pczt)
+            .with_orchard::<Infallible, _>(|bundle| {
+                orchard = for_bundle(bundle);
+                Ok(())
+            })
+            .unwrap()
+            .with_ironwood::<Infallible, _>(|bundle| {
+                ironwood = for_bundle(bundle);
+                Ok(())
+            })
+            .unwrap();
+        (orchard, ironwood)
+    }
+
     let original_sighash = Signer::new(pczt.clone()).unwrap().shielded_sighash();
+    let original_spend_states = spend_states(pczt.clone());
     let original_len = pczt.clone().serialize().unwrap().len();
     let signer_view = redact_pczt_for_signer(&pczt);
     let signer_view_bytes = signer_view.serialize().unwrap();
     assert!(signer_view_bytes.len() < original_len);
     let signer_view = pczt::Pczt::parse(&signer_view_bytes).unwrap();
+    assert_eq!(spend_states(signer_view.clone()), original_spend_states);
 
     // The backend metadata belongs to the authoritative wallet copy, not the
     // external Signer.
@@ -8091,31 +8131,188 @@ where
         + assert_redacted_bundle(pczt.ironwood(), signer_view.ironwood());
     assert!(memo_plaintexts > 0);
 
-    // Resolving the compact representation restores byte-identical effecting
-    // fields and therefore the same shielded signature digest.
-    let mut resolved = signer_view.clone();
-    resolved.resolve_fields().unwrap();
-    for (resolved_bundle, original_bundle) in [
-        (resolved.orchard(), pczt.orchard()),
-        (resolved.ironwood(), pczt.ironwood()),
+    let batch_view = redact_pczt_for_batch_signer(&pczt);
+    let batch_view_bytes = batch_view.serialize().unwrap();
+    assert!(batch_view_bytes.len() < signer_view_bytes.len());
+    let batch_view = pczt::Pczt::parse(&batch_view_bytes).unwrap();
+    let batch_spend_states = spend_states(batch_view.clone());
+
+    let mut preauthorized_actions = 0;
+    let mut unsigned_zero_value_actions = 0;
+    for (original_bundle, batch_bundle) in [
+        (&original_spend_states.0, &batch_spend_states.0),
+        (&original_spend_states.1, &batch_spend_states.1),
     ] {
-        for (resolved, original) in resolved_bundle
-            .actions()
-            .iter()
-            .zip(original_bundle.actions())
-        {
-            assert_eq!(resolved.cv_net(), original.cv_net());
-            assert_eq!(resolved.output().cmx(), original.output().cmx());
+        assert_eq!(batch_bundle.len(), original_bundle.len());
+        for (original, batch) in original_bundle.iter().zip(batch_bundle) {
+            assert!(!batch.has_fvk);
+            assert!(!batch.has_signature);
             assert_eq!(
-                resolved.output().enc_ciphertext(),
-                original.output().enc_ciphertext()
+                batch.has_alpha,
+                original.has_alpha && !original.has_signature
             );
+
+            if original.has_signature {
+                preauthorized_actions += 1;
+            } else if original.value == Some(0) && original.has_alpha {
+                unsigned_zero_value_actions += 1;
+            }
         }
     }
-    assert_eq!(
-        Signer::new(signer_view.clone()).unwrap().shielded_sighash(),
-        original_sighash,
+    assert!(preauthorized_actions > 0);
+    assert!(unsigned_zero_value_actions > 0);
+
+    // Resolving either compact representation restores byte-identical effecting
+    // fields and therefore the same shielded signature digest.
+    for compact_view in [&signer_view, &batch_view] {
+        let mut resolved = (*compact_view).clone();
+        resolved.resolve_fields().unwrap();
+        for (resolved_bundle, original_bundle) in [
+            (resolved.orchard(), pczt.orchard()),
+            (resolved.ironwood(), pczt.ironwood()),
+        ] {
+            for (resolved, original) in resolved_bundle
+                .actions()
+                .iter()
+                .zip(original_bundle.actions())
+            {
+                assert_eq!(resolved.cv_net(), original.cv_net());
+                assert_eq!(resolved.output().cmx(), original.output().cmx());
+                assert_eq!(
+                    resolved.output().enc_ciphertext(),
+                    original.output().enc_ciphertext()
+                );
+            }
+        }
+        assert_eq!(
+            Signer::new((*compact_view).clone())
+                .unwrap()
+                .shielded_sighash(),
+            original_sighash,
+        );
+    }
+
+    let signable_indices = |states: &[SpendState]| {
+        states
+            .iter()
+            .enumerate()
+            .filter_map(|(index, state)| (!state.has_signature && state.has_alpha).then_some(index))
+            .collect::<Vec<_>>()
+    };
+    let orchard_signable = signable_indices(&original_spend_states.0);
+    let ironwood_signable = signable_indices(&original_spend_states.1);
+    assert!(
+        orchard_signable
+            .iter()
+            .any(|&index| original_spend_states.0[index].value == Some(0))
     );
+
+    // The transported request contains no existing signatures. The batch Signer
+    // contributes signatures for every unsigned action, including the wallet
+    // controlled zero value spend, and returns only those new signatures.
+    let request = pczt::roles::signer::batch::BatchSignRequest::new(vec![batch_view]);
+    let request =
+        pczt::roles::signer::batch::BatchSignRequest::parse(&request.serialize().unwrap()).unwrap();
+    assert_eq!(request.pczts().len(), 1);
+    let transported_view = request.pczts()[0].clone();
+    assert_eq!(spend_states(transported_view.clone()), batch_spend_states);
+
+    let usk = st.get_account().usk().clone();
+    let ask = orchard::keys::SpendAuthorizingKey::from(OrchardPoolTester::usk_to_sk(&usk));
+    let signed_view = pczt::roles::low_level_signer::Signer::new(transported_view)
+        .sign_orchard_with::<pczt::roles::low_level_signer::OrchardParseError, _>(|_, bundle, _| {
+            for &index in &orchard_signable {
+                bundle.actions_mut()[index]
+                    .sign(original_sighash, &ask, OsRng)
+                    .unwrap();
+            }
+            Ok(())
+        })
+        .unwrap()
+        .sign_ironwood_with::<pczt::roles::low_level_signer::OrchardParseError, _>(
+            |_, bundle, _| {
+                for &index in &ironwood_signable {
+                    bundle.actions_mut()[index]
+                        .sign(original_sighash, &ask, OsRng)
+                        .unwrap();
+                }
+                Ok(())
+            },
+        )
+        .unwrap()
+        .finish();
+
+    let signatures = pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_view);
+    let expected_signature_positions = orchard_signable
+        .iter()
+        .copied()
+        .map(|index| (orchard::ValuePool::Orchard, index))
+        .chain(
+            ironwood_signable
+                .iter()
+                .copied()
+                .map(|index| (orchard::ValuePool::Ironwood, index)),
+        )
+        .collect::<Vec<_>>();
+    let signature_positions = signatures
+        .iter()
+        .map(|signature| (signature.value_pool(), signature.action_index()))
+        .collect::<Vec<_>>();
+    assert_eq!(signature_positions, expected_signature_positions);
+
+    let response = pczt::roles::signer::batch::BatchSignResponse::new(vec![signatures]);
+    let response =
+        pczt::roles::signer::batch::BatchSignResponse::parse(&response.serialize().unwrap())
+            .unwrap();
+    assert_eq!(response.signatures().len(), 1);
+
+    let mut signer = Signer::new(pczt.clone()).unwrap();
+    for signature in &response.signatures()[0] {
+        signer
+            .apply_orchard_spend_auth_signature(signature)
+            .unwrap();
+    }
+    let authorized = signer.finish();
+    assert_eq!(
+        authorized.global().proprietary(),
+        pczt.global().proprietary()
+    );
+
+    let authorized_spend_states = spend_states(authorized.clone());
+    for (original_bundle, authorized_bundle) in [
+        (&original_spend_states.0, &authorized_spend_states.0),
+        (&original_spend_states.1, &authorized_spend_states.1),
+    ] {
+        for (original, authorized) in original_bundle.iter().zip(authorized_bundle) {
+            assert_eq!(authorized.has_fvk, original.has_fvk);
+            assert_eq!(authorized.has_alpha, original.has_alpha);
+            assert!(authorized.has_signature);
+        }
+    }
+    for (authorized, original) in authorized
+        .orchard()
+        .actions()
+        .iter()
+        .zip(pczt.orchard().actions())
+        .chain(
+            authorized
+                .ironwood()
+                .actions()
+                .iter()
+                .zip(pczt.ironwood().actions()),
+        )
+    {
+        if original.spend().spend_auth_sig().is_some() {
+            assert_eq!(
+                authorized.spend().spend_auth_sig(),
+                original.spend().spend_auth_sig()
+            );
+        }
+        assert_eq!(
+            authorized.output().proprietary(),
+            original.output().proprietary()
+        );
+    }
 }
 
 /// The transaction version requested at proposal time is recorded on the proposal and preserved

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2392,6 +2392,9 @@ where
 ///
 /// Before sending the PCZT to an external Signer, create a signer view with
 /// [`redact_pczt_for_signer`] and retain the original for combination.
+/// A Signer that independently obtains the relevant full viewing keys and returns
+/// only Orchard-protocol signature contributions can instead use
+/// [`redact_pczt_for_batch_signer`].
 ///
 /// Once the PCZT fully authorized, call [`extract_and_store_transaction_from_pczt`] to
 /// finish transaction creation.
@@ -2873,6 +2876,69 @@ pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         })
         .redact_ironwood_with(|redactor| {
             redact_orchard_bundle(redactor, redact_v6_anchors);
+        })
+        .finish()
+}
+
+/// Creates a compact redacted copy of a wallet PCZT for a batch Signer that returns
+/// signatures only.
+///
+/// This is intended for PCZTs returned by [`create_pczt_from_proposal`] that will be
+/// sent in a [`BatchSignRequest`](pczt::roles::signer::batch::BatchSignRequest).
+/// It applies [`redact_pczt_for_signer`], then removes every Orchard and Ironwood
+/// spend's full viewing key and existing spend authorization signature. Actions
+/// that were already authorized in `pczt` also have their spend authorization
+/// randomizers removed. Unsigned actions retain their randomizers, including wallet
+/// controlled zero value spends.
+///
+/// The external Signer must derive or otherwise obtain the expected full viewing key
+/// independently and return only newly produced Orchard and Ironwood signatures, for
+/// example in a [`BatchSignResponse`](pczt::roles::signer::batch::BatchSignResponse).
+/// The returned view cannot be signed directly with
+/// [`pczt::roles::signer::Signer::sign_orchard`] or
+/// [`pczt::roles::signer::Signer::sign_ironwood`], because those APIs require the
+/// full viewing key to be present in the PCZT. Sapling signatures require a separate
+/// signing path.
+///
+/// The caller must invoke this function on the authoritative PCZT before any existing
+/// signatures have been redacted, retain that PCZT, and apply the Signer's returned
+/// signature contributions to it. The authoritative copy preserves every existing
+/// signature and all fields omitted from the batch Signer view.
+#[cfg(feature = "pczt")]
+pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
+    fn preauthorized_action_indices(bundle: &pczt::orchard::Bundle) -> Vec<usize> {
+        bundle
+            .actions()
+            .iter()
+            .enumerate()
+            .filter_map(|(index, action)| {
+                action.spend().spend_auth_sig().is_some().then_some(index)
+            })
+            .collect()
+    }
+
+    fn redact_orchard_bundle(
+        mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>,
+        preauthorized_action_indices: &[usize],
+    ) {
+        redactor.redact_actions(|mut action| {
+            action.clear_spend_fvk();
+            action.clear_spend_auth_sig();
+        });
+        for &index in preauthorized_action_indices {
+            redactor.redact_action(index, |mut action| action.clear_spend_alpha());
+        }
+    }
+
+    let orchard_preauthorized = preauthorized_action_indices(pczt.orchard());
+    let ironwood_preauthorized = preauthorized_action_indices(pczt.ironwood());
+
+    Redactor::new(redact_pczt_for_signer(pczt))
+        .redact_orchard_with(|redactor| {
+            redact_orchard_bundle(redactor, &orchard_preauthorized);
+        })
+        .redact_ironwood_with(|redactor| {
+            redact_orchard_bundle(redactor, &ironwood_preauthorized);
         })
         .finish()
 }

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2880,32 +2880,21 @@ pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         .finish()
 }
 
-/// Creates a compact redacted copy of a wallet PCZT for a batch Signer that returns
-/// signatures only.
+/// Creates a compact wallet PCZT for a batch Signer that obtains its full viewing key
+/// independently and returns only new Orchard and Ironwood signatures.
 ///
-/// This is intended for PCZTs returned by [`create_pczt_from_proposal`] that will be
-/// sent in a [`BatchSignRequest`](pczt::roles::signer::batch::BatchSignRequest).
-/// It applies [`redact_pczt_for_signer`], then removes every Orchard and Ironwood
-/// spend's full viewing key and existing spend authorization signature. Actions
-/// that were already authorized in `pczt` also have their spend authorization
-/// randomizers removed. Unsigned actions retain their randomizers, including wallet
-/// controlled zero value spends.
+/// In addition to [`redact_pczt_for_signer`], this removes spend full viewing keys and
+/// existing signatures. It also removes the randomizer from actions already authorized
+/// in `pczt`, while unsigned actions such as wallet controlled zero value spends retain
+/// theirs. Sapling signatures require a separate signing path.
 ///
-/// The external Signer must derive or otherwise obtain the expected full viewing key
-/// independently and return only newly produced Orchard and Ironwood signatures, for
-/// example in a [`BatchSignResponse`](pczt::roles::signer::batch::BatchSignResponse).
-/// The returned view cannot be signed directly with
-/// [`pczt::roles::signer::Signer::sign_orchard`] or
-/// [`pczt::roles::signer::Signer::sign_ironwood`], because those APIs require the
-/// full viewing key to be present in the PCZT. Sapling signatures require a separate
-/// signing path.
-///
-/// The caller must invoke this function on the authoritative PCZT before any existing
-/// signatures have been redacted, retain that PCZT, and apply the Signer's returned
-/// signature contributions to it. The authoritative copy preserves every existing
-/// signature and all fields omitted from the batch Signer view.
+/// The caller must retain the authoritative PCZT and apply the returned signature
+/// contributions to it. This function must run before its existing signatures are
+/// redacted. The returned view cannot be signed with the high level
+/// [`pczt::roles::signer::Signer`] because that role expects full viewing keys.
 #[cfg(feature = "pczt")]
 pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
+    // Snapshot existing signature positions before the batch view clears them.
     fn preauthorized_action_indices(bundle: &pczt::orchard::Bundle) -> Vec<usize> {
         bundle
             .actions()
@@ -2921,10 +2910,12 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>,
         preauthorized_action_indices: &[usize],
     ) {
+        // The batch Signer derives its FVK and returns only new signatures.
         redactor.redact_actions(|mut action| {
             action.clear_spend_fvk();
             action.clear_spend_auth_sig();
         });
+        // Unsigned actions keep alpha, including wallet controlled zero value spends.
         for &index in preauthorized_action_indices {
             redactor.redact_action(index, |mut action| action.clear_spend_alpha());
         }
@@ -2933,6 +2924,7 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
     let orchard_preauthorized = preauthorized_action_indices(pczt.orchard());
     let ironwood_preauthorized = preauthorized_action_indices(pczt.ironwood());
 
+    // Apply the policy shared by every external Signer first.
     Redactor::new(redact_pczt_for_signer(pczt))
         .redact_orchard_with(|redactor| {
             redact_orchard_bundle(redactor, &orchard_preauthorized);

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2841,7 +2841,7 @@ pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
             action.redact_output_proprietary(PROPRIETARY_OUTPUT_INFO);
         });
 
-        redactor.redact_recomputable_fields();
+        redactor.compact_resolvable_fields();
 
         if redact_v6_anchor {
             redactor.clear_anchor();


### PR DESCRIPTION
Adds a wallet helper for PCZTs sent through the signatures only batch protocol. It layers on general signer redaction, removes Orchard and Ironwood full viewing keys and existing signatures, and removes alpha only from actions already authorized in the retained authoritative PCZT while preserving unsigned zero value wallet spends for signing. This centralizes the capability policy without weakening the general signer path.

It also renames the Orchard protocol redactor operation to `compact_resolvable_fields` so the API reflects that it replaces decryptable ciphertext with memo plaintext as well as omitting fields.