### PR TITLE
zcash_pool_migration_backend: move the prep-tx fee onto FeePolicy

### DIFF
--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -168,6 +168,14 @@ pub trait FeePolicy {
         (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER)
             * self.marginal_fee_zatoshi()
     }
+
+    /// The fee (in zatoshi) reserved for one note-preparation transaction: a transaction padded to
+    /// [`PREP_TX_ACTIONS`](crate::preparation::PREP_TX_ACTIONS) logical actions (per ZIP 318), each
+    /// charged the marginal fee. This is the per-transaction reserve
+    /// [`plan_preparation`](crate::preparation::plan_preparation) subtracts from the inputs.
+    fn prep_transaction_fee_zatoshi(&self) -> u64 {
+        crate::preparation::PREP_TX_ACTIONS as u64 * self.marginal_fee_zatoshi()
+    }
 }
 
 /// The ZIP-317 fee model: the marginal fee is the ZIP-317 [`MARGINAL_FEE`].

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -693,12 +693,6 @@ mod tests {
 
     use crate::note_splitting::{FeePolicy, Zip317FeePolicy};
 
-    /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
-    /// action costs one [`Zip317FeePolicy`] marginal fee). The planner treats it opaquely.
-    fn fee_per_tx() -> u64 {
-        PREP_TX_ACTIONS as u64 * Zip317FeePolicy.marginal_fee_zatoshi()
-    }
-
     /// The funding values a plan mints, sorted, for multiset comparison against the request.
     fn sorted_funding(plan: &PreparationPlan) -> Vec<u64> {
         let mut out = plan.funding_notes();
@@ -823,7 +817,9 @@ mod tests {
     fn arb_sufficient() -> impl Strategy<Value = (Vec<u64>, Vec<u64>)> {
         prop::collection::vec(1u64..500_000, 1..20).prop_flat_map(|funding| {
             let need: u64 = funding.iter().sum();
-            let big = need + (funding.len() as u64 + 64) * fee_per_tx() + 1;
+            let big = need
+                + (funding.len() as u64 + 64) * Zip317FeePolicy.prep_transaction_fee_zatoshi()
+                + 1;
             (prop::collection::vec(1u64..100_000, 0..8), Just(funding)).prop_map(
                 move |(mut extra, funding)| {
                     extra.push(big);
@@ -837,8 +833,8 @@ mod tests {
         /// Whenever a plan is produced over arbitrary inputs, every structural invariant holds.
         #[test]
         fn valid_whenever_planned((available, funding) in arb_input()) {
-            if let Ok(plan) = plan_preparation(&available, &funding, fee_per_tx()) {
-                assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            if let Ok(plan) = plan_preparation(&available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()) {
+                assert_plan_valid(&plan, &available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
             }
         }
 
@@ -846,9 +842,9 @@ mod tests {
         /// plan (the planner never gives up when the value is amply present).
         #[test]
         fn always_plans_when_amply_funded((available, funding) in arb_sufficient()) {
-            let plan = plan_preparation(&available, &funding, fee_per_tx())
+            let plan = plan_preparation(&available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi())
                 .expect("ample funding must plan");
-            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            assert_plan_valid(&plan, &available, &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
             // The leftover is far larger than a fee, so it collapses to a single residual note.
             prop_assert!(plan.residual_count() <= 1, "{} residual notes", plan.residual_count());
         }
@@ -861,12 +857,23 @@ mod tests {
     #[test]
     fn common_case_is_one_layer_one_tx() {
         let funding = [500u64, 200, 100, 20, 5];
-        let total: u64 = funding.iter().sum::<u64>() + fee_per_tx() + 10_000;
-        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        let total: u64 =
+            funding.iter().sum::<u64>() + Zip317FeePolicy.prep_transaction_fee_zatoshi() + 10_000;
+        let plan = plan_preparation(
+            &[total],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
+        assert_plan_valid(
+            &plan,
+            &[total],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
     }
 
     /// One large note fanning out into more funding notes than a single transaction holds needs more
@@ -874,14 +881,25 @@ mod tests {
     #[test]
     fn whale_single_note_fans_out_across_layers() {
         let funding: Vec<u64> = (0..40).map(|_| 100u64).collect();
-        let total: u64 = funding.iter().sum::<u64>() + 60 * fee_per_tx();
-        let plan = plan_preparation(&[total], &funding, fee_per_tx()).unwrap();
+        let total: u64 =
+            funding.iter().sum::<u64>() + 60 * Zip317FeePolicy.prep_transaction_fee_zatoshi();
+        let plan = plan_preparation(
+            &[total],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
         assert!(
             plan.layer_count() >= 2,
             "40 funding notes cannot fit one tx"
         );
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(&plan, &[total], &funding, fee_per_tx());
+        assert_plan_valid(
+            &plan,
+            &[total],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
     }
 
     /// A sub-quantum note (smaller than any funding note) is consolidated into a feeder before it can
@@ -889,16 +907,26 @@ mod tests {
     #[test]
     fn sub_quantum_is_consolidated_first() {
         // Twenty notes each far below the single 100-unit funding note (plus fees).
-        let per = fee_per_tx() + 20;
+        let per = Zip317FeePolicy.prep_transaction_fee_zatoshi() + 20;
         let available: Vec<u64> = core::iter::repeat_n(per, 20).collect();
         let funding = [100u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
         assert!(
             plan.layer_count() >= 2,
             "sub-quantum notes must consolidate first"
         );
         assert_eq!(plan.residual_count(), 1, "one residual note");
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
     }
 
     /// When several notes each strand a sub-fee remainder whose total is below one transaction fee, the
@@ -908,25 +936,37 @@ mod tests {
     #[test]
     fn sub_fee_remainders_leave_multiple_residuals() {
         // Three notes, each funding one 100_000 note and stranding a 100-zatoshi remainder; the three
-        // remainders total 300 < fee_per_tx(), so no consolidation can merge them.
+        // remainders total 300 < Zip317FeePolicy.prep_transaction_fee_zatoshi(), so no consolidation can merge them.
         let f = 100_000u64;
         let eps = 100u64;
-        let note = f + fee_per_tx() + eps;
+        let note = f + Zip317FeePolicy.prep_transaction_fee_zatoshi() + eps;
         let available = [note, note, note];
         let funding = [f, f, f];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         let changes = plan.residual_notes();
         assert!(
             changes.len() > 1,
             "expected multiple sub-fee residuals: {changes:?}"
         );
         assert!(
-            changes.iter().all(|&v| v < fee_per_tx()),
+            changes
+                .iter()
+                .all(|&v| v < Zip317FeePolicy.prep_transaction_fee_zatoshi()),
             "all residuals sub-fee"
         );
         assert!(
-            changes.iter().sum::<u64>() < fee_per_tx(),
+            changes.iter().sum::<u64>() < Zip317FeePolicy.prep_transaction_fee_zatoshi(),
             "total residual sub-fee"
         );
     }
@@ -935,13 +975,21 @@ mod tests {
     #[test]
     fn edge_cases() {
         assert_eq!(
-            plan_preparation(&[1_000_000], &[], fee_per_tx())
-                .unwrap()
-                .layer_count(),
+            plan_preparation(
+                &[1_000_000],
+                &[],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            )
+            .unwrap()
+            .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(&[10], &[100], fee_per_tx()),
+            plan_preparation(
+                &[10],
+                &[100],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -967,10 +1015,14 @@ mod tests {
     #[test]
     fn many_tiny_notes_insufficient() {
         // 5 x 30_000 = 150_000 available. Funding one 100_000 note costs at least the note plus one
-        // fee: 100_000 + fee_per_tx() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
+        // fee: 100_000 + Zip317FeePolicy.prep_transaction_fee_zatoshi() (80_000) = 180_000. Since 150_000 < 180_000, it is unfundable.
         let available = vec![30_000u64; 5];
         assert_eq!(
-            plan_preparation(&available, &[100_000], fee_per_tx()),
+            plan_preparation(
+                &available,
+                &[100_000],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -984,8 +1036,18 @@ mod tests {
             // Each note is below the 100_000 funding note, so the whole first layer is consolidation.
             let available = vec![50_000u64; n];
             let funding = [100_000u64];
-            let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-            assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+            let plan = plan_preparation(
+                &available,
+                &funding,
+                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+            )
+            .unwrap();
+            assert_plan_valid(
+                &plan,
+                &available,
+                &funding,
+                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+            );
             let mut got: Vec<usize> = plan.layers()[0]
                 .iter()
                 .map(|tx| tx.inputs().len())
@@ -1005,8 +1067,18 @@ mod tests {
         let mut available = vec![40_000u64; 10]; // sub-quantum: needed to fund the 100_000 note
         available.push(400_000); // funds the 300_000 note directly, but not also the 100_000 note
         let funding = [300_000u64, 100_000];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         let layer0 = &plan.layers()[0];
         assert!(
             layer0.iter().any(|tx| tx.inputs().len() == 1),
@@ -1026,7 +1098,11 @@ mod tests {
         // Two 90_000 notes: one consolidation nets 100_000, still short of 100_000 + a funding fee.
         let available = vec![90_000u64; 2];
         assert_eq!(
-            plan_preparation(&available, &[100_000], fee_per_tx()),
+            plan_preparation(
+                &available,
+                &[100_000],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1036,13 +1112,21 @@ mod tests {
     #[test]
     fn lone_sub_quantum_note() {
         assert_eq!(
-            plan_preparation(&[50_000], &[100_000], fee_per_tx()),
+            plan_preparation(
+                &[50_000],
+                &[100_000],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
         assert_eq!(
-            plan_preparation(&[50_000], &[], fee_per_tx())
-                .unwrap()
-                .layer_count(),
+            plan_preparation(
+                &[50_000],
+                &[],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            )
+            .unwrap()
+            .layer_count(),
             0
         );
     }
@@ -1052,15 +1136,29 @@ mod tests {
     #[test]
     fn threshold_notes() {
         let f = 100_000u64;
-        let exact = f + fee_per_tx();
-        let plan = plan_preparation(&[exact], &[f], fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &[exact], &[f], fee_per_tx());
+        let exact = f + Zip317FeePolicy.prep_transaction_fee_zatoshi();
+        let plan = plan_preparation(
+            &[exact],
+            &[f],
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &[exact],
+            &[f],
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.transaction_count(), 1);
         assert_eq!(plan.residual_count(), 0, "exact funding leaves no residual");
 
         // A note worth only the fee has zero spendable budget; on its own it cannot fund anything.
         assert_eq!(
-            plan_preparation(&[fee_per_tx()], &[f], fee_per_tx()),
+            plan_preparation(
+                &[Zip317FeePolicy.prep_transaction_fee_zatoshi()],
+                &[f],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1072,8 +1170,18 @@ mod tests {
     fn deep_consolidation_layer_count() {
         let available = vec![50_000u64; 300];
         let funding = [1_000_000u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(
             plan.layer_count(),
             4,
@@ -1089,8 +1197,18 @@ mod tests {
     fn thousands_of_sub_quantum_notes_layer_count() {
         let available = vec![50_000u64; 3_000];
         let funding = [10_000_000u64];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(
             plan.layer_count(),
             4,
@@ -1107,9 +1225,20 @@ mod tests {
         for p in [1usize, 14, 15, 28, 100, 196, 197, 500] {
             let funding = vec![100u64; p];
             // The balanced tree costs more than a linear chain; fund exactly that plus a small residual.
-            let whale = subtree_cost(&funding, fee_per_tx()).1 + 9_999;
-            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
-            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+            let whale =
+                subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1 + 9_999;
+            let plan = plan_preparation(
+                &[whale],
+                &funding,
+                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+            )
+            .unwrap();
+            assert_plan_valid(
+                &plan,
+                &[whale],
+                &funding,
+                Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+            );
             assert_eq!(plan.layer_count(), split_depth(p), "p={p} layers");
         }
     }
@@ -1121,9 +1250,9 @@ mod tests {
         fn whale_fan_out_is_balanced_and_valid(
             funding in prop::collection::vec(1u64..10_000_000, 1..300),
         ) {
-            let whale = subtree_cost(&funding, fee_per_tx()).1 + 12_345;
-            let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
-            assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+            let whale = subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1 + 12_345;
+            let plan = plan_preparation(&[whale], &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).unwrap();
+            assert_plan_valid(&plan, &[whale], &funding, Zip317FeePolicy.prep_transaction_fee_zatoshi());
             prop_assert_eq!(plan.layer_count(), split_depth(funding.len()));
         }
     }
@@ -1152,9 +1281,19 @@ mod tests {
     #[test]
     fn exact_split_no_residual() {
         let funding = vec![100u64; 15];
-        let whale = subtree_cost(&funding, fee_per_tx()).1; // exact cost, no leftover
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        let whale = subtree_cost(&funding, Zip317FeePolicy.prep_transaction_fee_zatoshi()).1; // exact cost, no leftover
+        let plan = plan_preparation(
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.layer_count(), split_depth(15));
         assert_eq!(plan.residual_count(), 0, "exact split leaves no residual");
     }
@@ -1165,8 +1304,18 @@ mod tests {
     fn many_sub_quantum_fund_many_notes() {
         let available = vec![50_000u64; 100];
         let funding = vec![100_000u64; 30];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(
             plan.layer_count(),
             3,
@@ -1179,7 +1328,11 @@ mod tests {
     #[test]
     fn empty_available_insufficient() {
         assert_eq!(
-            plan_preparation(&[], &[100_000], fee_per_tx()),
+            plan_preparation(
+                &[],
+                &[100_000],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            ),
             Err(PrepError::InsufficientFunds)
         );
     }
@@ -1188,15 +1341,23 @@ mod tests {
     #[test]
     fn zero_value_funding_is_empty() {
         assert_eq!(
-            plan_preparation(&[1_000_000], &[0], fee_per_tx())
-                .unwrap()
-                .layer_count(),
+            plan_preparation(
+                &[1_000_000],
+                &[0],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            )
+            .unwrap()
+            .layer_count(),
             0
         );
         assert_eq!(
-            plan_preparation(&[1_000_000], &[0, 0], fee_per_tx())
-                .unwrap()
-                .layer_count(),
+            plan_preparation(
+                &[1_000_000],
+                &[0, 0],
+                Zip317FeePolicy.prep_transaction_fee_zatoshi()
+            )
+            .unwrap()
+            .layer_count(),
             0
         );
     }
@@ -1205,9 +1366,19 @@ mod tests {
     #[test]
     fn duplicate_funding_values() {
         let funding = [100u64, 100, 100, 100];
-        let whale = 400 + 3 * fee_per_tx();
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        let whale = 400 + 3 * Zip317FeePolicy.prep_transaction_fee_zatoshi();
+        let plan = plan_preparation(
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(sorted_funding(&plan), vec![100, 100, 100, 100]);
     }
 
@@ -1216,8 +1387,18 @@ mod tests {
     fn deterministic() {
         let available = vec![500_000u64, 300_000, 120_000, 60_000, 9_000];
         let funding = vec![100_000u64, 50_000, 50_000, 20_000, 5_000];
-        let a = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        let b = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
+        let a = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        let b = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
         assert_eq!(a, b);
     }
 
@@ -1227,8 +1408,14 @@ mod tests {
     #[test]
     fn note_equal_to_funding_value_is_used_directly() {
         let f = 100_000u64;
-        let plan = plan_preparation(&[f], &[f], fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &[f], &[f], fee_per_tx());
+        let plan =
+            plan_preparation(&[f], &[f], Zip317FeePolicy.prep_transaction_fee_zatoshi()).unwrap();
+        assert_plan_valid(
+            &plan,
+            &[f],
+            &[f],
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.transaction_count(), 0, "no transaction needed");
         assert_eq!(plan.direct_funding_notes(), &[(0, f)]);
         assert_eq!(plan.funding_notes(), vec![f]);
@@ -1242,8 +1429,18 @@ mod tests {
         // Note 0 exactly matches a funding value; note 1 (large) mints the other two.
         let available = vec![f, 10_000_000];
         let funding = vec![f, 50_000, 20_000];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(
             plan.direct_funding_notes(),
             &[(0, f)],
@@ -1260,8 +1457,18 @@ mod tests {
     fn all_exact_matches_need_no_transactions() {
         let funding = vec![100_000u64, 50_000, 50_000];
         let available = funding.clone();
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.transaction_count(), 0);
         assert_eq!(plan.layer_count(), 0);
         assert_eq!(plan.direct_funding_notes().len(), 3);
@@ -1273,9 +1480,20 @@ mod tests {
     #[test]
     fn varied_funding_from_one_whale() {
         let funding = [500_000u64, 200_000, 100_000, 20_000, 5_000, 2_000];
-        let whale = funding.iter().sum::<u64>() + fee_per_tx() + 12_345;
-        let plan = plan_preparation(&[whale], &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &[whale], &funding, fee_per_tx());
+        let whale =
+            funding.iter().sum::<u64>() + Zip317FeePolicy.prep_transaction_fee_zatoshi() + 12_345;
+        let plan = plan_preparation(
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &[whale],
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.layer_count(), 1);
         assert_eq!(plan.transaction_count(), 1);
     }
@@ -1286,10 +1504,20 @@ mod tests {
     fn parallel_funding_across_notes() {
         let f = 100_000u64;
         let n = 20usize;
-        let available = vec![f + fee_per_tx(); n]; // each note funds exactly one f note
+        let available = vec![f + Zip317FeePolicy.prep_transaction_fee_zatoshi(); n]; // each note funds exactly one f note
         let funding = vec![f; n];
-        let plan = plan_preparation(&available, &funding, fee_per_tx()).unwrap();
-        assert_plan_valid(&plan, &available, &funding, fee_per_tx());
+        let plan = plan_preparation(
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        )
+        .unwrap();
+        assert_plan_valid(
+            &plan,
+            &available,
+            &funding,
+            Zip317FeePolicy.prep_transaction_fee_zatoshi(),
+        );
         assert_eq!(plan.layer_count(), 1, "independent notes fund in one layer");
         assert_eq!(plan.transaction_count(), n, "one transaction per note");
         assert_eq!(


### PR DESCRIPTION
Closes #2685.

The per-transaction fee reserve, the ZIP-317 fee of a padded `PREP_TX_ACTIONS`-action transaction, was computed by a free `fee_per_tx` test helper in `preparation`. Per the review comment on #2685, move that computation onto the `FeePolicy` trait as a default `prep_transaction_fee_zatoshi` method, so it lives with the fee model (next to `transfer_fee_buffer_zatoshi`) and is reusable outside the tests, then inline `Zip317FeePolicy.prep_transaction_fee_zatoshi()` at the call sites and drop the helper.

No behaviour change: the value is identical (`PREP_TX_ACTIONS * marginal_fee`). All 46 crate tests pass.