### PR TITLE
zcash_encoding: round-trip proptest helper

### DIFF
--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_encoding::testing::check_roundtrip` (behind the new `test-dependencies`
+  feature), a helper that asserts a `write`/`read` codec pair are exact inverses
+  and that the encoding is stable across a round-trip.
+
 ### Changed
 - MSRV is now 1.88
 

--- a/components/zcash_encoding/Cargo.toml
+++ b/components/zcash_encoding/Cargo.toml
@@ -26,6 +26,9 @@ proptest.workspace = true
 [features]
 default = ["std"]
 std = ["corez/std"]
+## Exposes the `testing` module: helpers (e.g. `check_roundtrip`) for exercising
+## binary codecs built with this crate. Enable it as a dev-dependency feature.
+test-dependencies = []
 
 [lib]
 bench = false

--- a/components/zcash_encoding/src/lib.rs
+++ b/components/zcash_encoding/src/lib.rs
@@ -19,6 +19,9 @@ use corez::io::{self, Read, Write};
 
 use nonempty::NonEmpty;
 
+#[cfg(feature = "test-dependencies")]
+pub mod testing;
+
 /// The maximum allowed value representable as a `[CompactSize]`
 pub const MAX_COMPACT_SIZE: u32 = 0x02000000;
 

--- a/components/zcash_encoding/src/testing.rs
+++ b/components/zcash_encoding/src/testing.rs
@@ -1,0 +1,36 @@
+//! Test utilities for exercising binary codecs built with this crate.
+//!
+//! Enabled by the `test-dependencies` feature, so a downstream crate can reuse the round-trip
+//! property from its own tests instead of duplicating an ad-hoc assert per codec.
+
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use corez::io;
+
+/// Assert that a `write`/`read` pair are exact inverses for `value`: `read(write(value))` equals
+/// `value`, and the encoding is stable across a round-trip (re-encoding the decoded value yields the
+/// same bytes, which catches non-canonical or lossy codecs).
+///
+/// `write` serializes a value into a growable buffer (writing to a `Vec` is infallible); `read`
+/// deserializes it back from the produced bytes. The migration codecs pass their own
+/// `Type::write` / `Type::read` through small closures.
+pub fn check_roundtrip<T, W, R>(value: &T, write: W, read: R)
+where
+    T: PartialEq + Debug,
+    W: Fn(&T, &mut Vec<u8>) -> io::Result<()>,
+    R: Fn(&[u8]) -> io::Result<T>,
+{
+    let mut bytes = Vec::new();
+    write(value, &mut bytes).expect("writing to a Vec is infallible");
+
+    let decoded = read(&bytes).expect("the bytes written by `write` must decode");
+    assert_eq!(&decoded, value, "round-trip must preserve the value");
+
+    let mut reencoded = Vec::new();
+    write(&decoded, &mut reencoded).expect("writing to a Vec is infallible");
+    assert_eq!(
+        reencoded, bytes,
+        "encoding must be stable across a round-trip"
+    );
+}


### PR DESCRIPTION
Adds `testing::check_roundtrip` behind a new `test-dependencies` feature: a generic write-then-read identity helper for codec proptests. It asserts a `write`/`read` pair are exact inverses and that the encoding is stable across a round-trip (catching non-canonical or lossy codecs).

Extracted from #2669 as an independent, additive change.