### PR TITLE
zcash_pool_migration_backend: the migration engine (planning, state, commit preparation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,15 @@ since Mermaid layout is hard to reason about in plain text.
   below it, and `eip681` stands alone with no in-repo dependencies.
 - `zcash_client_sqlite` sits at the top, depending on `zcash_client_backend`.
 
+## Code Conventions
+
+- **Never use magic numbers.** Do not inline a bare numeric (or string) literal
+  whose meaning is not obvious from context. Give it a `const` with a
+  doc-commented rationale, and reuse the protocol's own named constants
+  (`COIN`, `MAX_MONEY`, the ZIP-317 `MARGINAL_FEE`, `PREP_TX_ACTIONS`,
+  `DENOM_CAP`, ...) rather than re-deriving their values. This applies to
+  production code, tests, and fixtures alike.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,17 @@ since Mermaid layout is hard to reason about in plain text.
   `DENOM_CAP`, ...) rather than re-deriving their values. This applies to
   production code, tests, and fixtures alike.
 
+- **Public APIs use semantic types, never bare primitives.** A `pub` function,
+  trait method, struct field accessor, or constructor must not represent a
+  domain quantity as a bare integer, byte array, or string: monetary values are
+  `Zatoshis` (or `ZatBalance` where signed), block heights are `BlockHeight`,
+  transaction ids are `TxId`, and so on — reuse the workspace's existing
+  newtype wrappers, or introduce one when none exists. Bare primitives are
+  acceptable only for genuinely unitless quantities (counts, indices) and in
+  module-internal arithmetic, converting at the public boundary; a conversion
+  that cannot fail there must say why in a comment, and one that can fail must
+  return a typed error rather than panic.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7260,6 +7260,7 @@ dependencies = [
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
 dependencies = [
+ "getset",
  "incrementalmerkletree",
  "libm",
  "orchard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7267,6 +7267,9 @@ dependencies = [
  "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,8 +3008,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,3 +229,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(zcash_unstable, values("nu7"))',
   'cfg(live_network_tests)',
 ] }
+
+[patch.crates-io]
+# ZIP 374 deferred-anchor builder support (orchard PR branch
+# `feat/deferred-anchor-builder`); to be dropped once it lands in an orchard
+# release.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,9 +11,17 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `pczt::Pczt`'s Orchard/Ironwood bundle spends now expose their `witness` field
+  via a getter.
 - `pczt::roles::redactor::orchard::OrchardRedactor::compact_resolvable_fields`,
   behind the `orchard` feature, which compacts the Orchard-protocol (Orchard and
   Ironwood) action fields that `pczt::orchard::Bundle::resolve_fields` can restore.
+
+### Changed
+- Serializing an Orchard-protocol bundle built with its anchor deferred to
+  proving time (`orchard`'s `Builder::new_with_anchor_deferred`, ZIP 374) now
+  emits the bundle's anchor as ABSENT (its real spends' witnesses are already
+  absent), for the `Updater` role to install at proving time.
 
 ## [0.8.0-rc.1] - 2026-07-12
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -569,6 +569,7 @@ pub struct Spend {
     ///
     /// - This is set by the Updater.
     /// - This is required by the Prover.
+    #[getset(get = "pub")]
     pub(crate) witness: Option<(u32, [[u8; 32]; 32])>,
 
     /// The spend authorization randomizer.
@@ -2279,13 +2280,16 @@ impl Bundle {
             let (magnitude, sign) = bundle.value_sum().magnitude_sign();
             (magnitude, matches!(sign, orchard::value::Sign::Negative))
         };
-        let anchor = bundle.anchor().to_bytes();
+        // A bundle built with its anchor deferred to proving time (ZIP 374) carries the
+        // empty-tree root purely as a placeholder; emit the anchor as ABSENT, for the
+        // Updater role to install before proving.
+        let anchor = (!bundle.anchor_deferred()).then(|| bundle.anchor().to_bytes());
 
         Self {
             actions,
             flags: bundle.flag_byte(),
             value_sum,
-            anchor: Some(anchor),
+            anchor,
             note_version,
             zkproof: bundle
                 .zkproof()

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -2343,3 +2343,172 @@ fn redacted_anchor_is_not_resolved() {
     redacted.resolve_fields().unwrap();
     assert!(redacted.orchard().anchor().is_none());
 }
+
+#[test]
+fn builder_can_defer_anchors_until_proving() {
+    use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Orchard note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let orchard_bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // The REAL tree state, available only at "proving time": the builder below never sees
+    // it, and neither does the signer.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    // Build the transaction with BOTH shielded anchors deferred to proving time (ZIP 374):
+    // no anchor and no witness is supplied at build time.
+    let mut builder = DeferredPcztBuilder::new::<zip317::FeeRule>(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        orchard::builder::BundleType::DEFAULT,
+        orchard::builder::BundleType::DEFAULT,
+    )
+    .unwrap();
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(980_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+    // The Creator strips the builder's internal placeholders: both anchors and the real
+    // spend's witness are ABSENT. The fabricated dummy spends keep their (dummy) witnesses:
+    // the prover needs a path for every spend, and any path is valid for a zero-valued
+    // note.
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    assert!(pczt.orchard().anchor().is_none());
+    assert!(pczt.ironwood().anchor().is_none());
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    for (i, action) in pczt.orchard().actions().iter().enumerate() {
+        if i == index {
+            assert!(action.spend().witness().is_none());
+        } else {
+            assert!(action.spend().witness().is_some());
+        }
+    }
+    check_v2_round_trip(&pczt);
+
+    // I/O finalization and signing need neither anchors nor witnesses under V6.
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+
+    // Proving without the real anchor fails: the deferral cannot be silently ignored.
+    assert!(
+        Prover::new(signed.clone())
+            .create_orchard_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    // At proving time, install the real anchor and witness. The sighash is unchanged and
+    // the pre-made signature still verifies, because V6 signatures commit to neither
+    // shielded anchors nor witnesses.
+    let updated = Updater::new(signed)
+        .set_orchard_anchor(anchor)
+        .unwrap()
+        .set_orchard_spend_witnesses([(index, merkle_path)])
+        .unwrap()
+        .set_ironwood_anchor(orchard::Anchor::empty_tree())
+        .unwrap()
+        .finish();
+    assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let produced_sig = updated.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_valid_spend_auth_sig(
+        updated.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&proved);
+
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
+fn deferred_anchors_require_v6() {
+    use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+
+    // Under a pre-NU6.3 branch the transaction version (V5) commits its signatures to the
+    // shielded anchors, so anchor deferral is refused at construction.
+    assert!(matches!(
+        DeferredPcztBuilder::new::<zip317::FeeRule>(
+            pre_nu6_3_test_network(),
+            10_000_000.into(),
+            orchard::builder::BundleType::DEFAULT,
+            orchard::builder::BundleType::DEFAULT,
+        ),
+        Err(zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported(_))
+    ));
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -39,6 +39,7 @@ audit-as-crates-io = true
 [policy.incrementalmerkletree-testing]
 
 [policy.orchard]
+audit-as-crates-io = false
 
 [policy.pczt]
 audit-as-crates-io = true

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -101,7 +101,8 @@ and this library adheres to Rust's notion of
   signing) and follow ZIP 318's two-phase signing (more than one signing session is permitted):
   `commit_preparation` builds and pre-signs the preparation transactions and records each transfer as a
   planned placeholder carrying its schedule; `commit_transfers`, once the preparation is mined and the
-  funding notes are witnessable, builds and pre-signs the transfers into those placeholders.
+  funding notes exist, builds and pre-signs the transfers into those placeholders with their
+  anchors and witnesses deferred to proving time (ZIP 374).
   `commit_preparation` handles single-layer preparation, the common case, and reports
   `UnsupportedMultiLayer` for a plan whose later layers spend earlier, still unmined layers' outputs
   (full one-session pre-signing awaits a public pczt output-recovery API). Planning is pure (`no_std`);

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -92,29 +92,29 @@ and this library adheres to Rust's notion of
   each step for the true fee cost, schedules the transfers (`scheduling`), and returns a
   `MigrationPlan` preview for user consent. It defines the persisted state model
   - a `MigrationState` (status, the note split, the reconciled funding-note values, and the
-  transactions) of `MigrationTransaction`s (each a stable id, kind, the pre-signed PCZT as bytes or
-  `None` until built, dependencies, scheduled and expiry heights, drawn anchor boundary, and lifecycle
-  state) - and the `MigrationBackend` persistence methods (`store_migration` / `load_migration` /
+  transactions) of `MigrationTransaction`s (each a stable id, kind, the pre-signed PCZT as bytes,
+  dependencies, scheduled and expiry heights, drawn anchor boundary, and lifecycle state) - and the
+  `MigrationBackend` persistence methods (`store_migration` / `load_migration` /
   `update_transaction`), so a committed migration is stored as the pre-signed PCZTs the consuming
   application later proves and broadcasts, and resumes after a restart. Building and signing use the
-  `orchard`-gated `MigrationCrypto` trait (the account's viewing key, note witnesses, an anchor, and
-  signing) and follow ZIP 318's two-phase signing (more than one signing session is permitted):
-  `commit_preparation` builds and pre-signs the preparation transactions and records each transfer as a
-  planned placeholder carrying its schedule; `commit_transfers`, once the preparation is mined and the
-  funding notes exist, builds and pre-signs the transfers into those placeholders with their
-  anchors and witnesses deferred to proving time (ZIP 374).
-  `commit_preparation` handles single-layer preparation, the common case, and reports
-  `UnsupportedMultiLayer` for a plan whose later layers spend earlier, still unmined layers' outputs
-  (full one-session pre-signing awaits a public pczt output-recovery API). Planning is pure (`no_std`);
-  reconciliation-on-launch is added by a later slice.
+  `orchard`-gated `MigrationCrypto` trait (the account's viewing key, its spendable notes'
+  plaintexts, and signing). Every transaction's anchors and witnesses are deferred to proving time
+  (ZIP 374), so a spent note's plaintext fully determines the signed data — including notes minted
+  by earlier, still-unmined migration transactions, recovered from their built bundles — and
+  `commit_preparation` builds and signs the WHOLE migration (every preparation layer in topological
+  order, then every transfer) in ONE signing phase, before anything is broadcast; mining gates only
+  the broadcast order. Planning is pure (`no_std`); proving (installing each transaction's anchor
+  and witnesses through the PCZT Updater role) and reconciliation-on-launch are consumer
+  responsibilities, the latter added by a later slice.
 - An external-signer seam on the `engine` module (behind the `orchard` feature), so a hardware or
-  offline signer can sign a migration's transactions out of band. `build_preparation_unsigned` and
-  `build_transfers_unsigned` mirror `commit_preparation` / `commit_transfers` but leave the transactions
-  UNSIGNED in a new `MigrationTxState::AwaitingSignature` state and return their serialized PCZTs
-  (`UnsignedMigrationTx`, paired with the transaction id) to route to the signing device. Once the
-  device returns a signed PCZT, `MigrationState::apply_signature` stores it and moves the transaction to
-  `Signed`, after which the normal state machine proves and broadcasts it unchanged (proving remains a
-  consumer responsibility, as for in-process signing). External signing therefore replaces only the
-  build-and-sign step; the rest of the lifecycle is identical. The status view surfaces an awaiting
-  transaction as blocked on `Blocker::Signature`. Deferred multi-layer preparation layers still sign in
-  process.
+  offline signer can sign a migration's transactions out of band. `build_preparation_unsigned`
+  mirrors `commit_preparation` but leaves every transaction UNSIGNED in a new
+  `MigrationTxState::AwaitingSignature` state and returns their serialized PCZTs
+  (`UnsignedMigrationTx`, paired with the transaction id and its padded action count) in
+  topological order; `batch_unsigned_by_action_budget` splits them into signing sessions bounded
+  by the device's per-interaction action budget — consecutive prefixes, never gated on mining.
+  Once the device returns a signed PCZT, `MigrationState::apply_signature` stores it and moves the
+  transaction to `Signed`, after which the normal state machine broadcasts it unchanged (proving
+  remains a consumer responsibility, as for in-process signing). External signing therefore
+  replaces only the sign step; the rest of the lifecycle is identical. The status view surfaces an
+  awaiting transaction as blocked on `Blocker::Signature`.

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -81,3 +81,24 @@ and this library adheres to Rust's notion of
   engine-enforced MUSTs (sync/broadcast decoupling, and at most one overdue transfer at wallet open)
   are documented as out of scope for this pure module. The exponential draw's natural log uses `libm`,
   since the crate is `no_std` and `std`'s `f64::ln` is unavailable.
+- The migration engine (the `engine` module): orchestration of a pool migration through a
+  `MigrationBackend` trait. `plan_migration` reads the account's spendable note values and the chain
+  tip from the backend, decomposes the balance into denominations (`note_splitting`), plans the
+  preparation transactions (`preparation`), schedules the transfers (`scheduling`), and reconciles the
+  split against the preparation fees (dropping the smallest denominations when they do not fit the
+  balance), returning a `MigrationPlan` preview for user consent. It defines the persisted state model
+  - a `MigrationState` (status, the note split, the reconciled funding-note values, and the
+  transactions) of `MigrationTransaction`s (each a stable id, kind, the pre-signed PCZT as bytes or
+  `None` until built, dependencies, scheduled and expiry heights, drawn anchor boundary, and lifecycle
+  state) - and the `MigrationBackend` persistence methods (`store_migration` / `load_migration` /
+  `update_transaction`), so a committed migration is stored as the pre-signed PCZTs the consuming
+  application later proves and broadcasts, and resumes after a restart. Building and signing use the
+  `orchard`-gated `MigrationCrypto` trait (the account's viewing key, note witnesses, an anchor, and
+  signing) and follow ZIP 318's two-phase signing (more than one signing session is permitted):
+  `commit_preparation` builds and pre-signs the preparation transactions and records each transfer as a
+  planned placeholder carrying its schedule; `commit_transfers`, once the preparation is mined and the
+  funding notes are witnessable, builds and pre-signs the transfers into those placeholders.
+  `commit_preparation` handles single-layer preparation, the common case, and reports
+  `UnsupportedMultiLayer` for a plan whose later layers spend earlier, still unmined layers' outputs
+  (full one-session pre-signing awaits a public pczt output-recovery API). Planning is pure (`no_std`);
+  reconciliation-on-launch is added by a later slice.

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -102,3 +102,14 @@ and this library adheres to Rust's notion of
   `UnsupportedMultiLayer` for a plan whose later layers spend earlier, still unmined layers' outputs
   (full one-session pre-signing awaits a public pczt output-recovery API). Planning is pure (`no_std`);
   reconciliation-on-launch is added by a later slice.
+- An external-signer seam on the `engine` module (behind the `orchard` feature), so a hardware or
+  offline signer can sign a migration's transactions out of band. `build_preparation_unsigned` and
+  `build_transfers_unsigned` mirror `commit_preparation` / `commit_transfers` but leave the transactions
+  UNSIGNED in a new `MigrationTxState::AwaitingSignature` state and return their serialized PCZTs
+  (`UnsignedMigrationTx`, paired with the transaction id) to route to the signing device. Once the
+  device returns a signed PCZT, `MigrationState::apply_signature` stores it and moves the transaction to
+  `Signed`, after which the normal state machine proves and broadcasts it unchanged (proving remains a
+  consumer responsibility, as for in-process signing). External signing therefore replaces only the
+  build-and-sign step; the rest of the lifecycle is identical. The status view surfaces an awaiting
+  transaction as blocked on `Blocker::Signature`. Deferred multi-layer preparation layers still sign in
+  process.

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -22,10 +22,13 @@ and this library adheres to Rust's notion of
   self-funding notes (each holding its crossing value plus a fee buffer), mints denominations from a
   maximum (ZIP 318's `DENOM_CAP`, bounding a whale's crossings to the shared denomination set) down to
   a sub-1-ZEC dust floor (ZIP 318's `MAX_RESIDUAL_VALUE`), and leaves any residual below that floor as
-  source-pool change rather than folded into a fee. The fee model is pluggable via the `FeePolicy`
-  trait (`Zip317FeePolicy` provided), and the maximum denomination, dust floor, and note cap are
-  strategy parameters. `plan_note_split` is a convenience wrapper over the recommended
-  `CanonicalOneTwoFive`. The crate is `no_std` (it needs only `alloc`), depending on
+  source-pool change rather than folded into a fee. The canonical fees come from the ZIP-317 fee
+  rule applied to the canonical transaction shapes, computed once by the caller (the engine) and
+  passed in: the strategy takes the per-note transfer-fee buffer, the per-transaction preparation
+  fee, and a preparation-layout capability it consults at each step of the decomposition, so the
+  true preparation cost (consolidation and fan-out layers included) is reserved as the split grows.
+  The maximum denomination, dust floor, and note cap are strategy parameters. `plan_note_split` is a
+  convenience wrapper over the recommended `CanonicalOneTwoFive`. The crate is `no_std` (it needs only `alloc`), depending on
   `zcash_protocol`, `zcash_primitives`, and `rand_core`.
 - The pure PCZT transfer builder (`build::build_transfer_pczt`, behind the `orchard` feature): spends
   one self-funding note the note split minted and outputs its crossing value into the Ironwood pool as
@@ -83,10 +86,11 @@ and this library adheres to Rust's notion of
   since the crate is `no_std` and `std`'s `f64::ln` is unavailable.
 - The migration engine (the `engine` module): orchestration of a pool migration through a
   `MigrationBackend` trait. `plan_migration` reads the account's spendable note values and the chain
-  tip from the backend, decomposes the balance into denominations (`note_splitting`), plans the
-  preparation transactions (`preparation`), schedules the transfers (`scheduling`), and reconciles the
-  split against the preparation fees (dropping the smallest denominations when they do not fit the
-  balance), returning a `MigrationPlan` preview for user consent. It defines the persisted state model
+  tip from the backend, computes the canonical ZIP-317 fees once from the canonical transaction
+  shapes (the fee rule is fixed, since ZIP 318 requires the canonical fee), decomposes the balance
+  into denominations (`note_splitting`) with the preparation planner (`preparation`) consulted at
+  each step for the true fee cost, schedules the transfers (`scheduling`), and returns a
+  `MigrationPlan` preview for user consent. It defines the persisted state model
   - a `MigrationState` (status, the note split, the reconciled funding-note values, and the
   transactions) of `MigrationTransaction`s (each a stable id, kind, the pre-signed PCZT as bytes or
   `None` until built, dependencies, scheduled and expiry heights, drawn anchor boundary, and lifecycle

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -33,6 +33,13 @@ pczt = { workspace = true, optional = true, features = [
     "zcp-builder",
 ] }
 
+# Enabled by the `wallet` feature: the wallet-backed adapter, sourcing the migration's cryptographic
+# ingredients from a `zcash_client_backend` wallet instead of a hand-written `MigrationCrypto`.
+zcash_client_backend = { workspace = true, optional = true, features = ["orchard"] }
+zcash_keys = { workspace = true, optional = true, features = ["orchard"] }
+shardtree = { workspace = true, optional = true }
+incrementalmerkletree = { workspace = true, optional = true }
+
 [dev-dependencies]
 incrementalmerkletree.workspace = true
 proptest.workspace = true
@@ -47,6 +54,16 @@ zcash_protocol = { workspace = true, features = ["local-consensus"] }
 ## Orchard pool; pulls in `orchard` and `pczt`. The caller supplies the RNG, so no `rand` dependency
 ## is added.
 orchard = ["dep:orchard", "dep:pczt"]
+## Builds the wallet-backed adapter (`wallet` module): a `WalletMigration` that implements the
+## engine's backend/crypto/store traits over a `zcash_client_backend` wallet, so any such wallet is a
+## migration wallet with no hand-wired crypto. Implies `orchard`.
+wallet = [
+    "orchard",
+    "dep:zcash_client_backend",
+    "dep:zcash_keys",
+    "dep:shardtree",
+    "dep:incrementalmerkletree",
+]
 
 [lints]
 workspace = true

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -19,6 +19,7 @@ categories.workspace = true
 all-features = true
 
 [dependencies]
+getset.workspace = true
 libm.workspace = true
 rand_core.workspace = true
 zcash_primitives.workspace = true

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -53,7 +53,10 @@ impl core::error::Error for BuildError {}
 
 /// The [`BuildConfig`] shared by the migration transactions: an Orchard-anchored bundle, with the
 /// destination-pool (Ironwood) bundle anchored only when that phase produces a crossing output
-/// (`None` for the same-pool note split).
+/// (`None` for the same-pool note split). The Ironwood bundle is UNPADDED (`pad_to_minimum: 1`):
+/// the canonical transfer carries exactly one Ironwood action, saving proving bandwidth on hardware
+/// signers, and since every migration transfer shares this canonical shape the one-action bundle
+/// reveals nothing extra.
 pub(crate) fn build_config(
     orchard_anchor: orchard::Anchor,
     ironwood_anchor: Option<orchard::Anchor>,
@@ -63,7 +66,10 @@ pub(crate) fn build_config(
         orchard_anchor: Some(orchard_anchor),
         ironwood_anchor,
         orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-        ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+        ironwood_bundle_type: orchard::builder::BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(1),
+        },
     }
 }
 

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -17,7 +17,7 @@ use alloc::string::String;
 use core::fmt;
 
 use pczt::roles::{creator::Creator, io_finalizer::IoFinalizer};
-use zcash_primitives::transaction::builder::{BuildConfig, PcztParts};
+use zcash_primitives::transaction::builder::PcztParts;
 use zcash_protocol::consensus::Parameters;
 
 mod prep;
@@ -50,28 +50,6 @@ impl fmt::Display for BuildError {
 }
 
 impl core::error::Error for BuildError {}
-
-/// The [`BuildConfig`] shared by the migration transactions: an Orchard-anchored bundle, with the
-/// destination-pool (Ironwood) bundle anchored only when that phase produces a crossing output
-/// (`None` for the same-pool note split). The Ironwood bundle is UNPADDED (`pad_to_minimum: 1`):
-/// the canonical transfer carries exactly one Ironwood action, saving proving bandwidth on hardware
-/// signers, and since every migration transfer shares this canonical shape the one-action bundle
-/// reveals nothing extra.
-pub(crate) fn build_config(
-    orchard_anchor: orchard::Anchor,
-    ironwood_anchor: Option<orchard::Anchor>,
-) -> BuildConfig {
-    BuildConfig::Standard {
-        sapling_anchor: None,
-        orchard_anchor: Some(orchard_anchor),
-        ironwood_anchor,
-        orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-        ironwood_bundle_type: orchard::builder::BundleType::Transactional {
-            bundle_required: false,
-            pad_to_minimum: Some(1),
-        },
-    }
-}
 
 /// Finish an unproven PCZT from the transaction builder's parts: run the [`Creator`] and
 /// [`IoFinalizer`] roles.

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -23,7 +23,7 @@ use zcash_protocol::consensus::Parameters;
 mod prep;
 mod sign;
 mod transfer;
-pub use prep::build_prep_tx;
+pub use prep::{PlacedPrepOutput, build_prep_tx};
 pub use sign::sign_pczt;
 pub use transfer::build_transfer_pczt;
 

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -9,7 +9,13 @@ use zcash_protocol::value::COIN;
 
 use super::test_util::{TARGET_HEIGHT, regtest_network, single_note_witness, spending_key};
 use super::{build_prep_tx, build_transfer_pczt, sign_pczt};
-use crate::note_splitting::{FeePolicy, Zip317FeePolicy, plan_note_split};
+use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
+use zcash_protocol::consensus::BlockHeight;
+
+use crate::note_splitting::{
+    DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, plan_note_split,
+};
 use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
 
 /// note split -> preparation plan -> build + sign a preparation transaction -> build + sign a
@@ -25,18 +31,26 @@ fn migration_pipeline_end_to_end() {
     let ask = SpendAuthorizingKey::from(&sk);
     let balance = 78 * COIN;
 
-    // 1. Note split: decompose the balance into canonical self-funding denominations.
-    let prep_fee = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
+    // 1. Note split: decompose the balance into canonical self-funding denominations, accounting
+    //    the true preparation cost (via the real preparation planner) at each step.
+    let prep_fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
+    let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+        * MARGINAL_FEE.into_u64();
+    let prep_tx_count = |funding: &[u64]| {
+        plan_preparation(&[balance], funding, prep_fee)
+            .ok()
+            .map(|p| p.transaction_count())
+    };
     let split = {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        plan_note_split(balance, prep_fee, &mut rng)
+        plan_note_split(balance, buffer, prep_fee, &prep_tx_count, &mut rng)
     };
     let funding = split.migration_outputs();
     assert!(!funding.is_empty(), "the balance yields funding notes");
 
     // 2. Preparation: plan the send-to-self transactions that mint those funding notes. A typical
     //    wallet (one note, a handful of funding notes) prepares in a single transaction.
-    let prep = plan_preparation(&[balance], &funding, split.prep_fee_zatoshi())
+    let prep = plan_preparation(&[balance], &funding, prep_fee)
         .expect("the balance funds the preparation");
     assert_eq!(prep.layer_count(), 1);
     assert_eq!(prep.transaction_count(), 1);
@@ -63,6 +77,36 @@ fn migration_pipeline_end_to_end() {
         "the preparation bundle is padded to exactly 16 actions"
     );
     assert_eq!(placed.len(), tx.outputs().len(), "every output is located");
+
+    // The REAL constructed preparation transaction pays exactly the canonical ZIP-317 fee of its
+    // padded shape: the value its spends bring in, minus the value its outputs (including change
+    // and zero-valued dummies) carry out, is the fee the planner reserved per transaction.
+    let fee_rule = zip317::FeeRule::standard();
+    let expected_prep_fee = fee_rule
+        .fee_required(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            core::iter::empty::<transparent::InputSize>(),
+            core::iter::empty::<usize>(),
+            0,
+            0,
+            PREP_TX_ACTIONS,
+            0,
+        )
+        .expect("the canonical preparation fee computes");
+    assert_eq!(
+        u64::from(expected_prep_fee),
+        prep_fee,
+        "the planner's per-transaction reserve is the rule's fee for the padded shape"
+    );
+    // The transaction's only spend is the wallet note supplied above (`balance`); its outputs
+    // (funding notes, change, and zero-valued padding dummies) are read back from the built PCZT.
+    let prep_out = bundle_output_value(prep_pczt.orchard());
+    assert_eq!(
+        balance - prep_out,
+        u64::from(expected_prep_fee),
+        "the built preparation transaction pays exactly the canonical fee"
+    );
     sign_pczt(prep_pczt, &ask).expect("pre-signing the preparation transaction");
 
     // 4. Build + pre-sign a pool-crossing transfer for one funding note (witnessed directly here, as
@@ -87,5 +131,59 @@ fn migration_pipeline_end_to_end() {
         ChaCha8Rng::seed_from_u64(seed + 3),
     )
     .expect("the transfer builds");
+
+    // The REAL constructed transfer pays exactly the canonical fee of the 2+2-action transfer
+    // shape (which is the buffer each prepared note carries), and crosses exactly the planned
+    // canonical denomination into the Ironwood pool.
+    let expected_transfer_fee = fee_rule
+        .fee_required(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            core::iter::empty::<transparent::InputSize>(),
+            core::iter::empty::<usize>(),
+            0,
+            0,
+            SOURCE_ACTIONS_PER_TRANSFER,
+            DESTINATION_ACTIONS_PER_TRANSFER,
+        )
+        .expect("the canonical transfer fee computes");
+    assert_eq!(
+        u64::from(expected_transfer_fee),
+        buffer,
+        "the per-note buffer is the rule's fee for the transfer shape"
+    );
+    // The transfer's only spend is the funding note supplied above (`funding_value`); the value
+    // that crosses is the Ironwood bundle's output total, and the change stays in Orchard.
+    let orchard_out = bundle_output_value(transfer_pczt.orchard());
+    let ironwood_out = bundle_output_value(transfer_pczt.ironwood());
+    assert_eq!(
+        transfer_pczt.orchard().actions().len(),
+        SOURCE_ACTIONS_PER_TRANSFER,
+        "the transfer's Orchard bundle is padded to the canonical two actions"
+    );
+    assert_eq!(
+        transfer_pczt.ironwood().actions().len(),
+        DESTINATION_ACTIONS_PER_TRANSFER,
+        "the transfer's Ironwood bundle is a single unpadded action"
+    );
+    assert_eq!(
+        ironwood_out, crossing,
+        "the value crossing the turnstile is exactly the planned canonical denomination"
+    );
+    assert_eq!(
+        funding_value - orchard_out - ironwood_out,
+        u64::from(expected_transfer_fee),
+        "the built transfer pays exactly the canonical fee"
+    );
     sign_pczt(transfer_pczt, &ask).expect("pre-signing the transfer");
+}
+
+/// The total output value a PCZT bundle carries (padded dummy outputs hold zero). Spend values are
+/// redactable and expose no getter; the tests know the input values they supplied.
+fn bundle_output_value(bundle: &pczt::orchard::Bundle) -> u64 {
+    bundle
+        .actions()
+        .iter()
+        .map(|action| action.output().value().unwrap_or(0))
+        .sum()
 }

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -141,7 +141,8 @@ fn migration_pipeline_end_to_end() {
     )
     .expect("the transfer builds");
 
-    // The REAL constructed transfer pays exactly the canonical fee of the 2+2-action transfer
+    // The REAL constructed transfer pays exactly the canonical fee of the 2-Orchard +
+    // 1-Ironwood-action transfer
     // shape (which is the buffer each prepared note carries), and crosses exactly the planned
     // canonical denomination into the Ironwood pool.
     let expected_transfer_fee = fee_rule

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -66,11 +66,11 @@ fn migration_pipeline_end_to_end() {
     assert_eq!(prep.transaction_count(), 1);
 
     // 3. Build + pre-sign the preparation transaction. The wallet backend resolves the transaction's
-    //    single input (PrepInput::Wallet { index: 0, .. }) to the account's note and its witness
-    //    against the anchor.
+    //    single input (PrepInput::Wallet { index: 0, .. }) to the account's note plaintext; no
+    //    witness and no anchor exist at build time (ZIP 374 deferral).
     let tx = &prep.layers()[0][0];
     assert!(matches!(tx.inputs(), [PrepInput::Wallet { index: 0, .. }]));
-    let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+    let (note, _path, _anchor) = single_note_witness(&fvk, balance, seed);
     let prep_expiry = u32::from(crate::scheduling::expiry_height(BlockHeight::from_u32(
         TARGET_HEIGHT,
     )));
@@ -79,8 +79,7 @@ fn migration_pipeline_end_to_end() {
         TARGET_HEIGHT,
         prep_expiry,
         &fvk,
-        anchor,
-        vec![(note, path)],
+        vec![note],
         tx.outputs(),
         ChaCha8Rng::seed_from_u64(seed + 1),
     )

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -71,9 +71,13 @@ fn migration_pipeline_end_to_end() {
     let tx = &prep.layers()[0][0];
     assert!(matches!(tx.inputs(), [PrepInput::Wallet { index: 0, .. }]));
     let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+    let prep_expiry = u32::from(crate::scheduling::expiry_height(BlockHeight::from_u32(
+        TARGET_HEIGHT,
+    )));
     let (prep_pczt, placed) = build_prep_tx(
         &params,
         TARGET_HEIGHT,
+        prep_expiry,
         &fvk,
         anchor,
         vec![(note, path)],

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -12,6 +12,7 @@ use super::{build_prep_tx, build_transfer_pczt, sign_pczt};
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::Zatoshis;
 
 use crate::note_splitting::{
     DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, plan_note_split,
@@ -33,24 +34,33 @@ fn migration_pipeline_end_to_end() {
 
     // 1. Note split: decompose the balance into canonical self-funding denominations, accounting
     //    the true preparation cost (via the real preparation planner) at each step.
-    let prep_fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
-    let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
-        * MARGINAL_FEE.into_u64();
-    let prep_tx_count = |funding: &[u64]| {
-        plan_preparation(&[balance], funding, prep_fee)
+    let prep_fee = Zatoshis::const_from_u64(PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64());
+    let buffer = Zatoshis::const_from_u64(
+        (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+            * MARGINAL_FEE.into_u64(),
+    );
+    let balance_zats = [Zatoshis::const_from_u64(balance)];
+    let prep_tx_count = |funding: &[Zatoshis]| {
+        plan_preparation(&balance_zats, funding, prep_fee)
             .ok()
             .map(|p| p.transaction_count())
     };
     let split = {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        plan_note_split(balance, buffer, prep_fee, &prep_tx_count, &mut rng)
+        plan_note_split(
+            Zatoshis::const_from_u64(balance),
+            buffer,
+            prep_fee,
+            &prep_tx_count,
+            &mut rng,
+        )
     };
     let funding = split.migration_outputs();
     assert!(!funding.is_empty(), "the balance yields funding notes");
 
     // 2. Preparation: plan the send-to-self transactions that mint those funding notes. A typical
     //    wallet (one note, a handful of funding notes) prepares in a single transaction.
-    let prep = plan_preparation(&[balance], &funding, prep_fee)
+    let prep = plan_preparation(&balance_zats, &funding, prep_fee)
         .expect("the balance funds the preparation");
     assert_eq!(prep.layer_count(), 1);
     assert_eq!(prep.transaction_count(), 1);
@@ -95,8 +105,7 @@ fn migration_pipeline_end_to_end() {
         )
         .expect("the canonical preparation fee computes");
     assert_eq!(
-        u64::from(expected_prep_fee),
-        prep_fee,
+        expected_prep_fee, prep_fee,
         "the planner's per-transaction reserve is the rule's fee for the padded shape"
     );
     // The transaction's only spend is the wallet note supplied above (`balance`); its outputs
@@ -114,10 +123,10 @@ fn migration_pipeline_end_to_end() {
     //    denomination into the Ironwood pool.
     let crossing = split.crossing_values()[0];
     let funding_value = funding[0];
-    let (fnote, fpath, fanchor) = single_note_witness(&fvk, funding_value, seed + 2);
+    let (fnote, fpath, fanchor) = single_note_witness(&fvk, u64::from(funding_value), seed + 2);
     // A recent Ironwood note-commitment-tree root (a one-note tree here) to anchor the transfer's
-    // padding dummy spends, as the wallet backend would supply from the live pool.
-    let (_, _, ironwood_anchor) = single_note_witness(&fvk, crossing, seed + 4);
+    // dummy spend half, as the wallet backend would supply from the live pool.
+    let (_, _, ironwood_anchor) = single_note_witness(&fvk, u64::from(crossing), seed + 4);
     let transfer_pczt = build_transfer_pczt(
         &params,
         TARGET_HEIGHT,
@@ -148,8 +157,7 @@ fn migration_pipeline_end_to_end() {
         )
         .expect("the canonical transfer fee computes");
     assert_eq!(
-        u64::from(expected_transfer_fee),
-        buffer,
+        expected_transfer_fee, buffer,
         "the per-note buffer is the rule's fee for the transfer shape"
     );
     // The transfer's only spend is the funding note supplied above (`funding_value`); the value
@@ -167,11 +175,12 @@ fn migration_pipeline_end_to_end() {
         "the transfer's Ironwood bundle is a single unpadded action"
     );
     assert_eq!(
-        ironwood_out, crossing,
+        ironwood_out,
+        u64::from(crossing),
         "the value crossing the turnstile is exactly the planned canonical denomination"
     );
     assert_eq!(
-        funding_value - orchard_out - ironwood_out,
+        u64::from(funding_value) - orchard_out - ironwood_out,
         u64::from(expected_transfer_fee),
         "the built transfer pays exactly the canonical fee"
     );

--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -127,19 +127,15 @@ fn migration_pipeline_end_to_end() {
     //    denomination into the Ironwood pool.
     let crossing = split.crossing_values()[0];
     let funding_value = funding[0];
-    let (fnote, fpath, fanchor) = single_note_witness(&fvk, u64::from(funding_value), seed + 2);
-    // A recent Ironwood note-commitment-tree root (a one-note tree here) to anchor the transfer's
-    // dummy spend half, as the wallet backend would supply from the live pool.
-    let (_, _, ironwood_anchor) = single_note_witness(&fvk, u64::from(crossing), seed + 4);
+    // Only the funding note itself is needed: the transfer's anchors and its witness are
+    // DEFERRED to proving time (ZIP 374), installed through the PCZT Updater role.
+    let (fnote, _fpath, _fanchor) = single_note_witness(&fvk, u64::from(funding_value), seed + 2);
     let transfer_pczt = build_transfer_pczt(
         &params,
         TARGET_HEIGHT,
         TARGET_HEIGHT + 40_000,
         &fvk,
-        fanchor,
         fnote,
-        fpath,
-        ironwood_anchor,
         crossing,
         ChaCha8Rng::seed_from_u64(seed + 3),
     )

--- a/zcash_pool_migration_backend/src/build/prep.rs
+++ b/zcash_pool_migration_backend/src/build/prep.rs
@@ -63,7 +63,6 @@ use zcash_primitives::transaction::builder::{BuildConfig, Builder};
 use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::memo::MemoBytes;
-use zcash_protocol::value::Zatoshis;
 
 use super::{BuildError, finalize_pczt, output_action_index};
 use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
@@ -149,7 +148,7 @@ where
                 orchard_fvk.clone(),
                 Some(internal_ovk.clone()),
                 change_address,
-                Zatoshis::const_from_u64(output.value()),
+                output.value(),
                 MemoBytes::empty(),
             )
             .map_err(|e| BuildError::Build(format!("preparation: add output: {e:?}")))?;
@@ -183,6 +182,8 @@ mod tests {
         TARGET_HEIGHT, account, regtest_network, shared_anchor_witnesses, single_note_witness,
     };
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+
+    use crate::note_splitting::zat;
 
     /// The ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action preparation transaction (each action
     /// costs one marginal fee), which the planner reserves per transaction.
@@ -222,7 +223,7 @@ mod tests {
             let fvk = account(account_seed);
             let (spends, anchor) = shared_anchor_witnesses(&fvk, &spend_values, note_seed);
             let outputs: Vec<PrepOutput> =
-                out_zats.iter().map(|&v| PrepOutput::Funding(v)).collect();
+                out_zats.iter().map(|&v| PrepOutput::Funding(zat(v))).collect();
 
             let params = regtest_network(true);
             let rng = ChaCha8Rng::seed_from_u64(note_seed);
@@ -252,7 +253,7 @@ mod tests {
         ) {
             let fvk = account(account_seed);
             let outputs: Vec<PrepOutput> =
-                output_zats.iter().map(|&v| PrepOutput::Funding(v)).collect();
+                output_zats.iter().map(|&v| PrepOutput::Funding(zat(v))).collect();
             // One spend that funds every output plus the padded fee.
             let spend_value = output_zats.iter().sum::<u64>() + prep_fee();
             let (note, path, anchor) = single_note_witness(&fvk, spend_value, note_seed);
@@ -272,7 +273,8 @@ mod tests {
 
             prop_assert_eq!(action_count(&pczt), PREP_TX_ACTIONS);
             prop_assert_eq!(placed.len(), outputs.len());
-            let placed_values: Vec<u64> = placed.iter().map(|(_, o)| o.value()).collect();
+            let placed_values: Vec<u64> =
+                placed.iter().map(|(_, o)| u64::from(o.value())).collect();
             prop_assert_eq!(placed_values, output_zats);
             // Every output maps to a distinct action index.
             let mut indices: Vec<u32> = placed.iter().map(|&(i, _)| i).collect();
@@ -286,7 +288,7 @@ mod tests {
     #[test]
     fn pads_a_minimal_prep_tx_to_the_action_budget() {
         let fvk = account(1);
-        let outputs = [PrepOutput::Intermediate(10 * COIN)];
+        let outputs = [PrepOutput::Intermediate(zat(10 * COIN))];
         let spend_value = 10 * COIN + prep_fee();
         let (note, path, anchor) = single_note_witness(&fvk, spend_value, 7);
         let params = regtest_network(true);
@@ -311,7 +313,7 @@ mod tests {
         let fvk = account(2);
         let params = regtest_network(true);
         let anchor = orchard::Anchor::empty_tree();
-        let one_output = [PrepOutput::Funding(COIN)];
+        let one_output = [PrepOutput::Funding(zat(COIN))];
 
         let no_spends = build_prep_tx(
             &params,
@@ -338,7 +340,7 @@ mod tests {
 
         // One spend plus more outputs than the remaining action budget.
         let too_many: Vec<PrepOutput> = (0..PREP_TX_ACTIONS)
-            .map(|_| PrepOutput::Funding(COIN))
+            .map(|_| PrepOutput::Funding(zat(COIN)))
             .collect();
         let (note2, path2, anchor2) = single_note_witness(&fvk, 1_000 * COIN, 4);
         let over_budget = build_prep_tx(

--- a/zcash_pool_migration_backend/src/build/prep.rs
+++ b/zcash_pool_migration_backend/src/build/prep.rs
@@ -80,6 +80,13 @@ const INTERNAL_ADDRESS_INDEX: u32 = 0;
 /// [`PREP_TX_ACTIONS`]-action transaction (the preparation planner reserves exactly this), or the
 /// build does not balance.
 ///
+/// The transaction is signed at build time but broadcast at its drawn scheduled height, so the
+/// caller passes the `expiry_height` matching that schedule (the engine uses the canonical rolling
+/// window of [`expiry_height`](crate::scheduling::expiry_height) at the scheduled height). It is
+/// embedded as the transaction's `nExpiryHeight`, which the pre-signature commits to; relying on
+/// the builder's default (a few dozen blocks past `target_height`) would make any transaction
+/// scheduled beyond that window dead on arrival.
+///
 /// Returns the finalized PCZT and, for each requested output in order, its `(action_index, output)`
 /// so the caller can locate each note after the transaction is mined (and spend the feeder notes in a
 /// later layer). The fabricated dummy actions are not returned.
@@ -95,6 +102,7 @@ const INTERNAL_ADDRESS_INDEX: u32 = 0;
 pub fn build_prep_tx<P, R>(
     params: &P,
     target_height: u32,
+    expiry_height: u32,
     orchard_fvk: &FullViewingKey,
     anchor: orchard::Anchor,
     spends: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
@@ -133,7 +141,8 @@ where
         },
         ironwood_bundle_type: BundleType::DEFAULT,
     };
-    let mut builder = Builder::new(params.clone(), BlockHeight::from_u32(target_height), config);
+    let mut builder = Builder::new(params.clone(), BlockHeight::from_u32(target_height), config)
+        .with_expiry_height(BlockHeight::from_u32(expiry_height));
     for (note, merkle_path) in spends {
         builder
             .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
@@ -191,6 +200,14 @@ mod tests {
         PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64()
     }
 
+    /// The canonical rolling-window expiry for a transaction scheduled at the build height, as the
+    /// engine embeds it.
+    fn test_expiry() -> u32 {
+        u32::from(crate::scheduling::expiry_height(BlockHeight::from_u32(
+            TARGET_HEIGHT,
+        )))
+    }
+
     /// The number of Orchard actions in the built transaction.
     fn action_count(pczt: &pczt::Pczt) -> usize {
         pczt.orchard().actions().len()
@@ -230,6 +247,7 @@ mod tests {
             let (pczt, placed) = build_prep_tx(
                 &params,
                 TARGET_HEIGHT,
+                test_expiry(),
                 &fvk,
                 anchor,
                 spends,
@@ -263,6 +281,7 @@ mod tests {
             let (pczt, placed) = build_prep_tx(
                 &params,
                 100,
+                test_expiry(),
                 &fvk,
                 anchor,
                 vec![(note, path)],
@@ -295,6 +314,7 @@ mod tests {
         let (pczt, placed) = build_prep_tx(
             &params,
             100,
+            test_expiry(),
             &fvk,
             anchor,
             vec![(note, path)],
@@ -318,6 +338,7 @@ mod tests {
         let no_spends = build_prep_tx(
             &params,
             100,
+            test_expiry(),
             &fvk,
             anchor,
             Vec::new(),
@@ -330,6 +351,7 @@ mod tests {
         let no_outputs = build_prep_tx(
             &params,
             100,
+            test_expiry(),
             &fvk,
             real_anchor,
             vec![(note, path)],
@@ -346,6 +368,7 @@ mod tests {
         let over_budget = build_prep_tx(
             &params,
             100,
+            test_expiry(),
             &fvk,
             anchor2,
             vec![(note2, path2)],

--- a/zcash_pool_migration_backend/src/build/prep.rs
+++ b/zcash_pool_migration_backend/src/build/prep.rs
@@ -53,14 +53,14 @@
 
 use alloc::vec::Vec;
 
-use core::convert::Infallible;
-
 use rand_core::{CryptoRng, RngCore};
 
 use orchard::builder::BundleType;
 use orchard::keys::{FullViewingKey, Scope};
-use zcash_primitives::transaction::builder::{BuildConfig, Builder};
-use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+use zcash_primitives::transaction::fees::zip317::{
+    FeeError as Zip317FeeError, FeeRule as Zip317FeeRule,
+};
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::memo::MemoBytes;
 
@@ -70,45 +70,58 @@ use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
 /// The internal-scope diversifier index for the wallet's own preparation outputs.
 const INTERNAL_ADDRESS_INDEX: u32 = 0;
 
+/// One built preparation output: its real post-shuffle action index, the planner output it
+/// realizes, and the RECOVERED note plaintext (see [`build_prep_tx`]).
+pub type PlacedPrepOutput = (u32, PrepOutput, orchard::note::Note);
+
 /// Build one note-preparation transaction as an unproven PCZT: spend every note in `spends` and create
 /// one internal change note per output in `outputs` (a funding, feeder, or residual note), in an
 /// Orchard bundle padded to exactly [`PREP_TX_ACTIONS`] actions with fabricated dummies.
 ///
-/// The caller (the wallet backend) resolves the transaction's inputs to the `(Note, MerklePath)`
-/// witnesses in `spends` against `anchor`, and supplies the `orchard_fvk` whose internal scope every
-/// output is derived from. The spent notes must total the outputs plus the ZIP-317 fee of a padded
+/// NO anchor and NO witnesses are supplied ([ZIP 374] deferral, as for the transfers): `spends`
+/// are bare notes, the emitted PCZT carries absent anchor and witness fields, and the consumer
+/// installs the real anchor and each spent note's witness through the PCZT `Updater` role at
+/// proving time, once the spent notes are mined. This is what makes a preparation transaction —
+/// and everything downstream of it — SIGNABLE before its inputs are mined: a spent note's
+/// plaintext fully determines the signed data, and its tree position matters only to the proof.
+/// The `orchard_fvk` must own every spent note, and derives the internal scope every output is
+/// addressed to. The spent notes must total the outputs plus the ZIP-317 fee of a padded
 /// [`PREP_TX_ACTIONS`]-action transaction (the preparation planner reserves exactly this), or the
 /// build does not balance.
 ///
 /// The transaction is signed at build time but broadcast at its drawn scheduled height, so the
 /// caller passes the `expiry_height` matching that schedule (the engine uses the canonical rolling
 /// window of [`expiry_height`](crate::scheduling::expiry_height) at the scheduled height). It is
-/// embedded as the transaction's `nExpiryHeight`, which the pre-signature commits to; relying on
-/// the builder's default (a few dozen blocks past `target_height`) would make any transaction
-/// scheduled beyond that window dead on arrival.
+/// embedded as the transaction's `nExpiryHeight`, which the pre-signature commits to.
 ///
-/// Returns the finalized PCZT and, for each requested output in order, its `(action_index, output)`
-/// so the caller can locate each note after the transaction is mined (and spend the feeder notes in a
-/// later layer). The fabricated dummy actions are not returned.
+/// Returns the finalized PCZT and, for each requested output in order, its
+/// `(action_index, output, note)`: the real post-shuffle action index (so the caller can locate
+/// the note on-chain; the fabricated dummies are not returned) and the RECOVERED note plaintext.
+/// The recovered note is what lets the engine build and sign the transactions that spend this
+/// output — a later preparation layer or a transfer — before this transaction is ever broadcast:
+/// the note's rho is the paired spend's nullifier and its rseed is drawn here, so mining changes
+/// nothing about it.
 ///
 /// # Errors
 ///
 /// Returns [`BuildError`] if there are no spends or outputs, if the logical action count
-/// (`spends + outputs`) exceeds [`PREP_TX_ACTIONS`], or if the builder/PCZT pipeline fails (including
-/// when the spent notes do not balance the outputs plus the fee).
+/// (`spends + outputs`) exceeds [`PREP_TX_ACTIONS`], or if the builder/PCZT pipeline fails
+/// (including when the spent notes do not balance the outputs plus the fee, and when
+/// `target_height` precedes NU6.3, whose V6 format is what permits deferring the anchor).
 ///
 /// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
 /// pass a seeded one), keeping this builder pure.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374
 pub fn build_prep_tx<P, R>(
     params: &P,
     target_height: u32,
     expiry_height: u32,
     orchard_fvk: &FullViewingKey,
-    anchor: orchard::Anchor,
-    spends: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
+    spends: Vec<orchard::note::Note>,
     outputs: &[PrepOutput],
     rng: R,
-) -> Result<(pczt::Pczt, Vec<(u32, PrepOutput)>), BuildError>
+) -> Result<(pczt::Pczt, Vec<PlacedPrepOutput>), BuildError>
 where
     P: Parameters + Clone,
     R: RngCore + CryptoRng,
@@ -130,50 +143,90 @@ where
     }
 
     // An Orchard-only send-to-self whose bundle is padded to exactly PREP_TX_ACTIONS actions with
-    // orchard's fabricated dummies (`pad_to_minimum`).
-    let config = BuildConfig::Standard {
-        sapling_anchor: None,
-        orchard_anchor: Some(anchor),
-        ironwood_anchor: None,
-        orchard_bundle_type: BundleType::Transactional {
+    // orchard's fabricated dummies (`pad_to_minimum`); the Ironwood pool is unused (its bundle
+    // type is irrelevant: nothing is added to it, so no Ironwood bundle is emitted).
+    let mut builder = DeferredPcztBuilder::new::<Zip317FeeError>(
+        params.clone(),
+        BlockHeight::from_u32(target_height),
+        BundleType::Transactional {
             bundle_required: false,
             pad_to_minimum: Some(PREP_TX_ACTIONS as u8),
         },
-        ironwood_bundle_type: BundleType::DEFAULT,
-    };
-    let mut builder = Builder::new(params.clone(), BlockHeight::from_u32(target_height), config)
-        .with_expiry_height(BlockHeight::from_u32(expiry_height));
-    for (note, merkle_path) in spends {
+        BundleType::DEFAULT,
+    )
+    .map_err(|e| BuildError::Build(format!("preparation: builder: {e}")))?
+    .with_expiry_height(BlockHeight::from_u32(expiry_height));
+
+    for note in spends {
         builder
-            .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
-            .map_err(|e| BuildError::Build(format!("preparation: add spend: {e:?}")))?;
+            .add_orchard_spend::<Zip317FeeError>(orchard_fvk.clone(), note)
+            .map_err(|e| BuildError::Build(format!("preparation: add spend: {e}")))?;
     }
 
     let change_address = orchard_fvk.address_at(INTERNAL_ADDRESS_INDEX, Scope::Internal);
     let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
     for output in outputs {
         builder
-            .add_orchard_change_output::<Infallible>(
+            .add_orchard_change_output::<Zip317FeeError>(
                 orchard_fvk.clone(),
                 Some(internal_ovk.clone()),
                 change_address,
                 output.value(),
                 MemoBytes::empty(),
             )
-            .map_err(|e| BuildError::Build(format!("preparation: add output: {e:?}")))?;
+            .map_err(|e| BuildError::Build(format!("preparation: add output: {e}")))?;
     }
 
     let build_result = builder
         .build_for_pczt(rng, &Zip317FeeRule::standard())
-        .map_err(|e| BuildError::Build(format!("preparation: build: {e:?}")))?;
+        .map_err(|e| BuildError::Build(format!("preparation: build: {e}")))?;
 
-    // Un-shuffle: map each requested output to its real action index (the fabricated dummies occupy
-    // the remaining actions) so the caller can store the right (action_index, output) references.
-    let placed: Vec<(u32, PrepOutput)> = outputs
+    // Un-shuffle and RECOVER: map each requested output to its real action index (the fabricated
+    // dummies occupy the remaining actions) and reconstruct its note plaintext from the built
+    // bundle — the recipient and rseed from the output, and rho from the paired spend's
+    // nullifier. The recovered note is fixed at build time (mining only assigns its tree
+    // position), which is what lets the engine sign this output's future spender now.
+    let bundle = build_result
+        .pczt_parts
+        .orchard
+        .as_ref()
+        .ok_or_else(|| BuildError::Build("preparation: no orchard bundle was built".into()))?;
+    let note_version = bundle.bundle_version().note_version();
+    let placed: Vec<PlacedPrepOutput> = outputs
         .iter()
         .enumerate()
-        .map(|(i, &out)| output_action_index(&build_result.orchard_meta, i).map(|ai| (ai, out)))
-        .collect::<Result<_, _>>()?;
+        .map(|(i, &out)| {
+            let ai = output_action_index(&build_result.orchard_meta, i)?;
+            let action = bundle.actions().get(ai as usize).ok_or_else(|| {
+                BuildError::Build(format!("preparation: no action at index {ai}"))
+            })?;
+            let recipient = action.output().recipient().ok_or_else(|| {
+                BuildError::Build("preparation: built output lacks its recipient".into())
+            })?;
+            let rseed = action.output().rseed().ok_or_else(|| {
+                BuildError::Build("preparation: built output lacks its rseed".into())
+            })?;
+            // rho of an action's output note is the action's nullifier; the two share one
+            // canonical base-field encoding, so the public byte round-trip cannot fail.
+            let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
+                .into_option()
+                .ok_or_else(|| {
+                    BuildError::Build("preparation: nullifier is not a valid rho".into())
+                })?;
+            let note = orchard::note::Note::from_parts(
+                recipient,
+                orchard::value::NoteValue::from_raw(u64::from(out.value())),
+                rho,
+                rseed,
+                note_version,
+            )
+            .into_option()
+            .ok_or_else(|| {
+                BuildError::Build("preparation: recovered note parts are invalid".into())
+            })?;
+            Ok((ai, out, note))
+        })
+        .collect::<Result<_, BuildError>>()?;
 
     let finalized = finalize_pczt(build_result.pczt_parts)?;
     Ok((finalized, placed))
@@ -238,7 +291,8 @@ mod tests {
             spend_values[0] += total_in % n_spend as u64;
 
             let fvk = account(account_seed);
-            let (spends, anchor) = shared_anchor_witnesses(&fvk, &spend_values, note_seed);
+            let (spends, _anchor) = shared_anchor_witnesses(&fvk, &spend_values, note_seed);
+            let spends: Vec<_> = spends.into_iter().map(|(note, _)| note).collect();
             let outputs: Vec<PrepOutput> =
                 out_zats.iter().map(|&v| PrepOutput::Funding(zat(v))).collect();
 
@@ -249,7 +303,6 @@ mod tests {
                 TARGET_HEIGHT,
                 test_expiry(),
                 &fvk,
-                anchor,
                 spends,
                 &outputs,
                 rng,
@@ -274,7 +327,7 @@ mod tests {
                 output_zats.iter().map(|&v| PrepOutput::Funding(zat(v))).collect();
             // One spend that funds every output plus the padded fee.
             let spend_value = output_zats.iter().sum::<u64>() + prep_fee();
-            let (note, path, anchor) = single_note_witness(&fvk, spend_value, note_seed);
+            let (note, _path, _anchor) = single_note_witness(&fvk, spend_value, note_seed);
 
             let params = regtest_network(true);
             let rng = ChaCha8Rng::seed_from_u64(note_seed);
@@ -283,8 +336,7 @@ mod tests {
                 100,
                 test_expiry(),
                 &fvk,
-                anchor,
-                vec![(note, path)],
+                vec![note],
                 &outputs,
                 rng,
             )
@@ -293,10 +345,10 @@ mod tests {
             prop_assert_eq!(action_count(&pczt), PREP_TX_ACTIONS);
             prop_assert_eq!(placed.len(), outputs.len());
             let placed_values: Vec<u64> =
-                placed.iter().map(|(_, o)| u64::from(o.value())).collect();
+                placed.iter().map(|(_, o, _)| u64::from(o.value())).collect();
             prop_assert_eq!(placed_values, output_zats);
             // Every output maps to a distinct action index.
-            let mut indices: Vec<u32> = placed.iter().map(|&(i, _)| i).collect();
+            let mut indices: Vec<u32> = placed.iter().map(|&(i, _, _)| i).collect();
             indices.sort_unstable();
             indices.dedup();
             prop_assert_eq!(indices.len(), outputs.len());
@@ -309,15 +361,14 @@ mod tests {
         let fvk = account(1);
         let outputs = [PrepOutput::Intermediate(zat(10 * COIN))];
         let spend_value = 10 * COIN + prep_fee();
-        let (note, path, anchor) = single_note_witness(&fvk, spend_value, 7);
+        let (note, _path, _anchor) = single_note_witness(&fvk, spend_value, 7);
         let params = regtest_network(true);
         let (pczt, placed) = build_prep_tx(
             &params,
             100,
             test_expiry(),
             &fvk,
-            anchor,
-            vec![(note, path)],
+            vec![note],
             &outputs,
             ChaCha8Rng::seed_from_u64(7),
         )
@@ -332,7 +383,6 @@ mod tests {
     fn rejects_bad_inputs() {
         let fvk = account(2);
         let params = regtest_network(true);
-        let anchor = orchard::Anchor::empty_tree();
         let one_output = [PrepOutput::Funding(zat(COIN))];
 
         let no_spends = build_prep_tx(
@@ -340,21 +390,19 @@ mod tests {
             100,
             test_expiry(),
             &fvk,
-            anchor,
             Vec::new(),
             &one_output,
             ChaCha8Rng::seed_from_u64(0),
         );
         assert!(matches!(no_spends, Err(BuildError::Balance(_))));
 
-        let (note, path, real_anchor) = single_note_witness(&fvk, COIN + prep_fee(), 3);
+        let (note, _path, _anchor) = single_note_witness(&fvk, COIN + prep_fee(), 3);
         let no_outputs = build_prep_tx(
             &params,
             100,
             test_expiry(),
             &fvk,
-            real_anchor,
-            vec![(note, path)],
+            vec![note],
             &[],
             ChaCha8Rng::seed_from_u64(0),
         );
@@ -364,14 +412,13 @@ mod tests {
         let too_many: Vec<PrepOutput> = (0..PREP_TX_ACTIONS)
             .map(|_| PrepOutput::Funding(zat(COIN)))
             .collect();
-        let (note2, path2, anchor2) = single_note_witness(&fvk, 1_000 * COIN, 4);
+        let (note2, _path2, _anchor2) = single_note_witness(&fvk, 1_000 * COIN, 4);
         let over_budget = build_prep_tx(
             &params,
             100,
             test_expiry(),
             &fvk,
-            anchor2,
-            vec![(note2, path2)],
+            vec![note2],
             &too_many,
             ChaCha8Rng::seed_from_u64(0),
         );

--- a/zcash_pool_migration_backend/src/build/prep.rs
+++ b/zcash_pool_migration_backend/src/build/prep.rs
@@ -182,12 +182,12 @@ mod tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, account, regtest_network, shared_anchor_witnesses, single_note_witness,
     };
-    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
     /// The ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action preparation transaction (each action
     /// costs one marginal fee), which the planner reserves per transaction.
     fn prep_fee() -> u64 {
-        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
+        PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64()
     }
 
     /// The number of Orchard actions in the built transaction.

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -68,9 +68,13 @@ mod tests {
         let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
         let params = regtest_network(true);
         let rng = ChaCha8Rng::seed_from_u64(note_seed);
+        let expiry = u32::from(crate::scheduling::expiry_height(
+            zcash_protocol::consensus::BlockHeight::from_u32(TARGET_HEIGHT),
+        ));
         let (pczt, _) = build_prep_tx(
             &params,
             TARGET_HEIGHT,
+            expiry,
             fvk,
             anchor,
             vec![(note, path)],

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -50,8 +50,8 @@ mod tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
     };
-    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
     use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
     /// Builds a note-preparation PCZT spending one note owned by `fvk`. Deterministic in `note_seed`.
     /// It uses one spend and `PREP_TX_ACTIONS - 1` outputs so the bundle fills the action budget
@@ -61,7 +61,7 @@ mod tests {
         let per = 4 * COIN;
         let outputs = [PrepOutput::Funding(per); PREP_TX_ACTIONS - 1];
         // The spent note funds the outputs plus the padded 16-action fee.
-        let fee = PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi();
+        let fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
         let note_value = (PREP_TX_ACTIONS as u64 - 1) * per + fee;
         let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
         let params = regtest_network(true);

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -53,13 +53,15 @@ mod tests {
     use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
+    use crate::note_splitting::zat;
+
     /// Builds a note-preparation PCZT spending one note owned by `fvk`. Deterministic in `note_seed`.
     /// It uses one spend and `PREP_TX_ACTIONS - 1` outputs so the bundle fills the action budget
     /// exactly, with no fabricated-only padding actions (which foreign-key signing would otherwise
     /// touch, since a padding spend is not the account's).
     fn build_prep(fvk: &FullViewingKey, note_seed: u64) -> pczt::Pczt {
         let per = 4 * COIN;
-        let outputs = [PrepOutput::Funding(per); PREP_TX_ACTIONS - 1];
+        let outputs = [PrepOutput::Funding(zat(per)); PREP_TX_ACTIONS - 1];
         // The spent note funds the outputs plus the padded 16-action fee.
         let fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
         let note_value = (PREP_TX_ACTIONS as u64 - 1) * per + fee;

--- a/zcash_pool_migration_backend/src/build/sign.rs
+++ b/zcash_pool_migration_backend/src/build/sign.rs
@@ -65,7 +65,7 @@ mod tests {
         // The spent note funds the outputs plus the padded 16-action fee.
         let fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
         let note_value = (PREP_TX_ACTIONS as u64 - 1) * per + fee;
-        let (note, path, anchor) = single_note_witness(fvk, note_value, note_seed);
+        let (note, _path, _anchor) = single_note_witness(fvk, note_value, note_seed);
         let params = regtest_network(true);
         let rng = ChaCha8Rng::seed_from_u64(note_seed);
         let expiry = u32::from(crate::scheduling::expiry_height(
@@ -76,8 +76,7 @@ mod tests {
             TARGET_HEIGHT,
             expiry,
             fvk,
-            anchor,
-            vec![(note, path)],
+            vec![note],
             &outputs,
             rng,
         )

--- a/zcash_pool_migration_backend/src/build/transfer.rs
+++ b/zcash_pool_migration_backend/src/build/transfer.rs
@@ -4,10 +4,11 @@
 //! [`build_transfer_pczt`] spends a single self-funding note (one the note split minted, worth its
 //! crossing value plus a fee buffer) and outputs that crossing value into the destination Ironwood
 //! pool, to the account's own internal (change) address as ZIP 318 requires. It has no change output:
-//! the self-funding note's buffer funds the transfer's fee exactly
-//! (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the transfer is
-//! four logical actions, matching the buffer of `2 source + 2 destination` actions). The transfer
-//! only exists post-NU6.3, when the Ironwood pool is live.
+//! the self-funding note's buffer funds the transfer's fee exactly. The Orchard spend pads to the
+//! two-action minimum, but the Ironwood side is a SINGLE unpadded action (the builder permits it,
+//! and it saves proving bandwidth on hardware signers), so the transfer is three logical actions,
+//! matching the buffer of `2 source + 1 destination` actions. The transfer only exists post-NU6.3,
+//! when the Ironwood pool is live.
 
 use core::convert::Infallible;
 
@@ -104,7 +105,12 @@ mod tests {
     use zcash_protocol::value::COIN;
 
     use crate::build::test_util::{account, regtest_network, single_note_witness};
-    use crate::note_splitting::{FeePolicy, RESIDUAL_MIGRATION_MIN_ZATOSHI, Zip317FeePolicy};
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+
+    use crate::note_splitting::{
+        DESTINATION_ACTIONS_PER_TRANSFER, RESIDUAL_MIGRATION_MIN_ZATOSHI,
+        SOURCE_ACTIONS_PER_TRANSFER,
+    };
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
@@ -119,7 +125,9 @@ mod tests {
             note_seed in any::<u64>(),
         ) {
             let fvk = account(account_seed);
-            let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+            let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER)
+                as u64
+                * MARGINAL_FEE.into_u64();
             let note_value = crossing_value + buffer;
             let (note, path, anchor) = single_note_witness(&fvk, note_value, note_seed);
 

--- a/zcash_pool_migration_backend/src/build/transfer.rs
+++ b/zcash_pool_migration_backend/src/build/transfer.rs
@@ -57,7 +57,7 @@ pub fn build_transfer_pczt<P, R>(
     note: orchard::note::Note,
     merkle_path: orchard::tree::MerklePath,
     ironwood_anchor: orchard::Anchor,
-    crossing_value: u64,
+    crossing_value: Zatoshis,
     rng: R,
 ) -> Result<pczt::Pczt, BuildError>
 where
@@ -83,7 +83,7 @@ where
     // cannot misdirect the crossing.
     let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
     let recipient = orchard_fvk.address_at(0u32, Scope::Internal);
-    let crossing = Zatoshis::const_from_u64(crossing_value);
+    let crossing = crossing_value;
     let memo = MemoBytes::empty();
     builder
         .add_ironwood_output::<Infallible>(Some(internal_ovk), recipient, crossing, memo)
@@ -108,8 +108,7 @@ mod tests {
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
     use crate::note_splitting::{
-        DESTINATION_ACTIONS_PER_TRANSFER, RESIDUAL_MIGRATION_MIN_ZATOSHI,
-        SOURCE_ACTIONS_PER_TRANSFER,
+        DESTINATION_ACTIONS_PER_TRANSFER, RESIDUAL_MIGRATION_MIN, SOURCE_ACTIONS_PER_TRANSFER, zat,
     };
 
     proptest! {
@@ -120,7 +119,7 @@ mod tests {
         /// buffer funds the transfer fee exactly, since the transfer has no change output.
         #[test]
         fn self_funding_notes_build_balanced_transfers(
-            crossing_value in RESIDUAL_MIGRATION_MIN_ZATOSHI..=(1_000 * COIN),
+            crossing_value in u64::from(RESIDUAL_MIGRATION_MIN)..=(1_000 * COIN),
             account_seed in any::<u64>(),
             note_seed in any::<u64>(),
         ) {
@@ -147,7 +146,7 @@ mod tests {
                 note,
                 path,
                 ironwood_anchor,
-                crossing_value,
+                zat(crossing_value),
                 rng,
             );
 

--- a/zcash_pool_migration_backend/src/build/transfer.rs
+++ b/zcash_pool_migration_backend/src/build/transfer.rs
@@ -9,34 +9,53 @@
 //! and it saves proving bandwidth on hardware signers), so the transfer is three logical actions,
 //! matching the buffer of `2 source + 1 destination` actions. The transfer only exists post-NU6.3,
 //! when the Ironwood pool is live.
-
-use core::convert::Infallible;
+//!
+//! Both bundle ANCHORS — and the spent note's Merkle witness — are DEFERRED to proving time
+//! ([ZIP 374]): a transfer is pre-signed long before it is proven and broadcast, against a bucketed
+//! boundary anchor drawn near its future broadcast height (see
+//! [`draw_anchor_boundary`](crate::scheduling::draw_anchor_boundary)), whose tree state does not
+//! exist at build time. The V6 txid and sighash exclude shielded anchors, so the PCZT is built and
+//! signed with ABSENT anchor and witness fields, and the consumer installs the drawn boundary
+//! anchor and the funding note's witness against it through the PCZT `Updater` role immediately
+//! before proving.
+//!
+//! [ZIP 374]: https://zips.z.cash/zip-0374
 
 use rand_core::{CryptoRng, RngCore};
 
+use orchard::builder::BundleType;
 use orchard::keys::{FullViewingKey, Scope};
-use zcash_primitives::transaction::builder::Builder;
-use zcash_primitives::transaction::fees::zip317::FeeRule as Zip317FeeRule;
+use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+use zcash_primitives::transaction::fees::zip317::{
+    FeeError as Zip317FeeError, FeeRule as Zip317FeeRule,
+};
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::memo::MemoBytes;
 use zcash_protocol::value::Zatoshis;
 
-use super::{BuildError, build_config, finalize_pczt};
+use super::{BuildError, finalize_pczt};
+
+/// The transfer's destination-pool bundle type: a SINGLE unpadded Ironwood action. The canonical
+/// transfer carries exactly one Ironwood output, and since every migration transfer shares this
+/// canonical shape the one-action bundle reveals nothing extra, while saving proving bandwidth on
+/// hardware signers.
+const IRONWOOD_TRANSFER_BUNDLE_TYPE: BundleType = BundleType::Transactional {
+    bundle_required: false,
+    pad_to_minimum: Some(1),
+};
 
 /// Build a migration transfer as an unproven PCZT: spend the supplied self-funding `note` and output
-/// its `crossing_value` into the Ironwood pool (which is output-only here, so it is anchored against
-/// the empty tree). The transfer's fee is funded entirely by the note's buffer, so there is no change
-/// output; a build that balances proves the buffer matches the fee.
+/// its `crossing_value` into the Ironwood pool. The transfer's fee is funded entirely by the note's
+/// buffer, so there is no change output; a build that balances proves the buffer matches the fee.
 ///
-/// The ingredients (which the wallet backend resolves) are: the `orchard_anchor` and the note's
-/// `merkle_path`; the `note` itself (a self-funding note the split minted, worth
-/// `crossing_value` plus the fee buffer); the `ironwood_anchor`, a recent root of the destination
-/// Ironwood note-commitment tree (the output-only bundle is padded with dummy spends that carry this
-/// anchor, and consensus rejects a stale one such as the empty-tree root once the pool holds notes);
-/// and the `orchard_fvk` (authorizes the spend, derives the
-/// output viewing key, and derives the destination: per ZIP 318 the crossing is sent to the account's
-/// own internal Ironwood change address). `target_height` and `expiry_height` bound the transaction.
-/// It mirrors the note split's
+/// No anchor and no witness is supplied: both bundles' anchors, and the spend's Merkle witness, are
+/// DEFERRED to proving time (ZIP 374; see the module docs). The wallet backend resolves only the
+/// `note` itself (a self-funding note the split minted, worth `crossing_value` plus the fee buffer);
+/// the `orchard_fvk` authorizes the spend, derives the output viewing key, and derives the
+/// destination: per ZIP 318 the crossing is sent to the account's own internal Ironwood change
+/// address. `target_height` and `expiry_height` bound the transaction; the pre-signature commits to
+/// the expiry, so the caller passes the canonical expiry for the transfer's drawn broadcast
+/// schedule. It mirrors the note split's
 /// [`crossing_values`](crate::note_splitting::NoteSplitPlan::crossing_values): one transfer per
 /// self-funding note.
 ///
@@ -46,17 +65,14 @@ use super::{BuildError, build_config, finalize_pczt};
 /// # Errors
 ///
 /// Returns [`BuildError::Build`] if the builder or PCZT pipeline fails (including when the note's
-/// buffer does not cover the transfer fee, which unbalances the transaction).
-#[allow(clippy::too_many_arguments)]
+/// buffer does not cover the transfer fee, which unbalances the transaction, and when
+/// `target_height` precedes NU6.3, whose V6 format is what permits deferring the anchors).
 pub fn build_transfer_pczt<P, R>(
     params: &P,
     target_height: u32,
     expiry_height: u32,
     orchard_fvk: &FullViewingKey,
-    orchard_anchor: orchard::Anchor,
     note: orchard::note::Note,
-    merkle_path: orchard::tree::MerklePath,
-    ironwood_anchor: orchard::Anchor,
     crossing_value: Zatoshis,
     rng: R,
 ) -> Result<pczt::Pczt, BuildError>
@@ -64,34 +80,36 @@ where
     P: Parameters + Clone,
     R: RngCore + CryptoRng,
 {
-    let target = BlockHeight::from_u32(target_height);
-    let expiry = BlockHeight::from_u32(expiry_height);
-    // The Ironwood bundle is output-only, but the DEFAULT bundle type pads it to the minimum action
-    // count with dummy spends, which carry the bundle's `ironwood_anchor`. Consensus requires that
-    // anchor to be a recent Ironwood note-commitment-tree root, so the caller passes the current
-    // root: the empty-tree root is a valid anchor only until the pool holds any notes, after which
-    // consensus rejects it.
-    let config = build_config(orchard_anchor, Some(ironwood_anchor));
-    let mut builder = Builder::new(params.clone(), target, config).with_expiry_height(expiry);
+    let mut builder = DeferredPcztBuilder::new::<Zip317FeeError>(
+        params.clone(),
+        BlockHeight::from_u32(target_height),
+        BundleType::DEFAULT,
+        IRONWOOD_TRANSFER_BUNDLE_TYPE,
+    )
+    .map_err(|e| BuildError::Build(format!("transfer: builder: {e}")))?
+    .with_expiry_height(BlockHeight::from_u32(expiry_height));
 
     builder
-        .add_orchard_spend::<Infallible>(orchard_fvk.clone(), note, merkle_path)
-        .map_err(|e| BuildError::Build(format!("transfer: add spend: {e:?}")))?;
+        .add_orchard_spend::<Zip317FeeError>(orchard_fvk.clone(), note)
+        .map_err(|e| BuildError::Build(format!("transfer: add spend: {e}")))?;
 
     // ZIP 318: the destination MUST be the account's own internal (change) Ironwood address, sent with
     // the internal outgoing viewing key so the wallet can recover the note. Derived here so a caller
     // cannot misdirect the crossing.
     let internal_ovk = orchard_fvk.to_ovk(Scope::Internal);
     let recipient = orchard_fvk.address_at(0u32, Scope::Internal);
-    let crossing = crossing_value;
-    let memo = MemoBytes::empty();
     builder
-        .add_ironwood_output::<Infallible>(Some(internal_ovk), recipient, crossing, memo)
-        .map_err(|e| BuildError::Build(format!("transfer: add ironwood output: {e:?}")))?;
+        .add_ironwood_output::<Zip317FeeError>(
+            Some(internal_ovk),
+            recipient,
+            crossing_value,
+            MemoBytes::empty(),
+        )
+        .map_err(|e| BuildError::Build(format!("transfer: add ironwood output: {e}")))?;
 
     let build_result = builder
         .build_for_pczt(rng, &Zip317FeeRule::standard())
-        .map_err(|e| BuildError::Build(format!("transfer: build: {e:?}")))?;
+        .map_err(|e| BuildError::Build(format!("transfer: build: {e}")))?;
 
     finalize_pczt(build_result.pczt_parts)
 }
@@ -115,8 +133,10 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(32))]
 
         /// Every self-funding note the split can mint (a crossing value plus the fee buffer, from
-        /// sub-ZEC up) builds into a balanced transfer post-NU6.3. A build that succeeds proves the
-        /// buffer funds the transfer fee exactly, since the transfer has no change output.
+        /// sub-ZEC up) builds into a balanced transfer post-NU6.3, with no anchor and no witness
+        /// supplied: the emitted PCZT carries ABSENT anchors and an absent witness for the real
+        /// spend (ZIP 374 deferral), to be installed at proving time. A build that succeeds proves
+        /// the buffer funds the transfer fee exactly, since the transfer has no change output.
         #[test]
         fn self_funding_notes_build_balanced_transfers(
             crossing_value in u64::from(RESIDUAL_MIGRATION_MIN)..=(1_000 * COIN),
@@ -128,24 +148,19 @@ mod tests {
                 as u64
                 * MARGINAL_FEE.into_u64();
             let note_value = crossing_value + buffer;
-            let (note, path, anchor) = single_note_witness(&fvk, note_value, note_seed);
+            // Only the note itself is needed; its witness and anchor are deferred.
+            let (note, _path, _anchor) = single_note_witness(&fvk, note_value, note_seed);
 
             let params = regtest_network(true);
             let target_height = 100;
             let expiry_height = 140;
             let rng = ChaCha8Rng::seed_from_u64(crossing_value);
-            // A real, non-empty Ironwood anchor (the root of a one-note tree): the transfer must
-            // build against a genuine recent root, not only the empty-tree root.
-            let (_, _, ironwood_anchor) = single_note_witness(&fvk, note_value, note_seed ^ 1);
             let result = build_transfer_pczt(
                 &params,
                 target_height,
                 expiry_height,
                 &fvk,
-                anchor,
                 note,
-                path,
-                ironwood_anchor,
                 zat(crossing_value),
                 rng,
             );
@@ -154,6 +169,16 @@ mod tests {
             let orchard_bundle = pczt.orchard();
             let actions = orchard_bundle.actions();
             prop_assert!(!actions.is_empty());
+
+            // ZIP 374 deferral: both anchors are ABSENT, and exactly the one real spend carries
+            // no witness (the padding dummy keeps its arbitrary witness for the prover).
+            prop_assert!(orchard_bundle.anchor().is_none());
+            prop_assert!(pczt.ironwood().anchor().is_none());
+            let unwitnessed = actions
+                .iter()
+                .filter(|a| a.spend().witness().is_none())
+                .count();
+            prop_assert_eq!(unwitnessed, 1);
         }
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -46,9 +46,9 @@ use crate::preparation::{PrepError, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
 
 /// What the migration engine needs from a wallet to PLAN a migration: the account's spendable notes and
-/// the chain state. Later slices add the methods for building (note witnesses, viewing keys), signing,
-/// persistence, and reconciliation; a backend implements this trait over its own note store and chain
-/// view (for example a `zcash_client_backend` wallet, or the migration's own SQLite store).
+/// the chain state. Following the `zcash_client_backend` pattern, a later slice replaces this with the
+/// wallet's own note-source and chain-view traits (`WalletRead` / `InputSource`), so any such wallet is a
+/// migration wallet; for now a backend implements it directly over its note store and chain view.
 pub trait MigrationBackend {
     /// The backend's own error type (a store or chain-access failure).
     type Error;
@@ -60,14 +60,27 @@ pub trait MigrationBackend {
 
     /// The current chain-tip height, from which the transfer schedule's delays accumulate.
     fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error>;
+}
 
-    /// Persist the migration state: every transaction as its pre-signed PCZT plus the metadata the
-    /// application needs to prove, schedule, and broadcast it. Storing the pre-signed transactions,
-    /// not just the plan, is what lets a wallet resume a migration after being closed or restarted.
-    fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
+/// Read access to a persisted pool migration: the store side of the migration interface, mirroring
+/// `zcash_client_backend`'s `WalletRead`. A store implements this over its own tables (the
+/// `zcash_pool_migration_sqlite` crate does so as a migration registered into `zcash_client_sqlite`'s
+/// `WalletDb`). The committed migration is a set of pre-signed PCZTs plus their schedule and lifecycle
+/// state, so a wallet resumes a migration entirely from the store after being closed or restarted.
+pub trait PoolMigrationRead {
+    /// The store's own error type.
+    type Error;
 
-    /// Load the persisted migration state, if a migration is in progress.
-    fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error>;
+    /// The migration currently in progress, if any.
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error>;
+}
+
+/// Write access to a persisted pool migration, mirroring `zcash_client_backend`'s `WalletWrite`.
+pub trait PoolMigrationWrite: PoolMigrationRead {
+    /// Persist a committed migration: every transaction as its pre-signed PCZT plus the metadata the
+    /// application needs to prove, schedule, and broadcast it. Storing the pre-signed transactions, not
+    /// just the plan, is what lets a wallet resume a migration after being closed or restarted.
+    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
 
     /// Advance one stored transaction's lifecycle state (for example after the application broadcasts
     /// it, or the chain mines it, or it expires).
@@ -420,7 +433,10 @@ pub fn commit_preparation<P, B, R>(
 ) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
 where
     P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
     use crate::build::build_prep_tx;
@@ -508,7 +524,7 @@ where
         transactions,
     };
     backend
-        .store_migration(&state)
+        .put_migration(&state)
         .map_err(CommitError::Backend)?;
     Ok(state)
 }
@@ -531,13 +547,16 @@ pub fn commit_transfers<P, B, R>(
 ) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
 where
     P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
     use crate::build::build_transfer_pczt;
 
     let mut state = backend
-        .load_migration()
+        .get_migration()
         .map_err(CommitError::Backend)?
         .ok_or(CommitError::NoMigrationInProgress)?;
 
@@ -596,7 +615,7 @@ where
     }
 
     backend
-        .store_migration(&state)
+        .put_migration(&state)
         .map_err(CommitError::Backend)?;
     Ok(state)
 }
@@ -647,14 +666,20 @@ mod tests {
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
             Ok(self.tip)
         }
+    }
 
-        fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+    impl PoolMigrationRead for MockBackend {
+        type Error = core::convert::Infallible;
+
+        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(self.stored.clone())
+        }
+    }
+
+    impl PoolMigrationWrite for MockBackend {
+        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
             self.stored = Some(state.clone());
             Ok(())
-        }
-
-        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-            Ok(self.stored.clone())
         }
 
         fn update_transaction(
@@ -702,7 +727,7 @@ mod tests {
     #[test]
     fn stores_loads_and_updates_a_migration() {
         let mut backend = MockBackend::new(Vec::new(), 0);
-        assert!(backend.load_migration().unwrap().is_none());
+        assert!(backend.get_migration().unwrap().is_none());
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let note_split =
@@ -723,11 +748,11 @@ mod tests {
             funding_notes: Vec::new(),
             transactions: vec![tx],
         };
-        backend.store_migration(&state).unwrap();
+        backend.put_migration(&state).unwrap();
 
         // The stored transactions round-trip, and a state update persists.
         let loaded = backend
-            .load_migration()
+            .get_migration()
             .unwrap()
             .expect("a migration is stored");
         assert_eq!(loaded.status, MigrationStatus::Committed);
@@ -741,7 +766,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let loaded = backend.load_migration().unwrap().unwrap();
+        let loaded = backend.get_migration().unwrap().unwrap();
         assert_eq!(
             loaded.transactions[0].state,
             MigrationTxState::Mined {
@@ -794,14 +819,20 @@ mod commit_tests {
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
             Ok(BlockHeight::from_u32(2_000_000))
         }
+    }
 
-        fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+    impl PoolMigrationRead for CommitMock {
+        type Error = core::convert::Infallible;
+
+        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(self.stored.clone())
+        }
+    }
+
+    impl PoolMigrationWrite for CommitMock {
+        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
             self.stored = Some(state.clone());
             Ok(())
-        }
-
-        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-            Ok(self.stored.clone())
         }
 
         fn update_transaction(
@@ -942,6 +973,6 @@ mod commit_tests {
             );
             assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
         }
-        assert!(backend.load_migration().unwrap().is_some());
+        assert!(backend.get_migration().unwrap().is_some());
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -395,11 +395,6 @@ pub enum CommitError<E> {
     Backend(E),
     /// Building or serializing a transaction failed.
     Build(alloc::string::String),
-    /// Retained for API compatibility; no longer returned. Multi-layer preparation is now committed
-    /// phase by phase: [`commit_preparation`] signs layer 0 and [`commit_pending_preparation`] signs
-    /// each later layer once its predecessor mines, so a plan whose later layers spend earlier layers'
-    /// outputs is fully supported.
-    UnsupportedMultiLayer,
     /// No committed migration was found to build the transfers for (nothing was loaded from storage).
     NoMigrationInProgress,
 }
@@ -410,9 +405,6 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
         match self {
             CommitError::Backend(e) => write!(f, "wallet backend error: {e}"),
             CommitError::Build(m) => write!(f, "building the migration failed: {m}"),
-            CommitError::UnsupportedMultiLayer => {
-                f.write_str("multi-layer preparation cannot yet be pre-signed (single-layer only)")
-            }
             CommitError::NoMigrationInProgress => {
                 f.write_str("no committed migration is in progress")
             }
@@ -591,7 +583,8 @@ where
 ///
 /// Loads the committed migration, finds the earliest still-`Planned` preparation layer (a `layer > 0`)
 /// whose whole immediately-prior layer is [`Mined`](MigrationTxState::Mined), builds and pre-signs
-/// EVERY transaction of that one layer (resolving each transaction's [`PrepInput::Prior`] spends to the
+/// EVERY transaction of that one layer (resolving each transaction's
+/// [`PrepInput::Prior`](crate::preparation::PrepInput::Prior) spends to the
 /// prior layer's now-witnessable feeder notes by value), and persists the result. If no layer is ready
 /// (the next layer's dependencies are not all mined, or every preparation layer is already built), it
 /// returns the migration unchanged, so a caller can poll it. Call it once per newly-mined layer until

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -178,6 +178,47 @@ pub enum MigrationStatus {
     Failed,
 }
 
+impl AsRef<str> for MigrationStatus {
+    /// The stable lowercase wire name of the status, as stored by a backend and parsed back with
+    /// [`TryFrom<&str>`](Self). Borrow-free: it returns a `&'static str`, so encoding a status
+    /// allocates nothing.
+    fn as_ref(&self) -> &str {
+        match self {
+            MigrationStatus::Planning => "planning",
+            MigrationStatus::Committed => "committed",
+            MigrationStatus::InProgress => "in_progress",
+            MigrationStatus::Complete => "complete",
+            MigrationStatus::Failed => "failed",
+        }
+    }
+}
+
+/// The error returned when a string does not name a [`MigrationStatus`] (its [`TryFrom<&str>`] impl).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParseMigrationStatusError;
+
+impl fmt::Display for ParseMigrationStatusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unrecognized migration status")
+    }
+}
+
+impl TryFrom<&str> for MigrationStatus {
+    type Error = ParseMigrationStatusError;
+
+    /// Parses the lowercase wire name produced by [`AsRef<str>`](AsRef).
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            "planning" => MigrationStatus::Planning,
+            "committed" => MigrationStatus::Committed,
+            "in_progress" => MigrationStatus::InProgress,
+            "complete" => MigrationStatus::Complete,
+            "failed" => MigrationStatus::Failed,
+            _ => return Err(ParseMigrationStatusError),
+        })
+    }
+}
+
 /// The persisted state of a migration: the note split (for the preview and residual accounting) and
 /// every transaction, each as its pre-signed PCZT and metadata. A wallet resumes a migration entirely
 /// from this state after being closed or restarted; this is what a [`MigrationBackend`] stores.

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -666,6 +666,11 @@ pub enum CommitError<E> {
     Build(alloc::string::String),
     /// No committed migration was found to build the transfers for (nothing was loaded from storage).
     NoMigrationInProgress,
+    /// A resolved wallet note's value does not match the value the plan recorded for it: the
+    /// wallet's spendable set changed between planning and commit (the plan captures notes by
+    /// their index into that set, so any receipt or spend since planning shifts them), and the
+    /// migration must be re-planned.
+    StalePlan,
     /// A non-terminal migration is already stored. A committed migration is resumed from the
     /// store (or cancelled), never rebuilt over: overwriting it would orphan its pre-signed —
     /// and possibly already broadcast — transactions, and a rebuilt layer 0 would double-spend
@@ -682,6 +687,10 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
             CommitError::NoMigrationInProgress => {
                 f.write_str("no committed migration is in progress")
             }
+            CommitError::StalePlan => f.write_str(
+                "a wallet note no longer matches the plan; the spendable set changed since \
+                 planning and the migration must be re-planned",
+            ),
             CommitError::MigrationInProgress => f.write_str(
                 "a non-terminal migration is already stored; resume or cancel it instead of \
                  committing a new one",
@@ -908,10 +917,19 @@ where
                 let mut spends = Vec::with_capacity(prep_tx.inputs().len());
                 for input in prep_tx.inputs() {
                     match input {
-                        PrepInput::Wallet { index, .. } => {
+                        PrepInput::Wallet { index, value } => {
                             let witness = backend
                                 .resolve_wallet_note(*index, anchor_height)
                                 .map_err(CommitError::Backend)?;
+                            // The plan captured this note by its index into the spendable set at
+                            // PLANNING time; any receipt or spend since then shifts the indices,
+                            // so a resolved note whose value differs from the planned one means
+                            // the plan is stale — caught here as a typed error rather than as an
+                            // opaque balance failure (or, for an equal-valued interloper, a
+                            // silently signed spend of a note the plan reserved elsewhere).
+                            if witness.0.value().inner() != u64::from(*value) {
+                                return Err(CommitError::StalePlan);
+                            }
                             spends.push(witness);
                         }
                         // A layer-0 transaction spends only wallet notes; a Prior input here is a
@@ -1172,10 +1190,15 @@ where
         let mut spends = Vec::with_capacity(prep_tx.inputs().len());
         for input in prep_tx.inputs() {
             match input {
-                PrepInput::Wallet { index, .. } => {
+                PrepInput::Wallet { index, value } => {
                     let witness = backend
                         .resolve_wallet_note(*index, anchor_height)
                         .map_err(CommitError::Backend)?;
+                    // As in `commit_preparation_inner`: a value mismatch means the spendable
+                    // set shifted since planning and the plan is stale.
+                    if witness.0.value().inner() != u64::from(*value) {
+                        return Err(CommitError::StalePlan);
+                    }
                     spends.push(witness);
                 }
                 PrepInput::Prior { .. } => {
@@ -1966,6 +1989,57 @@ mod commit_tests {
             &mut rng,
         )
         .expect("replaces a terminal migration");
+    }
+
+    /// A wallet note is resolved by its index into the CURRENT spendable set; if that set
+    /// changed since planning (the value at the planned index no longer matches), the commit
+    /// reports a stale plan instead of building against the wrong note.
+    #[test]
+    fn commit_preparation_detects_a_stale_plan() {
+        let seed = 17u64;
+        let sk = spending_key(seed);
+        let fvk = FullViewingKey::from(&sk);
+        let balance = 78 * COIN;
+
+        let plan = {
+            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+            let planner = CommitMock {
+                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+                witnesses: vec![(note, path)],
+                anchor,
+                fvk: fvk.clone(),
+                ask: SpendAuthorizingKey::from(&sk),
+                stored: None,
+            };
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
+        };
+
+        // The spendable set shifted between planning and commit: the note at index 0 now has a
+        // different value than the plan recorded.
+        let mut values = vec![balance + COIN];
+        values.extend(plan.funding_notes().iter().map(|&v| u64::from(v)));
+        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
+        let mut backend = CommitMock {
+            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+            witnesses,
+            anchor,
+            fvk,
+            ask: SpendAuthorizingKey::from(&sk),
+            stored: None,
+        };
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        assert!(matches!(
+            commit_preparation(
+                &regtest_network(true),
+                BlockHeight::from_u32(TARGET_HEIGHT),
+                &mut backend,
+                &plan,
+                &mut rng,
+            ),
+            Err(CommitError::StalePlan)
+        ));
     }
 
     /// A wallet mock for the MULTI-LAYER preparation test. The first `n_wallet` witnesses are the

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -484,39 +484,32 @@ where
     let (prep_tx_fee, transfer_fee_buffer) =
         canonical_fees(params, commit_height).map_err(MigrationError::Fee)?;
 
-    let note_values: Vec<u64> = notes.iter().map(|&n| u64::from(n)).collect();
     // The preparation-layout capability the decomposition consults at each step: how many
     // preparation transactions minting a candidate funding multiset takes, or `None` when the
     // wallet's notes cannot mint it (so the split stops or steps down a denomination).
-    let prep_tx_count = |funding: &[u64]| {
-        plan_preparation(&note_values, funding, u64::from(prep_tx_fee))
+    let prep_tx_count = |funding: &[Zatoshis]| {
+        plan_preparation(&notes, funding, prep_tx_fee)
             .ok()
             .map(|plan| plan.transaction_count())
     };
     let note_split = plan_note_split(
-        u64::from(balance),
-        u64::from(transfer_fee_buffer),
-        u64::from(prep_tx_fee),
+        balance,
+        transfer_fee_buffer,
+        prep_tx_fee,
         &prep_tx_count,
         rng,
     );
-    let funding_notes: Vec<u64> = note_split.migration_outputs();
+    let funding_notes = note_split.migration_outputs();
     if funding_notes.is_empty() {
         return Err(MigrationError::NothingToMigrate);
     }
 
     // The decomposition verified this multiset against the preparation planner at every step, so
     // this final planning pass succeeds by construction; the error path is kept for safety.
-    let preparation = plan_preparation(&note_values, &funding_notes, u64::from(prep_tx_fee))
+    let preparation = plan_preparation(&notes, &funding_notes, prep_tx_fee)
         .map_err(MigrationError::Preparation)?;
 
     let schedule = scheduling::schedule(commit_height, funding_notes.len(), rng);
-
-    let funding_notes = funding_notes
-        .into_iter()
-        .map(Zatoshis::from_u64)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(MigrationError::InvalidBalance)?;
 
     Ok(MigrationPlan {
         note_split,
@@ -1019,7 +1012,7 @@ where
     // resolve them together so each feeder note (distinct by tree position, even at equal value) is
     // matched to exactly one spend across the layer. Wallet inputs (not expected past layer 0) resolve
     // individually.
-    let mut prior_values: Vec<u64> = Vec::new();
+    let mut prior_values: Vec<Zatoshis> = Vec::new();
     for &(_, plan_index) in &targets {
         for input in state.preparation.layers()[ready_layer][plan_index].inputs() {
             if let PrepInput::Prior { value, .. } = input {
@@ -1027,11 +1020,6 @@ where
             }
         }
     }
-    let prior_values = prior_values
-        .into_iter()
-        .map(Zatoshis::from_u64)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| CommitError::Build("prior input value out of range".into()))?;
     let mut prior_notes = backend
         .resolve_funding_notes(&prior_values, anchor_height)
         .map_err(CommitError::Backend)?
@@ -1191,8 +1179,12 @@ where
         state.note_split.migration_outputs().first(),
         state.note_split.crossing_values().first(),
     ) {
-        (Some(funding), Some(crossing)) => funding.saturating_sub(*crossing),
-        _ => 0,
+        // A prepared note is its crossing plus the buffer by construction, so the checked
+        // subtraction underflows only for an inconsistently stored plan.
+        (Some(&funding), Some(&crossing)) => (funding - crossing).ok_or_else(|| {
+            CommitError::Build("stored note split has a crossing exceeding its note".into())
+        })?,
+        _ => Zatoshis::ZERO,
     };
 
     for tx in state.transactions.iter_mut() {
@@ -1207,7 +1199,10 @@ where
         let (note, merkle_path) = witnesses.get(crossing).cloned().ok_or_else(|| {
             CommitError::Build(format!("no funding note for crossing {crossing}"))
         })?;
-        let crossing_value = u64::from(state.funding_notes[crossing]).saturating_sub(buffer);
+        // The funding note is its crossing plus the buffer by construction (see above).
+        let crossing_value = (state.funding_notes[crossing] - buffer).ok_or_else(|| {
+            CommitError::Build("stored funding note is smaller than the fee buffer".into())
+        })?;
 
         let pczt = build_transfer_pczt(
             params,
@@ -1278,7 +1273,7 @@ mod tests {
 
     /// A count-only preparation-layout stub for tests that exercise the split in isolation: one
     /// padded transaction per [`FUNDING_OUTPUTS_PER_TX`] funding notes.
-    fn prep_tx_count_stub(notes: &[u64]) -> Option<usize> {
+    fn prep_tx_count_stub(notes: &[Zatoshis]) -> Option<usize> {
         Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
     }
 
@@ -1378,9 +1373,9 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let (prep_tx_fee, transfer_buffer) = test_fees();
         let note_split = crate::note_splitting::plan_note_split(
-            100 * COIN,
-            u64::from(transfer_buffer),
-            u64::from(prep_tx_fee),
+            Zatoshis::from_u64(100 * COIN).expect("test balance is valid"),
+            transfer_buffer,
+            prep_tx_fee,
             &prep_tx_count_stub,
             &mut rng,
         );
@@ -1795,7 +1790,12 @@ mod commit_tests {
 
         // A whale generously larger than the balanced-tree cost, so the fan-out fast path triggers.
         let whale = funding.iter().sum::<u64>() + 16 * u64::from(prep_fee());
-        let preparation = plan_preparation(&[whale], &funding, u64::from(prep_fee()))
+        let whale_zats = [Zatoshis::from_u64(whale).expect("test whale is valid")];
+        let funding_zats: Vec<Zatoshis> = funding
+            .iter()
+            .map(|&v| Zatoshis::from_u64(v).expect("test funding values are valid"))
+            .collect();
+        let preparation = plan_preparation(&whale_zats, &funding_zats, prep_fee())
             .expect("a fundable whale plans");
         assert_eq!(
             preparation.layers().len(),
@@ -1807,22 +1807,24 @@ mod commit_tests {
         // buffer, so the engine derives the same buffer and each transfer crosses one ZEC.
         let crossings: Vec<u64> = funding.iter().map(|&f| f - buffer).collect();
         let note_split = NoteSplitPlan::from_stored_parts(
-            crossings.clone(),
-            buffer,
+            crossings
+                .iter()
+                .map(|&v| Zatoshis::from_u64(v).expect("test crossings are valid"))
+                .collect(),
+            Zatoshis::from_u64(buffer).expect("the buffer is valid"),
             None,
-            preparation.transaction_count() as u64 * u64::from(prep_fee()),
-            whale,
-            crossings.iter().sum(),
-        );
+            Zatoshis::from_u64(preparation.transaction_count() as u64 * u64::from(prep_fee()))
+                .expect("the reserved fees are valid"),
+            whale_zats[0],
+            Zatoshis::from_u64(crossings.iter().sum()).expect("the crossing total is valid"),
+        )
+        .expect("a consistent stored plan reconstructs");
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let schedule =
             crate::scheduling::schedule(BlockHeight::from_u32(2_000_000), funding.len(), &mut rng);
         let plan = MigrationPlan {
             note_split,
-            funding_notes: funding
-                .iter()
-                .map(|&v| Zatoshis::from_u64(v).expect("test funding values are valid"))
-                .collect(),
+            funding_notes: funding_zats,
             preparation,
             schedule,
         };
@@ -1838,7 +1840,7 @@ mod commit_tests {
             for tx in layer {
                 for input in tx.inputs() {
                     if let PrepInput::Prior { value, .. } = input {
-                        feeder_values.push(*value);
+                        feeder_values.push(u64::from(*value));
                     }
                 }
             }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -113,7 +113,7 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
 
     /// Advance one stored transaction's lifecycle state (for example after the application broadcasts
-    /// it, or the chain mines it, or it expires).
+    /// it, or the chain mines it).
     fn update_transaction(
         &mut self,
         id: MigrationTxId,
@@ -172,8 +172,6 @@ pub enum MigrationTxState {
     Broadcast { txid: TxId },
     /// Mined at the given height.
     Mined { height: BlockHeight },
-    /// Expired before it could be mined, and to be rebuilt.
-    Expired,
 }
 
 /// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
@@ -202,7 +200,8 @@ pub struct MigrationTransaction {
     /// dependencies to mine and a boundary to pass rather than a fixed height).
     #[getset(get_copy = "pub")]
     pub(crate) scheduled_height: BlockHeight,
-    /// The height after which the transaction is invalid and must be rebuilt.
+    /// The height after which the transaction is invalid and must be rebuilt
+    /// (rebuild-on-expiry is grown by a later slice, alongside reconciliation-on-launch).
     #[getset(get_copy = "pub")]
     pub(crate) expiry_height: BlockHeight,
     /// The boundary height whose tree state the transaction proves against. For a transfer this is

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -312,6 +312,156 @@ where
     })
 }
 
+/// The Orchard-specific wallet operations the engine needs to BUILD and PRE-SIGN a migration: the
+/// account's viewing key, note witnesses, an anchor to build against, and spend-authorization signing.
+/// Kept separate from [`MigrationBackend`] so the planning and persistence parts stay pure; one wallet
+/// implements both over the same account. Behind the `orchard` feature.
+#[cfg(feature = "orchard")]
+pub trait MigrationCrypto {
+    /// The backend's error type (shared with its [`MigrationBackend`] impl).
+    type Error;
+
+    /// The account's Orchard full viewing key.
+    fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
+
+    /// A current Orchard anchor to build against; every spend's witness resolves against this same tree
+    /// state. The proof is re-anchored to a drawn boundary at proving time, and the anchor is not in the
+    /// sighash, so a current or placeholder anchor is fine here.
+    fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error>;
+
+    /// Resolve the spendable wallet note at `index` (into `spendable_orchard_note_values`) to its note
+    /// and a witness against `anchor`.
+    fn resolve_wallet_note(
+        &self,
+        index: usize,
+        anchor: orchard::Anchor,
+    ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error>;
+
+    /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
+    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
+}
+
+/// Why committing a migration's preparation failed.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum CommitError<E> {
+    /// A wallet backend operation (witness, key, signing, or storage) failed.
+    Backend(E),
+    /// Building or serializing a transaction failed.
+    Build(alloc::string::String),
+    /// The plan needs multi-layer preparation. Pre-signing a later layer requires the output notes of
+    /// an earlier, unmined layer, which cannot yet be recovered from a built PCZT, so two-phase signing
+    /// commits only single-layer preparation. Full one-session pre-signing awaits a public pczt
+    /// output-recovery API.
+    UnsupportedMultiLayer,
+}
+
+#[cfg(feature = "orchard")]
+impl<E: fmt::Display> fmt::Display for CommitError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommitError::Backend(e) => write!(f, "wallet backend error: {e}"),
+            CommitError::Build(m) => write!(f, "building the preparation failed: {m}"),
+            CommitError::UnsupportedMultiLayer => {
+                f.write_str("multi-layer preparation cannot yet be pre-signed (single-layer only)")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl<E: core::error::Error> core::error::Error for CommitError<E> {}
+
+/// Commit a planned migration's PREPARATION: build every preparation transaction, pre-sign it with the
+/// account's spend authorization, and persist it (as its serialized PCZT and metadata) through the
+/// backend, so the application can broadcast the preparation and, once it is mined, build and sign the
+/// transfers (the second phase). This is the two-phase signing path (ZIP 318 permits more than one
+/// signing session); it handles single-layer preparation, the common case, and reports
+/// [`CommitError::UnsupportedMultiLayer`] for a plan whose later layers spend earlier layers' still
+/// unmined outputs.
+///
+/// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
+/// `rng` a cryptographically secure RNG.
+#[cfg(feature = "orchard")]
+pub fn commit_preparation<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    plan: &MigrationPlan,
+    rng: &mut R,
+) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    R: RngCore + rand_core::CryptoRng,
+{
+    use crate::build::build_prep_tx;
+    use crate::preparation::PrepInput;
+
+    let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
+    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
+    let expiry_height = crate::scheduling::expiry_height(target_height);
+
+    let mut transactions: Vec<MigrationTransaction> = Vec::new();
+    let mut next_id = 0u32;
+
+    for (layer, prep_layer) in plan.preparation().layers().iter().enumerate() {
+        for (index, prep_tx) in prep_layer.iter().enumerate() {
+            let mut spends = Vec::with_capacity(prep_tx.inputs().len());
+            for input in prep_tx.inputs() {
+                match input {
+                    PrepInput::Wallet { index, .. } => {
+                        let witness = backend
+                            .resolve_wallet_note(*index, anchor)
+                            .map_err(CommitError::Backend)?;
+                        spends.push(witness);
+                    }
+                    // Two-phase signing cannot pre-sign a spend of an earlier layer's unmined output.
+                    PrepInput::Prior { .. } => return Err(CommitError::UnsupportedMultiLayer),
+                }
+            }
+
+            let (pczt, _placed) = build_prep_tx(
+                params,
+                u32::from(target_height),
+                &fvk,
+                anchor,
+                spends,
+                prep_tx.outputs(),
+                &mut *rng,
+            )
+            .map_err(|e| CommitError::Build(format!("{e}")))?;
+
+            let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+            let bytes = signed
+                .serialize()
+                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+
+            transactions.push(MigrationTransaction {
+                id: MigrationTxId(next_id),
+                kind: MigrationTxKind::Preparation { layer, index },
+                pczt: bytes,
+                depends_on: Vec::new(),
+                scheduled_height: target_height,
+                expiry_height,
+                anchor_boundary: None,
+                state: MigrationTxState::Signed,
+            });
+            next_id += 1;
+        }
+    }
+
+    let state = MigrationState {
+        status: MigrationStatus::Committed,
+        note_split: plan.note_split().clone(),
+        transactions,
+    };
+    backend
+        .store_migration(&state)
+        .map_err(CommitError::Backend)?;
+    Ok(state)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,6 +607,141 @@ mod tests {
             MigrationTxState::Mined {
                 height: BlockHeight::from_u32(2_000_105)
             }
+        );
+    }
+}
+
+#[cfg(all(test, feature = "orchard"))]
+mod commit_tests {
+    use super::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+
+    use crate::build::sign_pczt;
+    use crate::build::test_util::{
+        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
+    };
+    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+    use crate::preparation::PREP_TX_ACTIONS;
+
+    fn prep_fee() -> Zatoshis {
+        Zatoshis::from_u64(PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi())
+            .expect("the preparation fee is far below the money-supply cap")
+    }
+
+    /// A wallet with a single spendable note, which resolves every preparation input to that note's
+    /// witness, signs with its own spend-authorizing key, and stores the migration in memory.
+    struct CommitMock {
+        notes: Vec<Zatoshis>,
+        witness: (orchard::note::Note, orchard::tree::MerklePath),
+        anchor: orchard::Anchor,
+        fvk: FullViewingKey,
+        ask: SpendAuthorizingKey,
+        stored: Option<MigrationState>,
+    }
+
+    impl MigrationBackend for CommitMock {
+        type Error = core::convert::Infallible;
+
+        fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+            Ok(self.notes.clone())
+        }
+
+        fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+            Ok(BlockHeight::from_u32(2_000_000))
+        }
+
+        fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+            self.stored = Some(state.clone());
+            Ok(())
+        }
+
+        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(self.stored.clone())
+        }
+
+        fn update_transaction(
+            &mut self,
+            _id: MigrationTxId,
+            _state: MigrationTxState,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl MigrationCrypto for CommitMock {
+        type Error = core::convert::Infallible;
+
+        fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
+            Ok(self.fvk.clone())
+        }
+
+        fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+            Ok(self.anchor)
+        }
+
+        fn resolve_wallet_note(
+            &self,
+            _index: usize,
+            _anchor: orchard::Anchor,
+        ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
+            Ok(self.witness.clone())
+        }
+
+        fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
+            Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
+        }
+    }
+
+    #[test]
+    fn commits_single_layer_preparation() {
+        let seed = 7u64;
+        let sk = spending_key(seed);
+        let fvk = FullViewingKey::from(&sk);
+        let ask = SpendAuthorizingKey::from(&sk);
+        let balance = 78 * COIN;
+        let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+
+        let mut backend = CommitMock {
+            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+            witness: (note, path),
+            anchor,
+            fvk: fvk.clone(),
+            ask,
+            stored: None,
+        };
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&backend, prep_fee(), &mut rng).expect("plans a migration");
+        // A single note funding a handful of denominations needs one preparation layer.
+        assert_eq!(plan.preparation().layers().len(), 1);
+
+        let params = regtest_network(true);
+        let mut build_rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut build_rng,
+        )
+        .expect("commits the preparation");
+
+        // Every preparation transaction is built, pre-signed, and persisted as its PCZT bytes.
+        assert_eq!(state.status, MigrationStatus::Committed);
+        let prep_count: usize = plan.preparation().layers().iter().map(|l| l.len()).sum();
+        assert_eq!(state.transactions.len(), prep_count);
+        for tx in &state.transactions {
+            assert!(matches!(tx.kind, MigrationTxKind::Preparation { .. }));
+            assert_eq!(tx.state, MigrationTxState::Signed);
+            assert!(!tx.pczt.is_empty(), "the pre-signed PCZT is stored");
+        }
+        assert!(
+            backend.load_migration().unwrap().is_some(),
+            "the committed migration is persisted"
         );
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -117,9 +117,12 @@ pub struct MigrationTransaction {
     pub id: MigrationTxId,
     /// What it does (a preparation transaction or a transfer).
     pub kind: MigrationTxKind,
-    /// The pre-signed, unproven PCZT, serialized (`pczt::Pczt::serialize`). This is the durable
-    /// artifact: the application updates its proof against a fresh anchor and broadcasts it.
-    pub pczt: Vec<u8>,
+    /// The pre-signed, unproven PCZT, serialized (`pczt::Pczt::serialize`), or `None` until the
+    /// transaction is built and signed. A transfer is recorded as a `Planned` placeholder at commit
+    /// time and its PCZT is filled in once the preparation is mined (two-phase signing). When present
+    /// this is the durable artifact: the application updates its proof against a fresh anchor and
+    /// broadcasts it.
+    pub pczt: Option<Vec<u8>>,
     /// The transactions that must be mined before this one may be broadcast (the preparation layer
     /// dependency graph; empty for an independent transaction).
     pub depends_on: Vec<MigrationTxId>,
@@ -159,6 +162,10 @@ pub struct MigrationState {
     pub status: MigrationStatus,
     /// The note-split decomposition (the denominations and residual).
     pub note_split: NoteSplitPlan,
+    /// The reconciled self-funding note values (in zatoshi), one per crossing: a `Transfer { crossing }`
+    /// transaction spends `funding_notes[crossing]` and crosses `funding_notes[crossing]` minus the fee
+    /// buffer into the destination pool.
+    pub funding_notes: Vec<Zatoshis>,
     /// Every migration transaction, in dependency order.
     pub transactions: Vec<MigrationTransaction>,
 }
@@ -329,6 +336,11 @@ pub trait MigrationCrypto {
     /// sighash, so a current or placeholder anchor is fine here.
     fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error>;
 
+    /// A recent Ironwood anchor for a transfer's destination bundle: the output-only bundle's dummy
+    /// spends carry this anchor, and consensus requires a recent Ironwood note-commitment-tree root
+    /// (the empty-tree root is valid only until the pool holds notes).
+    fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error>;
+
     /// Resolve the spendable wallet note at `index` (into `spendable_orchard_note_values`) to its note
     /// and a witness against `anchor`.
     fn resolve_wallet_note(
@@ -336,6 +348,17 @@ pub trait MigrationCrypto {
         index: usize,
         anchor: orchard::Anchor,
     ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error>;
+
+    /// Resolve the self-funding notes minted by the preparation, one per requested value, each to its
+    /// note and a witness against `anchor`. Called after the preparation is mined, when these notes are
+    /// spendable: `values[crossing]` is the funding note for crossing `crossing`, and the backend
+    /// returns a DISTINCT note for each requested value (funding notes of equal value are
+    /// interchangeable).
+    fn resolve_funding_notes(
+        &self,
+        values: &[Zatoshis],
+        anchor: orchard::Anchor,
+    ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error>;
 
     /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
     fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
@@ -354,6 +377,8 @@ pub enum CommitError<E> {
     /// commits only single-layer preparation. Full one-session pre-signing awaits a public pczt
     /// output-recovery API.
     UnsupportedMultiLayer,
+    /// No committed migration was found to build the transfers for (nothing was loaded from storage).
+    NoMigrationInProgress,
 }
 
 #[cfg(feature = "orchard")]
@@ -361,9 +386,12 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CommitError::Backend(e) => write!(f, "wallet backend error: {e}"),
-            CommitError::Build(m) => write!(f, "building the preparation failed: {m}"),
+            CommitError::Build(m) => write!(f, "building the migration failed: {m}"),
             CommitError::UnsupportedMultiLayer => {
                 f.write_str("multi-layer preparation cannot yet be pre-signed (single-layer only)")
+            }
+            CommitError::NoMigrationInProgress => {
+                f.write_str("no committed migration is in progress")
             }
         }
     }
@@ -440,7 +468,7 @@ where
             transactions.push(MigrationTransaction {
                 id: MigrationTxId(next_id),
                 kind: MigrationTxKind::Preparation { layer, index },
-                pczt: bytes,
+                pczt: Some(bytes),
                 depends_on: Vec::new(),
                 scheduled_height: target_height,
                 expiry_height,
@@ -451,11 +479,122 @@ where
         }
     }
 
+    // Every transfer waits for the whole preparation to be mined, so its funding note exists on chain
+    // and can be witnessed before the transfer is built and broadcast.
+    let prep_ids: Vec<MigrationTxId> = transactions.iter().map(|tx| tx.id).collect();
+
+    // Record each transfer as a Planned placeholder carrying its schedule; its PCZT is built and
+    // signed later, once the preparation is mined (see `commit_transfers`). This persists the drawn
+    // schedule (which is not reproducible) as part of the committed migration.
+    let funding_notes = plan.funding_notes().to_vec();
+    for (crossing, schedule) in plan.schedule().iter().enumerate() {
+        transactions.push(MigrationTransaction {
+            id: MigrationTxId(next_id),
+            kind: MigrationTxKind::Transfer { crossing },
+            pczt: None,
+            depends_on: prep_ids.clone(),
+            scheduled_height: schedule.broadcast_height(),
+            expiry_height: schedule.expiry_height(),
+            anchor_boundary: None,
+            state: MigrationTxState::Planned,
+        });
+        next_id += 1;
+    }
+
     let state = MigrationState {
         status: MigrationStatus::Committed,
         note_split: plan.note_split().clone(),
+        funding_notes,
         transactions,
     };
+    backend
+        .store_migration(&state)
+        .map_err(CommitError::Backend)?;
+    Ok(state)
+}
+
+/// Commit a migration's TRANSFERS: the second phase of two-phase signing. Once the preparation has been
+/// mined and its self-funding notes are spendable, build each transfer transaction (spending one
+/// funding note and crossing its value into the destination pool), pre-sign it, and fill it into the
+/// migration's stored `Planned` transfer placeholders, persisting the result.
+///
+/// Loads the committed migration from the backend (the placeholders and their drawn schedule were
+/// stored by [`commit_preparation`]), resolves the funding notes, and builds only the transfers still
+/// `Planned`, so it is safe to call again after a partial failure. `params` is the network,
+/// `target_height` the height the transfers are built at, and `rng` a cryptographically secure RNG.
+#[cfg(feature = "orchard")]
+pub fn commit_transfers<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    rng: &mut R,
+) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    R: RngCore + rand_core::CryptoRng,
+{
+    use crate::build::build_transfer_pczt;
+
+    let mut state = backend
+        .load_migration()
+        .map_err(CommitError::Backend)?
+        .ok_or(CommitError::NoMigrationInProgress)?;
+
+    let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
+    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
+    let ironwood_anchor = backend.ironwood_anchor().map_err(CommitError::Backend)?;
+    let witnesses = backend
+        .resolve_funding_notes(&state.funding_notes, anchor)
+        .map_err(CommitError::Backend)?;
+
+    // The fee buffer each self-funding note carries (its value minus the value that crosses) is constant
+    // across notes, so a funding note's crossing value is its value minus that buffer.
+    let buffer = match (
+        state.note_split.migration_outputs().first(),
+        state.note_split.crossing_values().first(),
+    ) {
+        (Some(funding), Some(crossing)) => funding.saturating_sub(*crossing),
+        _ => 0,
+    };
+
+    for tx in state.transactions.iter_mut() {
+        let crossing = match tx.kind {
+            MigrationTxKind::Transfer { crossing } => crossing,
+            MigrationTxKind::Preparation { .. } => continue,
+        };
+        if !matches!(tx.state, MigrationTxState::Planned) {
+            continue;
+        }
+
+        let (note, merkle_path) = witnesses.get(crossing).cloned().ok_or_else(|| {
+            CommitError::Build(format!("no funding note for crossing {crossing}"))
+        })?;
+        let crossing_value = u64::from(state.funding_notes[crossing]).saturating_sub(buffer);
+
+        let pczt = build_transfer_pczt(
+            params,
+            u32::from(target_height),
+            u32::from(tx.expiry_height),
+            &fvk,
+            anchor,
+            note,
+            merkle_path,
+            ironwood_anchor,
+            crossing_value,
+            &mut *rng,
+        )
+        .map_err(|e| CommitError::Build(format!("{e}")))?;
+
+        let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+        let bytes = signed
+            .serialize()
+            .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+
+        tx.pczt = Some(bytes);
+        tx.state = MigrationTxState::Signed;
+    }
+
     backend
         .store_migration(&state)
         .map_err(CommitError::Backend)?;
@@ -571,7 +710,7 @@ mod tests {
         let tx = MigrationTransaction {
             id: MigrationTxId(0),
             kind: MigrationTxKind::Transfer { crossing: 0 },
-            pczt: vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
+            pczt: Some(vec![1, 2, 3]), // a stand-in for the serialized pre-signed PCZT
             depends_on: Vec::new(),
             scheduled_height: BlockHeight::from_u32(2_000_100),
             expiry_height: BlockHeight::from_u32(2_069_220),
@@ -581,6 +720,7 @@ mod tests {
         let state = MigrationState {
             status: MigrationStatus::Committed,
             note_split,
+            funding_notes: Vec::new(),
             transactions: vec![tx],
         };
         backend.store_migration(&state).unwrap();
@@ -622,7 +762,7 @@ mod commit_tests {
 
     use crate::build::sign_pczt;
     use crate::build::test_util::{
-        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
+        TARGET_HEIGHT, regtest_network, shared_anchor_witnesses, single_note_witness, spending_key,
     };
     use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
     use crate::preparation::PREP_TX_ACTIONS;
@@ -632,11 +772,12 @@ mod commit_tests {
             .expect("the preparation fee is far below the money-supply cap")
     }
 
-    /// A wallet with a single spendable note, which resolves every preparation input to that note's
-    /// witness, signs with its own spend-authorizing key, and stores the migration in memory.
+    /// A wallet holding the account's key and a set of note witnesses against one anchor: index 0 is the
+    /// source note the preparation spends, and the rest are the funding notes the transfers spend. It
+    /// signs with its own spend-authorizing key and stores the migration in memory.
     struct CommitMock {
         notes: Vec<Zatoshis>,
-        witness: (orchard::note::Note, orchard::tree::MerklePath),
+        witnesses: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
         anchor: orchard::Anchor,
         fvk: FullViewingKey,
         ask: SpendAuthorizingKey,
@@ -683,12 +824,25 @@ mod commit_tests {
             Ok(self.anchor)
         }
 
+        fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+            Ok(self.anchor)
+        }
+
         fn resolve_wallet_note(
             &self,
-            _index: usize,
+            index: usize,
             _anchor: orchard::Anchor,
         ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
-            Ok(self.witness.clone())
+            Ok(self.witnesses[index].clone())
+        }
+
+        fn resolve_funding_notes(
+            &self,
+            values: &[Zatoshis],
+            _anchor: orchard::Anchor,
+        ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
+            // The funding notes are the witnesses after the source note (index 0).
+            Ok(self.witnesses[1..1 + values.len()].to_vec())
         }
 
         fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
@@ -697,51 +851,97 @@ mod commit_tests {
     }
 
     #[test]
-    fn commits_single_layer_preparation() {
+    fn commits_preparation_then_transfers() {
         let seed = 7u64;
         let sk = spending_key(seed);
         let fvk = FullViewingKey::from(&sk);
-        let ask = SpendAuthorizingKey::from(&sk);
         let balance = 78 * COIN;
-        let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+
+        // Plan the migration from the single source note.
+        let plan = {
+            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+            let planner = CommitMock {
+                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+                witnesses: vec![(note, path)],
+                anchor,
+                fvk: fvk.clone(),
+                ask: SpendAuthorizingKey::from(&sk),
+                stored: None,
+            };
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            plan_migration(&planner, prep_fee(), &mut rng).expect("plans a migration")
+        };
+        // A single note funding a handful of denominations needs one preparation layer.
+        assert_eq!(plan.preparation().layers().len(), 1);
+        let funding_notes = plan.funding_notes().to_vec();
+
+        // Witness the source note (index 0) and the funding notes against one shared anchor.
+        let mut values = vec![balance];
+        values.extend(funding_notes.iter().map(|&v| u64::from(v)));
+        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
 
         let mut backend = CommitMock {
             notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-            witness: (note, path),
+            witnesses,
             anchor,
             fvk: fvk.clone(),
-            ask,
+            ask: SpendAuthorizingKey::from(&sk),
             stored: None,
         };
-
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let plan = plan_migration(&backend, prep_fee(), &mut rng).expect("plans a migration");
-        // A single note funding a handful of denominations needs one preparation layer.
-        assert_eq!(plan.preparation().layers().len(), 1);
-
         let params = regtest_network(true);
-        let mut build_rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let prep_count: usize = plan.preparation().layers().iter().map(|l| l.len()).sum();
+        let transfer_count = funding_notes.len();
+
+        // Phase 1: commit the preparation. It signs the preparation transactions and records the
+        // transfers as planned placeholders (no PCZT yet).
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
         let state = commit_preparation(
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
             &plan,
-            &mut build_rng,
+            &mut rng,
         )
         .expect("commits the preparation");
-
-        // Every preparation transaction is built, pre-signed, and persisted as its PCZT bytes.
         assert_eq!(state.status, MigrationStatus::Committed);
-        let prep_count: usize = plan.preparation().layers().iter().map(|l| l.len()).sum();
-        assert_eq!(state.transactions.len(), prep_count);
+        assert_eq!(state.transactions.len(), prep_count + transfer_count);
         for tx in &state.transactions {
-            assert!(matches!(tx.kind, MigrationTxKind::Preparation { .. }));
-            assert_eq!(tx.state, MigrationTxState::Signed);
-            assert!(!tx.pczt.is_empty(), "the pre-signed PCZT is stored");
+            match tx.kind {
+                MigrationTxKind::Preparation { .. } => {
+                    assert_eq!(tx.state, MigrationTxState::Signed);
+                    assert!(tx.pczt.is_some());
+                }
+                MigrationTxKind::Transfer { .. } => {
+                    assert_eq!(tx.state, MigrationTxState::Planned);
+                    assert!(tx.pczt.is_none());
+                    assert!(
+                        !tx.depends_on.is_empty(),
+                        "a transfer waits for the preparation to mine"
+                    );
+                }
+            }
         }
-        assert!(
-            backend.load_migration().unwrap().is_some(),
-            "the committed migration is persisted"
-        );
+
+        // Phase 2: once the preparation is mined, commit the transfers.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        let state = commit_transfers(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &mut rng,
+        )
+        .expect("commits the transfers");
+
+        // Every transaction is now built, pre-signed, and persisted.
+        assert_eq!(state.transactions.len(), prep_count + transfer_count);
+        for tx in &state.transactions {
+            assert_eq!(
+                tx.state,
+                MigrationTxState::Signed,
+                "every transaction is signed"
+            );
+            assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
+        }
+        assert!(backend.load_migration().unwrap().is_some());
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -55,6 +55,16 @@ use crate::note_splitting::{NoteSplitPlan, plan_note_split};
 use crate::preparation::{PrepError, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
 
+/// The estimated number of blocks for one preparation layer to mine and become spendable: mining
+/// latency plus the wallet's witness-sync and next-layer broadcast turnaround, a few 75-second
+/// block intervals. Preparation transactions are fully shielded self-sends, so successive layers
+/// need only TEMPORAL decoupling (the predecessor mined and witnessable) — they do not wait for
+/// anchor-bucket boundaries, which only the pool-crossing transfers anchor to. Used solely to
+/// lower-bound the transfer schedule (see [`plan_migration`]); an under-estimate is self-healing
+/// (the commit-time anchor draw re-checks and reports a stale plan), an over-estimate merely delays
+/// the first transfer.
+const EST_PREP_LAYER_MINING_BLOCKS: u32 = 10;
+
 /// What the migration engine needs from a wallet to PLAN a migration: the account's spendable notes and
 /// the chain state. Following the `zcash_client_backend` pattern, a later slice replaces this with the
 /// wallet's own note-source and chain-view traits (`WalletRead` / `InputSource`), so any such wallet is a
@@ -186,9 +196,9 @@ pub struct MigrationTransaction {
     #[getset(get_copy = "pub")]
     pub(crate) expiry_height: BlockHeight,
     /// The boundary height whose tree state the transaction proves against. For a transfer this is
-    /// drawn at SCHEDULING time (the schedule fully determines the candidate set; see
-    /// [`commit_preparation`]); `None` for a preparation transaction, or when no candidate boundary
-    /// exists at the scheduled height (the application then draws against its proving-time view).
+    /// always present, drawn at SCHEDULING time: `plan_migration` floors the schedule so a
+    /// candidate boundary exists for every transfer. `None` only for a preparation transaction
+    /// (which waits on its dependencies rather than anchoring to a drawn boundary).
     #[getset(get_copy = "pub")]
     pub(crate) anchor_boundary: Option<BlockHeight>,
     /// The transaction's lifecycle state.
@@ -377,6 +387,9 @@ pub enum MigrationError<E> {
     InvalidBalance(BalanceError),
     /// Computing the canonical ZIP-317 fees from the canonical transaction shapes failed.
     Fee(zip317::FeeError),
+    /// NU6.3 is not active on this network, so there is no destination pool to migrate into (and
+    /// no anchor bucket above its activation to schedule against).
+    Nu63NotActive,
 }
 
 impl<E: fmt::Display> fmt::Display for MigrationError<E> {
@@ -387,6 +400,7 @@ impl<E: fmt::Display> fmt::Display for MigrationError<E> {
             MigrationError::NothingToMigrate => f.write_str("no migratable balance"),
             MigrationError::InvalidBalance(e) => write!(f, "invalid balance: {e}"),
             MigrationError::Fee(e) => write!(f, "fee computation failed: {e}"),
+            MigrationError::Nu63NotActive => f.write_str("NU6.3 is not active on this network"),
         }
     }
 }
@@ -401,6 +415,7 @@ impl<E: core::error::Error + 'static> core::error::Error for MigrationError<E> {
             // `zcash_protocol/std`; the Display text above carries their messages instead.
             MigrationError::InvalidBalance(_) => None,
             MigrationError::Fee(_) => None,
+            MigrationError::Nu63NotActive => None,
         }
     }
 }
@@ -509,7 +524,24 @@ where
     let preparation = plan_preparation(&notes, &funding_notes, prep_tx_fee)
         .map_err(MigrationError::Preparation)?;
 
-    let schedule = scheduling::schedule(commit_height, funding_notes.len(), rng);
+    // Lower-bound the FIRST scheduled transfer so that every transfer is guaranteed a candidate
+    // anchor boundary: the preparation must mine first (a few blocks per layer — the layers are
+    // fully shielded self-sends that serialize only on mined-and-witnessable, not on anchor
+    // buckets; see [`EST_PREP_LAYER_MINING_BLOCKS`]), and a boundary must then exist above the
+    // funding notes' creation (see [`scheduling::earliest_broadcast_height`]). Basing the schedule
+    // at this bound, rather than the raw commit height, keeps the drawn inter-arrival gaps intact
+    // while making an empty candidate set impossible for a plan committed at (or reasonably near)
+    // its planning height.
+    let nu63_activation = params
+        .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
+        .ok_or(MigrationError::Nu63NotActive)?;
+    let est_last_prep_height =
+        commit_height + preparation.layer_count() as u32 * EST_PREP_LAYER_MINING_BLOCKS;
+    let schedule_base = commit_height.max(scheduling::earliest_broadcast_height(
+        nu63_activation,
+        est_last_prep_height,
+    ));
+    let schedule = scheduling::schedule(schedule_base, funding_notes.len(), rng);
 
     Ok(MigrationPlan {
         note_split,
@@ -880,8 +912,12 @@ where
     // funding preparation is built to mine (`target_height` bounds the funding notes' creation from
     // below), and strictly below the most recent boundary at the transfer's scheduled broadcast
     // height (the chain view the wallet will have observed when it proves, just before broadcast).
-    // `None` means no candidate boundary exists at that scheduled height (a transfer scheduled very
-    // close to activation); the application then draws against the proving-time view instead.
+    //
+    // `plan_migration` floors the first scheduled transfer on an estimate of the last preparation
+    // transaction's mining height, so every transfer has a candidate boundary by construction; an
+    // empty draw therefore means the plan has gone STALE (the preparation is being committed at a
+    // height far past the estimate the schedule was floored on) and must be re-planned — it is an
+    // error, never a deferred fallback.
     let funding_notes = plan.funding_notes().to_vec();
     for (crossing, schedule) in plan.schedule().iter().enumerate() {
         transactions.push(MigrationTransaction {
@@ -891,11 +927,20 @@ where
             depends_on: last_layer_ids.clone(),
             scheduled_height: schedule.broadcast_height(),
             expiry_height: schedule.expiry_height(),
-            anchor_boundary: scheduling::draw_anchor_boundary(
-                nu63_activation,
-                target_height,
-                schedule.broadcast_height(),
-                rng,
+            anchor_boundary: Some(
+                scheduling::draw_anchor_boundary(
+                    nu63_activation,
+                    target_height,
+                    schedule.broadcast_height(),
+                    rng,
+                )
+                .ok_or_else(|| {
+                    CommitError::Build(
+                        "transfer scheduled before any candidate anchor boundary; the plan is \
+                         stale relative to the build height and must be re-planned"
+                            .into(),
+                    )
+                })?,
             ),
             state: MigrationTxState::Planned,
         });
@@ -1348,6 +1393,20 @@ mod tests {
         // exactly the (reconciled) funding notes; and reconciliation only ever drops, never adds.
         assert!(!plan.funding_notes().is_empty());
         assert_eq!(plan.schedule().len(), plan.funding_notes().len());
+
+        // The schedule floor: no transfer is scheduled before the earliest height at which a
+        // candidate anchor boundary exists, given the estimated preparation mining time (a few
+        // blocks per layer past the commit height).
+        let est_last_prep = BlockHeight::from_u32(2_000_000)
+            + plan.preparation().layer_count() as u32 * EST_PREP_LAYER_MINING_BLOCKS;
+        let earliest =
+            crate::scheduling::earliest_broadcast_height(BlockHeight::from_u32(10), est_last_prep);
+        assert!(
+            plan.schedule()
+                .iter()
+                .all(|s| s.broadcast_height() >= earliest),
+            "every scheduled transfer is at or after the anchor-viability floor"
+        );
         assert_eq!(
             plan.preparation().funding_notes().len(),
             plan.funding_notes().len()
@@ -1614,7 +1673,10 @@ mod commit_tests {
                     // it lies on the boundary grid, strictly above the NU6.3 activation, at or
                     // after the funding preparation's build height, and strictly below the most
                     // recent boundary at the scheduled broadcast height.
-                    if let Some(b) = tx.anchor_boundary {
+                    {
+                        let b = tx
+                            .anchor_boundary
+                            .expect("every transfer carries its boundary");
                         let b = u32::from(b);
                         assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
                         assert!(b > 10, "boundary above the regtest NU6.3 activation");

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -7,27 +7,32 @@
 //! (plan -> build -> sign -> schedule -> persist) without knowing how the wallet stores notes, resolves
 //! witnesses, holds keys, or persists state.
 //!
-//! This first slice covers PLANNING: [`plan_migration`] decomposes the account's spendable balance into
-//! canonical denominations, plans the preparation transactions, schedules the transfers, and reconciles
-//! the split against the preparation fees (dropping the smallest denominations when the fees do not fit
-//! the balance), producing a [`MigrationPlan`] preview for the user to consent to (ZIP 318 requires
-//! consent before any funds leave the pool). Building, signing, anchoring at proving time, persistence,
-//! and reconciliation-on-launch are added by later slices, which grow [`MigrationBackend`] with the
-//! witness, key, and storage methods they need.
+//! [`plan_migration`] decomposes the account's spendable balance into canonical denominations, plans the
+//! preparation transactions, schedules the transfers, and reconciles the split against the preparation
+//! fees (dropping the smallest denominations when the fees do not fit the balance), producing a
+//! [`MigrationPlan`] preview for the user to consent to (ZIP 318 requires consent before any funds leave
+//! the pool). After consent, [`commit_preparation`] and [`commit_transfers`] build and pre-sign the
+//! transactions (see below), reading the account's notes and witnesses and signing through the backend
+//! traits, and persisting each transaction through the store traits. The concrete durable store,
+//! anchoring at proving time, and reconciliation-on-launch are grown by a later slice.
 //!
-//! # The committed migration is stored as pre-signed PCZTs
+//! # The committed migration is stored as its transactions' PCZTs
 //!
-//! Planning is only the first phase, and the app that broadcasts is separate from the engine that
-//! plans. Once the user consents, the engine will BUILD every preparation and transfer transaction as a
-//! PCZT and PRE-SIGN it in a single session (the Orchard spend authorization is fixed independently of
-//! the proofs and the anchor), then hand each pre-signed PCZT to the backend to PERSIST alongside its
-//! schedule: broadcast height, expiry, layer and dependencies, drawn anchor boundary, and state. The
-//! durable artifact is therefore the pre-signed PCZT ready to send, not just the plan. The consuming
-//! application later reads the due transactions back from the store, updates each proof against a fresh
-//! boundary anchor, broadcasts them at their scheduled heights, and reports the outcome so the engine
-//! can advance each transaction's state. A wallet closed between planning and broadcast, or restarted
-//! partway through, resumes from the stored PCZTs. This shapes the `MigrationBackend` storage methods
-//! (store/load a transaction PCZT + its state) and the persisted state model that later slices add.
+//! Planning is only the first phase, and the application that broadcasts is separate from the engine that
+//! plans and signs. Once the user consents, the engine builds each preparation and transfer transaction
+//! as a PCZT and pre-signs it (the Orchard spend authorization is fixed independently of the proofs and
+//! the anchor), then hands each to the backend to PERSIST alongside its schedule: broadcast height,
+//! expiry, layer and dependencies, drawn anchor boundary, and state. Signing spans MORE THAN ONE session,
+//! as ZIP 318 permits: [`commit_preparation`] builds and signs the preparation, and only once it has
+//! mined, so the funding notes it mints become witnessable, does [`commit_transfers`] build and sign the
+//! transfers. (Later slices extend this to a multi-layer preparation, signing each layer as its
+//! predecessor mines, and to an external hardware signer, which builds each transaction UNSIGNED and signs
+//! it out of band before it is applied back.) The durable artifact is therefore each transaction's PCZT
+//! plus its schedule and state, not just the plan. The consuming application later reads the due
+//! transactions back from the store, proves each against a fresh boundary anchor, broadcasts them at
+//! their scheduled heights, and reports the outcome so the engine can advance each transaction's state. A
+//! wallet closed between planning and broadcast, or restarted partway through, resumes from the stored
+//! PCZTs.
 //!
 //! [`note_splitting`]: crate::note_splitting
 //! [`preparation`]: crate::preparation

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -11,23 +11,24 @@
 //! preparation transactions, schedules the transfers, and reconciles the split against the preparation
 //! fees (dropping the smallest denominations when the fees do not fit the balance), producing a
 //! [`MigrationPlan`] preview for the user to consent to (ZIP 318 requires consent before any funds leave
-//! the pool). After consent, [`commit_preparation`] and [`commit_transfers`] build and pre-sign the
-//! transactions (see below), reading the account's notes and witnesses and signing through the backend
-//! traits, and persisting each transaction through the store traits. The concrete durable store,
-//! anchoring at proving time, and reconciliation-on-launch are grown by a later slice.
+//! the pool). After consent, [`commit_preparation`] builds and pre-signs EVERY transaction in one
+//! pass, reading the account's note plaintexts and signing through the backend traits, and
+//! persisting each transaction through the store traits. The concrete durable store, proving, and
+//! reconciliation-on-launch are grown by a later slice.
 //!
 //! # The committed migration is stored as its transactions' PCZTs
 //!
 //! Planning is only the first phase, and the application that broadcasts is separate from the engine that
 //! plans and signs. Once the user consents, the engine builds each preparation and transfer transaction
-//! as a PCZT and pre-signs it (the Orchard spend authorization is fixed independently of the proofs and
-//! the anchor), then hands each to the backend to PERSIST alongside its schedule: broadcast height,
-//! expiry, layer and dependencies, drawn anchor boundary, and state. Signing spans MORE THAN ONE session,
-//! as ZIP 318 permits: [`commit_preparation`] builds and signs the preparation, and only once it has
-//! mined, so the funding notes it mints become witnessable, does [`commit_transfers`] build and sign the
-//! transfers. (Later slices extend this to a multi-layer preparation, signing each layer as its
-//! predecessor mines, and to an external hardware signer, which builds each transaction UNSIGNED and signs
-//! it out of band before it is applied back.) The durable artifact is therefore each transaction's PCZT
+//! as a PCZT and pre-signs it (anchors and witnesses are deferred to proving time per ZIP 374, so a
+//! spent note's PLAINTEXT fully determines the signed data — even for a note minted by an earlier,
+//! still-unmined migration transaction, whose plaintext the engine recovers from the built bundle),
+//! then hands each to the backend to PERSIST alongside its schedule: broadcast height, expiry, layer
+//! and dependencies, drawn anchor boundary, and state. The whole migration — every preparation
+//! layer, in topological order, and every transfer — is therefore built and signed in ONE signing
+//! phase, before anything is broadcast; an external hardware signer receives the same transactions
+//! UNSIGNED, split into sessions bounded only by its per-interaction action budget (see
+//! [`batch_unsigned_by_action_budget`]), never by mining. The durable artifact is each transaction's PCZT
 //! plus its schedule and state, not just the plan. The consuming application later reads the due
 //! transactions back from the store, proves each transfer against its drawn boundary anchor —
 //! installing the anchor and the funding note's witness through the PCZT Updater role (ZIP 374
@@ -67,13 +68,6 @@ use crate::scheduling::{self, Schedule};
 /// under-estimate is self-healing (the commit-time anchor draw re-checks and reports a stale plan),
 /// an over-estimate merely delays the follow-on schedule.
 const EST_PREP_LAYER_MINING_BLOCKS: u32 = 10;
-
-/// The anchor depth for PREPARATION transactions: the ordinary near-tip depth a wallet uses for any
-/// shielded spend. Preparations are fully shielded self-sends whose balances are private, so their
-/// anchors need not obscure the wallet's sync relationship — no bucketed anchor, just a recent
-/// root a few confirmations below the build height. Only the pool-crossing transfers draw bucketed
-/// boundary anchors.
-const PREP_ANCHOR_DEPTH: u32 = 3;
 
 /// What the migration engine needs from a wallet to PLAN a migration: the account's spendable notes and
 /// the chain state. Following the `zcash_client_backend` pattern, a later slice replaces this with the
@@ -155,14 +149,12 @@ pub enum MigrationTxKind {
 /// Where a migration transaction is in its lifecycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MigrationTxState {
-    /// Built but not yet signed.
-    Planned,
     /// Built and awaiting an EXTERNAL signature: its UNSIGNED PCZT is held in
     /// [`pczt`](MigrationTransaction::pczt), exported for a hardware or offline signer.
     /// [`apply_signature`](MigrationState::apply_signature) moves it to [`Signed`](Self::Signed) once the
     /// signed PCZT is returned. Only the external-signing path
-    /// ([`build_preparation_unsigned`]/[`build_transfers_unsigned`]) produces this state; the in-process
-    /// commit functions sign immediately and go straight to [`Signed`](Self::Signed).
+    /// ([`build_preparation_unsigned`]) produces this state; the in-process commit function signs
+    /// immediately and goes straight to [`Signed`](Self::Signed).
     AwaitingSignature,
     /// Pre-signed (the account's spend authorization is attached), not yet proved.
     Signed,
@@ -185,13 +177,15 @@ pub struct MigrationTransaction {
     /// What it does (a preparation transaction or a transfer).
     #[getset(get_copy = "pub")]
     pub(crate) kind: MigrationTxKind,
-    /// The pre-signed, unproven PCZT, serialized (`pczt::Pczt::serialize`), or `None` until the
-    /// transaction is built and signed. A transfer is recorded as a `Planned` placeholder at commit
-    /// time and its PCZT is filled in once the preparation is mined (two-phase signing). When present
-    /// this is the durable artifact: the application updates its proof against a fresh anchor and
-    /// broadcasts it.
+    /// The unproven PCZT, serialized (`pczt::Pczt::serialize`): pre-signed, except while the
+    /// transaction awaits an external signature
+    /// ([`AwaitingSignature`](MigrationTxState::AwaitingSignature)), when these are the unsigned
+    /// bytes the signed PCZT replaces. Every transaction is built when the migration is
+    /// committed — one signing phase — so this is always present: the durable artifact the
+    /// application proves (installing its anchor and witnesses at that point; ZIP 374) and
+    /// broadcasts.
     #[getset(get = "pub")]
-    pub(crate) pczt: Option<Vec<u8>>,
+    pub(crate) pczt: Vec<u8>,
     /// The transactions that must be mined before this one may be broadcast (the preparation layer
     /// dependency graph; empty for an independent transaction).
     #[getset(get = "pub")]
@@ -218,12 +212,12 @@ pub struct MigrationTransaction {
 impl MigrationTransaction {
     /// Reassemble a stored migration transaction from its persisted parts, exactly as a store read
     /// them back (the inverse of the accessors). The caller is responsible for having persisted a
-    /// consistent row (for example, a `Broadcast` or `Mined` transaction carries its PCZT).
+    /// consistent row.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
         id: MigrationTxId,
         kind: MigrationTxKind,
-        pczt: Option<Vec<u8>>,
+        pczt: Vec<u8>,
         depends_on: Vec<MigrationTxId>,
         scheduled_height: BlockHeight,
         expiry_height: BlockHeight,
@@ -315,10 +309,9 @@ pub struct MigrationState {
     /// buffer into the destination pool.
     #[getset(get = "pub")]
     pub(crate) funding_notes: Vec<Zatoshis>,
-    /// The preparation plan (its layers and direct-funding notes), retained so the deferred preparation
-    /// layers can be rebuilt after their prior layer mines (see
-    /// [`commit_pending_preparation`]). A `Preparation { layer, index }` transaction's spends resolve
-    /// against `preparation.layers()[layer][index]`.
+    /// The preparation plan (its layers and direct-funding notes), retained for auditability and
+    /// for the rebuild-on-expiry slice. A `Preparation { layer, index }` transaction's spends
+    /// resolve against `preparation.layers()[layer][index]`.
     #[getset(get = "pub")]
     pub(crate) preparation: PreparationPlan,
     /// Every migration transaction, in dependency order.
@@ -601,9 +594,16 @@ where
 }
 
 /// The Orchard-specific wallet operations the engine needs to BUILD and PRE-SIGN a migration: the
-/// account's viewing key, note witnesses, an anchor to build against, and spend-authorization signing.
-/// Kept separate from [`MigrationBackend`] so the planning and persistence parts stay pure; one wallet
+/// account's viewing key, its spendable notes' plaintexts, and spend-authorization signing. Kept
+/// separate from [`MigrationBackend`] so the planning and persistence parts stay pure; one wallet
 /// implements both over the same account. Behind the `orchard` feature.
+///
+/// No anchors and no witnesses appear here: every migration transaction is built and signed with
+/// its anchor and witnesses DEFERRED to proving time ([ZIP 374]) — a spent note's plaintext fully
+/// determines the signed data, and its tree position matters only to the proof, which the consumer
+/// creates through the PCZT `Updater` role once the note is mined.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374
 #[cfg(feature = "orchard")]
 pub trait MigrationCrypto {
     /// The backend's error type (shared with its [`MigrationBackend`] impl).
@@ -612,45 +612,9 @@ pub trait MigrationCrypto {
     /// The account's Orchard full viewing key.
     fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
 
-    /// The Orchard anchor at the tree state of `anchor_height`, for building the PREPARATION
-    /// transactions; every preparation spend's witness resolves against this same tree state. The
-    /// engine passes an ordinary near-tip height (a few confirmations below the build height):
-    /// preparations are fully shielded self-sends, and only they anchor at build time — a
-    /// transfer's anchors and witness are DEFERRED to proving time (ZIP 374), when the consumer
-    /// installs the drawn boundary anchor through the PCZT Updater role.
-    fn orchard_anchor(&self, anchor_height: BlockHeight) -> Result<orchard::Anchor, Self::Error>;
-
-    /// Resolve the spendable wallet note at `index` (into `spendable_orchard_note_values`) to its note
-    /// and a witness against `anchor`.
-    fn resolve_wallet_note(
-        &self,
-        index: usize,
-        anchor_height: BlockHeight,
-    ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error>;
-
-    /// Resolve the FEEDER notes an earlier preparation layer minted, one per requested value, each
-    /// to its note and a witness against the tree state at `anchor_height`. Called by
-    /// [`commit_pending_preparation`] after the prior layer is mined, when its feeder notes are
-    /// spendable; the backend returns a DISTINCT note for each requested value (notes of equal
-    /// value are interchangeable). Preparations anchor at build time, so their spends are
-    /// witnessed here, unlike the transfers'.
-    fn resolve_feeder_notes(
-        &self,
-        values: &[Zatoshis],
-        anchor_height: BlockHeight,
-    ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error>;
-
-    /// Resolve the self-funding notes minted by the preparation, one per requested value. Called
-    /// after the whole preparation is mined, when these notes are spendable: `values[crossing]` is
-    /// the funding note for crossing `crossing`, and the backend returns a DISTINCT note for each
-    /// requested value (funding notes of equal value are interchangeable). NO witness is resolved:
-    /// a transfer is built and pre-signed with its anchors and witness DEFERRED to proving time
-    /// (ZIP 374), when the consumer installs the drawn boundary anchor and a witness against it
-    /// through the PCZT Updater role.
-    fn resolve_funding_notes(
-        &self,
-        values: &[Zatoshis],
-    ) -> Result<Vec<orchard::note::Note>, Self::Error>;
+    /// The plaintext of the spendable wallet note at `index` (into
+    /// `spendable_orchard_note_values`).
+    fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error>;
 
     /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
     fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
@@ -716,9 +680,10 @@ enum Signing {
 /// An UNSIGNED migration transaction PCZT to route to an external (hardware or offline) signer, paired
 /// with the id that [`MigrationState::apply_signature`] uses to store the signed PCZT it returns as.
 ///
-/// Produced by [`build_preparation_unsigned`] and [`build_transfers_unsigned`]. The `(id, pczt)` pairing
-/// MUST survive the round-trip to the signer, because `apply_signature` matches the returned signed PCZT
-/// back to its transaction by id.
+/// Produced by [`build_preparation_unsigned`]. The `(id, pczt)` pairing MUST survive the
+/// round-trip to the signer, because `apply_signature` matches the returned signed PCZT back to
+/// its transaction by id; [`batch_unsigned_by_action_budget`] splits a migration's worth of these
+/// into device-sized signing sessions.
 #[cfg(feature = "orchard")]
 #[derive(Clone, Debug, Getters, CopyGetters)]
 pub struct UnsignedMigrationTx {
@@ -728,6 +693,11 @@ pub struct UnsignedMigrationTx {
     /// The serialized UNSIGNED PCZT to sign out of band.
     #[getset(get = "pub")]
     pub(crate) pczt: Vec<u8>,
+    /// The number of Orchard-family actions the signer processes for this transaction (its
+    /// padded action count), so signing sessions can be bounded by a device's action budget
+    /// (see [`batch_unsigned_by_action_budget`]).
+    #[getset(get_copy = "pub")]
+    pub(crate) actions: usize,
 }
 
 #[cfg(feature = "orchard")]
@@ -738,6 +708,38 @@ impl UnsignedMigrationTx {
     pub fn into_parts(self) -> (MigrationTxId, Vec<u8>) {
         (self.id, self.pczt)
     }
+}
+
+/// Split unsigned migration transactions into SIGNING SESSIONS: consecutive batches, preserving
+/// the given order (the commit functions emit topological order), each holding at most
+/// `action_budget` total [`actions`](UnsignedMigrationTx::actions) — except that a batch always
+/// holds at least one transaction, so a single transaction larger than the budget still gets a
+/// session of its own.
+///
+/// Every transaction is fully built and independent at signing time (anchors and witnesses are
+/// deferred to proving; nothing waits on the chain), so a session boundary reflects only the
+/// signer's per-interaction capacity — a hardware device's action budget — and each session's
+/// results are applied back with [`MigrationState::apply_signature`] in any order.
+#[cfg(feature = "orchard")]
+pub fn batch_unsigned_by_action_budget(
+    unsigned: Vec<UnsignedMigrationTx>,
+    action_budget: usize,
+) -> Vec<Vec<UnsignedMigrationTx>> {
+    let mut sessions: Vec<Vec<UnsignedMigrationTx>> = Vec::new();
+    let mut current: Vec<UnsignedMigrationTx> = Vec::new();
+    let mut current_actions = 0usize;
+    for tx in unsigned {
+        if !current.is_empty() && current_actions.saturating_add(tx.actions) > action_budget {
+            sessions.push(core::mem::take(&mut current));
+            current_actions = 0;
+        }
+        current_actions = current_actions.saturating_add(tx.actions);
+        current.push(tx);
+    }
+    if !current.is_empty() {
+        sessions.push(current);
+    }
+    sessions
 }
 
 /// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the backend and
@@ -770,22 +772,17 @@ where
     }
 }
 
-/// Commit a planned migration's PREPARATION: build and pre-sign the FIRST layer of preparation
-/// transactions (the ones that spend the wallet's own notes) with the account's spend authorization,
-/// record every later preparation layer and every transfer as an unbuilt placeholder, and persist the
-/// whole committed migration through the backend. This is the two-phase (in general, multi-phase)
-/// signing path that ZIP 318 permits: the application broadcasts layer 0, and once a layer is mined the
-/// engine builds and signs the next one (see [`commit_pending_preparation`]) whose spends reference
-/// that layer's now-witnessable feeder notes, until the whole preparation is mined and the transfers
-/// are built (see [`commit_transfers`]).
+/// Commit a planned migration: build and pre-sign EVERY transaction — each preparation layer, in
+/// topological order, then every transfer — in this one pass, and persist the whole committed
+/// migration through the backend. Anchors and witnesses are deferred to proving time (ZIP 374), so
+/// a spent note's plaintext is all the builder needs: layer 0 spends the wallet's own notes, and
+/// each later layer's feeders and each transfer's funding note are recovered from the built (still
+/// unmined) bundles of the transactions that mint them. Mining gates only the BROADCAST order,
+/// which the state machine walks by dependencies and scheduled heights; nothing is ever signed in
+/// a second session because of on-chain state.
 ///
-/// A single-layer plan (the common case: a few wallet notes fanning into a handful of funding notes)
-/// signs its one layer here and records only the transfer placeholders; nothing is deferred. A
-/// multi-layer plan (a lone whale fanning out, or a dust-heavy balance) signs layer 0 here and defers
-/// the rest.
-///
-/// For an EXTERNAL signer (a hardware wallet), use [`build_preparation_unsigned`] instead, which builds
-/// the same layer-0 transactions but leaves them unsigned for the device and returns their PCZTs.
+/// For an EXTERNAL signer (a hardware wallet), use [`build_preparation_unsigned`] instead, which
+/// builds the same transactions but leaves them unsigned for the device.
 ///
 /// Refuses to overwrite a stored non-terminal migration
 /// ([`CommitError::MigrationInProgress`]): a committed migration is resumed from the store, or
@@ -820,16 +817,17 @@ where
     .map(|(state, _unsigned)| state)
 }
 
-/// Commit a planned migration's PREPARATION for an EXTERNAL signer: build the FIRST layer of preparation
-/// transactions but leave them UNSIGNED, persist the committed migration (with those transactions in the
-/// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state), and return the state together with
-/// the unsigned layer-0 PCZTs to route to the signing device. Later preparation layers and every transfer
-/// are recorded as unbuilt placeholders exactly as [`commit_preparation`] records them.
+/// Commit a planned migration for an EXTERNAL signer: build EVERY transaction exactly as
+/// [`commit_preparation`] does, but leave them UNSIGNED (in the
+/// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state), persist the committed
+/// migration, and return the state together with the unsigned PCZTs, in topological order, to
+/// route to the signing device — split them into device-sized sessions with
+/// [`batch_unsigned_by_action_budget`].
 ///
 /// After the device signs, call [`MigrationState::apply_signature`] for each returned PCZT (matched by
 /// [`UnsignedMigrationTx::id`]) to move it to [`Signed`](MigrationTxState::Signed), persist with
-/// `put_migration`, and drive the rest of the migration through the normal state machine (proving and
-/// broadcasting are unchanged). Transfers are signed later via [`build_transfers_unsigned`].
+/// `put_migration`, and drive the broadcasts through the normal state machine (proving remains a
+/// consumer responsibility, at broadcast time).
 ///
 /// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
 /// `rng` a cryptographically secure RNG.
@@ -872,8 +870,8 @@ where
         + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
-    use crate::build::build_prep_tx;
-    use crate::preparation::PrepInput;
+    use crate::build::{build_prep_tx, build_transfer_pczt};
+    use crate::preparation::{PrepInput, PrepOutput};
     use zcash_protocol::consensus::NetworkUpgrade;
 
     // A committed migration is resumed from the store (or cancelled), never rebuilt over (see
@@ -888,12 +886,6 @@ where
     }
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    // Preparations witness against the ORDINARY near-tip anchor (see [`PREP_ANCHOR_DEPTH`]); only
-    // the pool-crossing transfers use bucketed boundary anchors.
-    let anchor_height = target_height - PREP_ANCHOR_DEPTH;
-    let anchor = backend
-        .orchard_anchor(anchor_height)
-        .map_err(CommitError::Backend)?;
     let nu63_activation = params
         .activation_height(NetworkUpgrade::Nu6_3)
         .ok_or_else(|| CommitError::Build("NU6.3 is not active on this network".into()))?;
@@ -901,9 +893,19 @@ where
     let mut transactions: Vec<MigrationTransaction> = Vec::new();
     let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
     let mut next_id = 0u32;
-    // The transaction ids assigned to each preparation layer, so a later layer's placeholder can depend
-    // on the whole layer before it, and the transfers can depend on the last preparation layer.
+    // The transaction ids assigned to each preparation layer, so a later layer can depend on the
+    // whole layer before it, and the transfers on the last preparation layer. Dependencies gate
+    // BROADCAST order only: every transaction is built and signed here, in this one pass.
     let mut layer_ids: Vec<Vec<MigrationTxId>> = Vec::new();
+
+    // The spendable notes minted by already-built preparation transactions, RECOVERED from their
+    // built bundles (a minted note's plaintext is fixed at build time — its rho is the paired
+    // spend's nullifier and its rseed is drawn by the builder; mining only assigns its tree
+    // position, which matters only to the proof). A later layer's Prior spends and the transfers'
+    // funding notes draw from this pool by value, each note spent at most once. This is what
+    // makes the WHOLE migration signable in topological order before anything is broadcast:
+    // signing sessions are bounded by the signer's action budget, never by mining.
+    let mut minted: Vec<(Zatoshis, orchard::note::Note, bool)> = Vec::new();
 
     for (layer, prep_layer) in plan.preparation().layers().iter().enumerate() {
         let mut this_layer_ids: Vec<MigrationTxId> = Vec::with_capacity(prep_layer.len());
@@ -912,122 +914,132 @@ where
             next_id += 1;
             this_layer_ids.push(id);
 
-            if layer == 0 {
-                // Layer 0 spends only the wallet's own notes, so it is built and pre-signed now.
-                let mut spends = Vec::with_capacity(prep_tx.inputs().len());
-                for input in prep_tx.inputs() {
-                    match input {
-                        PrepInput::Wallet { index, value } => {
-                            let witness = backend
-                                .resolve_wallet_note(*index, anchor_height)
-                                .map_err(CommitError::Backend)?;
-                            // The plan captured this note by its index into the spendable set at
-                            // PLANNING time; any receipt or spend since then shifts the indices,
-                            // so a resolved note whose value differs from the planned one means
-                            // the plan is stale — caught here as a typed error rather than as an
-                            // opaque balance failure (or, for an equal-valued interloper, a
-                            // silently signed spend of a note the plan reserved elsewhere).
-                            if witness.0.value().inner() != u64::from(*value) {
-                                return Err(CommitError::StalePlan);
-                            }
-                            spends.push(witness);
+            let mut spends = Vec::with_capacity(prep_tx.inputs().len());
+            for input in prep_tx.inputs() {
+                match input {
+                    PrepInput::Wallet { index, value } => {
+                        let note = backend
+                            .resolve_wallet_note(*index)
+                            .map_err(CommitError::Backend)?;
+                        // The plan captured this note by its index into the spendable set at
+                        // PLANNING time; any receipt or spend since then shifts the indices,
+                        // so a resolved note whose value differs from the planned one means
+                        // the plan is stale — caught here as a typed error rather than as an
+                        // opaque balance failure (or, for an equal-valued interloper, a
+                        // silently signed spend of a note the plan reserved elsewhere).
+                        if note.value().inner() != u64::from(*value) {
+                            return Err(CommitError::StalePlan);
                         }
-                        // A layer-0 transaction spends only wallet notes; a Prior input here is a
-                        // planner bug (the layered planner puts every Prior input in a later layer).
-                        PrepInput::Prior { .. } => {
-                            return Err(CommitError::Build(
-                                "layer 0 preparation transaction spends a prior-layer output"
-                                    .into(),
-                            ));
-                        }
+                        spends.push(note);
+                    }
+                    PrepInput::Prior { value, .. } => {
+                        // A feeder minted by an earlier layer, recovered when that layer was
+                        // built above (the plan's layers are in topological order).
+                        let pos = minted
+                            .iter()
+                            .position(|(v, _, used)| !used && v == value)
+                            .ok_or_else(|| {
+                                CommitError::Build(format!(
+                                    "layer {layer} spends a feeder note of value {} that no \
+                                     earlier layer mints",
+                                    u64::from(*value)
+                                ))
+                            })?;
+                        minted[pos].2 = true;
+                        spends.push(minted[pos].1);
                     }
                 }
+            }
 
-                // The drawn preparation schedule temporally decouples the transactions of a
-                // layer from one another (see `MigrationPlan::prep_schedule`). The expiry the
-                // pre-signature commits to must match that schedule, not the build height: the
-                // canonical rolling window at the scheduled height.
-                let scheduled_height = plan.prep_schedule()[layer][index];
-                let expiry_height = crate::scheduling::expiry_height(scheduled_height);
-                let (pczt, _placed) = build_prep_tx(
-                    params,
-                    u32::from(target_height),
-                    u32::from(expiry_height),
-                    &fvk,
-                    anchor,
-                    spends,
-                    prep_tx.outputs(),
-                    &mut *rng,
-                )
-                .map_err(|e| CommitError::Build(format!("{e}")))?;
-
-                let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
-                if matches!(signing, Signing::External) {
-                    unsigned.push(UnsignedMigrationTx {
-                        id,
-                        pczt: bytes.clone(),
-                    });
-                }
-
-                transactions.push(MigrationTransaction {
-                    id,
-                    kind: MigrationTxKind::Preparation { layer, index },
-                    pczt: Some(bytes),
-                    depends_on: Vec::new(),
-                    scheduled_height,
-                    expiry_height,
-                    anchor_boundary: None,
-                    state: tx_state,
-                });
+            let depends_on = if layer == 0 {
+                Vec::new()
             } else {
-                // A later layer spends the previous layer's feeder notes, which are not witnessable
-                // until that layer is mined. Record it as an unbuilt placeholder depending on the whole
-                // immediately-prior layer; `commit_pending_preparation` builds and signs it once its
-                // dependencies mine. Its drawn scheduled height gates its broadcast in addition to
-                // its dependencies mining.
-                let depends_on = layer_ids
+                layer_ids
                     .last()
                     .cloned()
-                    .expect("a layer after layer 0 has a preceding layer");
-                let scheduled_height = plan.prep_schedule()[layer][index];
-                transactions.push(MigrationTransaction {
+                    .expect("a layer after layer 0 has a preceding layer")
+            };
+            // The drawn preparation schedule temporally decouples the transactions of a layer
+            // from one another (see `MigrationPlan::prep_schedule`). The expiry the
+            // pre-signature commits to must match that schedule, not the build height: the
+            // canonical rolling window at the scheduled height.
+            let scheduled_height = plan.prep_schedule()[layer][index];
+            let expiry_height = crate::scheduling::expiry_height(scheduled_height);
+            let (pczt, placed) = build_prep_tx(
+                params,
+                u32::from(target_height),
+                u32::from(expiry_height),
+                &fvk,
+                spends,
+                prep_tx.outputs(),
+                &mut *rng,
+            )
+            .map_err(|e| CommitError::Build(format!("{e}")))?;
+
+            // Grow the minted pool with this transaction's recovered spendable outputs. Change
+            // outputs are excluded: they stay in the source pool and must never be matched to a
+            // feeder or funding request of a coincidentally equal value.
+            for (_action_index, output, note) in placed {
+                match output {
+                    PrepOutput::Funding(value) | PrepOutput::Intermediate(value) => {
+                        minted.push((value, note, false));
+                    }
+                    PrepOutput::Change(_) => {}
+                }
+            }
+
+            let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
+            if matches!(signing, Signing::External) {
+                unsigned.push(UnsignedMigrationTx {
                     id,
-                    kind: MigrationTxKind::Preparation { layer, index },
-                    pczt: None,
-                    depends_on,
-                    scheduled_height,
-                    expiry_height: crate::scheduling::expiry_height(scheduled_height),
-                    anchor_boundary: None,
-                    state: MigrationTxState::Planned,
+                    pczt: bytes.clone(),
+                    actions: crate::preparation::PREP_TX_ACTIONS,
                 });
             }
+            transactions.push(MigrationTransaction {
+                id,
+                kind: MigrationTxKind::Preparation { layer, index },
+                pczt: bytes,
+                depends_on,
+                scheduled_height,
+                expiry_height,
+                anchor_boundary: None,
+                state: tx_state,
+            });
         }
         layer_ids.push(this_layer_ids);
     }
 
-    // Every transfer waits for the last preparation layer to be mined: a layer is broadcast only after
-    // its predecessor mines, so the last layer mining implies every layer (hence every funding note) is
-    // mined and witnessable. An empty preparation (every funding note used directly) leaves this empty.
+    // Direct-funding wallet notes (already exactly a funding value; no preparation transaction
+    // mints them) join the pool the transfers draw from.
+    for &(wallet_index, value) in plan.preparation().direct_funding_notes() {
+        let note = backend
+            .resolve_wallet_note(wallet_index)
+            .map_err(CommitError::Backend)?;
+        if note.value().inner() != u64::from(value) {
+            return Err(CommitError::StalePlan);
+        }
+        minted.push((value, note, false));
+    }
+
+    // Every transfer waits for the last preparation layer to be MINED before it broadcasts (a
+    // layer broadcasts only after its predecessor mines, so the last layer mining implies every
+    // funding note is on-chain); its PCZT, though, is built and signed right here. An empty
+    // preparation (every funding note used directly) leaves the dependency set empty.
     let last_layer_ids: Vec<MigrationTxId> = layer_ids.last().cloned().unwrap_or_default();
 
-    // Record each transfer as a Planned placeholder carrying its schedule; its PCZT is built and
-    // signed later, once the preparation is mined (see `commit_transfers`). This persists the drawn
-    // schedule (which is not reproducible) as part of the committed migration.
+    // The boundary anchor each transfer will PROVE against is drawn here, at scheduling time,
+    // because the schedule fully determines it: the candidate set lies strictly above the NU6.3
+    // activation, at or after the height the funding notes exist on-chain (the last drawn
+    // preparation height plus the mining margin — the estimate `plan_migration` floored the
+    // schedule on), and strictly below the most recent boundary at the transfer's scheduled
+    // broadcast height. The anchor and the funding note's witness are installed against that
+    // boundary through the PCZT Updater role at proving time (ZIP 374); nothing here needs them.
     //
-    // The boundary anchor is drawn HERE, at scheduling time, because the schedule fully determines
-    // it: the candidate set lies strictly above the NU6.3 activation, at or after the height the
-    // funding notes exist (they are minted only when the LAST preparation layer mines, so the floor
-    // is the last drawn preparation height plus the mining margin, exactly the estimate
-    // `plan_migration` floored the schedule on — flooring at `target_height` instead would admit
-    // boundaries whose tree state predates the funding notes, recording an anchor the transfer
-    // could never prove against), and strictly below the most recent boundary at the transfer's
-    // scheduled broadcast height (the chain view the wallet will have observed when it proves,
-    // just before broadcast).
-    //
-    // `plan_migration` floors the first scheduled transfer on this same estimate, so every transfer
-    // has a candidate boundary by construction; an empty draw therefore means the plan has gone
-    // STALE (the preparation is being committed at a height far past the estimate the schedule was
-    // floored on) and must be re-planned — it is an error, never a deferred fallback.
+    // `plan_migration` floors the first scheduled transfer on this same estimate, so every
+    // transfer has a candidate boundary by construction; an empty draw therefore means the plan
+    // has gone STALE (committed at a height far past the estimate the schedule was floored on)
+    // and must be re-planned — it is an error, never a deferred fallback.
     let est_last_prep_height = plan
         .prep_schedule()
         .last()
@@ -1035,10 +1047,51 @@ where
         .map_or(target_height, |&h| h + EST_PREP_LAYER_MINING_BLOCKS);
     let funding_notes = plan.funding_notes().to_vec();
     for (crossing, schedule) in plan.schedule().iter().enumerate() {
+        let id = MigrationTxId(next_id);
+        next_id += 1;
+
+        let funding_value = *funding_notes.get(crossing).ok_or_else(|| {
+            CommitError::Build(format!("no funding note value for crossing {crossing}"))
+        })?;
+        let pos = minted
+            .iter()
+            .position(|(v, _, used)| !used && *v == funding_value)
+            .ok_or_else(|| {
+                CommitError::Build(format!("no minted funding note for crossing {crossing}"))
+            })?;
+        minted[pos].2 = true;
+        let note = minted[pos].1;
+        let crossing_value = *plan
+            .note_split()
+            .crossing_values()
+            .get(crossing)
+            .ok_or_else(|| {
+                CommitError::Build(format!("no stored crossing value for transfer {crossing}"))
+            })?;
+
+        let pczt = build_transfer_pczt(
+            params,
+            u32::from(target_height),
+            u32::from(schedule.expiry_height()),
+            &fvk,
+            note,
+            crossing_value,
+            &mut *rng,
+        )
+        .map_err(|e| CommitError::Build(format!("{e}")))?;
+        let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
+        if matches!(signing, Signing::External) {
+            unsigned.push(UnsignedMigrationTx {
+                id,
+                pczt: bytes.clone(),
+                actions: crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
+                    + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER,
+            });
+        }
         transactions.push(MigrationTransaction {
-            id: MigrationTxId(next_id),
+            id,
             kind: MigrationTxKind::Transfer { crossing },
-            pczt: None,
+            pczt: bytes,
             depends_on: last_layer_ids.clone(),
             scheduled_height: schedule.broadcast_height(),
             expiry_height: schedule.expiry_height(),
@@ -1057,9 +1110,8 @@ where
                     )
                 })?,
             ),
-            state: MigrationTxState::Planned,
+            state: tx_state,
         });
-        next_id += 1;
     }
 
     let state = MigrationState {
@@ -1069,312 +1121,6 @@ where
         preparation: plan.preparation().clone(),
         transactions,
     };
-    backend
-        .put_migration(&state)
-        .map_err(CommitError::Backend)?;
-    Ok((state, unsigned))
-}
-
-/// Build and pre-sign the next READY preparation layer: the deferred second phase of committing a
-/// multi-layer preparation. A later preparation layer spends the previous layer's feeder notes, which
-/// become witnessable only after that layer is mined, so [`commit_preparation`] records those layers as
-/// unbuilt placeholders and this function fills them in once their dependencies mine.
-///
-/// Loads the committed migration, finds the earliest still-`Planned` preparation layer (a `layer > 0`)
-/// whose whole immediately-prior layer is [`Mined`](MigrationTxState::Mined), builds and pre-signs
-/// EVERY transaction of that one layer (resolving each transaction's
-/// [`PrepInput::Prior`](crate::preparation::PrepInput::Prior) spends to the
-/// prior layer's now-witnessable feeder notes by value), and persists the result. If no layer is ready
-/// (the next layer's dependencies are not all mined, or every preparation layer is already built), it
-/// returns the migration unchanged, so a caller can poll it. Call it once per newly-mined layer until
-/// the whole preparation is built, then [`commit_transfers`] for the transfers.
-///
-/// All the transactions of the one ready layer are resolved together in a single feeder-note lookup,
-/// so each feeder note is assigned to exactly one transaction (a note is spent at most once) even when
-/// two transactions in the layer request equal-valued feeders.
-///
-/// `params` is the network, `target_height` the height the layer's transactions are built at, and `rng`
-/// a cryptographically secure RNG.
-#[cfg(feature = "orchard")]
-pub fn commit_pending_preparation<P, B, R>(
-    params: &P,
-    target_height: BlockHeight,
-    backend: &mut B,
-    rng: &mut R,
-) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
-where
-    P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend
-        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationWrite,
-    R: RngCore + rand_core::CryptoRng,
-{
-    use crate::build::build_prep_tx;
-    use crate::preparation::PrepInput;
-
-    let mut state = backend
-        .get_migration()
-        .map_err(CommitError::Backend)?
-        .ok_or(CommitError::NoMigrationInProgress)?;
-
-    // The layer-readiness policy lives on the state machine (`next_step` dispatches
-    // `BuildPreparationLayer` from the same method), so the driver and this builder can
-    // never disagree about which layer is ready.
-    let Some(ready_layer) = state.ready_prep_layer() else {
-        // Nothing to build this step (the next layer is not mined yet, or all layers are built).
-        return Ok(state);
-    };
-
-    let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
-    // Preparations witness against the ORDINARY near-tip anchor (see [`PREP_ANCHOR_DEPTH`]).
-    let anchor_height = target_height - PREP_ANCHOR_DEPTH;
-    let anchor = backend
-        .orchard_anchor(anchor_height)
-        .map_err(CommitError::Backend)?;
-
-    // The (index-into-transactions, plan layer/index) of every still-Planned transaction of the ready
-    // layer, in plan order, so the built PCZTs go back into the right rows.
-    let mut targets: Vec<(usize, usize)> = Vec::new(); // (transactions index, plan tx index)
-    for (ti, tx) in state.transactions.iter().enumerate() {
-        if let MigrationTxKind::Preparation { layer, index } = tx.kind {
-            if layer == ready_layer && matches!(tx.state, MigrationTxState::Planned) {
-                targets.push((ti, index));
-            }
-        }
-    }
-
-    // Collect every Prior-input value of the whole ready layer, in transaction-then-input order, and
-    // resolve them together so each feeder note (distinct by tree position, even at equal value) is
-    // matched to exactly one spend across the layer. Wallet inputs (not expected past layer 0) resolve
-    // individually.
-    // The `Preparation { layer, index }` coordinates come from the STORE; a row whose
-    // coordinates fall outside the stored plan is an inconsistently persisted migration, and
-    // reports as an error rather than an out-of-bounds panic.
-    let plan_tx = |layer: usize, index: usize| {
-        state
-            .preparation
-            .layers()
-            .get(layer)
-            .and_then(|txs| txs.get(index))
-            .ok_or_else(|| {
-                CommitError::Build(format!(
-                    "stored migration references preparation transaction {layer}/{index}, \
-                     which the stored plan does not contain"
-                ))
-            })
-    };
-    let mut prior_values: Vec<Zatoshis> = Vec::new();
-    for &(_, plan_index) in &targets {
-        for input in plan_tx(ready_layer, plan_index)?.inputs() {
-            if let PrepInput::Prior { value, .. } = input {
-                prior_values.push(*value);
-            }
-        }
-    }
-    let mut prior_notes = backend
-        .resolve_feeder_notes(&prior_values, anchor_height)
-        .map_err(CommitError::Backend)?
-        .into_iter();
-
-    for &(ti, plan_index) in &targets {
-        let prep_tx = plan_tx(ready_layer, plan_index)?;
-        let mut spends = Vec::with_capacity(prep_tx.inputs().len());
-        for input in prep_tx.inputs() {
-            match input {
-                PrepInput::Wallet { index, value } => {
-                    let witness = backend
-                        .resolve_wallet_note(*index, anchor_height)
-                        .map_err(CommitError::Backend)?;
-                    // As in `commit_preparation_inner`: a value mismatch means the spendable
-                    // set shifted since planning and the plan is stale.
-                    if witness.0.value().inner() != u64::from(*value) {
-                        return Err(CommitError::StalePlan);
-                    }
-                    spends.push(witness);
-                }
-                PrepInput::Prior { .. } => {
-                    let note = prior_notes.next().ok_or_else(|| {
-                        CommitError::Build("fewer resolved feeder notes than prior inputs".into())
-                    })?;
-                    spends.push(note);
-                }
-            }
-        }
-
-        let outputs = prep_tx.outputs().to_vec();
-        // The stored row already carries the canonical expiry for this transaction's drawn
-        // scheduled height; embed the same value so the pre-signature commits to it.
-        let expiry_height = state.transactions[ti].expiry_height;
-        let (pczt, _placed) = build_prep_tx(
-            params,
-            u32::from(target_height),
-            u32::from(expiry_height),
-            &fvk,
-            anchor,
-            spends,
-            &outputs,
-            &mut *rng,
-        )
-        .map_err(|e| CommitError::Build(format!("{e}")))?;
-
-        let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
-        let bytes = signed
-            .serialize()
-            .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
-
-        let tx = &mut state.transactions[ti];
-        tx.pczt = Some(bytes);
-        tx.state = MigrationTxState::Signed;
-    }
-
-    backend
-        .put_migration(&state)
-        .map_err(CommitError::Backend)?;
-    Ok(state)
-}
-
-/// Commit a migration's TRANSFERS: the second phase of two-phase signing. Once the preparation has been
-/// mined and its self-funding notes are spendable, build each transfer transaction (spending one
-/// funding note and crossing its value into the destination pool), pre-sign it, and fill it into the
-/// migration's stored `Planned` transfer placeholders, persisting the result.
-///
-/// Loads the committed migration from the backend (the placeholders and their drawn schedule were
-/// stored by [`commit_preparation`]), resolves the funding notes, and builds only the transfers still
-/// `Planned`, so it is safe to call again after a partial failure. `params` is the network,
-/// `target_height` the height the transfers are built at, and `rng` a cryptographically secure RNG.
-///
-/// For an EXTERNAL signer, use [`build_transfers_unsigned`] instead.
-#[cfg(feature = "orchard")]
-pub fn commit_transfers<P, B, R>(
-    params: &P,
-    target_height: BlockHeight,
-    backend: &mut B,
-    rng: &mut R,
-) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
-where
-    P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend
-        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationWrite,
-    R: RngCore + rand_core::CryptoRng,
-{
-    commit_transfers_inner(params, target_height, backend, rng, Signing::InProcess)
-        .map(|(state, _unsigned)| state)
-}
-
-/// Commit a migration's TRANSFERS for an EXTERNAL signer: build each still-`Planned` transfer but leave
-/// it UNSIGNED (in the [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state), persist the
-/// migration, and return the state together with the unsigned transfer PCZTs to route to the signing
-/// device. After the device signs, call [`MigrationState::apply_signature`] for each returned PCZT
-/// (matched by [`UnsignedMigrationTx::id`]) to move it to [`Signed`](MigrationTxState::Signed), persist
-/// with `put_migration`, then prove and broadcast through the normal state machine.
-///
-/// Like [`commit_transfers`], only transfers still `Planned` are built, so it is safe to call again
-/// after a partial failure. `params` is the network, `target_height` the height the transfers are built
-/// at, and `rng` a cryptographically secure RNG.
-#[cfg(feature = "orchard")]
-pub fn build_transfers_unsigned<P, B, R>(
-    params: &P,
-    target_height: BlockHeight,
-    backend: &mut B,
-    rng: &mut R,
-) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
-where
-    P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend
-        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationWrite,
-    R: RngCore + rand_core::CryptoRng,
-{
-    commit_transfers_inner(params, target_height, backend, rng, Signing::External)
-}
-
-/// Shared body of [`commit_transfers`] (with [`Signing::InProcess`]) and [`build_transfers_unsigned`]
-/// (with [`Signing::External`]). The returned `Vec<UnsignedMigrationTx>` is empty for the in-process
-/// path.
-#[cfg(feature = "orchard")]
-fn commit_transfers_inner<P, B, R>(
-    params: &P,
-    target_height: BlockHeight,
-    backend: &mut B,
-    rng: &mut R,
-    signing: Signing,
-) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
-where
-    P: zcash_protocol::consensus::Parameters + Clone,
-    B: MigrationBackend
-        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
-        + PoolMigrationWrite,
-    R: RngCore + rand_core::CryptoRng,
-{
-    use crate::build::build_transfer_pczt;
-
-    let mut state = backend
-        .get_migration()
-        .map_err(CommitError::Backend)?
-        .ok_or(CommitError::NoMigrationInProgress)?;
-    let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
-
-    let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    // A transfer is built and pre-signed with its anchors and witness DEFERRED to proving time
-    // (ZIP 374): the drawn boundary anchor it proves against (see
-    // [`MigrationTransaction::anchor_boundary`]) typically lies near its future broadcast height,
-    // whose tree state does not exist yet at build time — so only the funding NOTES are resolved
-    // here, and the transfers are buildable as soon as the preparation has mined, with no wait
-    // for a boundary to pass.
-    let notes = backend
-        .resolve_funding_notes(&state.funding_notes)
-        .map_err(CommitError::Backend)?;
-
-    for tx in state.transactions.iter_mut() {
-        let crossing = match tx.kind {
-            MigrationTxKind::Transfer { crossing } => crossing,
-            MigrationTxKind::Preparation { .. } => continue,
-        };
-        if !matches!(tx.state, MigrationTxState::Planned) {
-            continue;
-        }
-
-        let note = notes.get(crossing).copied().ok_or_else(|| {
-            CommitError::Build(format!("no funding note for crossing {crossing}"))
-        })?;
-        // The value that crosses is stored on the note split itself; the funding note is this
-        // plus the split's constant fee buffer by construction.
-        let crossing_value = *state
-            .note_split
-            .crossing_values()
-            .get(crossing)
-            .ok_or_else(|| {
-                CommitError::Build(format!("no stored crossing value for transfer {crossing}"))
-            })?;
-
-        let pczt = build_transfer_pczt(
-            params,
-            u32::from(target_height),
-            u32::from(tx.expiry_height),
-            &fvk,
-            note,
-            crossing_value,
-            &mut *rng,
-        )
-        .map_err(|e| CommitError::Build(format!("{e}")))?;
-
-        let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
-        if matches!(signing, Signing::External) {
-            unsigned.push(UnsignedMigrationTx {
-                id: tx.id,
-                pczt: bytes.clone(),
-            });
-        }
-        tx.pczt = Some(bytes);
-        tx.state = tx_state;
-    }
-
     backend
         .put_migration(&state)
         .map_err(CommitError::Backend)?;
@@ -1589,7 +1335,7 @@ mod tests {
         let tx = MigrationTransaction {
             id: MigrationTxId(0),
             kind: MigrationTxKind::Transfer { crossing: 0 },
-            pczt: Some(vec![1, 2, 3]), // a stand-in for the serialized pre-signed PCZT
+            pczt: vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
             depends_on: Vec::new(),
             scheduled_height: BlockHeight::from_u32(2_000_100),
             expiry_height: BlockHeight::from_u32(2_069_220),
@@ -1634,7 +1380,6 @@ mod tests {
 #[cfg(all(test, feature = "orchard"))]
 mod commit_tests {
     use super::*;
-    use core::cell::RefCell;
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
     use zcash_protocol::value::COIN;
@@ -1643,10 +1388,10 @@ mod commit_tests {
 
     use crate::build::sign_pczt;
     use crate::build::test_util::{
-        TARGET_HEIGHT, regtest_network, shared_anchor_witnesses, single_note_witness, spending_key,
+        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
     };
     use crate::note_splitting::NoteSplitPlan;
-    use crate::preparation::{PrepInput, plan_preparation};
+    use crate::preparation::{PREP_TX_ACTIONS, plan_preparation};
 
     /// The canonical fees on the regtest network at the build height, computed exactly as
     /// `plan_migration` computes them.
@@ -1659,23 +1404,45 @@ mod commit_tests {
         commit_test_fees().0
     }
 
-    /// A wallet holding the account's key and a set of note witnesses against one anchor: index 0 is the
-    /// source note the preparation spends, and the rest are the funding notes the transfers spend. It
-    /// signs with its own spend-authorizing key and stores the migration in memory.
+    /// A wallet mock holding the account's key and its spendable notes' PLAINTEXTS — nothing
+    /// more: with anchors and witnesses deferred to proving time (ZIP 374), building and signing
+    /// an entire migration needs no tree access at all. It signs with its own spend-authorizing
+    /// key and stores the migration in memory.
     struct CommitMock {
-        notes: Vec<Zatoshis>,
-        witnesses: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
-        anchor: orchard::Anchor,
+        wallet_notes: Vec<orchard::note::Note>,
         fvk: FullViewingKey,
         ask: SpendAuthorizingKey,
         stored: Option<MigrationState>,
+    }
+
+    impl CommitMock {
+        /// A mock wallet holding single notes of the given values, derived from `seed`.
+        fn new(seed: u64, values: &[u64]) -> Self {
+            let sk = spending_key(seed);
+            let fvk = FullViewingKey::from(&sk);
+            let wallet_notes = values
+                .iter()
+                .enumerate()
+                .map(|(i, &v)| single_note_witness(&fvk, v, seed.wrapping_add(i as u64)).0)
+                .collect();
+            CommitMock {
+                wallet_notes,
+                fvk,
+                ask: SpendAuthorizingKey::from(&sk),
+                stored: None,
+            }
+        }
     }
 
     impl MigrationBackend for CommitMock {
         type Error = core::convert::Infallible;
 
         fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
-            Ok(self.notes.clone())
+            Ok(self
+                .wallet_notes
+                .iter()
+                .map(|n| Zatoshis::from_u64(n.value().inner()).expect("test note values are valid"))
+                .collect())
         }
 
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
@@ -1699,9 +1466,14 @@ mod commit_tests {
 
         fn update_transaction(
             &mut self,
-            _id: MigrationTxId,
-            _state: MigrationTxState,
+            id: MigrationTxId,
+            state: MigrationTxState,
         ) -> Result<(), Self::Error> {
+            if let Some(stored) = &mut self.stored {
+                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
+                    tx.state = state;
+                }
+            }
             Ok(())
         }
     }
@@ -1713,40 +1485,8 @@ mod commit_tests {
             Ok(self.fvk.clone())
         }
 
-        fn orchard_anchor(
-            &self,
-            _anchor_height: BlockHeight,
-        ) -> Result<orchard::Anchor, Self::Error> {
-            Ok(self.anchor)
-        }
-
-        fn resolve_wallet_note(
-            &self,
-            index: usize,
-            _anchor_height: BlockHeight,
-        ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
-            Ok(self.witnesses[index].clone())
-        }
-
-        fn resolve_feeder_notes(
-            &self,
-            values: &[Zatoshis],
-            _anchor_height: BlockHeight,
-        ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
-            // The minted notes are the witnesses after the source note (index 0).
-            Ok(self.witnesses[1..1 + values.len()].to_vec())
-        }
-
-        fn resolve_funding_notes(
-            &self,
-            values: &[Zatoshis],
-        ) -> Result<Vec<orchard::note::Note>, Self::Error> {
-            // The funding notes are the witnesses after the source note (index 0); a transfer's
-            // witness is deferred to proving time, so only the notes are returned.
-            Ok(self.witnesses[1..1 + values.len()]
-                .iter()
-                .map(|(note, _)| *note)
-                .collect())
+        fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error> {
+            Ok(self.wallet_notes[index])
         }
 
         fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
@@ -1754,50 +1494,30 @@ mod commit_tests {
         }
     }
 
-    #[test]
-    fn commits_preparation_then_transfers() {
-        let seed = 7u64;
-        let sk = spending_key(seed);
-        let fvk = FullViewingKey::from(&sk);
-        let balance = 78 * COIN;
+    /// A planned single-note migration and the mock wallet that holds the note.
+    fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
+        let backend = CommitMock::new(seed, &[balance]);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+            .expect("a fundable balance plans");
+        (backend, plan)
+    }
 
-        // Plan the migration from the single source note.
-        let plan = {
-            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
-            let planner = CommitMock {
-                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-                witnesses: vec![(note, path)],
-                anchor,
-                fvk: fvk.clone(),
-                ask: SpendAuthorizingKey::from(&sk),
-                stored: None,
-            };
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
-        };
+    /// The WHOLE migration — every preparation transaction and every transfer — is built and
+    /// SIGNED in the one commit pass, before anything is broadcast or mined: the funding notes
+    /// are recovered from the built preparation bundles, and every stored PCZT carries ABSENT
+    /// anchors (ZIP 374), to be installed at proving time against each transaction's anchor.
+    #[test]
+    fn commits_the_whole_migration_in_one_pass() {
+        let seed = 7u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
         // A single note funding a handful of denominations needs one preparation layer.
         assert_eq!(plan.preparation().layers().len(), 1);
-        let funding_notes = plan.funding_notes().to_vec();
-
-        // Witness the source note (index 0) and the funding notes against one shared anchor.
-        let mut values = vec![balance];
-        values.extend(funding_notes.iter().map(|&v| u64::from(v)));
-        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
-
-        let mut backend = CommitMock {
-            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-            witnesses,
-            anchor,
-            fvk: fvk.clone(),
-            ask: SpendAuthorizingKey::from(&sk),
-            stored: None,
-        };
         let params = regtest_network(true);
         let prep_count: usize = plan.preparation().layers().iter().map(|l| l.len()).sum();
-        let transfer_count = funding_notes.len();
+        let transfer_count = plan.funding_notes().len();
+        assert!(transfer_count >= 2, "several transfers: {transfer_count}");
 
-        // Phase 1: commit the preparation. It signs the preparation transactions and records the
-        // transfers as planned placeholders (no PCZT yet).
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
         let state = commit_preparation(
             &params,
@@ -1806,9 +1526,10 @@ mod commit_tests {
             &plan,
             &mut rng,
         )
-        .expect("commits the preparation");
+        .expect("commits the migration");
         assert_eq!(state.status, MigrationStatus::Committed);
         assert_eq!(state.transactions.len(), prep_count + transfer_count);
+
         // The funding notes exist only once the last preparation transaction has mined; every
         // drawn boundary must lie at or after that estimate, exactly as the draw is floored.
         let est_last_prep = state
@@ -1819,123 +1540,299 @@ mod commit_tests {
             .max()
             .expect("the plan has a preparation")
             + EST_PREP_LAYER_MINING_BLOCKS;
+
         for tx in &state.transactions {
+            // ONE signing phase: everything is signed at commit, before anything mines.
+            assert_eq!(tx.state, MigrationTxState::Signed, "signed at commit");
+            assert!(!tx.pczt.is_empty());
+            let parsed = pczt::Pczt::parse(&tx.pczt).expect("the stored PCZT parses");
+            // Anchors are deferred (ZIP 374): every stored PCZT carries ABSENT anchors, and the
+            // pre-signature commits to the stored canonical expiry for the drawn schedule.
+            assert!(parsed.orchard().anchor().is_none());
+            assert!(parsed.ironwood().anchor().is_none());
+            assert_eq!(
+                *parsed.global().expiry_height(),
+                u32::from(tx.expiry_height),
+                "the embedded expiry matches the stored schedule expiry"
+            );
             match tx.kind {
                 MigrationTxKind::Preparation { .. } => {
-                    assert_eq!(tx.state, MigrationTxState::Signed);
-                    // The pre-signature commits to nExpiryHeight, so the embedded expiry must be
-                    // the stored canonical expiry for the drawn schedule, not the builder's
-                    // near-build-height default (which the drawn broadcast heights routinely
-                    // exceed).
-                    let parsed = pczt::Pczt::parse(tx.pczt.as_ref().expect("layer 0 is built"))
-                        .expect("the stored PCZT parses");
-                    assert_eq!(
-                        *parsed.global().expiry_height(),
-                        u32::from(tx.expiry_height),
-                        "the embedded expiry matches the stored schedule expiry"
+                    assert!(
+                        tx.depends_on.is_empty(),
+                        "single-layer preps are independent"
                     );
+                    assert!(tx.anchor_boundary.is_none());
                 }
                 MigrationTxKind::Transfer { .. } => {
-                    assert_eq!(tx.state, MigrationTxState::Planned);
-                    assert!(tx.pczt.is_none());
                     assert!(
                         !tx.depends_on.is_empty(),
-                        "a transfer waits for the preparation to mine"
+                        "a transfer BROADCASTS only after the preparation mines"
                     );
-                    // The boundary anchor is drawn at scheduling time; when a candidate set exists
-                    // it lies on the boundary grid, strictly above the NU6.3 activation, at or
-                    // after the estimated height the last preparation has mined (before which no
-                    // funding note exists to witness), and strictly below the most recent boundary
-                    // at the scheduled broadcast height.
-                    {
-                        let b = tx
-                            .anchor_boundary
-                            .expect("every transfer carries its boundary");
-                        let b = u32::from(b);
-                        assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
-                        assert!(b > 10, "boundary above the regtest NU6.3 activation");
-                        assert!(
-                            b >= u32::from(est_last_prep)
-                                .div_ceil(crate::scheduling::BOUNDARY_MODULUS)
-                                * crate::scheduling::BOUNDARY_MODULUS
-                        );
-                        assert!(
-                            b < u32::from(crate::scheduling::most_recent_boundary(
-                                tx.scheduled_height
-                            ))
-                        );
-                    }
+                    // The boundary anchor the transfer will PROVE against is drawn at commit
+                    // time: on the boundary grid, strictly above the NU6.3 activation, at or
+                    // after the estimated height the last preparation has mined, and strictly
+                    // below the most recent boundary at the scheduled broadcast height.
+                    let b = u32::from(
+                        tx.anchor_boundary
+                            .expect("every transfer carries its boundary"),
+                    );
+                    assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
+                    assert!(b > 10, "boundary above the regtest NU6.3 activation");
+                    assert!(
+                        b >= u32::from(est_last_prep).div_ceil(crate::scheduling::BOUNDARY_MODULUS)
+                            * crate::scheduling::BOUNDARY_MODULUS
+                    );
+                    assert!(
+                        b < u32::from(crate::scheduling::most_recent_boundary(tx.scheduled_height))
+                    );
                 }
-            }
-        }
-
-        // Phase 2: once the preparation is mined, commit the transfers.
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
-        let state = commit_transfers(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT),
-            &mut backend,
-            &mut rng,
-        )
-        .expect("commits the transfers");
-
-        // Every transaction is now built, pre-signed, and persisted.
-        assert_eq!(state.transactions.len(), prep_count + transfer_count);
-        for tx in &state.transactions {
-            assert_eq!(
-                tx.state,
-                MigrationTxState::Signed,
-                "every transaction is signed"
-            );
-            assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
-            // A transfer is pre-signed with its anchors and witness DEFERRED (ZIP 374): the
-            // stored PCZT carries ABSENT anchors, to be installed at proving time against the
-            // drawn boundary anchor.
-            if matches!(tx.kind, MigrationTxKind::Transfer { .. }) {
-                let parsed = pczt::Pczt::parse(tx.pczt.as_ref().expect("transfer is built"))
-                    .expect("the stored PCZT parses");
-                assert!(parsed.orchard().anchor().is_none());
-                assert!(parsed.ironwood().anchor().is_none());
             }
         }
         assert!(backend.get_migration().unwrap().is_some());
     }
 
-    /// A committed migration must be resumed, never rebuilt over: a second commit while the
-    /// stored migration is non-terminal is refused (its pre-signed transactions may already be
-    /// broadcast, and a rebuilt layer 0 would double-spend the same notes); a terminal
-    /// (failed/cancelled) migration may be replaced.
+    /// A lone whale fanning out into more funding notes than one transaction holds needs a
+    /// MULTI-LAYER preparation — and it still signs in the SAME single pass: the later layer's
+    /// feeder spends and the transfers' funding notes are recovered from the earlier layers'
+    /// built (unmined) bundles. Mining then gates only the broadcast order, which the state
+    /// machine walks layer by layer.
     #[test]
-    fn commit_preparation_refuses_to_overwrite_a_live_migration() {
-        let seed = 13u64;
+    fn commits_a_multi_layer_migration_in_one_pass() {
+        let seed = 11u64;
         let sk = spending_key(seed);
         let fvk = FullViewingKey::from(&sk);
-        let balance = 78 * COIN;
 
-        let plan = {
-            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
-            let planner = CommitMock {
-                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-                witnesses: vec![(note, path)],
-                anchor,
-                fvk: fvk.clone(),
-                ask: SpendAuthorizingKey::from(&sk),
-                stored: None,
-            };
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
+        // 15 funding notes (one more than a single transaction's FUNDING_OUTPUTS_PER_TX) force a
+        // two-layer balanced fan-out. Each is a valid self-funding note (a crossing value plus
+        // the transfer fee buffer), so its transfer balances.
+        let buffer = u64::from(commit_test_fees().1);
+        let crossing = COIN; // 1 ZEC crossing per note
+        let funding_note = crossing + buffer;
+        let funding: Vec<u64> = core::iter::repeat_n(funding_note, 15).collect();
+
+        // A whale generously larger than the balanced-tree cost, so the fan-out fast path
+        // triggers.
+        let whale = funding.iter().sum::<u64>() + 16 * u64::from(prep_fee());
+        let whale_zats = [Zatoshis::from_u64(whale).expect("test whale is valid")];
+        let funding_zats: Vec<Zatoshis> = funding
+            .iter()
+            .map(|&v| Zatoshis::from_u64(v).expect("test funding values are valid"))
+            .collect();
+        let preparation = plan_preparation(&whale_zats, &funding_zats, prep_fee())
+            .expect("a fundable whale plans");
+        assert_eq!(
+            preparation.layers().len(),
+            2,
+            "15 funding notes fan out across two layers"
+        );
+
+        // A note split whose outputs are the funding notes and whose crossings are those less
+        // the buffer, so each transfer crosses one ZEC.
+        let crossings: Vec<u64> = funding.iter().map(|&f| f - buffer).collect();
+        let note_split = NoteSplitPlan::from_stored_parts(
+            crossings
+                .iter()
+                .map(|&v| Zatoshis::from_u64(v).expect("test crossings are valid"))
+                .collect(),
+            Zatoshis::from_u64(buffer).expect("the buffer is valid"),
+            None,
+            Zatoshis::from_u64(preparation.transaction_count() as u64 * u64::from(prep_fee()))
+                .expect("the reserved fees are valid"),
+            whale_zats[0],
+            Zatoshis::from_u64(crossings.iter().sum()).expect("the crossing total is valid"),
+        )
+        .expect("a consistent stored plan reconstructs");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        // A drawn preparation schedule in the layers' shape, each layer based past the previous
+        // one, exactly as `plan_migration` draws it.
+        let mut prep_schedule: Vec<Vec<BlockHeight>> = Vec::new();
+        let mut layer_base = BlockHeight::from_u32(2_000_000);
+        for layer in preparation.layers() {
+            let heights = crate::scheduling::schedule_prep_broadcast_heights(
+                layer_base,
+                layer.len(),
+                &mut rng,
+            );
+            layer_base =
+                heights.last().copied().unwrap_or(layer_base) + EST_PREP_LAYER_MINING_BLOCKS;
+            prep_schedule.push(heights);
+        }
+        // Floor the transfer schedule so every transfer has a candidate anchor boundary above
+        // the estimated last-preparation mining height, exactly as `plan_migration` floors it.
+        let nu63_activation = {
+            use zcash_protocol::consensus::{NetworkUpgrade, Parameters as _};
+            regtest_network(true)
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .expect("NU6.3 is active on the test network")
         };
-        let mut values = vec![balance];
-        values.extend(plan.funding_notes().iter().map(|&v| u64::from(v)));
-        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
+        let schedule_base =
+            crate::scheduling::earliest_broadcast_height(nu63_activation, layer_base);
+        let schedule = crate::scheduling::schedule(schedule_base, funding.len(), &mut rng);
+        let plan = MigrationPlan {
+            note_split,
+            funding_notes: funding_zats,
+            preparation,
+            prep_schedule,
+            schedule,
+        };
+
         let mut backend = CommitMock {
-            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-            witnesses,
-            anchor,
+            wallet_notes: vec![single_note_witness(&fvk, whale, seed).0],
             fvk,
             ask: SpendAuthorizingKey::from(&sk),
             stored: None,
         };
+        let params = regtest_network(true);
+        let prep_count = plan.preparation().transaction_count();
+        let transfer_count = funding.len();
+
+        // ONE pass builds and signs both layers and every transfer.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+        assert_eq!(state.transactions.len(), prep_count + transfer_count);
+        for tx in &state.transactions {
+            assert_eq!(tx.state, MigrationTxState::Signed, "signed at commit");
+            assert!(!tx.pczt.is_empty());
+        }
+        let layer0_ids: Vec<MigrationTxId> = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(layer0_ids.len(), 1, "one root transaction in layer 0");
+        for tx in &state.transactions {
+            match tx.kind {
+                MigrationTxKind::Preparation { layer, .. } if layer > 0 => {
+                    assert_eq!(
+                        tx.depends_on, layer0_ids,
+                        "a later layer broadcasts only after its predecessor mines"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // The state machine walks the broadcasts in dependency order: layer 0 first; layer 1
+        // only once layer 0 mines; the transfers only once the whole preparation mines.
+        let mut state = state;
+        let target = BlockHeight::from_u32(2_100_000);
+        match state.next_step(target) {
+            crate::state::AdvanceStep::Broadcast { id } => {
+                assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
+            }
+            other => panic!("expected a broadcast step, got {other:?}"),
+        }
+        for id in &layer0_ids {
+            state.mark_mined(*id, BlockHeight::from_u32(2_000_010));
+        }
+        let layer1_ids: Vec<MigrationTxId> = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 1, .. }))
+            .map(|t| t.id)
+            .collect();
+        match state.next_step(target) {
+            crate::state::AdvanceStep::Broadcast { id } => {
+                assert!(
+                    layer1_ids.contains(&id),
+                    "layer 1 broadcasts once layer 0 mines"
+                )
+            }
+            other => panic!("expected a broadcast step, got {other:?}"),
+        }
+        for id in &layer1_ids {
+            state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
+        }
+        match state.next_step(target) {
+            crate::state::AdvanceStep::Broadcast { id } => {
+                let tx = state
+                    .transactions
+                    .iter()
+                    .find(|t| t.id == id)
+                    .expect("the step names a stored transaction");
+                assert!(
+                    matches!(tx.kind, MigrationTxKind::Transfer { .. }),
+                    "the transfers broadcast once the whole preparation mines"
+                );
+            }
+            other => panic!("expected a broadcast step, got {other:?}"),
+        }
+    }
+
+    /// The EXTERNAL path builds the whole migration unsigned in the same one pass, and the
+    /// unsigned transactions split into signing sessions bounded by the device's action budget —
+    /// consecutive topological prefixes, never gated on mining.
+    #[test]
+    fn external_signing_batches_by_action_budget() {
+        let seed = 19u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+        let params = regtest_network(true);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (mut state, unsigned) = build_preparation_unsigned(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("builds the migration unsigned");
+        assert_eq!(unsigned.len(), state.transactions.len());
+        for tx in &state.transactions {
+            assert_eq!(tx.state, MigrationTxState::AwaitingSignature);
+        }
+
+        // Sessions are consecutive prefixes bounded by the action budget; a preparation is
+        // PREP_TX_ACTIONS actions, so a budget of one preparation plus one transfer splits the
+        // list without ever exceeding the budget (every batch is non-empty and within budget).
+        let budget = PREP_TX_ACTIONS
+            + crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
+            + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER;
+        let total = unsigned.len();
+        let sessions = batch_unsigned_by_action_budget(unsigned, budget);
+        assert!(sessions.len() > 1, "several sessions: {}", sessions.len());
+        assert_eq!(sessions.iter().map(|s| s.len()).sum::<usize>(), total);
+        for session in &sessions {
+            assert!(!session.is_empty());
+            assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget);
+        }
+
+        // Sign every session out of band and apply the signatures back; the whole migration is
+        // then Signed without anything having been broadcast or mined.
+        let ask = SpendAuthorizingKey::from(&spending_key(seed));
+        for session in sessions {
+            for unsigned_tx in session {
+                let (id, bytes) = unsigned_tx.into_parts();
+                let signed = sign_pczt(
+                    pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses"),
+                    &ask,
+                )
+                .expect("the device signs the transaction");
+                assert!(state.apply_signature(id, signed.serialize().expect("serializes")));
+            }
+        }
+        backend.put_migration(&state).unwrap();
+        for tx in &state.transactions {
+            assert_eq!(tx.state, MigrationTxState::Signed);
+        }
+    }
+
+    /// A committed migration must be resumed, never rebuilt over: a second commit while the
+    /// stored migration is non-terminal is refused (its pre-signed transactions may already be
+    /// broadcast, and a rebuilt migration would double-spend the same notes); a terminal
+    /// (failed/cancelled) migration may be replaced.
+    #[test]
+    fn commit_preparation_refuses_to_overwrite_a_live_migration() {
+        let seed = 13u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
         let params = regtest_network(true);
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
@@ -1946,7 +1843,7 @@ mod commit_tests {
             &plan,
             &mut rng,
         )
-        .expect("commits the preparation");
+        .expect("commits the migration");
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
         assert!(matches!(
@@ -1981,38 +1878,11 @@ mod commit_tests {
     #[test]
     fn commit_preparation_detects_a_stale_plan() {
         let seed = 17u64;
-        let sk = spending_key(seed);
-        let fvk = FullViewingKey::from(&sk);
-        let balance = 78 * COIN;
-
-        let plan = {
-            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
-            let planner = CommitMock {
-                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-                witnesses: vec![(note, path)],
-                anchor,
-                fvk: fvk.clone(),
-                ask: SpendAuthorizingKey::from(&sk),
-                stored: None,
-            };
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
-        };
+        let (_, plan) = single_note_setup(seed, 78 * COIN);
 
         // The spendable set shifted between planning and commit: the note at index 0 now has a
         // different value than the plan recorded.
-        let mut values = vec![balance + COIN];
-        values.extend(plan.funding_notes().iter().map(|&v| u64::from(v)));
-        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
-        let mut backend = CommitMock {
-            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
-            witnesses,
-            anchor,
-            fvk,
-            ask: SpendAuthorizingKey::from(&sk),
-            stored: None,
-        };
-
+        let mut backend = CommitMock::new(seed, &[78 * COIN + COIN]);
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
         assert!(matches!(
             commit_preparation(
@@ -2024,391 +1894,5 @@ mod commit_tests {
             ),
             Err(CommitError::StalePlan)
         ));
-    }
-
-    /// A wallet mock for the MULTI-LAYER preparation test. The first `n_wallet` witnesses are the
-    /// wallet notes (resolved by index for layer 0); the rest are the notes later layers and the
-    /// transfers mint (feeders, then funding notes), resolved by value. A persistent `used` set models
-    /// a real wallet where a spent note leaves the spendable set, so a feeder consumed by one layer is
-    /// never handed to a later resolution again. The store is real, so mining a layer persists.
-    struct LayeredMock {
-        n_wallet: usize,
-        witnesses: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
-        used: RefCell<Vec<bool>>,
-        anchor: orchard::Anchor,
-        fvk: FullViewingKey,
-        ask: SpendAuthorizingKey,
-        stored: Option<MigrationState>,
-    }
-
-    impl MigrationBackend for LayeredMock {
-        type Error = core::convert::Infallible;
-
-        fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
-            Ok(self.witnesses[..self.n_wallet]
-                .iter()
-                .map(|(n, _)| {
-                    Zatoshis::from_u64(n.value().inner()).expect("test note values are valid")
-                })
-                .collect())
-        }
-
-        fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
-            Ok(BlockHeight::from_u32(2_000_000))
-        }
-    }
-
-    impl PoolMigrationRead for LayeredMock {
-        type Error = core::convert::Infallible;
-
-        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-            Ok(self.stored.clone())
-        }
-    }
-
-    impl PoolMigrationWrite for LayeredMock {
-        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
-            self.stored = Some(state.clone());
-            Ok(())
-        }
-
-        fn update_transaction(
-            &mut self,
-            id: MigrationTxId,
-            state: MigrationTxState,
-        ) -> Result<(), Self::Error> {
-            if let Some(stored) = &mut self.stored {
-                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
-                    tx.state = state;
-                }
-            }
-            Ok(())
-        }
-    }
-
-    impl MigrationCrypto for LayeredMock {
-        type Error = core::convert::Infallible;
-
-        fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-            Ok(self.fvk.clone())
-        }
-
-        fn orchard_anchor(
-            &self,
-            _anchor_height: BlockHeight,
-        ) -> Result<orchard::Anchor, Self::Error> {
-            Ok(self.anchor)
-        }
-
-        fn resolve_wallet_note(
-            &self,
-            index: usize,
-            _anchor_height: BlockHeight,
-        ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
-            Ok(self.witnesses[index].clone())
-        }
-
-        fn resolve_feeder_notes(
-            &self,
-            values: &[Zatoshis],
-            _anchor_height: BlockHeight,
-        ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
-            // By-value greedy over the minted notes (index >= n_wallet), with a persistent used-set so
-            // successive resolutions (a layer's feeders, then a later layer's, then the funding notes)
-            // never reuse a note. Notes of equal value are interchangeable, so first-unused is correct.
-            let mut used = self.used.borrow_mut();
-            let mut out = Vec::with_capacity(values.len());
-            for &v in values {
-                let idx = (self.n_wallet..self.witnesses.len())
-                    .find(|&i| !used[i] && self.witnesses[i].0.value().inner() == u64::from(v))
-                    .expect("a minted note of the requested value exists");
-                used[idx] = true;
-                out.push(self.witnesses[idx].clone());
-            }
-            Ok(out)
-        }
-
-        fn resolve_funding_notes(
-            &self,
-            values: &[Zatoshis],
-        ) -> Result<Vec<orchard::note::Note>, Self::Error> {
-            // Draw from the same used-set as the feeder resolution, so a note consumed by a
-            // preparation layer is never handed to a transfer.
-            Ok(self
-                .resolve_feeder_notes(values, BlockHeight::from_u32(0))?
-                .into_iter()
-                .map(|(note, _)| note)
-                .collect())
-        }
-
-        fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
-            Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
-        }
-    }
-
-    /// A lone whale fanning out into more funding notes than one transaction holds needs a MULTI-LAYER
-    /// preparation. Layer 0 (spending the whale) is signed at commit time; the later layer, which
-    /// spends layer 0's feeder notes, is a placeholder until layer 0 mines, at which point
-    /// `commit_pending_preparation` builds and signs it; then the transfers build once the whole
-    /// preparation is mined. This exercises the phased per-layer commit end to end.
-    #[test]
-    fn commits_multi_layer_preparation_phase_by_phase() {
-        let seed = 11u64;
-        let sk = spending_key(seed);
-        let fvk = FullViewingKey::from(&sk);
-
-        // 15 funding notes (one more than a single transaction's FUNDING_OUTPUTS_PER_TX) force a
-        // two-layer balanced fan-out. Each is a valid self-funding note (a crossing value plus the
-        // transfer fee buffer), so its transfer balances.
-        let buffer = u64::from(commit_test_fees().1);
-        let crossing = COIN; // 1 ZEC crossing per note
-        let funding_note = crossing + buffer;
-        let funding: Vec<u64> = core::iter::repeat_n(funding_note, 15).collect();
-
-        // A whale generously larger than the balanced-tree cost, so the fan-out fast path triggers.
-        let whale = funding.iter().sum::<u64>() + 16 * u64::from(prep_fee());
-        let whale_zats = [Zatoshis::from_u64(whale).expect("test whale is valid")];
-        let funding_zats: Vec<Zatoshis> = funding
-            .iter()
-            .map(|&v| Zatoshis::from_u64(v).expect("test funding values are valid"))
-            .collect();
-        let preparation = plan_preparation(&whale_zats, &funding_zats, prep_fee())
-            .expect("a fundable whale plans");
-        assert_eq!(
-            preparation.layers().len(),
-            2,
-            "15 funding notes fan out across two layers"
-        );
-
-        // A note split whose outputs are the funding notes and whose crossings are those less the
-        // buffer, so the engine derives the same buffer and each transfer crosses one ZEC.
-        let crossings: Vec<u64> = funding.iter().map(|&f| f - buffer).collect();
-        let note_split = NoteSplitPlan::from_stored_parts(
-            crossings
-                .iter()
-                .map(|&v| Zatoshis::from_u64(v).expect("test crossings are valid"))
-                .collect(),
-            Zatoshis::from_u64(buffer).expect("the buffer is valid"),
-            None,
-            Zatoshis::from_u64(preparation.transaction_count() as u64 * u64::from(prep_fee()))
-                .expect("the reserved fees are valid"),
-            whale_zats[0],
-            Zatoshis::from_u64(crossings.iter().sum()).expect("the crossing total is valid"),
-        )
-        .expect("a consistent stored plan reconstructs");
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        // A drawn preparation schedule in the layers' shape, each layer based past the previous
-        // one, exactly as `plan_migration` draws it.
-        let mut prep_schedule: Vec<Vec<BlockHeight>> = Vec::new();
-        let mut layer_base = BlockHeight::from_u32(2_000_000);
-        for layer in preparation.layers() {
-            let heights = crate::scheduling::schedule_prep_broadcast_heights(
-                layer_base,
-                layer.len(),
-                &mut rng,
-            );
-            layer_base =
-                heights.last().copied().unwrap_or(layer_base) + EST_PREP_LAYER_MINING_BLOCKS;
-            prep_schedule.push(heights);
-        }
-        // Floor the transfer schedule so every transfer has a candidate anchor boundary above the
-        // estimated last-preparation mining height, exactly as `plan_migration` floors it.
-        let nu63_activation = {
-            use zcash_protocol::consensus::{NetworkUpgrade, Parameters as _};
-            regtest_network(true)
-                .activation_height(NetworkUpgrade::Nu6_3)
-                .expect("NU6.3 is active on the test network")
-        };
-        let schedule_base =
-            crate::scheduling::earliest_broadcast_height(nu63_activation, layer_base);
-        let schedule = crate::scheduling::schedule(schedule_base, funding.len(), &mut rng);
-        let plan = MigrationPlan {
-            note_split,
-            funding_notes: funding_zats,
-            preparation,
-            prep_schedule,
-            schedule,
-        };
-
-        // The shared-anchor witness pool: the whale, then every feeder a later layer spends (in the
-        // order `commit_pending_preparation` requests them), then the funding notes. All are leaves of
-        // one tree, so every spend across every layer and transfer anchors to the same root.
-        let mut feeder_values: Vec<u64> = Vec::new();
-        for (li, layer) in plan.preparation().layers().iter().enumerate() {
-            if li == 0 {
-                continue;
-            }
-            for tx in layer {
-                for input in tx.inputs() {
-                    if let PrepInput::Prior { value, .. } = input {
-                        feeder_values.push(u64::from(*value));
-                    }
-                }
-            }
-        }
-        let mut pool_values = vec![whale];
-        pool_values.extend_from_slice(&feeder_values);
-        pool_values.extend_from_slice(&funding);
-        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &pool_values, seed);
-
-        let used = RefCell::new(vec![false; witnesses.len()]);
-        let mut backend = LayeredMock {
-            n_wallet: 1, // the whale
-            witnesses,
-            used,
-            anchor,
-            fvk: fvk.clone(),
-            ask: SpendAuthorizingKey::from(&sk),
-            stored: None,
-        };
-        let params = regtest_network(true);
-
-        let prep_count = plan.preparation().transaction_count();
-        let transfer_count = funding.len();
-
-        // Phase 1: commit the preparation. Layer 0 is signed; the later layer and the transfers are
-        // planned placeholders.
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
-        let state = commit_preparation(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT),
-            &mut backend,
-            &plan,
-            &mut rng,
-        )
-        .expect("commits the preparation");
-        assert_eq!(state.transactions.len(), prep_count + transfer_count);
-        let layer0: Vec<&MigrationTransaction> = state
-            .transactions
-            .iter()
-            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
-            .collect();
-        assert_eq!(layer0.len(), 1, "one root transaction in layer 0");
-        assert_eq!(layer0[0].state, MigrationTxState::Signed);
-        assert!(layer0[0].pczt.is_some());
-        for tx in &state.transactions {
-            if let MigrationTxKind::Preparation { layer, .. } = tx.kind {
-                if layer > 0 {
-                    assert_eq!(tx.state, MigrationTxState::Planned, "later layer deferred");
-                    assert!(tx.pczt.is_none());
-                    assert!(
-                        !tx.depends_on.is_empty(),
-                        "later layer waits for its predecessor"
-                    );
-                }
-            }
-        }
-
-        // The plan round-trips through the persisted state.
-        assert_eq!(state.preparation.layers().len(), 2);
-
-        // Before layer 0 is mined, there is nothing to build.
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
-        let state = commit_pending_preparation(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT),
-            &mut backend,
-            &mut rng,
-        )
-        .expect("no ready layer is a no-op");
-        assert!(
-            state.transactions.iter().any(
-                |t| matches!(t.kind, MigrationTxKind::Preparation { layer, .. } if layer > 0)
-                    && matches!(t.state, MigrationTxState::Planned)
-            ),
-            "the later layer is still planned until layer 0 mines"
-        );
-
-        // Mine layer 0.
-        let layer0_ids: Vec<MigrationTxId> = state
-            .transactions
-            .iter()
-            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
-            .map(|t| t.id)
-            .collect();
-        for id in &layer0_ids {
-            backend
-                .update_transaction(
-                    *id,
-                    MigrationTxState::Mined {
-                        height: BlockHeight::from_u32(2_000_010),
-                    },
-                )
-                .unwrap();
-        }
-
-        // Phase 2: the later layer is now ready; build and sign it.
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 3);
-        let state = commit_pending_preparation(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT + 5),
-            &mut backend,
-            &mut rng,
-        )
-        .expect("builds the ready layer");
-        for tx in &state.transactions {
-            if let MigrationTxKind::Preparation { layer, .. } = tx.kind {
-                if layer > 0 {
-                    assert_eq!(tx.state, MigrationTxState::Signed, "later layer now signed");
-                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
-                }
-            }
-        }
-
-        // Calling again with no further ready layer is a no-op.
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 4);
-        let state = commit_pending_preparation(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT + 6),
-            &mut backend,
-            &mut rng,
-        )
-        .expect("no further ready layer");
-        assert!(
-            state.transactions.iter().all(|t| !matches!(
-                t.kind,
-                MigrationTxKind::Preparation { layer, .. } if layer > 0
-            ) || matches!(t.state, MigrationTxState::Signed)),
-            "every preparation layer is signed"
-        );
-
-        // Mine the whole preparation, then commit the transfers.
-        let prep_ids: Vec<MigrationTxId> = state
-            .transactions
-            .iter()
-            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
-            .map(|t| t.id)
-            .collect();
-        for id in &prep_ids {
-            backend
-                .update_transaction(
-                    *id,
-                    MigrationTxState::Mined {
-                        height: BlockHeight::from_u32(2_000_020),
-                    },
-                )
-                .unwrap();
-        }
-
-        let mut rng = ChaCha8Rng::seed_from_u64(seed + 5);
-        let state = commit_transfers(
-            &params,
-            BlockHeight::from_u32(TARGET_HEIGHT + 7),
-            &mut backend,
-            &mut rng,
-        )
-        .expect("commits the transfers");
-        assert_eq!(state.transactions.len(), prep_count + transfer_count);
-        for tx in &state.transactions {
-            match tx.kind {
-                MigrationTxKind::Transfer { .. } => {
-                    assert_eq!(tx.state, MigrationTxState::Signed, "transfer signed");
-                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
-                }
-                MigrationTxKind::Preparation { .. } => {
-                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
-                }
-            }
-        }
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -29,8 +29,10 @@
 //! predecessor mines, and to an external hardware signer, which builds each transaction UNSIGNED and signs
 //! it out of band before it is applied back.) The durable artifact is therefore each transaction's PCZT
 //! plus its schedule and state, not just the plan. The consuming application later reads the due
-//! transactions back from the store, proves each against a fresh boundary anchor, broadcasts them at
-//! their scheduled heights, and reports the outcome so the engine can advance each transaction's state. A
+//! transactions back from the store, proves each transfer against its drawn boundary anchor —
+//! installing the anchor and the funding note's witness through the PCZT Updater role (ZIP 374
+//! defers both past signing) — broadcasts them at their scheduled heights, and reports the outcome
+//! so the engine can advance each transaction's state. A
 //! wallet closed between planning and broadcast, or restarted partway through, resumes from the stored
 //! PCZTs.
 //!
@@ -595,18 +597,13 @@ pub trait MigrationCrypto {
     /// The account's Orchard full viewing key.
     fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
 
-    /// The Orchard anchor at the tree state of `anchor_height`; every spend's witness resolves
-    /// against this same tree state. The engine passes a BOUNDARY height (see
-    /// [`crate::scheduling::most_recent_boundary`]) so witnesses are computed against the bucketed
-    /// anchor rather than whatever the wallet's default confirmation policy would choose. The proof
-    /// is re-anchored to the drawn boundary at proving time, and the anchor is not in the sighash.
+    /// The Orchard anchor at the tree state of `anchor_height`, for building the PREPARATION
+    /// transactions; every preparation spend's witness resolves against this same tree state. The
+    /// engine passes an ordinary near-tip height (a few confirmations below the build height):
+    /// preparations are fully shielded self-sends, and only they anchor at build time — a
+    /// transfer's anchors and witness are DEFERRED to proving time (ZIP 374), when the consumer
+    /// installs the drawn boundary anchor through the PCZT Updater role.
     fn orchard_anchor(&self, anchor_height: BlockHeight) -> Result<orchard::Anchor, Self::Error>;
-
-    /// The Ironwood anchor at the tree state of `anchor_height`, for a transfer's destination
-    /// bundle: the output-only bundle's dummy spends carry this anchor, and consensus requires a
-    /// recent Ironwood note-commitment-tree root (the empty-tree root is valid only until the pool
-    /// holds notes).
-    fn ironwood_anchor(&self, anchor_height: BlockHeight) -> Result<orchard::Anchor, Self::Error>;
 
     /// Resolve the spendable wallet note at `index` (into `spendable_orchard_note_values`) to its note
     /// and a witness against `anchor`.
@@ -616,16 +613,29 @@ pub trait MigrationCrypto {
         anchor_height: BlockHeight,
     ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error>;
 
-    /// Resolve the self-funding notes minted by the preparation, one per requested value, each to its
-    /// note and a witness against `anchor`. Called after the preparation is mined, when these notes are
-    /// spendable: `values[crossing]` is the funding note for crossing `crossing`, and the backend
-    /// returns a DISTINCT note for each requested value (funding notes of equal value are
-    /// interchangeable).
-    fn resolve_funding_notes(
+    /// Resolve the FEEDER notes an earlier preparation layer minted, one per requested value, each
+    /// to its note and a witness against the tree state at `anchor_height`. Called by
+    /// [`commit_pending_preparation`] after the prior layer is mined, when its feeder notes are
+    /// spendable; the backend returns a DISTINCT note for each requested value (notes of equal
+    /// value are interchangeable). Preparations anchor at build time, so their spends are
+    /// witnessed here, unlike the transfers'.
+    fn resolve_feeder_notes(
         &self,
         values: &[Zatoshis],
         anchor_height: BlockHeight,
     ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error>;
+
+    /// Resolve the self-funding notes minted by the preparation, one per requested value. Called
+    /// after the whole preparation is mined, when these notes are spendable: `values[crossing]` is
+    /// the funding note for crossing `crossing`, and the backend returns a DISTINCT note for each
+    /// requested value (funding notes of equal value are interchangeable). NO witness is resolved:
+    /// a transfer is built and pre-signed with its anchors and witness DEFERRED to proving time
+    /// (ZIP 374), when the consumer installs the drawn boundary anchor and a witness against it
+    /// through the PCZT Updater role.
+    fn resolve_funding_notes(
+        &self,
+        values: &[Zatoshis],
+    ) -> Result<Vec<orchard::note::Note>, Self::Error>;
 
     /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
     fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
@@ -1022,7 +1032,7 @@ where
 /// returns the migration unchanged, so a caller can poll it. Call it once per newly-mined layer until
 /// the whole preparation is built, then [`commit_transfers`] for the transfers.
 ///
-/// All the transactions of the one ready layer are resolved together in a single funding-note lookup,
+/// All the transactions of the one ready layer are resolved together in a single feeder-note lookup,
 /// so each feeder note is assigned to exactly one transaction (a note is spent at most once) even when
 /// two transactions in the layer request equal-valued feeders.
 ///
@@ -1114,7 +1124,7 @@ where
         }
     }
     let mut prior_notes = backend
-        .resolve_funding_notes(&prior_values, anchor_height)
+        .resolve_feeder_notes(&prior_values, anchor_height)
         .map_err(CommitError::Backend)?
         .into_iter();
 
@@ -1256,16 +1266,14 @@ where
     let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
-    let anchor_height = scheduling::most_recent_boundary(target_height);
-    let anchor = backend
-        .orchard_anchor(anchor_height)
-        .map_err(CommitError::Backend)?;
-    let ironwood_anchor = backend
-        .ironwood_anchor(anchor_height)
-        .map_err(CommitError::Backend)?;
-    let witnesses = backend
-        .resolve_funding_notes(&state.funding_notes, anchor_height)
+    // A transfer is built and pre-signed with its anchors and witness DEFERRED to proving time
+    // (ZIP 374): the drawn boundary anchor it proves against (see
+    // [`MigrationTransaction::anchor_boundary`]) typically lies near its future broadcast height,
+    // whose tree state does not exist yet at build time — so only the funding NOTES are resolved
+    // here, and the transfers are buildable as soon as the preparation has mined, with no wait
+    // for a boundary to pass.
+    let notes = backend
+        .resolve_funding_notes(&state.funding_notes)
         .map_err(CommitError::Backend)?;
 
     // The fee buffer each self-funding note carries (its value minus the value that crosses) is constant
@@ -1291,7 +1299,7 @@ where
             continue;
         }
 
-        let (note, merkle_path) = witnesses.get(crossing).cloned().ok_or_else(|| {
+        let note = notes.get(crossing).copied().ok_or_else(|| {
             CommitError::Build(format!("no funding note for crossing {crossing}"))
         })?;
         // The funding note is its crossing plus the buffer by construction (see above).
@@ -1304,10 +1312,7 @@ where
             u32::from(target_height),
             u32::from(tx.expiry_height),
             &fvk,
-            anchor,
             note,
-            merkle_path,
-            ironwood_anchor,
             crossing_value,
             &mut *rng,
         )
@@ -1642,13 +1647,6 @@ mod commit_tests {
             Ok(self.anchor)
         }
 
-        fn ironwood_anchor(
-            &self,
-            _anchor_height: BlockHeight,
-        ) -> Result<orchard::Anchor, Self::Error> {
-            Ok(self.anchor)
-        }
-
         fn resolve_wallet_note(
             &self,
             index: usize,
@@ -1657,13 +1655,25 @@ mod commit_tests {
             Ok(self.witnesses[index].clone())
         }
 
-        fn resolve_funding_notes(
+        fn resolve_feeder_notes(
             &self,
             values: &[Zatoshis],
             _anchor_height: BlockHeight,
         ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
-            // The funding notes are the witnesses after the source note (index 0).
+            // The minted notes are the witnesses after the source note (index 0).
             Ok(self.witnesses[1..1 + values.len()].to_vec())
+        }
+
+        fn resolve_funding_notes(
+            &self,
+            values: &[Zatoshis],
+        ) -> Result<Vec<orchard::note::Note>, Self::Error> {
+            // The funding notes are the witnesses after the source note (index 0); a transfer's
+            // witness is deferred to proving time, so only the notes are returned.
+            Ok(self.witnesses[1..1 + values.len()]
+                .iter()
+                .map(|(note, _)| *note)
+                .collect())
         }
 
         fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
@@ -1805,6 +1815,15 @@ mod commit_tests {
                 "every transaction is signed"
             );
             assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
+            // A transfer is pre-signed with its anchors and witness DEFERRED (ZIP 374): the
+            // stored PCZT carries ABSENT anchors, to be installed at proving time against the
+            // drawn boundary anchor.
+            if matches!(tx.kind, MigrationTxKind::Transfer { .. }) {
+                let parsed = pczt::Pczt::parse(tx.pczt.as_ref().expect("transfer is built"))
+                    .expect("the stored PCZT parses");
+                assert!(parsed.orchard().anchor().is_none());
+                assert!(parsed.ironwood().anchor().is_none());
+            }
         }
         assert!(backend.get_migration().unwrap().is_some());
     }
@@ -1883,13 +1902,6 @@ mod commit_tests {
             Ok(self.anchor)
         }
 
-        fn ironwood_anchor(
-            &self,
-            _anchor_height: BlockHeight,
-        ) -> Result<orchard::Anchor, Self::Error> {
-            Ok(self.anchor)
-        }
-
         fn resolve_wallet_note(
             &self,
             index: usize,
@@ -1898,7 +1910,7 @@ mod commit_tests {
             Ok(self.witnesses[index].clone())
         }
 
-        fn resolve_funding_notes(
+        fn resolve_feeder_notes(
             &self,
             values: &[Zatoshis],
             _anchor_height: BlockHeight,
@@ -1916,6 +1928,19 @@ mod commit_tests {
                 out.push(self.witnesses[idx].clone());
             }
             Ok(out)
+        }
+
+        fn resolve_funding_notes(
+            &self,
+            values: &[Zatoshis],
+        ) -> Result<Vec<orchard::note::Note>, Self::Error> {
+            // Draw from the same used-set as the feeder resolution, so a note consumed by a
+            // preparation layer is never handed to a transfer.
+            Ok(self
+                .resolve_feeder_notes(values, BlockHeight::from_u32(0))?
+                .into_iter()
+                .map(|(note, _)| note)
+                .collect())
         }
 
         fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -161,8 +161,10 @@ pub struct MigrationTransaction {
     pub scheduled_height: BlockHeight,
     /// The height after which the transaction is invalid and must be rebuilt.
     pub expiry_height: BlockHeight,
-    /// The boundary height whose tree state the transaction proves against, drawn at proving time (for
-    /// a transfer); `None` until proved.
+    /// The boundary height whose tree state the transaction proves against. For a transfer this is
+    /// drawn at SCHEDULING time (the schedule fully determines the candidate set; see
+    /// [`commit_preparation`]); `None` for a preparation transaction, or when no candidate boundary
+    /// exists at the scheduled height (the application then draws against its proving-time view).
     pub anchor_boundary: Option<BlockHeight>,
     /// The transaction's lifecycle state.
     pub state: MigrationTxState,
@@ -624,10 +626,14 @@ where
 {
     use crate::build::build_prep_tx;
     use crate::preparation::PrepInput;
+    use zcash_protocol::consensus::NetworkUpgrade;
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
     let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
     let expiry_height = crate::scheduling::expiry_height(target_height);
+    let nu63_activation = params
+        .activation_height(NetworkUpgrade::Nu6_3)
+        .ok_or_else(|| CommitError::Build("NU6.3 is not active on this network".into()))?;
 
     let mut transactions: Vec<MigrationTransaction> = Vec::new();
     let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
@@ -727,6 +733,14 @@ where
     // Record each transfer as a Planned placeholder carrying its schedule; its PCZT is built and
     // signed later, once the preparation is mined (see `commit_transfers`). This persists the drawn
     // schedule (which is not reproducible) as part of the committed migration.
+    //
+    // The boundary anchor is drawn HERE, at scheduling time, because the schedule fully determines
+    // it: the candidate set lies strictly above the NU6.3 activation, at or after the height the
+    // funding preparation is built to mine (`target_height` bounds the funding notes' creation from
+    // below), and strictly below the most recent boundary at the transfer's scheduled broadcast
+    // height (the chain view the wallet will have observed when it proves, just before broadcast).
+    // `None` means no candidate boundary exists at that scheduled height (a transfer scheduled very
+    // close to activation); the application then draws against the proving-time view instead.
     let funding_notes = plan.funding_notes().to_vec();
     for (crossing, schedule) in plan.schedule().iter().enumerate() {
         transactions.push(MigrationTransaction {
@@ -736,7 +750,12 @@ where
             depends_on: last_layer_ids.clone(),
             scheduled_height: schedule.broadcast_height(),
             expiry_height: schedule.expiry_height(),
-            anchor_boundary: None,
+            anchor_boundary: scheduling::draw_anchor_boundary(
+                nu63_activation,
+                target_height,
+                schedule.broadcast_height(),
+                rng,
+            ),
             state: MigrationTxState::Planned,
         });
         next_id += 1;
@@ -1394,6 +1413,24 @@ mod commit_tests {
                         !tx.depends_on.is_empty(),
                         "a transfer waits for the preparation to mine"
                     );
+                    // The boundary anchor is drawn at scheduling time; when a candidate set exists
+                    // it lies on the boundary grid, strictly above the NU6.3 activation, at or
+                    // after the funding preparation's build height, and strictly below the most
+                    // recent boundary at the scheduled broadcast height.
+                    if let Some(b) = tx.anchor_boundary {
+                        let b = u32::from(b);
+                        assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
+                        assert!(b > 10, "boundary above the regtest NU6.3 activation");
+                        assert!(
+                            b >= TARGET_HEIGHT.div_ceil(crate::scheduling::BOUNDARY_MODULUS)
+                                * crate::scheduling::BOUNDARY_MODULUS
+                        );
+                        assert!(
+                            b < u32::from(crate::scheduling::most_recent_boundary(
+                                tx.scheduled_height
+                            ))
+                        );
+                    }
                 }
             }
         }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -446,7 +446,7 @@ impl<E: core::error::Error + 'static> core::error::Error for MigrationError<E> {
 /// The two canonical ZIP-317 fees of a migration, computed from the canonical transaction shapes:
 /// the fee of one padded [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS)-action preparation
 /// transaction, and the transfer-fee buffer each prepared note carries (the fee of the canonical
-/// 2-Orchard + 2-Ironwood-action transfer).
+/// 2-Orchard + 1-Ironwood-action transfer: the Ironwood side is a single unpadded action).
 fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
     params: &P,
     height: BlockHeight,
@@ -482,7 +482,7 @@ fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
 /// canonical denominations, plan the preparation transactions that mint the self-funding notes, and
 /// schedule the phase-2 transfers. The canonical ZIP-317 fees are computed here, once, from the two
 /// canonical transaction shapes — the padded [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS)-action preparation transaction and
-/// the 2+2-action transfer — and reused throughout planning; the fee rule is fixed (ZIP 318 requires
+/// the 2-Orchard + 1-Ironwood-action transfer — and reused throughout planning; the fee rule is fixed (ZIP 318 requires
 /// the canonical fee, since a nonstandard fee would partition the anonymity set), so it is not a
 /// parameter. The decomposition reserves the TRUE preparation cost at each step, consulting the
 /// preparation planner as it grows the split. `rng` must be a cryptographically secure RNG (the

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -55,15 +55,23 @@ use crate::note_splitting::{NoteSplitPlan, plan_note_split};
 use crate::preparation::{PrepError, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
 
-/// The estimated number of blocks for one preparation layer to mine and become spendable: mining
-/// latency plus the wallet's witness-sync and next-layer broadcast turnaround, a few 75-second
-/// block intervals. Preparation transactions are fully shielded self-sends, so successive layers
-/// need only TEMPORAL decoupling (the predecessor mined and witnessable) — they do not wait for
-/// anchor-bucket boundaries, which only the pool-crossing transfers anchor to. Used solely to
-/// lower-bound the transfer schedule (see [`plan_migration`]); an under-estimate is self-healing
-/// (the commit-time anchor draw re-checks and reports a stale plan), an over-estimate merely delays
-/// the first transfer.
+/// The estimated number of blocks for a preparation layer's LAST scheduled transaction to mine and
+/// become spendable: mining latency plus the wallet's witness-sync and next-broadcast turnaround, a
+/// few 75-second block intervals. Preparation transactions are fully shielded self-sends, so
+/// successive layers need only TEMPORAL serialization (the predecessor mined and witnessable) —
+/// they do not wait for anchor-bucket boundaries, which only the pool-crossing transfers anchor to.
+/// Appended after each layer's last scheduled broadcast to base the next layer's schedule, and
+/// after the final layer's to lower-bound the transfer schedule (see [`plan_migration`]); an
+/// under-estimate is self-healing (the commit-time anchor draw re-checks and reports a stale plan),
+/// an over-estimate merely delays the follow-on schedule.
 const EST_PREP_LAYER_MINING_BLOCKS: u32 = 10;
+
+/// The anchor depth for PREPARATION transactions: the ordinary near-tip depth a wallet uses for any
+/// shielded spend. Preparations are fully shielded self-sends whose balances are private, so their
+/// anchors need not obscure the wallet's sync relationship — no bucketed anchor, just a recent
+/// root a few confirmations below the build height. Only the pool-crossing transfers draw bucketed
+/// boundary anchors.
+const PREP_ANCHOR_DEPTH: u32 = 3;
 
 /// What the migration engine needs from a wallet to PLAN a migration: the account's spendable notes and
 /// the chain state. Following the `zcash_client_backend` pattern, a later slice replaces this with the
@@ -345,6 +353,7 @@ pub struct MigrationPlan {
     note_split: NoteSplitPlan,
     funding_notes: Vec<Zatoshis>,
     preparation: PreparationPlan,
+    prep_schedule: Vec<Vec<BlockHeight>>,
     schedule: Vec<Schedule>,
 }
 
@@ -365,6 +374,16 @@ impl MigrationPlan {
     /// The preparation transactions (in dependency layers) that mint the funding notes.
     pub fn preparation(&self) -> &PreparationPlan {
         &self.preparation
+    }
+
+    /// The preparation broadcast schedule, one height per preparation transaction, in the same
+    /// `[layer][index]` shape as [`preparation`](Self::preparation)'s layers: exponential
+    /// inter-arrival delays with the tighter preparation spacing (see
+    /// [`scheduling::PREP_MEAN_DELAY`]), each layer based past
+    /// the previous layer's last height plus a mining margin, so the transactions are temporally
+    /// decoupled from one another while the layers stay serialized.
+    pub fn prep_schedule(&self) -> &[Vec<BlockHeight>] {
+        &self.prep_schedule
     }
 
     /// The phase-2 transfer schedule, one entry per funding note (its broadcast height and expiry).
@@ -524,19 +543,31 @@ where
     let preparation = plan_preparation(&notes, &funding_notes, prep_tx_fee)
         .map_err(MigrationError::Preparation)?;
 
+    // Schedule the PREPARATION broadcasts: each transaction gets its own drawn height (temporal
+    // decoupling — a burst of identically shaped transactions from one wallet is a linkable
+    // cluster), with the tighter preparation spacing since no anchor bucketing constrains them.
+    // Each later layer's schedule bases past the previous layer's last height plus a mining
+    // margin, keeping the layers serialized.
+    let mut prep_schedule: Vec<Vec<BlockHeight>> = Vec::with_capacity(preparation.layer_count());
+    let mut layer_base = commit_height;
+    for layer in preparation.layers() {
+        let heights = scheduling::schedule_prep_broadcast_heights(layer_base, layer.len(), rng);
+        layer_base = heights.last().copied().unwrap_or(layer_base) + EST_PREP_LAYER_MINING_BLOCKS;
+        prep_schedule.push(heights);
+    }
+    // After the loop, `layer_base` estimates the height at which the last preparation transaction
+    // has mined and its funding notes are witnessable.
+    let est_last_prep_height = layer_base;
+
     // Lower-bound the FIRST scheduled transfer so that every transfer is guaranteed a candidate
-    // anchor boundary: the preparation must mine first (a few blocks per layer — the layers are
-    // fully shielded self-sends that serialize only on mined-and-witnessable, not on anchor
-    // buckets; see [`EST_PREP_LAYER_MINING_BLOCKS`]), and a boundary must then exist above the
-    // funding notes' creation (see [`scheduling::earliest_broadcast_height`]). Basing the schedule
-    // at this bound, rather than the raw commit height, keeps the drawn inter-arrival gaps intact
-    // while making an empty candidate set impossible for a plan committed at (or reasonably near)
-    // its planning height.
+    // anchor boundary: the funding notes exist only once the preparation has mined, and a boundary
+    // must then exist above their creation (see [`scheduling::earliest_broadcast_height`]). Basing
+    // the schedule at this bound, rather than the raw commit height, keeps the drawn inter-arrival
+    // gaps intact while making an empty candidate set impossible for a plan committed at (or
+    // reasonably near) its planning height.
     let nu63_activation = params
         .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
         .ok_or(MigrationError::Nu63NotActive)?;
-    let est_last_prep_height =
-        commit_height + preparation.layer_count() as u32 * EST_PREP_LAYER_MINING_BLOCKS;
     let schedule_base = commit_height.max(scheduling::earliest_broadcast_height(
         nu63_activation,
         est_last_prep_height,
@@ -547,6 +578,7 @@ where
         note_split,
         funding_notes,
         preparation,
+        prep_schedule,
         schedule,
     })
 }
@@ -798,12 +830,12 @@ where
     use zcash_protocol::consensus::NetworkUpgrade;
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
-    let anchor_height = scheduling::most_recent_boundary(target_height);
+    // Preparations witness against the ORDINARY near-tip anchor (see [`PREP_ANCHOR_DEPTH`]); only
+    // the pool-crossing transfers use bucketed boundary anchors.
+    let anchor_height = target_height - PREP_ANCHOR_DEPTH;
     let anchor = backend
         .orchard_anchor(anchor_height)
         .map_err(CommitError::Backend)?;
-    let expiry_height = crate::scheduling::expiry_height(target_height);
     let nu63_activation = params
         .activation_height(NetworkUpgrade::Nu6_3)
         .ok_or_else(|| CommitError::Build("NU6.3 is not active on this network".into()))?;
@@ -844,9 +876,16 @@ where
                     }
                 }
 
+                // The drawn preparation schedule temporally decouples the transactions of a
+                // layer from one another (see `MigrationPlan::prep_schedule`). The expiry the
+                // pre-signature commits to must match that schedule, not the build height: the
+                // canonical rolling window at the scheduled height.
+                let scheduled_height = plan.prep_schedule()[layer][index];
+                let expiry_height = crate::scheduling::expiry_height(scheduled_height);
                 let (pczt, _placed) = build_prep_tx(
                     params,
                     u32::from(target_height),
+                    u32::from(expiry_height),
                     &fvk,
                     anchor,
                     spends,
@@ -868,7 +907,7 @@ where
                     kind: MigrationTxKind::Preparation { layer, index },
                     pczt: Some(bytes),
                     depends_on: Vec::new(),
-                    scheduled_height: target_height,
+                    scheduled_height,
                     expiry_height,
                     anchor_boundary: None,
                     state: tx_state,
@@ -877,19 +916,20 @@ where
                 // A later layer spends the previous layer's feeder notes, which are not witnessable
                 // until that layer is mined. Record it as an unbuilt placeholder depending on the whole
                 // immediately-prior layer; `commit_pending_preparation` builds and signs it once its
-                // dependencies mine. The height fields are placeholders (a preparation transaction waits
-                // for its dependencies, not a fixed height); the real ones are set at build time.
+                // dependencies mine. Its drawn scheduled height gates its broadcast in addition to
+                // its dependencies mining.
                 let depends_on = layer_ids
                     .last()
                     .cloned()
                     .expect("a layer after layer 0 has a preceding layer");
+                let scheduled_height = plan.prep_schedule()[layer][index];
                 transactions.push(MigrationTransaction {
                     id,
                     kind: MigrationTxKind::Preparation { layer, index },
                     pczt: None,
                     depends_on,
-                    scheduled_height: target_height,
-                    expiry_height,
+                    scheduled_height,
+                    expiry_height: crate::scheduling::expiry_height(scheduled_height),
                     anchor_boundary: None,
                     state: MigrationTxState::Planned,
                 });
@@ -909,15 +949,23 @@ where
     //
     // The boundary anchor is drawn HERE, at scheduling time, because the schedule fully determines
     // it: the candidate set lies strictly above the NU6.3 activation, at or after the height the
-    // funding preparation is built to mine (`target_height` bounds the funding notes' creation from
-    // below), and strictly below the most recent boundary at the transfer's scheduled broadcast
-    // height (the chain view the wallet will have observed when it proves, just before broadcast).
+    // funding notes exist (they are minted only when the LAST preparation layer mines, so the floor
+    // is the last drawn preparation height plus the mining margin, exactly the estimate
+    // `plan_migration` floored the schedule on — flooring at `target_height` instead would admit
+    // boundaries whose tree state predates the funding notes, recording an anchor the transfer
+    // could never prove against), and strictly below the most recent boundary at the transfer's
+    // scheduled broadcast height (the chain view the wallet will have observed when it proves,
+    // just before broadcast).
     //
-    // `plan_migration` floors the first scheduled transfer on an estimate of the last preparation
-    // transaction's mining height, so every transfer has a candidate boundary by construction; an
-    // empty draw therefore means the plan has gone STALE (the preparation is being committed at a
-    // height far past the estimate the schedule was floored on) and must be re-planned — it is an
-    // error, never a deferred fallback.
+    // `plan_migration` floors the first scheduled transfer on this same estimate, so every transfer
+    // has a candidate boundary by construction; an empty draw therefore means the plan has gone
+    // STALE (the preparation is being committed at a height far past the estimate the schedule was
+    // floored on) and must be re-planned — it is an error, never a deferred fallback.
+    let est_last_prep_height = plan
+        .prep_schedule()
+        .last()
+        .and_then(|layer| layer.last())
+        .map_or(target_height, |&h| h + EST_PREP_LAYER_MINING_BLOCKS);
     let funding_notes = plan.funding_notes().to_vec();
     for (crossing, schedule) in plan.schedule().iter().enumerate() {
         transactions.push(MigrationTransaction {
@@ -930,7 +978,7 @@ where
             anchor_boundary: Some(
                 scheduling::draw_anchor_boundary(
                     nu63_activation,
-                    target_height,
+                    est_last_prep_height,
                     schedule.broadcast_height(),
                     rng,
                 )
@@ -1036,11 +1084,11 @@ where
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
     // Witness against the BUCKETED anchor: the most recent boundary at the build height.
-    let anchor_height = scheduling::most_recent_boundary(target_height);
+    // Preparations witness against the ORDINARY near-tip anchor (see [`PREP_ANCHOR_DEPTH`]).
+    let anchor_height = target_height - PREP_ANCHOR_DEPTH;
     let anchor = backend
         .orchard_anchor(anchor_height)
         .map_err(CommitError::Backend)?;
-    let expiry_height = crate::scheduling::expiry_height(target_height);
 
     // The (index-into-transactions, plan layer/index) of every still-Planned transaction of the ready
     // layer, in plan order, so the built PCZTs go back into the right rows.
@@ -1091,9 +1139,13 @@ where
         }
 
         let outputs = prep_tx.outputs().to_vec();
+        // The stored row already carries the canonical expiry for this transaction's drawn
+        // scheduled height; embed the same value so the pre-signature commits to it.
+        let expiry_height = state.transactions[ti].expiry_height;
         let (pczt, _placed) = build_prep_tx(
             params,
             u32::from(target_height),
+            u32::from(expiry_height),
             &fvk,
             anchor,
             spends,
@@ -1109,8 +1161,6 @@ where
 
         let tx = &mut state.transactions[ti];
         tx.pczt = Some(bytes);
-        tx.scheduled_height = target_height;
-        tx.expiry_height = expiry_height;
         tx.state = MigrationTxState::Signed;
     }
 
@@ -1394,11 +1444,31 @@ mod tests {
         assert!(!plan.funding_notes().is_empty());
         assert_eq!(plan.schedule().len(), plan.funding_notes().len());
 
+        // The preparation schedule mirrors the layers' shape, is non-decreasing within each
+        // layer, and each layer starts past the previous one (temporal decoupling with layer
+        // serialization).
+        assert_eq!(plan.prep_schedule().len(), plan.preparation().layer_count());
+        let mut prev_layer_end = BlockHeight::from_u32(2_000_000);
+        for (layer, heights) in plan.preparation().layers().iter().zip(plan.prep_schedule()) {
+            assert_eq!(heights.len(), layer.len());
+            let mut prev = prev_layer_end;
+            for &h in heights {
+                assert!(h >= prev, "prep schedule is non-decreasing across layers");
+                prev = h;
+            }
+            prev_layer_end = prev;
+        }
+
         // The schedule floor: no transfer is scheduled before the earliest height at which a
-        // candidate anchor boundary exists, given the estimated preparation mining time (a few
-        // blocks per layer past the commit height).
-        let est_last_prep = BlockHeight::from_u32(2_000_000)
-            + plan.preparation().layer_count() as u32 * EST_PREP_LAYER_MINING_BLOCKS;
+        // candidate anchor boundary exists, given the drawn preparation schedule plus the mining
+        // margin.
+        let est_last_prep = plan
+            .prep_schedule()
+            .last()
+            .and_then(|layer| layer.last())
+            .copied()
+            .unwrap_or(BlockHeight::from_u32(2_000_000))
+            + EST_PREP_LAYER_MINING_BLOCKS;
         let earliest =
             crate::scheduling::earliest_broadcast_height(BlockHeight::from_u32(10), est_last_prep);
         assert!(
@@ -1656,11 +1726,31 @@ mod commit_tests {
         .expect("commits the preparation");
         assert_eq!(state.status, MigrationStatus::Committed);
         assert_eq!(state.transactions.len(), prep_count + transfer_count);
+        // The funding notes exist only once the last preparation transaction has mined; every
+        // drawn boundary must lie at or after that estimate, exactly as the draw is floored.
+        let est_last_prep = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+            .map(|t| t.scheduled_height)
+            .max()
+            .expect("the plan has a preparation")
+            + EST_PREP_LAYER_MINING_BLOCKS;
         for tx in &state.transactions {
             match tx.kind {
                 MigrationTxKind::Preparation { .. } => {
                     assert_eq!(tx.state, MigrationTxState::Signed);
-                    assert!(tx.pczt.is_some());
+                    // The pre-signature commits to nExpiryHeight, so the embedded expiry must be
+                    // the stored canonical expiry for the drawn schedule, not the builder's
+                    // near-build-height default (which the drawn broadcast heights routinely
+                    // exceed).
+                    let parsed = pczt::Pczt::parse(tx.pczt.as_ref().expect("layer 0 is built"))
+                        .expect("the stored PCZT parses");
+                    assert_eq!(
+                        *parsed.global().expiry_height(),
+                        u32::from(tx.expiry_height),
+                        "the embedded expiry matches the stored schedule expiry"
+                    );
                 }
                 MigrationTxKind::Transfer { .. } => {
                     assert_eq!(tx.state, MigrationTxState::Planned);
@@ -1671,8 +1761,9 @@ mod commit_tests {
                     );
                     // The boundary anchor is drawn at scheduling time; when a candidate set exists
                     // it lies on the boundary grid, strictly above the NU6.3 activation, at or
-                    // after the funding preparation's build height, and strictly below the most
-                    // recent boundary at the scheduled broadcast height.
+                    // after the estimated height the last preparation has mined (before which no
+                    // funding note exists to witness), and strictly below the most recent boundary
+                    // at the scheduled broadcast height.
                     {
                         let b = tx
                             .anchor_boundary
@@ -1681,7 +1772,8 @@ mod commit_tests {
                         assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
                         assert!(b > 10, "boundary above the regtest NU6.3 activation");
                         assert!(
-                            b >= TARGET_HEIGHT.div_ceil(crate::scheduling::BOUNDARY_MODULUS)
+                            b >= u32::from(est_last_prep)
+                                .div_ceil(crate::scheduling::BOUNDARY_MODULUS)
                                 * crate::scheduling::BOUNDARY_MODULUS
                         );
                         assert!(
@@ -1882,12 +1974,36 @@ mod commit_tests {
         )
         .expect("a consistent stored plan reconstructs");
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let schedule =
-            crate::scheduling::schedule(BlockHeight::from_u32(2_000_000), funding.len(), &mut rng);
+        // A drawn preparation schedule in the layers' shape, each layer based past the previous
+        // one, exactly as `plan_migration` draws it.
+        let mut prep_schedule: Vec<Vec<BlockHeight>> = Vec::new();
+        let mut layer_base = BlockHeight::from_u32(2_000_000);
+        for layer in preparation.layers() {
+            let heights = crate::scheduling::schedule_prep_broadcast_heights(
+                layer_base,
+                layer.len(),
+                &mut rng,
+            );
+            layer_base =
+                heights.last().copied().unwrap_or(layer_base) + EST_PREP_LAYER_MINING_BLOCKS;
+            prep_schedule.push(heights);
+        }
+        // Floor the transfer schedule so every transfer has a candidate anchor boundary above the
+        // estimated last-preparation mining height, exactly as `plan_migration` floors it.
+        let nu63_activation = {
+            use zcash_protocol::consensus::{NetworkUpgrade, Parameters as _};
+            regtest_network(true)
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .expect("NU6.3 is active on the test network")
+        };
+        let schedule_base =
+            crate::scheduling::earliest_broadcast_height(nu63_activation, layer_base);
+        let schedule = crate::scheduling::schedule(schedule_base, funding.len(), &mut rng);
         let plan = MigrationPlan {
             note_split,
             funding_notes: funding_zats,
             preparation,
+            prep_schedule,
             schedule,
         };
 

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -1118,33 +1118,10 @@ where
         .map_err(CommitError::Backend)?
         .ok_or(CommitError::NoMigrationInProgress)?;
 
-    // A stored transaction is Mined iff its state says so; a layer is ready once every dependency is.
-    let is_mined = |id: MigrationTxId, txs: &[MigrationTransaction]| -> bool {
-        txs.iter()
-            .find(|t| t.id == id)
-            .is_some_and(|t| matches!(t.state, MigrationTxState::Mined { .. }))
-    };
-
-    // Find the earliest still-Planned preparation layer (layer > 0) whose dependencies are all mined.
-    let ready_layer = state
-        .transactions
-        .iter()
-        .filter_map(|tx| match tx.kind {
-            MigrationTxKind::Preparation { layer, .. }
-                if layer > 0
-                    && matches!(tx.state, MigrationTxState::Planned)
-                    && tx
-                        .depends_on
-                        .iter()
-                        .all(|d| is_mined(*d, &state.transactions)) =>
-            {
-                Some(layer)
-            }
-            _ => None,
-        })
-        .min();
-
-    let Some(ready_layer) = ready_layer else {
+    // The layer-readiness policy lives on the state machine (`next_step` dispatches
+    // `BuildPreparationLayer` from the same method), so the driver and this builder can
+    // never disagree about which layer is ready.
+    let Some(ready_layer) = state.ready_prep_layer() else {
         // Nothing to build this step (the next layer is not mined yet, or all layers are built).
         return Ok(state);
     };
@@ -1172,9 +1149,25 @@ where
     // resolve them together so each feeder note (distinct by tree position, even at equal value) is
     // matched to exactly one spend across the layer. Wallet inputs (not expected past layer 0) resolve
     // individually.
+    // The `Preparation { layer, index }` coordinates come from the STORE; a row whose
+    // coordinates fall outside the stored plan is an inconsistently persisted migration, and
+    // reports as an error rather than an out-of-bounds panic.
+    let plan_tx = |layer: usize, index: usize| {
+        state
+            .preparation
+            .layers()
+            .get(layer)
+            .and_then(|txs| txs.get(index))
+            .ok_or_else(|| {
+                CommitError::Build(format!(
+                    "stored migration references preparation transaction {layer}/{index}, \
+                     which the stored plan does not contain"
+                ))
+            })
+    };
     let mut prior_values: Vec<Zatoshis> = Vec::new();
     for &(_, plan_index) in &targets {
-        for input in state.preparation.layers()[ready_layer][plan_index].inputs() {
+        for input in plan_tx(ready_layer, plan_index)?.inputs() {
             if let PrepInput::Prior { value, .. } = input {
                 prior_values.push(*value);
             }
@@ -1186,7 +1179,7 @@ where
         .into_iter();
 
     for &(ti, plan_index) in &targets {
-        let prep_tx = &state.preparation.layers()[ready_layer][plan_index];
+        let prep_tx = plan_tx(ready_layer, plan_index)?;
         let mut spends = Vec::with_capacity(prep_tx.inputs().len());
         for input in prep_tx.inputs() {
             match input {
@@ -1338,20 +1331,6 @@ where
         .resolve_funding_notes(&state.funding_notes)
         .map_err(CommitError::Backend)?;
 
-    // The fee buffer each self-funding note carries (its value minus the value that crosses) is constant
-    // across notes, so a funding note's crossing value is its value minus that buffer.
-    let buffer = match (
-        state.note_split.migration_outputs().first(),
-        state.note_split.crossing_values().first(),
-    ) {
-        // A prepared note is its crossing plus the buffer by construction, so the checked
-        // subtraction underflows only for an inconsistently stored plan.
-        (Some(&funding), Some(&crossing)) => (funding - crossing).ok_or_else(|| {
-            CommitError::Build("stored note split has a crossing exceeding its note".into())
-        })?,
-        _ => Zatoshis::ZERO,
-    };
-
     for tx in state.transactions.iter_mut() {
         let crossing = match tx.kind {
             MigrationTxKind::Transfer { crossing } => crossing,
@@ -1364,10 +1343,15 @@ where
         let note = notes.get(crossing).copied().ok_or_else(|| {
             CommitError::Build(format!("no funding note for crossing {crossing}"))
         })?;
-        // The funding note is its crossing plus the buffer by construction (see above).
-        let crossing_value = (state.funding_notes[crossing] - buffer).ok_or_else(|| {
-            CommitError::Build("stored funding note is smaller than the fee buffer".into())
-        })?;
+        // The value that crosses is stored on the note split itself; the funding note is this
+        // plus the split's constant fee buffer by construction.
+        let crossing_value = *state
+            .note_split
+            .crossing_values()
+            .get(crossing)
+            .ok_or_else(|| {
+                CommitError::Build(format!("no stored crossing value for transfer {crossing}"))
+            })?;
 
         let pczt = build_transfer_pczt(
             params,

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -1,0 +1,462 @@
+//! The migration engine: orchestrating a pool migration end to end through a wallet backend.
+//!
+//! The crate's other modules are the individual planners and builders: [`note_splitting`] decides the
+//! denominations, [`preparation`] plans the transactions that mint them, [`scheduling`] shuffles and
+//! times the phase-2 transfers, and the `build` module turns plans into PCZTs. This module ties
+//! them together behind a [`MigrationBackend`] trait, so the engine drives the whole flow
+//! (plan -> build -> sign -> schedule -> persist) without knowing how the wallet stores notes, resolves
+//! witnesses, holds keys, or persists state.
+//!
+//! This first slice covers PLANNING: [`plan_migration`] decomposes the account's spendable balance into
+//! canonical denominations, plans the preparation transactions, schedules the transfers, and reconciles
+//! the split against the preparation fees (dropping the smallest denominations when the fees do not fit
+//! the balance), producing a [`MigrationPlan`] preview for the user to consent to (ZIP 318 requires
+//! consent before any funds leave the pool). Building, signing, anchoring at proving time, persistence,
+//! and reconciliation-on-launch are added by later slices, which grow [`MigrationBackend`] with the
+//! witness, key, and storage methods they need.
+//!
+//! # The committed migration is stored as pre-signed PCZTs
+//!
+//! Planning is only the first phase, and the app that broadcasts is separate from the engine that
+//! plans. Once the user consents, the engine will BUILD every preparation and transfer transaction as a
+//! PCZT and PRE-SIGN it in a single session (the Orchard spend authorization is fixed independently of
+//! the proofs and the anchor), then hand each pre-signed PCZT to the backend to PERSIST alongside its
+//! schedule: broadcast height, expiry, layer and dependencies, drawn anchor boundary, and state. The
+//! durable artifact is therefore the pre-signed PCZT ready to send, not just the plan. The consuming
+//! application later reads the due transactions back from the store, updates each proof against a fresh
+//! boundary anchor, broadcasts them at their scheduled heights, and reports the outcome so the engine
+//! can advance each transaction's state. A wallet closed between planning and broadcast, or restarted
+//! partway through, resumes from the stored PCZTs. This shapes the `MigrationBackend` storage methods
+//! (store/load a transaction PCZT + its state) and the persisted state model that later slices add.
+//!
+//! [`note_splitting`]: crate::note_splitting
+//! [`preparation`]: crate::preparation
+//! [`scheduling`]: crate::scheduling
+
+use alloc::vec::Vec;
+
+use core::fmt;
+
+use rand_core::RngCore;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::{BalanceError, Zatoshis};
+
+use crate::note_splitting::{NoteSplitPlan, plan_note_split};
+use crate::preparation::{PrepError, PreparationPlan, plan_preparation};
+use crate::scheduling::{self, Schedule};
+
+/// What the migration engine needs from a wallet to PLAN a migration: the account's spendable notes and
+/// the chain state. Later slices add the methods for building (note witnesses, viewing keys), signing,
+/// persistence, and reconciliation; a backend implements this trait over its own note store and chain
+/// view (for example a `zcash_client_backend` wallet, or the migration's own SQLite store).
+pub trait MigrationBackend {
+    /// The backend's own error type (a store or chain-access failure).
+    type Error;
+
+    /// The values of the account's spendable source-pool (Orchard) notes. The migration decomposes
+    /// their total into denominations; the same notes are later spent by the preparation
+    /// transactions, so the values must line up with what the build step will resolve to witnesses.
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error>;
+
+    /// The current chain-tip height, from which the transfer schedule's delays accumulate.
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error>;
+
+    /// Persist the migration state: every transaction as its pre-signed PCZT plus the metadata the
+    /// application needs to prove, schedule, and broadcast it. Storing the pre-signed transactions,
+    /// not just the plan, is what lets a wallet resume a migration after being closed or restarted.
+    fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
+
+    /// Load the persisted migration state, if a migration is in progress.
+    fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error>;
+
+    /// Advance one stored transaction's lifecycle state (for example after the application broadcasts
+    /// it, or the chain mines it, or it expires).
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        state: MigrationTxState,
+    ) -> Result<(), Self::Error>;
+}
+
+/// A stable identifier for a migration transaction within a migration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MigrationTxId(pub u32);
+
+/// What a migration transaction does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MigrationTxKind {
+    /// A note-preparation transaction: the `index`-th transaction of preparation `layer`.
+    Preparation { layer: usize, index: usize },
+    /// A phase-2 pool-crossing transfer of the `crossing`-th funding note.
+    Transfer { crossing: usize },
+}
+
+/// Where a migration transaction is in its lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MigrationTxState {
+    /// Built but not yet signed.
+    Planned,
+    /// Pre-signed (the account's spend authorization is attached), not yet proved.
+    Signed,
+    /// Proved against a real anchor, ready to broadcast.
+    Proved,
+    /// Broadcast to the network, with its transaction id.
+    Broadcast { txid: [u8; 32] },
+    /// Mined at the given height.
+    Mined { height: BlockHeight },
+    /// Expired before it could be mined, and to be rebuilt.
+    Expired,
+}
+
+/// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
+/// application needs to prove it against a fresh anchor, wait for its dependencies, broadcast it at
+/// its scheduled height, and track its state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MigrationTransaction {
+    /// This transaction's stable id.
+    pub id: MigrationTxId,
+    /// What it does (a preparation transaction or a transfer).
+    pub kind: MigrationTxKind,
+    /// The pre-signed, unproven PCZT, serialized (`pczt::Pczt::serialize`). This is the durable
+    /// artifact: the application updates its proof against a fresh anchor and broadcasts it.
+    pub pczt: Vec<u8>,
+    /// The transactions that must be mined before this one may be broadcast (the preparation layer
+    /// dependency graph; empty for an independent transaction).
+    pub depends_on: Vec<MigrationTxId>,
+    /// The height at which to broadcast (for a transfer; a preparation transaction waits for its
+    /// dependencies to mine and a boundary to pass rather than a fixed height).
+    pub scheduled_height: BlockHeight,
+    /// The height after which the transaction is invalid and must be rebuilt.
+    pub expiry_height: BlockHeight,
+    /// The boundary height whose tree state the transaction proves against, drawn at proving time (for
+    /// a transfer); `None` until proved.
+    pub anchor_boundary: Option<BlockHeight>,
+    /// The transaction's lifecycle state.
+    pub state: MigrationTxState,
+}
+
+/// The overall status of a migration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MigrationStatus {
+    /// Planned and previewed, not yet committed (nothing built or signed).
+    Planning,
+    /// Built, pre-signed, and persisted; ready for the application to prove and broadcast.
+    Committed,
+    /// Some transactions have been broadcast or mined.
+    InProgress,
+    /// Every crossing has been mined.
+    Complete,
+    /// The migration failed and needs attention.
+    Failed,
+}
+
+/// The persisted state of a migration: the note split (for the preview and residual accounting) and
+/// every transaction, each as its pre-signed PCZT and metadata. A wallet resumes a migration entirely
+/// from this state after being closed or restarted; this is what a [`MigrationBackend`] stores.
+#[derive(Clone, Debug)]
+pub struct MigrationState {
+    /// The overall status.
+    pub status: MigrationStatus,
+    /// The note-split decomposition (the denominations and residual).
+    pub note_split: NoteSplitPlan,
+    /// Every migration transaction, in dependency order.
+    pub transactions: Vec<MigrationTransaction>,
+}
+
+/// A planned migration, before anything is built, signed, or broadcast: the denomination split, the
+/// preparation transactions that mint the funding notes, and the phase-2 transfer schedule. This is the
+/// preview a wallet shows the user for consent (ZIP 318) to the pool-crossing amounts.
+#[derive(Clone, Debug)]
+pub struct MigrationPlan {
+    note_split: NoteSplitPlan,
+    funding_notes: Vec<Zatoshis>,
+    preparation: PreparationPlan,
+    schedule: Vec<Schedule>,
+}
+
+impl MigrationPlan {
+    /// The note-split decomposition (the denominations and self-funding note values it produced,
+    /// before reconciling against the preparation fees; see [`funding_notes`](Self::funding_notes)).
+    pub fn note_split(&self) -> &NoteSplitPlan {
+        &self.note_split
+    }
+
+    /// The funding-note values this migration will actually mint, one per phase-2 crossing. These are
+    /// the note split's outputs after reconciliation: when the preparation transactions' fees do not
+    /// fit the balance, the smallest denominations are dropped (left in the source pool) until they do.
+    pub fn funding_notes(&self) -> &[Zatoshis] {
+        &self.funding_notes
+    }
+
+    /// The preparation transactions (in dependency layers) that mint the funding notes.
+    pub fn preparation(&self) -> &PreparationPlan {
+        &self.preparation
+    }
+
+    /// The phase-2 transfer schedule, one entry per funding note (its broadcast height and expiry).
+    pub fn schedule(&self) -> &[Schedule] {
+        &self.schedule
+    }
+}
+
+/// Why a migration could not be planned.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MigrationError<E> {
+    /// The wallet backend failed (a store or chain-access error).
+    Backend(E),
+    /// The spendable notes cannot fund the planned migration (see [`PrepError`]).
+    Preparation(PrepError),
+    /// The account has no migratable balance.
+    NothingToMigrate,
+    /// The backend's note values do not form a valid balance (their sum exceeds the maximum money
+    /// supply).
+    InvalidBalance(BalanceError),
+}
+
+impl<E: fmt::Display> fmt::Display for MigrationError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MigrationError::Backend(e) => write!(f, "wallet backend error: {e}"),
+            MigrationError::Preparation(e) => write!(f, "cannot prepare the migration: {e}"),
+            MigrationError::NothingToMigrate => f.write_str("no migratable balance"),
+            MigrationError::InvalidBalance(e) => write!(f, "invalid balance: {e}"),
+        }
+    }
+}
+
+impl<E: core::error::Error + 'static> core::error::Error for MigrationError<E> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            MigrationError::Backend(e) => Some(e),
+            MigrationError::Preparation(e) => Some(e),
+            MigrationError::NothingToMigrate => None,
+            // `BalanceError` implements `Error` only with `zcash_protocol/std`; the Display text
+            // above carries its message instead.
+            MigrationError::InvalidBalance(_) => None,
+        }
+    }
+}
+
+/// Plan a migration for the account the `backend` represents: decompose its spendable balance into
+/// canonical denominations, plan the preparation transactions that mint the self-funding notes, and
+/// schedule the phase-2 transfers. `prep_fee` is the ZIP-317 fee of a padded 16-action preparation
+/// transaction, which the note split and the preparation planner both reserve. `rng` must be a
+/// cryptographically secure RNG (the schedule's shuffle, delays, and the note split's optional
+/// randomization draw from it).
+///
+/// This is pure orchestration of the note-split, preparation, and scheduling planners: no cryptography,
+/// and nothing is built, signed, or persisted. The result is the [`MigrationPlan`] preview to present
+/// for user consent before committing the migration.
+pub fn plan_migration<B, R>(
+    backend: &B,
+    prep_fee: Zatoshis,
+    rng: &mut R,
+) -> Result<MigrationPlan, MigrationError<B::Error>>
+where
+    B: MigrationBackend,
+    R: RngCore,
+{
+    let notes = backend
+        .spendable_orchard_note_values()
+        .map_err(MigrationError::Backend)?;
+    // Validate the balance once; every value the planners derive from it is bounded by it, so the
+    // internal (planner-domain) u64 arithmetic below cannot re-exceed the money-supply cap.
+    let balance = notes
+        .iter()
+        .copied()
+        .sum::<Option<Zatoshis>>()
+        .ok_or(MigrationError::InvalidBalance(BalanceError::Overflow))?;
+    if balance == Zatoshis::ZERO {
+        return Err(MigrationError::NothingToMigrate);
+    }
+    let commit_height = backend
+        .chain_tip_height()
+        .map_err(MigrationError::Backend)?;
+
+    let note_values: Vec<u64> = notes.iter().map(|&n| u64::from(n)).collect();
+    let note_split = plan_note_split(u64::from(balance), u64::from(prep_fee), rng);
+    if note_split.migration_outputs().is_empty() {
+        return Err(MigrationError::NothingToMigrate);
+    }
+
+    // Reconcile the note split against the preparation fees. The split reserves for a single prep
+    // transaction, but preparation may need several; when its fees do not fit the balance, drop the
+    // smallest funding note (leaving that denomination in the source pool) and retry until it does.
+    let mut funding_notes: Vec<u64> = note_split.migration_outputs().to_vec();
+    funding_notes.sort_unstable(); // ascending, so the smallest is dropped first
+    let preparation = loop {
+        if funding_notes.is_empty() {
+            return Err(MigrationError::Preparation(PrepError::InsufficientFunds));
+        }
+        match plan_preparation(&note_values, &funding_notes, u64::from(prep_fee)) {
+            Ok(preparation) => break preparation,
+            Err(PrepError::InsufficientFunds) => {
+                funding_notes.remove(0);
+            }
+        }
+    };
+
+    let schedule = scheduling::schedule(commit_height, funding_notes.len(), rng);
+
+    let funding_notes = funding_notes
+        .into_iter()
+        .map(Zatoshis::from_u64)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(MigrationError::InvalidBalance)?;
+
+    Ok(MigrationPlan {
+        note_split,
+        funding_notes,
+        preparation,
+        schedule,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::value::COIN;
+
+    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+    use crate::preparation::PREP_TX_ACTIONS;
+
+    /// The ZIP-317 fee of a padded preparation transaction, as the engine's caller would compute it.
+    fn prep_fee() -> Zatoshis {
+        Zatoshis::from_u64(PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi())
+            .expect("the preparation fee is far below the money-supply cap")
+    }
+
+    /// A minimal in-memory backend: a fixed set of note values and a chain tip.
+    struct MockBackend {
+        notes: Vec<Zatoshis>,
+        tip: BlockHeight,
+        stored: Option<MigrationState>,
+    }
+
+    impl MockBackend {
+        fn new(notes: Vec<u64>, tip: u32) -> Self {
+            MockBackend {
+                notes: notes
+                    .into_iter()
+                    .map(|v| Zatoshis::from_u64(v).expect("test note values are valid"))
+                    .collect(),
+                tip: BlockHeight::from_u32(tip),
+                stored: None,
+            }
+        }
+    }
+
+    impl MigrationBackend for MockBackend {
+        type Error = core::convert::Infallible;
+
+        fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+            Ok(self.notes.clone())
+        }
+
+        fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+            Ok(self.tip)
+        }
+
+        fn store_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+            self.stored = Some(state.clone());
+            Ok(())
+        }
+
+        fn load_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(self.stored.clone())
+        }
+
+        fn update_transaction(
+            &mut self,
+            id: MigrationTxId,
+            state: MigrationTxState,
+        ) -> Result<(), Self::Error> {
+            if let Some(stored) = &mut self.stored {
+                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
+                    tx.state = state;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn plans_a_migration_from_a_balance() {
+        let backend = MockBackend::new(vec![100 * COIN, 40 * COIN], 2_000_000);
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let plan =
+            plan_migration(&backend, prep_fee(), &mut rng).expect("a fundable balance plans");
+
+        // Something is migrated; the schedule has one entry per funding note; the preparation mints
+        // exactly the (reconciled) funding notes; and reconciliation only ever drops, never adds.
+        assert!(!plan.funding_notes().is_empty());
+        assert_eq!(plan.schedule().len(), plan.funding_notes().len());
+        assert_eq!(
+            plan.preparation().funding_notes().len(),
+            plan.funding_notes().len()
+        );
+        assert!(plan.funding_notes().len() <= plan.note_split().migration_outputs().len());
+    }
+
+    #[test]
+    fn empty_balance_has_nothing_to_migrate() {
+        let backend = MockBackend::new(Vec::new(), 2_000_000);
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        assert!(matches!(
+            plan_migration(&backend, prep_fee(), &mut rng),
+            Err(MigrationError::NothingToMigrate)
+        ));
+    }
+
+    #[test]
+    fn stores_loads_and_updates_a_migration() {
+        let mut backend = MockBackend::new(Vec::new(), 0);
+        assert!(backend.load_migration().unwrap().is_none());
+
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let note_split =
+            crate::note_splitting::plan_note_split(100 * COIN, u64::from(prep_fee()), &mut rng);
+        let tx = MigrationTransaction {
+            id: MigrationTxId(0),
+            kind: MigrationTxKind::Transfer { crossing: 0 },
+            pczt: vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
+            depends_on: Vec::new(),
+            scheduled_height: BlockHeight::from_u32(2_000_100),
+            expiry_height: BlockHeight::from_u32(2_069_220),
+            anchor_boundary: None,
+            state: MigrationTxState::Signed,
+        };
+        let state = MigrationState {
+            status: MigrationStatus::Committed,
+            note_split,
+            transactions: vec![tx],
+        };
+        backend.store_migration(&state).unwrap();
+
+        // The stored transactions round-trip, and a state update persists.
+        let loaded = backend
+            .load_migration()
+            .unwrap()
+            .expect("a migration is stored");
+        assert_eq!(loaded.status, MigrationStatus::Committed);
+        assert_eq!(loaded.transactions, state.transactions);
+
+        backend
+            .update_transaction(
+                MigrationTxId(0),
+                MigrationTxState::Mined {
+                    height: BlockHeight::from_u32(2_000_105),
+                },
+            )
+            .unwrap();
+        let loaded = backend.load_migration().unwrap().unwrap();
+        assert_eq!(
+            loaded.transactions[0].state,
+            MigrationTxState::Mined {
+                height: BlockHeight::from_u32(2_000_105)
+            }
+        );
+    }
+}

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -48,6 +48,9 @@ use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
+use zcash_primitives::transaction::fees::FeeRule as _;
+use zcash_primitives::transaction::fees::{transparent, zip317};
+
 use crate::note_splitting::{NoteSplitPlan, plan_note_split};
 use crate::preparation::{PrepError, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
@@ -372,6 +375,8 @@ pub enum MigrationError<E> {
     /// The backend's note values do not form a valid balance (their sum exceeds the maximum money
     /// supply).
     InvalidBalance(BalanceError),
+    /// Computing the canonical ZIP-317 fees from the canonical transaction shapes failed.
+    Fee(zip317::FeeError),
 }
 
 impl<E: fmt::Display> fmt::Display for MigrationError<E> {
@@ -381,6 +386,7 @@ impl<E: fmt::Display> fmt::Display for MigrationError<E> {
             MigrationError::Preparation(e) => write!(f, "cannot prepare the migration: {e}"),
             MigrationError::NothingToMigrate => f.write_str("no migratable balance"),
             MigrationError::InvalidBalance(e) => write!(f, "invalid balance: {e}"),
+            MigrationError::Fee(e) => write!(f, "fee computation failed: {e}"),
         }
     }
 }
@@ -391,29 +397,69 @@ impl<E: core::error::Error + 'static> core::error::Error for MigrationError<E> {
             MigrationError::Backend(e) => Some(e),
             MigrationError::Preparation(e) => Some(e),
             MigrationError::NothingToMigrate => None,
-            // `BalanceError` implements `Error` only with `zcash_protocol/std`; the Display text
-            // above carries its message instead.
+            // `BalanceError` (and `FeeError`, which wraps it) implements `Error` only with
+            // `zcash_protocol/std`; the Display text above carries their messages instead.
             MigrationError::InvalidBalance(_) => None,
+            MigrationError::Fee(_) => None,
         }
     }
 }
 
+/// The two canonical ZIP-317 fees of a migration, computed from the canonical transaction shapes:
+/// the fee of one padded [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS)-action preparation
+/// transaction, and the transfer-fee buffer each prepared note carries (the fee of the canonical
+/// 2-Orchard + 2-Ironwood-action transfer).
+fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
+    params: &P,
+    height: BlockHeight,
+) -> Result<(Zatoshis, Zatoshis), zip317::FeeError> {
+    use crate::note_splitting::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
+    use crate::preparation::PREP_TX_ACTIONS;
+
+    let fee_rule = zip317::FeeRule::standard();
+    let prep_tx_fee = fee_rule.fee_required(
+        params,
+        height,
+        core::iter::empty::<transparent::InputSize>(),
+        core::iter::empty::<usize>(),
+        0,
+        0,
+        PREP_TX_ACTIONS,
+        0,
+    )?;
+    let transfer_fee_buffer = fee_rule.fee_required(
+        params,
+        height,
+        core::iter::empty::<transparent::InputSize>(),
+        core::iter::empty::<usize>(),
+        0,
+        0,
+        SOURCE_ACTIONS_PER_TRANSFER,
+        DESTINATION_ACTIONS_PER_TRANSFER,
+    )?;
+    Ok((prep_tx_fee, transfer_fee_buffer))
+}
+
 /// Plan a migration for the account the `backend` represents: decompose its spendable balance into
 /// canonical denominations, plan the preparation transactions that mint the self-funding notes, and
-/// schedule the phase-2 transfers. `prep_fee` is the ZIP-317 fee of a padded 16-action preparation
-/// transaction, which the note split and the preparation planner both reserve. `rng` must be a
-/// cryptographically secure RNG (the schedule's shuffle, delays, and the note split's optional
-/// randomization draw from it).
+/// schedule the phase-2 transfers. The canonical ZIP-317 fees are computed here, once, from the two
+/// canonical transaction shapes — the padded [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS)-action preparation transaction and
+/// the 2+2-action transfer — and reused throughout planning; the fee rule is fixed (ZIP 318 requires
+/// the canonical fee, since a nonstandard fee would partition the anonymity set), so it is not a
+/// parameter. The decomposition reserves the TRUE preparation cost at each step, consulting the
+/// preparation planner as it grows the split. `rng` must be a cryptographically secure RNG (the
+/// schedule's shuffle, delays, and the note split's optional randomization draw from it).
 ///
 /// This is pure orchestration of the note-split, preparation, and scheduling planners: no cryptography,
 /// and nothing is built, signed, or persisted. The result is the [`MigrationPlan`] preview to present
 /// for user consent before committing the migration.
-pub fn plan_migration<B, R>(
+pub fn plan_migration<P, B, R>(
+    params: &P,
     backend: &B,
-    prep_fee: Zatoshis,
     rng: &mut R,
 ) -> Result<MigrationPlan, MigrationError<B::Error>>
 where
+    P: zcash_protocol::consensus::Parameters,
     B: MigrationBackend,
     R: RngCore,
 {
@@ -434,28 +480,35 @@ where
         .chain_tip_height()
         .map_err(MigrationError::Backend)?;
 
+    // The canonical fees, computed once from the canonical transaction shapes and reused throughout.
+    let (prep_tx_fee, transfer_fee_buffer) =
+        canonical_fees(params, commit_height).map_err(MigrationError::Fee)?;
+
     let note_values: Vec<u64> = notes.iter().map(|&n| u64::from(n)).collect();
-    let note_split = plan_note_split(u64::from(balance), u64::from(prep_fee), rng);
-    if note_split.migration_outputs().is_empty() {
+    // The preparation-layout capability the decomposition consults at each step: how many
+    // preparation transactions minting a candidate funding multiset takes, or `None` when the
+    // wallet's notes cannot mint it (so the split stops or steps down a denomination).
+    let prep_tx_count = |funding: &[u64]| {
+        plan_preparation(&note_values, funding, u64::from(prep_tx_fee))
+            .ok()
+            .map(|plan| plan.transaction_count())
+    };
+    let note_split = plan_note_split(
+        u64::from(balance),
+        u64::from(transfer_fee_buffer),
+        u64::from(prep_tx_fee),
+        &prep_tx_count,
+        rng,
+    );
+    let funding_notes: Vec<u64> = note_split.migration_outputs();
+    if funding_notes.is_empty() {
         return Err(MigrationError::NothingToMigrate);
     }
 
-    // Reconcile the note split against the preparation fees. The split reserves for a single prep
-    // transaction, but preparation may need several; when its fees do not fit the balance, drop the
-    // smallest funding note (leaving that denomination in the source pool) and retry until it does.
-    let mut funding_notes: Vec<u64> = note_split.migration_outputs().to_vec();
-    funding_notes.sort_unstable(); // ascending, so the smallest is dropped first
-    let preparation = loop {
-        if funding_notes.is_empty() {
-            return Err(MigrationError::Preparation(PrepError::InsufficientFunds));
-        }
-        match plan_preparation(&note_values, &funding_notes, u64::from(prep_fee)) {
-            Ok(preparation) => break preparation,
-            Err(PrepError::InsufficientFunds) => {
-                funding_notes.remove(0);
-            }
-        }
-    };
+    // The decomposition verified this multiset against the preparation planner at every step, so
+    // this final planning pass succeeds by construction; the error path is kept for safety.
+    let preparation = plan_preparation(&note_values, &funding_notes, u64::from(prep_tx_fee))
+        .map_err(MigrationError::Preparation)?;
 
     let schedule = scheduling::schedule(commit_height, funding_notes.len(), rng);
 
@@ -1194,13 +1247,39 @@ mod tests {
     use rand_core::SeedableRng;
     use zcash_protocol::value::COIN;
 
-    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
-    use crate::preparation::PREP_TX_ACTIONS;
+    use zcash_protocol::local_consensus::LocalNetwork;
 
-    /// The ZIP-317 fee of a padded preparation transaction, as the engine's caller would compute it.
-    fn prep_fee() -> Zatoshis {
-        Zatoshis::from_u64(PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi())
-            .expect("the preparation fee is far below the money-supply cap")
+    use crate::preparation::FUNDING_OUTPUTS_PER_TX;
+
+    /// A local network with NU6.3 active at a low height, matching the build test network, so the
+    /// canonical fees and activation checks compute in planning tests.
+    fn test_net() -> LocalNetwork {
+        LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(2)),
+            blossom: Some(BlockHeight::from_u32(3)),
+            heartwood: Some(BlockHeight::from_u32(4)),
+            canopy: Some(BlockHeight::from_u32(5)),
+            nu5: Some(BlockHeight::from_u32(6)),
+            nu6: Some(BlockHeight::from_u32(7)),
+            nu6_1: Some(BlockHeight::from_u32(8)),
+            nu6_2: Some(BlockHeight::from_u32(9)),
+            nu6_3: Some(BlockHeight::from_u32(10)),
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: None,
+        }
+    }
+
+    /// The canonical fees on the test network, computed exactly as `plan_migration` computes them.
+    fn test_fees() -> (Zatoshis, Zatoshis) {
+        canonical_fees(&test_net(), BlockHeight::from_u32(2_000_000))
+            .expect("the canonical fees compute")
+    }
+
+    /// A count-only preparation-layout stub for tests that exercise the split in isolation: one
+    /// padded transaction per [`FUNDING_OUTPUTS_PER_TX`] funding notes.
+    fn prep_tx_count_stub(notes: &[u64]) -> Option<usize> {
+        Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
     }
 
     /// A minimal in-memory backend: a fixed set of note values and a chain tip.
@@ -1268,7 +1347,7 @@ mod tests {
         let backend = MockBackend::new(vec![100 * COIN, 40 * COIN], 2_000_000);
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let plan =
-            plan_migration(&backend, prep_fee(), &mut rng).expect("a fundable balance plans");
+            plan_migration(&test_net(), &backend, &mut rng).expect("a fundable balance plans");
 
         // Something is migrated; the schedule has one entry per funding note; the preparation mints
         // exactly the (reconciled) funding notes; and reconciliation only ever drops, never adds.
@@ -1286,7 +1365,7 @@ mod tests {
         let backend = MockBackend::new(Vec::new(), 2_000_000);
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         assert!(matches!(
-            plan_migration(&backend, prep_fee(), &mut rng),
+            plan_migration(&test_net(), &backend, &mut rng),
             Err(MigrationError::NothingToMigrate)
         ));
     }
@@ -1297,8 +1376,14 @@ mod tests {
         assert!(backend.get_migration().unwrap().is_none());
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let note_split =
-            crate::note_splitting::plan_note_split(100 * COIN, u64::from(prep_fee()), &mut rng);
+        let (prep_tx_fee, transfer_buffer) = test_fees();
+        let note_split = crate::note_splitting::plan_note_split(
+            100 * COIN,
+            u64::from(transfer_buffer),
+            u64::from(prep_tx_fee),
+            &prep_tx_count_stub,
+            &mut rng,
+        );
         let tx = MigrationTransaction {
             id: MigrationTxId(0),
             kind: MigrationTxKind::Transfer { crossing: 0 },
@@ -1358,12 +1443,18 @@ mod commit_tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, regtest_network, shared_anchor_witnesses, single_note_witness, spending_key,
     };
-    use crate::note_splitting::{FeePolicy, NoteSplitPlan, Zip317FeePolicy};
-    use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
+    use crate::note_splitting::NoteSplitPlan;
+    use crate::preparation::{PrepInput, plan_preparation};
+
+    /// The canonical fees on the regtest network at the build height, computed exactly as
+    /// `plan_migration` computes them.
+    fn commit_test_fees() -> (Zatoshis, Zatoshis) {
+        canonical_fees(&regtest_network(true), BlockHeight::from_u32(TARGET_HEIGHT))
+            .expect("the canonical fees compute")
+    }
 
     fn prep_fee() -> Zatoshis {
-        Zatoshis::from_u64(PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi())
-            .expect("the preparation fee is far below the money-supply cap")
+        commit_test_fees().0
     }
 
     /// A wallet holding the account's key and a set of note witnesses against one anchor: index 0 is the
@@ -1475,7 +1566,7 @@ mod commit_tests {
                 stored: None,
             };
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            plan_migration(&planner, prep_fee(), &mut rng).expect("plans a migration")
+            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
         };
         // A single note funding a handful of denominations needs one preparation layer.
         assert_eq!(plan.preparation().layers().len(), 1);
@@ -1697,7 +1788,7 @@ mod commit_tests {
         // 15 funding notes (one more than a single transaction's FUNDING_OUTPUTS_PER_TX) force a
         // two-layer balanced fan-out. Each is a valid self-funding note (a crossing value plus the
         // transfer fee buffer), so its transfer balances.
-        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let buffer = u64::from(commit_test_fees().1);
         let crossing = COIN; // 1 ZEC crossing per note
         let funding_note = crossing + buffer;
         let funding: Vec<u64> = core::iter::repeat_n(funding_note, 15).collect();
@@ -1719,7 +1810,7 @@ mod commit_tests {
             crossings.clone(),
             buffer,
             None,
-            u64::from(prep_fee()),
+            preparation.transaction_count() as u64 * u64::from(prep_fee()),
             whale,
             crossings.iter().sum(),
         );

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -409,22 +409,25 @@ pub trait MigrationCrypto {
     /// The account's Orchard full viewing key.
     fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
 
-    /// A current Orchard anchor to build against; every spend's witness resolves against this same tree
-    /// state. The proof is re-anchored to a drawn boundary at proving time, and the anchor is not in the
-    /// sighash, so a current or placeholder anchor is fine here.
-    fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error>;
+    /// The Orchard anchor at the tree state of `anchor_height`; every spend's witness resolves
+    /// against this same tree state. The engine passes a BOUNDARY height (see
+    /// [`crate::scheduling::most_recent_boundary`]) so witnesses are computed against the bucketed
+    /// anchor rather than whatever the wallet's default confirmation policy would choose. The proof
+    /// is re-anchored to the drawn boundary at proving time, and the anchor is not in the sighash.
+    fn orchard_anchor(&self, anchor_height: BlockHeight) -> Result<orchard::Anchor, Self::Error>;
 
-    /// A recent Ironwood anchor for a transfer's destination bundle: the output-only bundle's dummy
-    /// spends carry this anchor, and consensus requires a recent Ironwood note-commitment-tree root
-    /// (the empty-tree root is valid only until the pool holds notes).
-    fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error>;
+    /// The Ironwood anchor at the tree state of `anchor_height`, for a transfer's destination
+    /// bundle: the output-only bundle's dummy spends carry this anchor, and consensus requires a
+    /// recent Ironwood note-commitment-tree root (the empty-tree root is valid only until the pool
+    /// holds notes).
+    fn ironwood_anchor(&self, anchor_height: BlockHeight) -> Result<orchard::Anchor, Self::Error>;
 
     /// Resolve the spendable wallet note at `index` (into `spendable_orchard_note_values`) to its note
     /// and a witness against `anchor`.
     fn resolve_wallet_note(
         &self,
         index: usize,
-        anchor: orchard::Anchor,
+        anchor_height: BlockHeight,
     ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error>;
 
     /// Resolve the self-funding notes minted by the preparation, one per requested value, each to its
@@ -435,7 +438,7 @@ pub trait MigrationCrypto {
     fn resolve_funding_notes(
         &self,
         values: &[Zatoshis],
-        anchor: orchard::Anchor,
+        anchor_height: BlockHeight,
     ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error>;
 
     /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
@@ -629,7 +632,11 @@ where
     use zcash_protocol::consensus::NetworkUpgrade;
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
+    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
+    let anchor_height = scheduling::most_recent_boundary(target_height);
+    let anchor = backend
+        .orchard_anchor(anchor_height)
+        .map_err(CommitError::Backend)?;
     let expiry_height = crate::scheduling::expiry_height(target_height);
     let nu63_activation = params
         .activation_height(NetworkUpgrade::Nu6_3)
@@ -656,7 +663,7 @@ where
                     match input {
                         PrepInput::Wallet { index, .. } => {
                             let witness = backend
-                                .resolve_wallet_note(*index, anchor)
+                                .resolve_wallet_note(*index, anchor_height)
                                 .map_err(CommitError::Backend)?;
                             spends.push(witness);
                         }
@@ -849,7 +856,11 @@ where
     };
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
+    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
+    let anchor_height = scheduling::most_recent_boundary(target_height);
+    let anchor = backend
+        .orchard_anchor(anchor_height)
+        .map_err(CommitError::Backend)?;
     let expiry_height = crate::scheduling::expiry_height(target_height);
 
     // The (index-into-transactions, plan layer/index) of every still-Planned transaction of the ready
@@ -881,7 +892,7 @@ where
         .collect::<Result<Vec<_>, _>>()
         .map_err(|_| CommitError::Build("prior input value out of range".into()))?;
     let mut prior_notes = backend
-        .resolve_funding_notes(&prior_values, anchor)
+        .resolve_funding_notes(&prior_values, anchor_height)
         .map_err(CommitError::Backend)?
         .into_iter();
 
@@ -892,7 +903,7 @@ where
             match input {
                 PrepInput::Wallet { index, .. } => {
                     let witness = backend
-                        .resolve_wallet_note(*index, anchor)
+                        .resolve_wallet_note(*index, anchor_height)
                         .map_err(CommitError::Backend)?;
                     spends.push(witness);
                 }
@@ -1021,10 +1032,16 @@ where
     let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
-    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
-    let ironwood_anchor = backend.ironwood_anchor().map_err(CommitError::Backend)?;
+    // Witness against the BUCKETED anchor: the most recent boundary at the build height.
+    let anchor_height = scheduling::most_recent_boundary(target_height);
+    let anchor = backend
+        .orchard_anchor(anchor_height)
+        .map_err(CommitError::Backend)?;
+    let ironwood_anchor = backend
+        .ironwood_anchor(anchor_height)
+        .map_err(CommitError::Backend)?;
     let witnesses = backend
-        .resolve_funding_notes(&state.funding_notes, anchor)
+        .resolve_funding_notes(&state.funding_notes, anchor_height)
         .map_err(CommitError::Backend)?;
 
     // The fee buffer each self-funding note carries (its value minus the value that crosses) is constant
@@ -1315,18 +1332,24 @@ mod commit_tests {
             Ok(self.fvk.clone())
         }
 
-        fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+        fn orchard_anchor(
+            &self,
+            _anchor_height: BlockHeight,
+        ) -> Result<orchard::Anchor, Self::Error> {
             Ok(self.anchor)
         }
 
-        fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+        fn ironwood_anchor(
+            &self,
+            _anchor_height: BlockHeight,
+        ) -> Result<orchard::Anchor, Self::Error> {
             Ok(self.anchor)
         }
 
         fn resolve_wallet_note(
             &self,
             index: usize,
-            _anchor: orchard::Anchor,
+            _anchor_height: BlockHeight,
         ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
             Ok(self.witnesses[index].clone())
         }
@@ -1334,7 +1357,7 @@ mod commit_tests {
         fn resolve_funding_notes(
             &self,
             values: &[Zatoshis],
-            _anchor: orchard::Anchor,
+            _anchor_height: BlockHeight,
         ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
             // The funding notes are the witnesses after the source note (index 0).
             Ok(self.witnesses[1..1 + values.len()].to_vec())
@@ -1525,18 +1548,24 @@ mod commit_tests {
             Ok(self.fvk.clone())
         }
 
-        fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+        fn orchard_anchor(
+            &self,
+            _anchor_height: BlockHeight,
+        ) -> Result<orchard::Anchor, Self::Error> {
             Ok(self.anchor)
         }
 
-        fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+        fn ironwood_anchor(
+            &self,
+            _anchor_height: BlockHeight,
+        ) -> Result<orchard::Anchor, Self::Error> {
             Ok(self.anchor)
         }
 
         fn resolve_wallet_note(
             &self,
             index: usize,
-            _anchor: orchard::Anchor,
+            _anchor_height: BlockHeight,
         ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
             Ok(self.witnesses[index].clone())
         }
@@ -1544,7 +1573,7 @@ mod commit_tests {
         fn resolve_funding_notes(
             &self,
             values: &[Zatoshis],
-            _anchor: orchard::Anchor,
+            _anchor_height: BlockHeight,
         ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
             // By-value greedy over the minted notes (index >= n_wallet), with a persistent used-set so
             // successive resolutions (a layer's feeders, then a later layer's, then the funding notes)

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -184,6 +184,11 @@ pub struct MigrationState {
     /// transaction spends `funding_notes[crossing]` and crosses `funding_notes[crossing]` minus the fee
     /// buffer into the destination pool.
     pub funding_notes: Vec<Zatoshis>,
+    /// The preparation plan (its layers and direct-funding notes), retained so the deferred preparation
+    /// layers can be rebuilt after their prior layer mines (see
+    /// [`commit_pending_preparation`]). A `Preparation { layer, index }` transaction's spends resolve
+    /// against `preparation.layers()[layer][index]`.
+    pub preparation: PreparationPlan,
     /// Every migration transaction, in dependency order.
     pub transactions: Vec<MigrationTransaction>,
 }
@@ -390,10 +395,10 @@ pub enum CommitError<E> {
     Backend(E),
     /// Building or serializing a transaction failed.
     Build(alloc::string::String),
-    /// The plan needs multi-layer preparation. Pre-signing a later layer requires the output notes of
-    /// an earlier, unmined layer, which cannot yet be recovered from a built PCZT, so two-phase signing
-    /// commits only single-layer preparation. Full one-session pre-signing awaits a public pczt
-    /// output-recovery API.
+    /// Retained for API compatibility; no longer returned. Multi-layer preparation is now committed
+    /// phase by phase: [`commit_preparation`] signs layer 0 and [`commit_pending_preparation`] signs
+    /// each later layer once its predecessor mines, so a plan whose later layers spend earlier layers'
+    /// outputs is fully supported.
     UnsupportedMultiLayer,
     /// No committed migration was found to build the transfers for (nothing was loaded from storage).
     NoMigrationInProgress,
@@ -418,13 +423,19 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
 #[cfg(feature = "orchard")]
 impl<E: core::error::Error> core::error::Error for CommitError<E> {}
 
-/// Commit a planned migration's PREPARATION: build every preparation transaction, pre-sign it with the
-/// account's spend authorization, and persist it (as its serialized PCZT and metadata) through the
-/// backend, so the application can broadcast the preparation and, once it is mined, build and sign the
-/// transfers (the second phase). This is the two-phase signing path (ZIP 318 permits more than one
-/// signing session); it handles single-layer preparation, the common case, and reports
-/// [`CommitError::UnsupportedMultiLayer`] for a plan whose later layers spend earlier layers' still
-/// unmined outputs.
+/// Commit a planned migration's PREPARATION: build and pre-sign the FIRST layer of preparation
+/// transactions (the ones that spend the wallet's own notes) with the account's spend authorization,
+/// record every later preparation layer and every transfer as an unbuilt placeholder, and persist the
+/// whole committed migration through the backend. This is the two-phase (in general, multi-phase)
+/// signing path that ZIP 318 permits: the application broadcasts layer 0, and once a layer is mined the
+/// engine builds and signs the next one (see [`commit_pending_preparation`]) whose spends reference
+/// that layer's now-witnessable feeder notes, until the whole preparation is mined and the transfers
+/// are built (see [`commit_transfers`]).
+///
+/// A single-layer plan (the common case: a few wallet notes fanning into a handful of funding notes)
+/// signs its one layer here and records only the transfer placeholders; nothing is deferred. A
+/// multi-layer plan (a lone whale fanning out, or a dust-heavy balance) signs layer 0 here and defers
+/// the rest.
 ///
 /// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
 /// `rng` a cryptographically secure RNG.
@@ -453,56 +464,94 @@ where
 
     let mut transactions: Vec<MigrationTransaction> = Vec::new();
     let mut next_id = 0u32;
+    // The transaction ids assigned to each preparation layer, so a later layer's placeholder can depend
+    // on the whole layer before it, and the transfers can depend on the last preparation layer.
+    let mut layer_ids: Vec<Vec<MigrationTxId>> = Vec::new();
 
     for (layer, prep_layer) in plan.preparation().layers().iter().enumerate() {
+        let mut this_layer_ids: Vec<MigrationTxId> = Vec::with_capacity(prep_layer.len());
         for (index, prep_tx) in prep_layer.iter().enumerate() {
-            let mut spends = Vec::with_capacity(prep_tx.inputs().len());
-            for input in prep_tx.inputs() {
-                match input {
-                    PrepInput::Wallet { index, .. } => {
-                        let witness = backend
-                            .resolve_wallet_note(*index, anchor)
-                            .map_err(CommitError::Backend)?;
-                        spends.push(witness);
-                    }
-                    // Two-phase signing cannot pre-sign a spend of an earlier layer's unmined output.
-                    PrepInput::Prior { .. } => return Err(CommitError::UnsupportedMultiLayer),
-                }
-            }
-
-            let (pczt, _placed) = build_prep_tx(
-                params,
-                u32::from(target_height),
-                &fvk,
-                anchor,
-                spends,
-                prep_tx.outputs(),
-                &mut *rng,
-            )
-            .map_err(|e| CommitError::Build(format!("{e}")))?;
-
-            let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
-            let bytes = signed
-                .serialize()
-                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
-
-            transactions.push(MigrationTransaction {
-                id: MigrationTxId(next_id),
-                kind: MigrationTxKind::Preparation { layer, index },
-                pczt: Some(bytes),
-                depends_on: Vec::new(),
-                scheduled_height: target_height,
-                expiry_height,
-                anchor_boundary: None,
-                state: MigrationTxState::Signed,
-            });
+            let id = MigrationTxId(next_id);
             next_id += 1;
+            this_layer_ids.push(id);
+
+            if layer == 0 {
+                // Layer 0 spends only the wallet's own notes, so it is built and pre-signed now.
+                let mut spends = Vec::with_capacity(prep_tx.inputs().len());
+                for input in prep_tx.inputs() {
+                    match input {
+                        PrepInput::Wallet { index, .. } => {
+                            let witness = backend
+                                .resolve_wallet_note(*index, anchor)
+                                .map_err(CommitError::Backend)?;
+                            spends.push(witness);
+                        }
+                        // A layer-0 transaction spends only wallet notes; a Prior input here is a
+                        // planner bug (the layered planner puts every Prior input in a later layer).
+                        PrepInput::Prior { .. } => {
+                            return Err(CommitError::Build(
+                                "layer 0 preparation transaction spends a prior-layer output"
+                                    .into(),
+                            ));
+                        }
+                    }
+                }
+
+                let (pczt, _placed) = build_prep_tx(
+                    params,
+                    u32::from(target_height),
+                    &fvk,
+                    anchor,
+                    spends,
+                    prep_tx.outputs(),
+                    &mut *rng,
+                )
+                .map_err(|e| CommitError::Build(format!("{e}")))?;
+
+                let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+                let bytes = signed
+                    .serialize()
+                    .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+
+                transactions.push(MigrationTransaction {
+                    id,
+                    kind: MigrationTxKind::Preparation { layer, index },
+                    pczt: Some(bytes),
+                    depends_on: Vec::new(),
+                    scheduled_height: target_height,
+                    expiry_height,
+                    anchor_boundary: None,
+                    state: MigrationTxState::Signed,
+                });
+            } else {
+                // A later layer spends the previous layer's feeder notes, which are not witnessable
+                // until that layer is mined. Record it as an unbuilt placeholder depending on the whole
+                // immediately-prior layer; `commit_pending_preparation` builds and signs it once its
+                // dependencies mine. The height fields are placeholders (a preparation transaction waits
+                // for its dependencies, not a fixed height); the real ones are set at build time.
+                let depends_on = layer_ids
+                    .last()
+                    .cloned()
+                    .expect("a layer after layer 0 has a preceding layer");
+                transactions.push(MigrationTransaction {
+                    id,
+                    kind: MigrationTxKind::Preparation { layer, index },
+                    pczt: None,
+                    depends_on,
+                    scheduled_height: target_height,
+                    expiry_height,
+                    anchor_boundary: None,
+                    state: MigrationTxState::Planned,
+                });
+            }
         }
+        layer_ids.push(this_layer_ids);
     }
 
-    // Every transfer waits for the whole preparation to be mined, so its funding note exists on chain
-    // and can be witnessed before the transfer is built and broadcast.
-    let prep_ids: Vec<MigrationTxId> = transactions.iter().map(|tx| tx.id).collect();
+    // Every transfer waits for the last preparation layer to be mined: a layer is broadcast only after
+    // its predecessor mines, so the last layer mining implies every layer (hence every funding note) is
+    // mined and witnessable. An empty preparation (every funding note used directly) leaves this empty.
+    let last_layer_ids: Vec<MigrationTxId> = layer_ids.last().cloned().unwrap_or_default();
 
     // Record each transfer as a Planned placeholder carrying its schedule; its PCZT is built and
     // signed later, once the preparation is mined (see `commit_transfers`). This persists the drawn
@@ -513,7 +562,7 @@ where
             id: MigrationTxId(next_id),
             kind: MigrationTxKind::Transfer { crossing },
             pczt: None,
-            depends_on: prep_ids.clone(),
+            depends_on: last_layer_ids.clone(),
             scheduled_height: schedule.broadcast_height(),
             expiry_height: schedule.expiry_height(),
             anchor_boundary: None,
@@ -526,8 +575,169 @@ where
         status: MigrationStatus::Committed,
         note_split: plan.note_split().clone(),
         funding_notes,
+        preparation: plan.preparation().clone(),
         transactions,
     };
+    backend
+        .put_migration(&state)
+        .map_err(CommitError::Backend)?;
+    Ok(state)
+}
+
+/// Build and pre-sign the next READY preparation layer: the deferred second phase of committing a
+/// multi-layer preparation. A later preparation layer spends the previous layer's feeder notes, which
+/// become witnessable only after that layer is mined, so [`commit_preparation`] records those layers as
+/// unbuilt placeholders and this function fills them in once their dependencies mine.
+///
+/// Loads the committed migration, finds the earliest still-`Planned` preparation layer (a `layer > 0`)
+/// whose whole immediately-prior layer is [`Mined`](MigrationTxState::Mined), builds and pre-signs
+/// EVERY transaction of that one layer (resolving each transaction's [`PrepInput::Prior`] spends to the
+/// prior layer's now-witnessable feeder notes by value), and persists the result. If no layer is ready
+/// (the next layer's dependencies are not all mined, or every preparation layer is already built), it
+/// returns the migration unchanged, so a caller can poll it. Call it once per newly-mined layer until
+/// the whole preparation is built, then [`commit_transfers`] for the transfers.
+///
+/// All the transactions of the one ready layer are resolved together in a single funding-note lookup,
+/// so each feeder note is assigned to exactly one transaction (a note is spent at most once) even when
+/// two transactions in the layer request equal-valued feeders.
+///
+/// `params` is the network, `target_height` the height the layer's transactions are built at, and `rng`
+/// a cryptographically secure RNG.
+#[cfg(feature = "orchard")]
+pub fn commit_pending_preparation<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    rng: &mut R,
+) -> Result<MigrationState, CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
+    use crate::build::build_prep_tx;
+    use crate::preparation::PrepInput;
+
+    let mut state = backend
+        .get_migration()
+        .map_err(CommitError::Backend)?
+        .ok_or(CommitError::NoMigrationInProgress)?;
+
+    // A stored transaction is Mined iff its state says so; a layer is ready once every dependency is.
+    let is_mined = |id: MigrationTxId, txs: &[MigrationTransaction]| -> bool {
+        txs.iter()
+            .find(|t| t.id == id)
+            .is_some_and(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+    };
+
+    // Find the earliest still-Planned preparation layer (layer > 0) whose dependencies are all mined.
+    let ready_layer = state
+        .transactions
+        .iter()
+        .filter_map(|tx| match tx.kind {
+            MigrationTxKind::Preparation { layer, .. }
+                if layer > 0
+                    && matches!(tx.state, MigrationTxState::Planned)
+                    && tx
+                        .depends_on
+                        .iter()
+                        .all(|d| is_mined(*d, &state.transactions)) =>
+            {
+                Some(layer)
+            }
+            _ => None,
+        })
+        .min();
+
+    let Some(ready_layer) = ready_layer else {
+        // Nothing to build this step (the next layer is not mined yet, or all layers are built).
+        return Ok(state);
+    };
+
+    let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
+    let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
+    let expiry_height = crate::scheduling::expiry_height(target_height);
+
+    // The (index-into-transactions, plan layer/index) of every still-Planned transaction of the ready
+    // layer, in plan order, so the built PCZTs go back into the right rows.
+    let mut targets: Vec<(usize, usize)> = Vec::new(); // (transactions index, plan tx index)
+    for (ti, tx) in state.transactions.iter().enumerate() {
+        if let MigrationTxKind::Preparation { layer, index } = tx.kind {
+            if layer == ready_layer && matches!(tx.state, MigrationTxState::Planned) {
+                targets.push((ti, index));
+            }
+        }
+    }
+
+    // Collect every Prior-input value of the whole ready layer, in transaction-then-input order, and
+    // resolve them together so each feeder note (distinct by tree position, even at equal value) is
+    // matched to exactly one spend across the layer. Wallet inputs (not expected past layer 0) resolve
+    // individually.
+    let mut prior_values: Vec<u64> = Vec::new();
+    for &(_, plan_index) in &targets {
+        for input in state.preparation.layers()[ready_layer][plan_index].inputs() {
+            if let PrepInput::Prior { value, .. } = input {
+                prior_values.push(*value);
+            }
+        }
+    }
+    let prior_values = prior_values
+        .into_iter()
+        .map(Zatoshis::from_u64)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| CommitError::Build("prior input value out of range".into()))?;
+    let mut prior_notes = backend
+        .resolve_funding_notes(&prior_values, anchor)
+        .map_err(CommitError::Backend)?
+        .into_iter();
+
+    for &(ti, plan_index) in &targets {
+        let prep_tx = &state.preparation.layers()[ready_layer][plan_index];
+        let mut spends = Vec::with_capacity(prep_tx.inputs().len());
+        for input in prep_tx.inputs() {
+            match input {
+                PrepInput::Wallet { index, .. } => {
+                    let witness = backend
+                        .resolve_wallet_note(*index, anchor)
+                        .map_err(CommitError::Backend)?;
+                    spends.push(witness);
+                }
+                PrepInput::Prior { .. } => {
+                    let note = prior_notes.next().ok_or_else(|| {
+                        CommitError::Build("fewer resolved feeder notes than prior inputs".into())
+                    })?;
+                    spends.push(note);
+                }
+            }
+        }
+
+        let outputs = prep_tx.outputs().to_vec();
+        let (pczt, _placed) = build_prep_tx(
+            params,
+            u32::from(target_height),
+            &fvk,
+            anchor,
+            spends,
+            &outputs,
+            &mut *rng,
+        )
+        .map_err(|e| CommitError::Build(format!("{e}")))?;
+
+        let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+        let bytes = signed
+            .serialize()
+            .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+
+        let tx = &mut state.transactions[ti];
+        tx.pczt = Some(bytes);
+        tx.scheduled_height = target_height;
+        tx.expiry_height = expiry_height;
+        tx.state = MigrationTxState::Signed;
+    }
+
     backend
         .put_migration(&state)
         .map_err(CommitError::Backend)?;
@@ -751,6 +961,7 @@ mod tests {
             status: MigrationStatus::Committed,
             note_split,
             funding_notes: Vec::new(),
+            preparation: crate::preparation::PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions: vec![tx],
         };
         backend.put_migration(&state).unwrap();
@@ -784,6 +995,7 @@ mod tests {
 #[cfg(all(test, feature = "orchard"))]
 mod commit_tests {
     use super::*;
+    use core::cell::RefCell;
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
     use zcash_protocol::value::COIN;
@@ -794,8 +1006,8 @@ mod commit_tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, regtest_network, shared_anchor_witnesses, single_note_witness, spending_key,
     };
-    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
-    use crate::preparation::PREP_TX_ACTIONS;
+    use crate::note_splitting::{FeePolicy, NoteSplitPlan, Zip317FeePolicy};
+    use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
 
     fn prep_fee() -> Zatoshis {
         Zatoshis::from_u64(PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi())
@@ -979,5 +1191,348 @@ mod commit_tests {
             assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
         }
         assert!(backend.get_migration().unwrap().is_some());
+    }
+
+    /// A wallet mock for the MULTI-LAYER preparation test. The first `n_wallet` witnesses are the
+    /// wallet notes (resolved by index for layer 0); the rest are the notes later layers and the
+    /// transfers mint (feeders, then funding notes), resolved by value. A persistent `used` set models
+    /// a real wallet where a spent note leaves the spendable set, so a feeder consumed by one layer is
+    /// never handed to a later resolution again. The store is real, so mining a layer persists.
+    struct LayeredMock {
+        n_wallet: usize,
+        witnesses: Vec<(orchard::note::Note, orchard::tree::MerklePath)>,
+        used: RefCell<Vec<bool>>,
+        anchor: orchard::Anchor,
+        fvk: FullViewingKey,
+        ask: SpendAuthorizingKey,
+        stored: Option<MigrationState>,
+    }
+
+    impl MigrationBackend for LayeredMock {
+        type Error = core::convert::Infallible;
+
+        fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+            Ok(self.witnesses[..self.n_wallet]
+                .iter()
+                .map(|(n, _)| {
+                    Zatoshis::from_u64(n.value().inner()).expect("test note values are valid")
+                })
+                .collect())
+        }
+
+        fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+            Ok(BlockHeight::from_u32(2_000_000))
+        }
+    }
+
+    impl PoolMigrationRead for LayeredMock {
+        type Error = core::convert::Infallible;
+
+        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(self.stored.clone())
+        }
+    }
+
+    impl PoolMigrationWrite for LayeredMock {
+        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+            self.stored = Some(state.clone());
+            Ok(())
+        }
+
+        fn update_transaction(
+            &mut self,
+            id: MigrationTxId,
+            state: MigrationTxState,
+        ) -> Result<(), Self::Error> {
+            if let Some(stored) = &mut self.stored {
+                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
+                    tx.state = state;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    impl MigrationCrypto for LayeredMock {
+        type Error = core::convert::Infallible;
+
+        fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
+            Ok(self.fvk.clone())
+        }
+
+        fn orchard_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+            Ok(self.anchor)
+        }
+
+        fn ironwood_anchor(&self) -> Result<orchard::Anchor, Self::Error> {
+            Ok(self.anchor)
+        }
+
+        fn resolve_wallet_note(
+            &self,
+            index: usize,
+            _anchor: orchard::Anchor,
+        ) -> Result<(orchard::note::Note, orchard::tree::MerklePath), Self::Error> {
+            Ok(self.witnesses[index].clone())
+        }
+
+        fn resolve_funding_notes(
+            &self,
+            values: &[Zatoshis],
+            _anchor: orchard::Anchor,
+        ) -> Result<Vec<(orchard::note::Note, orchard::tree::MerklePath)>, Self::Error> {
+            // By-value greedy over the minted notes (index >= n_wallet), with a persistent used-set so
+            // successive resolutions (a layer's feeders, then a later layer's, then the funding notes)
+            // never reuse a note. Notes of equal value are interchangeable, so first-unused is correct.
+            let mut used = self.used.borrow_mut();
+            let mut out = Vec::with_capacity(values.len());
+            for &v in values {
+                let idx = (self.n_wallet..self.witnesses.len())
+                    .find(|&i| !used[i] && self.witnesses[i].0.value().inner() == u64::from(v))
+                    .expect("a minted note of the requested value exists");
+                used[idx] = true;
+                out.push(self.witnesses[idx].clone());
+            }
+            Ok(out)
+        }
+
+        fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
+            Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
+        }
+    }
+
+    /// A lone whale fanning out into more funding notes than one transaction holds needs a MULTI-LAYER
+    /// preparation. Layer 0 (spending the whale) is signed at commit time; the later layer, which
+    /// spends layer 0's feeder notes, is a placeholder until layer 0 mines, at which point
+    /// `commit_pending_preparation` builds and signs it; then the transfers build once the whole
+    /// preparation is mined. This exercises the phased per-layer commit end to end.
+    #[test]
+    fn commits_multi_layer_preparation_phase_by_phase() {
+        let seed = 11u64;
+        let sk = spending_key(seed);
+        let fvk = FullViewingKey::from(&sk);
+
+        // 15 funding notes (one more than a single transaction's FUNDING_OUTPUTS_PER_TX) force a
+        // two-layer balanced fan-out. Each is a valid self-funding note (a crossing value plus the
+        // transfer fee buffer), so its transfer balances.
+        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let crossing = COIN; // 1 ZEC crossing per note
+        let funding_note = crossing + buffer;
+        let funding: Vec<u64> = core::iter::repeat_n(funding_note, 15).collect();
+
+        // A whale generously larger than the balanced-tree cost, so the fan-out fast path triggers.
+        let whale = funding.iter().sum::<u64>() + 16 * u64::from(prep_fee());
+        let preparation = plan_preparation(&[whale], &funding, u64::from(prep_fee()))
+            .expect("a fundable whale plans");
+        assert_eq!(
+            preparation.layers().len(),
+            2,
+            "15 funding notes fan out across two layers"
+        );
+
+        // A note split whose outputs are the funding notes and whose crossings are those less the
+        // buffer, so the engine derives the same buffer and each transfer crosses one ZEC.
+        let crossings: Vec<u64> = funding.iter().map(|&f| f - buffer).collect();
+        let note_split = NoteSplitPlan::from_stored_parts(
+            crossings.clone(),
+            buffer,
+            None,
+            u64::from(prep_fee()),
+            whale,
+            crossings.iter().sum(),
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let schedule =
+            crate::scheduling::schedule(BlockHeight::from_u32(2_000_000), funding.len(), &mut rng);
+        let plan = MigrationPlan {
+            note_split,
+            funding_notes: funding
+                .iter()
+                .map(|&v| Zatoshis::from_u64(v).expect("test funding values are valid"))
+                .collect(),
+            preparation,
+            schedule,
+        };
+
+        // The shared-anchor witness pool: the whale, then every feeder a later layer spends (in the
+        // order `commit_pending_preparation` requests them), then the funding notes. All are leaves of
+        // one tree, so every spend across every layer and transfer anchors to the same root.
+        let mut feeder_values: Vec<u64> = Vec::new();
+        for (li, layer) in plan.preparation().layers().iter().enumerate() {
+            if li == 0 {
+                continue;
+            }
+            for tx in layer {
+                for input in tx.inputs() {
+                    if let PrepInput::Prior { value, .. } = input {
+                        feeder_values.push(*value);
+                    }
+                }
+            }
+        }
+        let mut pool_values = vec![whale];
+        pool_values.extend_from_slice(&feeder_values);
+        pool_values.extend_from_slice(&funding);
+        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &pool_values, seed);
+
+        let used = RefCell::new(vec![false; witnesses.len()]);
+        let mut backend = LayeredMock {
+            n_wallet: 1, // the whale
+            witnesses,
+            used,
+            anchor,
+            fvk: fvk.clone(),
+            ask: SpendAuthorizingKey::from(&sk),
+            stored: None,
+        };
+        let params = regtest_network(true);
+
+        let prep_count = plan.preparation().transaction_count();
+        let transfer_count = funding.len();
+
+        // Phase 1: commit the preparation. Layer 0 is signed; the later layer and the transfers are
+        // planned placeholders.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the preparation");
+        assert_eq!(state.transactions.len(), prep_count + transfer_count);
+        let layer0: Vec<&MigrationTransaction> = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
+            .collect();
+        assert_eq!(layer0.len(), 1, "one root transaction in layer 0");
+        assert_eq!(layer0[0].state, MigrationTxState::Signed);
+        assert!(layer0[0].pczt.is_some());
+        for tx in &state.transactions {
+            if let MigrationTxKind::Preparation { layer, .. } = tx.kind {
+                if layer > 0 {
+                    assert_eq!(tx.state, MigrationTxState::Planned, "later layer deferred");
+                    assert!(tx.pczt.is_none());
+                    assert!(
+                        !tx.depends_on.is_empty(),
+                        "later layer waits for its predecessor"
+                    );
+                }
+            }
+        }
+
+        // The plan round-trips through the persisted state.
+        assert_eq!(state.preparation.layers().len(), 2);
+
+        // Before layer 0 is mined, there is nothing to build.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        let state = commit_pending_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &mut rng,
+        )
+        .expect("no ready layer is a no-op");
+        assert!(
+            state.transactions.iter().any(
+                |t| matches!(t.kind, MigrationTxKind::Preparation { layer, .. } if layer > 0)
+                    && matches!(t.state, MigrationTxState::Planned)
+            ),
+            "the later layer is still planned until layer 0 mines"
+        );
+
+        // Mine layer 0.
+        let layer0_ids: Vec<MigrationTxId> = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id)
+            .collect();
+        for id in &layer0_ids {
+            backend
+                .update_transaction(
+                    *id,
+                    MigrationTxState::Mined {
+                        height: BlockHeight::from_u32(2_000_010),
+                    },
+                )
+                .unwrap();
+        }
+
+        // Phase 2: the later layer is now ready; build and sign it.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 3);
+        let state = commit_pending_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT + 5),
+            &mut backend,
+            &mut rng,
+        )
+        .expect("builds the ready layer");
+        for tx in &state.transactions {
+            if let MigrationTxKind::Preparation { layer, .. } = tx.kind {
+                if layer > 0 {
+                    assert_eq!(tx.state, MigrationTxState::Signed, "later layer now signed");
+                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
+                }
+            }
+        }
+
+        // Calling again with no further ready layer is a no-op.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 4);
+        let state = commit_pending_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT + 6),
+            &mut backend,
+            &mut rng,
+        )
+        .expect("no further ready layer");
+        assert!(
+            state.transactions.iter().all(|t| !matches!(
+                t.kind,
+                MigrationTxKind::Preparation { layer, .. } if layer > 0
+            ) || matches!(t.state, MigrationTxState::Signed)),
+            "every preparation layer is signed"
+        );
+
+        // Mine the whole preparation, then commit the transfers.
+        let prep_ids: Vec<MigrationTxId> = state
+            .transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+            .map(|t| t.id)
+            .collect();
+        for id in &prep_ids {
+            backend
+                .update_transaction(
+                    *id,
+                    MigrationTxState::Mined {
+                        height: BlockHeight::from_u32(2_000_020),
+                    },
+                )
+                .unwrap();
+        }
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 5);
+        let state = commit_transfers(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT + 7),
+            &mut backend,
+            &mut rng,
+        )
+        .expect("commits the transfers");
+        assert_eq!(state.transactions.len(), prep_count + transfer_count);
+        for tx in &state.transactions {
+            match tx.kind {
+                MigrationTxKind::Transfer { .. } => {
+                    assert_eq!(tx.state, MigrationTxState::Signed, "transfer signed");
+                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
+                }
+                MigrationTxKind::Preparation { .. } => {
+                    assert!(tx.pczt.as_ref().is_some_and(|b| !b.is_empty()));
+                }
+            }
+        }
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -388,7 +388,10 @@ impl MigrationPlan {
         &self.prep_schedule
     }
 
-    /// The phase-2 transfer schedule, one entry per funding note (its broadcast height and expiry).
+    /// The phase-2 transfer schedule, one entry per funding note (its broadcast height and
+    /// expiry), in SHUFFLED broadcast order (ZIP 318): the heights are deliberately not monotone
+    /// in crossing index, so the on-chain temporal sequence of denominations is independent of
+    /// the balance.
     pub fn schedule(&self) -> &[Schedule] {
         &self.schedule
     }
@@ -574,7 +577,20 @@ where
         nu63_activation,
         est_last_prep_height,
     ));
-    let schedule = scheduling::schedule(schedule_base, funding_notes.len(), rng);
+    // SHUFFLE (ZIP 318 MUST): the cumulative broadcast heights are non-decreasing in draw
+    // order, and the split's crossing values are a non-increasing function of the balance, so
+    // pairing them in order would broadcast the denominations largest-first — an on-chain
+    // temporal sequence an observer could read the balance back out of. Drawing a uniform
+    // permutation and assigning the i-th drawn slot to the permuted crossing makes the
+    // broadcast order of denominations independent of the balance.
+    let slots = scheduling::schedule(schedule_base, funding_notes.len(), rng);
+    let mut schedule = slots.clone();
+    for (slot, &crossing) in scheduling::shuffle_indices(funding_notes.len(), rng)
+        .iter()
+        .enumerate()
+    {
+        schedule[crossing] = slots[slot];
+    }
 
     Ok(MigrationPlan {
         note_split,
@@ -1487,6 +1503,33 @@ mod tests {
             plan.funding_notes().len()
         );
         assert!(plan.funding_notes().len() <= plan.note_split().migration_outputs().len());
+    }
+
+    /// SHUFFLE (ZIP 318): the crossings are non-increasing, so an unshuffled schedule would
+    /// pair them with non-decreasing broadcast heights and the on-chain temporal sequence of
+    /// denominations would spell out the balance. The drawn permutation makes the heights
+    /// non-monotone in crossing index (deterministic for this seed).
+    #[test]
+    fn transfer_schedule_is_shuffled() {
+        // A balance that splits into several denominations, so the order is observable.
+        let backend = MockBackend::new(vec![78 * COIN], 2_000_000);
+        let mut rng = ChaCha8Rng::seed_from_u64(3);
+        let plan =
+            plan_migration(&test_net(), &backend, &mut rng).expect("a fundable balance plans");
+        assert!(
+            plan.funding_notes().len() >= 4,
+            "the balance splits into several transfers: {}",
+            plan.funding_notes().len()
+        );
+        let heights: Vec<u32> = plan
+            .schedule()
+            .iter()
+            .map(|s| u32::from(s.broadcast_height()))
+            .collect();
+        assert!(
+            heights.windows(2).any(|w| w[0] > w[1]),
+            "the transfer broadcast order is shuffled: {heights:?}"
+        );
     }
 
     #[test]

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -43,6 +43,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use rand_core::RngCore;
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
@@ -96,7 +97,11 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     ) -> Result<(), Self::Error>;
 }
 
-/// A stable identifier for a migration transaction within a migration.
+/// A stable ordinal identifier for a migration transaction within a migration. This is a ROW KEY
+/// into the persisted migration (usable before a transaction is built, when no [`TxId`] exists yet:
+/// deferred preparation layers and transfers are recorded as unbuilt placeholders); it is NOT a
+/// Zcash transaction id. The real [`TxId`] becomes available once a transaction is built and signed
+/// (it commits only effecting data), and is carried by [`MigrationTxState::Broadcast`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MigrationTxId(pub u32);
 
@@ -126,7 +131,7 @@ pub enum MigrationTxState {
     /// Proved against a real anchor, ready to broadcast.
     Proved,
     /// Broadcast to the network, with its transaction id.
-    Broadcast { txid: [u8; 32] },
+    Broadcast { txid: TxId },
     /// Mined at the given height.
     Mined { height: BlockHeight },
     /// Expired before it could be mined, and to be rebuilt.

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -114,6 +114,13 @@ pub enum MigrationTxKind {
 pub enum MigrationTxState {
     /// Built but not yet signed.
     Planned,
+    /// Built and awaiting an EXTERNAL signature: its UNSIGNED PCZT is held in
+    /// [`pczt`](MigrationTransaction::pczt), exported for a hardware or offline signer.
+    /// [`apply_signature`](MigrationState::apply_signature) moves it to [`Signed`](Self::Signed) once the
+    /// signed PCZT is returned. Only the external-signing path
+    /// ([`build_preparation_unsigned`]/[`build_transfers_unsigned`]) produces this state; the in-process
+    /// commit functions sign immediately and go straight to [`Signed`](Self::Signed).
+    AwaitingSignature,
     /// Pre-signed (the account's spend authorization is attached), not yet proved.
     Signed,
     /// Proved against a real anchor, ready to broadcast.
@@ -415,6 +422,62 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
 #[cfg(feature = "orchard")]
 impl<E: core::error::Error> core::error::Error for CommitError<E> {}
 
+/// How a freshly built migration PCZT is finished by the commit functions: signed in-process with the
+/// wallet's spend authority, or left unsigned for an external (hardware or offline) signer.
+#[cfg(feature = "orchard")]
+#[derive(Clone, Copy)]
+enum Signing {
+    /// Sign in-process via [`MigrationCrypto::sign`].
+    InProcess,
+    /// Leave the PCZT unsigned for an external signer; the caller receives it to sign out of band.
+    External,
+}
+
+/// An UNSIGNED migration transaction PCZT to route to an external (hardware or offline) signer, paired
+/// with the id that [`MigrationState::apply_signature`] uses to store the signed PCZT it returns as.
+///
+/// Produced by [`build_preparation_unsigned`] and [`build_transfers_unsigned`]. The `(id, pczt)` pairing
+/// MUST survive the round-trip to the signer, because `apply_signature` matches the returned signed PCZT
+/// back to its transaction by id.
+#[cfg(feature = "orchard")]
+#[derive(Clone, Debug)]
+pub struct UnsignedMigrationTx {
+    /// The transaction's id in the committed migration.
+    pub id: MigrationTxId,
+    /// The serialized UNSIGNED PCZT to sign out of band.
+    pub pczt: Vec<u8>,
+}
+
+/// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the backend and
+/// return the signed bytes as [`Signed`](MigrationTxState::Signed); for [`Signing::External`], return the
+/// unsigned bytes as [`AwaitingSignature`](MigrationTxState::AwaitingSignature) (the caller also routes a
+/// copy of those bytes to the external signer).
+#[cfg(feature = "orchard")]
+fn finish_built_pczt<B>(
+    backend: &mut B,
+    pczt: ::pczt::Pczt,
+    signing: Signing,
+) -> Result<(Vec<u8>, MigrationTxState), CommitError<<B as MigrationBackend>::Error>>
+where
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+{
+    match signing {
+        Signing::InProcess => {
+            let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+            let bytes = signed
+                .serialize()
+                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+            Ok((bytes, MigrationTxState::Signed))
+        }
+        Signing::External => {
+            let bytes = pczt
+                .serialize()
+                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+            Ok((bytes, MigrationTxState::AwaitingSignature))
+        }
+    }
+}
+
 /// Commit a planned migration's PREPARATION: build and pre-sign the FIRST layer of preparation
 /// transactions (the ones that spend the wallet's own notes) with the account's spend authorization,
 /// record every later preparation layer and every transfer as an unbuilt placeholder, and persist the
@@ -428,6 +491,9 @@ impl<E: core::error::Error> core::error::Error for CommitError<E> {}
 /// signs its one layer here and records only the transfer placeholders; nothing is deferred. A
 /// multi-layer plan (a lone whale fanning out, or a dust-heavy balance) signs layer 0 here and defers
 /// the rest.
+///
+/// For an EXTERNAL signer (a hardware wallet), use [`build_preparation_unsigned`] instead, which builds
+/// the same layer-0 transactions but leaves them unsigned for the device and returns their PCZTs.
 ///
 /// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
 /// `rng` a cryptographically secure RNG.
@@ -447,6 +513,69 @@ where
         + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
+    commit_preparation_inner(
+        params,
+        target_height,
+        backend,
+        plan,
+        rng,
+        Signing::InProcess,
+    )
+    .map(|(state, _unsigned)| state)
+}
+
+/// Commit a planned migration's PREPARATION for an EXTERNAL signer: build the FIRST layer of preparation
+/// transactions but leave them UNSIGNED, persist the committed migration (with those transactions in the
+/// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state), and return the state together with
+/// the unsigned layer-0 PCZTs to route to the signing device. Later preparation layers and every transfer
+/// are recorded as unbuilt placeholders exactly as [`commit_preparation`] records them.
+///
+/// After the device signs, call [`MigrationState::apply_signature`] for each returned PCZT (matched by
+/// [`UnsignedMigrationTx::id`]) to move it to [`Signed`](MigrationTxState::Signed), persist with
+/// `put_migration`, and drive the rest of the migration through the normal state machine (proving and
+/// broadcasting are unchanged). Transfers are signed later via [`build_transfers_unsigned`].
+///
+/// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
+/// `rng` a cryptographically secure RNG.
+#[cfg(feature = "orchard")]
+pub fn build_preparation_unsigned<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    plan: &MigrationPlan,
+    rng: &mut R,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
+    commit_preparation_inner(params, target_height, backend, plan, rng, Signing::External)
+}
+
+/// Shared body of [`commit_preparation`] (with [`Signing::InProcess`]) and
+/// [`build_preparation_unsigned`] (with [`Signing::External`]). Layer-0 transactions are finished via
+/// [`finish_built_pczt`]; the returned `Vec<UnsignedMigrationTx>` is empty for the in-process path.
+#[cfg(feature = "orchard")]
+fn commit_preparation_inner<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    plan: &MigrationPlan,
+    rng: &mut R,
+    signing: Signing,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
     use crate::build::build_prep_tx;
     use crate::preparation::PrepInput;
 
@@ -455,6 +584,7 @@ where
     let expiry_height = crate::scheduling::expiry_height(target_height);
 
     let mut transactions: Vec<MigrationTransaction> = Vec::new();
+    let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
     let mut next_id = 0u32;
     // The transaction ids assigned to each preparation layer, so a later layer's placeholder can depend
     // on the whole layer before it, and the transfers can depend on the last preparation layer.
@@ -500,10 +630,13 @@ where
                 )
                 .map_err(|e| CommitError::Build(format!("{e}")))?;
 
-                let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
-                let bytes = signed
-                    .serialize()
-                    .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+                let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
+                if matches!(signing, Signing::External) {
+                    unsigned.push(UnsignedMigrationTx {
+                        id,
+                        pczt: bytes.clone(),
+                    });
+                }
 
                 transactions.push(MigrationTransaction {
                     id,
@@ -513,7 +646,7 @@ where
                     scheduled_height: target_height,
                     expiry_height,
                     anchor_boundary: None,
-                    state: MigrationTxState::Signed,
+                    state: tx_state,
                 });
             } else {
                 // A later layer spends the previous layer's feeder notes, which are not witnessable
@@ -573,7 +706,7 @@ where
     backend
         .put_migration(&state)
         .map_err(CommitError::Backend)?;
-    Ok(state)
+    Ok((state, unsigned))
 }
 
 /// Build and pre-sign the next READY preparation layer: the deferred second phase of committing a
@@ -746,6 +879,8 @@ where
 /// stored by [`commit_preparation`]), resolves the funding notes, and builds only the transfers still
 /// `Planned`, so it is safe to call again after a partial failure. `params` is the network,
 /// `target_height` the height the transfers are built at, and `rng` a cryptographically secure RNG.
+///
+/// For an EXTERNAL signer, use [`build_transfers_unsigned`] instead.
 #[cfg(feature = "orchard")]
 pub fn commit_transfers<P, B, R>(
     params: &P,
@@ -761,12 +896,64 @@ where
         + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
+    commit_transfers_inner(params, target_height, backend, rng, Signing::InProcess)
+        .map(|(state, _unsigned)| state)
+}
+
+/// Commit a migration's TRANSFERS for an EXTERNAL signer: build each still-`Planned` transfer but leave
+/// it UNSIGNED (in the [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state), persist the
+/// migration, and return the state together with the unsigned transfer PCZTs to route to the signing
+/// device. After the device signs, call [`MigrationState::apply_signature`] for each returned PCZT
+/// (matched by [`UnsignedMigrationTx::id`]) to move it to [`Signed`](MigrationTxState::Signed), persist
+/// with `put_migration`, then prove and broadcast through the normal state machine.
+///
+/// Like [`commit_transfers`], only transfers still `Planned` are built, so it is safe to call again
+/// after a partial failure. `params` is the network, `target_height` the height the transfers are built
+/// at, and `rng` a cryptographically secure RNG.
+#[cfg(feature = "orchard")]
+pub fn build_transfers_unsigned<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    rng: &mut R,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
+    commit_transfers_inner(params, target_height, backend, rng, Signing::External)
+}
+
+/// Shared body of [`commit_transfers`] (with [`Signing::InProcess`]) and [`build_transfers_unsigned`]
+/// (with [`Signing::External`]). The returned `Vec<UnsignedMigrationTx>` is empty for the in-process
+/// path.
+#[cfg(feature = "orchard")]
+fn commit_transfers_inner<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    rng: &mut R,
+    signing: Signing,
+) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
     use crate::build::build_transfer_pczt;
 
     let mut state = backend
         .get_migration()
         .map_err(CommitError::Backend)?
         .ok_or(CommitError::NoMigrationInProgress)?;
+    let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
     let anchor = backend.orchard_anchor().map_err(CommitError::Backend)?;
@@ -813,19 +1000,21 @@ where
         )
         .map_err(|e| CommitError::Build(format!("{e}")))?;
 
-        let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
-        let bytes = signed
-            .serialize()
-            .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
-
+        let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
+        if matches!(signing, Signing::External) {
+            unsigned.push(UnsignedMigrationTx {
+                id: tx.id,
+                pczt: bytes.clone(),
+            });
+        }
         tx.pczt = Some(bytes);
-        tx.state = MigrationTxState::Signed;
+        tx.state = tx_state;
     }
 
     backend
         .put_migration(&state)
         .map_err(CommitError::Backend)?;
-    Ok(state)
+    Ok((state, unsigned))
 }
 
 #[cfg(test)]

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -667,6 +667,11 @@ pub enum CommitError<E> {
     Build(alloc::string::String),
     /// No committed migration was found to build the transfers for (nothing was loaded from storage).
     NoMigrationInProgress,
+    /// A non-terminal migration is already stored. A committed migration is resumed from the
+    /// store (or cancelled), never rebuilt over: overwriting it would orphan its pre-signed —
+    /// and possibly already broadcast — transactions, and a rebuilt layer 0 would double-spend
+    /// the same wallet notes.
+    MigrationInProgress,
 }
 
 #[cfg(feature = "orchard")]
@@ -678,6 +683,10 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
             CommitError::NoMigrationInProgress => {
                 f.write_str("no committed migration is in progress")
             }
+            CommitError::MigrationInProgress => f.write_str(
+                "a non-terminal migration is already stored; resume or cancel it instead of \
+                 committing a new one",
+            ),
         }
     }
 }
@@ -770,6 +779,10 @@ where
 /// For an EXTERNAL signer (a hardware wallet), use [`build_preparation_unsigned`] instead, which builds
 /// the same layer-0 transactions but leaves them unsigned for the device and returns their PCZTs.
 ///
+/// Refuses to overwrite a stored non-terminal migration
+/// ([`CommitError::MigrationInProgress`]): a committed migration is resumed from the store, or
+/// cancelled, never rebuilt over.
+///
 /// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
 /// `rng` a cryptographically secure RNG.
 #[cfg(feature = "orchard")]
@@ -854,6 +867,17 @@ where
     use crate::build::build_prep_tx;
     use crate::preparation::PrepInput;
     use zcash_protocol::consensus::NetworkUpgrade;
+
+    // A committed migration is resumed from the store (or cancelled), never rebuilt over (see
+    // [`MigrationState::is_terminal`]): checked FIRST, before any signing work, so a crashed or
+    // re-run consumer cannot orphan in-flight pre-signed transactions by re-committing.
+    if backend
+        .get_migration()
+        .map_err(CommitError::Backend)?
+        .is_some_and(|existing| !existing.is_terminal())
+    {
+        return Err(CommitError::MigrationInProgress);
+    }
 
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
     // Preparations witness against the ORDINARY near-tip anchor (see [`PREP_ANCHOR_DEPTH`]); only
@@ -1869,6 +1893,80 @@ mod commit_tests {
             }
         }
         assert!(backend.get_migration().unwrap().is_some());
+    }
+
+    /// A committed migration must be resumed, never rebuilt over: a second commit while the
+    /// stored migration is non-terminal is refused (its pre-signed transactions may already be
+    /// broadcast, and a rebuilt layer 0 would double-spend the same notes); a terminal
+    /// (failed/cancelled) migration may be replaced.
+    #[test]
+    fn commit_preparation_refuses_to_overwrite_a_live_migration() {
+        let seed = 13u64;
+        let sk = spending_key(seed);
+        let fvk = FullViewingKey::from(&sk);
+        let balance = 78 * COIN;
+
+        let plan = {
+            let (note, path, anchor) = single_note_witness(&fvk, balance, seed);
+            let planner = CommitMock {
+                notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+                witnesses: vec![(note, path)],
+                anchor,
+                fvk: fvk.clone(),
+                ask: SpendAuthorizingKey::from(&sk),
+                stored: None,
+            };
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            plan_migration(&regtest_network(true), &planner, &mut rng).expect("plans a migration")
+        };
+        let mut values = vec![balance];
+        values.extend(plan.funding_notes().iter().map(|&v| u64::from(v)));
+        let (witnesses, anchor) = shared_anchor_witnesses(&fvk, &values, seed);
+        let mut backend = CommitMock {
+            notes: vec![Zatoshis::from_u64(balance).expect("test balance is valid")],
+            witnesses,
+            anchor,
+            fvk,
+            ask: SpendAuthorizingKey::from(&sk),
+            stored: None,
+        };
+        let params = regtest_network(true);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the preparation");
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        assert!(matches!(
+            commit_preparation(
+                &params,
+                BlockHeight::from_u32(TARGET_HEIGHT),
+                &mut backend,
+                &plan,
+                &mut rng,
+            ),
+            Err(CommitError::MigrationInProgress)
+        ));
+
+        // A terminal (cancelled) migration may be replaced.
+        let mut stored = backend.get_migration().unwrap().expect("stored");
+        stored.status = MigrationStatus::Failed;
+        backend.put_migration(&stored).unwrap();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 3);
+        commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("replaces a terminal migration");
     }
 
     /// A wallet mock for the MULTI-LAYER preparation test. The first `n_wallet` witnesses are the

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -42,6 +42,7 @@ use alloc::vec::Vec;
 
 use core::fmt;
 
+use getset::{CopyGetters, Getters};
 use rand_core::RngCore;
 use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
@@ -103,7 +104,21 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
 /// Zcash transaction id. The real [`TxId`] becomes available once a transaction is built and signed
 /// (it commits only effecting data), and is carried by [`MigrationTxState::Broadcast`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct MigrationTxId(pub u32);
+pub struct MigrationTxId(pub(crate) u32);
+
+impl MigrationTxId {
+    /// Wrap a stored ordinal as a migration-transaction row key (for a store reading a persisted
+    /// migration back).
+    pub const fn new(index: u32) -> Self {
+        MigrationTxId(index)
+    }
+}
+
+impl From<MigrationTxId> for u32 {
+    fn from(id: MigrationTxId) -> u32 {
+        id.0
+    }
+}
 
 /// What a migration transaction does.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,33 +156,69 @@ pub enum MigrationTxState {
 /// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
 /// application needs to prove it against a fresh anchor, wait for its dependencies, broadcast it at
 /// its scheduled height, and track its state.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Getters, CopyGetters)]
 pub struct MigrationTransaction {
     /// This transaction's stable id.
-    pub id: MigrationTxId,
+    #[getset(get_copy = "pub")]
+    pub(crate) id: MigrationTxId,
     /// What it does (a preparation transaction or a transfer).
-    pub kind: MigrationTxKind,
+    #[getset(get_copy = "pub")]
+    pub(crate) kind: MigrationTxKind,
     /// The pre-signed, unproven PCZT, serialized (`pczt::Pczt::serialize`), or `None` until the
     /// transaction is built and signed. A transfer is recorded as a `Planned` placeholder at commit
     /// time and its PCZT is filled in once the preparation is mined (two-phase signing). When present
     /// this is the durable artifact: the application updates its proof against a fresh anchor and
     /// broadcasts it.
-    pub pczt: Option<Vec<u8>>,
+    #[getset(get = "pub")]
+    pub(crate) pczt: Option<Vec<u8>>,
     /// The transactions that must be mined before this one may be broadcast (the preparation layer
     /// dependency graph; empty for an independent transaction).
-    pub depends_on: Vec<MigrationTxId>,
+    #[getset(get = "pub")]
+    pub(crate) depends_on: Vec<MigrationTxId>,
     /// The height at which to broadcast (for a transfer; a preparation transaction waits for its
     /// dependencies to mine and a boundary to pass rather than a fixed height).
-    pub scheduled_height: BlockHeight,
+    #[getset(get_copy = "pub")]
+    pub(crate) scheduled_height: BlockHeight,
     /// The height after which the transaction is invalid and must be rebuilt.
-    pub expiry_height: BlockHeight,
+    #[getset(get_copy = "pub")]
+    pub(crate) expiry_height: BlockHeight,
     /// The boundary height whose tree state the transaction proves against. For a transfer this is
     /// drawn at SCHEDULING time (the schedule fully determines the candidate set; see
     /// [`commit_preparation`]); `None` for a preparation transaction, or when no candidate boundary
     /// exists at the scheduled height (the application then draws against its proving-time view).
-    pub anchor_boundary: Option<BlockHeight>,
+    #[getset(get_copy = "pub")]
+    pub(crate) anchor_boundary: Option<BlockHeight>,
     /// The transaction's lifecycle state.
-    pub state: MigrationTxState,
+    #[getset(get_copy = "pub")]
+    pub(crate) state: MigrationTxState,
+}
+
+impl MigrationTransaction {
+    /// Reassemble a stored migration transaction from its persisted parts, exactly as a store read
+    /// them back (the inverse of the accessors). The caller is responsible for having persisted a
+    /// consistent row (for example, a `Broadcast` or `Mined` transaction carries its PCZT).
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        id: MigrationTxId,
+        kind: MigrationTxKind,
+        pczt: Option<Vec<u8>>,
+        depends_on: Vec<MigrationTxId>,
+        scheduled_height: BlockHeight,
+        expiry_height: BlockHeight,
+        anchor_boundary: Option<BlockHeight>,
+        state: MigrationTxState,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            pczt,
+            depends_on,
+            scheduled_height,
+            expiry_height,
+            anchor_boundary,
+            state,
+        }
+    }
 }
 
 /// The overall status of a migration.
@@ -229,23 +280,48 @@ impl TryFrom<&str> for MigrationStatus {
 /// The persisted state of a migration: the note split (for the preview and residual accounting) and
 /// every transaction, each as its pre-signed PCZT and metadata. A wallet resumes a migration entirely
 /// from this state after being closed or restarted; this is what a [`MigrationBackend`] stores.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters, CopyGetters)]
 pub struct MigrationState {
     /// The overall status.
-    pub status: MigrationStatus,
+    #[getset(get_copy = "pub")]
+    pub(crate) status: MigrationStatus,
     /// The note-split decomposition (the denominations and residual).
-    pub note_split: NoteSplitPlan,
+    #[getset(get = "pub")]
+    pub(crate) note_split: NoteSplitPlan,
     /// The reconciled self-funding note values (in zatoshi), one per crossing: a `Transfer { crossing }`
     /// transaction spends `funding_notes[crossing]` and crosses `funding_notes[crossing]` minus the fee
     /// buffer into the destination pool.
-    pub funding_notes: Vec<Zatoshis>,
+    #[getset(get = "pub")]
+    pub(crate) funding_notes: Vec<Zatoshis>,
     /// The preparation plan (its layers and direct-funding notes), retained so the deferred preparation
     /// layers can be rebuilt after their prior layer mines (see
     /// [`commit_pending_preparation`]). A `Preparation { layer, index }` transaction's spends resolve
     /// against `preparation.layers()[layer][index]`.
-    pub preparation: PreparationPlan,
+    #[getset(get = "pub")]
+    pub(crate) preparation: PreparationPlan,
     /// Every migration transaction, in dependency order.
-    pub transactions: Vec<MigrationTransaction>,
+    #[getset(get = "pub")]
+    pub(crate) transactions: Vec<MigrationTransaction>,
+}
+
+impl MigrationState {
+    /// Reassemble a persisted migration from its stored parts, exactly as a store read them back
+    /// (the inverse of the accessors).
+    pub fn from_parts(
+        status: MigrationStatus,
+        note_split: NoteSplitPlan,
+        funding_notes: Vec<Zatoshis>,
+        preparation: PreparationPlan,
+        transactions: Vec<MigrationTransaction>,
+    ) -> Self {
+        Self {
+            status,
+            note_split,
+            funding_notes,
+            preparation,
+            transactions,
+        }
+    }
 }
 
 /// A planned migration, before anything is built, signed, or broadcast: the denomination split, the
@@ -491,12 +567,24 @@ enum Signing {
 /// MUST survive the round-trip to the signer, because `apply_signature` matches the returned signed PCZT
 /// back to its transaction by id.
 #[cfg(feature = "orchard")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters, CopyGetters)]
 pub struct UnsignedMigrationTx {
     /// The transaction's id in the committed migration.
-    pub id: MigrationTxId,
+    #[getset(get_copy = "pub")]
+    pub(crate) id: MigrationTxId,
     /// The serialized UNSIGNED PCZT to sign out of band.
-    pub pczt: Vec<u8>,
+    #[getset(get = "pub")]
+    pub(crate) pczt: Vec<u8>,
+}
+
+#[cfg(feature = "orchard")]
+impl UnsignedMigrationTx {
+    /// Take the id and the unsigned PCZT bytes (to route the bytes to the external signer while
+    /// keeping the id to match the signed result back; see
+    /// [`MigrationState::apply_signature`](crate::engine::MigrationState)).
+    pub fn into_parts(self) -> (MigrationTxId, Vec<u8>) {
+        (self.id, self.pczt)
+    }
 }
 
 /// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the backend and

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -21,6 +21,7 @@ extern crate std;
 
 #[cfg(feature = "orchard")]
 pub mod build;
+pub mod engine;
 pub mod note_splitting;
 pub mod preparation;
 pub mod scheduling;

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -16,7 +16,9 @@
 // macros into scope (the `build` module uses `format!`), and the tests link `std` for `proptest`.
 #[macro_use]
 extern crate alloc;
-#[cfg(test)]
+// The `wallet` adapter integrates with `zcash_client_backend`, which is a `std` crate; link `std`
+// whenever that feature (or the test harness) is active.
+#[cfg(any(test, feature = "wallet"))]
 extern crate std;
 
 #[cfg(feature = "orchard")]
@@ -25,3 +27,5 @@ pub mod engine;
 pub mod note_splitting;
 pub mod preparation;
 pub mod scheduling;
+#[cfg(feature = "wallet")]
+pub mod wallet;

--- a/zcash_pool_migration_backend/src/lib.rs
+++ b/zcash_pool_migration_backend/src/lib.rs
@@ -27,5 +27,6 @@ pub mod engine;
 pub mod note_splitting;
 pub mod preparation;
 pub mod scheduling;
+pub mod state;
 #[cfg(feature = "wallet")]
 pub mod wallet;

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -29,14 +29,16 @@
 //! frequency-constrained randomized substitution (which only varies which canonical denomination is
 //! chosen, never the values themselves).
 //!
-//! The other tunables are pluggable too: the per-note fee comes from a [`FeePolicy`], and the
-//! maximum denomination, minimum denomination, and note cap are constructor parameters of the strategy.
+//! The other tunables are pluggable too: the per-note transfer-fee buffer and the per-transaction
+//! preparation fee are computed by the caller from the canonical transaction shapes (using the
+//! ZIP-317 fee rule) and passed in, and the maximum denomination, minimum denomination, and note cap
+//! are constructor parameters of the strategy.
 //!
 //! # Common structure
 //!
 //! Whatever the strategy, the result is a [`NoteSplitPlan`]: a multiset of *denomination notes*,
 //! each holding `denomination + fee buffer` so that when it is later spent in a migration transfer
-//! it pays its own fee (the [`FeePolicy`] sizes the buffer). Every note is bounded by a maximum
+//! it pays its own fee (the buffer is the ZIP-317 fee of the canonical transfer shape). Every note is bounded by a maximum
 //! denomination, so even a whale crosses many bounded, collision-prone amounts rather than one
 //! distinctive one, and a balance beyond a single run's capacity migrates over several runs.
 //! Whatever cannot form a whole self-funding note is left in the source pool as change, never folded
@@ -119,7 +121,6 @@ use alloc::vec::Vec;
 
 use rand_core::RngCore;
 
-use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::value::COIN;
 
 pub mod strategies;
@@ -147,53 +148,24 @@ pub const MIGRATION_MAX_DENOMINATION_ZEC: u64 = 10_000;
 /// slice. Also the default minimum denomination of [`CanonicalOneTwoFive`] (ZIP 318's `MAX_RESIDUAL_VALUE`).
 pub const RESIDUAL_MIGRATION_MIN_ZATOSHI: u64 = COIN / 100; // 0.01 ZEC
 
-/// Source-pool logical actions in a migration transfer (the spend and its change), each charged the
-/// marginal fee.
-const SOURCE_ACTIONS_PER_TRANSFER: u64 = 2;
+/// Source-pool (Orchard) logical actions in a canonical migration transfer: the spend and its
+/// change. With [`DESTINATION_ACTIONS_PER_TRANSFER`], this is the canonical transfer shape whose
+/// ZIP-317 fee is the per-note transfer-fee buffer.
+pub(crate) const SOURCE_ACTIONS_PER_TRANSFER: usize = 2;
 
-/// Destination-pool logical actions in a migration transfer (the output and a dummy), each charged the
-/// marginal fee.
-const DESTINATION_ACTIONS_PER_TRANSFER: u64 = 2;
-
-/// How each prepared note is sized to fund the migration transfer that later spends it. Abstracted
-/// so the fee model can be swapped independently of the composition strategy.
-pub trait FeePolicy {
-    /// The per-logical-action fee (in zatoshi).
-    fn marginal_fee_zatoshi(&self) -> u64;
-
-    /// The fee buffer (in zatoshi) added to each prepared note so it self-funds its migration
-    /// transfer. The default charges the source-pool plus destination-pool actions of a transfer at the
-    /// marginal fee (see `SOURCE_ACTIONS_PER_TRANSFER` and `DESTINATION_ACTIONS_PER_TRANSFER`).
-    fn transfer_fee_buffer_zatoshi(&self) -> u64 {
-        (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER)
-            * self.marginal_fee_zatoshi()
-    }
-
-    /// The fee (in zatoshi) reserved for one note-preparation transaction: a transaction padded to
-    /// [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS) logical actions (per ZIP 318), each
-    /// charged the marginal fee. This is the per-transaction reserve
-    /// [`plan_preparation`](crate::preparation::plan_preparation) subtracts from the inputs.
-    fn prep_transaction_fee_zatoshi(&self) -> u64 {
-        crate::preparation::PREP_TX_ACTIONS as u64 * self.marginal_fee_zatoshi()
-    }
-}
-
-/// The ZIP-317 fee model: the marginal fee is the ZIP-317 [`MARGINAL_FEE`].
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Zip317FeePolicy;
-
-impl FeePolicy for Zip317FeePolicy {
-    fn marginal_fee_zatoshi(&self) -> u64 {
-        MARGINAL_FEE.into_u64()
-    }
-}
+/// Destination-pool (Ironwood) logical actions in a canonical migration transfer: the single
+/// canonical output, UNPADDED. The Ironwood builder permits a one-action bundle (no padding dummy),
+/// which the migration uses to save proving bandwidth on hardware signers; every migration transfer
+/// shares this shape, so the action count reveals nothing a canonical transfer does not already
+/// reveal.
+pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
 
 /// The outcome of planning a note split: the self-funding notes to create, the values that will
 /// cross the turnstile, and the residual kept in the source pool. Produced by a
 /// [`DenominationStrategy`].
 ///
 /// The plan stores the [`crossing_values`](Self::crossing_values) and one constant per-note fee
-/// buffer (see [`FeePolicy::transfer_fee_buffer_zatoshi`]); the prepared-note values are derived, not
+/// buffer (the ZIP-317 fee of the canonical transfer shape); the prepared-note values are derived, not
 /// stored, since every prepared note is exactly its crossing value plus that buffer. Each index `i`
 /// describes one prepared note at the two phases of the migration:
 /// - `crossing_values[i]` is the denomination that CROSSES the turnstile into the destination pool
@@ -210,7 +182,7 @@ pub struct NoteSplitPlan {
     crossing_values: Vec<u64>,
     note_fee_buffer_zatoshi: u64,
     change: Option<u64>,
-    prep_fee_zatoshi: u64,
+    prep_fees_zatoshi: u64,
     total_input_zatoshi: u64,
     total_migratable_zatoshi: u64,
 }
@@ -221,7 +193,7 @@ impl NoteSplitPlan {
     /// `remaining_budget` left after them, which becomes source-pool change.
     pub(crate) fn from_notes(
         total_input_zatoshi: u64,
-        prep_fee_zatoshi: u64,
+        prep_fees_zatoshi: u64,
         crossing_values: Vec<u64>,
         note_fee_buffer_zatoshi: u64,
         remaining_budget: u64,
@@ -231,25 +203,9 @@ impl NoteSplitPlan {
             crossing_values,
             note_fee_buffer_zatoshi,
             change: (remaining_budget > 0).then_some(remaining_budget),
-            prep_fee_zatoshi,
+            prep_fees_zatoshi,
             total_input_zatoshi,
             total_migratable_zatoshi,
-        }
-    }
-
-    /// An empty plan (nothing migrated), with the caller-supplied residual as `change`.
-    pub(crate) fn empty(
-        total_input_zatoshi: u64,
-        prep_fee_zatoshi: u64,
-        change: Option<u64>,
-    ) -> Self {
-        Self {
-            crossing_values: Vec::new(),
-            note_fee_buffer_zatoshi: 0,
-            change,
-            prep_fee_zatoshi,
-            total_input_zatoshi,
-            total_migratable_zatoshi: 0,
         }
     }
 
@@ -263,7 +219,7 @@ impl NoteSplitPlan {
         crossing_values: Vec<u64>,
         note_fee_buffer_zatoshi: u64,
         change: Option<u64>,
-        prep_fee_zatoshi: u64,
+        prep_fees_zatoshi: u64,
         total_input_zatoshi: u64,
         total_migratable_zatoshi: u64,
     ) -> Self {
@@ -271,7 +227,7 @@ impl NoteSplitPlan {
             crossing_values,
             note_fee_buffer_zatoshi,
             change,
-            prep_fee_zatoshi,
+            prep_fees_zatoshi,
             total_input_zatoshi,
             total_migratable_zatoshi,
         }
@@ -309,9 +265,12 @@ impl NoteSplitPlan {
         self.change
     }
 
-    /// The fee (in zatoshi) reserved for the note-split ("prep") transaction before decomposition.
-    pub fn prep_fee_zatoshi(&self) -> u64 {
-        self.prep_fee_zatoshi
+    /// The total preparation fees (in zatoshi) this plan reserves: the per-transaction fee times
+    /// the number of preparation transactions the decomposition determined it needs. Zero when
+    /// nothing is migrated (no preparation happens) or when every funding note is an exact match for
+    /// a wallet note (used directly, with no preparation transaction).
+    pub fn prep_fees_zatoshi(&self) -> u64 {
+        self.prep_fees_zatoshi
     }
 
     /// The total spendable source-pool balance (in zatoshi) this plan decomposes.
@@ -329,53 +288,39 @@ impl NoteSplitPlan {
 /// A rule for decomposing a spendable source-pool balance into the notes a migration run will prepare.
 /// See the module docs for the implementation and its denomination set.
 pub trait DenominationStrategy {
-    /// Decompose `total_input_zatoshi`, after reserving `prep_fee_zatoshi` for the note-split
-    /// transaction, into self-funding notes. `prep_fee_zatoshi` is a single constant (the fee for the
-    /// note-split transaction padded to the maximum split action count), not a fee rule, because the
-    /// migration pads that transaction to the maximum anyway; sizing the reservation to that padded
-    /// maximum lets the decomposition proceed without re-deriving a fee per candidate split. `rng` is
-    /// used by randomized strategies and ignored by deterministic ones.
+    /// Decompose `total_input_zatoshi` into self-funding notes, accounting the preparation fees at
+    /// each step of the decomposition.
+    ///
+    /// `prep_tx_fee_zatoshi` is the ZIP-317 fee of one canonical (padded) preparation transaction,
+    /// computed by the caller from the canonical shape. `prep_tx_count` is the capability that
+    /// answers, for a candidate multiset of prepared-note values (each `crossing + buffer`), how
+    /// many preparation transactions minting them will take — `None` when the wallet's notes cannot
+    /// mint that multiset at all. The engine backs it with the preparation planner, so the
+    /// decomposition reserves the TRUE preparation cost (consolidation, fan-out layers, and all) as
+    /// it grows, instead of a fixed guess repaired after the fact. `rng` is used by randomized
+    /// strategies and ignored by deterministic ones.
     fn plan<R: RngCore>(
         &self,
         total_input_zatoshi: u64,
-        prep_fee_zatoshi: u64,
+        prep_tx_fee_zatoshi: u64,
+        prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
         rng: &mut R,
     ) -> NoteSplitPlan;
 }
 
 /// Convenience wrapper: plan with the recommended [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
-/// quantization).
+/// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
 pub fn plan_note_split<R: RngCore>(
     total_input_zatoshi: u64,
-    prep_fee_zatoshi: u64,
+    transfer_fee_buffer_zatoshi: u64,
+    prep_tx_fee_zatoshi: u64,
+    prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
     rng: &mut R,
 ) -> NoteSplitPlan {
-    CanonicalOneTwoFive::recommended().plan(total_input_zatoshi, prep_fee_zatoshi, rng)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
-    proptest! {
-        /// The default fee buffer is four marginal fees (2 source-pool + 2 destination-pool
-        /// actions), for any marginal-fee model.
-        #[test]
-        fn default_buffer_is_four_marginal_fees(m in 0u64..10_000_000) {
-            struct FlatFee(u64);
-            impl FeePolicy for FlatFee {
-                fn marginal_fee_zatoshi(&self) -> u64 {
-                    self.0
-                }
-            }
-            prop_assert_eq!(FlatFee(m).transfer_fee_buffer_zatoshi(), 4 * m);
-        }
-    }
-
-    #[test]
-    fn zip317_marginal_fee_is_5000() {
-        assert_eq!(Zip317FeePolicy.marginal_fee_zatoshi(), 5_000);
-        assert_eq!(Zip317FeePolicy.transfer_fee_buffer_zatoshi(), 20_000);
-    }
+    CanonicalOneTwoFive::recommended(transfer_fee_buffer_zatoshi).plan(
+        total_input_zatoshi,
+        prep_tx_fee_zatoshi,
+        prep_tx_count,
+        rng,
+    )
 }

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -253,6 +253,30 @@ impl NoteSplitPlan {
         }
     }
 
+    /// Reassemble a plan from its stored fields, exactly as they were persisted. This is the inverse
+    /// of the accessors below: a store (for example `zcash_pool_migration_sqlite`) reads the columns
+    /// back and reconstructs the plan verbatim, so `total_migratable_zatoshi` is taken as stored
+    /// rather than recomputed (the caller is responsible for having persisted a consistent set, which
+    /// for a plan produced by [`Self::from_notes`] means `total_migratable_zatoshi` equals the sum of
+    /// `crossing_values`).
+    pub fn from_stored_parts(
+        crossing_values: Vec<u64>,
+        note_fee_buffer_zatoshi: u64,
+        change: Option<u64>,
+        prep_fee_zatoshi: u64,
+        total_input_zatoshi: u64,
+        total_migratable_zatoshi: u64,
+    ) -> Self {
+        Self {
+            crossing_values,
+            note_fee_buffer_zatoshi,
+            change,
+            prep_fee_zatoshi,
+            total_input_zatoshi,
+            total_migratable_zatoshi,
+        }
+    }
+
     /// The value (in zatoshi) of each prepared note the split will create: the crossing value at the
     /// same index plus the [fee buffer](Self::note_fee_buffer_zatoshi), so the note can later pay its
     /// own migration-transfer fee. Derived from [`crossing_values`](Self::crossing_values); the plan

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -257,7 +257,7 @@ impl NoteSplitPlan {
     /// of the accessors below: a store (for example `zcash_pool_migration_sqlite`) reads the columns
     /// back and reconstructs the plan verbatim, so `total_migratable_zatoshi` is taken as stored
     /// rather than recomputed (the caller is responsible for having persisted a consistent set, which
-    /// for a plan produced by [`Self::from_notes`] means `total_migratable_zatoshi` equals the sum of
+    /// for a plan produced by `Self::from_notes` means `total_migratable_zatoshi` equals the sum of
     /// `crossing_values`).
     pub fn from_stored_parts(
         crossing_values: Vec<u64>,

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -121,7 +121,7 @@ use alloc::vec::Vec;
 
 use rand_core::RngCore;
 
-use zcash_protocol::value::COIN;
+use zcash_protocol::value::{BalanceError, COIN, Zatoshis};
 
 pub mod strategies;
 mod utils;
@@ -146,7 +146,7 @@ pub const MIGRATION_MAX_DENOMINATION_ZEC: u64 = 10_000;
 /// user as an opt-in choice: migrate the remainder too (which can compromise privacy, so it is shown
 /// with a disclaimer) or lock it to keep that privacy. Consumed by the context module in a later
 /// slice. Also the default minimum denomination of [`CanonicalOneTwoFive`] (ZIP 318's `MAX_RESIDUAL_VALUE`).
-pub const RESIDUAL_MIGRATION_MIN_ZATOSHI: u64 = COIN / 100; // 0.01 ZEC
+pub const RESIDUAL_MIGRATION_MIN: Zatoshis = Zatoshis::const_from_u64(COIN / 100); // 0.01 ZEC
 
 /// Source-pool (Orchard) logical actions in a canonical migration transfer: the spend and its
 /// change. With [`DESTINATION_ACTIONS_PER_TRANSFER`], this is the canonical transfer shape whose
@@ -170,7 +170,7 @@ pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
 /// describes one prepared note at the two phases of the migration:
 /// - `crossing_values[i]` is the denomination that CROSSES the turnstile into the destination pool
 ///   when the note is spent (the privacy-relevant value an observer sees; their sum is
-///   [`total_migratable_zatoshi`](Self::total_migratable_zatoshi)).
+///   [`total_migratable`](Self::total_migratable)).
 /// - [`migration_outputs`](Self::migration_outputs)`[i] == crossing_values[i] + buffer` is the note
 ///   CREATED in the source pool during the prep phase, so it self-funds its own migration transfer
 ///   (the buffer pays that transfer's fee, and the crossing value is what remains to cross).
@@ -179,18 +179,19 @@ pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
 /// [`change`](Self::change), left untouched in the source pool.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoteSplitPlan {
-    crossing_values: Vec<u64>,
-    note_fee_buffer_zatoshi: u64,
-    change: Option<u64>,
-    prep_fees_zatoshi: u64,
-    total_input_zatoshi: u64,
-    total_migratable_zatoshi: u64,
+    crossing_values: Vec<Zatoshis>,
+    note_fee_buffer: Zatoshis,
+    change: Option<Zatoshis>,
+    prep_fees: Zatoshis,
+    total_input: Zatoshis,
+    total_migratable: Zatoshis,
 }
 
 impl NoteSplitPlan {
     /// Assemble a plan from a strategy's computed `crossing_values`, the per-note fee buffer they each
-    /// carry (the prepared-note values are `crossing + note_fee_buffer_zatoshi`), and the
-    /// `remaining_budget` left after them, which becomes source-pool change.
+    /// carry (the prepared-note values are `crossing + note_fee_buffer`), and the `remaining_budget`
+    /// left after them, which becomes source-pool change. The strategy's arithmetic partitions the
+    /// validated total input, so every part converts to a valid [`Zatoshis`] amount.
     pub(crate) fn from_notes(
         total_input_zatoshi: u64,
         prep_fees_zatoshi: u64,
@@ -198,49 +199,59 @@ impl NoteSplitPlan {
         note_fee_buffer_zatoshi: u64,
         remaining_budget: u64,
     ) -> Self {
-        let total_migratable_zatoshi = crossing_values.iter().sum();
+        let total_migratable_zatoshi: u64 = crossing_values.iter().sum();
         Self {
-            crossing_values,
-            note_fee_buffer_zatoshi,
-            change: (remaining_budget > 0).then_some(remaining_budget),
-            prep_fees_zatoshi,
-            total_input_zatoshi,
-            total_migratable_zatoshi,
+            crossing_values: crossing_values.into_iter().map(zat).collect(),
+            note_fee_buffer: zat(note_fee_buffer_zatoshi),
+            change: (remaining_budget > 0).then(|| zat(remaining_budget)),
+            prep_fees: zat(prep_fees_zatoshi),
+            total_input: zat(total_input_zatoshi),
+            total_migratable: zat(total_migratable_zatoshi),
         }
     }
 
     /// Reassemble a plan from its stored fields, exactly as they were persisted. This is the inverse
     /// of the accessors below: a store (for example `zcash_pool_migration_sqlite`) reads the columns
-    /// back and reconstructs the plan verbatim, so `total_migratable_zatoshi` is taken as stored
+    /// back and reconstructs the plan verbatim, so `total_migratable` is taken as stored
     /// rather than recomputed (the caller is responsible for having persisted a consistent set, which
-    /// for a plan produced by `Self::from_notes` means `total_migratable_zatoshi` equals the sum of
+    /// for a plan produced by `Self::from_notes` means `total_migratable` equals the sum of
     /// `crossing_values`).
+    /// Returns [`BalanceError::Overflow`] if any stored crossing value plus the fee buffer would
+    /// exceed the maximum money supply (such a pair cannot have come from a valid plan, and the
+    /// derived [`migration_outputs`](Self::migration_outputs) would not be representable).
     pub fn from_stored_parts(
-        crossing_values: Vec<u64>,
-        note_fee_buffer_zatoshi: u64,
-        change: Option<u64>,
-        prep_fees_zatoshi: u64,
-        total_input_zatoshi: u64,
-        total_migratable_zatoshi: u64,
-    ) -> Self {
-        Self {
-            crossing_values,
-            note_fee_buffer_zatoshi,
-            change,
-            prep_fees_zatoshi,
-            total_input_zatoshi,
-            total_migratable_zatoshi,
+        crossing_values: Vec<Zatoshis>,
+        note_fee_buffer: Zatoshis,
+        change: Option<Zatoshis>,
+        prep_fees: Zatoshis,
+        total_input: Zatoshis,
+        total_migratable: Zatoshis,
+    ) -> Result<Self, BalanceError> {
+        for &crossing in &crossing_values {
+            let _ = (crossing + note_fee_buffer).ok_or(BalanceError::Overflow)?;
         }
+        Ok(Self {
+            crossing_values,
+            note_fee_buffer,
+            change,
+            prep_fees,
+            total_input,
+            total_migratable,
+        })
     }
 
-    /// The value (in zatoshi) of each prepared note the split will create: the crossing value at the
-    /// same index plus the [fee buffer](Self::note_fee_buffer_zatoshi), so the note can later pay its
-    /// own migration-transfer fee. Derived from [`crossing_values`](Self::crossing_values); the plan
-    /// stores only the crossings and the constant buffer.
-    pub fn migration_outputs(&self) -> Vec<u64> {
+    /// The value of each prepared note the split will create: the crossing value at the same index
+    /// plus the [fee buffer](Self::note_fee_buffer), so the note can later pay its own
+    /// migration-transfer fee. Derived from [`crossing_values`](Self::crossing_values); the plan
+    /// stores only the crossings and the constant buffer. The sums are representable by
+    /// construction (both constructors establish it).
+    pub fn migration_outputs(&self) -> Vec<Zatoshis> {
         self.crossing_values
             .iter()
-            .map(|&c| c + self.note_fee_buffer_zatoshi)
+            .map(|&c| {
+                (c + self.note_fee_buffer)
+                    .expect("both constructors validate crossing + buffer sums")
+            })
             .collect()
     }
 
@@ -248,40 +259,40 @@ impl NoteSplitPlan {
     /// when the note at the same index is spent. Their exact form (a `{1, 2, 5} * 10^k` ZEC value, a
     /// power of ten, ...) depends on the strategy. Each prepared note (see
     /// [`migration_outputs`](Self::migration_outputs)) is one of these plus the fee buffer.
-    pub fn crossing_values(&self) -> &[u64] {
+    pub fn crossing_values(&self) -> &[Zatoshis] {
         &self.crossing_values
     }
 
-    /// The constant fee buffer (in zatoshi) added to every crossing value to form the prepared note,
-    /// so each note self-funds its own migration transfer. The same for every note in the plan.
-    pub fn note_fee_buffer_zatoshi(&self) -> u64 {
-        self.note_fee_buffer_zatoshi
+    /// The constant fee buffer added to every crossing value to form the prepared note, so each
+    /// note self-funds its own migration transfer. The same for every note in the plan.
+    pub fn note_fee_buffer(&self) -> Zatoshis {
+        self.note_fee_buffer
     }
 
-    /// Any residual left in the source pool (in zatoshi) because it could not form a whole
-    /// self-funding note, or the note cap was reached, or `None` if the balance was consumed
-    /// exactly. Includes dust.
-    pub fn change(&self) -> Option<u64> {
+    /// The source-pool CHANGE: value that stays in the wallet's source-pool balance, untouched by
+    /// the migration, because it could not form a whole self-funding note (or the note cap was
+    /// reached). It is neither migrated nor spent on fees; `None` when the decomposition consumed
+    /// the balance exactly. Includes dust.
+    pub fn change(&self) -> Option<Zatoshis> {
         self.change
     }
 
-    /// The total preparation fees (in zatoshi) this plan reserves: the per-transaction fee times
-    /// the number of preparation transactions the decomposition determined it needs. Zero when
-    /// nothing is migrated (no preparation happens) or when every funding note is an exact match for
-    /// a wallet note (used directly, with no preparation transaction).
-    pub fn prep_fees_zatoshi(&self) -> u64 {
-        self.prep_fees_zatoshi
+    /// The total preparation fees this plan reserves: the per-transaction fee times the number of
+    /// preparation transactions the decomposition determined it needs. Zero when nothing is
+    /// migrated (no preparation happens) or when every funding note is an exact match for a wallet
+    /// note (used directly, with no preparation transaction).
+    pub fn prep_fees(&self) -> Zatoshis {
+        self.prep_fees
     }
 
-    /// The total spendable source-pool balance (in zatoshi) this plan decomposes.
-    pub fn total_input_zatoshi(&self) -> u64 {
-        self.total_input_zatoshi
+    /// The total spendable source-pool balance this plan decomposes.
+    pub fn total_input(&self) -> Zatoshis {
+        self.total_input
     }
 
-    /// The total value (in zatoshi) that will migrate to the destination pool: the sum of the
-    /// crossing values.
-    pub fn total_migratable_zatoshi(&self) -> u64 {
-        self.total_migratable_zatoshi
+    /// The total value that will migrate to the destination pool: the sum of the crossing values.
+    pub fn total_migratable(&self) -> Zatoshis {
+        self.total_migratable
     }
 }
 
@@ -301,25 +312,32 @@ pub trait DenominationStrategy {
     /// strategies and ignored by deterministic ones.
     fn plan<R: RngCore>(
         &self,
-        total_input_zatoshi: u64,
-        prep_tx_fee_zatoshi: u64,
-        prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
+        total_input: Zatoshis,
+        prep_tx_fee: Zatoshis,
+        prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         rng: &mut R,
     ) -> NoteSplitPlan;
+}
+
+/// Convert a strategy-internal value to [`Zatoshis`]. Infallible by construction: the strategies'
+/// arithmetic only partitions the total input, which arrives as an already-valid [`Zatoshis`]
+/// amount, so every part is bounded by it.
+pub(crate) fn zat(value: u64) -> Zatoshis {
+    Zatoshis::from_u64(value).expect("split values are bounded by the validated total input")
 }
 
 /// Convenience wrapper: plan with the recommended [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
 /// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
 pub fn plan_note_split<R: RngCore>(
-    total_input_zatoshi: u64,
-    transfer_fee_buffer_zatoshi: u64,
-    prep_tx_fee_zatoshi: u64,
-    prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
+    total_input: Zatoshis,
+    transfer_fee_buffer: Zatoshis,
+    prep_tx_fee: Zatoshis,
+    prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
     rng: &mut R,
 ) -> NoteSplitPlan {
-    CanonicalOneTwoFive::recommended(transfer_fee_buffer_zatoshi).plan(
-        total_input_zatoshi,
-        prep_tx_fee_zatoshi,
+    CanonicalOneTwoFive::recommended(transfer_fee_buffer).plan(
+        total_input,
+        prep_tx_fee,
         prep_tx_count,
         rng,
     )

--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -14,9 +14,11 @@ use rand_core::RngCore;
 use zcash_protocol::value::COIN;
 
 use super::utils::largest_one_two_five;
+use zcash_protocol::value::Zatoshis;
+
 use super::{
     DenominationStrategy, MIGRATION_MAX_DENOMINATION_ZEC, MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
-    NoteSplitPlan, RESIDUAL_MIGRATION_MIN_ZATOSHI,
+    NoteSplitPlan, RESIDUAL_MIGRATION_MIN, zat,
 };
 
 /// The canonical `{1, 2, 5} * 10^k` quantization of [ZIP 318]: at each step it takes the largest such
@@ -46,26 +48,26 @@ impl CanonicalOneTwoFive {
     pub fn new(
         max_notes: usize,
         max_denomination_zec: u64,
-        min_denomination_zatoshi: u64,
-        transfer_fee_buffer_zatoshi: u64,
+        min_denomination: Zatoshis,
+        transfer_fee_buffer: Zatoshis,
     ) -> Self {
         Self {
             max_notes,
             max_denomination_zatoshi: max_denomination_zec.saturating_mul(COIN),
-            min_denomination_zatoshi,
-            buffer_zatoshi: transfer_fee_buffer_zatoshi,
+            min_denomination_zatoshi: u64::from(min_denomination),
+            buffer_zatoshi: u64::from(transfer_fee_buffer),
         }
     }
 
     /// The recommended configuration: [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes,
-    /// [`MIGRATION_MAX_DENOMINATION_ZEC`] cap, [`RESIDUAL_MIGRATION_MIN_ZATOSHI`] minimum
+    /// [`MIGRATION_MAX_DENOMINATION_ZEC`] cap, [`RESIDUAL_MIGRATION_MIN`] minimum
     /// denomination, and the caller-computed transfer-fee buffer.
-    pub fn recommended(transfer_fee_buffer_zatoshi: u64) -> Self {
+    pub fn recommended(transfer_fee_buffer: Zatoshis) -> Self {
         Self::new(
             MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
             MIGRATION_MAX_DENOMINATION_ZEC,
-            RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            transfer_fee_buffer_zatoshi,
+            RESIDUAL_MIGRATION_MIN,
+            transfer_fee_buffer,
         )
     }
 }
@@ -73,11 +75,16 @@ impl CanonicalOneTwoFive {
 impl DenominationStrategy for CanonicalOneTwoFive {
     fn plan<R: RngCore>(
         &self,
-        total_input_zatoshi: u64,
-        prep_tx_fee_zatoshi: u64,
-        prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
+        total_input: Zatoshis,
+        prep_tx_fee: Zatoshis,
+        prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         _rng: &mut R,
     ) -> NoteSplitPlan {
+        // The greedy partition arithmetic below runs in the u64 domain; every value it derives is
+        // bounded by the validated total input, so `zat` conversions at the capability boundary and
+        // in `from_notes` are infallible.
+        let total_input_zatoshi = u64::from(total_input);
+        let prep_tx_fee_zatoshi = u64::from(prep_tx_fee);
         let buffer = self.buffer_zatoshi;
         // Smallest self-funding note: the minimum denomination plus its transfer buffer.
         let min_note = self.min_denomination_zatoshi + buffer;
@@ -87,7 +94,8 @@ impl DenominationStrategy for CanonicalOneTwoFive {
         // every step, so consolidation and fan-out costs are reserved exactly as they arise.
         let mut crossing_values: Vec<u64> = Vec::new();
         let mut notes: Vec<u64> = Vec::new();
-        let mut n_txs = prep_tx_count(&notes).unwrap_or(0);
+        let typed = |notes: &[u64]| notes.iter().map(|&v| zat(v)).collect::<Vec<Zatoshis>>();
+        let mut n_txs = prep_tx_count(&typed(&notes)).unwrap_or(0);
 
         while crossing_values.len() < self.max_notes {
             let committed = notes.iter().sum::<u64>() + n_txs as u64 * prep_tx_fee_zatoshi;
@@ -106,7 +114,7 @@ impl DenominationStrategy for CanonicalOneTwoFive {
                     break;
                 }
                 notes.push(crossing + buffer);
-                let fits = prep_tx_count(&notes).filter(|&n| {
+                let fits = prep_tx_count(&typed(&notes)).filter(|&n| {
                     notes
                         .iter()
                         .sum::<u64>()
@@ -174,8 +182,13 @@ mod tests {
     /// A count-only preparation-layout stub: one padded transaction per [`FUNDING_OUTPUTS_PER_TX`]
     /// funding notes. Tests exercising the split in isolation use this in place of the real
     /// preparation planner.
-    fn prep_tx_count_stub(notes: &[u64]) -> Option<usize> {
+    fn prep_tx_count_stub(notes: &[Zatoshis]) -> Option<usize> {
         Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
+    }
+
+    /// Read a plan's crossing values back into the tests' u64 domain.
+    fn crossings_u64(p: &NoteSplitPlan) -> Vec<u64> {
+        p.crossing_values().iter().map(|&v| u64::from(v)).collect()
     }
 
     /// Upper bound on the prep fee sampled by [`arb_plan_input`], in zatoshi.
@@ -211,8 +224,8 @@ mod tests {
         CanonicalOneTwoFive::new(
             max_notes,
             MIGRATION_MAX_DENOMINATION_ZEC,
-            RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            zip317_buffer(),
+            RESIDUAL_MIGRATION_MIN,
+            zat(zip317_buffer()),
         )
     }
 
@@ -222,13 +235,11 @@ mod tests {
         let s = CanonicalOneTwoFive::new(
             64,
             MIGRATION_MAX_DENOMINATION_ZEC,
-            RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            0,
+            RESIDUAL_MIGRATION_MIN,
+            Zatoshis::ZERO,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        s.plan(total, 0, &prep_tx_count_stub, &mut rng)
-            .crossing_values()
-            .to_vec()
+        crossings_u64(&s.plan(zat(total), Zatoshis::ZERO, &prep_tx_count_stub, &mut rng))
     }
 
     proptest! {
@@ -241,39 +252,42 @@ mod tests {
             let s = canonical(max_notes);
             let buffer = zip317_buffer();
             let cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
-            let floor = RESIDUAL_MIGRATION_MIN_ZATOSHI;
+            let floor = u64::from(RESIDUAL_MIGRATION_MIN);
             let mut rng = ChaCha8Rng::seed_from_u64(0);
-            let p = s.plan(total, fee, &prep_tx_count_stub, &mut rng);
+            let p = s.plan(zat(total), zat(fee), &prep_tx_count_stub, &mut rng);
 
             // Value is conserved exactly: the prepared notes, the stepwise-reserved preparation
             // fees, and the change partition the balance; and the reserved fees are the per-tx fee
             // times the layout's transaction count (zero when nothing migrates).
-            let notes: u64 = p.migration_outputs().iter().sum();
-            let change = p.change().unwrap_or(0);
-            prop_assert_eq!(notes + p.prep_fees_zatoshi() + change, total);
-            if p.migration_outputs().is_empty() {
-                prop_assert_eq!(p.prep_fees_zatoshi(), 0);
+            let outputs = p.migration_outputs();
+            let notes: u64 = outputs.iter().map(|&v| u64::from(v)).sum();
+            let change = p.change().map(u64::from).unwrap_or(0);
+            let prep_fees = u64::from(p.prep_fees());
+            prop_assert_eq!(notes + prep_fees + change, total);
+            if outputs.is_empty() {
+                prop_assert_eq!(prep_fees, 0);
             } else {
-                let expected_txs = prep_tx_count_stub(p.migration_outputs().as_slice()).unwrap();
-                prop_assert_eq!(p.prep_fees_zatoshi(), expected_txs as u64 * fee);
+                let expected_txs = prep_tx_count_stub(&outputs).unwrap();
+                prop_assert_eq!(prep_fees, expected_txs as u64 * fee);
             }
 
-            prop_assert_eq!(p.migration_outputs().len(), p.crossing_values().len());
-            for (n, c) in p.migration_outputs().iter().zip(p.crossing_values()) {
-                prop_assert_eq!(*n, c + buffer);
+            let cvs = crossings_u64(&p);
+            prop_assert_eq!(outputs.len(), cvs.len());
+            for (&n, &c) in outputs.iter().zip(&cvs) {
+                prop_assert_eq!(u64::from(n), c + buffer);
             }
-            prop_assert!(p.migration_outputs().len() <= max_notes);
-            let sum: u64 = p.crossing_values().iter().sum();
-            prop_assert_eq!(p.total_migratable_zatoshi(), sum);
+            prop_assert!(outputs.len() <= max_notes);
+            let sum: u64 = cvs.iter().sum();
+            prop_assert_eq!(u64::from(p.total_migratable()), sum);
 
-            for &cv in p.crossing_values() {
+            for &cv in &cvs {
                 prop_assert!(is_one_two_five_zat(cv), "invalid denom {}", cv);
                 prop_assert!(cv >= floor && cv <= cap, "out of bounds {}", cv);
             }
-            for w in p.crossing_values().windows(2) {
+            for w in cvs.windows(2) {
                 prop_assert!(w[0] >= w[1], "crossings must be non-increasing");
             }
-            if p.migration_outputs().len() < max_notes {
+            if outputs.len() < max_notes {
                 // The loop stops when not even a minimum note fits — where fitting includes any
                 // preparation-fee step the extra note would trigger.
                 prop_assert!(change < floor + buffer + fee, "residual {}", change);
@@ -281,7 +295,7 @@ mod tests {
 
             // The RNG is ignored: a different seed yields the same plan.
             let mut other = ChaCha8Rng::seed_from_u64(1);
-            prop_assert_eq!(&p, &s.plan(total, fee, &prep_tx_count_stub, &mut other));
+            prop_assert_eq!(&p, &s.plan(zat(total), zat(fee), &prep_tx_count_stub, &mut other));
         }
     }
 
@@ -291,11 +305,19 @@ mod tests {
     fn whale_is_capped_and_rolls_over() {
         let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(MAX_MONEY, 0, &prep_tx_count_stub, &mut rng);
+        let p = s.plan(
+            zat(MAX_MONEY),
+            Zatoshis::ZERO,
+            &prep_tx_count_stub,
+            &mut rng,
+        );
         let per_run_cap =
             MIGRATION_MAX_PREPARED_NOTES_PER_RUN as u64 * MIGRATION_MAX_DENOMINATION_ZEC * COIN;
-        assert!(p.total_migratable_zatoshi() <= per_run_cap);
-        assert!(p.change().unwrap_or(0) > per_run_cap, "should roll over");
+        assert!(u64::from(p.total_migratable()) <= per_run_cap);
+        assert!(
+            p.change().map(u64::from).unwrap_or(0) > per_run_cap,
+            "should roll over"
+        );
     }
 
     /// A balance below the smallest self-funding note migrates nothing and keeps it all as change.
@@ -303,11 +325,11 @@ mod tests {
     fn below_min_note_migrates_nothing() {
         let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
         let buffer = zip317_buffer();
-        let below = RESIDUAL_MIGRATION_MIN_ZATOSHI + buffer - 1;
+        let below = u64::from(RESIDUAL_MIGRATION_MIN) + buffer - 1;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(below, 0, &prep_tx_count_stub, &mut rng);
+        let p = s.plan(zat(below), Zatoshis::ZERO, &prep_tx_count_stub, &mut rng);
         assert!(p.crossing_values().is_empty());
-        assert_eq!(p.change(), Some(below));
+        assert_eq!(p.change(), Some(zat(below)));
     }
 
     /// The ZIP 318 worked examples: canonical `{1, 2, 5} * 10^k` quantization.
@@ -378,21 +400,29 @@ mod tests {
             .iter()
             .map(|&c| c + buffer)
             .collect();
-        let s = CanonicalOneTwoFive::recommended(zip317_buffer());
+        let s = CanonicalOneTwoFive::recommended(zat(zip317_buffer()));
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let plan = s.plan(balance_zatoshi, 0, &prep_tx_count_stub, &mut rng);
+        let plan = s.plan(
+            zat(balance_zatoshi),
+            Zatoshis::ZERO,
+            &prep_tx_count_stub,
+            &mut rng,
+        );
         assert_eq!(
-            plan.crossing_values(),
+            crossings_u64(&plan),
             expected_crossings_zatoshi,
             "unexpected crossings for balance {balance_zatoshi} zat",
         );
         assert_eq!(
-            plan.migration_outputs(),
-            expected_notes.as_slice(),
+            plan.migration_outputs()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            expected_notes,
             "unexpected prepared notes for balance {balance_zatoshi} zat",
         );
         assert_eq!(
-            plan.change(),
+            plan.change().map(u64::from),
             expected_change_zatoshi,
             "unexpected change for balance {balance_zatoshi} zat",
         );

--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -15,9 +15,8 @@ use zcash_protocol::value::COIN;
 
 use super::utils::largest_one_two_five;
 use super::{
-    DenominationStrategy, FeePolicy, MIGRATION_MAX_DENOMINATION_ZEC,
-    MIGRATION_MAX_PREPARED_NOTES_PER_RUN, NoteSplitPlan, RESIDUAL_MIGRATION_MIN_ZATOSHI,
-    Zip317FeePolicy,
+    DenominationStrategy, MIGRATION_MAX_DENOMINATION_ZEC, MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+    NoteSplitPlan, RESIDUAL_MIGRATION_MIN_ZATOSHI,
 };
 
 /// The canonical `{1, 2, 5} * 10^k` quantization of [ZIP 318]: at each step it takes the largest such
@@ -42,30 +41,31 @@ pub struct CanonicalOneTwoFive {
 
 impl CanonicalOneTwoFive {
     /// A strategy with an explicit note cap, maximum denomination (in whole ZEC), minimum denomination (in
-    /// zatoshi, which MUST be a power of ten), and fee model.
+    /// zatoshi, which MUST be a power of ten), and per-note transfer-fee buffer (the ZIP-317 fee of
+    /// the canonical transfer shape, computed by the caller).
     pub fn new(
         max_notes: usize,
         max_denomination_zec: u64,
         min_denomination_zatoshi: u64,
-        fee: &impl FeePolicy,
+        transfer_fee_buffer_zatoshi: u64,
     ) -> Self {
         Self {
             max_notes,
             max_denomination_zatoshi: max_denomination_zec.saturating_mul(COIN),
             min_denomination_zatoshi,
-            buffer_zatoshi: fee.transfer_fee_buffer_zatoshi(),
+            buffer_zatoshi: transfer_fee_buffer_zatoshi,
         }
     }
 
     /// The recommended configuration: [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes,
-    /// [`MIGRATION_MAX_DENOMINATION_ZEC`] cap, [`RESIDUAL_MIGRATION_MIN_ZATOSHI`] minimum denomination, ZIP-317
-    /// fees.
-    pub fn recommended() -> Self {
+    /// [`MIGRATION_MAX_DENOMINATION_ZEC`] cap, [`RESIDUAL_MIGRATION_MIN_ZATOSHI`] minimum
+    /// denomination, and the caller-computed transfer-fee buffer.
+    pub fn recommended(transfer_fee_buffer_zatoshi: u64) -> Self {
         Self::new(
             MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
             MIGRATION_MAX_DENOMINATION_ZEC,
             RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            &Zip317FeePolicy,
+            transfer_fee_buffer_zatoshi,
         )
     }
 }
@@ -74,37 +74,80 @@ impl DenominationStrategy for CanonicalOneTwoFive {
     fn plan<R: RngCore>(
         &self,
         total_input_zatoshi: u64,
-        prep_fee_zatoshi: u64,
+        prep_tx_fee_zatoshi: u64,
+        prep_tx_count: &dyn Fn(&[u64]) -> Option<usize>,
         _rng: &mut R,
     ) -> NoteSplitPlan {
-        if total_input_zatoshi <= prep_fee_zatoshi {
-            return NoteSplitPlan::empty(total_input_zatoshi, prep_fee_zatoshi, None);
-        }
         let buffer = self.buffer_zatoshi;
         // Smallest self-funding note: the minimum denomination plus its transfer buffer.
         let min_note = self.min_denomination_zatoshi + buffer;
-        let mut budget = total_input_zatoshi - prep_fee_zatoshi;
 
-        let mut crossing_values = Vec::new();
-        while budget >= min_note && crossing_values.len() < self.max_notes {
-            // Largest `{1, 2, 5} * 10^k` denomination whose note fits the budget, capped.
-            let affordable = (budget - buffer).min(self.max_denomination_zatoshi);
-            let crossing = largest_one_two_five(affordable, self.min_denomination_zatoshi);
-            if crossing < self.min_denomination_zatoshi {
+        // The chosen crossings, their prepared-note values (`crossing + buffer`), and the
+        // preparation transaction count for the CURRENT multiset. The capability is consulted at
+        // every step, so consolidation and fan-out costs are reserved exactly as they arise.
+        let mut crossing_values: Vec<u64> = Vec::new();
+        let mut notes: Vec<u64> = Vec::new();
+        let mut n_txs = prep_tx_count(&notes).unwrap_or(0);
+
+        while crossing_values.len() < self.max_notes {
+            let committed = notes.iter().sum::<u64>() + n_txs as u64 * prep_tx_fee_zatoshi;
+            let budget = total_input_zatoshi.saturating_sub(committed);
+            if budget < min_note {
                 break;
             }
-            // The prepared note is `crossing + buffer`; only the crossing is stored (the buffer is
-            // constant), but the whole note is what the budget must fund.
-            budget -= crossing + buffer;
-            crossing_values.push(crossing);
+            // Try the largest `{1, 2, 5} * 10^k` denomination that fits the budget under the
+            // CURRENT preparation cost; a candidate whose minting raises that cost past the budget
+            // steps down the series.
+            let mut affordable = (budget - buffer).min(self.max_denomination_zatoshi);
+            let mut accepted = false;
+            while affordable >= self.min_denomination_zatoshi {
+                let crossing = largest_one_two_five(affordable, self.min_denomination_zatoshi);
+                if crossing < self.min_denomination_zatoshi {
+                    break;
+                }
+                notes.push(crossing + buffer);
+                let fits = prep_tx_count(&notes).filter(|&n| {
+                    notes
+                        .iter()
+                        .sum::<u64>()
+                        .checked_add(n as u64 * prep_tx_fee_zatoshi)
+                        .is_some_and(|c| c <= total_input_zatoshi)
+                });
+                match fits {
+                    Some(n) => {
+                        n_txs = n;
+                        crossing_values.push(crossing);
+                        accepted = true;
+                        break;
+                    }
+                    None => {
+                        notes.pop();
+                        if crossing == self.min_denomination_zatoshi {
+                            break;
+                        }
+                        affordable = crossing - 1;
+                    }
+                }
+            }
+            if !accepted {
+                break;
+            }
         }
 
+        // Nothing migrated means no preparation happens, so nothing is reserved for its fees.
+        if crossing_values.is_empty() {
+            n_txs = 0;
+        }
+        let prep_fees_zatoshi = n_txs as u64 * prep_tx_fee_zatoshi;
+        let remaining = total_input_zatoshi
+            .saturating_sub(notes.iter().sum::<u64>())
+            .saturating_sub(prep_fees_zatoshi);
         NoteSplitPlan::from_notes(
             total_input_zatoshi,
-            prep_fee_zatoshi,
+            prep_fees_zatoshi,
             crossing_values,
             buffer,
-            budget,
+            remaining,
         )
     }
 }
@@ -115,7 +158,25 @@ mod tests {
     use proptest::prelude::*;
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
     use zcash_protocol::value::MAX_MONEY;
+
+    use crate::note_splitting::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
+    use crate::preparation::FUNDING_OUTPUTS_PER_TX;
+
+    /// The ZIP-317 transfer-fee buffer of the canonical transfer shape (all four actions exceed the
+    /// grace allowance, so each pays the marginal fee).
+    fn zip317_buffer() -> u64 {
+        (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+            * MARGINAL_FEE.into_u64()
+    }
+
+    /// A count-only preparation-layout stub: one padded transaction per [`FUNDING_OUTPUTS_PER_TX`]
+    /// funding notes. Tests exercising the split in isolation use this in place of the real
+    /// preparation planner.
+    fn prep_tx_count_stub(notes: &[u64]) -> Option<usize> {
+        Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
+    }
 
     /// Upper bound on the prep fee sampled by [`arb_plan_input`], in zatoshi.
     const MAX_SAMPLED_PREP_FEE_ZATOSHI: u64 = 1_000_000;
@@ -145,34 +206,29 @@ mod tests {
         matches!(n, 1 | 2 | 5)
     }
 
-    /// A zero-fee policy, so the canonical digit expansion is exact (no buffer eats into the budget).
-    struct NoFeePolicy;
-    impl FeePolicy for NoFeePolicy {
-        fn marginal_fee_zatoshi(&self) -> u64 {
-            0
-        }
-    }
-
-    /// The canonical strategy with the given note cap and ZIP-317 fees.
+    /// The canonical strategy with the given note cap and the ZIP-317 transfer buffer.
     fn canonical(max_notes: usize) -> CanonicalOneTwoFive {
         CanonicalOneTwoFive::new(
             max_notes,
             MIGRATION_MAX_DENOMINATION_ZEC,
             RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            &Zip317FeePolicy,
+            zip317_buffer(),
         )
     }
 
-    /// The exact fee-free crossing decomposition of `total`, for the golden vectors.
+    /// The exact fee-free crossing decomposition of `total` (no buffer, no preparation fee), for
+    /// the golden vectors.
     fn crossings(total: u64) -> Vec<u64> {
         let s = CanonicalOneTwoFive::new(
             64,
             MIGRATION_MAX_DENOMINATION_ZEC,
             RESIDUAL_MIGRATION_MIN_ZATOSHI,
-            &NoFeePolicy,
+            0,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        s.plan(total, 0, &mut rng).crossing_values().to_vec()
+        s.plan(total, 0, &prep_tx_count_stub, &mut rng)
+            .crossing_values()
+            .to_vec()
     }
 
     proptest! {
@@ -183,19 +239,23 @@ mod tests {
         #[test]
         fn honours_the_contract((total, fee, max_notes) in arb_plan_input()) {
             let s = canonical(max_notes);
-            let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+            let buffer = zip317_buffer();
             let cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
             let floor = RESIDUAL_MIGRATION_MIN_ZATOSHI;
             let mut rng = ChaCha8Rng::seed_from_u64(0);
-            let p = s.plan(total, fee, &mut rng);
+            let p = s.plan(total, fee, &prep_tx_count_stub, &mut rng);
 
+            // Value is conserved exactly: the prepared notes, the stepwise-reserved preparation
+            // fees, and the change partition the balance; and the reserved fees are the per-tx fee
+            // times the layout's transaction count (zero when nothing migrates).
             let notes: u64 = p.migration_outputs().iter().sum();
             let change = p.change().unwrap_or(0);
-            if total <= fee {
-                prop_assert!(p.migration_outputs().is_empty());
-                prop_assert_eq!(change, 0);
+            prop_assert_eq!(notes + p.prep_fees_zatoshi() + change, total);
+            if p.migration_outputs().is_empty() {
+                prop_assert_eq!(p.prep_fees_zatoshi(), 0);
             } else {
-                prop_assert_eq!(notes + change, total - fee);
+                let expected_txs = prep_tx_count_stub(p.migration_outputs().as_slice()).unwrap();
+                prop_assert_eq!(p.prep_fees_zatoshi(), expected_txs as u64 * fee);
             }
 
             prop_assert_eq!(p.migration_outputs().len(), p.crossing_values().len());
@@ -214,12 +274,14 @@ mod tests {
                 prop_assert!(w[0] >= w[1], "crossings must be non-increasing");
             }
             if p.migration_outputs().len() < max_notes {
-                prop_assert!(change < floor + buffer, "residual {}", change);
+                // The loop stops when not even a minimum note fits — where fitting includes any
+                // preparation-fee step the extra note would trigger.
+                prop_assert!(change < floor + buffer + fee, "residual {}", change);
             }
 
             // The RNG is ignored: a different seed yields the same plan.
             let mut other = ChaCha8Rng::seed_from_u64(1);
-            prop_assert_eq!(&p, &s.plan(total, fee, &mut other));
+            prop_assert_eq!(&p, &s.plan(total, fee, &prep_tx_count_stub, &mut other));
         }
     }
 
@@ -229,7 +291,7 @@ mod tests {
     fn whale_is_capped_and_rolls_over() {
         let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(MAX_MONEY, 0, &mut rng);
+        let p = s.plan(MAX_MONEY, 0, &prep_tx_count_stub, &mut rng);
         let per_run_cap =
             MIGRATION_MAX_PREPARED_NOTES_PER_RUN as u64 * MIGRATION_MAX_DENOMINATION_ZEC * COIN;
         assert!(p.total_migratable_zatoshi() <= per_run_cap);
@@ -240,10 +302,10 @@ mod tests {
     #[test]
     fn below_min_note_migrates_nothing() {
         let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
-        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let buffer = zip317_buffer();
         let below = RESIDUAL_MIGRATION_MIN_ZATOSHI + buffer - 1;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(below, 0, &mut rng);
+        let p = s.plan(below, 0, &prep_tx_count_stub, &mut rng);
         assert!(p.crossing_values().is_empty());
         assert_eq!(p.change(), Some(below));
     }
@@ -304,21 +366,21 @@ mod tests {
     ///   `crossing + transfer buffer` (the output that funds one migration-transfer transaction),
     /// - the source-pool change left behind.
     ///
-    /// The transfer buffer is the ZIP-317 [`FeePolicy`] buffer, so this exercises the fee model the
+    /// The transfer buffer is the canonical ZIP-317 transfer fee, so this exercises the fee model the
     /// fee-free [`crossings`] helper deliberately skips.
     fn check_user_preparation(
         balance_zatoshi: u64,
         expected_crossings_zatoshi: &[u64],
         expected_change_zatoshi: Option<u64>,
     ) {
-        let buffer = Zip317FeePolicy.transfer_fee_buffer_zatoshi();
+        let buffer = zip317_buffer();
         let expected_notes: Vec<u64> = expected_crossings_zatoshi
             .iter()
             .map(|&c| c + buffer)
             .collect();
-        let s = CanonicalOneTwoFive::recommended();
+        let s = CanonicalOneTwoFive::recommended(zip317_buffer());
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let plan = s.plan(balance_zatoshi, 0, &mut rng);
+        let plan = s.plan(balance_zatoshi, 0, &prep_tx_count_stub, &mut rng);
         assert_eq!(
             plan.crossing_values(),
             expected_crossings_zatoshi,
@@ -338,8 +400,9 @@ mod tests {
 
     /// Golden vectors for the full migration preparation (the planned transaction set, fees included)
     /// of many different users' messy, non-round balances. Each note the plan creates is a real
-    /// transaction output holding `crossing + transfer buffer` (20,000 zat under ZIP-317), and the
-    /// leftover that cannot form a whole self-funding note stays as source-pool change.
+    /// transaction output holding `crossing + transfer buffer` (15,000 zat under ZIP-317: two
+    /// Orchard actions plus the single unpadded Ironwood action), and the leftover that cannot form
+    /// a whole self-funding note stays as source-pool change.
     ///
     /// Every expected split is derived BY HAND from the canonical `{1, 2, 5} * 10^k` greedy rule
     /// (digit expansion: 1->[1], 2->[2], 3->[2,1], 4->[2,2], 5->[5], 6->[5,1], 7->[5,2], 8->[5,2,1],
@@ -352,7 +415,7 @@ mod tests {
         // `(balance in zatoshi, expected crossings in zatoshi, expected source-pool change)`.
         let cases: Vec<(u64, Vec<u64>, Option<u64>)> = vec![
             // Ari, 3748.6174 ZEC: 3->[2,1] 7->[5,2] 4->[2,2] 8->[5,2,1] .6->[.5,.1] .01->[.01],
-            // 12 notes + 0.005 ZEC sub-floor change.
+            // 12 notes + 0.0056 ZEC sub-floor change (0.0174 - 12 * 0.00015 buffers - 0.01).
             (
                 374_861_740_000,
                 vec![
@@ -369,10 +432,11 @@ mod tests {
                     COIN / 10,
                     COIN / 100,
                 ],
-                Some(500_000),
+                Some(560_000),
             ),
-            // Bo, 9631.8827 ZEC: 9->[5,2,2] 6->[5,1] 3->[2,1] 1->[1] .8->[.5,.2,.1] .07->[.05,.02],
-            // 13 notes + 0.0101 ZEC change (at/above the minimum denomination but too small to self-fund).
+            // Bo, 9631.8827 ZEC: 9->[5,2,2] 6->[5,1] 3->[2,1] 1->[1] .8->[.5,.2,.1] .07->[.05,.02];
+            // the residual 0.0127 less 13 buffers (0.00195) still affords a 14th self-funding 0.01
+            // note, leaving 0.0006 ZEC sub-floor change.
             (
                 963_188_270_000,
                 vec![
@@ -389,11 +453,13 @@ mod tests {
                     COIN / 10,
                     COIN / 20,
                     COIN / 50,
+                    COIN / 100,
                 ],
-                Some(1_010_000),
+                Some(60_000),
             ),
             // Cleo, 27853.4226 ZEC: above the cap -> two 10,000; then 7853.42 = 7->[5,2] 8->[5,2,1]
-            // 5->[5] 3->[2,1] .4->[.2,.2] .02->[.02]. 13 notes, no change.
+            // 5->[5] 3->[2,1] .4->[.2,.2] .02->[.02]. 13 notes + 0.00065 ZEC sub-floor change
+            // (0.0026 less 13 buffers).
             (
                 2_785_342_260_000,
                 vec![
@@ -411,10 +477,11 @@ mod tests {
                     COIN / 5,
                     COIN / 50,
                 ],
-                None,
+                Some(65_000),
             ),
             // Dex, 61337.5028 ZEC: above the cap -> six 10,000; then 1337.5 = 1->[1] 3->[2,1]
-            // 3->[2,1] 7->[5,2] .5->[.5]. 14 notes, no change.
+            // 3->[2,1] 7->[5,2] .5->[.5]. 14 notes + 0.0007 ZEC sub-floor change (0.0028 less
+            // 14 buffers).
             (
                 6_133_750_280_000,
                 vec![
@@ -433,25 +500,27 @@ mod tests {
                     2 * COIN,
                     COIN / 2,
                 ],
-                None,
+                Some(70_000),
             ),
-            // Evie, 0.794 ZEC: .7->[.5,.2] .9->[.05,.02,.02], 5 notes + 0.003 ZEC sub-floor change.
+            // Evie, 0.794 ZEC: .7->[.5,.2] .9->[.05,.02,.02], 5 notes + 0.00325 ZEC sub-floor
+            // change (0.004 less 5 buffers).
             (
                 79_400_000,
                 vec![COIN / 2, COIN / 5, COIN / 20, COIN / 50, COIN / 50],
-                Some(300_000),
+                Some(325_000),
             ),
-            // Fin, 0.381 ZEC: .3->[.2,.1] .8->[.05,.02,.01] (down to the 0.01 minimum denomination), 5 notes,
-            // no change.
+            // Fin, 0.381 ZEC: .3->[.2,.1] .8->[.05,.02,.01] (down to the 0.01 minimum
+            // denomination), 5 notes + 0.00025 ZEC sub-floor change (0.001 less 5 buffers).
             (
                 38_100_000,
                 vec![COIN / 5, COIN / 10, COIN / 20, COIN / 50, COIN / 100],
-                None,
+                Some(25_000),
             ),
-            // Gwen, 0.0152 ZEC: a single 0.01 minimum-denomination note + 0.005 ZEC sub-floor change.
-            (1_520_000, vec![COIN / 100], Some(500_000)),
+            // Gwen, 0.0152 ZEC: a single 0.01 minimum-denomination note + 0.00505 ZEC sub-floor
+            // change.
+            (1_520_000, vec![COIN / 100], Some(505_000)),
             // Ivan, 142.5314 ZEC (typical wallet): 1->[1] 4->[2,2] 2->[2] .5->[.5] .03->[.02,.01],
-            // 7 notes, no change.
+            // 7 notes + 0.00035 ZEC sub-floor change (0.0014 less 7 buffers).
             (
                 14_253_140_000,
                 vec![
@@ -463,10 +532,10 @@ mod tests {
                     COIN / 50,
                     COIN / 100,
                 ],
-                None,
+                Some(35_000),
             ),
             // Jia, 76.1986 ZEC (typical wallet): 7->[5,2] 6->[5,1] .1->[.1] .09->[.05,.02,.02],
-            // 8 notes + 0.007 ZEC sub-floor change.
+            // 8 notes + 0.0074 ZEC sub-floor change (0.0086 less 8 buffers).
             (
                 7_619_860_000,
                 vec![
@@ -479,10 +548,11 @@ mod tests {
                     COIN / 50,
                     COIN / 50,
                 ],
-                Some(700_000),
+                Some(740_000),
             ),
             // Kai, 999.993 ZEC (every digit a 9 -> every place expands [5,2,2]): 999.99 =
-            // 9->[5,2,2] 9->[5,2,2] 9->[5,2,2] .9->[.5,.2,.2] .09->[.05,.02,.02]. 15 notes, no change.
+            // 9->[5,2,2] 9->[5,2,2] 9->[5,2,2] .9->[.5,.2,.2] .09->[.05,.02,.02]. 15 notes +
+            // 0.00075 ZEC sub-floor change (0.003 less 15 buffers).
             (
                 99_999_300_000,
                 vec![
@@ -502,10 +572,11 @@ mod tests {
                     COIN / 50,
                     COIN / 50,
                 ],
-                None,
+                Some(75_000),
             ),
             // Lex, 32222.2218 ZEC: above the cap -> three 10,000; then 2222.22 (every digit a 2 ->
-            // [2]): 2->[2] 2->[2] 2->[2] 2->[2] .2->[.2] .02->[.02]. 9 notes, no change.
+            // [2]): 2->[2] 2->[2] 2->[2] 2->[2] .2->[.2] .02->[.02]. 9 notes + 0.00045 ZEC
+            // sub-floor change (0.0018 less 9 buffers).
             (
                 3_222_222_180_000,
                 vec![
@@ -519,18 +590,18 @@ mod tests {
                     COIN / 5,
                     COIN / 50,
                 ],
-                None,
+                Some(45_000),
             ),
             // Mira, 4050.0735 ZEC (interior zero digits skipped): 4->[2,2] 0->[] 5->[5] 0->[] 0->[]
-            // .07->[.05,.02], 5 notes + 0.0025 ZEC sub-floor change.
+            // .07->[.05,.02], 5 notes + 0.00275 ZEC sub-floor change (0.0035 less 5 buffers).
             (
                 405_007_350_000,
                 vec![2_000 * COIN, 2_000 * COIN, 50 * COIN, COIN / 20, COIN / 50],
-                Some(250_000),
+                Some(275_000),
             ),
             // Ozan, 88.884 ZEC (independently chosen): 88.88 = 8->[5,2,1] 8->[5,2,1] .8->[.5,.2,.1]
             // .08->[.05,.02,.01]. The 0.004 ZEC fee-free residual exceeds the 12 notes' buffers
-            // (12 * 0.0002 = 0.0024 ZEC), so all 12 notes self-fund and 0.0016 ZEC stays as change.
+            // (12 * 0.00015 = 0.0018 ZEC), so all 12 notes self-fund and 0.0022 ZEC stays as change.
             (
                 8_888_400_000,
                 vec![
@@ -547,16 +618,16 @@ mod tests {
                     COIN / 50,
                     COIN / 100,
                 ],
-                Some(160_000),
+                Some(220_000),
             ),
             // Priya, 7.1101 ZEC (independently chosen): the fee-free split is 7->[5,2] .1->[.1]
             // .01->[.01], but only 0.0001 ZEC of residual is left for the buffers, so the 0.01
-            // crossing cannot self-fund (it needs 0.01 + 0.0002 ZEC). It is dropped: the plan is
-            // [5, 2, 0.1] and the unspent 0.0095 ZEC stays as change.
+            // crossing cannot self-fund (it needs 0.01 + 0.00015 ZEC). It is dropped: the plan is
+            // [5, 2, 0.1] and the unspent 0.00965 ZEC stays as change.
             (
                 711_010_000,
                 vec![5 * COIN, 2 * COIN, COIN / 10],
-                Some(950_000),
+                Some(965_000),
             ),
         ];
 

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -712,7 +712,13 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+
+    /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
+    /// action costs one ZIP-317 marginal fee). The planner treats it opaquely.
+    fn fee_per_tx() -> u64 {
+        PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64()
+    }
 
     /// The funding values a plan mints, sorted, for multiset comparison against the request.
     fn sorted_funding(plan: &PreparationPlan) -> Vec<u64> {
@@ -838,9 +844,7 @@ mod tests {
     fn arb_sufficient() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
         prop::collection::vec(1u64..500_000, 1..20).prop_flat_map(|funding| {
             let need: u64 = funding.iter().sum();
-            let big = need
-                + (funding.len() as u64 + 64) * Zip317FeePolicy.prep_transaction_fee_zatoshi()
-                + 1;
+            let big = need + (funding.len() as u64 + 64) * fee_per_tx() + 1;
             (prop::collection::vec(1u64..100_000, 0..8), Just(funding)).prop_map(
                 move |(mut extra, funding)| {
                     extra.push(big);
@@ -854,8 +858,8 @@ mod tests {
         /// Whenever a plan is produced over arbitrary inputs, every structural invariant holds.
         #[test]
         fn valid_whenever_planned((available, funding) in arb_input()) {
-            if let Ok(plan) = plan_preparation(&available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()) {
-                assert_plan_valid(&plan, &available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
+            if let Ok(plan) = plan_preparation(&available, &funding, fee_per_tx()) {
+                assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             }
         }
 
@@ -863,9 +867,9 @@ mod tests {
         /// plan (the planner never gives up when the value is amply present).
         #[test]
         fn always_plans_when_amply_funded((available, funding) in arb_sufficient()) {
-            let plan = plan_preparation(&available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi())
+            let plan = plan_preparation(&available, &funding, fee_per_tx())
                 .expect("ample funding must plan");
-            assert_plan_valid(&plan, &available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
+            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             // The leftover is far larger than a fee, so it collapses to a single residual note.
             prop_assert!(plan.residual_count() <= 1, "{} residual notes", plan.residual_count());
         }
@@ -878,23 +882,12 @@ mod tests {
     #[test]
     fn common_case_is_one_layer_one_tx() {
         let funding = [500u64, 200, 100, 20, 5];
-        let total: u64 =
-            funding.iter().sum::<u64>() + Zip317FeePolicy.prep_transaction_fee_zatoshi() + 10_000;
-        let plan = plan_preparation(
-            &[total],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
+        let total: u64 = funding.iter().sum::<u64>() + fee_per_tx() + 10_000;
+        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(
-            &plan,
-            &[total],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
     }
 
     /// One large note fanning out into more funding notes than a single transaction holds needs more
@@ -902,25 +895,14 @@ mod tests {
     #[test]
     fn whale_single_note_fans_out_across_layers() {
         let funding: Vec<u64> = (0..40).map(|_| 100u64).collect();
-        let total: u64 =
-            funding.iter().sum::<u64>() + 60 * Zip317FeePolicy.prep_transaction_fee_zatoshi();
-        let plan = plan_preparation(
-            &[total],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
+        let total: u64 = funding.iter().sum::<u64>() + 60 * fee_per_tx();
+        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
         assert!(
             plan.layer_count() >= 2,
             "40 funding notes cannot fit one tx"
         );
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(
-            &plan,
-            &[total],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
     }
 
     /// A sub-quantum note (smaller than any funding note) is consolidated into a feeder before it can
@@ -928,26 +910,16 @@ mod tests {
     #[test]
     fn sub_quantum_is_consolidated_first() {
         // Twenty notes each far below the single 100-unit funding note (plus fees).
-        let per = Zip317FeePolicy.prep_transaction_fee_zatoshi() + 20;
+        let per = fee_per_tx() + 20;
         let available: Vec<u64> = core::iter::repeat_n(per, 20).collect();
         let funding = [100u64];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
         assert!(
             plan.layer_count() >= 2,
             "sub-quantum notes must consolidate first"
         );
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
     }
 
     /// When several notes each strand a sub-fee remainder whose total is below one transaction fee, the
@@ -957,37 +929,25 @@ mod tests {
     #[test]
     fn sub_fee_remainders_leave_multiple_residuals() {
         // Three notes, each funding one 100_000 note and stranding a 100-zatoshi remainder; the three
-        // remainders total 300 < Zip317FeePolicy.prep_transaction_fee_zatoshi(), so no consolidation can merge them.
+        // remainders total 300 < fee_per_tx(), so no consolidation can merge them.
         let f = 100_000u64;
         let eps = 100u64;
-        let note = f + Zip317FeePolicy.prep_transaction_fee_zatoshi() + eps;
+        let note = f + fee_per_tx() + eps;
         let available = [note, note, note];
         let funding = [f, f, f];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         let changes = plan.residual_notes();
         assert!(
             changes.len() > 1,
             "expected multiple sub-fee residuals: {changes:?}"
         );
         assert!(
-            changes
-                .iter()
-                .all(|&v| v < Zip317FeePolicy.prep_transaction_fee_zatoshi()),
+            changes.iter().all(|&v| v < fee_per_tx()),
             "all residuals sub-fee"
         );
         assert!(
-            changes.iter().sum::<u64>() < Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+            changes.iter().sum::<u64>() < fee_per_tx(),
             "total residual sub-fee"
         );
     }
@@ -996,21 +956,13 @@ mod tests {
     #[test]
     fn edge_cases() {
         assert_eq!(
-            plan_preparation(
-                &[1_000_000],
-                &[],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            )
-            .unwrap()
-            .layer_count(),
+            plan_preparation(&[1_000_000], &[], fee_per_tx())
+                .unwrap()
+                .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(
-                &[10],
-                &[100],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&[10], &[100], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1036,14 +988,10 @@ mod tests {
     #[test]
     fn many_tiny_notes_insufficient() {
         // 5 x 30_000 = 150_000 available. Funding one 100_000 note costs at least the note plus one
-        // fee: 100_000 + Zip317FeePolicy.prep_transaction_fee_zatoshi() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
+        // fee: 100_000 + fee_per_tx() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
         let available = vec![30_000u64; 5];
         assert_eq!(
-            plan_preparation(
-                &available,
-                &[100_000],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&available, &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1057,18 +1005,8 @@ mod tests {
             // Each note is below the 100_000 funding note, so the whole first layer is consolidation.
             let available = vec![50_000u64; n];
             let funding = [100_000u64];
-            let plan = plan_preparation(
-                &available,
-                &funding,
-                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-            )
-            .unwrap();
-            assert_plan_valid(
-                &plan,
-                &available,
-                &funding,
-                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-            );
+            let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             let mut got: Vec<usize> = plan.layers()[0]
                 .iter()
                 .map(|tx| tx.inputs().len())
@@ -1088,18 +1026,8 @@ mod tests {
         let mut available = vec![40_000u64; 10]; // sub-quantum: needed to fund the 100_000 note
         available.push(400_000); // funds the 300_000 note directly, but not also the 100_000 note
         let funding = [300_000u64, 100_000];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         let layer0 = &plan.layers()[0];
         assert!(
             layer0.iter().any(|tx| tx.inputs().len() == 1),
@@ -1119,11 +1047,7 @@ mod tests {
         // Two 90_000 notes: one consolidation nets 100_000, still short of 100_000 + a funding fee.
         let available = vec![90_000u64; 2];
         assert_eq!(
-            plan_preparation(
-                &available,
-                &[100_000],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&available, &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1133,21 +1057,13 @@ mod tests {
     #[test]
     fn lone_sub_quantum_note() {
         assert_eq!(
-            plan_preparation(
-                &[50_000],
-                &[100_000],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&[50_000], &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
         assert_eq!(
-            plan_preparation(
-                &[50_000],
-                &[],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            )
-            .unwrap()
-            .layer_count(),
+            plan_preparation(&[50_000], &[], fee_per_tx())
+                .unwrap()
+                .layer_count(),
             0
         );
     }
@@ -1157,29 +1073,15 @@ mod tests {
     #[test]
     fn threshold_notes() {
         let f = 100_000u64;
-        let exact = f + Zip317FeePolicy.prep_transaction_fee_zatoshi();
-        let plan = plan_preparation(
-            &[exact],
-            &[f],
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &[exact],
-            &[f],
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let exact = f + fee_per_tx();
+        let plan = plan_preparation(&[exact], &[f], fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[exact], &[f], fee_per_tx());
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 0, "exact funding leaves no residual");
 
         // A note worth only the fee has zero spendable budget; on its own it cannot fund anything.
         assert_eq!(
-            plan_preparation(
-                &[Zip317FeePolicy.prep_transaction_fee_zatoshi()],
-                &[f],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&[fee_per_tx()], &[f], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1191,18 +1093,8 @@ mod tests {
     fn deep_consolidation_layer_count() {
         let available = vec![50_000u64; 300];
         let funding = [1_000_000u64];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
             4,
@@ -1218,18 +1110,8 @@ mod tests {
     fn thousands_of_sub_quantum_notes_layer_count() {
         let available = vec![50_000u64; 3_000];
         let funding = [10_000_000u64];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
             4,
@@ -1246,20 +1128,9 @@ mod tests {
         for p in [1usize, 14, 15, 28, 100, 196, 197, 500] {
             let funding = vec![100u64; p];
             // The balanced tree costs more than a linear chain; fund exactly that plus a small residual.
-            let whale =
-                subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1 + 9_999;
-            let plan = plan_preparation(
-                &[whale],
-                &funding,
-                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-            )
-            .unwrap();
-            assert_plan_valid(
-                &plan,
-                &[whale],
-                &funding,
-                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-            );
+            let whale = subtree_cost(&funding, fee_per_tx()).1 + 9_999;
+            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
             assert_eq!(plan.layer_count(), split_depth(p), "p={p} layers");
         }
     }
@@ -1271,9 +1142,9 @@ mod tests {
         fn whale_fan_out_is_balanced_and_valid(
             funding in prop::collection::vec(1u64..10_000_000, 1..300),
         ) {
-            let whale = subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1 + 12_345;
-            let plan = plan_preparation(&[whale], &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).unwrap();
-            assert_plan_valid(&plan, &[whale], &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
+            let whale = subtree_cost(&funding, fee_per_tx()).1 + 12_345;
+            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
             prop_assert_eq!(plan.layer_count(), split_depth(funding.len()));
         }
     }
@@ -1302,19 +1173,9 @@ mod tests {
     #[test]
     fn exact_split_no_residual() {
         let funding = vec![100u64; 15];
-        let whale = subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1; // exact cost, no leftover
-        let plan = plan_preparation(
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let whale = subtree_cost(&funding, fee_per_tx()).1; // exact cost, no leftover
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), split_depth(15));
         assert_eq!(plan.residual_count(), 0, "exact split leaves no residual");
     }
@@ -1325,18 +1186,8 @@ mod tests {
     fn many_sub_quantum_fund_many_notes() {
         let available = vec![50_000u64; 100];
         let funding = vec![100_000u64; 30];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
             3,
@@ -1349,11 +1200,7 @@ mod tests {
     #[test]
     fn empty_available_insufficient() {
         assert_eq!(
-            plan_preparation(
-                &[],
-                &[100_000],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            ),
+            plan_preparation(&[], &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1362,23 +1209,15 @@ mod tests {
     #[test]
     fn zero_value_funding_is_empty() {
         assert_eq!(
-            plan_preparation(
-                &[1_000_000],
-                &[0],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            )
-            .unwrap()
-            .layer_count(),
+            plan_preparation(&[1_000_000], &[0], fee_per_tx())
+                .unwrap()
+                .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(
-                &[1_000_000],
-                &[0, 0],
-                Zip317FeePolicy.prep_transaction_fee_zatoshi()
-            )
-            .unwrap()
-            .layer_count(),
+            plan_preparation(&[1_000_000], &[0, 0], fee_per_tx())
+                .unwrap()
+                .layer_count(),
             0
         );
     }
@@ -1387,19 +1226,9 @@ mod tests {
     #[test]
     fn duplicate_funding_values() {
         let funding = [100u64, 100, 100, 100];
-        let whale = 400 + 3 * Zip317FeePolicy.prep_transaction_fee_zatoshi();
-        let plan = plan_preparation(
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let whale = 400 + 3 * fee_per_tx();
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(sorted_funding(&plan), vec![100, 100, 100, 100]);
     }
 
@@ -1408,18 +1237,8 @@ mod tests {
     fn deterministic() {
         let available = vec![500_000u64, 300_000, 120_000, 60_000, 9_000];
         let funding = vec![100_000u64, 50_000, 50_000, 20_000, 5_000];
-        let a = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        let b = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
+        let a = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let b = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
         assert_eq!(a, b);
     }
 
@@ -1429,14 +1248,8 @@ mod tests {
     #[test]
     fn note_equal_to_funding_value_is_used_directly() {
         let f = 100_000u64;
-        let plan =
-            plan_preparation(&[f], &[f], Zip317FeePolicy.prep_transaction_fee_zatoshi()).unwrap();
-        assert_plan_valid(
-            &plan,
-            &[f],
-            &[f],
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&[f], &[f], fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[f], &[f], fee_per_tx());
         assert_eq!(plan.transaction_count(), 0, "no transaction needed");
         assert_eq!(plan.direct_funding_notes(), &[(0, f)]);
         assert_eq!(plan.funding_notes(), vec![f]);
@@ -1450,18 +1263,8 @@ mod tests {
         // Note 0 exactly matches a funding value; note 1 (large) mints the other two.
         let available = vec![f, 10_000_000];
         let funding = vec![f, 50_000, 20_000];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.direct_funding_notes(),
             &[(0, f)],
@@ -1478,18 +1281,8 @@ mod tests {
     fn all_exact_matches_need_no_transactions() {
         let funding = vec![100_000u64, 50_000, 50_000];
         let available = funding.clone();
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(plan.transaction_count(), 0);
         assert_eq!(plan.layer_count(), 0);
         assert_eq!(plan.direct_funding_notes().len(), 3);
@@ -1501,20 +1294,9 @@ mod tests {
     #[test]
     fn varied_funding_from_one_whale() {
         let funding = [500_000u64, 200_000, 100_000, 20_000, 5_000, 2_000];
-        let whale =
-            funding.iter().sum::<u64>() + Zip317FeePolicy.prep_transaction_fee_zatoshi() + 12_345;
-        let plan = plan_preparation(
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &[whale],
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let whale = funding.iter().sum::<u64>() + fee_per_tx() + 12_345;
+        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
     }
@@ -1525,20 +1307,10 @@ mod tests {
     fn parallel_funding_across_notes() {
         let f = 100_000u64;
         let n = 20usize;
-        let available = vec![f + Zip317FeePolicy.prep_transaction_fee_zatoshi(); n]; // each note funds exactly one f note
+        let available = vec![f + fee_per_tx(); n]; // each note funds exactly one f note
         let funding = vec![f; n];
-        let plan = plan_preparation(
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        )
-        .unwrap();
-        assert_plan_valid(
-            &plan,
-            &available,
-            &funding,
-            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
-        );
+        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), 1, "independent notes fund in one layer");
         assert_eq!(plan.transaction_count(), n, "one transaction per note");
         assert_eq!(

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -131,6 +131,13 @@ pub struct PrepTransaction {
 }
 
 impl PrepTransaction {
+    /// Construct a transaction from its spent and produced notes. Used to reconstruct a persisted plan
+    /// (the inverse of [`inputs`](Self::inputs) plus [`outputs`](Self::outputs)); the caller supplies
+    /// parts a valid plan could have produced.
+    pub fn from_parts(inputs: Vec<PrepInput>, outputs: Vec<PrepOutput>) -> Self {
+        PrepTransaction { inputs, outputs }
+    }
+
     /// The notes this transaction spends.
     pub fn inputs(&self) -> &[PrepInput] {
         &self.inputs
@@ -159,6 +166,20 @@ pub struct PreparationPlan {
 }
 
 impl PreparationPlan {
+    /// Reconstruct a plan from its parts: the layers in dependency order (see [`layers`](Self::layers))
+    /// and the direct-funding notes (see [`direct_funding_notes`](Self::direct_funding_notes)). Used by
+    /// a store to round-trip a persisted plan; the caller supplies parts a valid plan could have
+    /// produced (no validation beyond what the accessors expose is done here).
+    pub fn from_parts(
+        layers: Vec<Vec<PrepTransaction>>,
+        direct_funding: Vec<(usize, u64)>,
+    ) -> Self {
+        PreparationPlan {
+            layers,
+            direct_funding,
+        }
+    }
+
     /// The layers, in dependency order (later layers may spend earlier layers' outputs).
     pub fn layers(&self) -> &[Vec<PrepTransaction>] {
         &self.layers

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -59,6 +59,8 @@
 
 use alloc::vec::Vec;
 
+use zcash_protocol::value::Zatoshis;
+
 use core::fmt;
 
 /// The exact number of Orchard actions in every note-preparation transaction ([ZIP 318]): each is
@@ -81,20 +83,20 @@ pub const CONSOLIDATION_INPUTS_PER_TX: usize = PREP_TX_ACTIONS - 1;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PrepInput {
     /// The wallet note at this `index` in the caller-supplied `available` slice, worth `value`.
-    Wallet { index: usize, value: u64 },
+    Wallet { index: usize, value: Zatoshis },
     /// The `output`-th output of the `transaction`-th transaction of an earlier `layer`, worth
     /// `value`.
     Prior {
         layer: usize,
         transaction: usize,
         output: usize,
-        value: u64,
+        value: Zatoshis,
     },
 }
 
 impl PrepInput {
     /// The note value this input carries.
-    pub fn value(&self) -> u64 {
+    pub fn value(&self) -> Zatoshis {
         match self {
             PrepInput::Wallet { value, .. } | PrepInput::Prior { value, .. } => *value,
         }
@@ -105,16 +107,16 @@ impl PrepInput {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PrepOutput {
     /// A final self-funding note: one of the requested funding values.
-    Funding(u64),
+    Funding(Zatoshis),
     /// An intermediate ("feeder") note, spent by a later layer to route value forward.
-    Intermediate(u64),
+    Intermediate(Zatoshis),
     /// Leftover value returned to the source pool.
-    Change(u64),
+    Change(Zatoshis),
 }
 
 impl PrepOutput {
     /// The note value this output carries.
-    pub fn value(&self) -> u64 {
+    pub fn value(&self) -> Zatoshis {
         match self {
             PrepOutput::Funding(v) | PrepOutput::Intermediate(v) | PrepOutput::Change(v) => *v,
         }
@@ -162,7 +164,7 @@ pub struct PreparationPlan {
     layers: Vec<Vec<PrepTransaction>>,
     /// Wallet notes (by their index in `available`) already equal to a funding value, used directly as
     /// that funding note with no preparation transaction, paired with that value.
-    direct_funding: Vec<(usize, u64)>,
+    direct_funding: Vec<(usize, Zatoshis)>,
 }
 
 impl PreparationPlan {
@@ -172,7 +174,7 @@ impl PreparationPlan {
     /// produced (no validation beyond what the accessors expose is done here).
     pub fn from_parts(
         layers: Vec<Vec<PrepTransaction>>,
-        direct_funding: Vec<(usize, u64)>,
+        direct_funding: Vec<(usize, Zatoshis)>,
     ) -> Self {
         PreparationPlan {
             layers,
@@ -206,7 +208,7 @@ impl PreparationPlan {
     /// Wallet notes (by their index in the caller's `available` slice) already equal to a funding
     /// value, used directly as that funding note with no preparation transaction, each paired with
     /// that value. The caller must leave these notes unspent by preparation.
-    pub fn direct_funding_notes(&self) -> &[(usize, u64)] {
+    pub fn direct_funding_notes(&self) -> &[(usize, Zatoshis)] {
         &self.direct_funding
     }
 
@@ -214,8 +216,8 @@ impl PreparationPlan {
     /// its transactions create and the wallet notes used directly (see
     /// [`direct_funding_notes`](Self::direct_funding_notes)): the notes the migration transfers will
     /// each spend.
-    pub fn funding_notes(&self) -> Vec<u64> {
-        let mut out: Vec<u64> = self
+    pub fn funding_notes(&self) -> Vec<Zatoshis> {
+        let mut out: Vec<Zatoshis> = self
             .all_outputs()
             .filter_map(|o| match o {
                 PrepOutput::Funding(v) => Some(*v),
@@ -228,7 +230,7 @@ impl PreparationPlan {
 
     /// The values of the residual notes this plan leaves in the source pool (its
     /// [`PrepOutput::Change`] outputs): at most one worth a fee, plus any sub-fee dust.
-    pub fn residual_notes(&self) -> Vec<u64> {
+    pub fn residual_notes(&self) -> Vec<Zatoshis> {
         self.all_outputs()
             .filter_map(|o| match o {
                 PrepOutput::Change(v) => Some(*v),
@@ -249,6 +251,9 @@ impl PreparationPlan {
 pub enum PrepError {
     /// The available notes cannot fund every requested funding note plus the per-transaction fees.
     InsufficientFunds,
+    /// The total of the available (or requested funding) note values exceeds the maximum money
+    /// supply, so no consistent plan exists.
+    BalanceInvalid,
 }
 
 impl fmt::Display for PrepError {
@@ -257,11 +262,21 @@ impl fmt::Display for PrepError {
             PrepError::InsufficientFunds => {
                 f.write_str("available notes cannot fund the requested notes plus preparation fees")
             }
+            PrepError::BalanceInvalid => {
+                f.write_str("the note values exceed the maximum money supply in total")
+            }
         }
     }
 }
 
 impl core::error::Error for PrepError {}
+
+/// Convert a planner-internal value to [`Zatoshis`]. Infallible by construction:
+/// [`plan_preparation`] validates the available and funding totals at entry, and the affordability
+/// checks bound every note the plan mints by the validated available total.
+fn zat(value: u64) -> Zatoshis {
+    Zatoshis::from_u64(value).expect("planner values are bounded by the validated totals")
+}
 
 /// Plan the note-preparation transactions that mint `funding` (the self-funding note values, in
 /// zatoshi) from `available` (the wallet's spendable source-pool note values, in zatoshi), reserving
@@ -271,19 +286,41 @@ impl core::error::Error for PrepError {}
 /// Returns an empty plan when `funding` is empty, and [`PrepError::InsufficientFunds`] when the
 /// available value cannot cover the funding notes plus the per-transaction fees.
 pub fn plan_preparation(
-    available: &[u64],
-    funding: &[u64],
-    fee_per_tx: u64,
+    available: &[Zatoshis],
+    funding: &[Zatoshis],
+    fee_per_tx: Zatoshis,
 ) -> Result<PreparationPlan, PrepError> {
+    // Validate once that the available and requested totals are representable amounts. Combined
+    // with the affordability checks below (a note is only ever minted out of value the available
+    // notes actually carry), every value the plan constructs is bounded by the validated available
+    // total, which is what makes the internal [`zat`] conversions infallible.
+    let _: Zatoshis = available
+        .iter()
+        .copied()
+        .sum::<Option<Zatoshis>>()
+        .ok_or(PrepError::BalanceInvalid)?;
+    let _: Zatoshis = funding
+        .iter()
+        .copied()
+        .sum::<Option<Zatoshis>>()
+        .ok_or(PrepError::BalanceInvalid)?;
+    // The partition arithmetic below runs in the u64 domain.
+    let available: Vec<u64> = available.iter().map(|&v| u64::from(v)).collect();
+    let fee_per_tx = u64::from(fee_per_tx);
+
     // Funding values still to produce, largest first (so `last()` is the smallest).
-    let mut remaining: Vec<u64> = funding.iter().copied().filter(|&v| v > 0).collect();
+    let mut remaining: Vec<u64> = funding
+        .iter()
+        .map(|&v| u64::from(v))
+        .filter(|&v| v > 0)
+        .collect();
     remaining.sort_unstable_by(|a, b| b.cmp(a));
 
     // Exact-match pass: a wallet note already equal to a funding value IS that funding note, so it is
     // used directly, with no preparation transaction and no fee. The matched notes are removed from
     // both the funding still to produce and the notes available to spend.
     let mut used = vec![false; available.len()];
-    let mut direct_funding: Vec<(usize, u64)> = Vec::new();
+    let mut direct_funding: Vec<(usize, Zatoshis)> = Vec::new();
     remaining.retain(|&f| {
         match available
             .iter()
@@ -292,7 +329,7 @@ pub fn plan_preparation(
         {
             Some(i) => {
                 used[i] = true;
-                direct_funding.push((i, f));
+                direct_funding.push((i, zat(f)));
                 false
             }
             None => true,
@@ -324,7 +361,7 @@ pub fn plan_preparation(
             build_split(
                 PrepInput::Wallet {
                     index: idx,
-                    value: big,
+                    value: zat(big),
                 },
                 big,
                 &remaining,
@@ -342,7 +379,10 @@ pub fn plan_preparation(
         .iter()
         .enumerate()
         .filter(|(i, _)| !used[*i])
-        .map(|(i, &v)| PrepInput::Wallet { index: i, value: v })
+        .map(|(i, &v)| PrepInput::Wallet {
+            index: i,
+            value: zat(v),
+        })
         .collect();
 
     while !remaining.is_empty() {
@@ -350,7 +390,7 @@ pub fn plan_preparation(
             return Err(PrepError::InsufficientFunds);
         }
         // Largest notes first.
-        current.sort_unstable_by_key(|n| core::cmp::Reverse(n.value()));
+        current.sort_unstable_by_key(|n| core::cmp::Reverse(u64::from(n.value())));
 
         // Pass 1: assign funding to the notes that can fund at least the smallest remaining note.
         // `partial` holds a note, the funding values it will mint, and its leftover budget; the rest
@@ -363,7 +403,7 @@ pub fn plan_preparation(
                 // Everything is already scheduled; this note stays unspent in the wallet.
                 continue;
             }
-            let value = input.value();
+            let value = u64::from(input.value());
             let smallest = *remaining.last().expect("remaining is non-empty");
             if value <= fee_per_tx || value - fee_per_tx < smallest {
                 consolidatable.push(input);
@@ -391,16 +431,18 @@ pub fn plan_preparation(
         let mut txs: Vec<PrepTransaction> = Vec::new();
         let mut next: Vec<PrepInput> = Vec::new();
         for (input, assigned, leftover) in partial {
-            let mut outputs: Vec<PrepOutput> =
-                assigned.into_iter().map(PrepOutput::Funding).collect();
+            let mut outputs: Vec<PrepOutput> = assigned
+                .into_iter()
+                .map(|v| PrepOutput::Funding(zat(v)))
+                .collect();
             if leftover > 0 {
                 next.push(PrepInput::Prior {
                     layer: layers.len(),
                     transaction: txs.len(),
                     output: outputs.len(),
-                    value: leftover,
+                    value: zat(leftover),
                 });
-                outputs.push(PrepOutput::Intermediate(leftover));
+                outputs.push(PrepOutput::Intermediate(zat(leftover)));
             }
             txs.push(PrepTransaction {
                 inputs: vec![input],
@@ -511,11 +553,11 @@ fn consolidate(
     if pool.len() < 2 {
         return pool;
     }
-    pool.sort_unstable_by_key(|n| core::cmp::Reverse(n.value()));
+    pool.sort_unstable_by_key(|n| core::cmp::Reverse(u64::from(n.value())));
     let mut leftover = Vec::new();
     for size in consolidation_batch_sizes(pool.len()) {
         let batch: Vec<PrepInput> = pool.drain(..size).collect();
-        let sum: u64 = batch.iter().map(PrepInput::value).sum();
+        let sum: u64 = batch.iter().map(|n| u64::from(n.value())).sum();
         if sum <= fee {
             leftover.extend(batch); // too small to pay a fee; leave unspent
             continue;
@@ -525,11 +567,11 @@ fn consolidate(
             layer,
             transaction: txs.len(),
             output: 0,
-            value: feeder,
+            value: zat(feeder),
         });
         txs.push(PrepTransaction {
             inputs: batch,
-            outputs: vec![PrepOutput::Intermediate(feeder)],
+            outputs: vec![PrepOutput::Intermediate(zat(feeder))],
         });
     }
     leftover
@@ -646,12 +688,14 @@ fn build_split(
 
     if depth <= 1 {
         // Leaf: fund every target directly, with any leftover as an intermediate (residual) note.
-        let mut outputs: Vec<PrepOutput> =
-            targets.iter().copied().map(PrepOutput::Funding).collect();
+        let mut outputs: Vec<PrepOutput> = targets
+            .iter()
+            .map(|&v| PrepOutput::Funding(zat(v)))
+            .collect();
         let spent: u64 = targets.iter().sum();
         let leftover = source_value - fee - spent;
         if leftover > 0 {
-            outputs.push(PrepOutput::Intermediate(leftover));
+            outputs.push(PrepOutput::Intermediate(zat(leftover)));
         }
         layers[layer].push(PrepTransaction {
             inputs: vec![source],
@@ -676,13 +720,12 @@ fn build_split(
 
     let mut outputs: Vec<PrepOutput> = child_values
         .iter()
-        .copied()
-        .map(PrepOutput::Intermediate)
+        .map(|&v| PrepOutput::Intermediate(zat(v)))
         .collect();
     let spent: u64 = child_values.iter().sum();
     let leftover = source_value - fee - spent;
     if leftover > 0 {
-        outputs.push(PrepOutput::Intermediate(leftover));
+        outputs.push(PrepOutput::Intermediate(zat(leftover)));
     }
     layers[layer].push(PrepTransaction {
         inputs: vec![source],
@@ -694,7 +737,7 @@ fn build_split(
             layer,
             transaction: tx_index,
             output,
-            value: cv,
+            value: zat(cv),
         };
         build_split(
             child,
@@ -720,9 +763,24 @@ mod tests {
         PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64()
     }
 
+    /// Wrap test values as [`Zatoshis`] at the public boundary; the tables and arithmetic in these
+    /// tests stay in the readable u64 domain.
+    fn zats(values: &[u64]) -> Vec<Zatoshis> {
+        values.iter().map(|&v| zat(v)).collect()
+    }
+
+    /// [`plan_preparation`] over the tests' u64 values.
+    fn plan_prep(
+        available: &[u64],
+        funding: &[u64],
+        fee_per_tx: u64,
+    ) -> Result<PreparationPlan, PrepError> {
+        plan_preparation(&zats(available), &zats(funding), zat(fee_per_tx))
+    }
+
     /// The funding values a plan mints, sorted, for multiset comparison against the request.
     fn sorted_funding(plan: &PreparationPlan) -> Vec<u64> {
-        let mut out = plan.funding_notes();
+        let mut out: Vec<u64> = plan.funding_notes().iter().map(|&v| u64::from(v)).collect();
         out.sort_unstable();
         out
     }
@@ -776,19 +834,21 @@ mod tests {
                     if let PrepInput::Prior { layer, .. } = input {
                         assert!(*layer < li, "layer {li} tx {ti}: forward/self reference");
                     }
-                    let v = input.value();
+                    let v = u64::from(input.value());
                     in_sum += v;
                     if let PrepInput::Wallet { .. } = input {
                         wallet_spent += v;
                     }
                 }
-                let out_sum: u64 = tx.outputs().iter().map(PrepOutput::value).sum();
+                let out_sum: u64 = tx.outputs().iter().map(|o| u64::from(o.value())).sum();
                 // Value conservation: inputs = outputs + the reserved fee.
                 assert_eq!(in_sum, out_sum + fee, "layer {li} tx {ti}: conservation");
                 total_fees += fee;
                 for o in tx.outputs() {
                     match o {
-                        PrepOutput::Funding(v) | PrepOutput::Change(v) => final_out += v,
+                        PrepOutput::Funding(v) | PrepOutput::Change(v) => {
+                            final_out += u64::from(*v)
+                        }
                         PrepOutput::Intermediate(_) => {}
                     }
                 }
@@ -803,7 +863,7 @@ mod tests {
         for &(i, v) in plan.direct_funding_notes() {
             assert_eq!(
                 available.get(i).copied(),
-                Some(v),
+                Some(u64::from(v)),
                 "direct funding note {i} value"
             );
             assert!(
@@ -817,7 +877,11 @@ mod tests {
         // whose total is itself below one transaction fee, no consolidation can merge them (its output
         // would be negative), so they survive as multiple sub-fee Change notes. Two Change notes each
         // >= fee could always be merged, so the planner never leaves more than one.
-        let changes = plan.residual_notes();
+        let changes: Vec<u64> = plan
+            .residual_notes()
+            .iter()
+            .map(|&v| u64::from(v))
+            .collect();
         let fundable_residuals = changes.iter().filter(|&&v| v >= fee).count();
         assert!(
             fundable_residuals <= 1,
@@ -858,7 +922,7 @@ mod tests {
         /// Whenever a plan is produced over arbitrary inputs, every structural invariant holds.
         #[test]
         fn valid_whenever_planned((available, funding) in arb_input()) {
-            if let Ok(plan) = plan_preparation(&available, &funding, fee_per_tx()) {
+            if let Ok(plan) = plan_prep(&available, &funding, fee_per_tx()) {
                 assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             }
         }
@@ -867,7 +931,7 @@ mod tests {
         /// plan (the planner never gives up when the value is amply present).
         #[test]
         fn always_plans_when_amply_funded((available, funding) in arb_sufficient()) {
-            let plan = plan_preparation(&available, &funding, fee_per_tx())
+            let plan = plan_prep(&available, &funding, fee_per_tx())
                 .expect("ample funding must plan");
             assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             // The leftover is far larger than a fee, so it collapses to a single residual note.
@@ -883,7 +947,7 @@ mod tests {
     fn common_case_is_one_layer_one_tx() {
         let funding = [500u64, 200, 100, 20, 5];
         let total: u64 = funding.iter().sum::<u64>() + fee_per_tx() + 10_000;
-        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&[total], &funding, fee_per_tx()).unwrap();
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 1, "one residual note");
@@ -896,7 +960,7 @@ mod tests {
     fn whale_single_note_fans_out_across_layers() {
         let funding: Vec<u64> = (0..40).map(|_| 100u64).collect();
         let total: u64 = funding.iter().sum::<u64>() + 60 * fee_per_tx();
-        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&[total], &funding, fee_per_tx()).unwrap();
         assert!(
             plan.layer_count() >= 2,
             "40 funding notes cannot fit one tx"
@@ -913,7 +977,7 @@ mod tests {
         let per = fee_per_tx() + 20;
         let available: Vec<u64> = core::iter::repeat_n(per, 20).collect();
         let funding = [100u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert!(
             plan.layer_count() >= 2,
             "sub-quantum notes must consolidate first"
@@ -935,9 +999,13 @@ mod tests {
         let note = f + fee_per_tx() + eps;
         let available = [note, note, note];
         let funding = [f, f, f];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
-        let changes = plan.residual_notes();
+        let changes: Vec<u64> = plan
+            .residual_notes()
+            .iter()
+            .map(|&v| u64::from(v))
+            .collect();
         assert!(
             changes.len() > 1,
             "expected multiple sub-fee residuals: {changes:?}"
@@ -956,13 +1024,13 @@ mod tests {
     #[test]
     fn edge_cases() {
         assert_eq!(
-            plan_preparation(&[1_000_000], &[], fee_per_tx())
+            plan_prep(&[1_000_000], &[], fee_per_tx())
                 .unwrap()
                 .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(&[10], &[100], fee_per_tx()),
+            plan_prep(&[10], &[100], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -991,7 +1059,7 @@ mod tests {
         // fee: 100_000 + fee_per_tx() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
         let available = vec![30_000u64; 5];
         assert_eq!(
-            plan_preparation(&available, &[100_000], fee_per_tx()),
+            plan_prep(&available, &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1005,7 +1073,7 @@ mod tests {
             // Each note is below the 100_000 funding note, so the whole first layer is consolidation.
             let available = vec![50_000u64; n];
             let funding = [100_000u64];
-            let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+            let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
             assert_plan_valid(&plan, &available, &funding, fee_per_tx());
             let mut got: Vec<usize> = plan.layers()[0]
                 .iter()
@@ -1026,7 +1094,7 @@ mod tests {
         let mut available = vec![40_000u64; 10]; // sub-quantum: needed to fund the 100_000 note
         available.push(400_000); // funds the 300_000 note directly, but not also the 100_000 note
         let funding = [300_000u64, 100_000];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         let layer0 = &plan.layers()[0];
         assert!(
@@ -1047,7 +1115,7 @@ mod tests {
         // Two 90_000 notes: one consolidation nets 100_000, still short of 100_000 + a funding fee.
         let available = vec![90_000u64; 2];
         assert_eq!(
-            plan_preparation(&available, &[100_000], fee_per_tx()),
+            plan_prep(&available, &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1057,11 +1125,11 @@ mod tests {
     #[test]
     fn lone_sub_quantum_note() {
         assert_eq!(
-            plan_preparation(&[50_000], &[100_000], fee_per_tx()),
+            plan_prep(&[50_000], &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
         assert_eq!(
-            plan_preparation(&[50_000], &[], fee_per_tx())
+            plan_prep(&[50_000], &[], fee_per_tx())
                 .unwrap()
                 .layer_count(),
             0
@@ -1074,14 +1142,14 @@ mod tests {
     fn threshold_notes() {
         let f = 100_000u64;
         let exact = f + fee_per_tx();
-        let plan = plan_preparation(&[exact], &[f], fee_per_tx()).unwrap();
+        let plan = plan_prep(&[exact], &[f], fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &[exact], &[f], fee_per_tx());
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 0, "exact funding leaves no residual");
 
         // A note worth only the fee has zero spendable budget; on its own it cannot fund anything.
         assert_eq!(
-            plan_preparation(&[fee_per_tx()], &[f], fee_per_tx()),
+            plan_prep(&[fee_per_tx()], &[f], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1093,7 +1161,7 @@ mod tests {
     fn deep_consolidation_layer_count() {
         let available = vec![50_000u64; 300];
         let funding = [1_000_000u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
@@ -1110,7 +1178,7 @@ mod tests {
     fn thousands_of_sub_quantum_notes_layer_count() {
         let available = vec![50_000u64; 3_000];
         let funding = [10_000_000u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
@@ -1129,7 +1197,7 @@ mod tests {
             let funding = vec![100u64; p];
             // The balanced tree costs more than a linear chain; fund exactly that plus a small residual.
             let whale = subtree_cost(&funding, fee_per_tx()).1 + 9_999;
-            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            let plan = plan_prep(&[whale], &funding, fee_per_tx()).unwrap();
             assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
             assert_eq!(plan.layer_count(), split_depth(p), "p={p} layers");
         }
@@ -1143,7 +1211,7 @@ mod tests {
             funding in prop::collection::vec(1u64..10_000_000, 1..300),
         ) {
             let whale = subtree_cost(&funding, fee_per_tx()).1 + 12_345;
-            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+            let plan = plan_prep(&[whale], &funding, fee_per_tx()).unwrap();
             assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
             prop_assert_eq!(plan.layer_count(), split_depth(funding.len()));
         }
@@ -1174,7 +1242,7 @@ mod tests {
     fn exact_split_no_residual() {
         let funding = vec![100u64; 15];
         let whale = subtree_cost(&funding, fee_per_tx()).1; // exact cost, no leftover
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&[whale], &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), split_depth(15));
         assert_eq!(plan.residual_count(), 0, "exact split leaves no residual");
@@ -1186,7 +1254,7 @@ mod tests {
     fn many_sub_quantum_fund_many_notes() {
         let available = vec![50_000u64; 100];
         let funding = vec![100_000u64; 30];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.layer_count(),
@@ -1200,7 +1268,7 @@ mod tests {
     #[test]
     fn empty_available_insufficient() {
         assert_eq!(
-            plan_preparation(&[], &[100_000], fee_per_tx()),
+            plan_prep(&[], &[100_000], fee_per_tx()),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1209,13 +1277,13 @@ mod tests {
     #[test]
     fn zero_value_funding_is_empty() {
         assert_eq!(
-            plan_preparation(&[1_000_000], &[0], fee_per_tx())
+            plan_prep(&[1_000_000], &[0], fee_per_tx())
                 .unwrap()
                 .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(&[1_000_000], &[0, 0], fee_per_tx())
+            plan_prep(&[1_000_000], &[0, 0], fee_per_tx())
                 .unwrap()
                 .layer_count(),
             0
@@ -1227,7 +1295,7 @@ mod tests {
     fn duplicate_funding_values() {
         let funding = [100u64, 100, 100, 100];
         let whale = 400 + 3 * fee_per_tx();
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&[whale], &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(sorted_funding(&plan), vec![100, 100, 100, 100]);
     }
@@ -1237,8 +1305,8 @@ mod tests {
     fn deterministic() {
         let available = vec![500_000u64, 300_000, 120_000, 60_000, 9_000];
         let funding = vec![100_000u64, 50_000, 50_000, 20_000, 5_000];
-        let a = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        let b = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let a = plan_prep(&available, &funding, fee_per_tx()).unwrap();
+        let b = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_eq!(a, b);
     }
 
@@ -1248,11 +1316,11 @@ mod tests {
     #[test]
     fn note_equal_to_funding_value_is_used_directly() {
         let f = 100_000u64;
-        let plan = plan_preparation(&[f], &[f], fee_per_tx()).unwrap();
+        let plan = plan_prep(&[f], &[f], fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &[f], &[f], fee_per_tx());
         assert_eq!(plan.transaction_count(), 0, "no transaction needed");
-        assert_eq!(plan.direct_funding_notes(), &[(0, f)]);
-        assert_eq!(plan.funding_notes(), vec![f]);
+        assert_eq!(plan.direct_funding_notes(), &[(0, zat(f))]);
+        assert_eq!(plan.funding_notes(), vec![zat(f)]);
     }
 
     /// A wallet holding some notes already equal to funding values uses those directly and mints only
@@ -1263,11 +1331,11 @@ mod tests {
         // Note 0 exactly matches a funding value; note 1 (large) mints the other two.
         let available = vec![f, 10_000_000];
         let funding = vec![f, 50_000, 20_000];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(
             plan.direct_funding_notes(),
-            &[(0, f)],
+            &[(0, zat(f))],
             "the exact note is used directly"
         );
         // Only the remaining two funding notes are minted, from the large note, in one transaction.
@@ -1281,7 +1349,7 @@ mod tests {
     fn all_exact_matches_need_no_transactions() {
         let funding = vec![100_000u64, 50_000, 50_000];
         let available = funding.clone();
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(plan.transaction_count(), 0);
         assert_eq!(plan.layer_count(), 0);
@@ -1295,7 +1363,7 @@ mod tests {
     fn varied_funding_from_one_whale() {
         let funding = [500_000u64, 200_000, 100_000, 20_000, 5_000, 2_000];
         let whale = funding.iter().sum::<u64>() + fee_per_tx() + 12_345;
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&[whale], &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
@@ -1309,7 +1377,7 @@ mod tests {
         let n = 20usize;
         let available = vec![f + fee_per_tx(); n]; // each note funds exactly one f note
         let funding = vec![f; n];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_prep(&available, &funding, fee_per_tx()).unwrap();
         assert_plan_valid(&plan, &available, &funding, fee_per_tx());
         assert_eq!(plan.layer_count(), 1, "independent notes fund in one layer");
         assert_eq!(plan.transaction_count(), n, "one transaction per note");

--- a/zcash_pool_migration_backend/src/scheduling.rs
+++ b/zcash_pool_migration_backend/src/scheduling.rs
@@ -389,6 +389,22 @@ fn boundary_at_or_after(height: u32) -> u32 {
     }
 }
 
+/// The first chain height at which a transfer's candidate anchor set (see
+/// [`draw_anchor_boundary`]) is non-empty: one full boundary interval past the LOWEST candidate,
+/// which is the first boundary strictly above `nu63_activation` and at or after
+/// `funding_creation_height`. A transfer whose observed chain tip is at or after this height always
+/// has at least one boundary to anchor to, so a schedule that places every broadcast at or after it
+/// never needs an anchor fallback; the scheduler MUST NOT place a transfer before it.
+pub fn earliest_broadcast_height(
+    nu63_activation: BlockHeight,
+    funding_creation_height: BlockHeight,
+) -> BlockHeight {
+    let lowest = most_recent_boundary_u32(u32::from(nu63_activation))
+        .saturating_add(BOUNDARY_MODULUS)
+        .max(boundary_at_or_after(u32::from(funding_creation_height)));
+    BlockHeight::from_u32(lowest.saturating_add(BOUNDARY_MODULUS))
+}
+
 /// Like [`draw_anchor_boundary`], but additionally enforces the provisional per-wallet multiplicity
 /// cap [`K_MAX`] (ZIP 318 SHOULD / OPEN ISSUE): `chosen_counts` maps each boundary height already
 /// chosen by THIS wallet to how many of its parts landed there. A fresh draw whose boundary already
@@ -931,6 +947,28 @@ mod tests {
             draw_anchor_boundary(bh(0), bh(0), bh(2 * BOUNDARY_MODULUS - 1), &mut r),
             None
         );
+    }
+
+    proptest! {
+        /// [`earliest_broadcast_height`] is the exact viability threshold: a tip at that height
+        /// always yields an anchor, and a tip one block earlier never does.
+        #[test]
+        fn earliest_broadcast_height_is_the_viability_threshold(act in 0u32..1_000_000,
+                                                               funding_offset in 0u32..2_000,
+                                                               seed in any::<u64>()) {
+            let funding = act + funding_offset;
+            let earliest = earliest_broadcast_height(bh(act), bh(funding));
+            let mut r = rng(seed);
+            prop_assert!(
+                draw_anchor_boundary(bh(act), bh(funding), earliest, &mut r).is_some(),
+                "a tip at the earliest broadcast height must have a candidate boundary"
+            );
+            let mut r = rng(seed);
+            prop_assert!(
+                draw_anchor_boundary(bh(act), bh(funding), earliest - 1, &mut r).is_none(),
+                "a tip below the earliest broadcast height must not"
+            );
+        }
     }
 
     #[test]

--- a/zcash_pool_migration_backend/src/scheduling.rs
+++ b/zcash_pool_migration_backend/src/scheduling.rs
@@ -74,6 +74,19 @@ pub const MEAN_DELAY: u32 = 144;
 /// an unbounded time. 576 blocks is `4 * MEAN_DELAY`, about twelve hours. See [`draw_delay`].
 pub const MAX_DELAY: u32 = 576;
 
+/// Mean of the exponential inter-arrival delay between successive PREPARATION transactions, in
+/// blocks (~30 minutes at the ~75-second target spacing). Preparation transactions are fully
+/// shielded self-sends: they need TEMPORAL decoupling from one another (a burst of identically
+/// shaped transactions from one wallet is a linkable cluster), but no anchor bucketing — only the
+/// pool-crossing transfers anchor to boundaries — so their spacing can be much tighter than the
+/// transfers' [`MEAN_DELAY`]. Provisional; not yet specified by ZIP 318.
+pub const PREP_MEAN_DELAY: u32 = 24;
+
+/// Upper bound (inclusive) on a single preparation inter-arrival delay, in blocks: `4 *
+/// PREP_MEAN_DELAY` (~2 hours), the same tail-truncation ratio as the transfers' [`MAX_DELAY`].
+/// A draw exceeding this is discarded and redrawn. Provisional; not yet specified by ZIP 318.
+pub const PREP_MAX_DELAY: u32 = 4 * PREP_MEAN_DELAY;
+
 /// Block-height modulus defining the BOUNDARY blocks: a height `h` is a boundary iff
 /// `h % BOUNDARY_MODULUS == 0`. Boundaries are the only tree states a transfer may anchor to, so
 /// many transfers share a small, common set of anchors (cohorts) rather than each pinning a unique
@@ -170,21 +183,33 @@ fn round_nonneg_to_u32(x: f64) -> u32 {
     (x + 0.5) as u64 as u32
 }
 
-/// Draw one inter-arrival delay in blocks from the truncated exponential distribution: mean
-/// [`MEAN_DELAY`], discard-and-redraw above [`MAX_DELAY`] (ZIP 318 "Transfer scheduling" MUST).
-///
-/// Samples by inverse-CDF, `delay = round(-MEAN_DELAY * ln(u))` for `u` uniform in `(0, 1]` (so the
-/// exponential rate is `1 / MEAN_DELAY`), redrawing whenever the rounded delay exceeds
-/// [`MAX_DELAY`]. The return is always in `[0, MAX_DELAY]`.
-pub fn draw_delay<R: RngCore>(rng: &mut R) -> u32 {
+/// Draw one inter-arrival delay in blocks from a truncated exponential distribution with the given
+/// `mean`, discarding and redrawing above `cap`. Samples by inverse-CDF, `delay = round(-mean *
+/// ln(u))` for `u` uniform in `(0, 1]` (so the exponential rate is `1 / mean`). The return is
+/// always in `[0, cap]`.
+fn draw_delay_with<R: RngCore>(mean: u32, cap: u32, rng: &mut R) -> u32 {
     loop {
         let u = draw_unit_left_open(rng);
-        // ln(u) <= 0 for u in (0, 1], so -MEAN_DELAY * ln(u) >= 0.
-        let delay = round_nonneg_to_u32(-(MEAN_DELAY as f64) * libm::log(u));
-        if delay <= MAX_DELAY {
+        // ln(u) <= 0 for u in (0, 1], so -mean * ln(u) >= 0.
+        let delay = round_nonneg_to_u32(-(mean as f64) * libm::log(u));
+        if delay <= cap {
             return delay;
         }
     }
+}
+
+/// Draw one TRANSFER inter-arrival delay in blocks from the truncated exponential distribution:
+/// mean [`MEAN_DELAY`], discard-and-redraw above [`MAX_DELAY`] (ZIP 318 "Transfer scheduling"
+/// MUST). The return is always in `[0, MAX_DELAY]`.
+pub fn draw_delay<R: RngCore>(rng: &mut R) -> u32 {
+    draw_delay_with(MEAN_DELAY, MAX_DELAY, rng)
+}
+
+/// Draw one PREPARATION inter-arrival delay in blocks: mean [`PREP_MEAN_DELAY`],
+/// discard-and-redraw above [`PREP_MAX_DELAY`]. See [`PREP_MEAN_DELAY`] for why preparations are
+/// spaced tighter than transfers. The return is always in `[0, PREP_MAX_DELAY]`.
+pub fn draw_prep_delay<R: RngCore>(rng: &mut R) -> u32 {
+    draw_delay_with(PREP_MEAN_DELAY, PREP_MAX_DELAY, rng)
 }
 
 /// Produce a uniformly random permutation of `0..n` using an in-place Fisher-Yates shuffle driven by
@@ -236,6 +261,26 @@ fn gen_index<R: RngCore>(rng: &mut R, bound: usize) -> usize {
     }
 }
 
+/// The cumulative-heights core shared by [`schedule_broadcast_heights`] and
+/// [`schedule_prep_broadcast_heights`]: starting at `start`, advance a running height by an
+/// independently drawn delay for each of the `n` entries. The returned vector has length `n`, is
+/// non-decreasing, and every entry is `>= start`; heights saturate at `u32::MAX` rather than
+/// overflowing (`BlockHeight`'s delta addition saturates).
+fn cumulative_broadcast_heights<R: RngCore>(
+    start: BlockHeight,
+    n: usize,
+    draw: impl Fn(&mut R) -> u32,
+    rng: &mut R,
+) -> Vec<BlockHeight> {
+    let mut heights = Vec::with_capacity(n);
+    let mut height = start;
+    for _ in 0..n {
+        height = height + draw(rng);
+        heights.push(height);
+    }
+    heights
+}
+
 /// Compute the per-part scheduled broadcast heights: starting at `commit_height`, advance a running
 /// height by an independently drawn [`draw_delay`] for each of the `n_parts` transfers (ZIP 318
 /// CUMULATIVE MUST). The returned vector has length `n_parts`, is non-decreasing, and every entry is
@@ -245,14 +290,21 @@ pub fn schedule_broadcast_heights<R: RngCore>(
     n_parts: usize,
     rng: &mut R,
 ) -> Vec<BlockHeight> {
-    let mut heights = Vec::with_capacity(n_parts);
-    let mut height = commit_height;
-    for _ in 0..n_parts {
-        // `BlockHeight`'s delta addition saturates at `u32::MAX`.
-        height = height + draw_delay(rng);
-        heights.push(height);
-    }
-    heights
+    cumulative_broadcast_heights(commit_height, n_parts, draw_delay, rng)
+}
+
+/// Compute per-transaction scheduled broadcast heights for one PREPARATION layer: starting at
+/// `start`, advance a running height by an independently drawn [`draw_prep_delay`] for each of the
+/// `n_txs` transactions. The returned vector has length `n_txs`, is non-decreasing, and every entry
+/// is `>= start`; heights saturate at `u32::MAX`. The caller (the engine) bases each later layer's
+/// `start` past the previous layer's last scheduled height plus a mining margin, so layers stay
+/// serialized while the transactions within and across layers remain temporally decoupled.
+pub fn schedule_prep_broadcast_heights<R: RngCore>(
+    start: BlockHeight,
+    n_txs: usize,
+    rng: &mut R,
+) -> Vec<BlockHeight> {
+    cumulative_broadcast_heights(start, n_txs, draw_prep_delay, rng)
 }
 
 /// The canonical rolling EXPIRY height for a transfer at `current_height` (ZIP 318 EXPIRY MUST):
@@ -812,6 +864,48 @@ mod tests {
         check_schedule_golden(500_000, 3, 7, &[500_025, 500_051, 500_226]);
         // commit height 0; gaps: 11, 6, 225, 58, 13, 28
         check_schedule_golden(0, 6, 12_345, &[11, 17, 242, 300, 313, 341]);
+    }
+
+    proptest! {
+        /// Preparation delays respect their own (tighter) bounds, and the per-layer schedule is
+        /// non-decreasing from its start.
+        #[test]
+        fn prep_schedule_bounds_and_monotone(start in 0u32..5_000_000,
+                                            n in 0usize..40,
+                                            seed in any::<u64>()) {
+            let mut r = rng(seed);
+            let hs = schedule_prep_broadcast_heights(bh(start), n, &mut r);
+            prop_assert_eq!(hs.len(), n);
+            let mut prev = bh(start);
+            for h in hs {
+                prop_assert!(h >= prev);
+                prop_assert!(u32::from(h) - u32::from(prev) <= PREP_MAX_DELAY);
+                prev = h;
+            }
+        }
+    }
+
+    /// Golden vectors for [`draw_prep_delay`]: the exact deterministic draws for fixed seeds,
+    /// pinning the tighter preparation spacing as a regression guard, with every delay within
+    /// `[0, PREP_MAX_DELAY]`. Derivable from the transfer goldens in [`draw_delay_golden`] by the
+    /// scale law: the same unit draws scaled by the mean ratio `MEAN_DELAY / PREP_MEAN_DELAY = 6`
+    /// (for example seed 1's 74, 12, 131, ... become 12, 2, 22, ...).
+    #[test]
+    fn draw_prep_delay_golden() {
+        fn check(seed: u64, expected: &[u32]) {
+            let mut r = rng(seed);
+            let got: Vec<u32> = (0..expected.len())
+                .map(|_| draw_prep_delay(&mut r))
+                .collect();
+            assert_eq!(got, expected, "draw_prep_delay(seed={seed})");
+            for &d in &got {
+                assert!(d <= PREP_MAX_DELAY, "delay {d} exceeds PREP_MAX_DELAY");
+            }
+        }
+        let exp_seed1 = [12, 2, 22, 6, 8, 30, 15, 4];
+        let exp_seed42 = [27, 72, 13, 24, 8, 4, 9, 39];
+        check(1, &exp_seed1);
+        check(42, &exp_seed42);
     }
 
     // --- expiry_height ------------------------------------------------------------------------

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -10,10 +10,11 @@
 //! [`MigrationState::next_step`] tells it to do. The decision of WHAT to do next, and the transaction
 //! status a wallet shows the user, live here.
 //!
-//! The central invariant is the multi-layer anchor bucketing: a later preparation layer spends the
-//! feeder notes an earlier layer minted, which become witnessable only once that earlier layer is
-//! mined, so each layer is built, signed, and broadcast against a distinct anchor and a later layer is
-//! never actionable until its dependencies (its whole prior layer) have mined.
+//! Every transaction is built and pre-signed when the migration is committed (one signing phase;
+//! anchors and witnesses are deferred to proving time per ZIP 374), so the state machine's only
+//! job is to ORDER the broadcasts: a transaction becomes broadcastable once its dependencies (the
+//! preparation layers that mint its inputs) have mined and its scheduled height has arrived, and
+//! the consumer proves it — installing its anchor and witnesses — just before broadcasting.
 
 use alloc::vec::Vec;
 
@@ -31,15 +32,6 @@ use crate::engine::{
 /// [`MigrationState::next_step`] again.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdvanceStep {
-    /// Build and pre-sign the next ready preparation layer (its predecessor has mined). The consumer
-    /// calls [`commit_pending_preparation`](crate::engine::commit_pending_preparation).
-    BuildPreparationLayer {
-        /// The layer to build.
-        layer: usize,
-    },
-    /// Build and pre-sign the transfers; the whole preparation is mined. The consumer calls
-    /// [`commit_transfers`](crate::engine::commit_transfers).
-    BuildTransfers,
     /// Prove and broadcast this pre-signed transaction: its dependencies are mined and it is due.
     Broadcast {
         /// The transaction to prove and broadcast.
@@ -55,9 +47,6 @@ pub enum AdvanceStep {
 /// The action a wallet takes next on a ready migration transaction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NextAction {
-    /// Build and pre-sign this placeholder now that its dependencies are mined (a later preparation
-    /// layer, or the transfers once the whole preparation is mined).
-    BuildAndSign,
     /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
     /// due.
     ProveAndBroadcast,
@@ -130,41 +119,6 @@ impl MigrationState {
                 .map(|t| matches!(t.state, MigrationTxState::Mined { .. }))
                 .unwrap_or(false)
         })
-    }
-
-    /// Whether all preparation transactions are mined (so the funding notes exist and the transfers can
-    /// be built).
-    pub fn all_preparations_mined(&self) -> bool {
-        self.transactions
-            .iter()
-            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
-            .all(|t| matches!(t.state, MigrationTxState::Mined { .. }))
-    }
-
-    /// The earliest deferred preparation layer that is ready to build: a multi-layer preparation records
-    /// its later layers (`layer > 0`) as unbuilt placeholders, and one becomes buildable once its whole
-    /// prior layer (its `depends_on`) is mined and its feeder notes are witnessable. Returns the layer
-    /// number, or `None` if no later layer is ready.
-    pub fn ready_prep_layer(&self) -> Option<usize> {
-        self.transactions
-            .iter()
-            .filter_map(|t| match t.kind {
-                MigrationTxKind::Preparation { layer, .. }
-                    if layer > 0
-                        && matches!(t.state, MigrationTxState::Planned)
-                        && self.deps_mined(&t.depends_on) =>
-                {
-                    Some(layer)
-                }
-                _ => None,
-            })
-            .min()
-    }
-
-    /// Whether a deferred preparation layer is ready to build (see
-    /// [`ready_prep_layer`](MigrationState::ready_prep_layer)).
-    pub fn has_ready_prep_layer(&self) -> bool {
-        self.ready_prep_layer().is_some()
     }
 
     /// The id of the next transaction ready to prove and broadcast: pre-signed (`Signed`) or already
@@ -243,8 +197,7 @@ impl MigrationState {
     /// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) to [`Signed`](MigrationTxState::Signed)
     /// so the normal state machine can prove and broadcast it. This is the second half of the
     /// external-signing seam: after
-    /// [`build_preparation_unsigned`](crate::engine::build_preparation_unsigned) or
-    /// [`build_transfers_unsigned`](crate::engine::build_transfers_unsigned) exports the unsigned PCZT,
+    /// [`build_preparation_unsigned`](crate::engine::build_preparation_unsigned) exports the unsigned PCZT,
     /// the caller has it signed out of band and returns the signed PCZT here, matched by `id`. Persist
     /// the state afterwards (`put_migration`).
     ///
@@ -260,16 +213,15 @@ impl MigrationState {
         else {
             return false;
         };
-        tx.pczt = Some(signed_pczt);
+        tx.pczt = signed_pczt;
         tx.state = MigrationTxState::Signed;
         true
     }
 
-    /// Decides the next step to advance the migration, from state alone. The priority is: prove and
-    /// broadcast the next due, dependency-satisfied transaction; else build the next ready preparation
-    /// layer; else, once the whole preparation is mined, build the transfers; else report `Complete`
-    /// when everything is mined, or `Waiting` otherwise. This is made once, here, so it is never
-    /// duplicated per consumer.
+    /// Decides the next step to advance the migration, from state alone: prove and broadcast the
+    /// next due, dependency-satisfied transaction; else report `Complete` when everything is
+    /// mined, or `Waiting` otherwise. This is made once, here, so it is never duplicated per
+    /// consumer.
     pub fn next_step(&self, target_height: BlockHeight) -> AdvanceStep {
         // A terminal migration (complete, or failed/cancelled) has no next action: never build or
         // broadcast for it, so a cancelled migration cannot be driven further.
@@ -278,16 +230,6 @@ impl MigrationState {
         }
         if let Some(id) = self.next_broadcastable(target_height) {
             return AdvanceStep::Broadcast { id };
-        }
-        if let Some(layer) = self.ready_prep_layer() {
-            return AdvanceStep::BuildPreparationLayer { layer };
-        }
-        let has_unbuilt_transfer = self.transactions.iter().any(|t| {
-            matches!(t.kind, MigrationTxKind::Transfer { .. })
-                && matches!(t.state, MigrationTxState::Planned)
-        });
-        if self.all_preparations_mined() && has_unbuilt_transfer {
-            return AdvanceStep::BuildTransfers;
         }
         if !self.transactions.is_empty()
             && self
@@ -304,27 +246,18 @@ impl MigrationState {
     /// render progress and decide, deterministically and from persisted state alone, the next
     /// transaction to sign or broadcast.
     ///
-    /// A `Planned` placeholder whose dependencies are all mined is ready to build and
-    /// sign; a `Signed` (or `Proved`) transaction whose dependencies are mined and whose scheduled
-    /// height has arrived is ready to prove and broadcast. Otherwise a waiting transaction reports what
-    /// it is blocked on: its dependencies (a prior anchor bucket still to mine) or the broadcast
-    /// schedule.
+    /// A `Signed` (or `Proved`) transaction whose dependencies are mined and whose scheduled
+    /// height has arrived is ready to prove and broadcast. Otherwise a waiting transaction reports
+    /// what it is blocked on: its dependencies (a preparation still to mine), the broadcast
+    /// schedule, or an external signature.
     pub fn transaction_statuses(&self, target_height: BlockHeight) -> Vec<TransactionStatus> {
         self.transactions
             .iter()
             .map(|t| {
                 let deps_ok = self.deps_mined(&t.depends_on);
-                // `Planned` needs building; `Signed`/`Proved` need broadcasting. In both cases
-                // a transaction is actionable only once its dependencies (the prior anchor bucket) are
-                // mined, and a broadcastable one only once it is also due.
+                // `Signed`/`Proved` transactions are actionable only once their dependencies (the
+                // preparation layers that mint their inputs) are mined and they are due.
                 let (ready, action, blocked_on) = match t.state {
-                    MigrationTxState::Planned => {
-                        if deps_ok {
-                            (true, Some(NextAction::BuildAndSign), None)
-                        } else {
-                            (false, None, Some(Blocker::Dependencies))
-                        }
-                    }
                     // Built for an external signer and waiting for its signed PCZT; the wallet's
                     // automatic driver takes no action (the external-signing caller drives it via
                     // `apply_signature`), so it is neither ready nor blocked on the chain.
@@ -381,7 +314,7 @@ mod tests {
         MigrationTransaction {
             id: MigrationTxId(id),
             kind,
-            pczt: None,
+            pczt: Vec::new(),
             depends_on: Vec::new(),
             scheduled_height: BlockHeight::from_u32(0),
             expiry_height: BlockHeight::from_u32(0),
@@ -428,19 +361,16 @@ mod tests {
         let mut state = state_with(vec![tx(0, prep(0, 0), MigrationTxState::AwaitingSignature)]);
         assert!(state.apply_signature(MigrationTxId(0), vec![1u8, 2, 3]));
         assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
-        assert_eq!(
-            state.transactions[0].pczt.as_deref(),
-            Some(&[1u8, 2, 3][..])
-        );
+        assert_eq!(state.transactions[0].pczt, vec![1u8, 2, 3]);
     }
 
     #[test]
     fn apply_signature_rejects_unknown_or_wrong_state() {
         let mut state = state_with(vec![
             tx(0, prep(0, 0), MigrationTxState::AwaitingSignature),
-            tx(1, transfer(0), MigrationTxState::Planned),
+            tx(1, transfer(0), MigrationTxState::Signed),
         ]);
-        // An unknown id, and a transaction not awaiting a signature (a Planned placeholder), are both
+        // An unknown id, and a transaction not awaiting a signature (already signed), are both
         // rejected without changing any state.
         assert!(!state.apply_signature(MigrationTxId(9), vec![1u8]));
         assert!(!state.apply_signature(MigrationTxId(1), vec![1u8]));
@@ -452,7 +382,7 @@ mod tests {
         // misrouted signature cannot overwrite the stored one).
         assert!(state.apply_signature(MigrationTxId(0), vec![1u8]));
         assert!(!state.apply_signature(MigrationTxId(0), vec![2u8]));
-        assert_eq!(state.transactions[0].pczt.as_deref(), Some(&[1u8][..]));
+        assert_eq!(state.transactions[0].pczt, vec![1u8]);
     }
 
     #[test]
@@ -473,43 +403,6 @@ mod tests {
         assert!(s.deps_mined(&[MigrationTxId(0)]));
         assert!(!s.deps_mined(&[MigrationTxId(1)]));
         assert!(s.deps_mined(&[])); // empty deps are trivially satisfied
-        assert!(!s.all_preparations_mined()); // tx 1 is not mined
-    }
-
-    #[test]
-    fn ready_prep_layer_needs_prior_layer_mined() {
-        // Layer 0 half-mined: layer 1 (depending on both layer-0 txs) is not ready.
-        let mut l1 = tx(2, prep(1, 0), MigrationTxState::Planned);
-        l1.depends_on = vec![MigrationTxId(0), MigrationTxId(1)];
-        let mut s = state_with(vec![
-            tx(0, prep(0, 0), mined(10)),
-            tx(
-                1,
-                prep(0, 1),
-                MigrationTxState::Broadcast {
-                    txid: TxId::from_bytes([0; 32]),
-                },
-            ),
-            l1.clone(),
-        ]);
-        assert_eq!(s.ready_prep_layer(), None);
-        assert!(!s.has_ready_prep_layer());
-
-        // Mine the rest of layer 0: layer 1 becomes ready.
-        s.transactions[1].state = mined(11);
-        assert_eq!(s.ready_prep_layer(), Some(1));
-        assert!(s.has_ready_prep_layer());
-    }
-
-    #[test]
-    fn ready_prep_layer_picks_earliest() {
-        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
-        l1.depends_on = vec![MigrationTxId(0)];
-        let mut l2 = tx(2, prep(2, 0), MigrationTxState::Planned);
-        l2.depends_on = vec![MigrationTxId(1)];
-        // Only layer 0 is mined, so only layer 1 is ready.
-        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), l1, l2]);
-        assert_eq!(s.ready_prep_layer(), Some(1));
     }
 
     #[test]
@@ -543,10 +436,12 @@ mod tests {
 
     #[test]
     fn next_step_walks_the_lifecycle() {
-        // Layer 0 signed, layer 1 planned depending on it, one transfer planned depending on layer 1.
-        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
+        // Every transaction is pre-signed at commit; the state machine only orders the
+        // broadcasts: layer 0, then layer 1 once layer 0 mines, then the transfer once the
+        // whole preparation mines.
+        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Signed);
         l1.depends_on = vec![MigrationTxId(0)];
-        let mut xfer = tx(2, transfer(0), MigrationTxState::Planned);
+        let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
         xfer.depends_on = vec![MigrationTxId(1)];
         let mut s = state_with(vec![tx(0, prep(0, 0), MigrationTxState::Signed), l1, xfer]);
 
@@ -558,7 +453,7 @@ mod tests {
             }
         );
 
-        // 2) Layer 0 broadcast, not yet mined -> nothing ready, waiting.
+        // 2) Layer 0 broadcast, not yet mined -> its dependents stay blocked, waiting.
         s.transactions[0].state = MigrationTxState::Broadcast {
             txid: TxId::from_bytes([1; 32]),
         };
@@ -567,15 +462,8 @@ mod tests {
             AdvanceStep::Waiting
         );
 
-        // 3) Layer 0 mined -> layer 1 ready to build.
+        // 3) Layer 0 mined -> layer 1 becomes broadcastable.
         s.transactions[0].state = mined(10);
-        assert_eq!(
-            s.next_step(BlockHeight::from_u32(100)),
-            AdvanceStep::BuildPreparationLayer { layer: 1 }
-        );
-
-        // 4) Layer 1 signed and due -> broadcast it.
-        s.transactions[1].state = MigrationTxState::Signed;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
@@ -583,15 +471,8 @@ mod tests {
             }
         );
 
-        // 5) Layer 1 mined, all preparation mined -> build transfers.
+        // 4) Layer 1 mined -> the transfer becomes broadcastable.
         s.transactions[1].state = mined(11);
-        assert_eq!(
-            s.next_step(BlockHeight::from_u32(100)),
-            AdvanceStep::BuildTransfers
-        );
-
-        // 6) Transfer signed and due -> broadcast it.
-        s.transactions[2].state = MigrationTxState::Signed;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
@@ -599,7 +480,7 @@ mod tests {
             }
         );
 
-        // 7) Everything mined -> complete.
+        // 5) Everything mined -> complete.
         s.transactions[2].state = mined(12);
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
@@ -682,7 +563,7 @@ mod tests {
 
     #[test]
     fn transaction_statuses_report_ready_and_blockers() {
-        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
+        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Signed);
         l1.depends_on = vec![MigrationTxId(0)];
         let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
         xfer.depends_on = vec![MigrationTxId(1)];
@@ -697,9 +578,9 @@ mod tests {
         assert_eq!(views[0].blocked_on, None);
         assert_eq!(views[0].mined_height, Some(BlockHeight::from_u32(10)));
 
-        // tx 1: planned with its dependency (tx 0) mined -> ready to build.
+        // tx 1: signed with its dependency (tx 0) mined and due -> ready to broadcast.
         assert!(views[1].ready);
-        assert_eq!(views[1].action, Some(NextAction::BuildAndSign));
+        assert_eq!(views[1].action, Some(NextAction::ProveAndBroadcast));
         assert_eq!(views[1].blocked_on, None);
 
         // tx 2: signed but its dependency (tx 1) is not mined -> blocked on dependencies.

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -17,6 +17,7 @@
 
 use alloc::vec::Vec;
 
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
@@ -105,7 +106,7 @@ pub struct TransactionStatus {
     /// The height it was mined at, once mined.
     pub mined_height: Option<BlockHeight>,
     /// The transaction id (raw internal bytes), once broadcast.
-    pub txid: Option<[u8; 32]>,
+    pub txid: Option<TxId>,
 }
 
 impl MigrationState {
@@ -210,7 +211,7 @@ impl MigrationState {
     /// Records that the transaction `id` was broadcast with the given `txid`, then recomputes the
     /// overall status. The consumer calls this after it broadcasts the transaction the engine handed
     /// it.
-    pub fn mark_broadcast(&mut self, id: MigrationTxId, txid: [u8; 32]) {
+    pub fn mark_broadcast(&mut self, id: MigrationTxId, txid: TxId) {
         if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
             tx.state = MigrationTxState::Broadcast { txid };
         }
@@ -461,7 +462,13 @@ mod tests {
         l1.depends_on = vec![MigrationTxId(0), MigrationTxId(1)];
         let mut s = state_with(vec![
             tx(0, prep(0, 0), mined(10)),
-            tx(1, prep(0, 1), MigrationTxState::Broadcast { txid: [0; 32] }),
+            tx(
+                1,
+                prep(0, 1),
+                MigrationTxState::Broadcast {
+                    txid: TxId::from_bytes([0; 32]),
+                },
+            ),
             l1.clone(),
         ]);
         assert_eq!(s.ready_prep_layer(), None);
@@ -507,7 +514,9 @@ mod tests {
         );
 
         // Dependency not mined: not broadcastable.
-        s.transactions[0].state = MigrationTxState::Broadcast { txid: [0; 32] };
+        s.transactions[0].state = MigrationTxState::Broadcast {
+            txid: TxId::from_bytes([0; 32]),
+        };
         assert_eq!(s.next_broadcastable(BlockHeight::from_u32(5)), None);
     }
 
@@ -529,7 +538,9 @@ mod tests {
         );
 
         // 2) Layer 0 broadcast, not yet mined -> nothing ready, waiting.
-        s.transactions[0].state = MigrationTxState::Broadcast { txid: [1; 32] };
+        s.transactions[0].state = MigrationTxState::Broadcast {
+            txid: TxId::from_bytes([1; 32]),
+        };
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Waiting
@@ -598,10 +609,10 @@ mod tests {
         ]);
         assert_eq!(s.status, MigrationStatus::Committed);
 
-        s.mark_broadcast(MigrationTxId(0), [7; 32]);
+        s.mark_broadcast(MigrationTxId(0), TxId::from_bytes([7; 32]));
         assert!(matches!(
             s.transactions[0].state,
-            MigrationTxState::Broadcast { txid } if txid == [7; 32]
+            MigrationTxState::Broadcast { txid } if txid == TxId::from_bytes([7; 32])
         ));
         assert_eq!(s.status, MigrationStatus::InProgress);
         assert!(!s.is_terminal());
@@ -617,7 +628,13 @@ mod tests {
         // A cancelled migration (Failed) whose transactions were already broadcast must stay
         // terminal: neither recomputing the status nor asking for the next step may revive it.
         let mut s = state_with(vec![
-            tx(0, prep(0, 0), MigrationTxState::Broadcast { txid: [1; 32] }),
+            tx(
+                0,
+                prep(0, 0),
+                MigrationTxState::Broadcast {
+                    txid: TxId::from_bytes([1; 32]),
+                },
+            ),
             tx(1, transfer(0), MigrationTxState::Signed),
         ]);
         s.status = MigrationStatus::Failed;

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -1,0 +1,568 @@
+//! Migration state logic: the pure, backend-agnostic methods a consuming application uses to drive a
+//! committed migration and render its progress.
+//!
+//! These are methods on [`MigrationState`] that operate only on the persisted state and never touch a
+//! wallet, a prover, or the network, so every consumer (a mobile wallet using these crates directly,
+//! or a server like Zallet) makes the SAME decisions from the SAME state. The consumer supplies the
+//! I/O: it detects that a broadcast transaction has mined (via its own chain view) and calls
+//! [`MigrationState::mark_mined`], it broadcasts a transaction and calls
+//! [`MigrationState::mark_broadcast`], and it performs the build/prove/broadcast work that
+//! [`MigrationState::next_step`] tells it to do. The decision of WHAT to do next, and the transaction
+//! status a wallet shows the user, live here.
+//!
+//! The central invariant is the multi-layer anchor bucketing: a later preparation layer spends the
+//! feeder notes an earlier layer minted, which become witnessable only once that earlier layer is
+//! mined, so each layer is built, signed, and broadcast against a distinct anchor and a later layer is
+//! never actionable until its dependencies (its whole prior layer) have mined.
+
+use alloc::vec::Vec;
+
+use zcash_protocol::consensus::BlockHeight;
+
+use crate::engine::{
+    MigrationState, MigrationStatus, MigrationTxId, MigrationTxKind, MigrationTxState,
+};
+
+/// The next thing to do to advance a committed migration, decided purely from its state. The consumer
+/// performs the corresponding I/O and updates the state (via the commit functions and
+/// [`MigrationState::mark_broadcast`] / [`MigrationState::mark_mined`]), then calls
+/// [`MigrationState::next_step`] again.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdvanceStep {
+    /// Build and pre-sign the next ready preparation layer (its predecessor has mined). The consumer
+    /// calls [`commit_pending_preparation`](crate::engine::commit_pending_preparation).
+    BuildPreparationLayer {
+        /// The layer to build.
+        layer: usize,
+    },
+    /// Build and pre-sign the transfers; the whole preparation is mined. The consumer calls
+    /// [`commit_transfers`](crate::engine::commit_transfers).
+    BuildTransfers,
+    /// Prove and broadcast this pre-signed transaction: its dependencies are mined and it is due.
+    Broadcast {
+        /// The transaction to prove and broadcast.
+        id: MigrationTxId,
+    },
+    /// Nothing to do now: waiting for one or more transactions to mine, or for a scheduled height to
+    /// arrive.
+    Waiting,
+    /// Every transaction is mined; the migration is complete.
+    Complete,
+}
+
+/// The action a wallet takes next on a ready migration transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NextAction {
+    /// Build and pre-sign this placeholder now that its dependencies are mined (a later preparation
+    /// layer, or the transfers once the whole preparation is mined).
+    BuildAndSign,
+    /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
+    /// due.
+    ProveAndBroadcast,
+}
+
+/// Why a migration transaction is not yet actionable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Blocker {
+    /// Waiting for its dependency transactions (an earlier preparation layer, or the whole
+    /// preparation) to mine, so its input notes become witnessable in a new anchor bucket. A
+    /// multi-layer preparation signs and broadcasts each layer in a separate anchor bucket, so a later
+    /// layer cannot be built until its predecessor has mined.
+    Dependencies,
+    /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain tip
+    /// to reach its scheduled height.
+    Schedule,
+}
+
+/// The status of one migration transaction, as a wallet renders it and decides the next step. This is
+/// the machine-readable view a mobile wallet needs: it cannot pre-sign a multi-layer migration up
+/// front (later layers become witnessable only as earlier layers mine) and may be restarted between
+/// layers, so it decides which transaction to sign or broadcast next, and what the rest are waiting on,
+/// from this view of the persisted state alone.
+#[derive(Clone, Debug)]
+pub struct TransactionStatus {
+    /// This transaction's stable id.
+    pub id: MigrationTxId,
+    /// What it does (a preparation transaction, carrying its layer / anchor bucket, or a transfer).
+    pub kind: MigrationTxKind,
+    /// Its current lifecycle state.
+    pub state: MigrationTxState,
+    /// The transactions that must be mined before this one can be built or broadcast.
+    pub depends_on: Vec<MigrationTxId>,
+    /// The height at or after which it is due to broadcast.
+    pub scheduled_height: BlockHeight,
+    /// Whether the wallet can act on it right now.
+    pub ready: bool,
+    /// The action available now, when `ready` is true.
+    pub action: Option<NextAction>,
+    /// Why it is not yet actionable, when it is waiting (and not already broadcast or mined).
+    pub blocked_on: Option<Blocker>,
+    /// The height it was mined at, once mined.
+    pub mined_height: Option<BlockHeight>,
+    /// The transaction id (raw internal bytes), once broadcast.
+    pub txid: Option<[u8; 32]>,
+}
+
+impl MigrationState {
+    /// Whether every transaction in `depends_on` is mined.
+    pub fn deps_mined(&self, depends_on: &[MigrationTxId]) -> bool {
+        depends_on.iter().all(|dep| {
+            self.transactions
+                .iter()
+                .find(|t| t.id == *dep)
+                .map(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+                .unwrap_or(false)
+        })
+    }
+
+    /// Whether all preparation transactions are mined (so the funding notes exist and the transfers can
+    /// be built).
+    pub fn all_preparations_mined(&self) -> bool {
+        self.transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+            .all(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+    }
+
+    /// The earliest deferred preparation layer that is ready to build: a multi-layer preparation records
+    /// its later layers (`layer > 0`) as unbuilt placeholders, and one becomes buildable once its whole
+    /// prior layer (its `depends_on`) is mined and its feeder notes are witnessable. Returns the layer
+    /// number, or `None` if no later layer is ready.
+    pub fn ready_prep_layer(&self) -> Option<usize> {
+        self.transactions
+            .iter()
+            .filter_map(|t| match t.kind {
+                MigrationTxKind::Preparation { layer, .. }
+                    if layer > 0
+                        && matches!(t.state, MigrationTxState::Planned)
+                        && self.deps_mined(&t.depends_on) =>
+                {
+                    Some(layer)
+                }
+                _ => None,
+            })
+            .min()
+    }
+
+    /// Whether a deferred preparation layer is ready to build (see
+    /// [`ready_prep_layer`](MigrationState::ready_prep_layer)).
+    pub fn has_ready_prep_layer(&self) -> bool {
+        self.ready_prep_layer().is_some()
+    }
+
+    /// The id of the next transaction ready to prove and broadcast: pre-signed (`Signed`) or already
+    /// `Proved`, its dependencies mined, and scheduled at or before `target_height` (`chain_tip + 1`).
+    pub fn next_broadcastable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+        self.transactions
+            .iter()
+            .find(|t| {
+                matches!(t.state, MigrationTxState::Signed | MigrationTxState::Proved)
+                    && t.scheduled_height <= target_height
+                    && self.deps_mined(&t.depends_on)
+            })
+            .map(|t| t.id)
+    }
+
+    /// Recomputes the overall [`MigrationStatus`]: `Complete` once every transaction is mined,
+    /// `InProgress` once any has been broadcast or mined. Leaves the status unchanged otherwise (an
+    /// uncommitted or freshly committed migration keeps its `Planning`/`Committed` status until work
+    /// begins).
+    pub fn recompute_status(&mut self) {
+        let all_mined = !self.transactions.is_empty()
+            && self
+                .transactions
+                .iter()
+                .all(|t| matches!(t.state, MigrationTxState::Mined { .. }));
+        let any_started = self.transactions.iter().any(|t| {
+            matches!(
+                t.state,
+                MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
+            )
+        });
+        if all_mined {
+            self.status = MigrationStatus::Complete;
+        } else if any_started {
+            self.status = MigrationStatus::InProgress;
+        }
+    }
+
+    /// Whether this migration has reached a terminal status (`Complete` or `Failed`), so a new
+    /// migration may replace it. A non-terminal migration is still in progress and must not be
+    /// overwritten.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            MigrationStatus::Complete | MigrationStatus::Failed
+        )
+    }
+
+    /// Records that the transaction `id` was broadcast with the given `txid`, then recomputes the
+    /// overall status. The consumer calls this after it broadcasts the transaction the engine handed
+    /// it.
+    pub fn mark_broadcast(&mut self, id: MigrationTxId, txid: [u8; 32]) {
+        if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
+            tx.state = MigrationTxState::Broadcast { txid };
+        }
+        self.recompute_status();
+    }
+
+    /// Records that the transaction `id` was mined at `height`, then recomputes the overall status. The
+    /// consumer detects mining through its own chain view (matching a broadcast transaction's txid) and
+    /// calls this, which is what lets a later preparation layer or the transfers become actionable.
+    pub fn mark_mined(&mut self, id: MigrationTxId, height: BlockHeight) {
+        if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
+            tx.state = MigrationTxState::Mined { height };
+        }
+        self.recompute_status();
+    }
+
+    /// Decides the next step to advance the migration, from state alone. The priority is: prove and
+    /// broadcast the next due, dependency-satisfied transaction; else build the next ready preparation
+    /// layer; else, once the whole preparation is mined, build the transfers; else report `Complete`
+    /// when everything is mined, or `Waiting` otherwise. This is made once, here, so it is never
+    /// duplicated per consumer.
+    pub fn next_step(&self, target_height: BlockHeight) -> AdvanceStep {
+        if let Some(id) = self.next_broadcastable(target_height) {
+            return AdvanceStep::Broadcast { id };
+        }
+        if let Some(layer) = self.ready_prep_layer() {
+            return AdvanceStep::BuildPreparationLayer { layer };
+        }
+        let has_unbuilt_transfer = self.transactions.iter().any(|t| {
+            matches!(t.kind, MigrationTxKind::Transfer { .. })
+                && matches!(t.state, MigrationTxState::Planned)
+        });
+        if self.all_preparations_mined() && has_unbuilt_transfer {
+            return AdvanceStep::BuildTransfers;
+        }
+        if !self.transactions.is_empty()
+            && self
+                .transactions
+                .iter()
+                .all(|t| matches!(t.state, MigrationTxState::Mined { .. }))
+        {
+            return AdvanceStep::Complete;
+        }
+        AdvanceStep::Waiting
+    }
+
+    /// Builds the per-transaction status view at `target_height` (`chain_tip + 1`), so a wallet can
+    /// render progress and decide, deterministically and from persisted state alone, the next
+    /// transaction to sign or broadcast.
+    ///
+    /// A `Planned` (or `Expired`) placeholder whose dependencies are all mined is ready to build and
+    /// sign; a `Signed` (or `Proved`) transaction whose dependencies are mined and whose scheduled
+    /// height has arrived is ready to prove and broadcast. Otherwise a waiting transaction reports what
+    /// it is blocked on: its dependencies (a prior anchor bucket still to mine) or the broadcast
+    /// schedule.
+    pub fn transaction_statuses(&self, target_height: BlockHeight) -> Vec<TransactionStatus> {
+        self.transactions
+            .iter()
+            .map(|t| {
+                let deps_ok = self.deps_mined(&t.depends_on);
+                // `Planned`/`Expired` need building; `Signed`/`Proved` need broadcasting. In both cases
+                // a transaction is actionable only once its dependencies (the prior anchor bucket) are
+                // mined, and a broadcastable one only once it is also due.
+                let (ready, action, blocked_on) = match t.state {
+                    MigrationTxState::Planned | MigrationTxState::Expired => {
+                        if deps_ok {
+                            (true, Some(NextAction::BuildAndSign), None)
+                        } else {
+                            (false, None, Some(Blocker::Dependencies))
+                        }
+                    }
+                    MigrationTxState::Signed | MigrationTxState::Proved => {
+                        if !deps_ok {
+                            (false, None, Some(Blocker::Dependencies))
+                        } else if t.scheduled_height <= target_height {
+                            (true, Some(NextAction::ProveAndBroadcast), None)
+                        } else {
+                            (false, None, Some(Blocker::Schedule))
+                        }
+                    }
+                    MigrationTxState::Broadcast { .. } => (false, None, None),
+                    MigrationTxState::Mined { .. } => (false, None, None),
+                };
+                let txid = match t.state {
+                    MigrationTxState::Broadcast { txid } => Some(txid),
+                    _ => None,
+                };
+                let mined_height = match t.state {
+                    MigrationTxState::Mined { height } => Some(height),
+                    _ => None,
+                };
+                TransactionStatus {
+                    id: t.id,
+                    kind: t.kind,
+                    state: t.state,
+                    depends_on: t.depends_on.clone(),
+                    scheduled_height: t.scheduled_height,
+                    ready,
+                    action,
+                    blocked_on,
+                    mined_height,
+                    txid,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::MigrationTransaction;
+    use crate::note_splitting::NoteSplitPlan;
+    use crate::preparation::PreparationPlan;
+    use alloc::vec;
+
+    // A migration transaction with the given id/kind/state, no dependencies, scheduled at height 0.
+    fn tx(id: u32, kind: MigrationTxKind, state: MigrationTxState) -> MigrationTransaction {
+        MigrationTransaction {
+            id: MigrationTxId(id),
+            kind,
+            pczt: None,
+            depends_on: Vec::new(),
+            scheduled_height: BlockHeight::from_u32(0),
+            expiry_height: BlockHeight::from_u32(0),
+            anchor_boundary: None,
+            state,
+        }
+    }
+
+    fn prep(layer: usize, index: usize) -> MigrationTxKind {
+        MigrationTxKind::Preparation { layer, index }
+    }
+
+    fn transfer(crossing: usize) -> MigrationTxKind {
+        MigrationTxKind::Transfer { crossing }
+    }
+
+    // A state wrapping the given transactions; the plan pieces are empty (unused by state logic).
+    fn state_with(transactions: Vec<MigrationTransaction>) -> MigrationState {
+        MigrationState {
+            status: MigrationStatus::Committed,
+            note_split: NoteSplitPlan::from_stored_parts(Vec::new(), 0, None, 0, 0, 0),
+            funding_notes: Vec::new(),
+            preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            transactions,
+        }
+    }
+
+    fn mined(height: u32) -> MigrationTxState {
+        MigrationTxState::Mined {
+            height: BlockHeight::from_u32(height),
+        }
+    }
+
+    #[test]
+    fn deps_and_preparation_mining() {
+        let s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            tx(1, prep(0, 1), MigrationTxState::Signed),
+        ]);
+        assert!(s.deps_mined(&[MigrationTxId(0)]));
+        assert!(!s.deps_mined(&[MigrationTxId(1)]));
+        assert!(s.deps_mined(&[])); // empty deps are trivially satisfied
+        assert!(!s.all_preparations_mined()); // tx 1 is not mined
+    }
+
+    #[test]
+    fn ready_prep_layer_needs_prior_layer_mined() {
+        // Layer 0 half-mined: layer 1 (depending on both layer-0 txs) is not ready.
+        let mut l1 = tx(2, prep(1, 0), MigrationTxState::Planned);
+        l1.depends_on = vec![MigrationTxId(0), MigrationTxId(1)];
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            tx(1, prep(0, 1), MigrationTxState::Broadcast { txid: [0; 32] }),
+            l1.clone(),
+        ]);
+        assert_eq!(s.ready_prep_layer(), None);
+        assert!(!s.has_ready_prep_layer());
+
+        // Mine the rest of layer 0: layer 1 becomes ready.
+        s.transactions[1].state = mined(11);
+        assert_eq!(s.ready_prep_layer(), Some(1));
+        assert!(s.has_ready_prep_layer());
+    }
+
+    #[test]
+    fn ready_prep_layer_picks_earliest() {
+        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
+        l1.depends_on = vec![MigrationTxId(0)];
+        let mut l2 = tx(2, prep(2, 0), MigrationTxState::Planned);
+        l2.depends_on = vec![MigrationTxId(1)];
+        // Only layer 0 is mined, so only layer 1 is ready.
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), l1, l2]);
+        assert_eq!(s.ready_prep_layer(), Some(1));
+    }
+
+    #[test]
+    fn next_broadcastable_respects_state_deps_and_schedule() {
+        let mut signed = tx(1, transfer(0), MigrationTxState::Signed);
+        signed.depends_on = vec![MigrationTxId(0)];
+        signed.scheduled_height = BlockHeight::from_u32(5);
+        let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), signed]);
+
+        // Not due yet (target below scheduled height).
+        assert_eq!(s.next_broadcastable(BlockHeight::from_u32(4)), None);
+        // Due and deps mined.
+        assert_eq!(
+            s.next_broadcastable(BlockHeight::from_u32(5)),
+            Some(MigrationTxId(1))
+        );
+
+        // A Proved transaction is also broadcastable.
+        s.transactions[1].state = MigrationTxState::Proved;
+        assert_eq!(
+            s.next_broadcastable(BlockHeight::from_u32(5)),
+            Some(MigrationTxId(1))
+        );
+
+        // Dependency not mined: not broadcastable.
+        s.transactions[0].state = MigrationTxState::Broadcast { txid: [0; 32] };
+        assert_eq!(s.next_broadcastable(BlockHeight::from_u32(5)), None);
+    }
+
+    #[test]
+    fn next_step_walks_the_lifecycle() {
+        // Layer 0 signed, layer 1 planned depending on it, one transfer planned depending on layer 1.
+        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
+        l1.depends_on = vec![MigrationTxId(0)];
+        let mut xfer = tx(2, transfer(0), MigrationTxState::Planned);
+        xfer.depends_on = vec![MigrationTxId(1)];
+        let mut s = state_with(vec![tx(0, prep(0, 0), MigrationTxState::Signed), l1, xfer]);
+
+        // 1) Layer 0 is signed and due -> broadcast it.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Broadcast {
+                id: MigrationTxId(0)
+            }
+        );
+
+        // 2) Layer 0 broadcast, not yet mined -> nothing ready, waiting.
+        s.transactions[0].state = MigrationTxState::Broadcast { txid: [1; 32] };
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Waiting
+        );
+
+        // 3) Layer 0 mined -> layer 1 ready to build.
+        s.transactions[0].state = mined(10);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::BuildPreparationLayer { layer: 1 }
+        );
+
+        // 4) Layer 1 signed and due -> broadcast it.
+        s.transactions[1].state = MigrationTxState::Signed;
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Broadcast {
+                id: MigrationTxId(1)
+            }
+        );
+
+        // 5) Layer 1 mined, all preparation mined -> build transfers.
+        s.transactions[1].state = mined(11);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::BuildTransfers
+        );
+
+        // 6) Transfer signed and due -> broadcast it.
+        s.transactions[2].state = MigrationTxState::Signed;
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Broadcast {
+                id: MigrationTxId(2)
+            }
+        );
+
+        // 7) Everything mined -> complete.
+        s.transactions[2].state = mined(12);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Complete
+        );
+    }
+
+    #[test]
+    fn next_step_waiting_when_schedule_not_reached() {
+        let mut xfer = tx(1, transfer(0), MigrationTxState::Signed);
+        xfer.scheduled_height = BlockHeight::from_u32(50);
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
+        // The transfer is signed with deps mined but not due yet -> nothing else to do, waiting.
+        assert_eq!(s.next_step(BlockHeight::from_u32(20)), AdvanceStep::Waiting);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(50)),
+            AdvanceStep::Broadcast {
+                id: MigrationTxId(1)
+            }
+        );
+    }
+
+    #[test]
+    fn mark_transitions_and_status() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), MigrationTxState::Signed),
+            tx(1, transfer(0), MigrationTxState::Signed),
+        ]);
+        assert_eq!(s.status, MigrationStatus::Committed);
+
+        s.mark_broadcast(MigrationTxId(0), [7; 32]);
+        assert!(matches!(
+            s.transactions[0].state,
+            MigrationTxState::Broadcast { txid } if txid == [7; 32]
+        ));
+        assert_eq!(s.status, MigrationStatus::InProgress);
+        assert!(!s.is_terminal());
+
+        s.mark_mined(MigrationTxId(0), BlockHeight::from_u32(10));
+        s.mark_mined(MigrationTxId(1), BlockHeight::from_u32(11));
+        assert_eq!(s.status, MigrationStatus::Complete);
+        assert!(s.is_terminal());
+    }
+
+    #[test]
+    fn transaction_statuses_report_ready_and_blockers() {
+        let mut l1 = tx(1, prep(1, 0), MigrationTxState::Planned);
+        l1.depends_on = vec![MigrationTxId(0)];
+        let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
+        xfer.depends_on = vec![MigrationTxId(1)];
+        xfer.scheduled_height = BlockHeight::from_u32(30);
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), l1, xfer]);
+
+        let views = s.transaction_statuses(BlockHeight::from_u32(100));
+        assert_eq!(views.len(), 3);
+
+        // tx 0: mined -> done, not ready, no blocker.
+        assert!(!views[0].ready);
+        assert_eq!(views[0].blocked_on, None);
+        assert_eq!(views[0].mined_height, Some(BlockHeight::from_u32(10)));
+
+        // tx 1: planned with its dependency (tx 0) mined -> ready to build.
+        assert!(views[1].ready);
+        assert_eq!(views[1].action, Some(NextAction::BuildAndSign));
+        assert_eq!(views[1].blocked_on, None);
+
+        // tx 2: signed but its dependency (tx 1) is not mined -> blocked on dependencies.
+        assert!(!views[2].ready);
+        assert_eq!(views[2].blocked_on, Some(Blocker::Dependencies));
+    }
+
+    #[test]
+    fn transaction_statuses_block_on_schedule() {
+        let mut xfer = tx(1, transfer(0), MigrationTxState::Signed);
+        xfer.scheduled_height = BlockHeight::from_u32(30);
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
+        // Deps mined but not due at target 20 -> blocked on schedule; ready at target 30.
+        let blocked = s.transaction_statuses(BlockHeight::from_u32(20));
+        assert!(!blocked[1].ready);
+        assert_eq!(blocked[1].blocked_on, Some(Blocker::Schedule));
+        let ready = s.transaction_statuses(BlockHeight::from_u32(30));
+        assert!(ready[1].ready);
+        assert_eq!(ready[1].action, Some(NextAction::ProveAndBroadcast));
+    }
+}

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -304,7 +304,7 @@ impl MigrationState {
     /// render progress and decide, deterministically and from persisted state alone, the next
     /// transaction to sign or broadcast.
     ///
-    /// A `Planned` (or `Expired`) placeholder whose dependencies are all mined is ready to build and
+    /// A `Planned` placeholder whose dependencies are all mined is ready to build and
     /// sign; a `Signed` (or `Proved`) transaction whose dependencies are mined and whose scheduled
     /// height has arrived is ready to prove and broadcast. Otherwise a waiting transaction reports what
     /// it is blocked on: its dependencies (a prior anchor bucket still to mine) or the broadcast
@@ -314,11 +314,11 @@ impl MigrationState {
             .iter()
             .map(|t| {
                 let deps_ok = self.deps_mined(&t.depends_on);
-                // `Planned`/`Expired` need building; `Signed`/`Proved` need broadcasting. In both cases
+                // `Planned` needs building; `Signed`/`Proved` need broadcasting. In both cases
                 // a transaction is actionable only once its dependencies (the prior anchor bucket) are
                 // mined, and a broadcastable one only once it is also due.
                 let (ready, action, blocked_on) = match t.state {
-                    MigrationTxState::Planned | MigrationTxState::Expired => {
+                    MigrationTxState::Planned => {
                         if deps_ok {
                             (true, Some(NextAction::BuildAndSign), None)
                         } else {

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -168,6 +168,12 @@ impl MigrationState {
     /// uncommitted or freshly committed migration keeps its `Planning`/`Committed` status until work
     /// begins).
     pub fn recompute_status(&mut self) {
+        // A terminal status (Complete or Failed, the latter also used for a cancelled migration) is
+        // final: never move out of it. Otherwise a cancelled migration whose transactions were
+        // already broadcast would be resurrected to InProgress the next time the status is recomputed.
+        if self.is_terminal() {
+            return;
+        }
         let all_mined = !self.transactions.is_empty()
             && self
                 .transactions
@@ -222,6 +228,11 @@ impl MigrationState {
     /// when everything is mined, or `Waiting` otherwise. This is made once, here, so it is never
     /// duplicated per consumer.
     pub fn next_step(&self, target_height: BlockHeight) -> AdvanceStep {
+        // A terminal migration (complete, or failed/cancelled) has no next action: never build or
+        // broadcast for it, so a cancelled migration cannot be driven further.
+        if self.is_terminal() {
+            return AdvanceStep::Complete;
+        }
         if let Some(id) = self.next_broadcastable(target_height) {
             return AdvanceStep::Broadcast { id };
         }
@@ -523,6 +534,36 @@ mod tests {
         s.mark_mined(MigrationTxId(1), BlockHeight::from_u32(11));
         assert_eq!(s.status, MigrationStatus::Complete);
         assert!(s.is_terminal());
+    }
+
+    #[test]
+    fn terminal_status_is_not_resurrected() {
+        // A cancelled migration (Failed) whose transactions were already broadcast must stay
+        // terminal: neither recomputing the status nor asking for the next step may revive it.
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), MigrationTxState::Broadcast { txid: [1; 32] }),
+            tx(1, transfer(0), MigrationTxState::Signed),
+        ]);
+        s.status = MigrationStatus::Failed;
+
+        s.recompute_status();
+        assert_eq!(
+            s.status,
+            MigrationStatus::Failed,
+            "a Failed (cancelled) migration must not be revived to InProgress"
+        );
+        assert!(s.is_terminal());
+
+        // The next step for a terminal migration is Complete (no action), so a driver never
+        // broadcasts or builds for it; a Signed transaction is NOT offered for broadcast.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Complete
+        );
+
+        // Detecting a mined transaction still does not resurrect it.
+        s.mark_mined(MigrationTxId(0), BlockHeight::from_u32(10));
+        assert_eq!(s.status, MigrationStatus::Failed);
     }
 
     #[test]

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -370,6 +370,8 @@ impl MigrationState {
 mod tests {
     use super::*;
     use crate::engine::MigrationTransaction;
+    use zcash_protocol::value::Zatoshis;
+
     use crate::note_splitting::NoteSplitPlan;
     use crate::preparation::PreparationPlan;
     use alloc::vec;
@@ -400,7 +402,15 @@ mod tests {
     fn state_with(transactions: Vec<MigrationTransaction>) -> MigrationState {
         MigrationState {
             status: MigrationStatus::Committed,
-            note_split: NoteSplitPlan::from_stored_parts(Vec::new(), 0, None, 0, 0, 0),
+            note_split: NoteSplitPlan::from_stored_parts(
+                Vec::new(),
+                Zatoshis::ZERO,
+                None,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+            )
+            .expect("an empty stored plan reconstructs"),
             funding_notes: Vec::new(),
             preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions,

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -17,6 +17,7 @@
 
 use alloc::vec::Vec;
 
+use getset::{CopyGetters, Getters};
 use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
@@ -85,28 +86,38 @@ pub enum Blocker {
 /// front (later layers become witnessable only as earlier layers mine) and may be restarted between
 /// layers, so it decides which transaction to sign or broadcast next, and what the rest are waiting on,
 /// from this view of the persisted state alone.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters, CopyGetters)]
 pub struct TransactionStatus {
     /// This transaction's stable id.
-    pub id: MigrationTxId,
+    #[getset(get_copy = "pub")]
+    pub(crate) id: MigrationTxId,
     /// What it does (a preparation transaction, carrying its layer / anchor bucket, or a transfer).
-    pub kind: MigrationTxKind,
+    #[getset(get_copy = "pub")]
+    pub(crate) kind: MigrationTxKind,
     /// Its current lifecycle state.
-    pub state: MigrationTxState,
+    #[getset(get_copy = "pub")]
+    pub(crate) state: MigrationTxState,
     /// The transactions that must be mined before this one can be built or broadcast.
-    pub depends_on: Vec<MigrationTxId>,
+    #[getset(get = "pub")]
+    pub(crate) depends_on: Vec<MigrationTxId>,
     /// The height at or after which it is due to broadcast.
-    pub scheduled_height: BlockHeight,
+    #[getset(get_copy = "pub")]
+    pub(crate) scheduled_height: BlockHeight,
     /// Whether the wallet can act on it right now.
-    pub ready: bool,
+    #[getset(get_copy = "pub")]
+    pub(crate) ready: bool,
     /// The action available now, when `ready` is true.
-    pub action: Option<NextAction>,
+    #[getset(get_copy = "pub")]
+    pub(crate) action: Option<NextAction>,
     /// Why it is not yet actionable, when it is waiting (and not already broadcast or mined).
-    pub blocked_on: Option<Blocker>,
+    #[getset(get_copy = "pub")]
+    pub(crate) blocked_on: Option<Blocker>,
     /// The height it was mined at, once mined.
-    pub mined_height: Option<BlockHeight>,
+    #[getset(get_copy = "pub")]
+    pub(crate) mined_height: Option<BlockHeight>,
     /// The transaction id (raw internal bytes), once broadcast.
-    pub txid: Option<TxId>,
+    #[getset(get_copy = "pub")]
+    pub(crate) txid: Option<TxId>,
 }
 
 impl MigrationState {

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -72,6 +72,11 @@ pub enum Blocker {
     /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain tip
     /// to reach its scheduled height.
     Schedule,
+    /// Built but awaiting an EXTERNAL signature: its unsigned PCZT was exported to a hardware or offline
+    /// signer, and this transaction cannot advance until
+    /// [`MigrationState::apply_signature`](MigrationState::apply_signature) stores the signed PCZT
+    /// returned by the device.
+    Signature,
 }
 
 /// The status of one migration transaction, as a wallet renders it and decides the next step. This is
@@ -222,6 +227,32 @@ impl MigrationState {
         self.recompute_status();
     }
 
+    /// Store an EXTERNALLY signed PCZT for transaction `id`, moving it from
+    /// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) to [`Signed`](MigrationTxState::Signed)
+    /// so the normal state machine can prove and broadcast it. This is the second half of the
+    /// external-signing seam: after
+    /// [`build_preparation_unsigned`](crate::engine::build_preparation_unsigned) or
+    /// [`build_transfers_unsigned`](crate::engine::build_transfers_unsigned) exports the unsigned PCZT,
+    /// the caller has it signed out of band and returns the signed PCZT here, matched by `id`. Persist
+    /// the state afterwards (`put_migration`).
+    ///
+    /// Returns `true` if the signature was applied. Returns `false`, leaving the state unchanged, if no
+    /// transaction has that `id` or it is not awaiting a signature (already signed, still an unbuilt
+    /// placeholder, or already broadcast or mined), so a caller can detect a stale or misrouted signature.
+    #[must_use]
+    pub fn apply_signature(&mut self, id: MigrationTxId, signed_pczt: Vec<u8>) -> bool {
+        let Some(tx) = self
+            .transactions
+            .iter_mut()
+            .find(|t| t.id == id && matches!(t.state, MigrationTxState::AwaitingSignature))
+        else {
+            return false;
+        };
+        tx.pczt = Some(signed_pczt);
+        tx.state = MigrationTxState::Signed;
+        true
+    }
+
     /// Decides the next step to advance the migration, from state alone. The priority is: prove and
     /// broadcast the next due, dependency-satisfied transaction; else build the next ready preparation
     /// layer; else, once the whole preparation is mined, build the transfers; else report `Complete`
@@ -282,6 +313,10 @@ impl MigrationState {
                             (false, None, Some(Blocker::Dependencies))
                         }
                     }
+                    // Built for an external signer and waiting for its signed PCZT; the wallet's
+                    // automatic driver takes no action (the external-signing caller drives it via
+                    // `apply_signature`), so it is neither ready nor blocked on the chain.
+                    MigrationTxState::AwaitingSignature => (false, None, Some(Blocker::Signature)),
                     MigrationTxState::Signed | MigrationTxState::Proved => {
                         if !deps_ok {
                             (false, None, Some(Blocker::Dependencies))
@@ -364,6 +399,47 @@ mod tests {
         MigrationTxState::Mined {
             height: BlockHeight::from_u32(height),
         }
+    }
+
+    #[test]
+    fn apply_signature_moves_awaiting_to_signed() {
+        let mut state = state_with(vec![tx(0, prep(0, 0), MigrationTxState::AwaitingSignature)]);
+        assert!(state.apply_signature(MigrationTxId(0), vec![1u8, 2, 3]));
+        assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
+        assert_eq!(
+            state.transactions[0].pczt.as_deref(),
+            Some(&[1u8, 2, 3][..])
+        );
+    }
+
+    #[test]
+    fn apply_signature_rejects_unknown_or_wrong_state() {
+        let mut state = state_with(vec![
+            tx(0, prep(0, 0), MigrationTxState::AwaitingSignature),
+            tx(1, transfer(0), MigrationTxState::Planned),
+        ]);
+        // An unknown id, and a transaction not awaiting a signature (a Planned placeholder), are both
+        // rejected without changing any state.
+        assert!(!state.apply_signature(MigrationTxId(9), vec![1u8]));
+        assert!(!state.apply_signature(MigrationTxId(1), vec![1u8]));
+        assert_eq!(
+            state.transactions[0].state,
+            MigrationTxState::AwaitingSignature
+        );
+        // The first signature applies; a second, after it is already Signed, is rejected (a stale or
+        // misrouted signature cannot overwrite the stored one).
+        assert!(state.apply_signature(MigrationTxId(0), vec![1u8]));
+        assert!(!state.apply_signature(MigrationTxId(0), vec![2u8]));
+        assert_eq!(state.transactions[0].pczt.as_deref(), Some(&[1u8][..]));
+    }
+
+    #[test]
+    fn awaiting_signature_is_blocked_on_signature() {
+        let state = state_with(vec![tx(0, prep(0, 0), MigrationTxState::AwaitingSignature)]);
+        let views = state.transaction_statuses(BlockHeight::from_u32(100));
+        assert!(!views[0].ready);
+        assert_eq!(views[0].action, None);
+        assert_eq!(views[0].blocked_on, Some(Blocker::Signature));
     }
 
     #[test]

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -57,7 +57,7 @@ pub enum Error<WRE, ISE, SE> {
     /// not present in the note commitment tree yet.
     AnchorUnavailable,
     /// Signing the migration PCZT failed.
-    Sign(String),
+    Sign(crate::build::BuildError),
     /// A note commitment tree (shardtree) error, rendered to a string (the tree error type is a
     /// fourth, `WalletCommitmentTrees`-specific type, kept out of this enum's parameters).
     Tree(String),
@@ -74,7 +74,7 @@ impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Er
             Error::Store(e) => write!(f, "migration store error: {e}"),
             Error::NoteNotFound(i) => write!(f, "no spendable note for index/value {i}"),
             Error::AnchorUnavailable => f.write_str("no usable anchor checkpoint is available"),
-            Error::Sign(m) => write!(f, "signing the migration failed: {m}"),
+            Error::Sign(e) => write!(f, "signing the migration failed: {e}"),
             Error::Tree(m) => write!(f, "note commitment tree error: {m}"),
             Error::InvalidNoteValue(i) => {
                 write!(f, "spendable note {i} has an invalid (out-of-range) value")
@@ -319,7 +319,7 @@ where
 
     fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {
         let ask = SpendAuthorizingKey::from(self.usk.orchard());
-        sign_pczt(pczt, &ask).map_err(|e| Error::Sign(format!("{e:?}")))
+        sign_pczt(pczt, &ask).map_err(Error::Sign)
     }
 }
 

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -18,7 +18,6 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::fmt;
-use core::num::NonZeroU32;
 
 use ::orchard::Anchor;
 use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
@@ -39,12 +38,6 @@ use crate::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
     PoolMigrationRead, PoolMigrationWrite,
 };
-
-/// The confirmation depth used to pick the anchor checkpoint the migration builds against. The
-/// anchor is not committed to a transaction's sighash (the proof is re-anchored to a drawn boundary
-/// at proving time), so the exact depth is not security-critical; one confirmation is enough for a
-/// checkpoint that exists in the note commitment tree.
-const ANCHOR_CONFIRMATIONS: NonZeroU32 = NonZeroU32::MIN;
 
 /// A failure of the wallet-backed migration adapter. Parameterized by the error types of the three
 /// wallet traits and the store, which for `zcash_client_sqlite`'s `WalletDb` are all one type but in
@@ -156,18 +149,6 @@ where
         self.store
     }
 
-    /// The anchor checkpoint height the migration builds against (a checkpoint guaranteed to exist in
-    /// the note commitment tree).
-    fn anchor_height(&self) -> Result<BlockHeight, AdapterError<W, St>> {
-        let guard = self.wallet.borrow();
-        let wallet: &W = &guard;
-        let (_, anchor) = wallet
-            .get_target_and_anchor_heights(ANCHOR_CONFIRMATIONS)
-            .map_err(Error::WalletRead)?
-            .ok_or(Error::AnchorUnavailable)?;
-        Ok(anchor)
-    }
-
     /// The target height for note selection (the chain tip plus one).
     fn selection_target(&self) -> Result<TargetHeight, AdapterError<W, St>> {
         let guard = self.wallet.borrow();
@@ -202,12 +183,16 @@ where
         Ok(notes)
     }
 
-    /// Resolve the anchor and a witness for each requested tree position, all against one checkpoint.
+    /// Resolve the anchor and a witness for each requested tree position, all against the single
+    /// checkpoint at `anchor_height`. The caller (the engine) names the tree state — a bucketed
+    /// boundary height — so the witnesses are certain to match the anchor the transaction proves
+    /// against; the checkpoint must exist in the note commitment tree ([`Error::AnchorUnavailable`]
+    /// otherwise).
     fn witness(
         &self,
+        anchor_height: BlockHeight,
         positions: &[Position],
     ) -> Result<(Anchor, Vec<MerklePath>), AdapterError<W, St>> {
-        let anchor_height = self.anchor_height()?;
         let mut guard = self.wallet.borrow_mut();
         let wallet: &mut W = &mut guard;
         wallet.with_orchard_tree_mut::<_, (Anchor, Vec<MerklePath>), AdapterError<W, St>>(|tree| {
@@ -270,12 +255,11 @@ where
         Ok(FullViewingKey::from(self.usk.orchard()))
     }
 
-    fn orchard_anchor(&self) -> Result<Anchor, Self::Error> {
-        Ok(self.witness(&[])?.0)
+    fn orchard_anchor(&self, anchor_height: BlockHeight) -> Result<Anchor, Self::Error> {
+        Ok(self.witness(anchor_height, &[])?.0)
     }
 
-    fn ironwood_anchor(&self) -> Result<Anchor, Self::Error> {
-        let anchor_height = self.anchor_height()?;
+    fn ironwood_anchor(&self, anchor_height: BlockHeight) -> Result<Anchor, Self::Error> {
         let mut guard = self.wallet.borrow_mut();
         let wallet: &mut W = &mut guard;
         let root = wallet.with_ironwood_tree_mut::<_, _, AdapterError<W, St>>(|tree| {
@@ -294,18 +278,18 @@ where
     fn resolve_wallet_note(
         &self,
         index: usize,
-        _anchor: Anchor,
+        anchor_height: BlockHeight,
     ) -> Result<(OrchardNote, MerklePath), Self::Error> {
         let notes = self.spendable_orchard()?;
         let &(note, position, _) = notes.get(index).ok_or(Error::NoteNotFound(index))?;
-        let (_, mut paths) = self.witness(&[position])?;
+        let (_, mut paths) = self.witness(anchor_height, &[position])?;
         Ok((note, paths.remove(0)))
     }
 
     fn resolve_funding_notes(
         &self,
         values: &[Zatoshis],
-        _anchor: Anchor,
+        anchor_height: BlockHeight,
     ) -> Result<Vec<(OrchardNote, MerklePath)>, Self::Error> {
         let notes = self.spendable_orchard()?;
         let mut used = vec![false; notes.len()];
@@ -322,7 +306,7 @@ where
             chosen.push((notes[note_index].0, notes[note_index].1));
         }
         let positions: Vec<Position> = chosen.iter().map(|(_, pos)| *pos).collect();
-        let (_, paths) = self.witness(&positions)?;
+        let (_, paths) = self.witness(anchor_height, &positions)?;
         Ok(chosen
             .into_iter()
             .map(|(note, _)| note)

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -259,22 +259,6 @@ where
         Ok(self.witness(anchor_height, &[])?.0)
     }
 
-    fn ironwood_anchor(&self, anchor_height: BlockHeight) -> Result<Anchor, Self::Error> {
-        let mut guard = self.wallet.borrow_mut();
-        let wallet: &mut W = &mut guard;
-        let root = wallet.with_ironwood_tree_mut::<_, _, AdapterError<W, St>>(|tree| {
-            Ok(tree.root_at_checkpoint_id(&anchor_height)?)
-        })?;
-        match root {
-            // The backend tracks an Ironwood tree, so the checkpoint at the anchor height must
-            // exist in it.
-            Some(root) => Ok(root.ok_or(Error::AnchorUnavailable)?.into()),
-            // The backend tracks no Ironwood tree: as far as this wallet knows the pool holds no
-            // notes, and the empty-tree root is the valid anchor for exactly that state.
-            None => Ok(Anchor::empty_tree()),
-        }
-    }
-
     fn resolve_wallet_note(
         &self,
         index: usize,
@@ -286,7 +270,7 @@ where
         Ok((note, paths.remove(0)))
     }
 
-    fn resolve_funding_notes(
+    fn resolve_feeder_notes(
         &self,
         values: &[Zatoshis],
         anchor_height: BlockHeight,
@@ -295,7 +279,7 @@ where
         let mut used = vec![false; notes.len()];
         let mut chosen: Vec<(OrchardNote, Position)> = Vec::with_capacity(values.len());
         for (value_index, &value) in values.iter().enumerate() {
-            // Each funding value is matched to a DISTINCT spendable note of exactly that value; notes
+            // Each feeder value is matched to a DISTINCT spendable note of exactly that value; notes
             // of equal value are interchangeable, so a greedy first-unused match is correct.
             let note_index = notes
                 .iter()
@@ -312,6 +296,25 @@ where
             .map(|(note, _)| note)
             .zip(paths)
             .collect())
+    }
+
+    fn resolve_funding_notes(&self, values: &[Zatoshis]) -> Result<Vec<OrchardNote>, Self::Error> {
+        let notes = self.spendable_orchard()?;
+        let mut used = vec![false; notes.len()];
+        let mut chosen: Vec<OrchardNote> = Vec::with_capacity(values.len());
+        for (value_index, &value) in values.iter().enumerate() {
+            // Each funding value is matched to a DISTINCT spendable note of exactly that value; notes
+            // of equal value are interchangeable, so a greedy first-unused match is correct. No
+            // witness is resolved: a transfer's anchors and witness are deferred to proving time.
+            let note_index = notes
+                .iter()
+                .enumerate()
+                .position(|(i, (_, _, note_value))| !used[i] && *note_value == u64::from(value))
+                .ok_or(Error::NoteNotFound(value_index))?;
+            used[note_index] = true;
+            chosen.push(notes[note_index].0);
+        }
+        Ok(chosen)
     }
 
     fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -1,0 +1,405 @@
+//! A wallet-backed adapter that turns any `zcash_client_backend` wallet into a migration wallet.
+//!
+//! The engine's build and commit path needs an implementation of [`MigrationBackend`] +
+//! [`MigrationCrypto`] (the account's viewing key, note witnesses, an anchor, and signing) and a
+//! [`PoolMigrationRead`] / [`PoolMigrationWrite`] store. This module supplies the first two for free
+//! over the traits a `zcash_client_backend` wallet already implements ([`WalletRead`],
+//! [`InputSource`], [`WalletCommitmentTrees`]) plus the account's [`UnifiedSpendingKey`], and
+//! delegates the store to a value the caller supplies (for example
+//! `zcash_pool_migration_sqlite`'s store over the same wallet database). A consuming application
+//! (zallet, or any other `zcash_client_backend` wallet) then runs [`commit_preparation`] /
+//! [`commit_transfers`] with no hand-wired cryptography.
+//!
+//! [`commit_preparation`]: crate::engine::commit_preparation
+//! [`commit_transfers`]: crate::engine::commit_transfers
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt;
+use core::num::NonZeroU32;
+
+use ::orchard::Anchor;
+use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+use ::orchard::note::Note as OrchardNote;
+use ::orchard::tree::MerklePath;
+use incrementalmerkletree::Position;
+use shardtree::error::ShardTreeError;
+
+use zcash_client_backend::data_api::wallet::TargetHeight;
+use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_protocol::ShieldedPool;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::Zatoshis;
+
+use crate::build::sign_pczt;
+use crate::engine::{
+    MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
+    PoolMigrationRead, PoolMigrationWrite,
+};
+
+/// The confirmation depth used to pick the anchor checkpoint the migration builds against. The
+/// anchor is not committed to a transaction's sighash (the proof is re-anchored to a drawn boundary
+/// at proving time), so the exact depth is not security-critical; one confirmation is enough for a
+/// checkpoint that exists in the note commitment tree.
+const ANCHOR_CONFIRMATIONS: NonZeroU32 = NonZeroU32::MIN;
+
+/// A failure of the wallet-backed migration adapter. Parameterized by the error types of the three
+/// wallet traits and the store, which for `zcash_client_sqlite`'s `WalletDb` are all one type but in
+/// general need not be.
+#[derive(Debug)]
+pub enum Error<WRE, ISE, SE> {
+    /// A `WalletRead` failure (chain tip or anchor-height lookup).
+    WalletRead(WRE),
+    /// An `InputSource` failure (spendable-note selection).
+    InputSource(ISE),
+    /// A store failure (`PoolMigrationRead` / `PoolMigrationWrite`).
+    Store(SE),
+    /// No spendable note matched the requested index or value (for `index`, the position into the
+    /// spendable set; for a funding value, its index into the requested values).
+    NoteNotFound(usize),
+    /// No usable anchor could be obtained: the wallet has no chain tip, or the anchor checkpoint is
+    /// not present in the note commitment tree yet.
+    AnchorUnavailable,
+    /// Signing the migration PCZT failed.
+    Sign(String),
+    /// A note commitment tree (shardtree) error, rendered to a string (the tree error type is a
+    /// fourth, `WalletCommitmentTrees`-specific type, kept out of this enum's parameters).
+    Tree(String),
+    /// The spendable note at this index has a value that is not a valid [`Zatoshis`] amount
+    /// (it exceeds the money-supply cap).
+    InvalidNoteValue(usize),
+}
+
+impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Error<WRE, ISE, SE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::WalletRead(e) => write!(f, "wallet read error: {e}"),
+            Error::InputSource(e) => write!(f, "input source error: {e}"),
+            Error::Store(e) => write!(f, "migration store error: {e}"),
+            Error::NoteNotFound(i) => write!(f, "no spendable note for index/value {i}"),
+            Error::AnchorUnavailable => f.write_str("no usable anchor checkpoint is available"),
+            Error::Sign(m) => write!(f, "signing the migration failed: {m}"),
+            Error::Tree(m) => write!(f, "note commitment tree error: {m}"),
+            Error::InvalidNoteValue(i) => {
+                write!(f, "spendable note {i} has an invalid (out-of-range) value")
+            }
+        }
+    }
+}
+
+impl<WRE, ISE, SE> core::error::Error for Error<WRE, ISE, SE>
+where
+    WRE: fmt::Debug + fmt::Display,
+    ISE: fmt::Debug + fmt::Display,
+    SE: fmt::Debug + fmt::Display,
+{
+}
+
+impl<WRE, ISE, SE, WCE: fmt::Debug> From<ShardTreeError<WCE>> for Error<WRE, ISE, SE> {
+    fn from(e: ShardTreeError<WCE>) -> Self {
+        Error::Tree(format!("{e:?}"))
+    }
+}
+
+/// The adapter's error type for a wallet `W` and store `St`.
+type AdapterError<W, St> =
+    Error<<W as WalletRead>::Error, <W as InputSource>::Error, <St as PoolMigrationRead>::Error>;
+
+/// A spendable Orchard note as the adapter tracks it: the note, its note-commitment-tree position,
+/// and its value in zatoshi.
+type SpendableNote = (OrchardNote, Position, u64);
+
+/// A migration wallet built over a `zcash_client_backend` wallet `W`, an account, its
+/// [`UnifiedSpendingKey`], and a migration store `St`.
+///
+/// The wallet is held by a mutable borrow behind a [`RefCell`], because
+/// [`WalletCommitmentTrees::with_orchard_tree_mut`] requires `&mut W` while the [`MigrationCrypto`]
+/// methods take `&self`. The engine calls those methods sequentially (never nested), so the
+/// `RefCell` never observes an overlapping borrow.
+pub struct WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource,
+{
+    wallet: RefCell<&'a mut W>,
+    account: <W as InputSource>::AccountId,
+    usk: UnifiedSpendingKey,
+    store: St,
+}
+
+impl<'a, W, St> WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource + WalletCommitmentTrees,
+    <W as InputSource>::AccountId: Copy,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+    St: PoolMigrationRead,
+{
+    /// Wrap a wallet, an account, its spending key, and a store as a migration wallet.
+    pub fn new(
+        wallet: &'a mut W,
+        account: <W as InputSource>::AccountId,
+        usk: UnifiedSpendingKey,
+        store: St,
+    ) -> Self {
+        Self {
+            wallet: RefCell::new(wallet),
+            account,
+            usk,
+            store,
+        }
+    }
+
+    /// Recover the store.
+    pub fn into_store(self) -> St {
+        self.store
+    }
+
+    /// The anchor checkpoint height the migration builds against (a checkpoint guaranteed to exist in
+    /// the note commitment tree).
+    fn anchor_height(&self) -> Result<BlockHeight, AdapterError<W, St>> {
+        let guard = self.wallet.borrow();
+        let wallet: &W = &guard;
+        let (_, anchor) = wallet
+            .get_target_and_anchor_heights(ANCHOR_CONFIRMATIONS)
+            .map_err(Error::WalletRead)?
+            .ok_or(Error::AnchorUnavailable)?;
+        Ok(anchor)
+    }
+
+    /// The target height for note selection (the chain tip plus one).
+    fn selection_target(&self) -> Result<TargetHeight, AdapterError<W, St>> {
+        let guard = self.wallet.borrow();
+        let wallet: &W = &guard;
+        let tip = wallet
+            .chain_height()
+            .map_err(Error::WalletRead)?
+            .ok_or(Error::AnchorUnavailable)?;
+        Ok(TargetHeight::from(u32::from(tip) + 1))
+    }
+
+    /// The account's spendable Orchard notes as `(note, tree position, value)`, sorted by tree
+    /// position so the index is stable across calls (the engine maps a value index from
+    /// `spendable_orchard_note_values` back to a note by the same order).
+    fn spendable_orchard(&self) -> Result<Vec<SpendableNote>, AdapterError<W, St>> {
+        let target = self.selection_target()?;
+        let guard = self.wallet.borrow();
+        let wallet: &W = &guard;
+        let received = wallet
+            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
+            .map_err(Error::InputSource)?;
+        let mut notes: Vec<SpendableNote> = received
+            .orchard()
+            .iter()
+            .map(|rn| {
+                let note = *rn.note();
+                let value = note.value().inner();
+                (note, rn.note_commitment_tree_position(), value)
+            })
+            .collect();
+        notes.sort_by_key(|(_, pos, _)| *pos);
+        Ok(notes)
+    }
+
+    /// Resolve the anchor and a witness for each requested tree position, all against one checkpoint.
+    fn witness(
+        &self,
+        positions: &[Position],
+    ) -> Result<(Anchor, Vec<MerklePath>), AdapterError<W, St>> {
+        let anchor_height = self.anchor_height()?;
+        let mut guard = self.wallet.borrow_mut();
+        let wallet: &mut W = &mut guard;
+        wallet.with_orchard_tree_mut::<_, (Anchor, Vec<MerklePath>), AdapterError<W, St>>(|tree| {
+            let anchor: Anchor = tree
+                .root_at_checkpoint_id(&anchor_height)?
+                .ok_or(Error::AnchorUnavailable)?
+                .into();
+            let mut paths = Vec::with_capacity(positions.len());
+            for pos in positions {
+                let path: MerklePath = tree
+                    .witness_at_checkpoint_id_caching(*pos, &anchor_height)?
+                    .ok_or_else(|| Error::Tree(String::from("checkpoint pruned")))?
+                    .into();
+                paths.push(path);
+            }
+            Ok((anchor, paths))
+        })
+    }
+}
+
+impl<'a, W, St> MigrationBackend for WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource + WalletCommitmentTrees,
+    <W as InputSource>::AccountId: Copy,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+    St: PoolMigrationRead,
+{
+    type Error = AdapterError<W, St>;
+
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+        self.spendable_orchard()?
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_, _, value))| {
+                Zatoshis::from_u64(value).map_err(|_| Error::InvalidNoteValue(i))
+            })
+            .collect()
+    }
+
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+        let guard = self.wallet.borrow();
+        let wallet: &W = &guard;
+        wallet
+            .chain_height()
+            .map_err(Error::WalletRead)?
+            .ok_or(Error::AnchorUnavailable)
+    }
+}
+
+impl<'a, W, St> MigrationCrypto for WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource + WalletCommitmentTrees,
+    <W as InputSource>::AccountId: Copy,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+    St: PoolMigrationRead,
+{
+    type Error = AdapterError<W, St>;
+
+    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
+        Ok(FullViewingKey::from(self.usk.orchard()))
+    }
+
+    fn orchard_anchor(&self) -> Result<Anchor, Self::Error> {
+        Ok(self.witness(&[])?.0)
+    }
+
+    fn ironwood_anchor(&self) -> Result<Anchor, Self::Error> {
+        let anchor_height = self.anchor_height()?;
+        let mut guard = self.wallet.borrow_mut();
+        let wallet: &mut W = &mut guard;
+        let root = wallet.with_ironwood_tree_mut::<_, _, AdapterError<W, St>>(|tree| {
+            Ok(tree.root_at_checkpoint_id(&anchor_height)?)
+        })?;
+        match root {
+            // The backend tracks an Ironwood tree, so the checkpoint at the anchor height must
+            // exist in it.
+            Some(root) => Ok(root.ok_or(Error::AnchorUnavailable)?.into()),
+            // The backend tracks no Ironwood tree: as far as this wallet knows the pool holds no
+            // notes, and the empty-tree root is the valid anchor for exactly that state.
+            None => Ok(Anchor::empty_tree()),
+        }
+    }
+
+    fn resolve_wallet_note(
+        &self,
+        index: usize,
+        _anchor: Anchor,
+    ) -> Result<(OrchardNote, MerklePath), Self::Error> {
+        let notes = self.spendable_orchard()?;
+        let &(note, position, _) = notes.get(index).ok_or(Error::NoteNotFound(index))?;
+        let (_, mut paths) = self.witness(&[position])?;
+        Ok((note, paths.remove(0)))
+    }
+
+    fn resolve_funding_notes(
+        &self,
+        values: &[Zatoshis],
+        _anchor: Anchor,
+    ) -> Result<Vec<(OrchardNote, MerklePath)>, Self::Error> {
+        let notes = self.spendable_orchard()?;
+        let mut used = vec![false; notes.len()];
+        let mut chosen: Vec<(OrchardNote, Position)> = Vec::with_capacity(values.len());
+        for (value_index, &value) in values.iter().enumerate() {
+            // Each funding value is matched to a DISTINCT spendable note of exactly that value; notes
+            // of equal value are interchangeable, so a greedy first-unused match is correct.
+            let note_index = notes
+                .iter()
+                .enumerate()
+                .position(|(i, (_, _, note_value))| !used[i] && *note_value == u64::from(value))
+                .ok_or(Error::NoteNotFound(value_index))?;
+            used[note_index] = true;
+            chosen.push((notes[note_index].0, notes[note_index].1));
+        }
+        let positions: Vec<Position> = chosen.iter().map(|(_, pos)| *pos).collect();
+        let (_, paths) = self.witness(&positions)?;
+        Ok(chosen
+            .into_iter()
+            .map(|(note, _)| note)
+            .zip(paths)
+            .collect())
+    }
+
+    fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {
+        let ask = SpendAuthorizingKey::from(self.usk.orchard());
+        sign_pczt(pczt, &ask).map_err(|e| Error::Sign(format!("{e:?}")))
+    }
+}
+
+impl<'a, W, St> PoolMigrationRead for WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource + WalletCommitmentTrees,
+    <W as InputSource>::AccountId: Copy,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+    St: PoolMigrationRead,
+{
+    type Error = AdapterError<W, St>;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        self.store.get_migration().map_err(Error::Store)
+    }
+}
+
+impl<'a, W, St> PoolMigrationWrite for WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource + WalletCommitmentTrees,
+    <W as InputSource>::AccountId: Copy,
+    <W as WalletCommitmentTrees>::Error: fmt::Debug,
+    St: PoolMigrationWrite,
+{
+    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.store.put_migration(state).map_err(Error::Store)
+    }
+
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        self.store
+            .update_transaction(id, state)
+            .map_err(Error::Store)
+    }
+}
+
+#[cfg(all(test, feature = "wallet"))]
+mod tests {
+    use super::*;
+
+    use rand_core::{CryptoRng, RngCore};
+    use zcash_protocol::consensus::Parameters;
+
+    use crate::engine::{commit_preparation, commit_transfers};
+
+    /// Compile-time proof that `WalletMigration` over ANY `zcash_client_backend` wallet `W` and ANY
+    /// migration store `St` satisfies every trait bound `commit_preparation` / `commit_transfers`
+    /// require (backend + crypto + store, all sharing one error type). Naming the two generic
+    /// functions instantiated at `WalletMigration<W, St>` forces the type checker to verify that
+    /// instantiation's bounds hold; if the four trait impls ever stop lining up with the commit path,
+    /// this stops compiling. It is never called and needs no wallet instance, so it pulls in no
+    /// test-only wallet dependency (which would otherwise force `zcash_client_backend`'s Orchard
+    /// feature on across the whole workspace's test build).
+    #[allow(dead_code)]
+    fn assert_commit_bounds<'a, P, W, St, R>()
+    where
+        P: Parameters + Clone,
+        W: WalletRead + InputSource + WalletCommitmentTrees + 'a,
+        <W as InputSource>::AccountId: Copy,
+        <W as WalletCommitmentTrees>::Error: fmt::Debug,
+        St: PoolMigrationWrite,
+        R: RngCore + CryptoRng,
+    {
+        let _ = commit_preparation::<P, WalletMigration<'a, W, St>, R>;
+        let _ = commit_transfers::<P, WalletMigration<'a, W, St>, R>;
+    }
+}

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -1,33 +1,30 @@
 //! A wallet-backed adapter that turns any `zcash_client_backend` wallet into a migration wallet.
 //!
 //! The engine's build and commit path needs an implementation of [`MigrationBackend`] +
-//! [`MigrationCrypto`] (the account's viewing key, note witnesses, an anchor, and signing) and a
-//! [`PoolMigrationRead`] / [`PoolMigrationWrite`] store. This module supplies the first two for free
-//! over the traits a `zcash_client_backend` wallet already implements ([`WalletRead`],
-//! [`InputSource`], [`WalletCommitmentTrees`]) plus the account's [`UnifiedSpendingKey`], and
-//! delegates the store to a value the caller supplies (for example
-//! `zcash_pool_migration_sqlite`'s store over the same wallet database). A consuming application
-//! (zallet, or any other `zcash_client_backend` wallet) then runs [`commit_preparation`] /
-//! [`commit_transfers`] with no hand-wired cryptography.
+//! [`MigrationCrypto`] (the account's viewing key, its spendable notes' plaintexts, and signing)
+//! and a [`PoolMigrationRead`] / [`PoolMigrationWrite`] store. This module supplies the first two
+//! for free over the traits a `zcash_client_backend` wallet already implements ([`WalletRead`],
+//! [`InputSource`]) plus the account's [`UnifiedSpendingKey`], and delegates the store to a value
+//! the caller supplies (for example `zcash_pool_migration_sqlite`'s store over the same wallet
+//! database). A consuming application (zallet, or any other `zcash_client_backend` wallet) then
+//! runs [`commit_preparation`] with no hand-wired cryptography.
+//!
+//! No note commitment tree access appears here: every migration transaction is built and signed
+//! with its anchor and witnesses deferred to proving time (ZIP 374), so the adapter never
+//! resolves a witness — the consumer installs anchors and witnesses through the PCZT `Updater`
+//! role when it proves each transaction, just before broadcast.
 //!
 //! [`commit_preparation`]: crate::engine::commit_preparation
-//! [`commit_transfers`]: crate::engine::commit_transfers
 
-use alloc::format;
-use alloc::string::String;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::fmt;
 
-use ::orchard::Anchor;
 use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
 use ::orchard::note::Note as OrchardNote;
-use ::orchard::tree::MerklePath;
 use incrementalmerkletree::Position;
-use shardtree::error::ShardTreeError;
 
 use zcash_client_backend::data_api::wallet::TargetHeight;
-use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead};
+use zcash_client_backend::data_api::{InputSource, WalletRead};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_protocol::ShieldedPool;
 use zcash_protocol::consensus::BlockHeight;
@@ -39,28 +36,23 @@ use crate::engine::{
     PoolMigrationRead, PoolMigrationWrite,
 };
 
-/// A failure of the wallet-backed migration adapter. Parameterized by the error types of the three
+/// A failure of the wallet-backed migration adapter. Parameterized by the error types of the two
 /// wallet traits and the store, which for `zcash_client_sqlite`'s `WalletDb` are all one type but in
 /// general need not be.
 #[derive(Debug)]
 pub enum Error<WRE, ISE, SE> {
-    /// A `WalletRead` failure (chain tip or anchor-height lookup).
+    /// A `WalletRead` failure (chain-tip lookup).
     WalletRead(WRE),
     /// An `InputSource` failure (spendable-note selection).
     InputSource(ISE),
     /// A store failure (`PoolMigrationRead` / `PoolMigrationWrite`).
     Store(SE),
-    /// No spendable note matched the requested index or value (for `index`, the position into the
-    /// spendable set; for a funding value, its index into the requested values).
+    /// No spendable note exists at the requested index.
     NoteNotFound(usize),
-    /// No usable anchor could be obtained: the wallet has no chain tip, or the anchor checkpoint is
-    /// not present in the note commitment tree yet.
-    AnchorUnavailable,
+    /// The wallet has no chain tip (it has never synced), so no note selection target exists.
+    ChainTipUnknown,
     /// Signing the migration PCZT failed.
     Sign(crate::build::BuildError),
-    /// A note commitment tree (shardtree) error, rendered to a string (the tree error type is a
-    /// fourth, `WalletCommitmentTrees`-specific type, kept out of this enum's parameters).
-    Tree(String),
     /// The spendable note at this index has a value that is not a valid [`Zatoshis`] amount
     /// (it exceeds the money-supply cap).
     InvalidNoteValue(usize),
@@ -72,10 +64,9 @@ impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Er
             Error::WalletRead(e) => write!(f, "wallet read error: {e}"),
             Error::InputSource(e) => write!(f, "input source error: {e}"),
             Error::Store(e) => write!(f, "migration store error: {e}"),
-            Error::NoteNotFound(i) => write!(f, "no spendable note for index/value {i}"),
-            Error::AnchorUnavailable => f.write_str("no usable anchor checkpoint is available"),
+            Error::NoteNotFound(i) => write!(f, "no spendable note at index {i}"),
+            Error::ChainTipUnknown => f.write_str("the wallet has no chain tip"),
             Error::Sign(e) => write!(f, "signing the migration failed: {e}"),
-            Error::Tree(m) => write!(f, "note commitment tree error: {m}"),
             Error::InvalidNoteValue(i) => {
                 write!(f, "spendable note {i} has an invalid (out-of-range) value")
             }
@@ -91,12 +82,6 @@ where
 {
 }
 
-impl<WRE, ISE, SE, WCE: fmt::Debug> From<ShardTreeError<WCE>> for Error<WRE, ISE, SE> {
-    fn from(e: ShardTreeError<WCE>) -> Self {
-        Error::Tree(format!("{e:?}"))
-    }
-}
-
 /// The adapter's error type for a wallet `W` and store `St`.
 type AdapterError<W, St> =
     Error<<W as WalletRead>::Error, <W as InputSource>::Error, <St as PoolMigrationRead>::Error>;
@@ -108,15 +93,13 @@ type SpendableNote = (OrchardNote, Position, u64);
 /// A migration wallet built over a `zcash_client_backend` wallet `W`, an account, its
 /// [`UnifiedSpendingKey`], and a migration store `St`.
 ///
-/// The wallet is held by a mutable borrow behind a [`RefCell`], because
-/// [`WalletCommitmentTrees::with_orchard_tree_mut`] requires `&mut W` while the [`MigrationCrypto`]
-/// methods take `&self`. The engine calls those methods sequentially (never nested), so the
-/// `RefCell` never observes an overlapping borrow.
+/// The wallet is held by a shared borrow: the migration never touches the note commitment tree
+/// (anchors and witnesses are deferred to proving time), so nothing here needs `&mut W`.
 pub struct WalletMigration<'a, W, St>
 where
     W: WalletRead + InputSource,
 {
-    wallet: RefCell<&'a mut W>,
+    wallet: &'a W,
     account: <W as InputSource>::AccountId,
     usk: UnifiedSpendingKey,
     store: St,
@@ -124,20 +107,19 @@ where
 
 impl<'a, W, St> WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource + WalletCommitmentTrees,
+    W: WalletRead + InputSource,
     <W as InputSource>::AccountId: Copy,
-    <W as WalletCommitmentTrees>::Error: fmt::Debug,
     St: PoolMigrationRead,
 {
     /// Wrap a wallet, an account, its spending key, and a store as a migration wallet.
     pub fn new(
-        wallet: &'a mut W,
+        wallet: &'a W,
         account: <W as InputSource>::AccountId,
         usk: UnifiedSpendingKey,
         store: St,
     ) -> Self {
         Self {
-            wallet: RefCell::new(wallet),
+            wallet,
             account,
             usk,
             store,
@@ -151,12 +133,11 @@ where
 
     /// The target height for note selection (the chain tip plus one).
     fn selection_target(&self) -> Result<TargetHeight, AdapterError<W, St>> {
-        let guard = self.wallet.borrow();
-        let wallet: &W = &guard;
-        let tip = wallet
+        let tip = self
+            .wallet
             .chain_height()
             .map_err(Error::WalletRead)?
-            .ok_or(Error::AnchorUnavailable)?;
+            .ok_or(Error::ChainTipUnknown)?;
         Ok(TargetHeight::from(u32::from(tip) + 1))
     }
 
@@ -165,9 +146,8 @@ where
     /// `spendable_orchard_note_values` back to a note by the same order).
     fn spendable_orchard(&self) -> Result<Vec<SpendableNote>, AdapterError<W, St>> {
         let target = self.selection_target()?;
-        let guard = self.wallet.borrow();
-        let wallet: &W = &guard;
-        let received = wallet
+        let received = self
+            .wallet
             .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
             .map_err(Error::InputSource)?;
         let mut notes: Vec<SpendableNote> = received
@@ -182,42 +162,12 @@ where
         notes.sort_by_key(|(_, pos, _)| *pos);
         Ok(notes)
     }
-
-    /// Resolve the anchor and a witness for each requested tree position, all against the single
-    /// checkpoint at `anchor_height`. The caller (the engine) names the tree state — a bucketed
-    /// boundary height — so the witnesses are certain to match the anchor the transaction proves
-    /// against; the checkpoint must exist in the note commitment tree ([`Error::AnchorUnavailable`]
-    /// otherwise).
-    fn witness(
-        &self,
-        anchor_height: BlockHeight,
-        positions: &[Position],
-    ) -> Result<(Anchor, Vec<MerklePath>), AdapterError<W, St>> {
-        let mut guard = self.wallet.borrow_mut();
-        let wallet: &mut W = &mut guard;
-        wallet.with_orchard_tree_mut::<_, (Anchor, Vec<MerklePath>), AdapterError<W, St>>(|tree| {
-            let anchor: Anchor = tree
-                .root_at_checkpoint_id(&anchor_height)?
-                .ok_or(Error::AnchorUnavailable)?
-                .into();
-            let mut paths = Vec::with_capacity(positions.len());
-            for pos in positions {
-                let path: MerklePath = tree
-                    .witness_at_checkpoint_id_caching(*pos, &anchor_height)?
-                    .ok_or_else(|| Error::Tree(String::from("checkpoint pruned")))?
-                    .into();
-                paths.push(path);
-            }
-            Ok((anchor, paths))
-        })
-    }
 }
 
 impl<'a, W, St> MigrationBackend for WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource + WalletCommitmentTrees,
+    W: WalletRead + InputSource,
     <W as InputSource>::AccountId: Copy,
-    <W as WalletCommitmentTrees>::Error: fmt::Debug,
     St: PoolMigrationRead,
 {
     type Error = AdapterError<W, St>;
@@ -233,20 +183,17 @@ where
     }
 
     fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
-        let guard = self.wallet.borrow();
-        let wallet: &W = &guard;
-        wallet
+        self.wallet
             .chain_height()
             .map_err(Error::WalletRead)?
-            .ok_or(Error::AnchorUnavailable)
+            .ok_or(Error::ChainTipUnknown)
     }
 }
 
 impl<'a, W, St> MigrationCrypto for WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource + WalletCommitmentTrees,
+    W: WalletRead + InputSource,
     <W as InputSource>::AccountId: Copy,
-    <W as WalletCommitmentTrees>::Error: fmt::Debug,
     St: PoolMigrationRead,
 {
     type Error = AdapterError<W, St>;
@@ -255,66 +202,10 @@ where
         Ok(FullViewingKey::from(self.usk.orchard()))
     }
 
-    fn orchard_anchor(&self, anchor_height: BlockHeight) -> Result<Anchor, Self::Error> {
-        Ok(self.witness(anchor_height, &[])?.0)
-    }
-
-    fn resolve_wallet_note(
-        &self,
-        index: usize,
-        anchor_height: BlockHeight,
-    ) -> Result<(OrchardNote, MerklePath), Self::Error> {
+    fn resolve_wallet_note(&self, index: usize) -> Result<OrchardNote, Self::Error> {
         let notes = self.spendable_orchard()?;
-        let &(note, position, _) = notes.get(index).ok_or(Error::NoteNotFound(index))?;
-        let (_, mut paths) = self.witness(anchor_height, &[position])?;
-        Ok((note, paths.remove(0)))
-    }
-
-    fn resolve_feeder_notes(
-        &self,
-        values: &[Zatoshis],
-        anchor_height: BlockHeight,
-    ) -> Result<Vec<(OrchardNote, MerklePath)>, Self::Error> {
-        let notes = self.spendable_orchard()?;
-        let mut used = vec![false; notes.len()];
-        let mut chosen: Vec<(OrchardNote, Position)> = Vec::with_capacity(values.len());
-        for (value_index, &value) in values.iter().enumerate() {
-            // Each feeder value is matched to a DISTINCT spendable note of exactly that value; notes
-            // of equal value are interchangeable, so a greedy first-unused match is correct.
-            let note_index = notes
-                .iter()
-                .enumerate()
-                .position(|(i, (_, _, note_value))| !used[i] && *note_value == u64::from(value))
-                .ok_or(Error::NoteNotFound(value_index))?;
-            used[note_index] = true;
-            chosen.push((notes[note_index].0, notes[note_index].1));
-        }
-        let positions: Vec<Position> = chosen.iter().map(|(_, pos)| *pos).collect();
-        let (_, paths) = self.witness(anchor_height, &positions)?;
-        Ok(chosen
-            .into_iter()
-            .map(|(note, _)| note)
-            .zip(paths)
-            .collect())
-    }
-
-    fn resolve_funding_notes(&self, values: &[Zatoshis]) -> Result<Vec<OrchardNote>, Self::Error> {
-        let notes = self.spendable_orchard()?;
-        let mut used = vec![false; notes.len()];
-        let mut chosen: Vec<OrchardNote> = Vec::with_capacity(values.len());
-        for (value_index, &value) in values.iter().enumerate() {
-            // Each funding value is matched to a DISTINCT spendable note of exactly that value; notes
-            // of equal value are interchangeable, so a greedy first-unused match is correct. No
-            // witness is resolved: a transfer's anchors and witness are deferred to proving time.
-            let note_index = notes
-                .iter()
-                .enumerate()
-                .position(|(i, (_, _, note_value))| !used[i] && *note_value == u64::from(value))
-                .ok_or(Error::NoteNotFound(value_index))?;
-            used[note_index] = true;
-            chosen.push(notes[note_index].0);
-        }
-        Ok(chosen)
+        let &(note, _, _) = notes.get(index).ok_or(Error::NoteNotFound(index))?;
+        Ok(note)
     }
 
     fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {
@@ -325,9 +216,8 @@ where
 
 impl<'a, W, St> PoolMigrationRead for WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource + WalletCommitmentTrees,
+    W: WalletRead + InputSource,
     <W as InputSource>::AccountId: Copy,
-    <W as WalletCommitmentTrees>::Error: fmt::Debug,
     St: PoolMigrationRead,
 {
     type Error = AdapterError<W, St>;
@@ -339,9 +229,8 @@ where
 
 impl<'a, W, St> PoolMigrationWrite for WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource + WalletCommitmentTrees,
+    W: WalletRead + InputSource,
     <W as InputSource>::AccountId: Copy,
-    <W as WalletCommitmentTrees>::Error: fmt::Debug,
     St: PoolMigrationWrite,
 {
     fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
@@ -366,27 +255,25 @@ mod tests {
     use rand_core::{CryptoRng, RngCore};
     use zcash_protocol::consensus::Parameters;
 
-    use crate::engine::{commit_preparation, commit_transfers};
+    use crate::engine::commit_preparation;
 
     /// Compile-time proof that `WalletMigration` over ANY `zcash_client_backend` wallet `W` and ANY
-    /// migration store `St` satisfies every trait bound `commit_preparation` / `commit_transfers`
-    /// require (backend + crypto + store, all sharing one error type). Naming the two generic
-    /// functions instantiated at `WalletMigration<W, St>` forces the type checker to verify that
-    /// instantiation's bounds hold; if the four trait impls ever stop lining up with the commit path,
-    /// this stops compiling. It is never called and needs no wallet instance, so it pulls in no
-    /// test-only wallet dependency (which would otherwise force `zcash_client_backend`'s Orchard
-    /// feature on across the whole workspace's test build).
+    /// migration store `St` satisfies every trait bound `commit_preparation` requires (backend +
+    /// crypto + store, all sharing one error type). Naming the generic function instantiated at
+    /// `WalletMigration<W, St>` forces the type checker to verify that instantiation's bounds hold;
+    /// if the four trait impls ever stop lining up with the commit path, this stops compiling. It
+    /// is never called and needs no wallet instance, so it pulls in no test-only wallet dependency
+    /// (which would otherwise force `zcash_client_backend`'s Orchard feature on across the whole
+    /// workspace's test build).
     #[allow(dead_code)]
     fn assert_commit_bounds<'a, P, W, St, R>()
     where
         P: Parameters + Clone,
-        W: WalletRead + InputSource + WalletCommitmentTrees + 'a,
+        W: WalletRead + InputSource + 'a,
         <W as InputSource>::AccountId: Copy,
-        <W as WalletCommitmentTrees>::Error: fmt::Debug,
         St: PoolMigrationWrite,
         R: RngCore + CryptoRng,
     {
         let _ = commit_preparation::<P, WalletMigration<'a, W, St>, R>;
-        let _ = commit_transfers::<P, WalletMigration<'a, W, St>, R>;
     }
 }

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -16,6 +16,16 @@ workspace.
   the action's spend authorization signature and its share of the bundle's proof,
   which are encoded separately, so dividing a size budget by it yields an upper
   bound on the number of actions that fit within that budget.
+- `zcash_primitives::transaction::builder::DeferredPcztBuilder`, a builder for
+  V6 (NU6.3 onward) PCZTs whose Orchard-family anchors — and real-spend
+  witnesses — are deferred to proving time (ZIP 374): spends are added as bare
+  `(fvk, note)` pairs (via `orchard`'s new deferred-anchor builder support),
+  the emitted PCZT carries absent anchor and witness fields, and the real
+  values are installed after signing through the PCZT `Updater` role.
+  Restricted to the Orchard and Ironwood pools (Sapling nullifiers commit to
+  note positions, so Sapling spends cannot be signed before their witnesses
+  are final).
+- `zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported`
 
 ### Changed
 - `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -109,6 +109,11 @@ pub enum Error<FE> {
     /// The builder was constructed with a target height before NU6.3 activation,
     /// or without an Ironwood anchor, but an Ironwood spend or output was added.
     IronwoodBuilderNotAvailable,
+    /// Anchors can be deferred to proving time only under a transaction version whose
+    /// txid and sighash exclude shielded anchors (V6, NU6.3 onward); this version commits
+    /// its signatures to the anchors, so they must be supplied at build time (use
+    /// [`Builder`]).
+    AnchorDeferralUnsupported(TxVersion),
     /// An error occurred in constructing a coinbase transaction.
     Coinbase(coinbase::Error),
     /// A coinbase transaction's expiry height does not match its target block height.
@@ -160,6 +165,10 @@ impl<FE: fmt::Display> fmt::Display for Error<FE> {
             Error::IronwoodBuilderNotAvailable => write!(
                 f,
                 "Cannot create Ironwood transactions without an Ironwood anchor, or before NU6.3 activation"
+            ),
+            Error::AnchorDeferralUnsupported(version) => write!(
+                f,
+                "Transaction version {version:?} commits its signatures to shielded anchors, so anchors cannot be deferred to proving time"
             ),
             Error::Coinbase(err) => write!(
                 f,
@@ -385,6 +394,294 @@ fn orchard_action_count(
     };
 
     bundle_type.num_actions(flags, num_spends, num_outputs)
+}
+
+/// A builder for V6 (NU6.3 onward) transactions constructed as PCZTs with their
+/// Orchard-family anchors DEFERRED to proving time, per [ZIP 374].
+///
+/// [`Builder`] requires each shielded pool's anchor in its [`BuildConfig`] and a Merkle
+/// witness rooting to it for every spend it adds. This builder takes no anchors at all:
+/// spends are added as bare `(fvk, note)` pairs through the `orchard` crate's own
+/// deferred-anchor support ([`orchard::builder::Builder::new_with_anchor_deferred`]), and the
+/// emitted PCZT carries ABSENT anchor and witness fields, which the PCZT Updater role
+/// (`set_{orchard,ironwood}_anchor` / `set_*_spend_witnesses`) fills in at proving time,
+/// after the transaction has been finalized and SIGNED. This is sound exactly for the V6
+/// transaction format, whose txid and sighash exclude shielded anchors (they are
+/// committed only by the authorizing-data digest), so neither the transaction id nor any
+/// signature commits to the deferred values; [`Self::new`] refuses any earlier format.
+/// The witness-to-anchor consistency check that [`Builder`] performs per spend at
+/// add-spend time is performed instead by the PCZT Prover role, once the real anchor and
+/// witnesses are present.
+///
+/// The builder is deliberately restricted to the two Orchard-family pools (Orchard and
+/// Ironwood): their nullifiers are derived from the note alone, so a spend can be signed
+/// before its witness is known. A Sapling nullifier commits to the note's tree position,
+/// so Sapling spends can never defer their witnesses, and transparent inputs are out of
+/// scope for the pre-signing flows this builder serves; use [`Builder`] for those.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374
+pub struct DeferredPcztBuilder<P> {
+    params: P,
+    tx_version: TxVersion,
+    consensus_branch_id: BranchId,
+    target_height: BlockHeight,
+    expiry_height: BlockHeight,
+    orchard_builder: orchard::builder::Builder,
+    orchard_bundle_version: orchard::bundle::BundleVersion,
+    ironwood_builder: orchard::builder::Builder,
+}
+
+impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
+    /// Creates a builder targeting the block at `target_height`, with the given
+    /// transactional bundle type for each Orchard-family pool.
+    ///
+    /// The expiry height defaults to `target_height` plus the default transaction expiry
+    /// delta; override it with [`Self::with_expiry_height`].
+    ///
+    /// Returns [`Error::AnchorDeferralUnsupported`] if the consensus branch in effect at
+    /// `target_height` does not use the V6 transaction format, whose txid and sighash
+    /// exclude shielded anchors; under any earlier format the anchors cannot outlive
+    /// signing.
+    pub fn new<FE>(
+        params: P,
+        target_height: BlockHeight,
+        orchard_bundle_type: orchard::builder::BundleType,
+        ironwood_bundle_type: orchard::builder::BundleType,
+    ) -> Result<Self, Error<FE>> {
+        let consensus_branch_id = BranchId::for_height(&params, target_height);
+        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
+        if !tx_version.has_ironwood() {
+            return Err(Error::AnchorDeferralUnsupported(tx_version));
+        }
+        let orchard_bundle_version =
+            bundle_version_for_branch(consensus_branch_id, orchard::ValuePool::Orchard)
+                .expect("a branch with the V6 format supports the Orchard pool");
+        let orchard_builder = orchard::builder::Builder::new_with_anchor_deferred(
+            orchard_bundle_type,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::bundle::TxVersion::V6,
+        )
+        .map_err(Error::OrchardBuild)?;
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let ironwood_builder = orchard::builder::Builder::new_with_anchor_deferred(
+            ironwood_bundle_type,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::bundle::TxVersion::V6,
+        )
+        .map_err(Error::IronwoodBuild)?;
+        Ok(DeferredPcztBuilder {
+            params,
+            tx_version,
+            consensus_branch_id,
+            target_height,
+            expiry_height: target_height + DEFAULT_TX_EXPIRY_DELTA,
+            orchard_builder,
+            orchard_bundle_version,
+            ironwood_builder,
+        })
+    }
+
+    /// Overrides the expiry height for the transaction under construction.
+    ///
+    /// A pre-signed transaction is often broadcast well after it is built, so the caller
+    /// typically sets an expiry derived from the intended broadcast schedule rather than
+    /// the build height; the signatures commit to it.
+    pub fn with_expiry_height(mut self, expiry_height: BlockHeight) -> Self {
+        self.expiry_height = expiry_height;
+        self
+    }
+
+    /// Adds an Orchard note to be spent in this bundle, WITHOUT a witness: the witness,
+    /// like the bundle's anchor, is installed at proving time through the PCZT Updater
+    /// role.
+    pub fn add_orchard_spend<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        note: orchard::Note,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder.add_spend_unwitnessed(fvk, note)?;
+        Ok(())
+    }
+
+    /// Adds an Orchard recipient to the transaction.
+    pub fn add_orchard_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder
+            .add_output(
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::OrchardRecipient)
+    }
+
+    /// Adds a wallet-controlled Orchard change output to the transaction.
+    pub fn add_orchard_change_output<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder
+            .add_change_output(
+                fvk,
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::OrchardRecipient)
+    }
+
+    /// Adds an Ironwood note to be spent in this bundle, WITHOUT a witness (see
+    /// [`Self::add_orchard_spend`]).
+    ///
+    /// The note must use [`orchard::note::NoteVersion::V3`], the Ironwood note plaintext
+    /// format.
+    pub fn add_ironwood_spend<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        note: orchard::Note,
+    ) -> Result<(), Error<FE>> {
+        if note.version() != orchard::note::NoteVersion::V3 {
+            return Err(Error::IronwoodSpendUnsupportedNoteVersion(note.version()));
+        }
+        self.ironwood_builder
+            .add_spend_unwitnessed(fvk, note)
+            .map_err(Error::IronwoodSpend)
+    }
+
+    /// Adds an Ironwood recipient to the transaction.
+    ///
+    /// This uses [`orchard::note::NoteVersion::V3`], the Ironwood note plaintext format.
+    pub fn add_ironwood_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.ironwood_builder
+            .add_output(
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::IronwoodRecipient)
+    }
+
+    /// Reports the calculated fee given the specified fee rule, as a function of the
+    /// spends and outputs added so far (each pool's action count includes the padding its
+    /// bundle type prescribes).
+    pub fn get_fee<FR: FeeRule>(&self, fee_rule: &FR) -> Result<Zatoshis, FeeError<FR::Error>> {
+        fee_rule
+            .fee_required(
+                &self.params,
+                self.target_height,
+                core::iter::empty::<crate::transaction::fees::transparent::InputSize>(),
+                core::iter::empty::<usize>(),
+                0,
+                0,
+                orchard_action_count(&self.orchard_builder, false, self.orchard_bundle_version)
+                    .map_err(FeeError::Bundle)?,
+                orchard_action_count(
+                    &self.ironwood_builder,
+                    false,
+                    orchard::bundle::BundleVersion::ironwood_v3(),
+                )
+                .map_err(FeeError::Bundle)?,
+            )
+            .map_err(FeeError::FeeRule)
+    }
+
+    /// Builds the added spends and outputs into the parts of an unproven PCZT whose
+    /// anchors and real-spend witnesses are ABSENT, deferred to proving time: pass the
+    /// result to the PCZT Creator (`build_from_parts`), then finalize, sign, and — at
+    /// proving time — install the real anchor and witnesses through the PCZT Updater
+    /// role before proving.
+    pub fn build_for_pczt<R: RngCore + CryptoRng, FR: FeeRule>(
+        self,
+        mut rng: R,
+        fee_rule: &FR,
+    ) -> Result<PcztResult<P>, Error<FR::Error>> {
+        fn in_use(builder: &orchard::builder::Builder) -> bool {
+            !builder.spends().is_empty()
+                || !builder.outputs().is_empty()
+                || !builder.changes().is_empty()
+        }
+
+        let fee = self.get_fee(fee_rule).map_err(Error::Fee)?;
+
+        // After fees are accounted for, the value balance of the transaction must be zero.
+        let value_balance = [
+            self.orchard_builder
+                .value_balance::<ZatBalance>()
+                .map_err(|_| BalanceError::Overflow)?,
+            self.ironwood_builder
+                .value_balance::<ZatBalance>()
+                .map_err(|_| BalanceError::Overflow)?,
+        ]
+        .into_iter()
+        .sum::<Option<ZatBalance>>()
+        .ok_or(BalanceError::Overflow)?;
+        let balance_after_fees = (value_balance - fee).ok_or(BalanceError::Underflow)?;
+        match balance_after_fees.cmp(&ZatBalance::zero()) {
+            Ordering::Less => {
+                return Err(Error::InsufficientFunds(-balance_after_fees));
+            }
+            Ordering::Greater => {
+                return Err(Error::ChangeRequired(balance_after_fees));
+            }
+            Ordering::Equal => (),
+        };
+
+        let (orchard_bundle, orchard_meta) = if in_use(&self.orchard_builder) {
+            let (bundle, meta) = self
+                .orchard_builder
+                .build_for_pczt(&mut rng)
+                .map_err(Error::OrchardBuild)?;
+            (Some(bundle), meta)
+        } else {
+            (None, orchard::builder::BundleMetadata::empty())
+        };
+        let (ironwood_bundle, ironwood_meta) = if in_use(&self.ironwood_builder) {
+            let (bundle, meta) = self
+                .ironwood_builder
+                .build_for_pczt(&mut rng)
+                .map_err(Error::IronwoodBuild)?;
+            (Some(bundle), meta)
+        } else {
+            (None, orchard::builder::BundleMetadata::empty())
+        };
+
+        Ok(PcztResult {
+            pczt_parts: PcztParts {
+                params: self.params,
+                version: self.tx_version,
+                consensus_branch_id: self.consensus_branch_id,
+                lock_time: 0,
+                expiry_height: self.expiry_height,
+                transparent: None,
+                sapling: None,
+                orchard: orchard_bundle,
+                ironwood: ironwood_bundle,
+            },
+            sapling_meta: SaplingMetadata::empty(),
+            orchard_meta,
+            ironwood_meta,
+        })
+    }
 }
 
 /// The result of a transaction build operation, which includes the resulting transaction along


### PR DESCRIPTION
Stacked on #2695 (`feat/deferred-shielded-anchors`, which depends on zcash/orchard#534). Part of the Orchard → Ironwood pool migration (ZIP 318). Merge zcash/orchard#534 → #2695 first.

Adds the `engine` module: the orchestration layer that ties the note-split, preparation, and scheduling planners together behind a `MigrationBackend` trait, so the engine drives a migration without knowing how the wallet stores notes, holds keys, or persists state.

## What's here
- `plan_migration` (pure, `no_std`): reads the account's spendable notes and the chain tip from the backend, decomposes the balance into denominations, plans the preparation transactions, schedules the transfers — broadcast order SHUFFLED per ZIP 318, so the on-chain sequence of denominations is independent of the balance — and reconciles the split against the preparation fees (drop-smallest when they do not fit), returning a `MigrationPlan` preview for user consent.
- The persisted state model: a `MigrationState` of `MigrationTransaction`s, each storing its pre-signed PCZT plus schedule, dependencies, drawn anchor boundary, and lifecycle state, behind `PoolMigrationRead`/`PoolMigrationWrite` store traits. The durable artifact is the pre-signed PCZT, so a wallet resumes a migration entirely from the store after a restart — and a live (non-terminal) migration is never overwritten by a re-commit.
- **ONE signing phase** (`commit_preparation`): every transaction — each preparation layer in topological order, then every transfer — is built and signed in a single pass, before anything is broadcast. This rests on ZIP 374: the V6 txid and sighash exclude shielded anchors, so every PCZT is built with ABSENT anchors and witnesses (via #2695's `DeferredPcztBuilder`), and a spent note's plaintext fully determines the signed data — including a note minted by a still-unmined earlier migration transaction, whose plaintext the engine recovers from the built bundle (its rho is the paired spend's nullifier and its rseed is drawn at build; mining only assigns the tree position, which matters only to the proof). Mining therefore gates only the BROADCAST order, which the state machine walks by dependencies and the drawn schedule; the consumer proves each transaction — installing its anchor (for a transfer, its drawn boundary) and witnesses through the PCZT `Updater` role — just before broadcasting it.
- The external-signer seam: `build_preparation_unsigned` returns the same transactions UNSIGNED, in topological order, and `batch_unsigned_by_action_budget` splits them into signing sessions bounded by the device's per-interaction action budget (16 actions per preparation, 3 per transfer) — consecutive prefixes, never gated on mining. `MigrationState::apply_signature` applies each signed PCZT back.
- A wallet-backed adapter (`wallet` module, behind the `wallet` feature): `WalletMigration` implements the backend/crypto/store traits over any `zcash_client_backend` wallet (`WalletRead` + `InputSource` only — the migration never touches the note commitment tree) plus the account's `UnifiedSpendingKey` and a caller-supplied store.

## Follow-ups (not in this PR)
- The proving/broadcast driver: install each due transaction's anchor and witnesses via the PCZT `Updater`, prove, and broadcast at the drawn heights.
- Reconciliation-on-launch (at most one overdue transfer released on reopen) and rebuild-on-expiry (rebuilding a preparation redraws its outputs' rseeds, so its dependents rebuild with it).
- A concrete store (`zcash_pool_migration_sqlite`).

Planning is pure (`no_std`); building and signing sit behind the `orchard` feature.

Description updated with Claude Code assistance.