### PR TITLE
zcash_pool_migration: canonical codecs on the migration types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7260,6 +7260,7 @@ dependencies = [
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
 dependencies = [
+ "corez",
  "getset",
  "incrementalmerkletree",
  "libm",
@@ -7270,6 +7271,7 @@ dependencies = [
  "rand_core 0.6.4",
  "shardtree",
  "zcash_client_backend",
+ "zcash_encoding",
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -118,3 +118,8 @@ and this library adheres to Rust's notion of
   remains a consumer responsibility, as for in-process signing). External signing therefore
   replaces only the sign step; the rest of the lifecycle is identical. The status view surfaces an
   awaiting transaction as blocked on `Blocker::Signature`.
+- Canonical binary codecs on the migration types (`PreparationPlan`, `NoteSplitPlan`,
+  `PrepInput`/`PrepOutput`/`PrepTransaction`, and `MigrationTxKind`), plus `MigrationTxState`'s
+  `AsRef<str>` discriminant and `from_stored` reconstruction, all built on `zcash_encoding` over
+  `corez::io`, so a persistence backend serializes the types through their own `write`/`read` rather
+  than a bespoke codec.

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -19,9 +19,11 @@ categories.workspace = true
 all-features = true
 
 [dependencies]
+corez.workspace = true
 getset.workspace = true
 libm.workspace = true
 rand_core.workspace = true
+zcash_encoding.workspace = true
 zcash_primitives.workspace = true
 zcash_protocol.workspace = true
 
@@ -45,6 +47,8 @@ incrementalmerkletree = { workspace = true, optional = true }
 incrementalmerkletree.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
+# The `testing` module (round-trip codec helpers) is used by the serialization proptests.
+zcash_encoding = { workspace = true, features = ["test-dependencies"] }
 # The `local-consensus` feature exposes `LocalNetwork`, used to build the migration transactions
 # against regtest params with the relevant network upgrades (including NU6.3) active.
 zcash_protocol = { workspace = true, features = ["local-consensus"] }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -45,8 +45,10 @@ use alloc::vec::Vec;
 
 use core::fmt;
 
+use corez::io::{self, Read, Write};
 use getset::{CopyGetters, Getters};
 use rand_core::RngCore;
+use zcash_encoding::CompactSize;
 use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::{BalanceError, Zatoshis};
@@ -146,6 +148,48 @@ pub enum MigrationTxKind {
     Transfer { crossing: usize },
 }
 
+/// The tag byte for a [`MigrationTxKind::Preparation`] in the canonical serialization.
+const KIND_TAG_PREPARATION: u8 = 0;
+/// The tag byte for a [`MigrationTxKind::Transfer`] in the canonical serialization.
+const KIND_TAG_TRANSFER: u8 = 1;
+
+impl MigrationTxKind {
+    /// Serialize this kind: a `u8` tag (`0` for `Preparation`, `1` for `Transfer`) then its
+    /// `CompactSize` indices. The inverse of [`read`](Self::read).
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        match self {
+            MigrationTxKind::Preparation { layer, index } => {
+                writer.write_all(&[KIND_TAG_PREPARATION])?;
+                CompactSize::write(&mut writer, *layer)?;
+                CompactSize::write(&mut writer, *index)
+            }
+            MigrationTxKind::Transfer { crossing } => {
+                writer.write_all(&[KIND_TAG_TRANSFER])?;
+                CompactSize::write(&mut writer, *crossing)
+            }
+        }
+    }
+
+    /// Deserialize a kind written by [`write`](Self::write), erroring on an unknown tag.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let mut tag = [0u8; 1];
+        reader.read_exact(&mut tag)?;
+        match tag[0] {
+            KIND_TAG_PREPARATION => Ok(MigrationTxKind::Preparation {
+                layer: CompactSize::read(&mut reader)? as usize,
+                index: CompactSize::read(&mut reader)? as usize,
+            }),
+            KIND_TAG_TRANSFER => Ok(MigrationTxKind::Transfer {
+                crossing: CompactSize::read(&mut reader)? as usize,
+            }),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown MigrationTxKind tag",
+            )),
+        }
+    }
+}
+
 /// Where a migration transaction is in its lifecycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MigrationTxState {
@@ -164,6 +208,76 @@ pub enum MigrationTxState {
     Broadcast { txid: TxId },
     /// Mined at the given height.
     Mined { height: BlockHeight },
+}
+
+impl AsRef<str> for MigrationTxState {
+    /// The stable lowercase wire name of this state's lifecycle stage, parsed back by
+    /// [`from_stored`](Self::from_stored). Mirrors [`MigrationStatus`]'s `AsRef<str>`: a store keeps it
+    /// in a queryable (and indexable) column so due transactions can be found without deserializing
+    /// every row. The [`Broadcast`](Self::Broadcast) txid and [`Mined`](Self::Mined) height payloads
+    /// are carried separately (see [`broadcast_txid`](Self::broadcast_txid) and
+    /// [`mined_height`](Self::mined_height)). Borrow-free: it returns a `&'static str`.
+    fn as_ref(&self) -> &str {
+        match self {
+            MigrationTxState::AwaitingSignature => "awaiting_signature",
+            MigrationTxState::Signed => "signed",
+            MigrationTxState::Proved => "proved",
+            MigrationTxState::Broadcast { .. } => "broadcast",
+            MigrationTxState::Mined { .. } => "mined",
+        }
+    }
+}
+
+impl MigrationTxState {
+    /// The raw transaction-id bytes carried by [`Broadcast`](Self::Broadcast), or `None` for any
+    /// other state.
+    pub fn broadcast_txid(&self) -> Option<[u8; 32]> {
+        match self {
+            MigrationTxState::Broadcast { txid } => Some(*txid.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// The block height carried by [`Mined`](Self::Mined), or `None` for any other state.
+    pub fn mined_height(&self) -> Option<BlockHeight> {
+        match self {
+            MigrationTxState::Mined { height } => Some(*height),
+            _ => None,
+        }
+    }
+
+    /// Reconstruct a state from the stored discriminant (see the [`AsRef<str>`](AsRef) impl) and its
+    /// payload: `txid` must be present exactly for `"broadcast"` and `mined_height` exactly for
+    /// `"mined"`. Errors on an unknown discriminant or a missing payload.
+    pub fn from_stored(
+        state: &str,
+        txid: Option<[u8; 32]>,
+        mined_height: Option<BlockHeight>,
+    ) -> Result<Self, ParseMigrationTxStateError> {
+        Ok(match state {
+            "awaiting_signature" => MigrationTxState::AwaitingSignature,
+            "signed" => MigrationTxState::Signed,
+            "proved" => MigrationTxState::Proved,
+            "broadcast" => MigrationTxState::Broadcast {
+                txid: TxId::from_bytes(txid.ok_or(ParseMigrationTxStateError)?),
+            },
+            "mined" => MigrationTxState::Mined {
+                height: mined_height.ok_or(ParseMigrationTxStateError)?,
+            },
+            _ => return Err(ParseMigrationTxStateError),
+        })
+    }
+}
+
+/// The error returned when a stored discriminant plus payload does not name a valid
+/// [`MigrationTxState`] (its [`from_stored`](MigrationTxState::from_stored) constructor).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParseMigrationTxStateError;
+
+impl fmt::Display for ParseMigrationTxStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unrecognized or malformed migration transaction state")
+    }
 }
 
 /// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
@@ -1894,5 +2008,30 @@ mod commit_tests {
             ),
             Err(CommitError::StalePlan)
         ));
+    }
+}
+
+#[cfg(test)]
+mod codec_tests {
+    use super::MigrationTxKind;
+
+    use proptest::prelude::*;
+    use zcash_encoding::testing::check_roundtrip;
+
+    /// An arbitrary [`MigrationTxKind`], exercising both variants.
+    fn arb_migration_tx_kind() -> impl Strategy<Value = MigrationTxKind> {
+        prop_oneof![
+            (0usize..1000, 0usize..1000)
+                .prop_map(|(layer, index)| MigrationTxKind::Preparation { layer, index }),
+            (0usize..1000).prop_map(|crossing| MigrationTxKind::Transfer { crossing }),
+        ]
+    }
+
+    proptest! {
+        /// `write` and `read` are exact inverses for every [`MigrationTxKind`].
+        #[test]
+        fn migration_tx_kind_round_trips(kind in arb_migration_tx_kind()) {
+            check_roundtrip(&kind, |v, buf| v.write(buf), |b| MigrationTxKind::read(b));
+        }
     }
 }

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -119,7 +119,9 @@
 
 use alloc::vec::Vec;
 
+use corez::io::{self, Read, Write};
 use rand_core::RngCore;
+use zcash_encoding::{Optional, Vector};
 
 use zcash_protocol::value::{BalanceError, COIN, Zatoshis};
 
@@ -294,6 +296,43 @@ impl NoteSplitPlan {
     pub fn total_migratable(&self) -> Zatoshis {
         self.total_migratable
     }
+
+    /// Serialize this plan into its canonical binary form, covering every stored field: the
+    /// [`crossing_values`](Self::crossing_values) as a [`Vector`] of little-endian `u64` amounts,
+    /// then the [`note_fee_buffer`](Self::note_fee_buffer), the optional [`change`](Self::change),
+    /// the [`prep_fees`](Self::prep_fees), the [`total_input`](Self::total_input), and the
+    /// [`total_migratable`](Self::total_migratable), each as a little-endian `u64`. The inverse of
+    /// [`read`](Self::read).
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        Vector::write(&mut writer, &self.crossing_values, |w, v| v.write(w))?;
+        self.note_fee_buffer.write(&mut writer)?;
+        Optional::write(&mut writer, self.change, |w, v| v.write(w))?;
+        self.prep_fees.write(&mut writer)?;
+        self.total_input.write(&mut writer)?;
+        self.total_migratable.write(&mut writer)
+    }
+
+    /// Deserialize a plan written by [`write`](Self::write), reconstructing it through
+    /// [`from_stored_parts`](Self::from_stored_parts) (which validates that each crossing value plus
+    /// the fee buffer is representable). Maps a [`BalanceError`] from that validation to
+    /// [`io::ErrorKind::InvalidData`].
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let crossing_values = Vector::read(&mut reader, |r| Zatoshis::read(r))?;
+        let note_fee_buffer = Zatoshis::read(&mut reader)?;
+        let change = Optional::read(&mut reader, Zatoshis::read)?;
+        let prep_fees = Zatoshis::read(&mut reader)?;
+        let total_input = Zatoshis::read(&mut reader)?;
+        let total_migratable = Zatoshis::read(&mut reader)?;
+        Self::from_stored_parts(
+            crossing_values,
+            note_fee_buffer,
+            change,
+            prep_fees,
+            total_input,
+            total_migratable,
+        )
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid note split"))
+    }
 }
 
 /// A rule for decomposing a spendable source-pool balance into the notes a migration run will prepare.
@@ -341,4 +380,59 @@ pub fn plan_note_split<R: RngCore>(
         prep_tx_count,
         rng,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    use zcash_encoding::testing::check_roundtrip;
+
+    /// A [`Zatoshis`] amount well within the money supply, for round-trip fixtures.
+    fn arb_zatoshis() -> impl Strategy<Value = Zatoshis> {
+        (0u64..100_000_000).prop_map(zat)
+    }
+
+    /// An arbitrary [`NoteSplitPlan`], covering all stored fields (an empty or populated crossing
+    /// set, present or absent change). Bounded so every `crossing + note_fee_buffer` is
+    /// representable, which is what [`NoteSplitPlan::from_stored_parts`] requires.
+    fn arb_note_split_plan() -> impl Strategy<Value = NoteSplitPlan> {
+        (
+            prop::collection::vec(arb_zatoshis(), 0..8),
+            (0u64..1_000_000).prop_map(zat),
+            prop::option::of(arb_zatoshis()),
+            (0u64..1_000_000).prop_map(zat),
+            (0u64..1_000_000_000).prop_map(zat),
+            (0u64..1_000_000_000).prop_map(zat),
+        )
+            .prop_map(
+                |(
+                    crossing_values,
+                    note_fee_buffer,
+                    change,
+                    prep_fees,
+                    total_input,
+                    total_migratable,
+                )| {
+                    NoteSplitPlan::from_stored_parts(
+                        crossing_values,
+                        note_fee_buffer,
+                        change,
+                        prep_fees,
+                        total_input,
+                        total_migratable,
+                    )
+                    .expect("crossing + buffer within the money supply")
+                },
+            )
+    }
+
+    proptest! {
+        /// `write` and `read` are exact inverses for every [`NoteSplitPlan`].
+        #[test]
+        fn note_split_plan_round_trips(plan in arb_note_split_plan()) {
+            check_roundtrip(&plan, |v, buf| v.write(buf), |b| NoteSplitPlan::read(b));
+        }
+    }
 }

--- a/zcash_pool_migration_backend/src/preparation.rs
+++ b/zcash_pool_migration_backend/src/preparation.rs
@@ -59,9 +59,22 @@
 
 use alloc::vec::Vec;
 
+use corez::io::{self, Read, Write};
+use zcash_encoding::{CompactSize, Vector};
 use zcash_protocol::value::Zatoshis;
 
 use core::fmt;
+
+/// The input tag byte for a [`PrepInput::Wallet`] in the canonical serialization.
+const INPUT_TAG_WALLET: u8 = 0;
+/// The input tag byte for a [`PrepInput::Prior`] in the canonical serialization.
+const INPUT_TAG_PRIOR: u8 = 1;
+/// The output tag byte for a [`PrepOutput::Funding`] in the canonical serialization.
+const OUTPUT_TAG_FUNDING: u8 = 0;
+/// The output tag byte for a [`PrepOutput::Intermediate`] in the canonical serialization.
+const OUTPUT_TAG_INTERMEDIATE: u8 = 1;
+/// The output tag byte for a [`PrepOutput::Change`] in the canonical serialization.
+const OUTPUT_TAG_CHANGE: u8 = 2;
 
 /// The exact number of Orchard actions in every note-preparation transaction ([ZIP 318]): each is
 /// padded up to this count, so no preparation transaction is distinguishable from another by its
@@ -101,6 +114,52 @@ impl PrepInput {
             PrepInput::Wallet { value, .. } | PrepInput::Prior { value, .. } => *value,
         }
     }
+
+    /// Serialize this input: a `u8` tag (`0` for `Wallet`, `1` for `Prior`), then its `CompactSize`
+    /// indices and its little-endian `u64` value.
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        match self {
+            PrepInput::Wallet { index, value } => {
+                writer.write_all(&[INPUT_TAG_WALLET])?;
+                CompactSize::write(&mut writer, *index)?;
+                value.write(&mut writer)
+            }
+            PrepInput::Prior {
+                layer,
+                transaction,
+                output,
+                value,
+            } => {
+                writer.write_all(&[INPUT_TAG_PRIOR])?;
+                CompactSize::write(&mut writer, *layer)?;
+                CompactSize::write(&mut writer, *transaction)?;
+                CompactSize::write(&mut writer, *output)?;
+                value.write(&mut writer)
+            }
+        }
+    }
+
+    /// Deserialize an input written by [`write`](Self::write), erroring on an unknown tag.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let mut tag = [0u8; 1];
+        reader.read_exact(&mut tag)?;
+        match tag[0] {
+            INPUT_TAG_WALLET => Ok(PrepInput::Wallet {
+                index: CompactSize::read(&mut reader)? as usize,
+                value: Zatoshis::read(&mut reader)?,
+            }),
+            INPUT_TAG_PRIOR => Ok(PrepInput::Prior {
+                layer: CompactSize::read(&mut reader)? as usize,
+                transaction: CompactSize::read(&mut reader)? as usize,
+                output: CompactSize::read(&mut reader)? as usize,
+                value: Zatoshis::read(&mut reader)?,
+            }),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown PrepInput tag",
+            )),
+        }
+    }
 }
 
 /// A note a preparation transaction produces.
@@ -119,6 +178,34 @@ impl PrepOutput {
     pub fn value(&self) -> Zatoshis {
         match self {
             PrepOutput::Funding(v) | PrepOutput::Intermediate(v) | PrepOutput::Change(v) => *v,
+        }
+    }
+
+    /// Serialize this output: a `u8` tag (`0` for `Funding`, `1` for `Intermediate`, `2` for
+    /// `Change`) then its little-endian `u64` value.
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        let (tag, value) = match self {
+            PrepOutput::Funding(v) => (OUTPUT_TAG_FUNDING, *v),
+            PrepOutput::Intermediate(v) => (OUTPUT_TAG_INTERMEDIATE, *v),
+            PrepOutput::Change(v) => (OUTPUT_TAG_CHANGE, *v),
+        };
+        writer.write_all(&[tag])?;
+        value.write(&mut writer)
+    }
+
+    /// Deserialize an output written by [`write`](Self::write), erroring on an unknown tag.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let mut tag = [0u8; 1];
+        reader.read_exact(&mut tag)?;
+        let value = Zatoshis::read(&mut reader)?;
+        match tag[0] {
+            OUTPUT_TAG_FUNDING => Ok(PrepOutput::Funding(value)),
+            OUTPUT_TAG_INTERMEDIATE => Ok(PrepOutput::Intermediate(value)),
+            OUTPUT_TAG_CHANGE => Ok(PrepOutput::Change(value)),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown PrepOutput tag",
+            )),
         }
     }
 }
@@ -153,6 +240,20 @@ impl PrepTransaction {
     /// The logical Orchard action count before padding (`inputs + outputs`).
     pub fn action_count(&self) -> usize {
         self.inputs.len() + self.outputs.len()
+    }
+
+    /// Serialize this transaction: its inputs then its outputs, each as a `CompactSize`-prefixed
+    /// [`Vector`] (see [`PrepInput::write`] and [`PrepOutput::write`]).
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        Vector::write(&mut writer, self.inputs(), |w, i| i.write(w))?;
+        Vector::write(&mut writer, self.outputs(), |w, o| o.write(w))
+    }
+
+    /// Deserialize a transaction written by [`write`](Self::write).
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let inputs = Vector::read(&mut reader, |r| PrepInput::read(r))?;
+        let outputs = Vector::read(&mut reader, |r| PrepOutput::read(r))?;
+        Ok(PrepTransaction::from_parts(inputs, outputs))
     }
 }
 
@@ -243,6 +344,37 @@ impl PreparationPlan {
     /// [`residual_notes`](Self::residual_notes)).
     pub fn residual_count(&self) -> usize {
         self.residual_notes().len()
+    }
+
+    /// Serialize this plan into the canonical binary form: the direct-funding notes as a [`Vector`]
+    /// of `(CompactSize index, little-endian u64 value)`, then the layers as a [`Vector`] of layers,
+    /// each a [`Vector`] of [`PrepTransaction`]. The inverse of [`read`](Self::read).
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        Vector::write(
+            &mut writer,
+            self.direct_funding_notes(),
+            |w, &(index, value)| {
+                CompactSize::write(&mut *w, index)?;
+                value.write(w)
+            },
+        )?;
+        Vector::write(&mut writer, self.layers(), |w, layer| {
+            Vector::write(w, layer, |w, tx| tx.write(w))
+        })
+    }
+
+    /// Deserialize a plan written by [`write`](Self::write), rebuilding it through
+    /// [`from_parts`](Self::from_parts).
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+        let direct_funding = Vector::read(&mut reader, |r| {
+            let index = CompactSize::read(&mut *r)? as usize;
+            let value = Zatoshis::read(r)?;
+            Ok((index, value))
+        })?;
+        let layers = Vector::read(&mut reader, |r| {
+            Vector::read(r, |r| PrepTransaction::read(r))
+        })?;
+        Ok(PreparationPlan::from_parts(layers, direct_funding))
     }
 }
 
@@ -755,7 +887,82 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    use zcash_encoding::testing::check_roundtrip;
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+
+    /// A [`Zatoshis`] amount well within the money supply, for round-trip fixtures.
+    fn arb_zatoshis() -> impl Strategy<Value = Zatoshis> {
+        (0u64..100_000_000).prop_map(zat)
+    }
+
+    /// An arbitrary [`PrepInput`], exercising both tags.
+    fn arb_prep_input() -> impl Strategy<Value = PrepInput> {
+        prop_oneof![
+            (0usize..1000, arb_zatoshis())
+                .prop_map(|(index, value)| PrepInput::Wallet { index, value }),
+            (0usize..1000, 0usize..1000, 0usize..1000, arb_zatoshis()).prop_map(
+                |(layer, transaction, output, value)| PrepInput::Prior {
+                    layer,
+                    transaction,
+                    output,
+                    value,
+                }
+            ),
+        ]
+    }
+
+    /// An arbitrary [`PrepOutput`], exercising all three tags.
+    fn arb_prep_output() -> impl Strategy<Value = PrepOutput> {
+        prop_oneof![
+            arb_zatoshis().prop_map(PrepOutput::Funding),
+            arb_zatoshis().prop_map(PrepOutput::Intermediate),
+            arb_zatoshis().prop_map(PrepOutput::Change),
+        ]
+    }
+
+    /// An arbitrary [`PrepTransaction`] (possibly with no inputs or outputs).
+    fn arb_prep_transaction() -> impl Strategy<Value = PrepTransaction> {
+        (
+            prop::collection::vec(arb_prep_input(), 0..6),
+            prop::collection::vec(arb_prep_output(), 0..6),
+        )
+            .prop_map(|(inputs, outputs)| PrepTransaction::from_parts(inputs, outputs))
+    }
+
+    /// An arbitrary [`PreparationPlan`]: arbitrary layers of transactions plus direct-funding notes.
+    fn arb_preparation_plan() -> impl Strategy<Value = PreparationPlan> {
+        (
+            prop::collection::vec(prop::collection::vec(arb_prep_transaction(), 0..4), 0..4),
+            prop::collection::vec((0usize..1000, arb_zatoshis()), 0..5),
+        )
+            .prop_map(|(layers, direct)| PreparationPlan::from_parts(layers, direct))
+    }
+
+    proptest! {
+        /// `write` and `read` are exact inverses for every [`PrepInput`].
+        #[test]
+        fn prep_input_round_trips(input in arb_prep_input()) {
+            check_roundtrip(&input, |v, buf| v.write(buf), |b| PrepInput::read(b));
+        }
+
+        /// `write` and `read` are exact inverses for every [`PrepOutput`].
+        #[test]
+        fn prep_output_round_trips(output in arb_prep_output()) {
+            check_roundtrip(&output, |v, buf| v.write(buf), |b| PrepOutput::read(b));
+        }
+
+        /// `write` and `read` are exact inverses for every [`PrepTransaction`].
+        #[test]
+        fn prep_transaction_round_trips(tx in arb_prep_transaction()) {
+            check_roundtrip(&tx, |v, buf| v.write(buf), |b| PrepTransaction::read(b));
+        }
+
+        /// `write` and `read` are exact inverses for every [`PreparationPlan`].
+        #[test]
+        fn preparation_plan_round_trips(plan in arb_preparation_plan()) {
+            check_roundtrip(&plan, |v, buf| v.write(buf), |b| PreparationPlan::read(b));
+        }
+    }
 
     /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
     /// action costs one ZIP-317 marginal fee). The planner treats it opaquely.


### PR DESCRIPTION
Extracted from #2669 (B1 of the review split). Adds canonical `write`/`read` binary codecs onto the pool-migration types (`PreparationPlan`, `NoteSplitPlan`, `PrepInput`/`Output`/`Transaction`, `MigrationTxKind`, `MigrationTxId`, `MigrationTxState`), built on `zcash_encoding` + the `Zatoshis` codec, so a store serializes the types through their own methods. Stacked on the `Zatoshis` codec PR (#2704) which is stacked on the `zcash_encoding` helper PR (#2703).