### PR TITLE
AGENTS: pool-migration design conventions (domain types, serialization, store structure)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,17 @@ since Mermaid layout is hard to reason about in plain text.
   backend calls the canonical codec for its blob columns and maps only the
   queryable scalar fields to its own columns.
 
+- **A `proptest` strategy lives with the type it generates.** An `arb_*`
+  strategy for a type belongs in that type's own crate, in its `testing` module
+  behind the `test-dependencies` feature (e.g. `arb_zatoshis` in
+  `zcash_protocol::value::testing`, `arb_txid` next to `TxId`), NOT redefined in
+  each consumer's test module. Before writing an `arb_*`, search the repository
+  for an existing one and reuse it; if the type has none, add the strategy to the
+  type's crate (adding the `testing` module / `test-dependencies` feature there
+  if needed) rather than to the consumer. A downstream crate composes these
+  canonical leaf strategies into strategies for its own types; it does not
+  re-derive the leaves.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,17 @@ since Mermaid layout is hard to reason about in plain text.
   that cannot fail there must say why in a comment, and one that can fail must
   return a typed error rather than panic.
 
+- **Keep domain types whole, and convert only at the storage edge.** A newtype
+  must hide its inner primitive (`pub(crate)` field plus `::new` and a
+  `From`/accessor), so no caller can pass a raw `u32`/`u64` where an id or an
+  amount is meant. Collections and options carry the newtype too
+  (`Vec<Zatoshis>` and `Option<Zatoshis>`, never `Vec<u64>`/`Option<u64>`), and
+  reconstruction constructors (`from_parts`, `from_stored_parts`) take and
+  return it. Down-convert to a bare primitive in exactly one place, the storage
+  or wire boundary (binding a SQLite integer, writing a byte blob), and convert
+  straight back on read; a persisted store is then the only code that ever sees
+  the primitive.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,20 @@ since Mermaid layout is hard to reason about in plain text.
   straight back on read; a persisted store is then the only code that ever sees
   the primitive.
 
+- **Canonical binary serialization lives with the type, via `zcash_encoding`.**
+  A type's on-disk / on-wire byte format is a property of the type, not of any
+  one consumer, so define it next to the definition: `read<R: Read>(r) ->
+  io::Result<Self>` and `write<W: Write>(&self, w) -> io::Result<()>`, built
+  from `zcash_encoding` (`Vector` for length-prefixed lists, `CompactSize` for
+  counts and indices, `Optional` for options) over `corez::io::{Read, Write}`
+  so it stays `no_std` (see `zcash_primitives::merkle_tree`,
+  `zcash_protocol::txid`). Serialize an amount as `Zatoshis` -> `u64` LE
+  (`Zatoshis::from_u64(reader.read_u64_le()?)` on read). Do NOT hand-roll a
+  bespoke byte codec inside a downstream (storage) crate, and do NOT use `serde`
+  for a canonical binary format (reserve `serde` for JSON/config). A persistence
+  backend calls the canonical codec for its blob columns and maps only the
+  queryable scalar fields to its own columns.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.
@@ -338,6 +352,15 @@ Type safety is paramount. This is a security-critical codebase.
 - **`from_parts` constructors**: Preferred over public struct fields.
 - **`testing` submodules**: Exposed via `test-dependencies` feature for cross-crate
   test utilities (proptest strategies, mock implementations).
+- **Instance-parameterized store crates**: a persistence crate keeps its generic
+  machinery crate-internal (DDL builders parameterized by table names, the
+  connection wrapper) and exposes ONE public submodule per concrete
+  instantiation that binds the table names, so nothing generic leaks and the
+  table names reflect the instance (e.g. `zcash_pool_migration_sqlite::orchard_ironwood`
+  over `orchard_ironwood_migrations`). A second instance is a sibling submodule,
+  not a fork. The blob (de)serialization is not defined here: it is the canonical
+  codec on the types (see the serialization convention above), which the store
+  calls.
 
 ## Database Write Atomicity (`zcash_client_sqlite`)
 


### PR DESCRIPTION
Extends the "public APIs use semantic types" convention (added in #2663) with the nuance the recent `Zatoshis`/newtype consolidation demonstrated: the earlier code satisfied that convention at the *signature* while struct fields, `Vec` elements, and reconstruction constructors (`from_stored_parts`, `from_parts`) still carried raw `u64`/`u32`.

The new bullet adds three points the existing one does not cover:

1. **The newtype hides its own inner primitive** (`pub(crate)` field + `::new` + a `From`/accessor), so a caller cannot pass a raw `u32` where an id is meant (the `MigrationTxId(pub u32)` -> `pub(crate)` + `::new` shape).
2. **Collections and options carry the newtype** (`Vec<Zatoshis>`, not `Vec<u64>`; `Option<Zatoshis>`, not `Option<u64>`).
3. **The down-conversion has exactly one home**: the storage/wire boundary. Reconstruction constructors take and return the newtype, and only the persisted store down-converts to `i64`/blob at the column bind and back.

Docs-only; no code change.