### PR TITLE
zcash_pool_migration_backend: fix the test build after migration_outputs change

### DIFF
--- a/zcash_pool_migration_backend/src/build/end_to_end.rs
+++ b/zcash_pool_migration_backend/src/build/end_to_end.rs
@@ -36,7 +36,7 @@ fn migration_pipeline_end_to_end() {
 
     // 2. Preparation: plan the send-to-self transactions that mint those funding notes. A typical
     //    wallet (one note, a handful of funding notes) prepares in a single transaction.
-    let prep = plan_preparation(&[balance], funding, split.prep_fee_zatoshi())
+    let prep = plan_preparation(&[balance], &funding, split.prep_fee_zatoshi())
         .expect("the balance funds the preparation");
     assert_eq!(prep.layer_count(), 1);
     assert_eq!(prep.transaction_count(), 1);


### PR DESCRIPTION
main's `cargo test --all-features -p zcash_pool_migration_backend` currently
fails to compile. Two independently-green PRs collided:

- #2647 added `build/end_to_end.rs`, which does
  `let funding = split.migration_outputs(); plan_preparation(&[balance], funding, ...)`.
- The note-split review change made `NoteSplitPlan::migration_outputs()` return
  an owned `Vec<u64>` (it now derives the prepared-note values from the crossing
  values plus the fee buffer) instead of a borrowed `&[u64]`.

`plan_preparation` takes `&[u64]`, so passing the `Vec` no longer compiles.
One-character fix: borrow it (`&funding`). Verified `cargo test --all-features`
is green again (46 passed).