### PR TITLE
zcash_primitives, pczt: defer shielded anchors to proving time (ZIP 374)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,8 +3008,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,3 +229,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(zcash_unstable, values("nu7"))',
   'cfg(live_network_tests)',
 ] }
+
+[patch.crates-io]
+# ZIP 374 deferred-anchor builder support (orchard PR branch
+# `feat/deferred-anchor-builder`); to be dropped once it lands in an orchard
+# release.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,9 +11,17 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `pczt::Pczt`'s Orchard/Ironwood bundle spends now expose their `witness` field
+  via a getter.
 - `pczt::roles::redactor::orchard::OrchardRedactor::compact_resolvable_fields`,
   behind the `orchard` feature, which compacts the Orchard-protocol (Orchard and
   Ironwood) action fields that `pczt::orchard::Bundle::resolve_fields` can restore.
+
+### Changed
+- Serializing an Orchard-protocol bundle built with its anchor deferred to
+  proving time (`orchard`'s `Builder::new_with_anchor_deferred`, ZIP 374) now
+  emits the bundle's anchor as ABSENT (its real spends' witnesses are already
+  absent), for the `Updater` role to install at proving time.
 
 ## [0.8.0-rc.1] - 2026-07-12
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -569,6 +569,7 @@ pub struct Spend {
     ///
     /// - This is set by the Updater.
     /// - This is required by the Prover.
+    #[getset(get = "pub")]
     pub(crate) witness: Option<(u32, [[u8; 32]; 32])>,
 
     /// The spend authorization randomizer.
@@ -2279,13 +2280,16 @@ impl Bundle {
             let (magnitude, sign) = bundle.value_sum().magnitude_sign();
             (magnitude, matches!(sign, orchard::value::Sign::Negative))
         };
-        let anchor = bundle.anchor().to_bytes();
+        // A bundle built with its anchor deferred to proving time (ZIP 374) carries the
+        // empty-tree root purely as a placeholder; emit the anchor as ABSENT, for the
+        // Updater role to install before proving.
+        let anchor = (!bundle.anchor_deferred()).then(|| bundle.anchor().to_bytes());
 
         Self {
             actions,
             flags: bundle.flag_byte(),
             value_sum,
-            anchor: Some(anchor),
+            anchor,
             note_version,
             zkproof: bundle
                 .zkproof()

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -2343,3 +2343,172 @@ fn redacted_anchor_is_not_resolved() {
     redacted.resolve_fields().unwrap();
     assert!(redacted.orchard().anchor().is_none());
 }
+
+#[test]
+fn builder_can_defer_anchors_until_proving() {
+    use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+
+    let mut rng = OsRng;
+
+    let orchard_sk = orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap();
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(&orchard_sk);
+    let orchard_fvk = orchard::keys::FullViewingKey::from(&orchard_sk);
+    let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+    let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
+    let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+
+    // Pretend we already received an Orchard note.
+    let value = orchard::value::NoteValue::from_raw(1_000_000);
+    let note = {
+        let orchard_bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+        let mut orchard_builder = orchard::builder::Builder::new(
+            orchard::builder::BundleType::DEFAULT,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::Anchor::empty_tree(),
+        )
+        .unwrap();
+        orchard_builder
+            .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+            .unwrap();
+        let (bundle, meta) = orchard_builder.build::<i64>(&mut rng).unwrap().unwrap();
+        let action = bundle
+            .actions()
+            .get(meta.output_action_index(0).unwrap())
+            .unwrap();
+        let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+        let (note, _, _) = try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
+        note
+    };
+
+    // The REAL tree state, available only at "proving time": the builder below never sees
+    // it, and neither does the signer.
+    let (anchor, merkle_path): (orchard::Anchor, orchard::tree::MerklePath) = {
+        let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+        let leaf = MerkleHashOrchard::from_cmx(&cmx);
+        let mut tree =
+            ShardTree::<_, 32, 16>::new(MemoryShardStore::<MerkleHashOrchard, u32>::empty(), 100);
+        tree.append(leaf, incrementalmerkletree::Retention::Marked)
+            .unwrap();
+        tree.checkpoint(9_999_999).unwrap();
+        let position = 0.into();
+        let merkle_path = tree
+            .witness_at_checkpoint_depth(position, 0)
+            .unwrap()
+            .unwrap();
+        let anchor = merkle_path.root(leaf);
+        (anchor.into(), merkle_path.into())
+    };
+
+    // Build the transaction with BOTH shielded anchors deferred to proving time (ZIP 374):
+    // no anchor and no witness is supplied at build time.
+    let mut builder = DeferredPcztBuilder::new::<zip317::FeeRule>(
+        nu6_3_test_network(),
+        10_000_000.into(),
+        orchard::builder::BundleType::DEFAULT,
+        orchard::builder::BundleType::DEFAULT,
+    )
+    .unwrap();
+    builder
+        .add_orchard_spend::<zip317::FeeRule>(orchard_fvk.clone(), note)
+        .unwrap();
+    builder
+        .add_ironwood_output::<zip317::FeeRule>(
+            Some(orchard_ovk),
+            recipient,
+            Zatoshis::const_from_u64(980_000),
+            MemoBytes::empty(),
+        )
+        .unwrap();
+    let PcztResult {
+        pczt_parts,
+        orchard_meta,
+        ..
+    } = builder
+        .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+        .unwrap();
+    // The Creator strips the builder's internal placeholders: both anchors and the real
+    // spend's witness are ABSENT. The fabricated dummy spends keep their (dummy) witnesses:
+    // the prover needs a path for every spend, and any path is valid for a zero-valued
+    // note.
+    let pczt = Creator::build_from_parts(pczt_parts).unwrap();
+    assert!(pczt.orchard().anchor().is_none());
+    assert!(pczt.ironwood().anchor().is_none());
+    let index = orchard_meta.spend_action_index(0).unwrap();
+    for (i, action) in pczt.orchard().actions().iter().enumerate() {
+        if i == index {
+            assert!(action.spend().witness().is_none());
+        } else {
+            assert!(action.spend().witness().is_some());
+        }
+    }
+    check_v2_round_trip(&pczt);
+
+    // I/O finalization and signing need neither anchors nor witnesses under V6.
+    let pczt = IoFinalizer::new(pczt).finalize_io().unwrap();
+    let mut signer = Signer::new(pczt).unwrap();
+    let sighash = signer.shielded_sighash();
+    signer.sign_orchard(index, &orchard_ask).unwrap();
+    let signed = signer.finish();
+
+    // Proving without the real anchor fails: the deferral cannot be silently ignored.
+    assert!(
+        Prover::new(signed.clone())
+            .create_orchard_proof(post_nu6_3_orchard_proving_key())
+            .is_err()
+    );
+
+    // At proving time, install the real anchor and witness. The sighash is unchanged and
+    // the pre-made signature still verifies, because V6 signatures commit to neither
+    // shielded anchors nor witnesses.
+    let updated = Updater::new(signed)
+        .set_orchard_anchor(anchor)
+        .unwrap()
+        .set_orchard_spend_witnesses([(index, merkle_path)])
+        .unwrap()
+        .set_ironwood_anchor(orchard::Anchor::empty_tree())
+        .unwrap()
+        .finish();
+    assert_eq!(updated.orchard().anchor(), &Some(anchor.to_bytes()));
+    assert_eq!(
+        Signer::new(updated.clone()).unwrap().shielded_sighash(),
+        sighash
+    );
+    let produced_sig = updated.orchard().actions()[index]
+        .spend()
+        .spend_auth_sig()
+        .expect("action was signed");
+    assert_valid_spend_auth_sig(
+        updated.orchard().actions()[index].spend().rk(),
+        sighash,
+        produced_sig,
+    );
+
+    let proved = Prover::new(updated)
+        .create_orchard_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .create_ironwood_proof(post_nu6_3_orchard_proving_key())
+        .unwrap()
+        .finish();
+    check_v2_round_trip(&proved);
+
+    let tx = TransactionExtractor::new(proved).extract().unwrap();
+    assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
+}
+
+#[test]
+fn deferred_anchors_require_v6() {
+    use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+
+    // Under a pre-NU6.3 branch the transaction version (V5) commits its signatures to the
+    // shielded anchors, so anchor deferral is refused at construction.
+    assert!(matches!(
+        DeferredPcztBuilder::new::<zip317::FeeRule>(
+            pre_nu6_3_test_network(),
+            10_000_000.into(),
+            orchard::builder::BundleType::DEFAULT,
+            orchard::builder::BundleType::DEFAULT,
+        ),
+        Err(zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported(_))
+    ));
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -39,6 +39,7 @@ audit-as-crates-io = true
 [policy.incrementalmerkletree-testing]
 
 [policy.orchard]
+audit-as-crates-io = false
 
 [policy.pczt]
 audit-as-crates-io = true

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -16,6 +16,16 @@ workspace.
   the action's spend authorization signature and its share of the bundle's proof,
   which are encoded separately, so dividing a size budget by it yields an upper
   bound on the number of actions that fit within that budget.
+- `zcash_primitives::transaction::builder::DeferredPcztBuilder`, a builder for
+  V6 (NU6.3 onward) PCZTs whose Orchard-family anchors — and real-spend
+  witnesses — are deferred to proving time (ZIP 374): spends are added as bare
+  `(fvk, note)` pairs (via `orchard`'s new deferred-anchor builder support),
+  the emitted PCZT carries absent anchor and witness fields, and the real
+  values are installed after signing through the PCZT `Updater` role.
+  Restricted to the Orchard and Ironwood pools (Sapling nullifiers commit to
+  note positions, so Sapling spends cannot be signed before their witnesses
+  are final).
+- `zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported`
 
 ### Changed
 - `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -109,6 +109,11 @@ pub enum Error<FE> {
     /// The builder was constructed with a target height before NU6.3 activation,
     /// or without an Ironwood anchor, but an Ironwood spend or output was added.
     IronwoodBuilderNotAvailable,
+    /// Anchors can be deferred to proving time only under a transaction version whose
+    /// txid and sighash exclude shielded anchors (V6, NU6.3 onward); this version commits
+    /// its signatures to the anchors, so they must be supplied at build time (use
+    /// [`Builder`]).
+    AnchorDeferralUnsupported(TxVersion),
     /// An error occurred in constructing a coinbase transaction.
     Coinbase(coinbase::Error),
     /// A coinbase transaction's expiry height does not match its target block height.
@@ -160,6 +165,10 @@ impl<FE: fmt::Display> fmt::Display for Error<FE> {
             Error::IronwoodBuilderNotAvailable => write!(
                 f,
                 "Cannot create Ironwood transactions without an Ironwood anchor, or before NU6.3 activation"
+            ),
+            Error::AnchorDeferralUnsupported(version) => write!(
+                f,
+                "Transaction version {version:?} commits its signatures to shielded anchors, so anchors cannot be deferred to proving time"
             ),
             Error::Coinbase(err) => write!(
                 f,
@@ -385,6 +394,294 @@ fn orchard_action_count(
     };
 
     bundle_type.num_actions(flags, num_spends, num_outputs)
+}
+
+/// A builder for V6 (NU6.3 onward) transactions constructed as PCZTs with their
+/// Orchard-family anchors DEFERRED to proving time, per [ZIP 374].
+///
+/// [`Builder`] requires each shielded pool's anchor in its [`BuildConfig`] and a Merkle
+/// witness rooting to it for every spend it adds. This builder takes no anchors at all:
+/// spends are added as bare `(fvk, note)` pairs through the `orchard` crate's own
+/// deferred-anchor support ([`orchard::builder::Builder::new_with_anchor_deferred`]), and the
+/// emitted PCZT carries ABSENT anchor and witness fields, which the PCZT Updater role
+/// (`set_{orchard,ironwood}_anchor` / `set_*_spend_witnesses`) fills in at proving time,
+/// after the transaction has been finalized and SIGNED. This is sound exactly for the V6
+/// transaction format, whose txid and sighash exclude shielded anchors (they are
+/// committed only by the authorizing-data digest), so neither the transaction id nor any
+/// signature commits to the deferred values; [`Self::new`] refuses any earlier format.
+/// The witness-to-anchor consistency check that [`Builder`] performs per spend at
+/// add-spend time is performed instead by the PCZT Prover role, once the real anchor and
+/// witnesses are present.
+///
+/// The builder is deliberately restricted to the two Orchard-family pools (Orchard and
+/// Ironwood): their nullifiers are derived from the note alone, so a spend can be signed
+/// before its witness is known. A Sapling nullifier commits to the note's tree position,
+/// so Sapling spends can never defer their witnesses, and transparent inputs are out of
+/// scope for the pre-signing flows this builder serves; use [`Builder`] for those.
+///
+/// [ZIP 374]: https://zips.z.cash/zip-0374
+pub struct DeferredPcztBuilder<P> {
+    params: P,
+    tx_version: TxVersion,
+    consensus_branch_id: BranchId,
+    target_height: BlockHeight,
+    expiry_height: BlockHeight,
+    orchard_builder: orchard::builder::Builder,
+    orchard_bundle_version: orchard::bundle::BundleVersion,
+    ironwood_builder: orchard::builder::Builder,
+}
+
+impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
+    /// Creates a builder targeting the block at `target_height`, with the given
+    /// transactional bundle type for each Orchard-family pool.
+    ///
+    /// The expiry height defaults to `target_height` plus the default transaction expiry
+    /// delta; override it with [`Self::with_expiry_height`].
+    ///
+    /// Returns [`Error::AnchorDeferralUnsupported`] if the consensus branch in effect at
+    /// `target_height` does not use the V6 transaction format, whose txid and sighash
+    /// exclude shielded anchors; under any earlier format the anchors cannot outlive
+    /// signing.
+    pub fn new<FE>(
+        params: P,
+        target_height: BlockHeight,
+        orchard_bundle_type: orchard::builder::BundleType,
+        ironwood_bundle_type: orchard::builder::BundleType,
+    ) -> Result<Self, Error<FE>> {
+        let consensus_branch_id = BranchId::for_height(&params, target_height);
+        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
+        if !tx_version.has_ironwood() {
+            return Err(Error::AnchorDeferralUnsupported(tx_version));
+        }
+        let orchard_bundle_version =
+            bundle_version_for_branch(consensus_branch_id, orchard::ValuePool::Orchard)
+                .expect("a branch with the V6 format supports the Orchard pool");
+        let orchard_builder = orchard::builder::Builder::new_with_anchor_deferred(
+            orchard_bundle_type,
+            orchard_bundle_version,
+            orchard_bundle_version.default_flags(),
+            orchard::bundle::TxVersion::V6,
+        )
+        .map_err(Error::OrchardBuild)?;
+        let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
+        let ironwood_builder = orchard::builder::Builder::new_with_anchor_deferred(
+            ironwood_bundle_type,
+            ironwood_bundle_version,
+            ironwood_bundle_version.default_flags(),
+            orchard::bundle::TxVersion::V6,
+        )
+        .map_err(Error::IronwoodBuild)?;
+        Ok(DeferredPcztBuilder {
+            params,
+            tx_version,
+            consensus_branch_id,
+            target_height,
+            expiry_height: target_height + DEFAULT_TX_EXPIRY_DELTA,
+            orchard_builder,
+            orchard_bundle_version,
+            ironwood_builder,
+        })
+    }
+
+    /// Overrides the expiry height for the transaction under construction.
+    ///
+    /// A pre-signed transaction is often broadcast well after it is built, so the caller
+    /// typically sets an expiry derived from the intended broadcast schedule rather than
+    /// the build height; the signatures commit to it.
+    pub fn with_expiry_height(mut self, expiry_height: BlockHeight) -> Self {
+        self.expiry_height = expiry_height;
+        self
+    }
+
+    /// Adds an Orchard note to be spent in this bundle, WITHOUT a witness: the witness,
+    /// like the bundle's anchor, is installed at proving time through the PCZT Updater
+    /// role.
+    pub fn add_orchard_spend<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        note: orchard::Note,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder.add_spend_unwitnessed(fvk, note)?;
+        Ok(())
+    }
+
+    /// Adds an Orchard recipient to the transaction.
+    pub fn add_orchard_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder
+            .add_output(
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::OrchardRecipient)
+    }
+
+    /// Adds a wallet-controlled Orchard change output to the transaction.
+    pub fn add_orchard_change_output<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.orchard_builder
+            .add_change_output(
+                fvk,
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::OrchardRecipient)
+    }
+
+    /// Adds an Ironwood note to be spent in this bundle, WITHOUT a witness (see
+    /// [`Self::add_orchard_spend`]).
+    ///
+    /// The note must use [`orchard::note::NoteVersion::V3`], the Ironwood note plaintext
+    /// format.
+    pub fn add_ironwood_spend<FE>(
+        &mut self,
+        fvk: orchard::keys::FullViewingKey,
+        note: orchard::Note,
+    ) -> Result<(), Error<FE>> {
+        if note.version() != orchard::note::NoteVersion::V3 {
+            return Err(Error::IronwoodSpendUnsupportedNoteVersion(note.version()));
+        }
+        self.ironwood_builder
+            .add_spend_unwitnessed(fvk, note)
+            .map_err(Error::IronwoodSpend)
+    }
+
+    /// Adds an Ironwood recipient to the transaction.
+    ///
+    /// This uses [`orchard::note::NoteVersion::V3`], the Ironwood note plaintext format.
+    pub fn add_ironwood_output<FE>(
+        &mut self,
+        ovk: Option<orchard::keys::OutgoingViewingKey>,
+        recipient: orchard::Address,
+        value: Zatoshis,
+        memo: MemoBytes,
+    ) -> Result<(), Error<FE>> {
+        self.ironwood_builder
+            .add_output(
+                ovk,
+                recipient,
+                orchard::value::NoteValue::from_raw(value.into()),
+                memo.into_bytes(),
+            )
+            .map_err(Error::IronwoodRecipient)
+    }
+
+    /// Reports the calculated fee given the specified fee rule, as a function of the
+    /// spends and outputs added so far (each pool's action count includes the padding its
+    /// bundle type prescribes).
+    pub fn get_fee<FR: FeeRule>(&self, fee_rule: &FR) -> Result<Zatoshis, FeeError<FR::Error>> {
+        fee_rule
+            .fee_required(
+                &self.params,
+                self.target_height,
+                core::iter::empty::<crate::transaction::fees::transparent::InputSize>(),
+                core::iter::empty::<usize>(),
+                0,
+                0,
+                orchard_action_count(&self.orchard_builder, false, self.orchard_bundle_version)
+                    .map_err(FeeError::Bundle)?,
+                orchard_action_count(
+                    &self.ironwood_builder,
+                    false,
+                    orchard::bundle::BundleVersion::ironwood_v3(),
+                )
+                .map_err(FeeError::Bundle)?,
+            )
+            .map_err(FeeError::FeeRule)
+    }
+
+    /// Builds the added spends and outputs into the parts of an unproven PCZT whose
+    /// anchors and real-spend witnesses are ABSENT, deferred to proving time: pass the
+    /// result to the PCZT Creator (`build_from_parts`), then finalize, sign, and — at
+    /// proving time — install the real anchor and witnesses through the PCZT Updater
+    /// role before proving.
+    pub fn build_for_pczt<R: RngCore + CryptoRng, FR: FeeRule>(
+        self,
+        mut rng: R,
+        fee_rule: &FR,
+    ) -> Result<PcztResult<P>, Error<FR::Error>> {
+        fn in_use(builder: &orchard::builder::Builder) -> bool {
+            !builder.spends().is_empty()
+                || !builder.outputs().is_empty()
+                || !builder.changes().is_empty()
+        }
+
+        let fee = self.get_fee(fee_rule).map_err(Error::Fee)?;
+
+        // After fees are accounted for, the value balance of the transaction must be zero.
+        let value_balance = [
+            self.orchard_builder
+                .value_balance::<ZatBalance>()
+                .map_err(|_| BalanceError::Overflow)?,
+            self.ironwood_builder
+                .value_balance::<ZatBalance>()
+                .map_err(|_| BalanceError::Overflow)?,
+        ]
+        .into_iter()
+        .sum::<Option<ZatBalance>>()
+        .ok_or(BalanceError::Overflow)?;
+        let balance_after_fees = (value_balance - fee).ok_or(BalanceError::Underflow)?;
+        match balance_after_fees.cmp(&ZatBalance::zero()) {
+            Ordering::Less => {
+                return Err(Error::InsufficientFunds(-balance_after_fees));
+            }
+            Ordering::Greater => {
+                return Err(Error::ChangeRequired(balance_after_fees));
+            }
+            Ordering::Equal => (),
+        };
+
+        let (orchard_bundle, orchard_meta) = if in_use(&self.orchard_builder) {
+            let (bundle, meta) = self
+                .orchard_builder
+                .build_for_pczt(&mut rng)
+                .map_err(Error::OrchardBuild)?;
+            (Some(bundle), meta)
+        } else {
+            (None, orchard::builder::BundleMetadata::empty())
+        };
+        let (ironwood_bundle, ironwood_meta) = if in_use(&self.ironwood_builder) {
+            let (bundle, meta) = self
+                .ironwood_builder
+                .build_for_pczt(&mut rng)
+                .map_err(Error::IronwoodBuild)?;
+            (Some(bundle), meta)
+        } else {
+            (None, orchard::builder::BundleMetadata::empty())
+        };
+
+        Ok(PcztResult {
+            pczt_parts: PcztParts {
+                params: self.params,
+                version: self.tx_version,
+                consensus_branch_id: self.consensus_branch_id,
+                lock_time: 0,
+                expiry_height: self.expiry_height,
+                transparent: None,
+                sapling: None,
+                orchard: orchard_bundle,
+                ironwood: ironwood_bundle,
+            },
+            sapling_meta: SaplingMetadata::empty(),
+            orchard_meta,
+            ironwood_meta,
+        })
+    }
 }
 
 /// The result of a transaction build operation, which includes the resulting transaction along


### PR DESCRIPTION
Depends on zcash/orchard#534, pinned here via `[patch.crates-io]` until it lands in an orchard release (per the usual policy, a merge non-blocker but a publish blocker).

For V6 (NU6.3) transactions neither the txid nor the sighash commits to a shielded anchor (ZIP 374 moved them to the authorizing-data digest), and witnesses are pure proving inputs — but the transaction builder demanded every Orchard-family anchor in its `BuildConfig` and a rooting Merkle witness per spend at add-spend time. Flows that pre-sign transactions long before proving them — notably the ZIP 318 pool-migration transfers (#2663), whose proving anchor is a bucketed boundary drawn near each transfer's future broadcast height — were forced to witness against whatever tree state existed at build time, or to wait after their funding notes mined for an anchor they do not actually need at signing.

This adds `zcash_primitives::transaction::builder::DeferredPcztBuilder`, a builder crafted exclusively for that flow rather than a mode grafted onto the general-purpose `Builder` (whose API is unchanged):

- V6-only by construction: `new` fails under any earlier format, whose signatures commit to anchors.
- Takes no anchors at all; spends are added as bare `(fvk, note)` pairs through orchard's new deferred-anchor support (`Builder::new_with_anchor_deferred` / `add_spend_unwitnessed`).
- Covers exactly the two Orchard-family pools: their nullifiers are rho-based, so a spend can be signed before its witness is known; a Sapling nullifier commits to its note's position, so Sapling can never defer, and is excluded along with transparent inputs.
- The emitted PCZT carries ABSENT anchor and witness fields for the deferred bundles (`pczt`'s serialization honors orchard's deferral flag; padding dummies keep their witnesses, which the prover requires and the consistency check exempts). From there the existing ZIP 374 machinery takes over unchanged: IoFinalizer and Signer already operate with absent V6 anchors, the Updater's `set_{orchard,ironwood}_anchor` / `set_*_spend_witnesses` install the real values after signing, and the Prover enforces witness-to-anchor consistency — the same check an anchored build performs at add-spend time, relocated to where the real anchor first exists.

The end-to-end test builds an Orchard-spend/Ironwood-output V6 transaction with both anchors deferred, signs it, installs the real anchor and witness afterwards, and proves and extracts it, asserting the sighash is unchanged by the installation and the pre-made spend-auth signature still verifies.

Follow-up: the #2663 migration engine's `commit_transfers` adopts this builder, so transfers need no anchor or witness at commit time and the persisted per-transfer `anchor_boundary` becomes purely the proving-time anchor.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)