### PR TITLE
zcash_pool_migration: typed CommitError + transfer-shape doc fix

### DIFF
--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -119,3 +119,14 @@ and this library adheres to Rust's notion of
   remains a consumer responsibility, as for in-process signing). External signing therefore
   replaces only the sign step; the rest of the lifecycle is identical. The status view surfaces an
   awaiting transaction as blocked on `Blocker::Signature`.
+- `commit_preparation` (and `build_preparation_unsigned`) report a malformed migration plan - one
+  whose parallel structures disagree, such as a preparation layer with no matching scheduled height -
+  as a typed `CommitError::InconsistentPlan` rather than panicking on an out-of-bounds index, so an
+  unvalidated plan built through `from_parts` fails at the boundary instead of aborting.
+- `CommitError` no longer funnels every build-time failure through an opaque `Build(String)`: it
+  now carries the structured `build::BuildError` in `Build`, the PCZT `EncodingError` in a new
+  `Serialize` variant, and models the NU6.3-not-active condition as `Nu63NotActive` (mirroring
+  `MigrationError::Nu63NotActive`). The "the schedule has advanced past every candidate anchor
+  boundary" case now shares the `StalePlan` variant with the note-value mismatch, and the remaining
+  internal-invariant failures use `InconsistentPlan`, so a caller can match on the condition rather
+  than parsing a message.

--- a/zcash_pool_migration_backend/CHANGELOG.md
+++ b/zcash_pool_migration_backend/CHANGELOG.md
@@ -34,8 +34,9 @@ and this library adheres to Rust's notion of
   one self-funding note the note split minted and outputs its crossing value into the Ironwood pool as
   an unproven `pczt::Pczt`, sent to the account's own internal Ironwood change address (derived inside
   the builder, per ZIP 318). It has no change output; the note's fee buffer funds the transfer's fee
-  exactly (the Orchard spend and the Ironwood output each pad to the two-action minimum, so the
-  transfer is four logical actions, matching the buffer of `2 source + 2 destination` actions). It
+  exactly (the Orchard spend pads to the two-action minimum, hiding whether an Orchard change output
+  exists, while the Ironwood output is a single unpadded action, so the transfer is three logical
+  actions, matching the buffer of `2 source + 1 destination` actions, per ZIP 318). It
   runs post-NU6.3 (when the Ironwood pool is live), is pure (no database or wallet-backend access),
   and takes the RNG as a parameter. Adds optional `orchard` and `pczt` dependencies, enabled only by
   the feature.

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -640,6 +640,12 @@ pub enum CommitError<E> {
     /// and possibly already broadcast — transactions, and a rebuilt layer 0 would double-spend
     /// the same wallet notes.
     MigrationInProgress,
+    /// The migration plan is internally inconsistent: two of its parallel structures disagree
+    /// (for example a preparation layer has no matching entry in the preparation schedule), so
+    /// it cannot be committed. A plan assembled through `from_parts` is not validated, so a
+    /// malformed one reaches the commit boundary as this typed error rather than a panic; the
+    /// string names which structure and index disagreed, for diagnosis.
+    InconsistentPlan(alloc::string::String),
 }
 
 #[cfg(feature = "orchard")]
@@ -659,6 +665,9 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
                 "a non-terminal migration is already stored; resume or cancel it instead of \
                  committing a new one",
             ),
+            CommitError::InconsistentPlan(m) => {
+                write!(f, "the migration plan is internally inconsistent: {m}")
+            }
         }
     }
 }
@@ -963,7 +972,15 @@ where
             // from one another (see `MigrationPlan::prep_schedule`). The expiry the
             // pre-signature commits to must match that schedule, not the build height: the
             // canonical rolling window at the scheduled height.
-            let scheduled_height = plan.prep_schedule()[layer][index];
+            let scheduled_height = *plan
+                .prep_schedule()
+                .get(layer)
+                .and_then(|layer_schedule| layer_schedule.get(index))
+                .ok_or_else(|| {
+                    CommitError::InconsistentPlan(format!(
+                        "preparation schedule has no entry for layer {layer} transaction {index}"
+                    ))
+                })?;
             let expiry_height = crate::scheduling::expiry_height(scheduled_height);
             let (pczt, placed) = build_prep_tx(
                 params,

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -626,14 +626,21 @@ pub trait MigrationCrypto {
 pub enum CommitError<E> {
     /// A wallet backend operation (witness, key, signing, or storage) failed.
     Backend(E),
-    /// Building or serializing a transaction failed.
-    Build(alloc::string::String),
+    /// Building a migration transaction failed. Carries the structured builder error.
+    Build(crate::build::BuildError),
+    /// Serializing a built migration PCZT (for storage or an external signer) failed.
+    Serialize(pczt::EncodingError),
+    /// NU6.3 is not active on this network, so there is no destination pool to migrate into. The
+    /// planning side models the same recoverable condition as
+    /// [`MigrationError::Nu63NotActive`](MigrationError::Nu63NotActive).
+    Nu63NotActive,
     /// No committed migration was found to build the transfers for (nothing was loaded from storage).
     NoMigrationInProgress,
-    /// A resolved wallet note's value does not match the value the plan recorded for it: the
-    /// wallet's spendable set changed between planning and commit (the plan captures notes by
-    /// their index into that set, so any receipt or spend since planning shifts them), and the
-    /// migration must be re-planned.
+    /// The plan is stale and must be re-planned. Either a resolved wallet note's value no longer
+    /// matches the value the plan recorded for it (the plan captures notes by their index into the
+    /// spendable set at planning time, so any receipt or spend since planning shifts them), or the
+    /// build height has advanced past every candidate anchor boundary the schedule can prove
+    /// against.
     StalePlan,
     /// A non-terminal migration is already stored. A committed migration is resumed from the
     /// store (or cancelled), never rebuilt over: overwriting it would orphan its pre-signed —
@@ -653,13 +660,16 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CommitError::Backend(e) => write!(f, "wallet backend error: {e}"),
-            CommitError::Build(m) => write!(f, "building the migration failed: {m}"),
+            CommitError::Build(e) => write!(f, "building the migration failed: {e}"),
+            CommitError::Serialize(e) => {
+                write!(f, "serializing a migration transaction failed: {e:?}")
+            }
+            CommitError::Nu63NotActive => f.write_str("NU6.3 is not active on this network"),
             CommitError::NoMigrationInProgress => {
                 f.write_str("no committed migration is in progress")
             }
             CommitError::StalePlan => f.write_str(
-                "a wallet note no longer matches the plan; the spendable set changed since \
-                 planning and the migration must be re-planned",
+                "the plan no longer matches the wallet or the build height and must be re-planned",
             ),
             CommitError::MigrationInProgress => f.write_str(
                 "a non-terminal migration is already stored; resume or cancel it instead of \
@@ -767,15 +777,11 @@ where
     match signing {
         Signing::InProcess => {
             let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
-            let bytes = signed
-                .serialize()
-                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+            let bytes = signed.serialize().map_err(CommitError::Serialize)?;
             Ok((bytes, MigrationTxState::Signed))
         }
         Signing::External => {
-            let bytes = pczt
-                .serialize()
-                .map_err(|e| CommitError::Build(format!("serialize: {e:?}")))?;
+            let bytes = pczt.serialize().map_err(CommitError::Serialize)?;
             Ok((bytes, MigrationTxState::AwaitingSignature))
         }
     }
@@ -897,7 +903,7 @@ where
     let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
     let nu63_activation = params
         .activation_height(NetworkUpgrade::Nu6_3)
-        .ok_or_else(|| CommitError::Build("NU6.3 is not active on this network".into()))?;
+        .ok_or(CommitError::Nu63NotActive)?;
 
     let mut transactions: Vec<MigrationTransaction> = Vec::new();
     let mut unsigned: Vec<UnsignedMigrationTx> = Vec::new();
@@ -948,7 +954,7 @@ where
                             .iter()
                             .position(|(v, _, used)| !used && v == value)
                             .ok_or_else(|| {
-                                CommitError::Build(format!(
+                                CommitError::InconsistentPlan(format!(
                                     "layer {layer} spends a feeder note of value {} that no \
                                      earlier layer mints",
                                     u64::from(*value)
@@ -991,7 +997,7 @@ where
                 prep_tx.outputs(),
                 &mut *rng,
             )
-            .map_err(|e| CommitError::Build(format!("{e}")))?;
+            .map_err(CommitError::Build)?;
 
             // Grow the minted pool with this transaction's recovered spendable outputs. Change
             // outputs are excluded: they stay in the source pool and must never be matched to a
@@ -1068,13 +1074,15 @@ where
         next_id += 1;
 
         let funding_value = *funding_notes.get(crossing).ok_or_else(|| {
-            CommitError::Build(format!("no funding note value for crossing {crossing}"))
+            CommitError::InconsistentPlan(format!("no funding note value for crossing {crossing}"))
         })?;
         let pos = minted
             .iter()
             .position(|(v, _, used)| !used && *v == funding_value)
             .ok_or_else(|| {
-                CommitError::Build(format!("no minted funding note for crossing {crossing}"))
+                CommitError::InconsistentPlan(format!(
+                    "no minted funding note for crossing {crossing}"
+                ))
             })?;
         minted[pos].2 = true;
         let note = minted[pos].1;
@@ -1083,7 +1091,9 @@ where
             .crossing_values()
             .get(crossing)
             .ok_or_else(|| {
-                CommitError::Build(format!("no stored crossing value for transfer {crossing}"))
+                CommitError::InconsistentPlan(format!(
+                    "no stored crossing value for transfer {crossing}"
+                ))
             })?;
 
         let pczt = build_transfer_pczt(
@@ -1095,7 +1105,7 @@ where
             crossing_value,
             &mut *rng,
         )
-        .map_err(|e| CommitError::Build(format!("{e}")))?;
+        .map_err(CommitError::Build)?;
         let (bytes, tx_state) = finish_built_pczt(backend, pczt, signing)?;
         if matches!(signing, Signing::External) {
             unsigned.push(UnsignedMigrationTx {
@@ -1119,13 +1129,7 @@ where
                     schedule.broadcast_height(),
                     rng,
                 )
-                .ok_or_else(|| {
-                    CommitError::Build(
-                        "transfer scheduled before any candidate anchor boundary; the plan is \
-                         stale relative to the build height and must be re-planned"
-                            .into(),
-                    )
-                })?,
+                .ok_or(CommitError::StalePlan)?,
             ),
             state: tx_state,
         });


### PR DESCRIPTION
Extracted from #2669 — two small, independent backend improvements to the merged pool-migration engine, in one PR:

**Transfer-shape doc fix** — the CHANGELOG described the transfer as `four logical actions / 2 source + 2 destination`; the code builds three (`2 source + 1 destination`, the single unpadded Ironwood output, per ZIP 318). One-line correction.

**CommitError error modeling** (two atomic commits):
- Replace the `plan.prep_schedule()[layer][index]` out-of-bounds *panic* on a malformed/inconsistent stored plan with a typed `CommitError::InconsistentPlan` at the public boundary.
- De-stringify `CommitError::Build(String)`: carry the structured `build::BuildError` in `Build`, add a `Serialize(EncodingError)` variant, and model NU6.3-not-active as `Nu63NotActive`; the re-plan case shares `StalePlan`. Callers can now match on the condition instead of parsing a message.