### PR TITLE
zcash_pool_migration: consult the drawn anchor boundary at proving time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,12 @@ since Mermaid layout is hard to reason about in plain text.
   canonical leaf strategies into strategies for its own types; it does not
   re-derive the leaves.
 
+- **No issue or PR numbers in code comments.** A comment must stand on its own,
+  explaining the code in words. Do not annotate it with an issue/PR reference
+  (`issue #2700`, `see #1234`): when the patch already solves the problem the
+  reference is stale noise, and when it tracks future work that belongs in the
+  issue tracker, not the source. Name the concern instead of linking to it.
+
 ## Build & Test Commands
 
 For the most part we follow standard Rust `cargo` practices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,11 +185,14 @@ since Mermaid layout is hard to reason about in plain text.
   canonical leaf strategies into strategies for its own types; it does not
   re-derive the leaves.
 
-- **No issue or PR numbers in code comments.** A comment must stand on its own,
-  explaining the code in words. Do not annotate it with an issue/PR reference
-  (`issue #2700`, `see #1234`): when the patch already solves the problem the
-  reference is stale noise, and when it tracks future work that belongs in the
-  issue tracker, not the source. Name the concern instead of linking to it.
+- **No issue or PR numbers in code comments, except in TODOs.** A comment must
+  stand on its own, explaining the code in words. Do not annotate it with an
+  issue/PR reference (`issue #2700`, `see #1234`): when the patch already solves
+  the problem the reference is stale noise, and when it tracks future work that
+  belongs in the issue tracker, not the source. Name the concern instead of
+  linking to it. The exception is a `TODO`: referencing the tracking issue from
+  a `TODO` is helpful and does not go stale, because the `TODO` comment should
+  be removed at the time the issue is resolved.
 
 ## Build & Test Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7326,13 +7326,18 @@ dependencies = [
  "orchard",
  "pczt",
  "proptest",
+ "prost",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "rusqlite",
  "shardtree",
+ "tempfile",
  "zcash_client_backend",
+ "zcash_client_sqlite",
  "zcash_keys",
  "zcash_pool_migration_memory",
  "zcash_primitives",
+ "zcash_proofs",
  "zcash_protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ categories = ["cryptography::cryptocurrencies"]
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.24.0-rc.1", path = "zcash_client_backend" }
+zcash_client_sqlite = { version = "0.22.0-rc.1", path = "zcash_client_sqlite" }
 zcash_encoding = { version = "0.4", path = "components/zcash_encoding", default-features = false }
 zcash_keys = { version = "0.15.0", path = "zcash_keys", default-features = false  }
 zcash_pool_migration_backend = { version = "0.1.0", path = "zcash_pool_migration_backend" }
@@ -56,6 +57,7 @@ ff = { version = "0.13", default-features = false }
 group = "0.13"
 incrementalmerkletree = { version = "0.8.2", default-features = false }
 shardtree = "0.7"
+tempfile = "3.5.0"
 zcash_spec = "0.2"
 
 # Payment protocols

--- a/components/zcash_protocol/src/value.rs
+++ b/components/zcash_protocol/src/value.rs
@@ -547,6 +547,15 @@ pub mod testing {
 
     use super::{MAX_BALANCE, MAX_MONEY, ZatBalance, Zatoshis};
 
+    /// A raw zatoshi amount as [`Zatoshis`], for terse test fixtures.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `amount` exceeds [`MAX_MONEY`](super::MAX_MONEY).
+    pub fn zats(amount: u64) -> Zatoshis {
+        Zatoshis::const_from_u64(amount)
+    }
+
     prop_compose! {
         pub fn arb_zat_balance()(amt in -MAX_BALANCE..MAX_BALANCE) -> ZatBalance {
             ZatBalance::from_i64(amt).unwrap()

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -95,6 +95,13 @@ rand_core.workspace = true
 rand_distr.workspace = true
 rand.workspace = true
 
+# Enabled by the `test-dependencies` feature, which exposes the in-crate test harness
+# (`testing::db::TestDbFactory`, `testing::BlockCache`) to external test code. They stay in
+# `[dev-dependencies]` too so the crate's own tests build without enabling the feature.
+ambassador = { workspace = true, optional = true }
+rand_chacha = { workspace = true, optional = true }
+tempfile = { version = "3.5.0", optional = true }
+
 [dev-dependencies]
 ambassador.workspace = true
 assert_matches.workspace = true
@@ -134,6 +141,9 @@ orchard = ["dep:orchard", "zcash_client_backend/orchard", "zcash_keys/orchard"]
 
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.
 test-dependencies = [
+    "dep:ambassador",
+    "dep:rand_chacha",
+    "dep:tempfile",
     "incrementalmerkletree/test-dependencies",
     "zcash_primitives/test-dependencies",
     "zcash_client_backend/test-dependencies",

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -95,9 +95,6 @@ rand_core.workspace = true
 rand_distr.workspace = true
 rand.workspace = true
 
-# Enabled by the `test-dependencies` feature, which exposes the in-crate test harness
-# (`testing::db::TestDbFactory`, `testing::BlockCache`) to external test code. They stay in
-# `[dev-dependencies]` too so the crate's own tests build without enabling the feature.
 ambassador = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 tempfile = { version = "3.5.0", optional = true }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -161,8 +161,9 @@ pub mod wallet;
 #[cfg(feature = "zewif")]
 pub mod zewif;
 
-#[cfg(test)]
-mod testing;
+#[cfg(any(test, feature = "test-dependencies"))]
+#[allow(missing_docs)]
+pub mod testing;
 
 /// The maximum number of blocks the wallet is allowed to rewind. This is
 /// consistent with the bound in zcashd, and allows block data deeper than

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -162,7 +162,6 @@ pub mod wallet;
 pub mod zewif;
 
 #[cfg(any(test, feature = "test-dependencies"))]
-#[allow(missing_docs)]
 pub mod testing;
 
 /// The maximum number of blocks the wallet is allowed to rewind. This is

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -47,6 +47,12 @@ impl BlockCache {
     }
 }
 
+impl Default for BlockCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct BlockCacheInsertionResult {
     txids: Vec<TxId>,
     #[allow(dead_code)]

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -103,6 +103,40 @@ impl TestCache for BlockCache {
     }
 }
 
+/// The highest checkpoint at or below `from` whose Orchard commitment-tree root is available, or
+/// `None` if there is none at or below `from`. Right after scanning, the tip checkpoint is not yet
+/// rooted, so a spend anchors to the newest settled checkpoint below it (every note mined at or
+/// before that height is still witnessable there).
+#[cfg(feature = "orchard")]
+pub fn highest_rooted_orchard_checkpoint<W>(
+    db: &mut W,
+    from: zcash_protocol::consensus::BlockHeight,
+) -> Option<zcash_protocol::consensus::BlockHeight>
+where
+    W: zcash_client_backend::data_api::WalletCommitmentTrees,
+{
+    use shardtree::error::ShardTreeError;
+    use zcash_client_backend::data_api::WalletCommitmentTrees;
+    use zcash_protocol::consensus::BlockHeight;
+
+    let mut height = u32::from(from);
+    loop {
+        let bh = BlockHeight::from_u32(height);
+        let rooted = db
+            .with_orchard_tree_mut::<_, _, ShardTreeError<<W as WalletCommitmentTrees>::Error>>(
+                |tree| Ok(tree.root_at_checkpoint_id(&bh)?.is_some()),
+            )
+            .expect("queries the Orchard tree");
+        if rooted {
+            return Some(bh);
+        }
+        if height == 0 {
+            return None;
+        }
+        height -= 1;
+    }
+}
+
 #[cfg(feature = "unstable")]
 pub(crate) struct FsBlockCache {
     fsblockdb_root: TempDir,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -22,16 +22,20 @@ use {
     tempfile::TempDir,
 };
 
-pub(crate) mod db;
+pub mod db;
+// The shielded-pool testers are used only by this crate's own in-crate tests, not by external
+// consumers of the exposed harness, so they stay test-only and keep their heavier test-only
+// dependencies (proptest, incrementalmerkletree-testing) out of the `test-dependencies` build.
+#[cfg(test)]
 pub(crate) mod pool;
 
-pub(crate) struct BlockCache {
+pub struct BlockCache {
     _cache_file: NamedTempFile,
     db_cache: BlockDb,
 }
 
 impl BlockCache {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let cache_file = NamedTempFile::new().unwrap();
         let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
         init_cache_database(&db_cache).unwrap();
@@ -43,7 +47,7 @@ impl BlockCache {
     }
 }
 
-pub(crate) struct BlockCacheInsertionResult {
+pub struct BlockCacheInsertionResult {
     txids: Vec<TxId>,
     #[allow(dead_code)]
     note_commitments: NoteCommitments,

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -12,6 +12,7 @@ use zcash_client_backend::{
     proto::compact_formats::CompactBlock,
 };
 use zcash_protocol::TxId;
+use zcash_protocol::consensus::BlockHeight;
 
 use crate::{chain::init::init_cache_database, error::SqliteClientError};
 
@@ -124,16 +125,12 @@ impl TestCache for BlockCache {
 /// rooted, so a spend anchors to the newest settled checkpoint below it (every note mined at or
 /// before that height is still witnessable there).
 #[cfg(feature = "orchard")]
-pub fn highest_rooted_orchard_checkpoint<W>(
-    db: &mut W,
-    from: zcash_protocol::consensus::BlockHeight,
-) -> Option<zcash_protocol::consensus::BlockHeight>
+pub fn highest_rooted_orchard_checkpoint<W>(db: &mut W, from: BlockHeight) -> Option<BlockHeight>
 where
     W: zcash_client_backend::data_api::WalletCommitmentTrees,
 {
     use shardtree::error::ShardTreeError;
     use zcash_client_backend::data_api::WalletCommitmentTrees;
-    use zcash_protocol::consensus::BlockHeight;
 
     let mut height = u32::from(from);
     loop {

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1,3 +1,8 @@
+//! Test-support utilities exposed under the `test-dependencies` feature: an in-memory
+//! [`db::TestDbFactory`] / [`db::TestDb`] wallet for the `zcash_client_backend` testing framework, a
+//! [`BlockCache`] compact-block source, and the [`highest_rooted_orchard_checkpoint`] commitment-tree
+//! helper. Consumed by this crate's own tests and, through the feature, by downstream crates' tests.
+
 use prost::Message;
 use rusqlite::params;
 use tempfile::NamedTempFile;
@@ -12,7 +17,7 @@ use crate::{chain::init::init_cache_database, error::SqliteClientError};
 
 use super::BlockDb;
 
-#[cfg(feature = "unstable")]
+#[cfg(all(test, feature = "unstable"))]
 use {
     crate::{
         FsBlockDb, FsBlockDbError,
@@ -29,12 +34,15 @@ pub mod db;
 #[cfg(test)]
 pub(crate) mod pool;
 
+/// An in-memory compact-block cache backed by a temporary [`BlockDb`], implementing the
+/// `zcash_client_backend` testing framework's [`TestCache`].
 pub struct BlockCache {
     _cache_file: NamedTempFile,
     db_cache: BlockDb,
 }
 
 impl BlockCache {
+    /// Creates an empty cache over a fresh temporary block database.
     pub fn new() -> Self {
         let cache_file = NamedTempFile::new().unwrap();
         let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
@@ -53,6 +61,8 @@ impl Default for BlockCache {
     }
 }
 
+/// The result of inserting a compact block into a [`BlockCache`]: the block's transaction ids and
+/// the note commitments it added.
 pub struct BlockCacheInsertionResult {
     txids: Vec<TxId>,
     #[allow(dead_code)]
@@ -143,13 +153,13 @@ where
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(all(test, feature = "unstable"))]
 pub(crate) struct FsBlockCache {
     fsblockdb_root: TempDir,
     db_meta: FsBlockDb,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(all(test, feature = "unstable"))]
 impl FsBlockCache {
     pub(crate) fn new() -> Self {
         let fsblockdb_root = tempfile::tempdir().unwrap();
@@ -163,21 +173,23 @@ impl FsBlockCache {
     }
 }
 
-#[cfg(feature = "unstable")]
+/// The result of inserting a compact block into an [`FsBlockCache`]: the block's transaction ids and
+/// its on-disk block metadata.
+#[cfg(all(test, feature = "unstable"))]
 #[derive(Debug)]
 pub struct FsBlockCacheInsertionResult {
     txids: Vec<TxId>,
     pub(crate) block_meta: BlockMeta,
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(all(test, feature = "unstable"))]
 impl CacheInsertionResult for FsBlockCacheInsertionResult {
     fn txids(&self) -> &[TxId] {
         &self.txids[..]
     }
 }
 
-#[cfg(feature = "unstable")]
+#[cfg(all(test, feature = "unstable"))]
 impl TestCache for FsBlockCache {
     type BsError = FsBlockDbError;
     type BlockSource = FsBlockDb;

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -1,3 +1,6 @@
+//! An in-memory [`WalletDb`]-backed data store and [`DataStoreFactory`] for the
+//! `zcash_client_backend` testing framework.
+
 use ambassador::Delegate;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
@@ -66,6 +69,8 @@ pub(crate) fn test_rng() -> ChaChaRng {
     ChaChaRng::from_seed([0u8; 32])
 }
 
+/// A [`WalletDb`] wrapped as a testing-framework data store: it delegates the wallet traits to the
+/// inner database and owns the temporary file backing it.
 #[allow(clippy::duplicated_attributes, reason = "False positive")]
 #[derive(Delegate)]
 #[delegate(InputSource, target = "wallet_db")]
@@ -89,10 +94,12 @@ impl TestDb {
         }
     }
 
+    /// The wrapped wallet database.
     pub fn db(&self) -> &WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
         &self.wallet_db
     }
 
+    /// The wrapped wallet database, mutably.
     pub fn db_mut(&mut self) -> &mut WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
         &mut self.wallet_db
     }
@@ -176,6 +183,8 @@ unsafe fn run_sqlite3<S: AsRef<OsStr>>(db_path: S, command: &str) {
     eprintln!("------");
 }
 
+/// A [`DataStoreFactory`] that builds fresh in-memory [`TestDb`] wallets, optionally migrated only
+/// to a given set of migrations rather than all of them.
 #[derive(Default)]
 pub struct TestDbFactory {
     target_migrations: Option<Vec<Uuid>>,

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -73,7 +73,7 @@ pub(crate) fn test_rng() -> ChaChaRng {
 #[delegate(WalletTest, target = "wallet_db")]
 #[delegate(WalletWrite, target = "wallet_db")]
 #[delegate(WalletCommitmentTrees, target = "wallet_db")]
-pub(crate) struct TestDb {
+pub struct TestDb {
     wallet_db: WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng>,
     data_file: NamedTempFile,
 }
@@ -89,20 +89,22 @@ impl TestDb {
         }
     }
 
-    pub(crate) fn db(&self) -> &WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
+    pub fn db(&self) -> &WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
         &self.wallet_db
     }
 
-    pub(crate) fn db_mut(
-        &mut self,
-    ) -> &mut WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
+    pub fn db_mut(&mut self) -> &mut WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng> {
         &mut self.wallet_db
     }
 
+    // Used only by this crate's own `#[cfg(test)]` tests, not by the harness exposed under
+    // `test-dependencies`, so it is dead in a non-test `test-dependencies` build.
+    #[allow(dead_code)]
     pub(crate) fn conn(&self) -> &Connection {
         &self.wallet_db.conn
     }
 
+    #[allow(dead_code)]
     pub(crate) fn conn_mut(&mut self) -> &mut Connection {
         &mut self.wallet_db.conn
     }
@@ -175,7 +177,7 @@ unsafe fn run_sqlite3<S: AsRef<OsStr>>(db_path: S, command: &str) {
 }
 
 #[derive(Default)]
-pub(crate) struct TestDbFactory {
+pub struct TestDbFactory {
     target_migrations: Option<Vec<Uuid>>,
 }
 

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -49,8 +49,20 @@ incrementalmerkletree = { workspace = true, optional = true }
 
 [dev-dependencies]
 incrementalmerkletree.workspace = true
+pczt = { workspace = true, features = ["orchard", "tx-extractor"] }
+prost.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
+rusqlite.workspace = true
+shardtree.workspace = true
+tempfile.workspace = true
+# The wallet-backed real-proving E2E (`tests/prove_chain_sim.rs`) drives a real in-memory
+# `WalletDb` through the `zcash_client_backend` testing framework: fund an account, commit a
+# migration, then prove + mine + scan the preparation and prove the transfer against the wallet's
+# own Orchard commitment tree. `zcash_proofs` supplies the halo2 proving parameters.
+zcash_client_backend = { workspace = true, features = ["orchard", "test-dependencies"] }
+zcash_client_sqlite = { workspace = true, features = ["orchard", "test-dependencies"] }
+zcash_proofs.workspace = true
 
 # The `local-consensus` feature exposes `LocalNetwork`, used to build the migration transactions
 # against regtest params with the relevant network upgrades (including NU6.3) active.
@@ -86,6 +98,13 @@ test-dependencies = [
     "zcash_primitives/test-dependencies",
     "zcash_protocol/test-dependencies",
 ]
+## A marker that tracks `zcash_client_backend`'s `transparent-inputs` feature so the funded-wallet
+## end-to-end test's `DataStoreFactory` implementation matches the trait, whose `new_data_store`
+## gains a `gap_limits` parameter under `transparent-inputs`. It intentionally enables nothing on its
+## own: under a `--workspace` build (all workspace members get `transparent-inputs` together) and
+## under `--all-features`, this is on exactly when the wallet crates' `transparent-inputs` is, which
+## is the only build that compiles that test (it needs `wallet` too).
+transparent-inputs = []
 
 [lints]
 workspace = true

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -35,6 +35,7 @@ orchard = { workspace = true, optional = true }
 pczt = { workspace = true, optional = true, features = [
     "io-finalizer",
     "orchard",
+    "prover",
     "signer",
     "zcp-builder",
 ] }

--- a/zcash_pool_migration_backend/Cargo.toml
+++ b/zcash_pool_migration_backend/Cargo.toml
@@ -56,10 +56,6 @@ rand_chacha.workspace = true
 rusqlite.workspace = true
 shardtree.workspace = true
 tempfile.workspace = true
-# The wallet-backed real-proving E2E (`tests/prove_chain_sim.rs`) drives a real in-memory
-# `WalletDb` through the `zcash_client_backend` testing framework: fund an account, commit a
-# migration, then prove + mine + scan the preparation and prove the transfer against the wallet's
-# own Orchard commitment tree. `zcash_proofs` supplies the halo2 proving parameters.
 zcash_client_backend = { workspace = true, features = ["orchard", "test-dependencies"] }
 zcash_client_sqlite = { workspace = true, features = ["orchard", "test-dependencies"] }
 zcash_proofs.workspace = true

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -787,11 +787,12 @@ pub trait MigrationCrypto {
 /// (ZIP 374) against the boundary its schedule drew, then prove it.
 ///
 /// This is deliberately SEPARATE from [`MigrationCrypto`]. Signing needs only the account's spend
-/// authority and is a cheap, read-only (`&self`) operation; proving needs the wallet's Orchard
-/// commitment tree at a historical checkpoint plus the Orchard and Ironwood proving keys, a heavier
-/// capability with a different lifetime. Keeping proving in its own trait lets a wallet expose
-/// signing without dragging commitment-tree access and proving parameters into the same type, and
-/// lets a consumer supply a prover independently of the signer.
+/// authority and is a cheap, read-only (`&self`) operation; proving needs MUTABLE access to the
+/// wallet's Orchard commitment tree at a historical checkpoint (resolving a witness caches into the
+/// tree) plus the Orchard and Ironwood proving keys, a heavier capability with a different lifetime.
+/// Keeping proving in its own trait lets a wallet expose signing without dragging commitment-tree
+/// access and proving parameters into the same type, and lets a consumer supply a prover
+/// independently of the signer.
 #[cfg(feature = "orchard")]
 pub trait MigrationProver {
     /// The prover's error type.
@@ -813,7 +814,7 @@ pub trait MigrationProver {
     /// wallet's commitment tree at proving time; a wallet backend keeps it alive through migration
     /// anchor-checkpoint retention (see issue #2700).
     fn prove_transfer(
-        &self,
+        &mut self,
         pczt: pczt::Pczt,
         anchor_boundary: BlockHeight,
     ) -> Result<pczt::Pczt, Self::Error>;
@@ -958,7 +959,7 @@ impl<E: core::error::Error> core::error::Error for ProveError<E> {}
 /// is rejected with [`ProveError::NotReady`] rather than re-proved.
 #[cfg(feature = "orchard")]
 pub fn prove_transfer<P>(
-    prover: &P,
+    prover: &mut P,
     state: &mut MigrationState,
     id: MigrationTxId,
 ) -> Result<(), ProveError<P::Error>>
@@ -1975,7 +1976,7 @@ mod commit_tests {
         type Error = core::convert::Infallible;
 
         fn prove_transfer(
-            &self,
+            &mut self,
             pczt: pczt::Pczt,
             _anchor_boundary: BlockHeight,
         ) -> Result<pczt::Pczt, Self::Error> {
@@ -2609,7 +2610,7 @@ mod commit_tests {
             .expect("a committed migration has transfers");
 
         // Proving reads the persisted boundary, proves, and advances Signed -> Proved.
-        prove_transfer(&backend, &mut state, transfer_id).expect("proves the due transfer");
+        prove_transfer(&mut backend, &mut state, transfer_id).expect("proves the due transfer");
         let proved = state
             .transactions
             .iter()
@@ -2622,7 +2623,7 @@ mod commit_tests {
 
         // An already-proved transfer is not re-proved.
         assert!(matches!(
-            prove_transfer(&backend, &mut state, transfer_id),
+            prove_transfer(&mut backend, &mut state, transfer_id),
             Err(ProveError::NotReady(_))
         ));
 
@@ -2635,7 +2636,7 @@ mod commit_tests {
             .expect("a committed migration has preparation transactions")
             .id;
         assert!(matches!(
-            prove_transfer(&backend, &mut state, prep_id),
+            prove_transfer(&mut backend, &mut state, prep_id),
             Err(ProveError::NotATransfer(_))
         ));
     }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -487,6 +487,21 @@ impl MigrationState {
     pub fn funding_notes(&self) -> Vec<Zatoshis> {
         self.note_split.migration_outputs()
     }
+
+    /// Replace transfer `id`'s stored PCZT with its proven bytes and move it to
+    /// [`Proved`](MigrationTxState::Proved). Called after [`prove_transfer`] installs the drawn
+    /// anchor and witnesses and proves the transaction, so the durable artifact becomes the proven,
+    /// ready-to-broadcast PCZT.
+    #[cfg(feature = "orchard")]
+    pub fn set_transaction_proved(&mut self, id: MigrationTxId, proven_pczt: Vec<u8>) {
+        for tx in &mut self.transactions {
+            if tx.id() == id {
+                tx.pczt = proven_pczt;
+                tx.state = MigrationTxState::Proved;
+                break;
+            }
+        }
+    }
 }
 
 /// A planned migration, before anything is built, signed, or broadcast: the denomination split, the
@@ -768,6 +783,42 @@ pub trait MigrationCrypto {
     fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
 }
 
+/// The proving seam for a migration transfer: install a transfer's deferred anchors and witnesses
+/// (ZIP 374) against the boundary its schedule drew, then prove it.
+///
+/// This is deliberately SEPARATE from [`MigrationCrypto`]. Signing needs only the account's spend
+/// authority and is a cheap, read-only (`&self`) operation; proving needs the wallet's Orchard
+/// commitment tree at a historical checkpoint plus the Orchard and Ironwood proving keys, a heavier
+/// capability with a different lifetime. Keeping proving in its own trait lets a wallet expose
+/// signing without dragging commitment-tree access and proving parameters into the same type, and
+/// lets a consumer supply a prover independently of the signer.
+#[cfg(feature = "orchard")]
+pub trait MigrationProver {
+    /// The prover's error type.
+    type Error;
+
+    /// Prove a pre-signed transfer against the boundary its schedule drew.
+    ///
+    /// This is where a transfer's DEFERRED anchors and witnesses (ZIP 374) are finally resolved and
+    /// installed: the implementation reads the Orchard source-tree root at the `anchor_boundary`
+    /// checkpoint (the source anchor) and the funding note's Merkle witness against it, installs both
+    /// through the PCZT `Updater` role (`set_anchor` / `set_spend_witness`), installs the Ironwood
+    /// destination anchor for the output bundle, then proves both bundles and returns the proven
+    /// PCZT, ready to broadcast. The `anchor_boundary` is the boundary height drawn at SCHEDULING
+    /// time and persisted on the transaction ([`MigrationTransaction::anchor_boundary`]); passing it
+    /// here is what makes the drawn boundary, not the tip, the tree state the transfer proves
+    /// against.
+    ///
+    /// Resolving the funding note's witness requires the boundary checkpoint to still exist in the
+    /// wallet's commitment tree at proving time; a wallet backend keeps it alive through migration
+    /// anchor-checkpoint retention (see issue #2700).
+    fn prove_transfer(
+        &self,
+        pczt: pczt::Pczt,
+        anchor_boundary: BlockHeight,
+    ) -> Result<pczt::Pczt, Self::Error>;
+}
+
 /// Why committing a migration's preparation failed.
 #[cfg(feature = "orchard")]
 #[derive(Debug)]
@@ -832,6 +883,112 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
 
 #[cfg(feature = "orchard")]
 impl<E: core::error::Error> core::error::Error for CommitError<E> {}
+
+/// Why proving a migration transfer failed.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum ProveError<E> {
+    /// No transaction with the given id belongs to the migration.
+    UnknownTransaction(MigrationTxId),
+    /// The transaction is a preparation transaction, not a transfer; only transfers are proved
+    /// against a drawn anchor boundary (a preparation transaction carries no boundary).
+    NotATransfer(MigrationTxId),
+    /// The transaction is not in the [`Signed`](MigrationTxState::Signed) state, so it is not ready
+    /// to prove (it is unsigned, already proved, or already broadcast).
+    NotReady(MigrationTxId),
+    /// A transfer carries no anchor boundary. Every transfer draws one at scheduling time, so this
+    /// indicates a corrupt stored state rather than a normal condition.
+    NoAnchorBoundary(MigrationTxId),
+    /// The stored PCZT could not be parsed.
+    Parse(pczt::ParseError),
+    /// The proven PCZT could not be serialized.
+    Serialize(pczt::EncodingError),
+    /// The prover failed to resolve, install, or prove the transfer.
+    Prover(E),
+}
+
+#[cfg(feature = "orchard")]
+impl<E: fmt::Display> fmt::Display for ProveError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProveError::UnknownTransaction(id) => {
+                write!(f, "no migration transaction with id {}", u32::from(*id))
+            }
+            ProveError::NotATransfer(id) => write!(
+                f,
+                "transaction {} is a preparation transaction, not a transfer",
+                u32::from(*id)
+            ),
+            ProveError::NotReady(id) => {
+                write!(
+                    f,
+                    "transaction {} is not signed and ready to prove",
+                    u32::from(*id)
+                )
+            }
+            ProveError::NoAnchorBoundary(id) => write!(
+                f,
+                "transfer {} has no drawn anchor boundary; the stored state is inconsistent",
+                u32::from(*id)
+            ),
+            ProveError::Parse(e) => write!(f, "parsing the stored PCZT failed: {e:?}"),
+            ProveError::Serialize(e) => write!(f, "serializing the proven PCZT failed: {e:?}"),
+            ProveError::Prover(e) => write!(f, "proving the transfer failed: {e}"),
+        }
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl<E: core::error::Error> core::error::Error for ProveError<E> {}
+
+/// Prove a pre-signed migration transfer against the boundary its schedule drew, moving it
+/// `Signed -> Proved`.
+///
+/// This is the step that finally consults a transfer's PERSISTED
+/// [`anchor_boundary`](MigrationTransaction::anchor_boundary), drawn at scheduling time: it reads
+/// that boundary and hands the stored PCZT and the boundary to
+/// [`MigrationProver::prove_transfer`], which installs the Orchard source anchor and the funding
+/// note's witness against that boundary and the Ironwood destination anchor (through the PCZT
+/// `Updater` role), then proves both bundles. The proven PCZT replaces the stored one and the
+/// transaction becomes [`Proved`](MigrationTxState::Proved), ready to broadcast.
+///
+/// The CALLER decides WHEN to prove each transfer (once its funding note is mined and witnessable
+/// and its scheduled height reached); this function performs the proof for the one transfer `id`. It
+/// is idempotent only in the sense that a transaction not in [`Signed`](MigrationTxState::Signed)
+/// is rejected with [`ProveError::NotReady`] rather than re-proved.
+#[cfg(feature = "orchard")]
+pub fn prove_transfer<P>(
+    prover: &P,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+) -> Result<(), ProveError<P::Error>>
+where
+    P: MigrationProver,
+{
+    let tx = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == id)
+        .ok_or(ProveError::UnknownTransaction(id))?;
+    if !matches!(tx.kind(), MigrationTxKind::Transfer { .. }) {
+        return Err(ProveError::NotATransfer(id));
+    }
+    if !matches!(tx.state(), MigrationTxState::Signed) {
+        return Err(ProveError::NotReady(id));
+    }
+    let anchor_boundary = tx
+        .anchor_boundary()
+        .ok_or(ProveError::NoAnchorBoundary(id))?;
+
+    let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
+    let proven = prover
+        .prove_transfer(pczt, anchor_boundary)
+        .map_err(ProveError::Prover)?;
+    let bytes = proven.serialize().map_err(ProveError::Serialize)?;
+
+    state.set_transaction_proved(id, bytes);
+    Ok(())
+}
 
 /// How a freshly built migration PCZT is finished by the commit functions: signed in-process with the
 /// wallet's spend authority, or left unsigned for an external (hardware or offline) signer.
@@ -1814,6 +1971,25 @@ mod commit_tests {
         }
     }
 
+    impl MigrationProver for CommitMock {
+        type Error = core::convert::Infallible;
+
+        fn prove_transfer(
+            &self,
+            pczt: pczt::Pczt,
+            _anchor_boundary: BlockHeight,
+        ) -> Result<pczt::Pczt, Self::Error> {
+            // A stand-in for proving. A real prover resolves the funding note's witness against
+            // `anchor_boundary`, installs the Orchard source and Ironwood destination anchors
+            // through the PCZT `Updater` role, and runs the Orchard + Ironwood provers. Resolving
+            // the funding note requires commitment-tree access this mock does not model, so it
+            // returns the PCZT unchanged; the engine's `prove_transfer` orchestration (reading and
+            // passing the persisted `anchor_boundary`, and the Signed -> Proved transition) is what
+            // the tests exercise.
+            Ok(pczt)
+        }
+    }
+
     /// A planned single-note migration and the mock wallet that holds the note.
     fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
         let backend = CommitMock::new(seed, &[balance]);
@@ -2393,6 +2569,74 @@ mod commit_tests {
                 &mut rng,
             ),
             Err(CommitError::StalePlan)
+        ));
+    }
+
+    /// Proving a due transfer consults the anchor boundary the schedule DREW and persisted on the
+    /// transaction (not the tip), moving it `Signed -> Proved`. This exercises the engine
+    /// orchestration of [`prove_transfer`]: it reads the persisted `anchor_boundary`, hands it to
+    /// the crypto backend (here the in-memory mock stands in for the real prover), stores the
+    /// returned PCZT, and advances the state. It also checks the guards: a preparation transaction
+    /// is not a transfer, and an already-proved transfer is not re-proved.
+    #[test]
+    fn prove_transfer_consults_the_persisted_anchor_boundary() {
+        let seed = 7u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+        let params = regtest_network(true);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+
+        // Every transfer is Signed and carries a drawn anchor boundary after commit.
+        let transfer_id = state
+            .transactions
+            .iter()
+            .find(|t| matches!(t.kind, MigrationTxKind::Transfer { .. }))
+            .map(|t| {
+                assert!(
+                    t.anchor_boundary.is_some(),
+                    "a transfer carries the boundary its schedule drew"
+                );
+                assert!(matches!(t.state, MigrationTxState::Signed));
+                t.id
+            })
+            .expect("a committed migration has transfers");
+
+        // Proving reads the persisted boundary, proves, and advances Signed -> Proved.
+        prove_transfer(&backend, &mut state, transfer_id).expect("proves the due transfer");
+        let proved = state
+            .transactions
+            .iter()
+            .find(|t| t.id == transfer_id)
+            .expect("the transfer is still present");
+        assert!(
+            matches!(proved.state, MigrationTxState::Proved),
+            "the transfer is proved"
+        );
+
+        // An already-proved transfer is not re-proved.
+        assert!(matches!(
+            prove_transfer(&backend, &mut state, transfer_id),
+            Err(ProveError::NotReady(_))
+        ));
+
+        // A preparation transaction is not a transfer: it anchors to its dependencies, not a drawn
+        // boundary, so it is rejected rather than proved.
+        let prep_id = state
+            .transactions
+            .iter()
+            .find(|t| matches!(t.kind, MigrationTxKind::Preparation { .. }))
+            .expect("a committed migration has preparation transactions")
+            .id;
+        assert!(matches!(
+            prove_transfer(&backend, &mut state, prep_id),
+            Err(ProveError::NotATransfer(_))
         ));
     }
 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -2372,7 +2372,8 @@ mod commit_tests {
         let mut state = state;
         let target = BlockHeight::from_u32(2_100_000);
         match state.next_step(target) {
-            crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { id }
+            | crate::state::AdvanceStep::Broadcast { id } => {
                 assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
             }
             other => panic!("expected a broadcast step, got {other:?}"),
@@ -2387,7 +2388,8 @@ mod commit_tests {
             .map(|t| t.id)
             .collect();
         match state.next_step(target) {
-            crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { id }
+            | crate::state::AdvanceStep::Broadcast { id } => {
                 assert!(
                     layer1_ids.contains(&id),
                     "layer 1 broadcasts once layer 0 mines"
@@ -2399,7 +2401,8 @@ mod commit_tests {
             state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
         }
         match state.next_step(target) {
-            crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { id }
+            | crate::state::AdvanceStep::Broadcast { id } => {
                 let tx = state
                     .transactions
                     .iter()
@@ -2544,9 +2547,10 @@ mod commit_tests {
         for layer in 0..layer_count {
             let ids = layer_ids(&state, layer);
             match state.next_step(target) {
-                crate::state::AdvanceStep::Broadcast { id } => assert!(
+                crate::state::AdvanceStep::Prove { id }
+                | crate::state::AdvanceStep::Broadcast { id } => assert!(
                     ids.contains(&id),
-                    "layer {layer} broadcasts once its predecessor has mined"
+                    "layer {layer} is proved or broadcast once its predecessor has mined"
                 ),
                 other => panic!("expected a layer-{layer} broadcast, got {other:?}"),
             }
@@ -2573,7 +2577,8 @@ mod commit_tests {
             }
         }
         match state.next_step(target) {
-            crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { id }
+            | crate::state::AdvanceStep::Broadcast { id } => {
                 let tx = state.transactions.iter().find(|t| t.id == id).unwrap();
                 assert!(
                     matches!(tx.kind, MigrationTxKind::Transfer { .. }),

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -1300,7 +1300,7 @@ where
 /// locate each transfer's spend in the wallet's Orchard commitment tree at proving time; a
 /// production consumer recovers them from its own scanned note store, so this entry point exists
 /// for tests (and downstream test harnesses) that drive real proving without a scanning wallet.
-#[cfg(any(test, feature = "test-dependencies"))]
+#[cfg(all(feature = "orchard", any(test, feature = "test-dependencies")))]
 pub fn commit_preparation_with_funding<P, B, R>(
     params: &P,
     target_height: BlockHeight,

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -818,6 +818,25 @@ pub trait MigrationProver {
         pczt: pczt::Pczt,
         anchor_boundary: BlockHeight,
     ) -> Result<pczt::Pczt, Self::Error>;
+
+    /// Prove a pre-signed PREPARATION transaction against a checkpoint at which its spent notes are
+    /// witnessable.
+    ///
+    /// Like a transfer, a preparation transaction defers its Orchard anchor and its spends'
+    /// witnesses to proving time (ZIP 374), but it carries NO drawn
+    /// [`anchor_boundary`](MigrationTransaction::anchor_boundary) (it anchors to its already-mined
+    /// dependencies, not to a bucketed boundary), so the `anchor` height is passed in: the caller
+    /// proves a preparation once its inputs are mined and picks a checkpoint at or after that (for
+    /// example the current chain tip). A preparation spends the wallet's own notes (layer 0) or
+    /// feeder notes minted by an earlier layer — one or MANY, unlike a transfer's single funding
+    /// note — and produces only an Orchard bundle (no Ironwood output), so the implementation
+    /// installs the anchor and every real spend's witness through the PCZT `Updater` role and proves
+    /// the single Orchard bundle.
+    fn prove_preparation(
+        &mut self,
+        pczt: pczt::Pczt,
+        anchor: BlockHeight,
+    ) -> Result<pczt::Pczt, Self::Error>;
 }
 
 /// Why committing a migration's preparation failed.
@@ -894,6 +913,9 @@ pub enum ProveError<E> {
     /// The transaction is a preparation transaction, not a transfer; only transfers are proved
     /// against a drawn anchor boundary (a preparation transaction carries no boundary).
     NotATransfer(MigrationTxId),
+    /// The transaction is a transfer, not a preparation transaction; only preparation transactions
+    /// are proved against a caller-supplied anchor (a transfer proves against its drawn boundary).
+    NotAPreparation(MigrationTxId),
     /// The transaction is not in the [`Signed`](MigrationTxState::Signed) state, so it is not ready
     /// to prove (it is unsigned, already proved, or already broadcast).
     NotReady(MigrationTxId),
@@ -918,6 +940,11 @@ impl<E: fmt::Display> fmt::Display for ProveError<E> {
             ProveError::NotATransfer(id) => write!(
                 f,
                 "transaction {} is a preparation transaction, not a transfer",
+                u32::from(*id)
+            ),
+            ProveError::NotAPreparation(id) => write!(
+                f,
+                "transaction {} is a transfer, not a preparation transaction",
                 u32::from(*id)
             ),
             ProveError::NotReady(id) => {
@@ -984,6 +1011,54 @@ where
     let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
     let proven = prover
         .prove_transfer(pczt, anchor_boundary)
+        .map_err(ProveError::Prover)?;
+    let bytes = proven.serialize().map_err(ProveError::Serialize)?;
+
+    state.set_transaction_proved(id, bytes);
+    Ok(())
+}
+
+/// Prove a pre-signed migration PREPARATION transaction against a checkpoint at which its spent
+/// notes are witnessable, moving it `Signed -> Proved`.
+///
+/// A preparation transaction carries no drawn
+/// [`anchor_boundary`](MigrationTransaction::anchor_boundary) (it anchors to its already-mined
+/// dependencies, not to a bucketed boundary), so the `anchor` height is supplied by the caller: it
+/// proves a preparation once the notes it spends are mined and picks a checkpoint at or after that
+/// (for example the current chain tip). It hands the stored PCZT and the `anchor` to
+/// [`MigrationProver::prove_preparation`], which installs the Orchard source anchor and every real
+/// spend's witness against that checkpoint (through the PCZT `Updater` role) and proves the single
+/// Orchard bundle. The proven PCZT replaces the stored one and the transaction becomes
+/// [`Proved`](MigrationTxState::Proved), ready to broadcast.
+///
+/// A transaction not in [`Signed`](MigrationTxState::Signed) is rejected with
+/// [`ProveError::NotReady`] rather than re-proved; a transfer is rejected with
+/// [`ProveError::NotAPreparation`].
+#[cfg(feature = "orchard")]
+pub fn prove_preparation<P>(
+    prover: &mut P,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+    anchor: BlockHeight,
+) -> Result<(), ProveError<P::Error>>
+where
+    P: MigrationProver,
+{
+    let tx = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == id)
+        .ok_or(ProveError::UnknownTransaction(id))?;
+    if !matches!(tx.kind(), MigrationTxKind::Preparation { .. }) {
+        return Err(ProveError::NotAPreparation(id));
+    }
+    if !matches!(tx.state(), MigrationTxState::Signed) {
+        return Err(ProveError::NotReady(id));
+    }
+
+    let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
+    let proven = prover
+        .prove_preparation(pczt, anchor)
         .map_err(ProveError::Prover)?;
     let bytes = proven.serialize().map_err(ProveError::Serialize)?;
 
@@ -1150,7 +1225,7 @@ where
         rng,
         Signing::InProcess,
     )
-    .map(|(state, _unsigned)| state)
+    .map(|(state, _unsigned, _funding)| state)
 }
 
 /// Commit a planned migration for an EXTERNAL signer: build EVERY transaction exactly as
@@ -1184,6 +1259,7 @@ where
     R: RngCore + rand_core::CryptoRng,
 {
     commit_preparation_inner(params, target_height, backend, plan, rng, Signing::External)
+        .map(|(state, unsigned, _funding)| (state, unsigned))
 }
 
 /// Shared body of [`commit_preparation`] (with [`Signing::InProcess`]) and
@@ -1197,7 +1273,7 @@ fn commit_preparation_inner<P, B, R>(
     plan: &MigrationPlan,
     rng: &mut R,
     signing: Signing,
-) -> Result<(MigrationState, Vec<UnsignedMigrationTx>), CommitError<<B as MigrationBackend>::Error>>
+) -> Result<CommitOutput, CommitError<<B as MigrationBackend>::Error>>
 where
     P: zcash_protocol::consensus::Parameters + Clone,
     B: MigrationBackend
@@ -1212,11 +1288,43 @@ where
     committer.build_transfers(plan)?;
     // `into_state` consumes the committer, releasing its `&mut backend` reborrow, so the store
     // write below can borrow `backend` again.
-    let (state, unsigned) = committer.into_state(plan);
+    let (state, unsigned, transfer_funding) = committer.into_state(plan);
     backend
         .replace_migration(&state)
         .map_err(CommitError::Backend)?;
-    Ok((state, unsigned))
+    Ok((state, unsigned, transfer_funding))
+}
+
+/// Commit a planned migration in-process (as [`commit_preparation`]) and additionally return each
+/// transfer paired with the funding note it spends. The funding notes are what a prover needs to
+/// locate each transfer's spend in the wallet's Orchard commitment tree at proving time; a
+/// production consumer recovers them from its own scanned note store, so this entry point exists
+/// for tests (and downstream test harnesses) that drive real proving without a scanning wallet.
+#[cfg(any(test, feature = "test-dependencies"))]
+pub fn commit_preparation_with_funding<P, B, R>(
+    params: &P,
+    target_height: BlockHeight,
+    backend: &mut B,
+    plan: &MigrationPlan,
+    rng: &mut R,
+) -> Result<(MigrationState, TransferFunding), CommitError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters + Clone,
+    B: MigrationBackend
+        + MigrationCrypto<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationRead<Error = <B as MigrationBackend>::Error>
+        + PoolMigrationWrite,
+    R: RngCore + rand_core::CryptoRng,
+{
+    commit_preparation_inner(
+        params,
+        target_height,
+        backend,
+        plan,
+        rng,
+        Signing::InProcess,
+    )
+    .map(|(state, _unsigned, funding)| (state, funding))
 }
 
 /// Hosts the shared mutable state that building a whole committed migration threads through its
@@ -1244,6 +1352,12 @@ struct Committer<'a, P, B, R> {
     next_id: u32,
     layer_ids: Vec<Vec<MigrationTxId>>,
     minted: Vec<MintedNote>,
+    /// Each transfer paired with the funding note it spends, captured as the transfer is built.
+    /// The commit path already recovers every funding note's plaintext to build the transfer; a
+    /// prover needs it at proving time to locate the note in the wallet's commitment tree (in
+    /// production the wallet finds it by nullifier in its own note store). Surfaced through
+    /// [`commit_preparation_with_funding`]; the normal commit path drops it.
+    transfer_funding: TransferFunding,
 }
 
 #[cfg(feature = "orchard")]
@@ -1290,6 +1404,7 @@ where
             next_id: 0,
             layer_ids: Vec::new(),
             minted: Vec::new(),
+            transfer_funding: Vec::new(),
         })
     }
 
@@ -1589,23 +1704,36 @@ where
                 anchor_boundary: Some(anchor_boundary),
                 state: tx_state,
             });
+            self.transfer_funding.push((id, note));
         }
         Ok(())
     }
 
     /// Assemble the committed [`MigrationState`] from the accumulated transactions and return it
-    /// with the unsigned PCZTs. Consuming `self` releases the `&mut backend` reborrow, so the
-    /// caller can persist the state through the backend afterward.
-    fn into_state(self, plan: &MigrationPlan) -> (MigrationState, Vec<UnsignedMigrationTx>) {
+    /// with the unsigned PCZTs and each transfer's funding note. Consuming `self` releases the
+    /// `&mut backend` reborrow, so the caller can persist the state through the backend afterward.
+    fn into_state(self, plan: &MigrationPlan) -> CommitOutput {
         let state = MigrationState {
             status: MigrationStatus::Committed,
             note_split: plan.note_split().clone(),
             preparation: plan.preparation().clone(),
             transactions: self.transactions,
         };
-        (state, self.unsigned)
+        (state, self.unsigned, self.transfer_funding)
     }
 }
+
+/// Each transfer paired with the funding note it spends, recovered from the built preparation
+/// bundles during a commit pass. A prover needs it to locate each transfer's spend in the wallet's
+/// commitment tree at proving time.
+#[cfg(feature = "orchard")]
+type TransferFunding = Vec<(MigrationTxId, orchard::note::Note)>;
+
+/// What one commit pass produces: the persisted [`MigrationState`], the unsigned PCZTs (empty for
+/// the in-process signing path), and each transfer paired with the funding note it spends. The
+/// public commit entry points drop the parts they do not surface.
+#[cfg(feature = "orchard")]
+type CommitOutput = (MigrationState, Vec<UnsignedMigrationTx>, TransferFunding);
 
 #[cfg(test)]
 mod tests {
@@ -1987,6 +2115,18 @@ mod commit_tests {
             // returns the PCZT unchanged; the engine's `prove_transfer` orchestration (reading and
             // passing the persisted `anchor_boundary`, and the Signed -> Proved transition) is what
             // the tests exercise.
+            Ok(pczt)
+        }
+
+        fn prove_preparation(
+            &mut self,
+            pczt: pczt::Pczt,
+            _anchor: BlockHeight,
+        ) -> Result<pczt::Pczt, Self::Error> {
+            // A stand-in for proving, as `prove_transfer` above: a real prover installs the Orchard
+            // anchor and every spend's witness and runs the Orchard prover (see
+            // `WalletMigrationProver`). This mock models no commitment tree, so it returns the PCZT
+            // unchanged; the engine's `prove_preparation` orchestration is what the tests exercise.
             Ok(pczt)
         }
     }

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -23,7 +23,8 @@ use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTxId, MigrationTxKind, MigrationTxState,
+    MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
+    MigrationTxState,
 };
 
 /// The next thing to do to advance a committed migration, decided purely from its state. The consumer
@@ -32,13 +33,25 @@ use crate::engine::{
 /// [`MigrationState::next_step`] again.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdvanceStep {
-    /// Prove and broadcast this pre-signed transaction: its dependencies are mined and it is due.
-    Broadcast {
-        /// The transaction to prove and broadcast.
+    /// Prove this pre-signed transaction (install its deferred Orchard anchor and spend witnesses and
+    /// store the proven PCZT), WITHOUT broadcasting: its dependencies are mined and, for a transfer,
+    /// its drawn anchor boundary has settled (the boundary block is below the tip, so its checkpoint
+    /// exists and is still within the wallet's checkpoint-pruning window). Broadcast is a separate
+    /// later step once the privacy broadcast schedule is due. Proving is time-critical: the boundary
+    /// checkpoint is pruned once the tip advances past it by the wallet's pruning depth, so a transfer
+    /// must be proved while its boundary is fresh, not deferred to its (later) broadcast height.
+    Prove {
+        /// The transaction to prove.
         id: MigrationTxId,
     },
-    /// Nothing to do now: waiting for one or more transactions to mine, or for a scheduled height to
-    /// arrive.
+    /// Broadcast this already-proven transaction: it is `Proved`, its dependencies are mined, and its
+    /// scheduled broadcast height has arrived.
+    Broadcast {
+        /// The transaction to broadcast.
+        id: MigrationTxId,
+    },
+    /// Nothing to do now: waiting for one or more transactions to mine, for an anchor boundary to
+    /// settle, or for a scheduled height to arrive.
     Waiting,
     /// Every transaction is mined; the migration is complete.
     Complete,
@@ -47,9 +60,13 @@ pub enum AdvanceStep {
 /// The action a wallet takes next on a ready migration transaction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NextAction {
-    /// Prove and broadcast this pre-signed transaction now that its dependencies are mined and it is
-    /// due.
-    ProveAndBroadcast,
+    /// Prove this pre-signed transaction now (install its deferred anchor and witnesses and store the
+    /// proven PCZT): its dependencies are mined and, for a transfer, its anchor boundary has settled
+    /// within the wallet's checkpoint-pruning window. It is not broadcast yet.
+    Prove,
+    /// Broadcast this already-proven transaction now: it is `Proved` and its scheduled broadcast
+    /// height has arrived.
+    Broadcast,
 }
 
 /// Why a migration transaction is not yet actionable.
@@ -63,6 +80,10 @@ pub enum Blocker {
     /// Built and due only at a later height (the privacy broadcast schedule): waiting for the chain tip
     /// to reach its scheduled height.
     Schedule,
+    /// A transfer whose drawn anchor boundary has not yet settled: waiting for the chain tip to move
+    /// strictly past the boundary block, so the boundary checkpoint exists and the transfer can be
+    /// proved against it (while it is still within the wallet's checkpoint-pruning window).
+    AnchorBoundary,
     /// Built but awaiting an EXTERNAL signature: its unsigned PCZT was exported to a hardware or offline
     /// signer, and this transaction cannot advance until
     /// [`MigrationState::apply_signature`](MigrationState::apply_signature) stores the signed PCZT
@@ -121,13 +142,51 @@ impl MigrationState {
         })
     }
 
-    /// The id of the next transaction ready to prove and broadcast: pre-signed (`Signed`) or already
-    /// `Proved`, its dependencies mined, and scheduled at or before `target_height` (`chain_tip + 1`).
+    /// Whether transaction `t` is ready to PROVE at `target_height` (`chain_tip + 1`): its
+    /// dependencies are mined and its Orchard anchor is resolvable from the wallet's commitment tree
+    /// right now.
+    ///
+    /// A TRANSFER anchors to a drawn boundary ([`anchor_boundary`](MigrationTransaction::anchor_boundary)),
+    /// which must have SETTLED: the boundary block must be strictly below the chain tip so its
+    /// checkpoint exists in the tree. Proving is due as soon as that holds, decoupled from the (later)
+    /// broadcast schedule, because the boundary checkpoint is pruned once the tip advances past it by
+    /// the wallet's pruning depth; a transfer must therefore be proved while its boundary is still
+    /// fresh, not deferred to its broadcast height. A PREPARATION carries no drawn boundary and
+    /// anchors to a fresh checkpoint at the tip when proved, so it is prove-ready once its
+    /// dependencies are mined and its scheduled height has arrived.
+    fn prove_ready(&self, t: &MigrationTransaction, target_height: BlockHeight) -> bool {
+        if !self.deps_mined(&t.depends_on) {
+            return false;
+        }
+        match t.anchor_boundary {
+            // A transfer: the boundary must be strictly below the tip. `target_height` is `tip + 1`,
+            // so `boundary < tip` is `boundary + 1 < target_height`.
+            Some(boundary) => u32::from(boundary) + 1 < u32::from(target_height),
+            // A preparation: prove-ready once its schedule is due.
+            None => t.scheduled_height <= target_height,
+        }
+    }
+
+    /// The id of the next pre-signed transaction ready to PROVE (move `Signed -> Proved`): its anchor
+    /// is resolvable now (see [`Self::prove_ready`]). Proving is decoupled from broadcasting so a
+    /// transfer is proved while its anchor boundary checkpoint is still within the wallet's pruning
+    /// window, then broadcast later at its scheduled height.
+    pub fn next_provable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+        self.transactions
+            .iter()
+            .find(|t| {
+                matches!(t.state, MigrationTxState::Signed) && self.prove_ready(t, target_height)
+            })
+            .map(|t| t.id)
+    }
+
+    /// The id of the next transaction ready to BROADCAST: already `Proved`, its dependencies mined,
+    /// and scheduled at or before `target_height` (`chain_tip + 1`).
     pub fn next_broadcastable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
         self.transactions
             .iter()
             .find(|t| {
-                matches!(t.state, MigrationTxState::Signed | MigrationTxState::Proved)
+                matches!(t.state, MigrationTxState::Proved)
                     && t.scheduled_height <= target_height
                     && self.deps_mined(&t.depends_on)
             })
@@ -228,6 +287,12 @@ impl MigrationState {
         if self.is_terminal() {
             return AdvanceStep::Complete;
         }
+        // Prove before broadcasting: a transfer's anchor boundary checkpoint is only briefly within
+        // the wallet's pruning window, so proving is time-critical, whereas broadcasting a proven
+        // transaction can wait for its (later) schedule.
+        if let Some(id) = self.next_provable(target_height) {
+            return AdvanceStep::Prove { id };
+        }
         if let Some(id) = self.next_broadcastable(target_height) {
             return AdvanceStep::Broadcast { id };
         }
@@ -262,11 +327,31 @@ impl MigrationState {
                     // automatic driver takes no action (the external-signing caller drives it via
                     // `apply_signature`), so it is neither ready nor blocked on the chain.
                     MigrationTxState::AwaitingSignature => (false, None, Some(Blocker::Signature)),
-                    MigrationTxState::Signed | MigrationTxState::Proved => {
+                    // Pre-signed and awaiting proof: ready to PROVE once its anchor is resolvable (a
+                    // transfer's boundary has settled, or a preparation is due). Not yet proved, so
+                    // not yet broadcast.
+                    MigrationTxState::Signed => {
+                        if !deps_ok {
+                            (false, None, Some(Blocker::Dependencies))
+                        } else if self.prove_ready(t, target_height) {
+                            (true, Some(NextAction::Prove), None)
+                        } else {
+                            // Deps mined but not prove-ready: a transfer waiting for its anchor
+                            // boundary to settle, or a preparation not yet due on its schedule.
+                            let blocker = match t.anchor_boundary {
+                                Some(_) => Blocker::AnchorBoundary,
+                                None => Blocker::Schedule,
+                            };
+                            (false, None, Some(blocker))
+                        }
+                    }
+                    // Proved and awaiting broadcast: ready to BROADCAST once its scheduled height has
+                    // arrived, otherwise waiting on the broadcast schedule.
+                    MigrationTxState::Proved => {
                         if !deps_ok {
                             (false, None, Some(Blocker::Dependencies))
                         } else if t.scheduled_height <= target_height {
-                            (true, Some(NextAction::ProveAndBroadcast), None)
+                            (true, Some(NextAction::Broadcast), None)
                         } else {
                             (false, None, Some(Blocker::Schedule))
                         }
@@ -406,10 +491,11 @@ mod tests {
 
     #[test]
     fn next_broadcastable_respects_state_deps_and_schedule() {
-        let mut signed = tx(1, transfer(0), MigrationTxState::Signed);
-        signed.depends_on = vec![MigrationTxId(0)];
-        signed.scheduled_height = BlockHeight::from_u32(5);
-        let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), signed]);
+        // Only a PROVED transaction is broadcastable (proving is a separate earlier step).
+        let mut proved = tx(1, transfer(0), MigrationTxState::Proved);
+        proved.depends_on = vec![MigrationTxId(0)];
+        proved.scheduled_height = BlockHeight::from_u32(5);
+        let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), proved]);
 
         // Not due yet (target below scheduled height).
         assert_eq!(s.next_broadcastable(BlockHeight::from_u32(4)), None);
@@ -419,14 +505,12 @@ mod tests {
             Some(MigrationTxId(1))
         );
 
-        // A Proved transaction is also broadcastable.
-        s.transactions[1].state = MigrationTxState::Proved;
-        assert_eq!(
-            s.next_broadcastable(BlockHeight::from_u32(5)),
-            Some(MigrationTxId(1))
-        );
+        // A Signed (not yet proved) transaction is NOT broadcastable: it must be proved first.
+        s.transactions[1].state = MigrationTxState::Signed;
+        assert_eq!(s.next_broadcastable(BlockHeight::from_u32(5)), None);
 
-        // Dependency not mined: not broadcastable.
+        // Dependency not mined: not broadcastable even when Proved.
+        s.transactions[1].state = MigrationTxState::Proved;
         s.transactions[0].state = MigrationTxState::Broadcast {
             txid: TxId::from_bytes([0; 32]),
         };
@@ -435,16 +519,24 @@ mod tests {
 
     #[test]
     fn next_step_walks_the_lifecycle() {
-        // Every transaction is pre-signed at commit; the state machine only orders the
-        // broadcasts: layer 0, then layer 1 once layer 0 mines, then the transfer once the
-        // whole preparation mines.
+        // Every transaction is pre-signed at commit; the state machine orders proving then
+        // broadcasting, respecting the anchor-bucket dependency order: prove-then-broadcast layer 0,
+        // then layer 1 once layer 0 mines, then the transfer once the whole preparation mines. Each
+        // transaction is PROVED (`Signed -> Proved`) before it is broadcast.
         let mut l1 = tx(1, prep(1, 0), MigrationTxState::Signed);
         l1.depends_on = vec![MigrationTxId(0)];
         let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
         xfer.depends_on = vec![MigrationTxId(1)];
         let mut s = state_with(vec![tx(0, prep(0, 0), MigrationTxState::Signed), l1, xfer]);
 
-        // 1) Layer 0 is signed and due -> broadcast it.
+        // 1) Layer 0 is signed and due -> prove it first, then broadcast it once proved.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Prove {
+                id: MigrationTxId(0)
+            }
+        );
+        s.transactions[0].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
@@ -461,8 +553,15 @@ mod tests {
             AdvanceStep::Waiting
         );
 
-        // 3) Layer 0 mined -> layer 1 becomes broadcastable.
+        // 3) Layer 0 mined -> layer 1 becomes provable, then broadcastable.
         s.transactions[0].state = mined(10);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Prove {
+                id: MigrationTxId(1)
+            }
+        );
+        s.transactions[1].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
@@ -470,8 +569,15 @@ mod tests {
             }
         );
 
-        // 4) Layer 1 mined -> the transfer becomes broadcastable.
+        // 4) Layer 1 mined -> the transfer becomes provable, then broadcastable.
         s.transactions[1].state = mined(11);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Prove {
+                id: MigrationTxId(2)
+            }
+        );
+        s.transactions[2].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
@@ -494,9 +600,11 @@ mod tests {
         let s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
         // The transfer is signed with deps mined but not due yet -> nothing else to do, waiting.
         assert_eq!(s.next_step(BlockHeight::from_u32(20)), AdvanceStep::Waiting);
+        // Once due, the first step on a still-`Signed` transaction is to PROVE it (broadcasting is a
+        // separate later step, once proved).
         assert_eq!(
             s.next_step(BlockHeight::from_u32(50)),
-            AdvanceStep::Broadcast {
+            AdvanceStep::Prove {
                 id: MigrationTxId(1)
             }
         );
@@ -577,9 +685,9 @@ mod tests {
         assert_eq!(views[0].blocked_on, None);
         assert_eq!(views[0].mined_height, Some(BlockHeight::from_u32(10)));
 
-        // tx 1: signed with its dependency (tx 0) mined and due -> ready to broadcast.
+        // tx 1: signed with its dependency (tx 0) mined and due -> ready to prove.
         assert!(views[1].ready);
-        assert_eq!(views[1].action, Some(NextAction::ProveAndBroadcast));
+        assert_eq!(views[1].action, Some(NextAction::Prove));
         assert_eq!(views[1].blocked_on, None);
 
         // tx 2: signed but its dependency (tx 1) is not mined -> blocked on dependencies.
@@ -598,6 +706,48 @@ mod tests {
         assert_eq!(blocked[1].blocked_on, Some(Blocker::Schedule));
         let ready = s.transaction_statuses(BlockHeight::from_u32(30));
         assert!(ready[1].ready);
-        assert_eq!(ready[1].action, Some(NextAction::ProveAndBroadcast));
+        assert_eq!(ready[1].action, Some(NextAction::Prove));
+    }
+
+    #[test]
+    fn transfer_prove_ready_waits_for_its_anchor_boundary() {
+        // A transfer anchors to a drawn boundary; it is not provable until the boundary block is
+        // strictly below the tip (its checkpoint has settled), decoupled from the broadcast schedule.
+        let mut xfer = tx(1, transfer(0), MigrationTxState::Signed);
+        xfer.depends_on = vec![MigrationTxId(0)];
+        xfer.anchor_boundary = Some(BlockHeight::from_u32(40));
+        xfer.scheduled_height = BlockHeight::from_u32(60);
+        let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
+
+        // `target_height` is `tip + 1`. At tip 40 (target 41) the boundary is not yet strictly below
+        // the tip -> not provable, blocked on the anchor boundary.
+        assert_eq!(s.next_step(BlockHeight::from_u32(41)), AdvanceStep::Waiting);
+        let v = s.transaction_statuses(BlockHeight::from_u32(41));
+        assert!(!v[1].ready);
+        assert_eq!(v[1].blocked_on, Some(Blocker::AnchorBoundary));
+
+        // At tip 41 (target 42) boundary 40 is strictly below the tip -> provable now, even though
+        // the broadcast schedule (60) has not arrived.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(42)),
+            AdvanceStep::Prove {
+                id: MigrationTxId(1)
+            }
+        );
+
+        // Once proved, it is NOT broadcast until its scheduled height arrives.
+        s.transactions[1].state = MigrationTxState::Proved;
+        assert_eq!(s.next_step(BlockHeight::from_u32(42)), AdvanceStep::Waiting);
+        let v = s.transaction_statuses(BlockHeight::from_u32(42));
+        assert!(!v[1].ready);
+        assert_eq!(v[1].blocked_on, Some(Blocker::Schedule));
+
+        // At the scheduled height it becomes broadcastable.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(60)),
+            AdvanceStep::Broadcast {
+                id: MigrationTxId(1)
+            }
+        );
     }
 }

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -13,9 +13,10 @@
 //! [`WalletMigration`] holds the wallet by a SHARED borrow and touches no note commitment tree:
 //! every migration transaction is built and signed with its anchor and witnesses deferred to
 //! proving time (ZIP 374). Proving is the separate [`WalletMigrationProver`], which borrows the
-//! wallet as `&mut W` to resolve the drawn source anchor and the funding note's witness from the
-//! wallet's Orchard commitment tree and installs them through the PCZT `Updater` role before
-//! proving both bundles, just before broadcast.
+//! wallet as `&mut W` to resolve the source anchor and each spend's witness from the wallet's
+//! Orchard commitment tree and installs them through the PCZT `Updater` role before proving the
+//! transaction (a transfer's Orchard + Ironwood bundles, or a preparation's Orchard bundle), just
+//! before broadcast.
 //!
 //! [`commit_preparation`]: crate::engine::commit_preparation
 
@@ -268,30 +269,34 @@ fn post_nu6_3_orchard_proving_key() -> &'static ProvingKey {
     PROVING_KEY.get_or_init(|| ProvingKey::build(OrchardCircuitVersion::PostNu6_3))
 }
 
-/// Why proving a migration transfer through the wallet-backed prover failed. `TE` is the wallet's
-/// commitment-tree error type ([`WalletCommitmentTrees::Error`]).
+/// Why proving a migration transaction through the wallet-backed prover failed. `TE` is the
+/// wallet's commitment-tree error type ([`WalletCommitmentTrees::Error`]); `NE` is its note-source
+/// error type ([`InputSource::Error`]).
 #[derive(Debug)]
-pub enum WalletProveError<TE> {
-    /// The transfer PCZT has no real Orchard spend to witness. Every migration transfer spends one
-    /// funding note, so its bundle carries exactly one action whose witness is still deferred (all
-    /// the fabricated dummy spends keep their own witnesses); its absence means the PCZT is not a
-    /// deferred-anchor transfer awaiting proof.
+pub enum WalletProveError<TE, NE> {
+    /// The PCZT has no real Orchard spend whose witness is still deferred. A migration transfer
+    /// spends one funding note and a preparation transaction one or more, so the Orchard bundle
+    /// carries at least one action with an absent witness (the fabricated dummy spends keep their
+    /// own); none means the PCZT is not a deferred-anchor migration transaction awaiting proof.
     NoRealSpend,
-    /// No tree position is known for the funding note the transfer spends (keyed by the revealed
-    /// spend nullifier). The caller's position map does not cover this note.
-    UnknownFundingNote([u8; 32]),
-    /// The Orchard commitment tree has no root at the drawn anchor-boundary checkpoint (the
-    /// checkpoint was never created, or was pruned before proving; see issue #2700).
+    /// No spendable Orchard note in the wallet matches a spend's revealed nullifier, so its tree
+    /// position is unknown: the note the transaction spends is not among the account's unspent
+    /// notes (it was never scanned, or has already been spent).
+    UnknownSpentNote([u8; 32]),
+    /// Enumerating the account's spendable Orchard notes (to locate each spend by nullifier) failed.
+    Notes(NE),
+    /// The Orchard commitment tree has no root at the anchor checkpoint (the checkpoint was never
+    /// created, or was pruned before proving; see issue #2700).
     AnchorNotFound(BlockHeight),
-    /// The funding note has no witness at the drawn anchor-boundary checkpoint (the checkpoint was
-    /// pruned, or the note's position is not marked in the tree).
+    /// A spent note has no witness at the anchor checkpoint (the checkpoint was pruned, or the
+    /// note's position is not marked in the tree).
     WitnessNotFound(BlockHeight),
     /// A commitment-tree query failed.
     Tree(ShardTreeError<TE>),
     /// Installing the Orchard source or Ironwood destination anchor through the PCZT `Updater` role
     /// failed.
     Anchor(AnchorUpdateError),
-    /// Installing the funding note's spend witness through the PCZT `Updater` role failed.
+    /// Installing a spend witness through the PCZT `Updater` role failed.
     Witness(SpendWitnessUpdateError),
     /// Creating the Orchard or Ironwood proof failed. The two proof roles return distinct error
     /// types and `pczt` does not export the Ironwood one, so the failure is carried as a labeled
@@ -299,140 +304,228 @@ pub enum WalletProveError<TE> {
     Prove(alloc::string::String),
 }
 
-impl<TE> From<ShardTreeError<TE>> for WalletProveError<TE> {
+impl<TE, NE> From<ShardTreeError<TE>> for WalletProveError<TE, NE> {
     fn from(e: ShardTreeError<TE>) -> Self {
         WalletProveError::Tree(e)
     }
 }
 
-impl<TE: fmt::Debug> fmt::Display for WalletProveError<TE> {
+impl<TE: fmt::Debug, NE: fmt::Debug> fmt::Display for WalletProveError<TE, NE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             WalletProveError::NoRealSpend => {
-                f.write_str("the transfer PCZT has no deferred-witness Orchard spend to prove")
+                f.write_str("the PCZT has no deferred-witness Orchard spend to prove")
             }
-            WalletProveError::UnknownFundingNote(nf) => {
+            WalletProveError::UnknownSpentNote(nf) => {
                 write!(
                     f,
-                    "no tree position known for funding note nullifier {nf:?}"
+                    "no spendable Orchard note matches spend nullifier {nf:?}"
                 )
+            }
+            WalletProveError::Notes(e) => {
+                write!(f, "enumerating spendable Orchard notes failed: {e:?}")
             }
             WalletProveError::AnchorNotFound(h) => write!(
                 f,
-                "the Orchard tree has no root at the drawn anchor-boundary checkpoint {}",
+                "the Orchard tree has no root at the anchor checkpoint {}",
                 u32::from(*h)
             ),
             WalletProveError::WitnessNotFound(h) => write!(
                 f,
-                "the funding note has no witness at the drawn anchor-boundary checkpoint {}",
+                "a spent note has no witness at the anchor checkpoint {}",
                 u32::from(*h)
             ),
             WalletProveError::Tree(e) => write!(f, "commitment-tree query failed: {e:?}"),
             WalletProveError::Anchor(e) => write!(f, "installing an anchor failed: {e:?}"),
-            WalletProveError::Witness(e) => write!(f, "installing the spend witness failed: {e:?}"),
+            WalletProveError::Witness(e) => write!(f, "installing a spend witness failed: {e:?}"),
             WalletProveError::Prove(msg) => write!(f, "creating a bundle proof failed: {msg}"),
         }
     }
 }
 
-impl<TE: fmt::Debug> core::error::Error for WalletProveError<TE> {}
+impl<TE: fmt::Debug, NE: fmt::Debug> core::error::Error for WalletProveError<TE, NE> {}
 
-/// A wallet-backed prover for migration transfers: the mutable counterpart to [`WalletMigration`].
+/// The wallet-backed prover's error for a wallet `W`: a [`WalletProveError`] over the wallet's
+/// commitment-tree and note-source error types.
+type ProverError<W> =
+    WalletProveError<<W as WalletCommitmentTrees>::Error, <W as InputSource>::Error>;
+
+/// A wallet-backed prover for migration transactions: the mutable counterpart to [`WalletMigration`].
 ///
-/// Proving a transfer resolves its DEFERRED Orchard source anchor and the funding note's Merkle
-/// witness against the boundary the schedule drew (ZIP 374), which needs MUTABLE access to the
-/// wallet's Orchard commitment tree ([`WalletCommitmentTrees::with_orchard_tree_mut`], whose witness
-/// resolution caches into the tree). That is why proving lives here, borrowing the wallet as
-/// `&mut W`, rather than on the shared-borrow [`WalletMigration`] used to build and sign.
+/// Proving resolves a transaction's DEFERRED Orchard anchor and its spends' Merkle witnesses against
+/// a checkpoint (ZIP 374), which needs MUTABLE access to the wallet's Orchard commitment tree
+/// ([`WalletCommitmentTrees::with_orchard_tree_mut`], whose witness resolution caches into the
+/// tree). That is why proving lives here, borrowing the wallet as `&mut W`, rather than on the
+/// shared-borrow [`WalletMigration`] used to build and sign.
 ///
-/// The funding note a transfer spends is identified by the revealed spend nullifier; `funding_positions`
-/// maps that nullifier to the note's position in the wallet's Orchard commitment tree. A production
-/// consumer fills this map from the wallet's own note store (looking each nullifier up in the
-/// received-notes table); the anchor-boundary checkpoint the witness is taken against must still
-/// exist in the tree at proving time (migration anchor-checkpoint retention, issue #2700).
-pub struct WalletMigrationProver<'a, W> {
+/// Each spend is located by the nullifier it reveals: the prover enumerates the account's unspent
+/// Orchard notes ([`InputSource::select_unspent_notes`]), recomputes each note's nullifier under the
+/// account's full viewing key, and matches. This serves both a transfer (one funding-note spend
+/// plus an Ironwood output) and a preparation transaction (one or more spends, no Ironwood). The
+/// anchor checkpoint the witnesses are taken against must still exist in the tree at proving time
+/// (migration anchor-checkpoint retention, issue #2700).
+pub struct WalletMigrationProver<'a, W>
+where
+    W: InputSource,
+{
     wallet: &'a mut W,
-    funding_positions: BTreeMap<[u8; 32], Position>,
+    account: <W as InputSource>::AccountId,
+    fvk: FullViewingKey,
 }
 
-impl<'a, W> WalletMigrationProver<'a, W> {
-    /// Wrap a wallet (borrowed mutably for commitment-tree access) and the map from each funding
-    /// note's revealed spend nullifier to its position in the wallet's Orchard commitment tree.
-    pub fn new(wallet: &'a mut W, funding_positions: BTreeMap<[u8; 32], Position>) -> Self {
+impl<'a, W> WalletMigrationProver<'a, W>
+where
+    W: InputSource,
+{
+    /// Wrap a wallet (borrowed mutably for commitment-tree access), the account whose notes the
+    /// migration spends, and that account's Orchard full viewing key (used to recompute each spent
+    /// note's nullifier when locating it among the account's unspent notes).
+    pub fn new(
+        wallet: &'a mut W,
+        account: <W as InputSource>::AccountId,
+        fvk: FullViewingKey,
+    ) -> Self {
         Self {
             wallet,
-            funding_positions,
+            account,
+            fvk,
         }
+    }
+}
+
+impl<'a, W> WalletMigrationProver<'a, W>
+where
+    W: WalletCommitmentTrees + InputSource,
+    <W as InputSource>::AccountId: Copy,
+{
+    /// Prove one migration transaction's Orchard bundle (and its Ironwood bundle, when it has one)
+    /// against `anchor`: install the source anchor and every deferred spend's witness through the
+    /// PCZT `Updater` role, then run the provers. Shared by
+    /// [`prove_transfer`](MigrationProver::prove_transfer) (a transfer: one Orchard spend plus an
+    /// Ironwood output) and [`prove_preparation`](MigrationProver::prove_preparation) (a preparation:
+    /// one or more Orchard spends, no Ironwood).
+    fn prove_orchard(
+        &mut self,
+        pczt: ::pczt::Pczt,
+        anchor: BlockHeight,
+    ) -> Result<::pczt::Pczt, ProverError<W>> {
+        // Every Orchard action whose witness is still deferred is a real spend to witness; the padded
+        // dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
+        let real_spends: Vec<(usize, [u8; 32])> = pczt
+            .orchard()
+            .actions()
+            .iter()
+            .enumerate()
+            .filter(|(_, action)| action.spend().witness().is_none())
+            .map(|(index, action)| (index, *action.spend().nullifier()))
+            .collect();
+        if real_spends.is_empty() {
+            return Err(WalletProveError::NoRealSpend);
+        }
+
+        // Locate each spend in the wallet's note store: map every unspent Orchard note's nullifier
+        // (recomputed under the account FVK) to its commitment-tree position, then look up each spend.
+        let target = TargetHeight::from(u32::from(anchor) + 1);
+        let received = self
+            .wallet
+            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
+            .map_err(WalletProveError::Notes)?;
+        let positions: BTreeMap<[u8; 32], Position> = received
+            .orchard()
+            .iter()
+            .map(|rn| {
+                (
+                    rn.note().nullifier(&self.fvk).to_bytes(),
+                    rn.note_commitment_tree_position(),
+                )
+            })
+            .collect();
+        let spend_positions: Vec<(usize, Position)> = real_spends
+            .iter()
+            .map(|(index, nf)| {
+                positions
+                    .get(nf)
+                    .map(|pos| (*index, *pos))
+                    .ok_or(WalletProveError::UnknownSpentNote(*nf))
+            })
+            .collect::<Result<_, _>>()?;
+
+        // A transfer carries an Ironwood output bundle; a preparation transaction is Orchard-only.
+        let has_ironwood = !pczt.ironwood().actions().is_empty();
+
+        // Resolve the source anchor (the tree root at the checkpoint) and each spend's Merkle witness
+        // against it, mirroring `create_proposed_transactions`.
+        let (anchor_root, witnesses): (Anchor, Vec<(usize, MerklePath)>) =
+            self.wallet
+                .with_orchard_tree_mut::<_, _, ProverError<W>>(|tree| {
+                    let root: Anchor = tree
+                        .root_at_checkpoint_id(&anchor)?
+                        .ok_or(WalletProveError::AnchorNotFound(anchor))?
+                        .into();
+                    let mut witnesses = Vec::with_capacity(spend_positions.len());
+                    for (index, position) in &spend_positions {
+                        let path: MerklePath = tree
+                            .witness_at_checkpoint_id_caching(*position, &anchor)?
+                            .ok_or(WalletProveError::WitnessNotFound(anchor))?
+                            .into();
+                        witnesses.push((*index, path));
+                    }
+                    Ok((root, witnesses))
+                })?;
+
+        // Install the deferred data through the Updater role: the Orchard source anchor and every
+        // spend's witness, plus (for a transfer) the Ironwood destination anchor (the output side
+        // anchors to the empty tree; it has no spend to witness).
+        let mut updater = Updater::new(pczt)
+            .set_orchard_anchor(anchor_root)
+            .map_err(WalletProveError::Anchor)?
+            .set_orchard_spend_witnesses(witnesses)
+            .map_err(WalletProveError::Witness)?;
+        if has_ironwood {
+            updater = updater
+                .set_ironwood_anchor(Anchor::empty_tree())
+                .map_err(WalletProveError::Anchor)?;
+        }
+        let updated = updater.finish();
+
+        // Prove the Orchard bundle, and the Ironwood bundle too when present, with the single
+        // post-NU6.3 Orchard proving key.
+        let pk = post_nu6_3_orchard_proving_key();
+        let orchard_proven = Prover::new(updated)
+            .create_orchard_proof(pk)
+            .map_err(|e| WalletProveError::Prove(alloc::format!("orchard proof: {e:?}")))?;
+        let proven = if has_ironwood {
+            orchard_proven
+                .create_ironwood_proof(pk)
+                .map_err(|e| WalletProveError::Prove(alloc::format!("ironwood proof: {e:?}")))?
+        } else {
+            orchard_proven
+        };
+        Ok(proven.finish())
     }
 }
 
 impl<'a, W> MigrationProver for WalletMigrationProver<'a, W>
 where
-    W: WalletCommitmentTrees,
+    W: WalletCommitmentTrees + InputSource,
+    <W as InputSource>::AccountId: Copy,
 {
-    type Error = WalletProveError<<W as WalletCommitmentTrees>::Error>;
+    type Error = ProverError<W>;
 
     fn prove_transfer(
         &mut self,
         pczt: ::pczt::Pczt,
         anchor_boundary: BlockHeight,
     ) -> Result<::pczt::Pczt, Self::Error> {
-        // The one Orchard action whose witness is still deferred is the real funding-note spend; the
-        // padded dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
-        let (spend_index, nullifier) = pczt
-            .orchard()
-            .actions()
-            .iter()
-            .enumerate()
-            .find(|(_, action)| action.spend().witness().is_none())
-            .map(|(index, action)| (index, *action.spend().nullifier()))
-            .ok_or(WalletProveError::NoRealSpend)?;
+        self.prove_orchard(pczt, anchor_boundary)
+    }
 
-        let position = *self
-            .funding_positions
-            .get(&nullifier)
-            .ok_or(WalletProveError::UnknownFundingNote(nullifier))?;
-
-        // Resolve the source anchor (the tree root at the boundary checkpoint) and the funding note's
-        // Merkle witness against it, mirroring `create_proposed_transactions`.
-        let (anchor, merkle_path): (Anchor, MerklePath) = self
-            .wallet
-            .with_orchard_tree_mut::<_, _, WalletProveError<<W as WalletCommitmentTrees>::Error>>(
-                |tree| {
-                    let anchor: Anchor = tree
-                        .root_at_checkpoint_id(&anchor_boundary)?
-                        .ok_or(WalletProveError::AnchorNotFound(anchor_boundary))?
-                        .into();
-                    let merkle_path: MerklePath = tree
-                        .witness_at_checkpoint_id_caching(position, &anchor_boundary)?
-                        .ok_or(WalletProveError::WitnessNotFound(anchor_boundary))?
-                        .into();
-                    Ok((anchor, merkle_path))
-                },
-            )?;
-
-        // Install the deferred data through the Updater role: the Orchard source anchor and the
-        // funding note's witness, and the Ironwood destination anchor (the output side anchors to the
-        // empty tree; it has no spend to witness).
-        let updated = Updater::new(pczt)
-            .set_orchard_anchor(anchor)
-            .map_err(WalletProveError::Anchor)?
-            .set_orchard_spend_witnesses([(spend_index, merkle_path)])
-            .map_err(WalletProveError::Witness)?
-            .set_ironwood_anchor(Anchor::empty_tree())
-            .map_err(WalletProveError::Anchor)?
-            .finish();
-
-        // Prove both bundles with the single post-NU6.3 Orchard proving key.
-        let pk = post_nu6_3_orchard_proving_key();
-        let proven = Prover::new(updated)
-            .create_orchard_proof(pk)
-            .map_err(|e| WalletProveError::Prove(alloc::format!("orchard proof: {e:?}")))?
-            .create_ironwood_proof(pk)
-            .map_err(|e| WalletProveError::Prove(alloc::format!("ironwood proof: {e:?}")))?
-            .finish();
-
-        Ok(proven)
+    fn prove_preparation(
+        &mut self,
+        pczt: ::pczt::Pczt,
+        anchor: BlockHeight,
+    ) -> Result<::pczt::Pczt, Self::Error> {
+        self.prove_orchard(pczt, anchor)
     }
 }
 

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -28,7 +28,7 @@ use std::sync::OnceLock;
 use ::orchard::Anchor;
 use ::orchard::circuit::{OrchardCircuitVersion, ProvingKey};
 use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
-use ::orchard::note::Note as OrchardNote;
+use ::orchard::note::{Note as OrchardNote, Nullifier};
 use ::orchard::tree::MerklePath;
 use incrementalmerkletree::Position;
 use shardtree::error::ShardTreeError;
@@ -282,7 +282,10 @@ pub enum WalletProveError<TE, NE> {
     /// No spendable Orchard note in the wallet matches a spend's revealed nullifier, so its tree
     /// position is unknown: the note the transaction spends is not among the account's unspent
     /// notes (it was never scanned, or has already been spent).
-    UnknownSpentNote([u8; 32]),
+    UnknownSpentNote(Nullifier),
+    /// A deferred-witness Orchard spend's nullifier bytes are not a valid Orchard nullifier, so the
+    /// PCZT is not a well-formed migration transaction awaiting proof.
+    MalformedNullifier([u8; 32]),
     /// Enumerating the account's spendable Orchard notes (to locate each spend by nullifier) failed.
     Notes(NE),
     /// The Orchard commitment tree has no root at the anchor checkpoint (the checkpoint was never
@@ -320,6 +323,12 @@ impl<TE: fmt::Debug, NE: fmt::Debug> fmt::Display for WalletProveError<TE, NE> {
                 write!(
                     f,
                     "no spendable Orchard note matches spend nullifier {nf:?}"
+                )
+            }
+            WalletProveError::MalformedNullifier(bytes) => {
+                write!(
+                    f,
+                    "a spend's nullifier bytes are not a valid nullifier: {bytes:?}"
                 )
             }
             WalletProveError::Notes(e) => {
@@ -411,14 +420,19 @@ where
     ) -> Result<::pczt::Pczt, ProverError<W>> {
         // Every Orchard action whose witness is still deferred is a real spend to witness; the padded
         // dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
-        let real_spends: Vec<(usize, [u8; 32])> = pczt
+        let real_spends: Vec<(usize, Nullifier)> = pczt
             .orchard()
             .actions()
             .iter()
             .enumerate()
             .filter(|(_, action)| action.spend().witness().is_none())
-            .map(|(index, action)| (index, *action.spend().nullifier()))
-            .collect();
+            .map(|(index, action)| {
+                let bytes = action.spend().nullifier();
+                Option::<Nullifier>::from(Nullifier::from_bytes(bytes))
+                    .map(|nf| (index, nf))
+                    .ok_or(WalletProveError::MalformedNullifier(*bytes))
+            })
+            .collect::<Result<_, _>>()?;
         if real_spends.is_empty() {
             return Err(WalletProveError::NoRealSpend);
         }
@@ -430,12 +444,12 @@ where
             .wallet
             .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
             .map_err(WalletProveError::Notes)?;
-        let positions: BTreeMap<[u8; 32], Position> = received
+        let positions: BTreeMap<Nullifier, Position> = received
             .orchard()
             .iter()
             .map(|rn| {
                 (
-                    rn.note().nullifier(&self.fvk).to_bytes(),
+                    rn.note().nullifier(&self.fvk),
                     rn.note_commitment_tree_position(),
                 )
             })

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -33,8 +33,8 @@ use zcash_protocol::value::Zatoshis;
 
 use crate::build::sign_pczt;
 use crate::engine::{
-    MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
-    PoolMigrationRead, PoolMigrationWrite,
+    MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTxId,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 
 /// A failure of the wallet-backed migration adapter. Parameterized by the error types of the two
@@ -57,6 +57,12 @@ pub enum Error<WRE, ISE, SE> {
     /// The spendable note at this index has a value that is not a valid [`Zatoshis`] amount
     /// (it exceeds the money-supply cap).
     InvalidNoteValue(usize),
+    /// Proving a transfer requires resolving the funding note's witness against the drawn anchor
+    /// boundary checkpoint, which the wallet keeps alive through migration anchor-checkpoint
+    /// retention (issue #2700). Until that retention lands, the wallet adapter cannot prove a
+    /// transfer; the engine's [`prove_transfer`](crate::engine::prove_transfer) flow and the
+    /// in-memory mock exercise the path in the meantime.
+    ProvingUnsupported,
 }
 
 impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Error<WRE, ISE, SE> {
@@ -71,6 +77,10 @@ impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Er
             Error::InvalidNoteValue(i) => {
                 write!(f, "spendable note {i} has an invalid (out-of-range) value")
             }
+            Error::ProvingUnsupported => f.write_str(
+                "proving a migration transfer is not yet supported by the wallet adapter; it \
+                 requires migration anchor-checkpoint retention (issue #2700)",
+            ),
         }
     }
 }
@@ -212,6 +222,33 @@ where
     fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {
         let ask = SpendAuthorizingKey::from(self.usk.orchard());
         sign_pczt(pczt, &ask).map_err(Error::Sign)
+    }
+}
+
+impl<'a, W, St> MigrationProver for WalletMigration<'a, W, St>
+where
+    W: WalletRead + InputSource,
+    <W as InputSource>::AccountId: Copy,
+    St: PoolMigrationRead,
+{
+    type Error = AdapterError<W, St>;
+
+    fn prove_transfer(
+        &self,
+        _pczt: ::pczt::Pczt,
+        _anchor_boundary: zcash_protocol::consensus::BlockHeight,
+    ) -> Result<::pczt::Pczt, Self::Error> {
+        // Resolving the funding note's witness against the drawn boundary requires that boundary's
+        // checkpoint to still exist in the wallet's Orchard commitment tree at proving time, via
+        // `WalletCommitmentTrees::with_orchard_tree_mut` at the retained checkpoint. That retention
+        // is migration anchor-checkpoint retention (issue #2700), which is not yet wired here; until
+        // it lands, the wallet adapter cannot prove a transfer. The engine `prove_transfer` step and
+        // the in-memory mock exercise the flow in the meantime.
+        //
+        // This stub stays on `WalletMigration` because the adapter borrows the wallet immutably
+        // (`&W`); the real body needs `&mut W` plus proving keys, so it will move to a dedicated
+        // mutable prover adapter when #2700 lands.
+        Err(Error::ProvingUnsupported)
     }
 }
 

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -363,7 +363,7 @@ type ProverError<W> =
 /// account's full viewing key, and matches. This serves both a transfer (one funding-note spend
 /// plus an Ironwood output) and a preparation transaction (one or more spends, no Ironwood). The
 /// anchor checkpoint the witnesses are taken against must still exist in the tree at proving time
-/// (migration anchor-checkpoint retention, issue #2700).
+/// (the wallet backend must retain that checkpoint until the migration's transfers are proven).
 pub struct WalletMigrationProver<'a, W>
 where
     W: InputSource,

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -234,7 +234,7 @@ where
     type Error = AdapterError<W, St>;
 
     fn prove_transfer(
-        &self,
+        &mut self,
         _pczt: ::pczt::Pczt,
         _anchor_boundary: zcash_protocol::consensus::BlockHeight,
     ) -> Result<::pczt::Pczt, Self::Error> {

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -288,12 +288,16 @@ pub enum WalletProveError<TE, NE> {
     MalformedNullifier([u8; 32]),
     /// Enumerating the account's spendable Orchard notes (to locate each spend by nullifier) failed.
     Notes(NE),
-    /// The Orchard commitment tree has no root at the anchor checkpoint (the checkpoint was never
-    /// created, or was pruned before proving; see issue #2700).
+    /// A commitment tree (the Orchard source tree, or the Ironwood destination tree for a transfer)
+    /// has no root at the anchor checkpoint (the checkpoint was never created, or was pruned before
+    /// proving; see issue #2700).
     AnchorNotFound(BlockHeight),
     /// A spent note has no witness at the anchor checkpoint (the checkpoint was pruned, or the
     /// note's position is not marked in the tree).
     WitnessNotFound(BlockHeight),
+    /// The wallet backend tracks no Ironwood commitment tree, so a transfer's Ironwood destination
+    /// anchor cannot be resolved (the backend does not support the Ironwood pool).
+    IronwoodTreeUnavailable,
     /// A commitment-tree query failed.
     Tree(ShardTreeError<TE>),
     /// Installing the Orchard source or Ironwood destination anchor through the PCZT `Updater` role
@@ -336,7 +340,7 @@ impl<TE: fmt::Debug, NE: fmt::Debug> fmt::Display for WalletProveError<TE, NE> {
             }
             WalletProveError::AnchorNotFound(h) => write!(
                 f,
-                "the Orchard tree has no root at the anchor checkpoint {}",
+                "a commitment tree has no root at the anchor checkpoint {}",
                 u32::from(*h)
             ),
             WalletProveError::WitnessNotFound(h) => write!(
@@ -344,6 +348,9 @@ impl<TE: fmt::Debug, NE: fmt::Debug> fmt::Display for WalletProveError<TE, NE> {
                 "a spent note has no witness at the anchor checkpoint {}",
                 u32::from(*h)
             ),
+            WalletProveError::IronwoodTreeUnavailable => {
+                f.write_str("the wallet backend tracks no Ironwood commitment tree")
+            }
             WalletProveError::Tree(e) => write!(f, "commitment-tree query failed: {e:?}"),
             WalletProveError::Anchor(e) => write!(f, "installing an anchor failed: {e:?}"),
             WalletProveError::Witness(e) => write!(f, "installing a spend witness failed: {e:?}"),
@@ -487,17 +494,37 @@ where
                 Ok((root, witnesses))
             })?;
 
+        // A transfer's Ironwood destination bundle must anchor at the SAME height as its Orchard
+        // source bundle: all anchors in a transaction are computed for one height. Resolve the
+        // Ironwood tree root at `anchor_height` (its output-only action's padding spend is a value-0
+        // dummy whose Merkle path the circuit does not enforce, so no Ironwood witness is installed,
+        // but the anchor must still be a real historical Ironwood root the consensus rules accept:
+        // the empty-tree root is only valid while no Ironwood notes have been committed).
+        let ironwood_anchor: Option<Anchor> = if has_ironwood {
+            Some(
+                self.wallet
+                    .with_ironwood_tree_mut::<_, Anchor, ProverError<W>>(|tree| {
+                        Ok(tree
+                            .root_at_checkpoint_id(&anchor_height)?
+                            .ok_or(WalletProveError::AnchorNotFound(anchor_height))?
+                            .into())
+                    })?
+                    .ok_or(WalletProveError::IronwoodTreeUnavailable)?,
+            )
+        } else {
+            None
+        };
+
         // Install the deferred data through the Updater role: the Orchard source anchor and every
-        // spend's witness, plus (for a transfer) the Ironwood destination anchor (the output side
-        // anchors to the empty tree; it has no spend to witness).
+        // spend's witness, plus (for a transfer) the Ironwood destination anchor.
         let mut updater = Updater::new(pczt)
             .set_orchard_anchor(anchor)
             .map_err(WalletProveError::Anchor)?
             .set_orchard_spend_witnesses(witnesses)
             .map_err(WalletProveError::Witness)?;
-        if has_ironwood {
+        if let Some(ironwood_anchor) = ironwood_anchor {
             updater = updater
-                .set_ironwood_anchor(Anchor::empty_tree())
+                .set_ironwood_anchor(ironwood_anchor)
                 .map_err(WalletProveError::Anchor)?;
         }
         let updated = updater.finish();

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -408,7 +408,7 @@ where
     <W as InputSource>::AccountId: Copy,
 {
     /// Prove one migration transaction's Orchard bundle (and its Ironwood bundle, when it has one)
-    /// against `anchor`: install the source anchor and every deferred spend's witness through the
+    /// against `anchor_height`: install the source anchor and every deferred spend's witness through the
     /// PCZT `Updater` role, then run the provers. Shared by
     /// [`prove_transfer`](MigrationProver::prove_transfer) (a transfer: one Orchard spend plus an
     /// Ironwood output) and [`prove_preparation`](MigrationProver::prove_preparation) (a preparation:
@@ -416,7 +416,7 @@ where
     fn prove_orchard(
         &mut self,
         pczt: ::pczt::Pczt,
-        anchor: BlockHeight,
+        anchor_height: BlockHeight,
     ) -> Result<::pczt::Pczt, ProverError<W>> {
         // Every Orchard action whose witness is still deferred is a real spend to witness; the padded
         // dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
@@ -439,7 +439,7 @@ where
 
         // Locate each spend in the wallet's note store: map every unspent Orchard note's nullifier
         // (recomputed under the account FVK) to its commitment-tree position, then look up each spend.
-        let target = TargetHeight::from(u32::from(anchor) + 1);
+        let target = TargetHeight::from(u32::from(anchor_height) + 1);
         let received = self
             .wallet
             .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
@@ -473,14 +473,14 @@ where
             self.wallet
                 .with_orchard_tree_mut::<_, _, ProverError<W>>(|tree| {
                     let root: Anchor = tree
-                        .root_at_checkpoint_id(&anchor)?
-                        .ok_or(WalletProveError::AnchorNotFound(anchor))?
+                        .root_at_checkpoint_id(&anchor_height)?
+                        .ok_or(WalletProveError::AnchorNotFound(anchor_height))?
                         .into();
                     let mut witnesses = Vec::with_capacity(spend_positions.len());
                     for (index, position) in &spend_positions {
                         let path: MerklePath = tree
-                            .witness_at_checkpoint_id_caching(*position, &anchor)?
-                            .ok_or(WalletProveError::WitnessNotFound(anchor))?
+                            .witness_at_checkpoint_id_caching(*position, &anchor_height)?
+                            .ok_or(WalletProveError::WitnessNotFound(anchor_height))?
                             .into();
                         witnesses.push((*index, path));
                     }

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -469,29 +469,29 @@ where
 
         // Resolve the source anchor (the tree root at the checkpoint) and each spend's Merkle witness
         // against it, mirroring `create_proposed_transactions`.
-        let (anchor_root, witnesses): (Anchor, Vec<(usize, MerklePath)>) =
-            self.wallet
-                .with_orchard_tree_mut::<_, _, ProverError<W>>(|tree| {
-                    let root: Anchor = tree
-                        .root_at_checkpoint_id(&anchor_height)?
-                        .ok_or(WalletProveError::AnchorNotFound(anchor_height))?
+        let (anchor, witnesses): (Anchor, Vec<(usize, MerklePath)>) = self
+            .wallet
+            .with_orchard_tree_mut::<_, _, ProverError<W>>(|tree| {
+                let root: Anchor = tree
+                    .root_at_checkpoint_id(&anchor_height)?
+                    .ok_or(WalletProveError::AnchorNotFound(anchor_height))?
+                    .into();
+                let mut witnesses = Vec::with_capacity(spend_positions.len());
+                for (index, position) in &spend_positions {
+                    let path: MerklePath = tree
+                        .witness_at_checkpoint_id_caching(*position, &anchor_height)?
+                        .ok_or(WalletProveError::WitnessNotFound(anchor_height))?
                         .into();
-                    let mut witnesses = Vec::with_capacity(spend_positions.len());
-                    for (index, position) in &spend_positions {
-                        let path: MerklePath = tree
-                            .witness_at_checkpoint_id_caching(*position, &anchor_height)?
-                            .ok_or(WalletProveError::WitnessNotFound(anchor_height))?
-                            .into();
-                        witnesses.push((*index, path));
-                    }
-                    Ok((root, witnesses))
-                })?;
+                    witnesses.push((*index, path));
+                }
+                Ok((root, witnesses))
+            })?;
 
         // Install the deferred data through the Updater role: the Orchard source anchor and every
         // spend's witness, plus (for a transfer) the Ironwood destination anchor (the output side
         // anchors to the empty tree; it has no spend to witness).
         let mut updater = Updater::new(pczt)
-            .set_orchard_anchor(anchor_root)
+            .set_orchard_anchor(anchor)
             .map_err(WalletProveError::Anchor)?
             .set_orchard_spend_witnesses(witnesses)
             .map_err(WalletProveError::Witness)?;

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -10,22 +10,32 @@
 //! then
 //! runs [`commit_preparation`] with no hand-wired cryptography.
 //!
-//! No note commitment tree access appears here: every migration transaction is built and signed
-//! with its anchor and witnesses deferred to proving time (ZIP 374), so the adapter never
-//! resolves a witness — the consumer installs anchors and witnesses through the PCZT `Updater`
-//! role when it proves each transaction, just before broadcast.
+//! [`WalletMigration`] holds the wallet by a SHARED borrow and touches no note commitment tree:
+//! every migration transaction is built and signed with its anchor and witnesses deferred to
+//! proving time (ZIP 374). Proving is the separate [`WalletMigrationProver`], which borrows the
+//! wallet as `&mut W` to resolve the drawn source anchor and the funding note's witness from the
+//! wallet's Orchard commitment tree and installs them through the PCZT `Updater` role before
+//! proving both bundles, just before broadcast.
 //!
 //! [`commit_preparation`]: crate::engine::commit_preparation
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::fmt;
+use std::sync::OnceLock;
 
+use ::orchard::Anchor;
+use ::orchard::circuit::{OrchardCircuitVersion, ProvingKey};
 use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
 use ::orchard::note::Note as OrchardNote;
+use ::orchard::tree::MerklePath;
 use incrementalmerkletree::Position;
+use shardtree::error::ShardTreeError;
 
+use ::pczt::roles::prover::Prover;
+use ::pczt::roles::updater::{AnchorUpdateError, SpendWitnessUpdateError, Updater};
 use zcash_client_backend::data_api::wallet::TargetHeight;
-use zcash_client_backend::data_api::{InputSource, WalletRead};
+use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_protocol::ShieldedPool;
 use zcash_protocol::consensus::BlockHeight;
@@ -57,12 +67,6 @@ pub enum Error<WRE, ISE, SE> {
     /// The spendable note at this index has a value that is not a valid [`Zatoshis`] amount
     /// (it exceeds the money-supply cap).
     InvalidNoteValue(usize),
-    /// Proving a transfer requires resolving the funding note's witness against the drawn anchor
-    /// boundary checkpoint, which the wallet keeps alive through migration anchor-checkpoint
-    /// retention (issue #2700). Until that retention lands, the wallet adapter cannot prove a
-    /// transfer; the engine's [`prove_transfer`](crate::engine::prove_transfer) flow and the
-    /// in-memory mock exercise the path in the meantime.
-    ProvingUnsupported,
 }
 
 impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Error<WRE, ISE, SE> {
@@ -77,10 +81,6 @@ impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Er
             Error::InvalidNoteValue(i) => {
                 write!(f, "spendable note {i} has an invalid (out-of-range) value")
             }
-            Error::ProvingUnsupported => f.write_str(
-                "proving a migration transfer is not yet supported by the wallet adapter; it \
-                 requires migration anchor-checkpoint retention (issue #2700)",
-            ),
         }
     }
 }
@@ -225,33 +225,6 @@ where
     }
 }
 
-impl<'a, W, St> MigrationProver for WalletMigration<'a, W, St>
-where
-    W: WalletRead + InputSource,
-    <W as InputSource>::AccountId: Copy,
-    St: PoolMigrationRead,
-{
-    type Error = AdapterError<W, St>;
-
-    fn prove_transfer(
-        &mut self,
-        _pczt: ::pczt::Pczt,
-        _anchor_boundary: zcash_protocol::consensus::BlockHeight,
-    ) -> Result<::pczt::Pczt, Self::Error> {
-        // Resolving the funding note's witness against the drawn boundary requires that boundary's
-        // checkpoint to still exist in the wallet's Orchard commitment tree at proving time, via
-        // `WalletCommitmentTrees::with_orchard_tree_mut` at the retained checkpoint. That retention
-        // is migration anchor-checkpoint retention (issue #2700), which is not yet wired here; until
-        // it lands, the wallet adapter cannot prove a transfer. The engine `prove_transfer` step and
-        // the in-memory mock exercise the flow in the meantime.
-        //
-        // This stub stays on `WalletMigration` because the adapter borrows the wallet immutably
-        // (`&W`); the real body needs `&mut W` plus proving keys, so it will move to a dedicated
-        // mutable prover adapter when #2700 lands.
-        Err(Error::ProvingUnsupported)
-    }
-}
-
 impl<'a, W, St> PoolMigrationRead for WalletMigration<'a, W, St>
 where
     W: WalletRead + InputSource,
@@ -283,6 +256,183 @@ where
         self.store
             .update_transaction(id, state)
             .map_err(Error::Store)
+    }
+}
+
+/// The single Orchard proving key used for both the source (Orchard) and destination (Ironwood)
+/// bundles of a post-NU6.3 migration transfer. Building it is expensive (it materializes the halo2
+/// circuit parameters), so it is built once and cached for the process. Ironwood proofs reuse the
+/// same key as Orchard (both are the `PostNu6_3` circuit).
+fn post_nu6_3_orchard_proving_key() -> &'static ProvingKey {
+    static PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
+    PROVING_KEY.get_or_init(|| ProvingKey::build(OrchardCircuitVersion::PostNu6_3))
+}
+
+/// Why proving a migration transfer through the wallet-backed prover failed. `TE` is the wallet's
+/// commitment-tree error type ([`WalletCommitmentTrees::Error`]).
+#[derive(Debug)]
+pub enum WalletProveError<TE> {
+    /// The transfer PCZT has no real Orchard spend to witness. Every migration transfer spends one
+    /// funding note, so its bundle carries exactly one action whose witness is still deferred (all
+    /// the fabricated dummy spends keep their own witnesses); its absence means the PCZT is not a
+    /// deferred-anchor transfer awaiting proof.
+    NoRealSpend,
+    /// No tree position is known for the funding note the transfer spends (keyed by the revealed
+    /// spend nullifier). The caller's position map does not cover this note.
+    UnknownFundingNote([u8; 32]),
+    /// The Orchard commitment tree has no root at the drawn anchor-boundary checkpoint (the
+    /// checkpoint was never created, or was pruned before proving; see issue #2700).
+    AnchorNotFound(BlockHeight),
+    /// The funding note has no witness at the drawn anchor-boundary checkpoint (the checkpoint was
+    /// pruned, or the note's position is not marked in the tree).
+    WitnessNotFound(BlockHeight),
+    /// A commitment-tree query failed.
+    Tree(ShardTreeError<TE>),
+    /// Installing the Orchard source or Ironwood destination anchor through the PCZT `Updater` role
+    /// failed.
+    Anchor(AnchorUpdateError),
+    /// Installing the funding note's spend witness through the PCZT `Updater` role failed.
+    Witness(SpendWitnessUpdateError),
+    /// Creating the Orchard or Ironwood proof failed. The two proof roles return distinct error
+    /// types and `pczt` does not export the Ironwood one, so the failure is carried as a labeled
+    /// diagnostic string rather than a typed value.
+    Prove(alloc::string::String),
+}
+
+impl<TE> From<ShardTreeError<TE>> for WalletProveError<TE> {
+    fn from(e: ShardTreeError<TE>) -> Self {
+        WalletProveError::Tree(e)
+    }
+}
+
+impl<TE: fmt::Debug> fmt::Display for WalletProveError<TE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WalletProveError::NoRealSpend => {
+                f.write_str("the transfer PCZT has no deferred-witness Orchard spend to prove")
+            }
+            WalletProveError::UnknownFundingNote(nf) => {
+                write!(
+                    f,
+                    "no tree position known for funding note nullifier {nf:?}"
+                )
+            }
+            WalletProveError::AnchorNotFound(h) => write!(
+                f,
+                "the Orchard tree has no root at the drawn anchor-boundary checkpoint {}",
+                u32::from(*h)
+            ),
+            WalletProveError::WitnessNotFound(h) => write!(
+                f,
+                "the funding note has no witness at the drawn anchor-boundary checkpoint {}",
+                u32::from(*h)
+            ),
+            WalletProveError::Tree(e) => write!(f, "commitment-tree query failed: {e:?}"),
+            WalletProveError::Anchor(e) => write!(f, "installing an anchor failed: {e:?}"),
+            WalletProveError::Witness(e) => write!(f, "installing the spend witness failed: {e:?}"),
+            WalletProveError::Prove(msg) => write!(f, "creating a bundle proof failed: {msg}"),
+        }
+    }
+}
+
+impl<TE: fmt::Debug> core::error::Error for WalletProveError<TE> {}
+
+/// A wallet-backed prover for migration transfers: the mutable counterpart to [`WalletMigration`].
+///
+/// Proving a transfer resolves its DEFERRED Orchard source anchor and the funding note's Merkle
+/// witness against the boundary the schedule drew (ZIP 374), which needs MUTABLE access to the
+/// wallet's Orchard commitment tree ([`WalletCommitmentTrees::with_orchard_tree_mut`], whose witness
+/// resolution caches into the tree). That is why proving lives here, borrowing the wallet as
+/// `&mut W`, rather than on the shared-borrow [`WalletMigration`] used to build and sign.
+///
+/// The funding note a transfer spends is identified by the revealed spend nullifier; `funding_positions`
+/// maps that nullifier to the note's position in the wallet's Orchard commitment tree. A production
+/// consumer fills this map from the wallet's own note store (looking each nullifier up in the
+/// received-notes table); the anchor-boundary checkpoint the witness is taken against must still
+/// exist in the tree at proving time (migration anchor-checkpoint retention, issue #2700).
+pub struct WalletMigrationProver<'a, W> {
+    wallet: &'a mut W,
+    funding_positions: BTreeMap<[u8; 32], Position>,
+}
+
+impl<'a, W> WalletMigrationProver<'a, W> {
+    /// Wrap a wallet (borrowed mutably for commitment-tree access) and the map from each funding
+    /// note's revealed spend nullifier to its position in the wallet's Orchard commitment tree.
+    pub fn new(wallet: &'a mut W, funding_positions: BTreeMap<[u8; 32], Position>) -> Self {
+        Self {
+            wallet,
+            funding_positions,
+        }
+    }
+}
+
+impl<'a, W> MigrationProver for WalletMigrationProver<'a, W>
+where
+    W: WalletCommitmentTrees,
+{
+    type Error = WalletProveError<<W as WalletCommitmentTrees>::Error>;
+
+    fn prove_transfer(
+        &mut self,
+        pczt: ::pczt::Pczt,
+        anchor_boundary: BlockHeight,
+    ) -> Result<::pczt::Pczt, Self::Error> {
+        // The one Orchard action whose witness is still deferred is the real funding-note spend; the
+        // padded dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
+        let (spend_index, nullifier) = pczt
+            .orchard()
+            .actions()
+            .iter()
+            .enumerate()
+            .find(|(_, action)| action.spend().witness().is_none())
+            .map(|(index, action)| (index, *action.spend().nullifier()))
+            .ok_or(WalletProveError::NoRealSpend)?;
+
+        let position = *self
+            .funding_positions
+            .get(&nullifier)
+            .ok_or(WalletProveError::UnknownFundingNote(nullifier))?;
+
+        // Resolve the source anchor (the tree root at the boundary checkpoint) and the funding note's
+        // Merkle witness against it, mirroring `create_proposed_transactions`.
+        let (anchor, merkle_path): (Anchor, MerklePath) = self
+            .wallet
+            .with_orchard_tree_mut::<_, _, WalletProveError<<W as WalletCommitmentTrees>::Error>>(
+                |tree| {
+                    let anchor: Anchor = tree
+                        .root_at_checkpoint_id(&anchor_boundary)?
+                        .ok_or(WalletProveError::AnchorNotFound(anchor_boundary))?
+                        .into();
+                    let merkle_path: MerklePath = tree
+                        .witness_at_checkpoint_id_caching(position, &anchor_boundary)?
+                        .ok_or(WalletProveError::WitnessNotFound(anchor_boundary))?
+                        .into();
+                    Ok((anchor, merkle_path))
+                },
+            )?;
+
+        // Install the deferred data through the Updater role: the Orchard source anchor and the
+        // funding note's witness, and the Ironwood destination anchor (the output side anchors to the
+        // empty tree; it has no spend to witness).
+        let updated = Updater::new(pczt)
+            .set_orchard_anchor(anchor)
+            .map_err(WalletProveError::Anchor)?
+            .set_orchard_spend_witnesses([(spend_index, merkle_path)])
+            .map_err(WalletProveError::Witness)?
+            .set_ironwood_anchor(Anchor::empty_tree())
+            .map_err(WalletProveError::Anchor)?
+            .finish();
+
+        // Prove both bundles with the single post-NU6.3 Orchard proving key.
+        let pk = post_nu6_3_orchard_proving_key();
+        let proven = Prover::new(updated)
+            .create_orchard_proof(pk)
+            .map_err(|e| WalletProveError::Prove(alloc::format!("orchard proof: {e:?}")))?
+            .create_ironwood_proof(pk)
+            .map_err(|e| WalletProveError::Prove(alloc::format!("ironwood proof: {e:?}")))?
+            .finish();
+
+        Ok(proven)
     }
 }
 

--- a/zcash_pool_migration_backend/tests/engine_commit.rs
+++ b/zcash_pool_migration_backend/tests/engine_commit.rs
@@ -156,7 +156,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     let mut state = state;
     let target = BlockHeight::from_u32(2_100_000);
     match state.next_step(target) {
-        AdvanceStep::Broadcast { id } => {
+        AdvanceStep::Prove { id } | AdvanceStep::Broadcast { id } => {
             assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
         }
         other => panic!("expected a broadcast step, got {other:?}"),
@@ -171,7 +171,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
         .map(|t| t.id())
         .collect();
     match state.next_step(target) {
-        AdvanceStep::Broadcast { id } => {
+        AdvanceStep::Prove { id } | AdvanceStep::Broadcast { id } => {
             assert!(
                 layer1_ids.contains(&id),
                 "layer 1 broadcasts once layer 0 mines"
@@ -183,7 +183,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
         state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
     }
     match state.next_step(target) {
-        AdvanceStep::Broadcast { id } => {
+        AdvanceStep::Prove { id } | AdvanceStep::Broadcast { id } => {
             let tx = state
                 .transactions()
                 .iter()

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -1,0 +1,403 @@
+//! End-to-end, real-proving chain simulation of a whole migration over a genuine wallet.
+//!
+//! This drives a real (in-memory) `zcash_client_sqlite` `WalletDb` through the
+//! `zcash_client_backend` testing framework, exercising the migration engine's proving path against
+//! the wallet's OWN Orchard commitment tree instead of a hand-built one:
+//!
+//! 1. fund an account with a spendable Orchard note and commit a migration over the
+//!    [`WalletMigration`] adapter (so the plan, the prep transactions, and the transfers all come
+//!    from the real wallet);
+//! 2. prove each PREPARATION transaction against the chain tip (installing the source anchor and its
+//!    spends' witnesses through the PCZT `Updater` role), extract it, mine it, and scan it — so its
+//!    minted funding notes become genuinely scanned received notes with real tree positions;
+//! 3. advance the chain to each TRANSFER's drawn anchor boundary and prove it (resolving the funding
+//!    note's witness from the wallet's tree by the nullifier its spend reveals), extract it, and
+//!    assert both its Orchard and Ironwood bundles verify.
+//!
+//! [`WalletMigrationProver`] resolves every spend's tree position from the wallet's own note store
+//! (no hand-supplied map), so this test also covers that production lookup path. It keeps each
+//! transfer's boundary within `zcash_client_sqlite`'s checkpoint pruning window (100 blocks of the
+//! tip), so it needs no migration anchor-checkpoint retention (issue #2700), which is a wallet
+//! backend concern out of the migration crate's control.
+//!
+//! Run with `--features wallet,test-dependencies` (the latter exposes
+//! [`commit_preparation_with_funding`], which hands the test each transfer's funding note).
+#![cfg(all(feature = "wallet", feature = "test-dependencies"))]
+
+use std::convert::Infallible;
+use std::time::{Duration, SystemTime};
+
+use prost::Message;
+use rand_chacha::ChaCha8Rng;
+use rand_chacha::ChaChaRng;
+use rand_core::SeedableRng;
+use rusqlite::{Connection, params};
+
+use pczt::roles::tx_extractor::TransactionExtractor;
+
+use shardtree::error::ShardTreeError;
+use zcash_client_backend::data_api::testing::{
+    AddressType, CacheInsertionResult, DataStoreFactory, TestBuilder, TestCache,
+    orchard::OrchardPoolTester, pool::ShieldedPoolTester,
+};
+use zcash_client_backend::data_api::{Account, WalletCommitmentTrees, WalletRead};
+use zcash_client_backend::proto::compact_formats::CompactBlock;
+use zcash_client_sqlite::chain::init::init_cache_database;
+use zcash_client_sqlite::error::SqliteClientError;
+use zcash_client_sqlite::util::testing::FixedClock;
+use zcash_client_sqlite::wallet::init::WalletMigrator;
+use zcash_client_sqlite::{BlockDb, WalletDb};
+// Only referenced when `transparent-inputs` is active: the `DataStoreFactory::new_data_store`
+// signature grows a `gap_limits` parameter under that feature, so the impl below must match it.
+#[cfg(feature = "transparent-inputs")]
+use zcash_keys::keys::transparent::gap_limits::GapLimits;
+
+use tempfile::NamedTempFile;
+
+use zcash_primitives::block::BlockHash;
+use zcash_protocol::TxId;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::local_consensus::LocalNetwork;
+use zcash_protocol::value::{COIN, Zatoshis};
+
+use zcash_pool_migration_backend::engine::{
+    self, MigrationState, MigrationTxId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
+    PoolMigrationWrite,
+};
+use zcash_pool_migration_backend::wallet::{WalletMigration, WalletMigrationProver};
+
+/// Every network upgrade (through NU6.3, which activates the Ironwood pool) is active from this
+/// height, so a migration built at or above it is post-NU6.3 and its transfers cross into Ironwood.
+const ACTIVATION: u32 = 100_000;
+/// The account is funded with this many ZEC in a single Orchard note; large enough that the
+/// note-split planner produces at least one preparation transaction and one pool-crossing transfer.
+const FUNDING_ZEC: u64 = 78;
+/// Empty blocks scanned after a note is received so its commitment-tree shard completes and an
+/// anchor at that height is available.
+const SHARD_COMPLETION_BLOCKS: usize = 5;
+/// A deterministic wall-clock instant for the wallet's clock; the value is irrelevant to proving.
+const CLOCK_EPOCH_OFFSET_SECS: u64 = 1_700_000_000;
+
+/// The concrete in-memory wallet the harness drives.
+type MigrationWalletDb = WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng>;
+
+/// The highest checkpoint at or below `from` whose Orchard tree root is available. The tip
+/// checkpoint is not yet rooted right after scanning, so a spend anchors to the newest settled
+/// checkpoint below it (every note mined at or before that height is still witnessable there).
+fn highest_rooted_checkpoint(db: &mut MigrationWalletDb, from: BlockHeight) -> BlockHeight {
+    let mut height = u32::from(from);
+    loop {
+        let bh = BlockHeight::from_u32(height);
+        let rooted = db
+            .with_orchard_tree_mut::<_, _, ShardTreeError<<MigrationWalletDb as WalletCommitmentTrees>::Error>>(
+                |tree| Ok(tree.root_at_checkpoint_id(&bh)?.is_some()),
+            )
+            .expect("queries the Orchard tree");
+        if rooted {
+            return bh;
+        }
+        assert!(height > ACTIVATION, "no rooted Orchard checkpoint exists");
+        height -= 1;
+    }
+}
+
+/// A network with every upgrade through NU6.3 active at [`ACTIVATION`].
+fn nu63_network() -> LocalNetwork {
+    let h = BlockHeight::from_u32(ACTIVATION);
+    LocalNetwork {
+        nu6: Some(h),
+        nu6_1: Some(h),
+        nu6_2: Some(h),
+        nu6_3: Some(h),
+        ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+    }
+}
+
+/// Builds a fresh in-memory `WalletDb` for the testing framework. `zcash_client_sqlite`'s own
+/// `TestDbFactory` is `pub(crate)`, so the harness supplies this minimal equivalent over the public
+/// `WalletDb::for_path` + `WalletMigrator` API (the same seam a future migration sqlite backend
+/// would conform to).
+struct MigrationDbFactory;
+
+impl DataStoreFactory for MigrationDbFactory {
+    type Error = ();
+    type AccountId = <MigrationWalletDb as WalletRead>::AccountId;
+    type Account = <MigrationWalletDb as WalletRead>::Account;
+    type DsError = <MigrationWalletDb as WalletRead>::Error;
+    type DataStore = MigrationWalletDb;
+
+    fn new_data_store(
+        &self,
+        network: LocalNetwork,
+        #[cfg(feature = "transparent-inputs")] _gap_limits: Option<GapLimits>,
+    ) -> Result<Self::DataStore, Self::Error> {
+        let clock =
+            FixedClock::new(SystemTime::UNIX_EPOCH + Duration::from_secs(CLOCK_EPOCH_OFFSET_SECS));
+        let mut db = WalletDb::for_path(":memory:", network, clock, ChaChaRng::seed_from_u64(0))
+            .expect("opens an in-memory wallet database");
+        WalletMigrator::new()
+            .init_or_migrate(&mut db)
+            .expect("applies the wallet migrations");
+        Ok(db)
+    }
+}
+
+/// A minimal in-memory compact-block cache for the testing framework. `zcash_client_sqlite`'s own
+/// `BlockCache` is `pub(crate)` and writes through `BlockDb`'s private connection, so the harness
+/// keeps a second connection to the same cache file to insert blocks the scanner then reads through
+/// the `BlockDb`.
+struct BlockCache {
+    _cache_file: NamedTempFile,
+    write_conn: Connection,
+    block_source: BlockDb,
+}
+
+impl BlockCache {
+    fn new() -> Self {
+        let cache_file = NamedTempFile::new().expect("creates a temporary cache file");
+        let block_source = BlockDb::for_path(cache_file.path()).expect("opens the block cache");
+        init_cache_database(&block_source).expect("initializes the block cache schema");
+        let write_conn =
+            Connection::open(cache_file.path()).expect("opens a writer to the block cache");
+        BlockCache {
+            _cache_file: cache_file,
+            write_conn,
+            block_source,
+        }
+    }
+}
+
+/// The txids inserted with one compact block; the framework needs only these.
+struct BlockCacheInsert {
+    txids: Vec<TxId>,
+}
+
+impl CacheInsertionResult for BlockCacheInsert {
+    fn txids(&self) -> &[TxId] {
+        &self.txids
+    }
+}
+
+impl TestCache for BlockCache {
+    type BsError = SqliteClientError;
+    type BlockSource = BlockDb;
+    type InsertResult = BlockCacheInsert;
+
+    fn block_source(&self) -> &Self::BlockSource {
+        &self.block_source
+    }
+
+    fn insert(&mut self, cb: &CompactBlock) -> Self::InsertResult {
+        self.write_conn
+            .execute(
+                "INSERT INTO compactblocks (height, data) VALUES (?, ?)",
+                params![u32::from(cb.height()), cb.encode_to_vec()],
+            )
+            .expect("inserts a compact block");
+        BlockCacheInsert {
+            txids: cb.vtx.iter().map(|tx| tx.txid()).collect(),
+        }
+    }
+
+    fn truncate_to_height(&mut self, height: BlockHeight) {
+        self.write_conn
+            .execute(
+                "DELETE FROM compactblocks WHERE height > ?",
+                params![u32::from(height)],
+            )
+            .expect("truncates the block cache");
+    }
+}
+
+/// A trivial in-memory migration store for the [`WalletMigration`] adapter. The chain simulation
+/// drives proving through the engine's free functions (which mutate the in-memory
+/// [`MigrationState`] directly), so only `replace_migration` (used by commit) is exercised.
+#[derive(Default)]
+struct MigrationTestStore {
+    state: Option<MigrationState>,
+}
+
+impl PoolMigrationRead for MigrationTestStore {
+    type Error = Infallible;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        Ok(self.state.clone())
+    }
+}
+
+impl PoolMigrationWrite for MigrationTestStore {
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.state = Some(state.clone());
+        Ok(())
+    }
+
+    fn update_transaction(
+        &mut self,
+        _id: MigrationTxId,
+        _state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        // Not exercised: the chain simulation advances proving state through the engine's
+        // `prove_preparation` / `prove_transfer` on the in-memory `MigrationState`, not the store.
+        Ok(())
+    }
+}
+
+#[test]
+fn migration_proves_end_to_end_against_a_funded_wallet() {
+    let network = nu63_network();
+
+    let mut st = TestBuilder::new()
+        .with_network(network)
+        .with_data_store_factory(MigrationDbFactory)
+        .with_block_cache(BlockCache::new())
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().expect("the test account exists");
+    let account_id = account.id();
+    let usk = account.usk().clone();
+    let fvk = OrchardPoolTester::test_account_fvk(&st);
+
+    // Fund the account with a single spendable Orchard note, then let its shard complete so an
+    // anchor is available at the tip.
+    let funding = Zatoshis::const_from_u64(FUNDING_ZEC * COIN);
+    let (fund_height, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, funding);
+    st.scan_cached_blocks(fund_height, 1);
+    assert_eq!(st.get_total_balance(account_id), funding);
+    for _ in 0..SHARD_COMPLETION_BLOCKS {
+        let (h, _) = st.generate_empty_block();
+        st.scan_cached_blocks(h, 1);
+    }
+
+    // Commit a migration over the wallet adapter: the plan, the preparation transactions, and the
+    // transfers all come from the real wallet's spendable notes.
+    let tip = st
+        .wallet()
+        .chain_height()
+        .expect("reads the chain height")
+        .expect("the wallet has a chain tip");
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let (mut state, _funding_notes) = {
+        let adapter =
+            WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
+        let plan =
+            engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+        let mut adapter = adapter;
+        engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
+            .expect("commits the migration")
+    };
+
+    // Every transaction is Signed with anchors and witnesses deferred.
+    for tx in state.transactions() {
+        assert!(matches!(tx.state(), MigrationTxState::Signed));
+    }
+
+    // Prove each preparation transaction against the current tip, extract it, mine it, and scan it,
+    // so its minted funding notes become spendable received notes in the wallet.
+    let prep_ids: Vec<MigrationTxId> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .map(|t| t.id())
+        .collect();
+    assert!(
+        !prep_ids.is_empty(),
+        "the migration has preparation transactions"
+    );
+
+    for prep_id in prep_ids {
+        let tip = st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        let anchor = highest_rooted_checkpoint(st.wallet_mut(), tip);
+        {
+            let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+            engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+                .expect("proves the preparation transaction");
+        }
+        let proven = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == prep_id)
+            .expect("the preparation transaction is present");
+        assert!(matches!(proven.state(), MigrationTxState::Proved));
+        let tx = TransactionExtractor::new(
+            pczt::Pczt::parse(proven.pczt()).expect("parses the proven preparation PCZT"),
+        )
+        .extract()
+        .expect("extracts and verifies the preparation transaction");
+        // A preparation transaction is Orchard-only: no Ironwood bundle.
+        assert!(
+            tx.orchard_bundle().is_some(),
+            "the preparation has an Orchard bundle"
+        );
+        assert!(
+            tx.ironwood_bundle().is_none(),
+            "the preparation has no Ironwood bundle"
+        );
+
+        let (prep_height, _) = st.generate_next_block_from_tx(1, &tx);
+        st.scan_cached_blocks(prep_height, 1);
+    }
+
+    // Prove each transfer once the chain has reached its drawn anchor boundary (so that checkpoint
+    // exists and holds the funding note), staying within the pruning window.
+    let mut transfers: Vec<(MigrationTxId, BlockHeight)> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+        .map(|t| {
+            (
+                t.id(),
+                t.anchor_boundary()
+                    .expect("a transfer carries a drawn boundary"),
+            )
+        })
+        .collect();
+    transfers.sort_by_key(|(_, boundary)| *boundary);
+    assert!(!transfers.is_empty(), "the migration has transfers");
+
+    for (transfer_id, boundary) in transfers {
+        // Advance (scanning empty blocks) until the tip is strictly past the transfer's boundary, so
+        // the boundary checkpoint is settled and rooted (the tip checkpoint is not yet rooted).
+        loop {
+            let tip = st
+                .wallet()
+                .chain_height()
+                .expect("reads the chain height")
+                .expect("the wallet has a chain tip");
+            if tip > boundary {
+                break;
+            }
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+        }
+
+        {
+            let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+            engine::prove_transfer(&mut prover, &mut state, transfer_id)
+                .expect("proves the transfer against its drawn boundary");
+        }
+        let proven = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == transfer_id)
+            .expect("the transfer is present");
+        assert!(matches!(proven.state(), MigrationTxState::Proved));
+        let tx = TransactionExtractor::new(
+            pczt::Pczt::parse(proven.pczt()).expect("parses the proven transfer PCZT"),
+        )
+        .extract()
+        .expect("extracts and verifies the transfer's Orchard and Ironwood proofs");
+        assert!(
+            tx.orchard_bundle().is_some(),
+            "the transfer has an Orchard bundle"
+        );
+        assert!(
+            tx.ironwood_bundle().is_some(),
+            "the transfer has an Ironwood bundle"
+        );
+    }
+}

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -51,9 +51,6 @@ use zcash_pool_migration_backend::wallet::{WalletMigration, WalletMigrationProve
 /// Every network upgrade (through NU6.3, which activates the Ironwood pool) is active from this
 /// height, so a migration built at or above it is post-NU6.3 and its transfers cross into Ironwood.
 const ACTIVATION: u32 = 100_000;
-/// The account is funded with this many ZEC in a single Orchard note; large enough that the
-/// note-split planner produces at least one preparation transaction and one pool-crossing transfer.
-const FUNDING_ZEC: u64 = 78;
 /// Empty blocks scanned after a note is received so its commitment-tree shard completes and an
 /// anchor at that height is available.
 const SHARD_COMPLETION_BLOCKS: usize = 5;
@@ -103,8 +100,41 @@ impl PoolMigrationWrite for MigrationTestStore {
     }
 }
 
+/// One end-to-end proving scenario. Kept as data, with its expected observable amounts, so more
+/// balances and note shapes can be added to [`SCENARIOS`] without duplicating the proving flow.
+struct Scenario {
+    /// A label for assertion messages.
+    label: &'static str,
+    /// The single spendable Orchard note the account is funded with.
+    funding: Zatoshis,
+    /// The number of preparation transactions the migration is expected to produce.
+    expected_preparations: usize,
+    /// The number of pool-crossing transfers (one per prepared funding note).
+    expected_transfers: usize,
+    /// The total value expected to cross into Ironwood: the sum of the crossing denominations.
+    expected_migrated: Zatoshis,
+}
+
+/// The proving scenarios exercised end to end. A single balance for now; the harness is
+/// scenario-driven so more (different balances, multi-note sources) can be added here.
+const SCENARIOS: &[Scenario] = &[Scenario {
+    label: "78 ZEC in a single note",
+    funding: Zatoshis::const_from_u64(78 * COIN),
+    expected_preparations: 1,
+    expected_transfers: 10,
+    // 77.99 ZEC: the canonical {1, 2, 5} * 10^k decomposition of 78 ZEC less the reserved transfer
+    // buffers and preparation fee, leaving 0.0077 ZEC of source-pool change.
+    expected_migrated: Zatoshis::const_from_u64(7_799 * (COIN / 100)),
+}];
+
 #[test]
 fn migration_proves_end_to_end_against_a_funded_wallet() {
+    for scenario in SCENARIOS {
+        run_scenario(scenario);
+    }
+}
+
+fn run_scenario(scenario: &Scenario) {
     let network = nu63_network();
 
     let mut st = TestBuilder::new()
@@ -119,34 +149,59 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
     let usk = account.usk().clone();
     let fvk = OrchardPoolTester::test_account_fvk(&st);
 
-    // Fund the account with a single spendable Orchard note, then let its shard complete so an
-    // anchor is available at the tip.
-    let funding = Zatoshis::const_from_u64(FUNDING_ZEC * COIN);
-    let (fund_height, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, funding);
+    // Fund the account with the scenario's single spendable Orchard note, then let its shard
+    // complete so an anchor is available at the tip.
+    let (fund_height, _, _) =
+        st.generate_next_block(&fvk, AddressType::DefaultExternal, scenario.funding);
     st.scan_cached_blocks(fund_height, 1);
-    assert_eq!(st.get_total_balance(account_id), funding);
+    assert_eq!(
+        st.get_total_balance(account_id),
+        scenario.funding,
+        "{}: funded balance",
+        scenario.label
+    );
     for _ in 0..SHARD_COMPLETION_BLOCKS {
         let (h, _) = st.generate_empty_block();
         st.scan_cached_blocks(h, 1);
     }
 
     // Commit a migration over the wallet adapter: the plan, the preparation transactions, and the
-    // transfers all come from the real wallet's spendable notes.
+    // transfers all come from the real wallet's spendable notes. Capture the planned amounts so the
+    // real chain state can be held to them below.
     let tip = st
         .wallet()
         .chain_height()
         .expect("reads the chain height")
         .expect("the wallet has a chain tip");
     let mut rng = ChaCha8Rng::seed_from_u64(0);
-    let (mut state, _funding_notes) = {
+    let (mut state, funding_notes, migrated, change) = {
         let adapter =
             WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
         let plan =
             engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+        let funding_notes = plan.funding_notes();
+        let migrated = plan.note_split().total_migratable();
+        let change = plan.note_split().change().map(u64::from).unwrap_or(0);
         let mut adapter = adapter;
-        engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
-            .expect("commits the migration")
+        let (state, _) =
+            engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
+                .expect("commits the migration");
+        (state, funding_notes, migrated, change)
     };
+
+    // The observable amounts match what this balance is expected to migrate: one funding note (and
+    // one transfer) per crossing denomination, and the whole value carried into Ironwood.
+    assert_eq!(
+        funding_notes.len(),
+        scenario.expected_transfers,
+        "{}: prepared funding notes",
+        scenario.label
+    );
+    assert_eq!(
+        migrated, scenario.expected_migrated,
+        "{}: total migrated value",
+        scenario.label
+    );
 
     // Every transaction is Signed with anchors and witnesses deferred.
     for tx in state.transactions() {
@@ -161,9 +216,11 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
         .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
         .map(|t| t.id())
         .collect();
-    assert!(
-        !prep_ids.is_empty(),
-        "the migration has preparation transactions"
+    assert_eq!(
+        prep_ids.len(),
+        scenario.expected_preparations,
+        "{}: preparation transactions",
+        scenario.label
     );
 
     for prep_id in prep_ids {
@@ -204,6 +261,17 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
         st.scan_cached_blocks(prep_height, 1);
     }
 
+    // With every preparation mined and scanned, the original note has been spent and replaced by the
+    // prepared funding notes plus the source-pool change, so the wallet's balance is exactly the
+    // funding minus the reserved preparation fees.
+    let funding_notes_total: u64 = funding_notes.iter().map(|&v| u64::from(v)).sum();
+    assert_eq!(
+        st.get_total_balance(account_id),
+        Zatoshis::from_u64(funding_notes_total + change).expect("a valid balance"),
+        "{}: balance after preparations",
+        scenario.label
+    );
+
     // Prove each transfer once the chain has reached its drawn anchor boundary (so that checkpoint
     // exists and holds the funding note), staying within the pruning window.
     let mut transfers: Vec<(MigrationTxId, BlockHeight)> = state
@@ -219,7 +287,12 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
         })
         .collect();
     transfers.sort_by_key(|(_, boundary)| *boundary);
-    assert!(!transfers.is_empty(), "the migration has transfers");
+    assert_eq!(
+        transfers.len(),
+        scenario.expected_transfers,
+        "{}: transfers",
+        scenario.label
+    );
 
     for (transfer_id, boundary) in transfers {
         // Advance (scanning empty blocks) until the tip is strictly past the transfer's boundary, so

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -31,15 +31,14 @@ use rand_core::SeedableRng;
 
 use pczt::roles::tx_extractor::TransactionExtractor;
 
-use shardtree::error::ShardTreeError;
 use zcash_client_backend::data_api::testing::{
     AddressType, TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
 };
-use zcash_client_backend::data_api::{Account, WalletCommitmentTrees, WalletRead};
-// The wallet, block cache, and DB factory come from `zcash_client_sqlite`'s own test harness,
-// exposed under its `test-dependencies` feature — no hand-rolled equivalents.
-use zcash_client_sqlite::testing::BlockCache;
-use zcash_client_sqlite::testing::db::{TestDb, TestDbFactory};
+use zcash_client_backend::data_api::{Account, WalletRead};
+// The wallet, block cache, DB factory, and Orchard-checkpoint helper come from
+// `zcash_client_sqlite`'s own test harness, exposed under its `test-dependencies` feature.
+use zcash_client_sqlite::testing::db::TestDbFactory;
+use zcash_client_sqlite::testing::{BlockCache, highest_rooted_orchard_checkpoint};
 
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
@@ -61,26 +60,6 @@ const FUNDING_ZEC: u64 = 78;
 /// Empty blocks scanned after a note is received so its commitment-tree shard completes and an
 /// anchor at that height is available.
 const SHARD_COMPLETION_BLOCKS: usize = 5;
-
-/// The highest checkpoint at or below `from` whose Orchard tree root is available. The tip
-/// checkpoint is not yet rooted right after scanning, so a spend anchors to the newest settled
-/// checkpoint below it (every note mined at or before that height is still witnessable there).
-fn highest_rooted_checkpoint(db: &mut TestDb, from: BlockHeight) -> BlockHeight {
-    let mut height = u32::from(from);
-    loop {
-        let bh = BlockHeight::from_u32(height);
-        let rooted = db
-            .with_orchard_tree_mut::<_, _, ShardTreeError<<TestDb as WalletCommitmentTrees>::Error>>(
-                |tree| Ok(tree.root_at_checkpoint_id(&bh)?.is_some()),
-            )
-            .expect("queries the Orchard tree");
-        if rooted {
-            return bh;
-        }
-        assert!(height > ACTIVATION, "no rooted Orchard checkpoint exists");
-        height -= 1;
-    }
-}
 
 /// A network with every upgrade through NU6.3 active at [`ACTIVATION`].
 fn nu63_network() -> LocalNetwork {
@@ -196,7 +175,8 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
             .chain_height()
             .expect("reads the chain height")
             .expect("the wallet has a chain tip");
-        let anchor = highest_rooted_checkpoint(st.wallet_mut(), tip);
+        let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
+            .expect("a rooted Orchard checkpoint exists");
         {
             let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
             engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -345,7 +345,9 @@ impl Run {
 
     /// Phase 4 (prove transfers): advances the chain to each transfer's drawn anchor boundary (so
     /// that checkpoint is settled and holds the funding note, within the pruning window), proves the
-    /// transfer, extracts it, and asserts both its Orchard and Ironwood bundles verify.
+    /// transfer, extracts it, and asserts both its Orchard and Ironwood bundles verify. Finally
+    /// checks the destination pool: the migration created exactly one Ironwood note per transfer,
+    /// together holding the whole migrated value.
     fn prove_transfers(&mut self, committed: &mut Committed, scenario: &Scenario) {
         let mut transfers: Vec<(MigrationTxId, BlockHeight)> = committed
             .state
@@ -367,6 +369,9 @@ impl Run {
             "{}: transfers",
             scenario.label
         );
+
+        // The Ironwood output note each transfer creates, collected to check the destination pool.
+        let mut ironwood_notes: Vec<Zatoshis> = Vec::new();
 
         for (transfer_id, boundary) in transfers {
             loop {
@@ -408,11 +413,38 @@ impl Run {
                 tx.orchard_bundle().is_some(),
                 "the transfer has an Orchard bundle"
             );
-            assert!(
-                tx.ironwood_bundle().is_some(),
-                "the transfer has an Ironwood bundle"
+            let ironwood = tx
+                .ironwood_bundle()
+                .expect("the transfer has an Ironwood bundle");
+            // A transfer creates exactly one Ironwood output: the migrated crossing note. Its value
+            // is the magnitude of the (output-only) bundle's value balance.
+            assert_eq!(
+                ironwood.actions().len(),
+                1,
+                "{}: Ironwood outputs per transfer",
+                scenario.label
+            );
+            ironwood_notes.push(
+                Zatoshis::from_u64(i64::from(ironwood.value_balance()).unsigned_abs())
+                    .expect("a valid Ironwood note value"),
             );
         }
+
+        // The destination pool holds exactly one Ironwood note per crossing, together carrying the
+        // whole migrated value.
+        assert_eq!(
+            ironwood_notes.len(),
+            scenario.expected_transfers,
+            "{}: Ironwood notes",
+            scenario.label
+        );
+        let ironwood_total: u64 = ironwood_notes.iter().map(|&v| u64::from(v)).sum();
+        assert_eq!(
+            Zatoshis::from_u64(ironwood_total).expect("a valid balance"),
+            scenario.expected_migrated,
+            "{}: Ironwood balance",
+            scenario.label
+        );
     }
 }
 

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -41,6 +41,7 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
+use zcash_protocol::value::testing::zats;
 use zcash_protocol::value::{COIN, Zatoshis};
 
 use zcash_pool_migration_backend::engine::{
@@ -101,13 +102,14 @@ impl PoolMigrationWrite for MigrationTestStore {
     }
 }
 
-/// An end-to-end migration proving scenario, built fluently: [`Scenario::funded`] sets the source
-/// note, the `expect_*` setters declare the observable outcomes, and [`Scenario::prove_end_to_end`]
-/// funds a real wallet, runs the whole migration, and asserts those outcomes phase by phase. Each new
-/// balance or note shape is a new builder in the test below.
+/// An end-to-end migration proving scenario, built fluently: [`Scenario::funded`] /
+/// [`Scenario::funded_notes`] set the source note shape, the `expect_*` setters declare the
+/// observable outcomes, and [`Scenario::prove_end_to_end`] funds a real wallet, runs the whole
+/// migration, and asserts those outcomes phase by phase. Each new balance or note shape is a new
+/// builder in the test below.
 struct Scenario {
     label: &'static str,
-    funding: Zatoshis,
+    funding: Vec<Zatoshis>,
     expected_preparations: usize,
     expected_transfers: usize,
     expected_migrated: Zatoshis,
@@ -116,6 +118,12 @@ struct Scenario {
 impl Scenario {
     /// Starts a scenario whose account is funded with a single Orchard note worth `funding`.
     fn funded(label: &'static str, funding: Zatoshis) -> Self {
+        Self::funded_notes(label, vec![funding])
+    }
+
+    /// Starts a scenario whose account is funded with several source Orchard notes (the "exchange" /
+    /// dusty shapes whose consolidation drives multi-layer preparation).
+    fn funded_notes(label: &'static str, funding: Vec<Zatoshis>) -> Self {
         Self {
             label,
             funding,
@@ -172,8 +180,8 @@ struct Committed {
 }
 
 impl Run {
-    /// Phase 1 (setup): builds an NU6.3 wallet, funds the account with the scenario's single Orchard
-    /// note, and completes the note's shard so an anchor is available at the tip.
+    /// Phase 1 (setup): builds an NU6.3 wallet, funds the account with the scenario's source Orchard
+    /// notes (one per block), and completes their shards so an anchor is available at the tip.
     fn setup(scenario: &Scenario) -> Self {
         let network = nu63_network();
 
@@ -189,12 +197,19 @@ impl Run {
         let usk = account.usk().clone();
         let fvk = OrchardPoolTester::test_account_fvk(&st);
 
-        let (fund_height, _, _) =
-            st.generate_next_block(&fvk, AddressType::DefaultExternal, scenario.funding);
-        st.scan_cached_blocks(fund_height, 1);
+        for &note in &scenario.funding {
+            let (h, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, note);
+            st.scan_cached_blocks(h, 1);
+        }
+        let funded_total: Zatoshis = scenario
+            .funding
+            .iter()
+            .copied()
+            .sum::<Option<Zatoshis>>()
+            .expect("the funded total is a valid amount");
         assert_eq!(
             st.get_total_balance(account_id),
-            scenario.funding,
+            funded_total,
             "{}: funded balance",
             scenario.label
         );
@@ -448,17 +463,85 @@ impl Run {
     }
 }
 
+/// Every proving scenario, spanning the migration personas exercised across the codebase (the Python
+/// integration-test suite and the note-split golden vectors): single small / medium / large
+/// balances, the minimum-denomination and buffer-pruned edges, and the many-note "exchange" / dust /
+/// whale shapes whose consolidation drives multi-layer preparation.
+fn scenarios() -> Vec<Scenario> {
+    // 0.02 ZEC dust notes.
+    let dust = zats(COIN / 50);
+    let dust_heavy: Vec<Zatoshis> = std::iter::once(zats(COIN))
+        .chain(std::iter::repeat(dust).take(12))
+        .collect();
+    // The migrated total is the balance less the reserved transfer buffers and preparation fees, so
+    // it is a multiple of the 0.01-ZEC minimum denomination; expressed here in hundredths of a ZEC.
+    let hundredths = COIN / 100;
+    vec![
+        // Single-note balances.
+        Scenario::funded("small holder, 2 ZEC", zats(2 * COIN))
+            .expect_preparations(1)
+            .expect_transfers(7)
+            .expect_migrated(zats(199 * hundredths)),
+        Scenario::funded("retail, 15 ZEC", zats(15 * COIN))
+            .expect_preparations(1)
+            .expect_transfers(9)
+            .expect_migrated(zats(1_499 * hundredths)),
+        Scenario::funded("denominations, 60 ZEC", zats(60 * COIN))
+            .expect_preparations(1)
+            .expect_transfers(10)
+            .expect_migrated(zats(5_999 * hundredths)),
+        Scenario::funded("78 ZEC in a single note", zats(78 * COIN))
+            .expect_preparations(1)
+            .expect_transfers(10)
+            .expect_migrated(zats(7_799 * hundredths)),
+        Scenario::funded(
+            "Gwen, 0.0152 ZEC (a single minimum-denomination note)",
+            zats(1_520_000),
+        )
+        .expect_preparations(1)
+        .expect_transfers(1)
+        .expect_migrated(zats(hundredths)),
+        Scenario::funded(
+            "Priya, 7.1101 ZEC (the buffer prunes the trailing crossing)",
+            zats(711_010_000),
+        )
+        .expect_preparations(1)
+        .expect_transfers(3)
+        .expect_migrated(zats(710 * hundredths)),
+        // Many-note shapes, consolidated across preparation layers.
+        Scenario::funded_notes("exchange, ten 5 ZEC notes", vec![zats(5 * COIN); 10])
+            .expect_preparations(2)
+            .expect_transfers(3)
+            .expect_migrated(zats(4_500 * hundredths)),
+        Scenario::funded_notes("monotonic, ten 12 ZEC notes", vec![zats(12 * COIN); 10])
+            .expect_preparations(5)
+            .expect_transfers(11)
+            .expect_migrated(zats(11_999 * hundredths)),
+        Scenario::funded_notes("dust-heavy, 1 ZEC and twelve 0.02 ZEC notes", dust_heavy)
+            .expect_preparations(4)
+            .expect_transfers(4)
+            .expect_migrated(zats(123 * hundredths)),
+        Scenario::funded_notes(
+            "whale plus dust, 40 ZEC and a six-note dust tail",
+            vec![
+                zats(40 * COIN),
+                zats(COIN / 50),
+                zats(COIN / 50),
+                zats(COIN / 20),
+                zats(COIN / 20),
+                zats(COIN / 10),
+                zats(COIN / 10),
+            ],
+        )
+        .expect_preparations(4)
+        .expect_transfers(6)
+        .expect_migrated(zats(4_033 * hundredths)),
+    ]
+}
+
 #[test]
 fn migration_proves_end_to_end_against_a_funded_wallet() {
-    // 78 ZEC decomposes into ten canonical crossings and migrates 77.99 ZEC (the balance less the
-    // reserved transfer buffers and preparation fee, leaving 0.0077 ZEC of source-pool change) via a
-    // single preparation transaction.
-    Scenario::funded(
-        "78 ZEC in a single note",
-        Zatoshis::const_from_u64(78 * COIN),
-    )
-    .expect_preparations(1)
-    .expect_transfers(10)
-    .expect_migrated(Zatoshis::const_from_u64(7_799 * (COIN / 100)))
-    .prove_end_to_end();
+    for scenario in scenarios() {
+        scenario.prove_end_to_end();
+    }
 }

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -17,11 +17,8 @@
 //! [`WalletMigrationProver`] resolves every spend's tree position from the wallet's own note store
 //! (no hand-supplied map), so this test also covers that production lookup path. It keeps each
 //! transfer's boundary within `zcash_client_sqlite`'s checkpoint pruning window (100 blocks of the
-//! tip), so it needs no migration anchor-checkpoint retention (issue #2700), which is a wallet
-//! backend concern out of the migration crate's control.
-//!
-//! Run with `--features wallet,test-dependencies` (the latter exposes
-//! [`commit_preparation_with_funding`], which hands the test each transfer's funding note).
+//! tip), so it needs no migration anchor-checkpoint retention, which is a wallet backend concern
+//! out of the migration crate's control.
 #![cfg(all(feature = "wallet", feature = "test-dependencies"))]
 
 use std::convert::Infallible;

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -29,13 +29,14 @@ use rand_core::SeedableRng;
 use pczt::roles::tx_extractor::TransactionExtractor;
 
 use zcash_client_backend::data_api::testing::{
-    AddressType, TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
+    AddressType, TestBuilder, TestState, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
 };
 use zcash_client_backend::data_api::{Account, WalletRead};
 // The wallet, block cache, DB factory, and Orchard-checkpoint helper come from
 // `zcash_client_sqlite`'s own test harness, exposed under its `test-dependencies` feature.
-use zcash_client_sqlite::testing::db::TestDbFactory;
+use zcash_client_sqlite::testing::db::{TestDb, TestDbFactory};
 use zcash_client_sqlite::testing::{BlockCache, highest_rooted_orchard_checkpoint};
+use zcash_keys::keys::UnifiedSpendingKey;
 
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
@@ -142,8 +143,38 @@ impl Scenario {
         self
     }
 
-    /// Runs the whole migration for this scenario and asserts every declared expectation.
+    /// Runs the whole migration for this scenario, phase by phase, asserting every declared
+    /// expectation as it goes: setup, plan-and-commit, prove-preparations, prove-transfers.
     fn prove_end_to_end(self) {
+        let mut run = Run::setup(&self);
+        let mut committed = run.plan_and_commit(&self);
+        run.prove_preparations(&mut committed, &self);
+        run.prove_transfers(&mut committed, &self);
+    }
+}
+
+/// The running harness of one [`Scenario`]: a funded wallet plus the account identity, carried
+/// across the proving phases.
+struct Run {
+    network: LocalNetwork,
+    st: TestState<BlockCache, TestDb, LocalNetwork>,
+    account_id: <TestDb as WalletRead>::AccountId,
+    usk: UnifiedSpendingKey,
+    fvk: <OrchardPoolTester as ShieldedPoolTester>::Fvk,
+}
+
+/// The committed migration produced by [`Run::plan_and_commit`] and advanced by the proving phases,
+/// with the planned amounts those phases hold the real chain state to.
+struct Committed {
+    state: MigrationState,
+    funding_notes: Vec<Zatoshis>,
+    change: u64,
+}
+
+impl Run {
+    /// Phase 1 (setup): builds an NU6.3 wallet, funds the account with the scenario's single Orchard
+    /// note, and completes the note's shard so an anchor is available at the tip.
+    fn setup(scenario: &Scenario) -> Self {
         let network = nu63_network();
 
         let mut st = TestBuilder::new()
@@ -158,42 +189,56 @@ impl Scenario {
         let usk = account.usk().clone();
         let fvk = OrchardPoolTester::test_account_fvk(&st);
 
-        // Fund the account with the scenario's single spendable Orchard note, then let its shard
-        // complete so an anchor is available at the tip.
         let (fund_height, _, _) =
-            st.generate_next_block(&fvk, AddressType::DefaultExternal, self.funding);
+            st.generate_next_block(&fvk, AddressType::DefaultExternal, scenario.funding);
         st.scan_cached_blocks(fund_height, 1);
         assert_eq!(
             st.get_total_balance(account_id),
-            self.funding,
+            scenario.funding,
             "{}: funded balance",
-            self.label
+            scenario.label
         );
         for _ in 0..SHARD_COMPLETION_BLOCKS {
             let (h, _) = st.generate_empty_block();
             st.scan_cached_blocks(h, 1);
         }
 
-        // Commit a migration over the wallet adapter: the plan, the preparation transactions, and the
-        // transfers all come from the real wallet's spendable notes. Capture the planned amounts so the
-        // real chain state can be held to them below.
-        let tip = st
+        Self {
+            network,
+            st,
+            account_id,
+            usk,
+            fvk,
+        }
+    }
+
+    /// Phase 2 (plan and commit): plans and commits the migration over the wallet adapter (its plan,
+    /// preparations, and transfers all drawn from the real wallet's notes), checks the planned
+    /// funding-note count and migrated value against the scenario, and returns the committed
+    /// migration (every transaction Signed, with anchors and witnesses deferred).
+    fn plan_and_commit(&mut self, scenario: &Scenario) -> Committed {
+        let tip = self
+            .st
             .wallet()
             .chain_height()
             .expect("reads the chain height")
             .expect("the wallet has a chain tip");
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let (mut state, funding_notes, migrated, change) = {
-            let adapter =
-                WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
-            let plan =
-                engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+        let (state, funding_notes, migrated, change) = {
+            let adapter = WalletMigration::new(
+                self.st.wallet(),
+                self.account_id,
+                self.usk.clone(),
+                MigrationTestStore::default(),
+            );
+            let plan = engine::plan_migration(&self.network, &adapter, &mut rng)
+                .expect("plans the migration");
             let funding_notes = plan.funding_notes();
             let migrated = plan.note_split().total_migratable();
             let change = plan.note_split().change().map(u64::from).unwrap_or(0);
             let mut adapter = adapter;
             let (state, _) = engine::commit_preparation_with_funding(
-                &network,
+                &self.network,
                 tip,
                 &mut adapter,
                 &plan,
@@ -203,28 +248,36 @@ impl Scenario {
             (state, funding_notes, migrated, change)
         };
 
-        // The observable amounts match what this balance is expected to migrate: one funding note (and
-        // one transfer) per crossing denomination, and the whole value carried into Ironwood.
+        // The observable amounts match what this balance is expected to migrate: one funding note
+        // (and one transfer) per crossing denomination, and the whole value carried into Ironwood.
         assert_eq!(
             funding_notes.len(),
-            self.expected_transfers,
+            scenario.expected_transfers,
             "{}: prepared funding notes",
-            self.label
+            scenario.label
         );
         assert_eq!(
-            migrated, self.expected_migrated,
+            migrated, scenario.expected_migrated,
             "{}: total migrated value",
-            self.label
+            scenario.label
         );
-
-        // Every transaction is Signed with anchors and witnesses deferred.
         for tx in state.transactions() {
             assert!(matches!(tx.state(), MigrationTxState::Signed));
         }
 
-        // Prove each preparation transaction against the current tip, extract it, mine it, and scan it,
-        // so its minted funding notes become spendable received notes in the wallet.
-        let prep_ids: Vec<MigrationTxId> = state
+        Committed {
+            state,
+            funding_notes,
+            change,
+        }
+    }
+
+    /// Phase 3 (prove preparations): proves each preparation against the current tip, extracts it
+    /// (asserting it is Orchard-only), then mines and scans it so its minted funding notes become
+    /// spendable; finally checks the wallet balance is the funding less the reserved preparation fees.
+    fn prove_preparations(&mut self, committed: &mut Committed, scenario: &Scenario) {
+        let prep_ids: Vec<MigrationTxId> = committed
+            .state
             .transactions()
             .iter()
             .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
@@ -232,26 +285,31 @@ impl Scenario {
             .collect();
         assert_eq!(
             prep_ids.len(),
-            self.expected_preparations,
+            scenario.expected_preparations,
             "{}: preparation transactions",
-            self.label
+            scenario.label
         );
 
         for prep_id in prep_ids {
-            let tip = st
+            let tip = self
+                .st
                 .wallet()
                 .chain_height()
                 .expect("reads the chain height")
                 .expect("the wallet has a chain tip");
-            let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
+            let anchor = highest_rooted_orchard_checkpoint(self.st.wallet_mut(), tip)
                 .expect("a rooted Orchard checkpoint exists");
             {
-                let mut prover =
-                    WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
-                engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+                let mut prover = WalletMigrationProver::new(
+                    self.st.wallet_mut(),
+                    self.account_id,
+                    self.fvk.clone(),
+                );
+                engine::prove_preparation(&mut prover, &mut committed.state, prep_id, anchor)
                     .expect("proves the preparation transaction");
             }
-            let proven = state
+            let proven = committed
+                .state
                 .transactions()
                 .iter()
                 .find(|t| t.id() == prep_id)
@@ -272,24 +330,25 @@ impl Scenario {
                 "the preparation has no Ironwood bundle"
             );
 
-            let (prep_height, _) = st.generate_next_block_from_tx(1, &tx);
-            st.scan_cached_blocks(prep_height, 1);
+            let (prep_height, _) = self.st.generate_next_block_from_tx(1, &tx);
+            self.st.scan_cached_blocks(prep_height, 1);
         }
 
-        // With every preparation mined and scanned, the original note has been spent and replaced by the
-        // prepared funding notes plus the source-pool change, so the wallet's balance is exactly the
-        // funding minus the reserved preparation fees.
-        let funding_notes_total: u64 = funding_notes.iter().map(|&v| u64::from(v)).sum();
+        let funding_notes_total: u64 = committed.funding_notes.iter().map(|&v| u64::from(v)).sum();
         assert_eq!(
-            st.get_total_balance(account_id),
-            Zatoshis::from_u64(funding_notes_total + change).expect("a valid balance"),
+            self.st.get_total_balance(self.account_id),
+            Zatoshis::from_u64(funding_notes_total + committed.change).expect("a valid balance"),
             "{}: balance after preparations",
-            self.label
+            scenario.label
         );
+    }
 
-        // Prove each transfer once the chain has reached its drawn anchor boundary (so that checkpoint
-        // exists and holds the funding note), staying within the pruning window.
-        let mut transfers: Vec<(MigrationTxId, BlockHeight)> = state
+    /// Phase 4 (prove transfers): advances the chain to each transfer's drawn anchor boundary (so
+    /// that checkpoint is settled and holds the funding note, within the pruning window), proves the
+    /// transfer, extracts it, and asserts both its Orchard and Ironwood bundles verify.
+    fn prove_transfers(&mut self, committed: &mut Committed, scenario: &Scenario) {
+        let mut transfers: Vec<(MigrationTxId, BlockHeight)> = committed
+            .state
             .transactions()
             .iter()
             .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
@@ -304,16 +363,15 @@ impl Scenario {
         transfers.sort_by_key(|(_, boundary)| *boundary);
         assert_eq!(
             transfers.len(),
-            self.expected_transfers,
+            scenario.expected_transfers,
             "{}: transfers",
-            self.label
+            scenario.label
         );
 
         for (transfer_id, boundary) in transfers {
-            // Advance (scanning empty blocks) until the tip is strictly past the transfer's boundary, so
-            // the boundary checkpoint is settled and rooted (the tip checkpoint is not yet rooted).
             loop {
-                let tip = st
+                let tip = self
+                    .st
                     .wallet()
                     .chain_height()
                     .expect("reads the chain height")
@@ -321,17 +379,21 @@ impl Scenario {
                 if tip > boundary {
                     break;
                 }
-                let (h, _) = st.generate_empty_block();
-                st.scan_cached_blocks(h, 1);
+                let (h, _) = self.st.generate_empty_block();
+                self.st.scan_cached_blocks(h, 1);
             }
 
             {
-                let mut prover =
-                    WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
-                engine::prove_transfer(&mut prover, &mut state, transfer_id)
+                let mut prover = WalletMigrationProver::new(
+                    self.st.wallet_mut(),
+                    self.account_id,
+                    self.fvk.clone(),
+                );
+                engine::prove_transfer(&mut prover, &mut committed.state, transfer_id)
                     .expect("proves the transfer against its drawn boundary");
             }
-            let proven = state
+            let proven = committed
+                .state
                 .transactions()
                 .iter()
                 .find(|t| t.id() == transfer_id)

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -471,7 +471,7 @@ fn scenarios() -> Vec<Scenario> {
     // 0.02 ZEC dust notes.
     let dust = zats(COIN / 50);
     let dust_heavy: Vec<Zatoshis> = std::iter::once(zats(COIN))
-        .chain(std::iter::repeat(dust).take(12))
+        .chain(std::iter::repeat_n(dust, 12))
         .collect();
     // The migrated total is the balance less the reserved transfer buffers and preparation fees, so
     // it is a multiple of the 0.01-ZEC minimum denomination; expressed here in hundredths of a ZEC.

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -25,37 +25,23 @@
 #![cfg(all(feature = "wallet", feature = "test-dependencies"))]
 
 use std::convert::Infallible;
-use std::time::{Duration, SystemTime};
 
-use prost::Message;
 use rand_chacha::ChaCha8Rng;
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
-use rusqlite::{Connection, params};
 
 use pczt::roles::tx_extractor::TransactionExtractor;
 
 use shardtree::error::ShardTreeError;
 use zcash_client_backend::data_api::testing::{
-    AddressType, CacheInsertionResult, DataStoreFactory, TestBuilder, TestCache,
-    orchard::OrchardPoolTester, pool::ShieldedPoolTester,
+    AddressType, TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
 };
 use zcash_client_backend::data_api::{Account, WalletCommitmentTrees, WalletRead};
-use zcash_client_backend::proto::compact_formats::CompactBlock;
-use zcash_client_sqlite::chain::init::init_cache_database;
-use zcash_client_sqlite::error::SqliteClientError;
-use zcash_client_sqlite::util::testing::FixedClock;
-use zcash_client_sqlite::wallet::init::WalletMigrator;
-use zcash_client_sqlite::{BlockDb, WalletDb};
-// Only referenced when `transparent-inputs` is active: the `DataStoreFactory::new_data_store`
-// signature grows a `gap_limits` parameter under that feature, so the impl below must match it.
-#[cfg(feature = "transparent-inputs")]
-use zcash_keys::keys::transparent::gap_limits::GapLimits;
-
-use tempfile::NamedTempFile;
+// The wallet, block cache, and DB factory come from `zcash_client_sqlite`'s own test harness,
+// exposed under its `test-dependencies` feature — no hand-rolled equivalents.
+use zcash_client_sqlite::testing::BlockCache;
+use zcash_client_sqlite::testing::db::{TestDb, TestDbFactory};
 
 use zcash_primitives::block::BlockHash;
-use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::value::{COIN, Zatoshis};
@@ -75,21 +61,16 @@ const FUNDING_ZEC: u64 = 78;
 /// Empty blocks scanned after a note is received so its commitment-tree shard completes and an
 /// anchor at that height is available.
 const SHARD_COMPLETION_BLOCKS: usize = 5;
-/// A deterministic wall-clock instant for the wallet's clock; the value is irrelevant to proving.
-const CLOCK_EPOCH_OFFSET_SECS: u64 = 1_700_000_000;
-
-/// The concrete in-memory wallet the harness drives.
-type MigrationWalletDb = WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng>;
 
 /// The highest checkpoint at or below `from` whose Orchard tree root is available. The tip
 /// checkpoint is not yet rooted right after scanning, so a spend anchors to the newest settled
 /// checkpoint below it (every note mined at or before that height is still witnessable there).
-fn highest_rooted_checkpoint(db: &mut MigrationWalletDb, from: BlockHeight) -> BlockHeight {
+fn highest_rooted_checkpoint(db: &mut TestDb, from: BlockHeight) -> BlockHeight {
     let mut height = u32::from(from);
     loop {
         let bh = BlockHeight::from_u32(height);
         let rooted = db
-            .with_orchard_tree_mut::<_, _, ShardTreeError<<MigrationWalletDb as WalletCommitmentTrees>::Error>>(
+            .with_orchard_tree_mut::<_, _, ShardTreeError<<TestDb as WalletCommitmentTrees>::Error>>(
                 |tree| Ok(tree.root_at_checkpoint_id(&bh)?.is_some()),
             )
             .expect("queries the Orchard tree");
@@ -110,102 +91,6 @@ fn nu63_network() -> LocalNetwork {
         nu6_2: Some(h),
         nu6_3: Some(h),
         ..TestBuilder::<(), ()>::DEFAULT_NETWORK
-    }
-}
-
-/// Builds a fresh in-memory `WalletDb` for the testing framework. `zcash_client_sqlite`'s own
-/// `TestDbFactory` is `pub(crate)`, so the harness supplies this minimal equivalent over the public
-/// `WalletDb::for_path` + `WalletMigrator` API (the same seam a future migration sqlite backend
-/// would conform to).
-struct MigrationDbFactory;
-
-impl DataStoreFactory for MigrationDbFactory {
-    type Error = ();
-    type AccountId = <MigrationWalletDb as WalletRead>::AccountId;
-    type Account = <MigrationWalletDb as WalletRead>::Account;
-    type DsError = <MigrationWalletDb as WalletRead>::Error;
-    type DataStore = MigrationWalletDb;
-
-    fn new_data_store(
-        &self,
-        network: LocalNetwork,
-        #[cfg(feature = "transparent-inputs")] _gap_limits: Option<GapLimits>,
-    ) -> Result<Self::DataStore, Self::Error> {
-        let clock =
-            FixedClock::new(SystemTime::UNIX_EPOCH + Duration::from_secs(CLOCK_EPOCH_OFFSET_SECS));
-        let mut db = WalletDb::for_path(":memory:", network, clock, ChaChaRng::seed_from_u64(0))
-            .expect("opens an in-memory wallet database");
-        WalletMigrator::new()
-            .init_or_migrate(&mut db)
-            .expect("applies the wallet migrations");
-        Ok(db)
-    }
-}
-
-/// A minimal in-memory compact-block cache for the testing framework. `zcash_client_sqlite`'s own
-/// `BlockCache` is `pub(crate)` and writes through `BlockDb`'s private connection, so the harness
-/// keeps a second connection to the same cache file to insert blocks the scanner then reads through
-/// the `BlockDb`.
-struct BlockCache {
-    _cache_file: NamedTempFile,
-    write_conn: Connection,
-    block_source: BlockDb,
-}
-
-impl BlockCache {
-    fn new() -> Self {
-        let cache_file = NamedTempFile::new().expect("creates a temporary cache file");
-        let block_source = BlockDb::for_path(cache_file.path()).expect("opens the block cache");
-        init_cache_database(&block_source).expect("initializes the block cache schema");
-        let write_conn =
-            Connection::open(cache_file.path()).expect("opens a writer to the block cache");
-        BlockCache {
-            _cache_file: cache_file,
-            write_conn,
-            block_source,
-        }
-    }
-}
-
-/// The txids inserted with one compact block; the framework needs only these.
-struct BlockCacheInsert {
-    txids: Vec<TxId>,
-}
-
-impl CacheInsertionResult for BlockCacheInsert {
-    fn txids(&self) -> &[TxId] {
-        &self.txids
-    }
-}
-
-impl TestCache for BlockCache {
-    type BsError = SqliteClientError;
-    type BlockSource = BlockDb;
-    type InsertResult = BlockCacheInsert;
-
-    fn block_source(&self) -> &Self::BlockSource {
-        &self.block_source
-    }
-
-    fn insert(&mut self, cb: &CompactBlock) -> Self::InsertResult {
-        self.write_conn
-            .execute(
-                "INSERT INTO compactblocks (height, data) VALUES (?, ?)",
-                params![u32::from(cb.height()), cb.encode_to_vec()],
-            )
-            .expect("inserts a compact block");
-        BlockCacheInsert {
-            txids: cb.vtx.iter().map(|tx| tx.txid()).collect(),
-        }
-    }
-
-    fn truncate_to_height(&mut self, height: BlockHeight) {
-        self.write_conn
-            .execute(
-                "DELETE FROM compactblocks WHERE height > ?",
-                params![u32::from(height)],
-            )
-            .expect("truncates the block cache");
     }
 }
 
@@ -248,7 +133,7 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
 
     let mut st = TestBuilder::new()
         .with_network(network)
-        .with_data_store_factory(MigrationDbFactory)
+        .with_data_store_factory(TestDbFactory::default())
         .with_block_cache(BlockCache::new())
         .with_account_from_sapling_activation(BlockHash([0; 32]))
         .build();

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -100,239 +100,271 @@ impl PoolMigrationWrite for MigrationTestStore {
     }
 }
 
-/// One end-to-end proving scenario. Kept as data, with its expected observable amounts, so more
-/// balances and note shapes can be added to [`SCENARIOS`] without duplicating the proving flow.
+/// An end-to-end migration proving scenario, built fluently: [`Scenario::funded`] sets the source
+/// note, the `expect_*` setters declare the observable outcomes, and [`Scenario::prove_end_to_end`]
+/// funds a real wallet, runs the whole migration, and asserts those outcomes phase by phase. Each new
+/// balance or note shape is a new builder in the test below.
 struct Scenario {
-    /// A label for assertion messages.
     label: &'static str,
-    /// The single spendable Orchard note the account is funded with.
     funding: Zatoshis,
-    /// The number of preparation transactions the migration is expected to produce.
     expected_preparations: usize,
-    /// The number of pool-crossing transfers (one per prepared funding note).
     expected_transfers: usize,
-    /// The total value expected to cross into Ironwood: the sum of the crossing denominations.
     expected_migrated: Zatoshis,
 }
 
-/// The proving scenarios exercised end to end. A single balance for now; the harness is
-/// scenario-driven so more (different balances, multi-note sources) can be added here.
-const SCENARIOS: &[Scenario] = &[Scenario {
-    label: "78 ZEC in a single note",
-    funding: Zatoshis::const_from_u64(78 * COIN),
-    expected_preparations: 1,
-    expected_transfers: 10,
-    // 77.99 ZEC: the canonical {1, 2, 5} * 10^k decomposition of 78 ZEC less the reserved transfer
-    // buffers and preparation fee, leaving 0.0077 ZEC of source-pool change.
-    expected_migrated: Zatoshis::const_from_u64(7_799 * (COIN / 100)),
-}];
-
-#[test]
-fn migration_proves_end_to_end_against_a_funded_wallet() {
-    for scenario in SCENARIOS {
-        run_scenario(scenario);
-    }
-}
-
-fn run_scenario(scenario: &Scenario) {
-    let network = nu63_network();
-
-    let mut st = TestBuilder::new()
-        .with_network(network)
-        .with_data_store_factory(TestDbFactory::default())
-        .with_block_cache(BlockCache::new())
-        .with_account_from_sapling_activation(BlockHash([0; 32]))
-        .build();
-
-    let account = st.test_account().cloned().expect("the test account exists");
-    let account_id = account.id();
-    let usk = account.usk().clone();
-    let fvk = OrchardPoolTester::test_account_fvk(&st);
-
-    // Fund the account with the scenario's single spendable Orchard note, then let its shard
-    // complete so an anchor is available at the tip.
-    let (fund_height, _, _) =
-        st.generate_next_block(&fvk, AddressType::DefaultExternal, scenario.funding);
-    st.scan_cached_blocks(fund_height, 1);
-    assert_eq!(
-        st.get_total_balance(account_id),
-        scenario.funding,
-        "{}: funded balance",
-        scenario.label
-    );
-    for _ in 0..SHARD_COMPLETION_BLOCKS {
-        let (h, _) = st.generate_empty_block();
-        st.scan_cached_blocks(h, 1);
+impl Scenario {
+    /// Starts a scenario whose account is funded with a single Orchard note worth `funding`.
+    fn funded(label: &'static str, funding: Zatoshis) -> Self {
+        Self {
+            label,
+            funding,
+            expected_preparations: 0,
+            expected_transfers: 0,
+            expected_migrated: Zatoshis::ZERO,
+        }
     }
 
-    // Commit a migration over the wallet adapter: the plan, the preparation transactions, and the
-    // transfers all come from the real wallet's spendable notes. Capture the planned amounts so the
-    // real chain state can be held to them below.
-    let tip = st
-        .wallet()
-        .chain_height()
-        .expect("reads the chain height")
-        .expect("the wallet has a chain tip");
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
-    let (mut state, funding_notes, migrated, change) = {
-        let adapter =
-            WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
-        let plan =
-            engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
-        let funding_notes = plan.funding_notes();
-        let migrated = plan.note_split().total_migratable();
-        let change = plan.note_split().change().map(u64::from).unwrap_or(0);
-        let mut adapter = adapter;
-        let (state, _) =
-            engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
-                .expect("commits the migration");
-        (state, funding_notes, migrated, change)
-    };
-
-    // The observable amounts match what this balance is expected to migrate: one funding note (and
-    // one transfer) per crossing denomination, and the whole value carried into Ironwood.
-    assert_eq!(
-        funding_notes.len(),
-        scenario.expected_transfers,
-        "{}: prepared funding notes",
-        scenario.label
-    );
-    assert_eq!(
-        migrated, scenario.expected_migrated,
-        "{}: total migrated value",
-        scenario.label
-    );
-
-    // Every transaction is Signed with anchors and witnesses deferred.
-    for tx in state.transactions() {
-        assert!(matches!(tx.state(), MigrationTxState::Signed));
+    /// Declares the number of preparation transactions the migration should produce.
+    fn expect_preparations(mut self, n: usize) -> Self {
+        self.expected_preparations = n;
+        self
     }
 
-    // Prove each preparation transaction against the current tip, extract it, mine it, and scan it,
-    // so its minted funding notes become spendable received notes in the wallet.
-    let prep_ids: Vec<MigrationTxId> = state
-        .transactions()
-        .iter()
-        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
-        .map(|t| t.id())
-        .collect();
-    assert_eq!(
-        prep_ids.len(),
-        scenario.expected_preparations,
-        "{}: preparation transactions",
-        scenario.label
-    );
+    /// Declares the number of pool-crossing transfers (one per prepared funding note).
+    fn expect_transfers(mut self, n: usize) -> Self {
+        self.expected_transfers = n;
+        self
+    }
 
-    for prep_id in prep_ids {
+    /// Declares the total value that should cross into Ironwood (the sum of the crossings).
+    fn expect_migrated(mut self, migrated: Zatoshis) -> Self {
+        self.expected_migrated = migrated;
+        self
+    }
+
+    /// Runs the whole migration for this scenario and asserts every declared expectation.
+    fn prove_end_to_end(self) {
+        let network = nu63_network();
+
+        let mut st = TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().expect("the test account exists");
+        let account_id = account.id();
+        let usk = account.usk().clone();
+        let fvk = OrchardPoolTester::test_account_fvk(&st);
+
+        // Fund the account with the scenario's single spendable Orchard note, then let its shard
+        // complete so an anchor is available at the tip.
+        let (fund_height, _, _) =
+            st.generate_next_block(&fvk, AddressType::DefaultExternal, self.funding);
+        st.scan_cached_blocks(fund_height, 1);
+        assert_eq!(
+            st.get_total_balance(account_id),
+            self.funding,
+            "{}: funded balance",
+            self.label
+        );
+        for _ in 0..SHARD_COMPLETION_BLOCKS {
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+        }
+
+        // Commit a migration over the wallet adapter: the plan, the preparation transactions, and the
+        // transfers all come from the real wallet's spendable notes. Capture the planned amounts so the
+        // real chain state can be held to them below.
         let tip = st
             .wallet()
             .chain_height()
             .expect("reads the chain height")
             .expect("the wallet has a chain tip");
-        let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
-            .expect("a rooted Orchard checkpoint exists");
-        {
-            let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
-            engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
-                .expect("proves the preparation transaction");
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let (mut state, funding_notes, migrated, change) = {
+            let adapter =
+                WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
+            let plan =
+                engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+            let funding_notes = plan.funding_notes();
+            let migrated = plan.note_split().total_migratable();
+            let change = plan.note_split().change().map(u64::from).unwrap_or(0);
+            let mut adapter = adapter;
+            let (state, _) = engine::commit_preparation_with_funding(
+                &network,
+                tip,
+                &mut adapter,
+                &plan,
+                &mut rng,
+            )
+            .expect("commits the migration");
+            (state, funding_notes, migrated, change)
+        };
+
+        // The observable amounts match what this balance is expected to migrate: one funding note (and
+        // one transfer) per crossing denomination, and the whole value carried into Ironwood.
+        assert_eq!(
+            funding_notes.len(),
+            self.expected_transfers,
+            "{}: prepared funding notes",
+            self.label
+        );
+        assert_eq!(
+            migrated, self.expected_migrated,
+            "{}: total migrated value",
+            self.label
+        );
+
+        // Every transaction is Signed with anchors and witnesses deferred.
+        for tx in state.transactions() {
+            assert!(matches!(tx.state(), MigrationTxState::Signed));
         }
-        let proven = state
+
+        // Prove each preparation transaction against the current tip, extract it, mine it, and scan it,
+        // so its minted funding notes become spendable received notes in the wallet.
+        let prep_ids: Vec<MigrationTxId> = state
             .transactions()
             .iter()
-            .find(|t| t.id() == prep_id)
-            .expect("the preparation transaction is present");
-        assert!(matches!(proven.state(), MigrationTxState::Proved));
-        let tx = TransactionExtractor::new(
-            pczt::Pczt::parse(proven.pczt()).expect("parses the proven preparation PCZT"),
-        )
-        .extract()
-        .expect("extracts and verifies the preparation transaction");
-        // A preparation transaction is Orchard-only: no Ironwood bundle.
-        assert!(
-            tx.orchard_bundle().is_some(),
-            "the preparation has an Orchard bundle"
-        );
-        assert!(
-            tx.ironwood_bundle().is_none(),
-            "the preparation has no Ironwood bundle"
+            .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+            .map(|t| t.id())
+            .collect();
+        assert_eq!(
+            prep_ids.len(),
+            self.expected_preparations,
+            "{}: preparation transactions",
+            self.label
         );
 
-        let (prep_height, _) = st.generate_next_block_from_tx(1, &tx);
-        st.scan_cached_blocks(prep_height, 1);
-    }
-
-    // With every preparation mined and scanned, the original note has been spent and replaced by the
-    // prepared funding notes plus the source-pool change, so the wallet's balance is exactly the
-    // funding minus the reserved preparation fees.
-    let funding_notes_total: u64 = funding_notes.iter().map(|&v| u64::from(v)).sum();
-    assert_eq!(
-        st.get_total_balance(account_id),
-        Zatoshis::from_u64(funding_notes_total + change).expect("a valid balance"),
-        "{}: balance after preparations",
-        scenario.label
-    );
-
-    // Prove each transfer once the chain has reached its drawn anchor boundary (so that checkpoint
-    // exists and holds the funding note), staying within the pruning window.
-    let mut transfers: Vec<(MigrationTxId, BlockHeight)> = state
-        .transactions()
-        .iter()
-        .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
-        .map(|t| {
-            (
-                t.id(),
-                t.anchor_boundary()
-                    .expect("a transfer carries a drawn boundary"),
-            )
-        })
-        .collect();
-    transfers.sort_by_key(|(_, boundary)| *boundary);
-    assert_eq!(
-        transfers.len(),
-        scenario.expected_transfers,
-        "{}: transfers",
-        scenario.label
-    );
-
-    for (transfer_id, boundary) in transfers {
-        // Advance (scanning empty blocks) until the tip is strictly past the transfer's boundary, so
-        // the boundary checkpoint is settled and rooted (the tip checkpoint is not yet rooted).
-        loop {
+        for prep_id in prep_ids {
             let tip = st
                 .wallet()
                 .chain_height()
                 .expect("reads the chain height")
                 .expect("the wallet has a chain tip");
-            if tip > boundary {
-                break;
+            let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
+                .expect("a rooted Orchard checkpoint exists");
+            {
+                let mut prover =
+                    WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+                engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+                    .expect("proves the preparation transaction");
             }
-            let (h, _) = st.generate_empty_block();
-            st.scan_cached_blocks(h, 1);
+            let proven = state
+                .transactions()
+                .iter()
+                .find(|t| t.id() == prep_id)
+                .expect("the preparation transaction is present");
+            assert!(matches!(proven.state(), MigrationTxState::Proved));
+            let tx = TransactionExtractor::new(
+                pczt::Pczt::parse(proven.pczt()).expect("parses the proven preparation PCZT"),
+            )
+            .extract()
+            .expect("extracts and verifies the preparation transaction");
+            // A preparation transaction is Orchard-only: no Ironwood bundle.
+            assert!(
+                tx.orchard_bundle().is_some(),
+                "the preparation has an Orchard bundle"
+            );
+            assert!(
+                tx.ironwood_bundle().is_none(),
+                "the preparation has no Ironwood bundle"
+            );
+
+            let (prep_height, _) = st.generate_next_block_from_tx(1, &tx);
+            st.scan_cached_blocks(prep_height, 1);
         }
 
-        {
-            let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
-            engine::prove_transfer(&mut prover, &mut state, transfer_id)
-                .expect("proves the transfer against its drawn boundary");
-        }
-        let proven = state
+        // With every preparation mined and scanned, the original note has been spent and replaced by the
+        // prepared funding notes plus the source-pool change, so the wallet's balance is exactly the
+        // funding minus the reserved preparation fees.
+        let funding_notes_total: u64 = funding_notes.iter().map(|&v| u64::from(v)).sum();
+        assert_eq!(
+            st.get_total_balance(account_id),
+            Zatoshis::from_u64(funding_notes_total + change).expect("a valid balance"),
+            "{}: balance after preparations",
+            self.label
+        );
+
+        // Prove each transfer once the chain has reached its drawn anchor boundary (so that checkpoint
+        // exists and holds the funding note), staying within the pruning window.
+        let mut transfers: Vec<(MigrationTxId, BlockHeight)> = state
             .transactions()
             .iter()
-            .find(|t| t.id() == transfer_id)
-            .expect("the transfer is present");
-        assert!(matches!(proven.state(), MigrationTxState::Proved));
-        let tx = TransactionExtractor::new(
-            pczt::Pczt::parse(proven.pczt()).expect("parses the proven transfer PCZT"),
-        )
-        .extract()
-        .expect("extracts and verifies the transfer's Orchard and Ironwood proofs");
-        assert!(
-            tx.orchard_bundle().is_some(),
-            "the transfer has an Orchard bundle"
+            .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+            .map(|t| {
+                (
+                    t.id(),
+                    t.anchor_boundary()
+                        .expect("a transfer carries a drawn boundary"),
+                )
+            })
+            .collect();
+        transfers.sort_by_key(|(_, boundary)| *boundary);
+        assert_eq!(
+            transfers.len(),
+            self.expected_transfers,
+            "{}: transfers",
+            self.label
         );
-        assert!(
-            tx.ironwood_bundle().is_some(),
-            "the transfer has an Ironwood bundle"
-        );
+
+        for (transfer_id, boundary) in transfers {
+            // Advance (scanning empty blocks) until the tip is strictly past the transfer's boundary, so
+            // the boundary checkpoint is settled and rooted (the tip checkpoint is not yet rooted).
+            loop {
+                let tip = st
+                    .wallet()
+                    .chain_height()
+                    .expect("reads the chain height")
+                    .expect("the wallet has a chain tip");
+                if tip > boundary {
+                    break;
+                }
+                let (h, _) = st.generate_empty_block();
+                st.scan_cached_blocks(h, 1);
+            }
+
+            {
+                let mut prover =
+                    WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+                engine::prove_transfer(&mut prover, &mut state, transfer_id)
+                    .expect("proves the transfer against its drawn boundary");
+            }
+            let proven = state
+                .transactions()
+                .iter()
+                .find(|t| t.id() == transfer_id)
+                .expect("the transfer is present");
+            assert!(matches!(proven.state(), MigrationTxState::Proved));
+            let tx = TransactionExtractor::new(
+                pczt::Pczt::parse(proven.pczt()).expect("parses the proven transfer PCZT"),
+            )
+            .extract()
+            .expect("extracts and verifies the transfer's Orchard and Ironwood proofs");
+            assert!(
+                tx.orchard_bundle().is_some(),
+                "the transfer has an Orchard bundle"
+            );
+            assert!(
+                tx.ironwood_bundle().is_some(),
+                "the transfer has an Ironwood bundle"
+            );
+        }
     }
+}
+
+#[test]
+fn migration_proves_end_to_end_against_a_funded_wallet() {
+    // 78 ZEC decomposes into ten canonical crossings and migrates 77.99 ZEC (the balance less the
+    // reserved transfer buffers and preparation fee, leaving 0.0077 ZEC of source-pool change) via a
+    // single preparation transaction.
+    Scenario::funded(
+        "78 ZEC in a single note",
+        Zatoshis::const_from_u64(78 * COIN),
+    )
+    .expect_preparations(1)
+    .expect_transfers(10)
+    .expect_migrated(Zatoshis::const_from_u64(7_799 * (COIN / 100)))
+    .prove_end_to_end();
 }


### PR DESCRIPTION
## Summary

A migration transfer draws an Orchard anchor boundary at scheduling time and
persists it on the transaction, but until now nothing consulted it: proving was
left entirely to the consumer, so the drawn boundary never determined the tree
state a transfer proved against (a #2663 review finding).

This adds a proving step so the engine finally consults each transfer's
persisted `anchor_boundary` at proving time, via a new `MigrationCrypto` seam:

- `MigrationCrypto` gains `prove_transfer(pczt, anchor_boundary)`.
- A free engine function `prove_transfer(crypto, state, id)` reads a transfer's
  persisted `anchor_boundary` (drawn at scheduling time), hands it and the
  stored PCZT to the crypto backend to install the Orchard source anchor and the
  funding note's witness against that boundary and the Ironwood destination
  anchor (through the PCZT `Updater` role, ZIP 374) and prove both bundles, then
  stores the proven PCZT and moves the transaction `Signed -> Proved` via
  `MigrationState::set_transaction_proved`.
- A new `ProveError` guards the flow: it rejects an unknown transaction, a
  preparation transaction (`NotATransfer`), a non-`Signed` transaction
  (`NotReady`), a transfer with no drawn boundary (`NoAnchorBoundary`), and
  surfaces parse/serialize/crypto failures.

The `WalletMigration` adapter's leg needs the drawn boundary's commitment-tree
checkpoint to still exist at proving time, so it is gated on migration
anchor-checkpoint retention (#2700) for now and returns a new
`Error::ProvingUnsupported`; the in-memory mock stands in for the prover to
exercise the engine flow, and an inline test drives a committed transfer
`Signed -> Proved` and checks the `NotReady` / `NotATransfer` guards.

Extracted from #2669.

## Notes

No `orchard` patch is needed: the code does not call the #535 `Updater` /
`Prover` API (`set_anchor` / `set_spend_witness` appear only in doc comments),
so it compiles against main's `orchard 0.15.0` with no `[patch.crates-io]`
change.

`cargo test --release --all-features -p zcash_pool_migration_backend` is green
(99 tests), and stable `cargo fmt` is clean.