### PR TITLE
zcash_pool_migration_backend: test reconciliation on a many-equal-note source

### DIFF
--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -1318,6 +1318,83 @@ mod tests {
         ));
     }
 
+    /// Reconciliation on a many-equal-note source (the "exchange" wallet shape). Ten identical 5-ZEC
+    /// notes (50 ZEC) decompose into `[20, 20, 5, 2, 2, 0.5, ...]`, but equal source notes cannot fund
+    /// that whole split: each funding note is its crossing plus a transfer buffer and costs a
+    /// preparation fee, so a lone 5-ZEC note cannot even self-fund a 5-ZEC crossing. The split
+    /// consults the preparation planner against the source notes at every step, so it reconciles
+    /// inline, dropping the smallest funding notes (smallest first) and leaving those denominations
+    /// in the source pool as residual. We reconstruct the UNCONSTRAINED split (the same strategy with
+    /// an always-fundable preparation stub) as the baseline the source-constrained split is measured
+    /// against, and pin the documented behavior end to end: the source constraint actually drops for
+    /// this shape, drops only from the bottom, never invents a denomination, never creates value, and
+    /// yields a preparation that is fundable from the source notes.
+    #[test]
+    fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
+        let balance = 50 * COIN;
+        let backend = MockBackend::new(vec![5 * COIN; 10], 2_000_000); // ten equal 5-ZEC notes
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let plan =
+            plan_migration(&test_net(), &backend, &mut rng).expect("a fundable balance plans");
+
+        let kept = plan.funding_notes();
+
+        // The baseline: the same split with an always-fundable preparation stub, i.e. what the
+        // strategy proposes for this balance absent the equal-note source's fundability constraint.
+        let (prep_tx_fee, transfer_buffer) = test_fees();
+        let mut ref_rng = ChaCha8Rng::seed_from_u64(1);
+        let proposed = plan_note_split(
+            Zatoshis::from_u64(balance).expect("test balance is valid"),
+            transfer_buffer,
+            prep_tx_fee,
+            &prep_tx_count_stub,
+            &mut ref_rng,
+        )
+        .migration_outputs();
+
+        // The unconstrained split proposes more funding notes than the equal-note source can fund, so
+        // the source-constrained split must drop some. This is the case this test exists to cover: the
+        // general `plans_a_migration_from_a_balance` test uses a shape that happens to drop nothing.
+        assert!(
+            kept.len() < proposed.len(),
+            "the many-equal-note source should force a drop: kept {} of {}",
+            kept.len(),
+            proposed.len()
+        );
+
+        // Only ever DROPS: every kept funding note is one the unconstrained split proposed (a
+        // sub-multiset of it), so no denomination or value is invented. Removing the kept notes from a
+        // copy of the proposed outputs leaves exactly the dropped notes.
+        let mut dropped = proposed.clone();
+        for &k in kept {
+            let pos = dropped
+                .iter()
+                .position(|&v| v == k)
+                .expect("every kept funding note came from the proposed outputs");
+            dropped.swap_remove(pos);
+        }
+
+        // The drop is from the BOTTOM: every kept note is at least as large as every dropped one.
+        let smallest_kept = kept
+            .iter()
+            .copied()
+            .min()
+            .expect("at least one note is kept");
+        assert!(
+            dropped.iter().all(|&d| d <= smallest_kept),
+            "reconciliation must drop the smallest denominations first"
+        );
+
+        // No value is created: the reconciled funding notes never exceed the balance.
+        assert!(kept.iter().map(|z| z.into_u64()).sum::<u64>() <= balance);
+
+        // The reconciled plan is actually fundable from the source notes.
+        assert!(
+            crate::preparation::plan_preparation(&backend.notes, kept, prep_tx_fee).is_ok(),
+            "the reconciled funding set must be preparable from the source notes"
+        );
+    }
+
     #[test]
     fn stores_loads_and_updates_a_migration() {
         let mut backend = MockBackend::new(Vec::new(), 0);


### PR DESCRIPTION
The reconciliation loop in `plan_migration` drops the smallest funding notes
until the preparation fits, but no unit test exercised a source shape that forces
a drop; the general planning test uses a balance whose whole split is fundable, so
the drop path was only covered indirectly by an integration test.

Adds a test for the "exchange" shape: ten identical 5-ZEC notes (50 ZEC) whose
greedy split has a small tail the equal source notes cannot fund. It asserts
reconciliation actually drops for this shape, drops only the smallest
denominations (a sub-multiset of the split, from the bottom), never creates value,
and leaves a preparation that is fundable from the source notes.

Based on #2663.