### PR TITLE
zcash_protocol: canonical Zatoshis binary codec

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -15,6 +15,8 @@ workspace.
 - `zcash_protocol::consensus::BLOCKS_PER_HOUR`
 - `zcash_protocol::constants::MAX_BLOCK_BYTES`, the Zcash consensus maximum
   block size and therefore the maximum size of any single transaction.
+- `zcash_protocol::value::Zatoshis::{write, read, to_u64_le_bytes}`, a canonical
+  little-endian `u64` binary codec for amounts.
 
 ## [0.10.0] - 2026-07-09
 

--- a/components/zcash_protocol/src/value.rs
+++ b/components/zcash_protocol/src/value.rs
@@ -4,6 +4,8 @@ use core::iter::Sum;
 use core::num::NonZeroU64;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 
+use corez::io;
+
 #[cfg(feature = "std")]
 use std::error;
 
@@ -350,6 +352,25 @@ impl Zatoshis {
     /// little-endian value.
     pub fn to_i64_le_bytes(self) -> [u8; 8] {
         (self.0 as i64).to_le_bytes()
+    }
+
+    /// Returns this Zatoshis encoded as an unsigned 64-bit little-endian value.
+    pub fn to_u64_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+
+    /// Writes this Zatoshis as an unsigned 64-bit little-endian integer.
+    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+        writer.write_all(&self.to_u64_le_bytes())
+    }
+
+    /// Reads a Zatoshis from an unsigned 64-bit little-endian integer, mapping an
+    /// out-of-range amount to [`io::ErrorKind::InvalidData`].
+    pub fn read<R: io::Read>(mut reader: R) -> io::Result<Self> {
+        let mut bytes = [0u8; 8];
+        reader.read_exact(&mut bytes)?;
+        Self::from_u64_le_bytes(bytes)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "amount out of range"))
     }
 
     /// Returns whether or not this `Zatoshis` is the zero value.


### PR DESCRIPTION
Adds `Zatoshis::write`/`read` (an unsigned 64-bit little-endian integer over `corez::io`) plus a `to_u64_le_bytes` accessor: the canonical on-wire form, living with the type. `read` maps an out-of-range amount to `InvalidData`.

Extracted from #2669 as an independent, additive change.