### PR TITLE
zcash_pool_migration_memory: in-memory test backends crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,9 @@ jobs:
       - name: Add zcash_primitives as a dependency of the synthetic crate
         working-directory: ./ci-build
         run: cargo add --no-default-features --path ../crates/zcash_primitives
+      - name: Add zcash_pool_migration_backend as a dependency of the synthetic crate
+        working-directory: ./ci-build
+        run: cargo add --no-default-features --path ../crates/zcash_pool_migration_backend
       - name: Add lazy_static with the spin_no_std feature
         working-directory: ./ci-build
         run: cargo add lazy_static --features "spin_no_std"
@@ -533,6 +536,7 @@ jobs:
       - required-test
       - build-latest
       - build-nodefault
+      - build-nostd
       - bitrot
       - clippy
       - doc-links

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7260,6 +7260,7 @@ dependencies = [
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
 dependencies = [
+ "corez",
  "getset",
  "incrementalmerkletree",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,7 +7272,21 @@ dependencies = [
  "shardtree",
  "zcash_client_backend",
  "zcash_keys",
+ "zcash_pool_migration_memory",
  "zcash_primitives",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_pool_migration_memory"
+version = "0.1.0"
+dependencies = [
+ "incrementalmerkletree",
+ "orchard",
+ "pczt",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "zcash_pool_migration_backend",
  "zcash_protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "zcash_history",
     "zcash_keys",
     "zcash_pool_migration_backend",
+    "zcash_pool_migration_memory",
     "zcash_primitives",
     "zcash_proofs",
     "zcash_transparent",

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -50,9 +50,16 @@ incrementalmerkletree = { workspace = true, optional = true }
 incrementalmerkletree.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
+
 # The `local-consensus` feature exposes `LocalNetwork`, used to build the migration transactions
 # against regtest params with the relevant network upgrades (including NU6.3) active.
 zcash_protocol = { workspace = true, features = ["local-consensus", "test-dependencies"] }
+
+# Shared, test-only in-memory backends (`MockBackend`, `CommitMock`) and witness
+# helpers the engine tests use. The dev-dependency cycle back onto this crate is fine: dev-deps do
+# not enter the normal build graph (the same relationship zcash_client_memory has with
+# zcash_client_backend).
+zcash_pool_migration_memory = { path = "../zcash_pool_migration_memory" }
 
 [features]
 ## Builds the pure PCZT transaction builder (the `build` module), which turns a note-split plan and

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -19,6 +19,7 @@ categories.workspace = true
 all-features = true
 
 [dependencies]
+corez.workspace = true
 getset.workspace = true
 libm.workspace = true
 rand_core.workspace = true

--- a/zcash_pool_migration_backend/src/build.rs
+++ b/zcash_pool_migration_backend/src/build.rs
@@ -73,190 +73,19 @@ pub(crate) fn output_action_index(
 }
 
 /// Test helpers shared by the split and transfer builders: a deterministic account, regtest network
-/// params, and a single-leaf Orchard witness. Kept here so both submodules' tests reuse them.
+/// params, and a single-leaf Orchard witness. The seed-derived key, network, and witness helpers now
+/// live in the `zcash_pool_migration_memory` test-support crate and are re-exported here so both
+/// submodules' tests reuse them without change.
 #[cfg(test)]
 pub(crate) mod test_util {
-    use alloc::vec::Vec;
+    use orchard::keys::FullViewingKey;
 
-    use incrementalmerkletree::{Hashable, Level};
-    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
-    use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
-    use orchard::tree::{MerkleHashOrchard, MerklePath};
-    use orchard::value::NoteValue;
-    use orchard::{Anchor, NOTE_COMMITMENT_TREE_DEPTH};
-    use rand_chacha::ChaCha8Rng;
-    use rand_core::{RngCore, SeedableRng};
-    use zcash_protocol::consensus::BlockHeight;
-    use zcash_protocol::local_consensus::LocalNetwork;
-
-    /// 32 random bytes from a `seed`-derived RNG, keeping calls deterministic per case.
-    fn draw_bytes(rng: &mut ChaCha8Rng) -> [u8; 32] {
-        let mut bytes = [0u8; 32];
-        rng.fill_bytes(&mut bytes);
-        bytes
-    }
-
-    /// A post-NU6.3 height (past the regtest NU6.3 activation) at which the migration transactions
-    /// are built and their fees computed.
-    pub(crate) const TARGET_HEIGHT: u32 = 100;
-
-    /// An account's Orchard spending key, derived from `seed` so tests can vary the account across
-    /// proptest cases. Draws bytes until they form a valid spending key.
-    pub(crate) fn spending_key(seed: u64) -> SpendingKey {
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        loop {
-            let bytes = draw_bytes(&mut rng);
-            if let Some(sk) = SpendingKey::from_bytes(bytes).into_option() {
-                return sk;
-            }
-        }
-    }
+    pub(crate) use zcash_pool_migration_memory::{
+        TARGET_HEIGHT, regtest_network, shared_anchor_witnesses, single_note_witness, spending_key,
+    };
 
     /// An account's Orchard full viewing key (see [`spending_key`]).
     pub(crate) fn account(seed: u64) -> FullViewingKey {
         FullViewingKey::from(&spending_key(seed))
-    }
-
-    /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
-    /// The migration builds on a network where NU6.3 (the Ironwood pool) is live.
-    pub(crate) fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
-        let nu6_3 = if nu6_3_active {
-            Some(BlockHeight::from_u32(10))
-        } else {
-            None
-        };
-        LocalNetwork {
-            overwinter: Some(BlockHeight::from_u32(1)),
-            sapling: Some(BlockHeight::from_u32(2)),
-            blossom: Some(BlockHeight::from_u32(3)),
-            heartwood: Some(BlockHeight::from_u32(4)),
-            canopy: Some(BlockHeight::from_u32(5)),
-            nu5: Some(BlockHeight::from_u32(6)),
-            nu6: Some(BlockHeight::from_u32(7)),
-            nu6_1: Some(BlockHeight::from_u32(8)),
-            nu6_2: Some(BlockHeight::from_u32(9)),
-            nu6_3,
-            #[cfg(zcash_unstable = "nu7")]
-            nu7: None,
-        }
-    }
-
-    /// An Orchard note of `value` owned by `fvk`, with its randomness drawn from `rng`.
-    fn orchard_note(fvk: &FullViewingKey, value: u64, rng: &mut ChaCha8Rng) -> Note {
-        let recipient = fvk.address_at(0u32, Scope::External);
-        let note_value = NoteValue::from_raw(value);
-        let rho = loop {
-            let bytes = draw_bytes(rng);
-            if let Some(rho) = Rho::from_bytes(&bytes).into_option() {
-                break rho;
-            }
-        };
-        let rseed = loop {
-            let bytes = draw_bytes(rng);
-            if let Some(rseed) = RandomSeed::from_bytes(bytes, &rho).into_option() {
-                break rseed;
-            }
-        };
-        Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2)
-            .into_option()
-            .expect("valid note parts")
-    }
-
-    /// An Orchard note of `value` owned by `fvk`, with its randomness derived from `seed` (so
-    /// proptest varies the note across cases), placed as the sole leaf of an otherwise-empty
-    /// note-commitment tree, with the matching anchor. The authentication path uses the empty-subtree
-    /// roots for a single leaf at position 0, so `add_orchard_spend`'s anchor check
-    /// (`path.root(cmx) == anchor`) accepts it.
-    pub(crate) fn single_note_witness(
-        fvk: &FullViewingKey,
-        value: u64,
-        seed: u64,
-    ) -> (Note, MerklePath, Anchor) {
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let note = orchard_note(fvk, value, &mut rng);
-        let cmx = ExtractedNoteCommitment::from(note.commitment());
-        let auth_path = core::array::from_fn(|level| {
-            let level = Level::from(level as u8);
-            MerkleHashOrchard::empty_root(level)
-        });
-        let path = MerklePath::from_parts(0, auth_path);
-        let anchor = path.root(cmx);
-        (note, path, anchor)
-    }
-
-    /// `values.len()` Orchard notes owned by `fvk`, placed as the first leaves of one note-commitment
-    /// tree, each paired with its authentication path against the single shared anchor. Randomness is
-    /// derived from `seed`. This lets a test build a multi-spend transaction whose spends all anchor to
-    /// the same root. Assumes `values` is non-empty.
-    pub(crate) fn shared_anchor_witnesses(
-        fvk: &FullViewingKey,
-        values: &[u64],
-        seed: u64,
-    ) -> (Vec<(Note, MerklePath)>, Anchor) {
-        // The notes and their leaf hashes.
-        let notes: Vec<Note> = values
-            .iter()
-            .enumerate()
-            .map(|(i, &v)| {
-                let mut rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(i as u64));
-                orchard_note(fvk, v, &mut rng)
-            })
-            .collect();
-        let leaves: Vec<MerkleHashOrchard> = notes
-            .iter()
-            .map(|n| MerkleHashOrchard::from_cmx(&ExtractedNoteCommitment::from(n.commitment())))
-            .collect();
-
-        // Filled subtree roots per level: `levels[l][p]` is the root of the subtree at level `l`,
-        // position `p`. Level 0 is the leaves; each higher level combines pairs, using the
-        // empty-subtree root for a missing right sibling. Positions past `levels[l].len()` are empty.
-        let mut levels: Vec<Vec<MerkleHashOrchard>> =
-            Vec::with_capacity(NOTE_COMMITMENT_TREE_DEPTH + 1);
-        levels.push(leaves);
-        for l in 0..NOTE_COMMITMENT_TREE_DEPTH {
-            let level = Level::from(l as u8);
-            let cur = &levels[l];
-            let mut next = Vec::with_capacity(cur.len().div_ceil(2));
-            let mut p = 0;
-            while p < cur.len() {
-                let left = cur[p];
-                let right = cur
-                    .get(p + 1)
-                    .copied()
-                    .unwrap_or_else(|| MerkleHashOrchard::empty_root(level));
-                next.push(MerkleHashOrchard::combine(level, &left, &right));
-                p += 2;
-            }
-            levels.push(next);
-        }
-
-        // Each leaf's authentication path: the sibling subtree root at every level (its computed value
-        // when filled, else the empty-subtree root).
-        let witnesses: Vec<(Note, MerklePath)> = notes
-            .into_iter()
-            .enumerate()
-            .map(|(i, note)| {
-                let auth_path = core::array::from_fn(|l| {
-                    let level = Level::from(l as u8);
-                    let sibling = (i >> l) ^ 1;
-                    levels[l]
-                        .get(sibling)
-                        .copied()
-                        .unwrap_or_else(|| MerkleHashOrchard::empty_root(level))
-                });
-                (note, MerklePath::from_parts(i as u32, auth_path))
-            })
-            .collect();
-
-        // Every leaf's path yields the same root; assert it so a broken helper fails loudly rather
-        // than silently producing mismatched anchors.
-        let root_of = |(note, path): &(Note, MerklePath)| {
-            path.root(ExtractedNoteCommitment::from(note.commitment()))
-        };
-        let anchor = root_of(&witnesses[0]);
-        for w in &witnesses {
-            assert_eq!(root_of(w), anchor, "shared-anchor witnesses inconsistent");
-        }
-        (witnesses, anchor)
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -105,7 +105,7 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     /// Persist a committed migration: every transaction as its pre-signed PCZT plus the metadata the
     /// application needs to prove, schedule, and broadcast it. Storing the pre-signed transactions, not
     /// just the plan, is what lets a wallet resume a migration after being closed or restarted.
-    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error>;
 
     /// Advance one stored transaction's lifecycle state (for example after the application broadcasts
     /// it, or the chain mines it).
@@ -854,7 +854,7 @@ where
 ///
 /// After the device signs, call [`MigrationState::apply_signature`] for each returned PCZT (matched by
 /// [`UnsignedMigrationTx::id`]) to move it to [`Signed`](MigrationTxState::Signed), persist with
-/// `put_migration`, and drive the broadcasts through the normal state machine (proving remains a
+/// `replace_migration`, and drive the broadcasts through the normal state machine (proving remains a
 /// consumer responsibility, at broadcast time).
 ///
 /// `params` is the network, `target_height` the height the transactions are built at (post-NU6.3), and
@@ -1156,7 +1156,7 @@ where
         transactions,
     };
     backend
-        .put_migration(&state)
+        .replace_migration(&state)
         .map_err(CommitError::Backend)?;
     Ok((state, unsigned))
 }
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     impl PoolMigrationWrite for MockBackend {
-        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
             self.stored = Some(state.clone());
             Ok(())
         }
@@ -1383,7 +1383,7 @@ mod tests {
             preparation: crate::preparation::PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions: vec![tx],
         };
-        backend.put_migration(&state).unwrap();
+        backend.replace_migration(&state).unwrap();
 
         // The stored transactions round-trip, and a state update persists.
         let loaded = backend
@@ -1493,7 +1493,7 @@ mod commit_tests {
     }
 
     impl PoolMigrationWrite for CommitMock {
-        fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
             self.stored = Some(state.clone());
             Ok(())
         }
@@ -1853,7 +1853,7 @@ mod commit_tests {
                 assert!(state.apply_signature(id, signed.serialize().expect("serializes")));
             }
         }
-        backend.put_migration(&state).unwrap();
+        backend.replace_migration(&state).unwrap();
         for tx in &state.transactions {
             assert_eq!(tx.state, MigrationTxState::Signed);
         }
@@ -1894,7 +1894,7 @@ mod commit_tests {
         // A terminal (cancelled) migration may be replaced.
         let mut stored = backend.get_migration().unwrap().expect("stored");
         stored.status = MigrationStatus::Failed;
-        backend.put_migration(&stored).unwrap();
+        backend.replace_migration(&stored).unwrap();
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 3);
         commit_preparation(
             &params,

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -43,7 +43,8 @@
 
 use alloc::vec::Vec;
 use core::fmt;
-use std::io::{self, Read, Write};
+
+use corez::io;
 
 use getset::{CopyGetters, Getters};
 use rand_core::RngCore;
@@ -131,12 +132,12 @@ impl MigrationTxId {
     }
 
     /// Writes this id as an unsigned 32-bit little-endian integer.
-    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.0.to_le_bytes())
     }
 
     /// Reads an id written by [`write`](Self::write).
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    pub fn read<R: io::Read>(mut reader: R) -> io::Result<Self> {
         let mut bytes = [0u8; 4];
         reader.read_exact(&mut bytes)?;
         Ok(MigrationTxId::new(u32::from_le_bytes(bytes)))

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -199,7 +199,7 @@ impl MigrationState {
     /// external-signing seam: after
     /// [`build_preparation_unsigned`](crate::engine::build_preparation_unsigned) exports the unsigned PCZT,
     /// the caller has it signed out of band and returns the signed PCZT here, matched by `id`. Persist
-    /// the state afterwards (`put_migration`).
+    /// the state afterwards (`replace_migration`).
     ///
     /// Returns `true` if the signature was applied. Returns `false`, leaving the state unchanged, if no
     /// transaction has that `id` or it is not awaiting a signature (already signed, still an unbuilt

--- a/zcash_pool_migration_backend/src/testing.rs
+++ b/zcash_pool_migration_backend/src/testing.rs
@@ -7,8 +7,8 @@
 //!   [`Zatoshis`] up to a whole [`MigrationState`]. The crate's own codec proptests consume these,
 //!   and so does any downstream store crate.
 //! - a backend-agnostic conformance suite (`assert_*`) over the [`PoolMigrationRead`] /
-//!   [`PoolMigrationWrite`] store traits: an empty store reads back nothing, a put/get round-trips,
-//!   a second put replaces the first, and a transaction state update persists. Point any store
+//!   [`PoolMigrationWrite`] store traits: an empty store reads back nothing, a replace/get round-trips,
+//!   a second replace overwrites the first, and a transaction state update persists. Point any store
 //!   (the SQLite store, a future in-memory backend) at these and it inherits the same coverage.
 //!
 //! Enabled by the `test-dependencies` feature (and by the crate's own `test` build), so a
@@ -249,13 +249,15 @@ where
     );
 }
 
-/// Assert a put/get round-trip: after [`put_migration`](PoolMigrationWrite::put_migration), the
+/// Assert a replace/get round-trip: after [`replace_migration`](PoolMigrationWrite::replace_migration), the
 /// store reads back exactly the migration that was written.
 pub fn assert_put_get_roundtrip<S: PoolMigrationWrite>(store: &mut S, state: &MigrationState)
 where
     S::Error: Debug,
 {
-    store.put_migration(state).expect("put_migration succeeds");
+    store
+        .replace_migration(state)
+        .expect("replace_migration succeeds");
     let loaded = store.get_migration().expect("get_migration succeeds");
     assert_eq!(
         loaded,
@@ -264,7 +266,7 @@ where
     );
 }
 
-/// Assert that a second put replaces the first: after putting `first` then `second`, the store holds
+/// Assert that a second replace overwrites the first: after putting `first` then `second`, the store holds
 /// exactly `second`.
 pub fn assert_put_replaces<S: PoolMigrationWrite>(
     store: &mut S,
@@ -274,11 +276,11 @@ pub fn assert_put_replaces<S: PoolMigrationWrite>(
     S::Error: Debug,
 {
     store
-        .put_migration(first)
-        .expect("first put_migration succeeds");
+        .replace_migration(first)
+        .expect("first replace_migration succeeds");
     store
-        .put_migration(second)
-        .expect("second put_migration succeeds");
+        .replace_migration(second)
+        .expect("second replace_migration succeeds");
     assert_eq!(
         store.get_migration().expect("get_migration succeeds"),
         Some(second.clone()),
@@ -300,7 +302,9 @@ pub fn assert_update_transaction<S: PoolMigrationWrite>(
 ) where
     S::Error: Debug,
 {
-    store.put_migration(state).expect("put_migration succeeds");
+    store
+        .replace_migration(state)
+        .expect("replace_migration succeeds");
     store
         .update_transaction(id, new)
         .expect("update_transaction succeeds");

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -233,8 +233,8 @@ where
     <W as InputSource>::AccountId: Copy,
     St: PoolMigrationWrite,
 {
-    fn put_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
-        self.store.put_migration(state).map_err(Error::Store)
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.store.replace_migration(state).map_err(Error::Store)
     }
 
     fn update_transaction(

--- a/zcash_pool_migration_backend/tests/engine_commit.rs
+++ b/zcash_pool_migration_backend/tests/engine_commit.rs
@@ -1,0 +1,257 @@
+//! Integration tests for the one-pass migration commit, driven by the in-memory `CommitMock` crypto
+//! backend from the `zcash_pool_migration_memory` test-support crate.
+//!
+//! These are integration tests rather than `#[cfg(test)]` unit tests for the same reason as
+//! `engine_plan.rs`: the mock implements the engine's traits, so it must link the same library
+//! instance the test binary uses, which a dev-dependency cycle only provides to integration tests.
+//!
+//! The whole file is gated on the `orchard` feature (the crypto commit path); without it, it
+//! compiles to nothing.
+#![cfg(feature = "orchard")]
+
+use orchard::keys::SpendAuthorizingKey;
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::COIN;
+
+use zcash_pool_migration_backend::build::sign_pczt;
+use zcash_pool_migration_backend::engine::{
+    MigrationPlan, MigrationStatus, MigrationTxKind, MigrationTxState, PoolMigrationRead,
+    PoolMigrationWrite, batch_unsigned_by_action_budget, build_preparation_unsigned,
+    commit_preparation, plan_migration,
+};
+use zcash_pool_migration_backend::preparation::PREP_TX_ACTIONS;
+use zcash_pool_migration_backend::state::AdvanceStep;
+use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
+
+/// A planned single-note migration and the mock wallet that holds the note.
+fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
+    let backend = CommitMock::new(seed, &[balance]);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance plans");
+    (backend, plan)
+}
+
+/// The WHOLE migration, every preparation transaction and every transfer, is built and SIGNED in the
+/// one commit pass, before anything is broadcast or mined: the funding notes are recovered from the
+/// built preparation bundles, and every stored PCZT carries ABSENT anchors (ZIP 374), to be
+/// installed at proving time against each transaction's anchor.
+#[test]
+fn commits_the_whole_migration_in_one_pass() {
+    let seed = 7u64;
+    let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+    // A single note funding a handful of denominations needs one preparation layer.
+    assert_eq!(plan.preparation().layers().len(), 1);
+    let params = regtest_network(true);
+    let prep_count: usize = plan.preparation().layers().iter().map(|l| l.len()).sum();
+    let transfer_count = plan.funding_notes().len();
+    assert!(transfer_count >= 2, "several transfers: {transfer_count}");
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+    let state = commit_preparation(
+        &params,
+        BlockHeight::from_u32(TARGET_HEIGHT),
+        &mut backend,
+        &plan,
+        &mut rng,
+    )
+    .expect("commits the migration");
+    assert_eq!(state.status(), MigrationStatus::Committed);
+    assert_eq!(state.transactions().len(), prep_count + transfer_count);
+
+    for tx in state.transactions() {
+        // ONE signing phase: everything is signed at commit, before anything mines.
+        assert_eq!(tx.state(), MigrationTxState::Signed, "signed at commit");
+        assert!(!tx.pczt().is_empty());
+        let parsed = pczt::Pczt::parse(tx.pczt()).expect("the stored PCZT parses");
+        // Anchors are deferred (ZIP 374): every stored PCZT carries ABSENT anchors, and the
+        // pre-signature commits to the stored canonical expiry for the drawn schedule.
+        assert!(parsed.orchard().anchor().is_none());
+        assert!(parsed.ironwood().anchor().is_none());
+        assert_eq!(
+            *parsed.global().expiry_height(),
+            u32::from(tx.expiry_height()),
+            "the embedded expiry matches the stored schedule expiry"
+        );
+        match tx.kind() {
+            MigrationTxKind::Preparation { .. } => {
+                assert!(
+                    tx.depends_on().is_empty(),
+                    "single-layer preps are independent"
+                );
+                assert!(tx.anchor_boundary().is_none());
+            }
+            MigrationTxKind::Transfer { .. } => {
+                assert!(
+                    !tx.depends_on().is_empty(),
+                    "a transfer BROADCASTS only after the preparation mines"
+                );
+                assert!(
+                    tx.anchor_boundary().is_some(),
+                    "every transfer carries its boundary"
+                );
+            }
+        }
+    }
+    assert!(backend.get_migration().unwrap().is_some());
+}
+
+/// A lone whale fanning out into more funding notes than one transaction holds needs a MULTI-LAYER
+/// preparation, and it still signs in the SAME single pass: the later layer's feeder spends and the
+/// transfers' funding notes are recovered from the earlier layers' built (unmined) bundles. Mining
+/// then gates only the broadcast order, which the state machine walks layer by layer.
+#[test]
+fn commits_a_multi_layer_migration_in_one_pass() {
+    // A 1000 ZEC whale splits into 15 funding notes, one more than a single transaction holds, so
+    // the preparation fans out across two layers.
+    let seed = 11u64;
+    let (mut backend, plan) = single_note_setup(seed, 1_000 * COIN);
+    assert_eq!(
+        plan.preparation().layers().len(),
+        2,
+        "the whale fans out across two layers"
+    );
+    let params = regtest_network(true);
+    let prep_count = plan.preparation().transaction_count();
+    let transfer_count = plan.funding_notes().len();
+
+    // ONE pass builds and signs both layers and every transfer.
+    let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+    let state = commit_preparation(
+        &params,
+        BlockHeight::from_u32(TARGET_HEIGHT),
+        &mut backend,
+        &plan,
+        &mut rng,
+    )
+    .expect("commits the migration");
+    assert_eq!(state.transactions().len(), prep_count + transfer_count);
+    for tx in state.transactions() {
+        assert_eq!(tx.state(), MigrationTxState::Signed, "signed at commit");
+        assert!(!tx.pczt().is_empty());
+    }
+    let layer0_ids: Vec<_> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 0, .. }))
+        .map(|t| t.id())
+        .collect();
+    assert_eq!(layer0_ids.len(), 1, "one root transaction in layer 0");
+    for tx in state.transactions() {
+        if let MigrationTxKind::Preparation { layer, .. } = tx.kind() {
+            if layer > 0 {
+                assert_eq!(
+                    tx.depends_on(),
+                    &layer0_ids,
+                    "a later layer broadcasts only after its predecessor mines"
+                );
+            }
+        }
+    }
+
+    // The state machine walks the broadcasts in dependency order: layer 0 first; layer 1 only once
+    // layer 0 mines; the transfers only once the whole preparation mines.
+    let mut state = state;
+    let target = BlockHeight::from_u32(2_100_000);
+    match state.next_step(target) {
+        AdvanceStep::Broadcast { id } => {
+            assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
+        }
+        other => panic!("expected a broadcast step, got {other:?}"),
+    }
+    for id in &layer0_ids {
+        state.mark_mined(*id, BlockHeight::from_u32(2_000_010));
+    }
+    let layer1_ids: Vec<_> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 1, .. }))
+        .map(|t| t.id())
+        .collect();
+    match state.next_step(target) {
+        AdvanceStep::Broadcast { id } => {
+            assert!(
+                layer1_ids.contains(&id),
+                "layer 1 broadcasts once layer 0 mines"
+            )
+        }
+        other => panic!("expected a broadcast step, got {other:?}"),
+    }
+    for id in &layer1_ids {
+        state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
+    }
+    match state.next_step(target) {
+        AdvanceStep::Broadcast { id } => {
+            let tx = state
+                .transactions()
+                .iter()
+                .find(|t| t.id() == id)
+                .expect("the step names a stored transaction");
+            assert!(
+                matches!(tx.kind(), MigrationTxKind::Transfer { .. }),
+                "the transfers broadcast once the whole preparation mines"
+            );
+        }
+        other => panic!("expected a broadcast step, got {other:?}"),
+    }
+}
+
+/// The EXTERNAL path builds the whole migration unsigned in the same one pass, and the unsigned
+/// transactions split into signing sessions bounded by the device's action budget: consecutive
+/// topological prefixes, never gated on mining.
+#[test]
+fn external_signing_batches_by_action_budget() {
+    let seed = 19u64;
+    let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+    let params = regtest_network(true);
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+    let (mut state, unsigned) = build_preparation_unsigned(
+        &params,
+        BlockHeight::from_u32(TARGET_HEIGHT),
+        &mut backend,
+        &plan,
+        &mut rng,
+    )
+    .expect("builds the migration unsigned");
+    assert_eq!(unsigned.len(), state.transactions().len());
+    for tx in state.transactions() {
+        assert_eq!(tx.state(), MigrationTxState::AwaitingSignature);
+    }
+
+    // Sessions are consecutive prefixes bounded by the action budget; a preparation is
+    // PREP_TX_ACTIONS actions and a transfer is three (two source, one destination), so a budget of
+    // one preparation plus one transfer splits the list without ever exceeding the budget (every
+    // batch is non-empty and within budget).
+    const ACTIONS_PER_TRANSFER: usize = 3;
+    let budget = PREP_TX_ACTIONS + ACTIONS_PER_TRANSFER;
+    let total = unsigned.len();
+    let sessions = batch_unsigned_by_action_budget(unsigned, budget);
+    assert!(sessions.len() > 1, "several sessions: {}", sessions.len());
+    assert_eq!(sessions.iter().map(|s| s.len()).sum::<usize>(), total);
+    for session in &sessions {
+        assert!(!session.is_empty());
+        assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget);
+    }
+
+    // Sign every session out of band and apply the signatures back; the whole migration is then
+    // Signed without anything having been broadcast or mined.
+    let ask = SpendAuthorizingKey::from(&spending_key(seed));
+    for session in sessions {
+        for unsigned_tx in session {
+            let (id, bytes) = unsigned_tx.into_parts();
+            let signed = sign_pczt(
+                pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses"),
+                &ask,
+            )
+            .expect("the device signs the transaction");
+            assert!(state.apply_signature(id, signed.serialize().expect("serializes")));
+        }
+    }
+    backend.replace_migration(&state).unwrap();
+    for tx in state.transactions() {
+        assert_eq!(tx.state(), MigrationTxState::Signed);
+    }
+}

--- a/zcash_pool_migration_backend/tests/engine_plan.rs
+++ b/zcash_pool_migration_backend/tests/engine_plan.rs
@@ -1,0 +1,205 @@
+//! Integration tests for the migration planner and store, driven by the in-memory `MockBackend`
+//! from the `zcash_pool_migration_memory` test-support crate.
+//!
+//! These are integration tests rather than `#[cfg(test)]` unit tests because the mock implements the
+//! engine's traits from `zcash_pool_migration_backend`. A dev-dependency cycle cannot be consumed by
+//! the backend's own unit tests: the unit-test build recompiles the library as a distinct instance,
+//! so the mock's trait impls (built against the plain library) would not satisfy the trait as seen
+//! inside the test binary. An integration test links the same library instance the mock was built
+//! against, so the types unify.
+
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::{COIN, Zatoshis};
+
+use zcash_pool_migration_backend::engine::{
+    MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTransaction,
+    MigrationTxId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    plan_migration,
+};
+use zcash_pool_migration_backend::note_splitting::{NoteSplitPlan, plan_note_split};
+use zcash_pool_migration_backend::preparation::{
+    FUNDING_OUTPUTS_PER_TX, PreparationPlan, plan_preparation,
+};
+use zcash_pool_migration_memory::{MockBackend, regtest_network};
+
+/// Wrap a raw zatoshi amount as [`Zatoshis`] for the tests.
+fn zat(n: u64) -> Zatoshis {
+    Zatoshis::from_u64(n).expect("valid amount")
+}
+
+/// A count-only preparation-layout stub for the reconciliation baseline: one padded transaction per
+/// [`FUNDING_OUTPUTS_PER_TX`] funding notes, always fundable (never returns `None`).
+fn prep_tx_count_stub(notes: &[Zatoshis]) -> Option<usize> {
+    Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
+}
+
+#[test]
+fn plans_a_migration_from_a_balance() {
+    let backend = MockBackend::new(vec![100 * COIN, 40 * COIN], 2_000_000);
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance plans");
+
+    // Something is migrated; the schedule has one entry per funding note; the preparation mints
+    // exactly the (reconciled) funding notes; and reconciliation only ever drops, never adds.
+    assert!(!plan.funding_notes().is_empty());
+    assert_eq!(plan.schedule().len(), plan.funding_notes().len());
+    assert_eq!(
+        plan.preparation().funding_notes().len(),
+        plan.funding_notes().len()
+    );
+    assert!(plan.funding_notes().len() <= plan.note_split().migration_outputs().len());
+}
+
+#[test]
+fn empty_balance_has_nothing_to_migrate() {
+    let backend = MockBackend::new(Vec::new(), 2_000_000);
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    assert!(matches!(
+        plan_migration(&regtest_network(true), &backend, &mut rng),
+        Err(MigrationError::NothingToMigrate)
+    ));
+}
+
+/// Reconciliation on a many-equal-note source (the "exchange" wallet shape). Ten identical 5-ZEC
+/// notes (50 ZEC) decompose into `[20, 20, 5, 2, 2, 0.5, ...]`, but equal source notes cannot fund
+/// that whole split: each funding note is its crossing plus a transfer buffer and costs a
+/// preparation fee, so a lone 5-ZEC note cannot even self-fund a 5-ZEC crossing. The split
+/// consults the preparation planner against the source notes at every step, so it reconciles
+/// inline, dropping the smallest funding notes (smallest first) and leaving those denominations
+/// in the source pool as residual. We reconstruct the UNCONSTRAINED split (the same strategy with
+/// an always-fundable preparation stub) as the baseline the source-constrained split is measured
+/// against, and pin the documented behavior end to end: the source constraint actually drops for
+/// this shape, drops only from the bottom, never invents a denomination, never creates value, and
+/// yields a preparation that is fundable from the source notes.
+#[test]
+fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
+    let balance = 50 * COIN;
+    let backend = MockBackend::new(vec![5 * COIN; 10], 2_000_000); // ten equal 5-ZEC notes
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance plans");
+
+    let kept = plan.funding_notes();
+
+    // The baseline: the same split with an always-fundable preparation stub, i.e. what the strategy
+    // proposes for this balance absent the equal-note source's fundability constraint. Recover the
+    // exact fees `plan_migration` used from the produced note split so the baseline matches.
+    let transfer_buffer = plan.note_split().note_fee_buffer();
+    let prep_tx_fee = plan.note_split().prep_fees();
+    let mut ref_rng = ChaCha8Rng::seed_from_u64(1);
+    let proposed = plan_note_split(
+        zat(balance),
+        transfer_buffer,
+        prep_tx_fee,
+        &prep_tx_count_stub,
+        &mut ref_rng,
+    )
+    .migration_outputs();
+
+    // The unconstrained split proposes more funding notes than the equal-note source can fund, so
+    // the source-constrained split must drop some. This is the case this test exists to cover: the
+    // general `plans_a_migration_from_a_balance` test uses a shape that happens to drop nothing.
+    assert!(
+        kept.len() < proposed.len(),
+        "the many-equal-note source should force a drop: kept {} of {}",
+        kept.len(),
+        proposed.len()
+    );
+
+    // Only ever DROPS: every kept funding note is one the unconstrained split proposed (a
+    // sub-multiset of it), so no denomination or value is invented. Removing the kept notes from a
+    // copy of the proposed outputs leaves exactly the dropped notes.
+    let mut dropped = proposed.clone();
+    for &k in kept {
+        let pos = dropped
+            .iter()
+            .position(|&v| v == k)
+            .expect("every kept funding note came from the proposed outputs");
+        dropped.swap_remove(pos);
+    }
+
+    // The drop is from the BOTTOM: every kept note is at least as large as every dropped one.
+    let smallest_kept = kept
+        .iter()
+        .copied()
+        .min()
+        .expect("at least one note is kept");
+    assert!(
+        dropped.iter().all(|&d| d <= smallest_kept),
+        "reconciliation must drop the smallest denominations first"
+    );
+
+    // No value is created: the reconciled funding notes never exceed the balance.
+    assert!(kept.iter().map(|z| z.into_u64()).sum::<u64>() <= balance);
+
+    // The reconciled plan is actually fundable from the source notes.
+    let source = backend
+        .spendable_orchard_note_values()
+        .expect("the mock source notes are available");
+    assert!(
+        plan_preparation(&source, kept, prep_tx_fee).is_ok(),
+        "the reconciled funding set must be preparable from the source notes"
+    );
+}
+
+#[test]
+fn stores_loads_and_updates_a_migration() {
+    let mut backend = MockBackend::new(Vec::new(), 0);
+    assert!(backend.get_migration().unwrap().is_none());
+
+    // A consistent stored note split (its exact values are immaterial to the store round-trip).
+    let note_split = NoteSplitPlan::from_stored_parts(
+        vec![zat(100 * COIN)],
+        zat(10_000),
+        None,
+        zat(1_000),
+        zat(100 * COIN),
+        zat(100 * COIN),
+    )
+    .expect("a consistent stored split reconstructs");
+    let tx = MigrationTransaction::from_parts(
+        MigrationTxId::new(0),
+        MigrationTxKind::Transfer { crossing: 0 },
+        vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
+        Vec::new(),
+        BlockHeight::from_u32(2_000_100),
+        BlockHeight::from_u32(2_069_220),
+        None,
+        MigrationTxState::Signed,
+    );
+    let state = MigrationState::from_parts(
+        MigrationStatus::Committed,
+        note_split,
+        Vec::new(),
+        PreparationPlan::from_parts(Vec::new(), Vec::new()),
+        vec![tx],
+    );
+    backend.replace_migration(&state).unwrap();
+
+    // The stored transactions round-trip, and a state update persists.
+    let loaded = backend
+        .get_migration()
+        .unwrap()
+        .expect("a migration is stored");
+    assert_eq!(loaded.status(), MigrationStatus::Committed);
+    assert_eq!(loaded.transactions(), state.transactions());
+
+    backend
+        .update_transaction(
+            MigrationTxId::new(0),
+            MigrationTxState::Mined {
+                height: BlockHeight::from_u32(2_000_105),
+            },
+        )
+        .unwrap();
+    let loaded = backend.get_migration().unwrap().unwrap();
+    assert_eq!(
+        loaded.transactions()[0].state(),
+        MigrationTxState::Mined {
+            height: BlockHeight::from_u32(2_000_105)
+        }
+    );
+}

--- a/zcash_pool_migration_memory/Cargo.toml
+++ b/zcash_pool_migration_memory/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "zcash_pool_migration_memory"
+description = "In-memory, test-only implementations of the zcash_pool_migration_backend engine traits"
+version = "0.1.0"
+authors = [
+    "Danny Willems <be.danny.willems@gmail.com>",
+    "John Boyd <john@coldnoise.net>",
+    "Michal Fousek <michal.fousek@chlup.info>",
+]
+homepage = "https://github.com/zcash/librustzcash"
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+categories.workspace = true
+
+[dependencies]
+# The engine traits and types these mocks implement. The crypto mocks and the witness helpers need
+# the backend's Orchard surface (`MigrationCrypto`, `build::sign_pczt`), so enable its `orchard`
+# feature unconditionally: this crate exists only to support the backend's tests.
+zcash_pool_migration_backend = { path = "../zcash_pool_migration_backend", features = [
+    "orchard",
+] }
+
+orchard = { workspace = true }
+pczt = { workspace = true }
+rand_chacha.workspace = true
+rand_core.workspace = true
+incrementalmerkletree.workspace = true
+# `local-consensus` exposes `LocalNetwork`, used to build regtest params with NU6.3 active.
+zcash_protocol = { workspace = true, features = ["local-consensus"] }
+
+[lints]
+workspace = true

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -1,0 +1,397 @@
+//! In-memory implementations of the [`zcash_pool_migration_backend`] engine traits, **FOR TESTING
+//! ONLY**.
+//!
+//! This crate provides in-memory implementations of the pool-migration engine traits
+//! ([`MigrationBackend`], [`PoolMigrationRead`], [`PoolMigrationWrite`], and [`MigrationCrypto`]) for
+//! TESTING ONLY; it is not intended for production use. The mock backends hold their notes and
+//! migration state in memory, sign with a hand-held Orchard spend-authorizing key, and
+//! deterministically derive keys and note-commitment-tree witnesses from a seed. None of this is a
+//! substitute for a real wallet backend.
+//!
+//! Two mocks are provided: [`MockBackend`], a note-values-and-store backend for the planning and
+//! store tests, and [`CommitMock`], which additionally holds the account's key and note plaintexts
+//! so it can sign, for the commit tests. The seed-derived witness helpers ([`single_note_witness`],
+//! [`shared_anchor_witnesses`]) build single-leaf and shared-anchor Orchard witnesses.
+//!
+//! It mirrors how [`zcash_client_memory`] relates to `zcash_client_backend`: a shared, test-support
+//! crate so several test suites can reuse the same mock implementations.
+//!
+//! [`MigrationBackend`]: zcash_pool_migration_backend::engine::MigrationBackend
+//! [`PoolMigrationRead`]: zcash_pool_migration_backend::engine::PoolMigrationRead
+//! [`PoolMigrationWrite`]: zcash_pool_migration_backend::engine::PoolMigrationWrite
+//! [`MigrationCrypto`]: zcash_pool_migration_backend::engine::MigrationCrypto
+//! [`zcash_client_memory`]: https://docs.rs/zcash_client_memory
+
+use incrementalmerkletree::{Hashable, Level};
+use orchard::keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey};
+use orchard::note::{ExtractedNoteCommitment, Note, NoteVersion, RandomSeed, Rho};
+use orchard::tree::{MerkleHashOrchard, MerklePath};
+use orchard::value::NoteValue;
+use orchard::{Anchor, NOTE_COMMITMENT_TREE_DEPTH};
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::local_consensus::LocalNetwork;
+use zcash_protocol::value::Zatoshis;
+
+use zcash_pool_migration_backend::build::sign_pczt;
+use zcash_pool_migration_backend::engine::{
+    MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTxId,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+};
+
+/// A post-NU6.3 height (past the regtest NU6.3 activation) at which the migration transactions are
+/// built and their fees computed.
+pub const TARGET_HEIGHT: u32 = 100;
+
+/// 32 random bytes from a `seed`-derived RNG, keeping calls deterministic per case.
+fn draw_bytes(rng: &mut ChaCha8Rng) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
+/// An account's Orchard spending key, derived from `seed` so tests can vary the account across
+/// proptest cases. Draws bytes until they form a valid spending key.
+pub fn spending_key(seed: u64) -> SpendingKey {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    loop {
+        let bytes = draw_bytes(&mut rng);
+        if let Some(sk) = SpendingKey::from_bytes(bytes).into_option() {
+            return sk;
+        }
+    }
+}
+
+/// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
+/// The migration builds on a network where NU6.3 (the Ironwood pool) is live.
+pub fn regtest_network(nu6_3_active: bool) -> LocalNetwork {
+    let nu6_3 = if nu6_3_active {
+        Some(BlockHeight::from_u32(10))
+    } else {
+        None
+    };
+    LocalNetwork {
+        overwinter: Some(BlockHeight::from_u32(1)),
+        sapling: Some(BlockHeight::from_u32(2)),
+        blossom: Some(BlockHeight::from_u32(3)),
+        heartwood: Some(BlockHeight::from_u32(4)),
+        canopy: Some(BlockHeight::from_u32(5)),
+        nu5: Some(BlockHeight::from_u32(6)),
+        nu6: Some(BlockHeight::from_u32(7)),
+        nu6_1: Some(BlockHeight::from_u32(8)),
+        nu6_2: Some(BlockHeight::from_u32(9)),
+        nu6_3,
+        #[cfg(zcash_unstable = "nu7")]
+        nu7: None,
+    }
+}
+
+/// An Orchard note of `value` owned by `fvk`, with its randomness drawn from `rng`.
+fn orchard_note(fvk: &FullViewingKey, value: u64, rng: &mut ChaCha8Rng) -> Note {
+    let recipient = fvk.address_at(0u32, Scope::External);
+    let note_value = NoteValue::from_raw(value);
+    let rho = loop {
+        let bytes = draw_bytes(rng);
+        if let Some(rho) = Rho::from_bytes(&bytes).into_option() {
+            break rho;
+        }
+    };
+    let rseed = loop {
+        let bytes = draw_bytes(rng);
+        if let Some(rseed) = RandomSeed::from_bytes(bytes, &rho).into_option() {
+            break rseed;
+        }
+    };
+    Note::from_parts(recipient, note_value, rho, rseed, NoteVersion::V2)
+        .into_option()
+        .expect("valid note parts")
+}
+
+/// An Orchard note of `value` owned by `fvk`, with its randomness derived from `seed` (so
+/// proptest varies the note across cases), placed as the sole leaf of an otherwise-empty
+/// note-commitment tree, with the matching anchor. The authentication path uses the empty-subtree
+/// roots for a single leaf at position 0, so `add_orchard_spend`'s anchor check
+/// (`path.root(cmx) == anchor`) accepts it.
+pub fn single_note_witness(
+    fvk: &FullViewingKey,
+    value: u64,
+    seed: u64,
+) -> (Note, MerklePath, Anchor) {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let note = orchard_note(fvk, value, &mut rng);
+    let cmx = ExtractedNoteCommitment::from(note.commitment());
+    let auth_path = core::array::from_fn(|level| {
+        let level = Level::from(level as u8);
+        MerkleHashOrchard::empty_root(level)
+    });
+    let path = MerklePath::from_parts(0, auth_path);
+    let anchor = path.root(cmx);
+    (note, path, anchor)
+}
+
+/// `values.len()` Orchard notes owned by `fvk`, placed as the first leaves of one note-commitment
+/// tree, each paired with its authentication path against the single shared anchor. Randomness is
+/// derived from `seed`. This lets a test build a multi-spend transaction whose spends all anchor to
+/// the same root. Assumes `values` is non-empty.
+pub fn shared_anchor_witnesses(
+    fvk: &FullViewingKey,
+    values: &[u64],
+    seed: u64,
+) -> (Vec<(Note, MerklePath)>, Anchor) {
+    // The notes and their leaf hashes.
+    let notes: Vec<Note> = values
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(i as u64));
+            orchard_note(fvk, v, &mut rng)
+        })
+        .collect();
+    let leaves: Vec<MerkleHashOrchard> = notes
+        .iter()
+        .map(|n| MerkleHashOrchard::from_cmx(&ExtractedNoteCommitment::from(n.commitment())))
+        .collect();
+
+    // Filled subtree roots per level: `levels[l][p]` is the root of the subtree at level `l`,
+    // position `p`. Level 0 is the leaves; each higher level combines pairs, using the
+    // empty-subtree root for a missing right sibling. Positions past `levels[l].len()` are empty.
+    let mut levels: Vec<Vec<MerkleHashOrchard>> =
+        Vec::with_capacity(NOTE_COMMITMENT_TREE_DEPTH + 1);
+    levels.push(leaves);
+    for l in 0..NOTE_COMMITMENT_TREE_DEPTH {
+        let level = Level::from(l as u8);
+        let cur = &levels[l];
+        let mut next = Vec::with_capacity(cur.len().div_ceil(2));
+        let mut p = 0;
+        while p < cur.len() {
+            let left = cur[p];
+            let right = cur
+                .get(p + 1)
+                .copied()
+                .unwrap_or_else(|| MerkleHashOrchard::empty_root(level));
+            next.push(MerkleHashOrchard::combine(level, &left, &right));
+            p += 2;
+        }
+        levels.push(next);
+    }
+
+    // Each leaf's authentication path: the sibling subtree root at every level (its computed value
+    // when filled, else the empty-subtree root).
+    let witnesses: Vec<(Note, MerklePath)> = notes
+        .into_iter()
+        .enumerate()
+        .map(|(i, note)| {
+            let auth_path = core::array::from_fn(|l| {
+                let level = Level::from(l as u8);
+                let sibling = (i >> l) ^ 1;
+                levels[l]
+                    .get(sibling)
+                    .copied()
+                    .unwrap_or_else(|| MerkleHashOrchard::empty_root(level))
+            });
+            (note, MerklePath::from_parts(i as u32, auth_path))
+        })
+        .collect();
+
+    // Every leaf's path yields the same root; assert it so a broken helper fails loudly rather
+    // than silently producing mismatched anchors.
+    let root_of = |(note, path): &(Note, MerklePath)| {
+        path.root(ExtractedNoteCommitment::from(note.commitment()))
+    };
+    let anchor = root_of(&witnesses[0]);
+    for w in &witnesses {
+        assert_eq!(root_of(w), anchor, "shared-anchor witnesses inconsistent");
+    }
+    (witnesses, anchor)
+}
+
+/// Rebuild `stored` with the transaction identified by `id` moved to `state`, leaving the rest
+/// untouched. The engine's [`MigrationState`] keeps its transactions behind read-only accessors, so
+/// an external test backend advances one transaction's lifecycle by reconstructing the state from
+/// its public parts.
+fn set_transaction_state(stored: &mut MigrationState, id: MigrationTxId, state: MigrationTxState) {
+    let transactions: Vec<MigrationTransaction> = stored
+        .transactions()
+        .iter()
+        .map(|t| {
+            if t.id() == id {
+                MigrationTransaction::from_parts(
+                    t.id(),
+                    t.kind(),
+                    t.pczt().clone(),
+                    t.depends_on().clone(),
+                    t.scheduled_height(),
+                    t.expiry_height(),
+                    t.anchor_boundary(),
+                    state,
+                )
+            } else {
+                t.clone()
+            }
+        })
+        .collect();
+    *stored = MigrationState::from_parts(
+        stored.status(),
+        stored.note_split().clone(),
+        stored.funding_notes().clone(),
+        stored.preparation().clone(),
+        transactions,
+    );
+}
+
+/// A minimal in-memory backend: a fixed set of note values and a chain tip. Implements the planning
+/// traits ([`MigrationBackend`], [`PoolMigrationRead`], [`PoolMigrationWrite`]); it holds no keys and
+/// cannot sign, so it is used for the plan/store tests, not the commit tests.
+pub struct MockBackend {
+    notes: Vec<Zatoshis>,
+    tip: BlockHeight,
+    stored: Option<MigrationState>,
+}
+
+impl MockBackend {
+    /// A backend offering `notes` as the spendable Orchard note values and `tip` as the chain-tip
+    /// height, with no migration stored yet.
+    pub fn new(notes: Vec<u64>, tip: u32) -> Self {
+        MockBackend {
+            notes: notes
+                .into_iter()
+                .map(|v| Zatoshis::from_u64(v).expect("test note values are valid"))
+                .collect(),
+            tip: BlockHeight::from_u32(tip),
+            stored: None,
+        }
+    }
+}
+
+impl MigrationBackend for MockBackend {
+    type Error = core::convert::Infallible;
+
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+        Ok(self.notes.clone())
+    }
+
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+        Ok(self.tip)
+    }
+}
+
+impl PoolMigrationRead for MockBackend {
+    type Error = core::convert::Infallible;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        Ok(self.stored.clone())
+    }
+}
+
+impl PoolMigrationWrite for MockBackend {
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.stored = Some(state.clone());
+        Ok(())
+    }
+
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        if let Some(stored) = &mut self.stored {
+            set_transaction_state(stored, id, state);
+        }
+        Ok(())
+    }
+}
+
+/// A wallet mock holding the account's key and its spendable notes' PLAINTEXTS, nothing more: with
+/// anchors and witnesses deferred to proving time (ZIP 374), building and signing an entire
+/// migration needs no tree access at all. It signs with its own spend-authorizing key and stores the
+/// migration in memory. All fields are public so a test can construct it directly for a specific
+/// scenario.
+pub struct CommitMock {
+    /// The wallet's spendable Orchard note plaintexts (their values are reported to the planner and
+    /// resolved by index at build time).
+    pub wallet_notes: Vec<Note>,
+    /// The account's Orchard full viewing key.
+    pub fvk: FullViewingKey,
+    /// The account's Orchard spend-authorizing key, used to sign the migration PCZTs.
+    pub ask: SpendAuthorizingKey,
+    /// The in-memory migration state (`None` until a migration is committed).
+    pub stored: Option<MigrationState>,
+}
+
+impl CommitMock {
+    /// A mock wallet holding single notes of the given values, derived from `seed`.
+    pub fn new(seed: u64, values: &[u64]) -> Self {
+        let sk = spending_key(seed);
+        let fvk = FullViewingKey::from(&sk);
+        let wallet_notes = values
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| single_note_witness(&fvk, v, seed.wrapping_add(i as u64)).0)
+            .collect();
+        CommitMock {
+            wallet_notes,
+            fvk,
+            ask: SpendAuthorizingKey::from(&sk),
+            stored: None,
+        }
+    }
+}
+
+impl MigrationBackend for CommitMock {
+    type Error = core::convert::Infallible;
+
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+        Ok(self
+            .wallet_notes
+            .iter()
+            .map(|n| Zatoshis::from_u64(n.value().inner()).expect("test note values are valid"))
+            .collect())
+    }
+
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+        Ok(BlockHeight::from_u32(2_000_000))
+    }
+}
+
+impl PoolMigrationRead for CommitMock {
+    type Error = core::convert::Infallible;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        Ok(self.stored.clone())
+    }
+}
+
+impl PoolMigrationWrite for CommitMock {
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.stored = Some(state.clone());
+        Ok(())
+    }
+
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        if let Some(stored) = &mut self.stored {
+            set_transaction_state(stored, id, state);
+        }
+        Ok(())
+    }
+}
+
+impl MigrationCrypto for CommitMock {
+    type Error = core::convert::Infallible;
+
+    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
+        Ok(self.fvk.clone())
+    }
+
+    fn resolve_wallet_note(&self, index: usize) -> Result<Note, Self::Error> {
+        Ok(self.wallet_notes[index])
+    }
+
+    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
+        Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
+    }
+}


### PR DESCRIPTION
Extracted from #2669 (B3 of the review split). Two atomic, semantically independent commits:

1. `zcash_pool_migration: rename put/write_migration to replace_migration` — a pure rename of the store trait's persist method and its callers, no behavior change.
2. `zcash_pool_migration_memory: extract the in-memory test backends into a crate` — move the `MockBackend`/`CommitMock` test backends and the seed-derived Orchard witness helpers out of the engine crate's inline test module into a dedicated `zcash_pool_migration_memory` test-support crate (like `zcash_client_memory`), so the engine's integration tests and any downstream store reuse the same mocks.

Stacked on the store-conformance framework PR (#2706).