### PR TITLE
feat: note locking

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -28,6 +28,7 @@ workspace.
 - `zcash_client_backend::data_api::error::LockError`
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
+- `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
@@ -76,6 +77,13 @@ workspace.
   `lock_outputs` and `unlock_output`.
 - `zcash_client_backend::data_api::WalletTest` has added method
   `get_locked_outputs`.
+- The following `zcash_client_backend::data_api::wallet::` proposal creation
+  functions now take a `lock_for_blocks: Option<u32>` parameter and require
+  `WalletWrite` instead of `WalletRead`:
+  - `propose_transfer`
+  - `propose_standard_transfer_to_address`
+  - `propose_send_max_transfer`
+  - `propose_shielding`
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -48,6 +48,24 @@ workspace.
   condition that callers should respond to by retrying, distinct from
   `ProposalError::ChainDoubleSpend`, which continues to indicate a proposal
   that attempts to spend the same output twice.
+- `zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy`,
+  a `SpendPolicy` field (`SpendPolicy::locked_input_policy` /
+  `with_locked_input_policy`, default `Exclude`) governing whether
+  `GreedyInputSelector::propose_transaction` may draw on locked outputs, and if
+  so, with what preference: `Exclude` never selects one; `PreferUnlocked` and
+  `PreferLocked` each carry the set of `LockOwner`s whose locks may be drawn
+  upon, preferring unlocked or owned-locked outputs respectively, and drawing
+  on the other tier only as needed to reach the target value. An output locked
+  by an owner outside that set is never selected, under either variant. This
+  is how a caller (for example, the wallet's own pool-migration PCZTs) spends
+  through its own advisory lock without weakening the exclusion every other
+  flow relies on.
+- `zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelector::with_locked_input_policy`,
+  the shielding-specific counterpart: it configures the `LockedInputPolicy`
+  that `ShieldingSelector::propose_shielding` and
+  `propose_shielding_coinbase` apply when gathering transparent inputs
+  (default `Exclude`). Shielding has no per-call `SpendPolicy` argument, so
+  this is set once on the selector instance rather than passed to each call.
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
@@ -125,6 +143,11 @@ workspace.
   `transparent-inputs` feature is not enabled. Balance errors encountered
   during send-max input selection are now wrapped in
   `GreedyInputSelectorError::Balance`.
+- `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
+  takes an additional `locked_input_policy: &LockedInputPolicy` argument,
+  positioned before `lock_inputs`; pass `&LockedInputPolicy::Exclude` (its
+  `Default`) to preserve the previous behavior of never drawing on a locked
+  note.
 - `zcash_client_backend::proposal::Step::orchard_action_count` now takes the
   `orchard::builder::BundleType` and `orchard::bundle::BundleVersion` that the
   transaction builder will be configured with, and returns a `Result`. It

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -28,6 +28,15 @@ workspace.
 - `zcash_client_backend::data_api::error::LockError`
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
+- `zcash_client_backend::wallet::LockOwner`, an opaque token identifying the
+  holder of an output lock. Locks record their owner: unlocking is scoped to
+  the owner that took the lock, and re-locking by the same owner is an
+  idempotent acquire/extend (supporting crash-retry of a flow that had already
+  locked its inputs), while an active lock held by a different owner cannot be
+  acquired or released until it expires.
+- `zcash_client_backend::data_api::wallet::LockRequest`, the
+  `(owner, for_blocks)` pair accepted by the proposal-creation functions to
+  lock the proposal's inputs.
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
 - `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
   proposal-creation functions when an input selected by the proposal is already
@@ -84,16 +93,24 @@ workspace.
   required to unlock any locked outputs that are recorded as spent by
   the stored transactions.
 - `zcash_client_backend::data_api::WalletWrite` has added methods
-  `lock_outputs`, `unlock_output`, and `clear_locked_outputs`.
+  `lock_outputs`, `unlock_output`, and `clear_locked_outputs`. Locks are keyed
+  by a `LockOwner` token: `lock_outputs` takes the outputs as a slice together
+  with the owner and fails only on an active lock held by a different owner;
+  `unlock_output` releases only a lock held by the given owner;
+  `clear_locked_outputs` releases every lock for an account regardless of
+  owner, as a recovery mechanism.
 - `zcash_client_backend::data_api::WalletTest` has added method
   `get_locked_outputs`.
 - The following `zcash_client_backend::data_api::wallet::` proposal creation
-  functions now take a `lock_for_blocks: Option<u32>` parameter and require
-  `WalletWrite` instead of `WalletRead`:
+  functions now take a `lock_inputs: Option<LockRequest>` parameter and require
+  `WalletWrite` instead of `WalletRead`; `Some(request)` locks the proposal's
+  inputs on behalf of the request's owner until `target_height +
+  request.for_blocks()`:
   - `propose_transfer`
   - `propose_standard_transfer_to_address`
   - `propose_send_max_transfer`
   - `propose_shielding`
+  - `propose_shielding_coinbase` (under `transparent-inputs`)
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -23,6 +23,8 @@ workspace.
   API of this crate; it exists so code in this crate that constructs
   `zcash_primitives` transactions can pass the feature-gated ZIP 233 arguments
   exactly when the underlying crate expects them.
+- `zcash_client_backend::data_api::Balance::{locked_value, add_locked_value}`
+- `zcash_client_backend::data_api::AccountBalance::locked_value`
 - `zcash_client_backend::data_api::error::LockError`
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
@@ -53,6 +55,9 @@ workspace.
     reaches coinbase maturity.
 - `zcash_client_backend::proposal::ProposalError::ChainDoubleSpend` now wraps an
   `OutputRef` instead of `(PoolType, TxId, u32)`.
+- `zcash_client_backend::data_api::Balance` has been modified to now make it
+  possible to represent locked value; this is value that is committed to be
+  spent by an in-flight proposal or PCZT.
 - The following `InputSource` trait methods now take an additional
   `include_locked: bool` parameter that controls whether locked notes
   are included in results:

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -83,8 +83,10 @@ workspace.
   total but remain part of the total), so callers that displayed a total by
   reading `spendable_value` alone should add `locked_value`.
 - The following `InputSource` trait methods now take an additional
-  `include_locked: bool` parameter that controls whether locked notes
-  are included in results:
+  `lock_filter: LockFilter<'_>` parameter that controls how locked outputs are
+  selected: `LockFilter::Policy(&policy)` applies an owner-scoped
+  `LockedInputPolicy` (whose default, `LockedInputPolicy::Exclude`, selects no
+  locked outputs), while `LockFilter::Unfiltered` ignores lock state entirely:
   - `get_spendable_note`
   - `select_spendable_notes`
   - `select_unspent_notes`
@@ -135,7 +137,7 @@ workspace.
 
 ### Fixed
 - Proposal decoding (`proto::proposal::Proposal::try_into_standard_proposal`)
-  now retrieves inputs with `include_locked: true`. A proposal created with
+  now retrieves inputs with `LockFilter::Unfiltered`. A proposal created with
   `lock_for_blocks: Some(_)` locks its own inputs, so the previous behavior
   made such a proposal fail to decode from its serialized form with
   `ProposalDecodingError::InputNotFound` for every locked shielded input,

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -23,6 +23,8 @@ workspace.
   API of this crate; it exists so code in this crate that constructs
   `zcash_primitives` transactions can pass the feature-gated ZIP 233 arguments
   exactly when the underlying crate expects them.
+- `zcash_client_backend::wallet::OutputRef`
+- `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now
@@ -48,6 +50,8 @@ workspace.
     reported in the `value_pending_spendability` field of the coinbase bucket
     rather than as spendable value; it becomes spendable only once the output
     reaches coinbase maturity.
+- `zcash_client_backend::proposal::ProposalError::ChainDoubleSpend` now wraps an
+  `OutputRef` instead of `(PoolType, TxId, u32)`.
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -74,7 +74,7 @@ workspace.
   required to unlock any locked outputs that are recorded as spent by
   the stored transactions.
 - `zcash_client_backend::data_api::WalletWrite` has added methods
-  `lock_outputs` and `unlock_output`.
+  `lock_outputs`, `unlock_output`, and `clear_locked_outputs`.
 - `zcash_client_backend::data_api::WalletTest` has added method
   `get_locked_outputs`.
 - The following `zcash_client_backend::data_api::wallet::` proposal creation

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -113,6 +113,12 @@ workspace.
   feature.
 
 ### Fixed
+- Proposal decoding (`proto::proposal::Proposal::try_into_standard_proposal`)
+  now retrieves inputs with `include_locked: true`. A proposal created with
+  `lock_for_blocks: Some(_)` locks its own inputs, so the previous behavior
+  made such a proposal fail to decode from its serialized form with
+  `ProposalDecodingError::InputNotFound` for every locked shielded input,
+  breaking persist-and-restore of in-flight locking proposals.
 - `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
   correctly constructs proposals paying a transparent (non-TEX) recipient — a
   bare transparent address, or a unified address having no shielded receiver.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -23,6 +23,7 @@ workspace.
   API of this crate; it exists so code in this crate that constructs
   `zcash_primitives` transactions can pass the feature-gated ZIP 233 arguments
   exactly when the underlying crate expects them.
+- `zcash_client_backend::data_api::error::LockError`
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
 
@@ -52,6 +53,10 @@ workspace.
     reaches coinbase maturity.
 - `zcash_client_backend::proposal::ProposalError::ChainDoubleSpend` now wraps an
   `OutputRef` instead of `(PoolType, TxId, u32)`.
+- `zcash_client_backend::data_api::WalletWrite` has added methods
+  `lock_outputs` and `unlock_output`.
+- `zcash_client_backend::data_api::WalletTest` has added method
+  `get_locked_outputs`.
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -53,6 +53,20 @@ workspace.
     reaches coinbase maturity.
 - `zcash_client_backend::proposal::ProposalError::ChainDoubleSpend` now wraps an
   `OutputRef` instead of `(PoolType, TxId, u32)`.
+- The following `InputSource` trait methods now take an additional
+  `include_locked: bool` parameter that controls whether locked notes
+  are included in results:
+  - `get_spendable_note`
+  - `select_spendable_notes`
+  - `select_unspent_notes`
+  - `get_account_metadata`
+  - `get_unspent_transparent_output` (under `transparent-inputs`)
+  - `get_spendable_transparent_outputs` (under `transparent-inputs`)
+  - `get_spendable_transparent_outputs_for_addresses` (under `transparent-inputs`)
+  - `select_spendable_transparent_outputs` (under `transparent-inputs`)
+- `WalletWrite::store_transactions_to_be_sent` implementations are now
+  required to unlock any locked outputs that are recorded as spent by
+  the stored transactions.
 - `zcash_client_backend::data_api::WalletWrite` has added methods
   `lock_outputs` and `unlock_output`.
 - `zcash_client_backend::data_api::WalletTest` has added method

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -109,7 +109,6 @@ workspace.
   - `select_spendable_notes`
   - `select_unspent_notes`
   - `get_account_metadata`
-  - `get_unspent_transparent_output` (under `transparent-inputs`)
   - `get_spendable_transparent_outputs` (under `transparent-inputs`)
   - `get_spendable_transparent_outputs_for_addresses` (under `transparent-inputs`)
   - `select_spendable_transparent_outputs` (under `transparent-inputs`)

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -58,7 +58,11 @@ workspace.
   `OutputRef` instead of `(PoolType, TxId, u32)`.
 - `zcash_client_backend::data_api::Balance` has been modified to now make it
   possible to represent locked value; this is value that is committed to be
-  spent by an in-flight proposal or PCZT.
+  spent by an in-flight proposal or PCZT. Locked value is a component of the
+  account's total funds: `Balance::total` and `AccountBalance::total` now
+  include locked value in their result (locked funds move out of the spendable
+  total but remain part of the total), so callers that displayed a total by
+  reading `spendable_value` alone should add `locked_value`.
 - The following `InputSource` trait methods now take an additional
   `include_locked: bool` parameter that controls whether locked notes
   are included in results:

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -37,6 +37,10 @@ workspace.
 - `zcash_client_backend::data_api::wallet::LockRequest`, the
   `(owner, for_blocks)` pair accepted by the proposal-creation functions to
   lock the proposal's inputs.
+- `impl From<TxId> for zcash_client_backend::wallet::LockOwner`, for flows
+  that hold a durable transaction identity while their locks are alive (such
+  as a persisted PCZT with final effecting data), enabling the owner token to
+  be re-derived after a restart.
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
 - `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
   proposal-creation functions when an input selected by the proposal is already

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -29,6 +29,12 @@ workspace.
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
+- `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
+  proposal-creation functions when an input selected by the proposal is already
+  locked by a concurrent proposal or PCZT. This is a transient "account busy"
+  condition that callers should respond to by retrying, distinct from
+  `ProposalError::ChainDoubleSpend`, which continues to indicate a proposal
+  that attempts to spend the same output twice.
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1763,14 +1763,11 @@ pub trait InputSource {
     ///
     /// Returns `Ok(None)` if the UTXO is not known to belong to the wallet or would not be
     /// spendable in a transaction mined in the block at the target height.
-    /// Locked outputs are selected according to `lock_filter` (see [`LockFilter`]; a
-    /// [`LockFilter::Policy`] carrying the default `Exclude` selects none).
     #[cfg(feature = "transparent-inputs")]
     fn get_unspent_transparent_output(
         &self,
         _outpoint: &OutPoint,
         _target_height: TargetHeight,
-        _lock_filter: LockFilter<'_>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         unimplemented!(
             "InputSource::get_spendable_transparent_output must be overridden for wallets to use the `transparent-inputs` feature"

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1660,18 +1660,21 @@ pub trait InputSource {
     /// specified shielded protocol.
     ///
     /// Returns `Ok(None)` if the note is not known to belong to the wallet or if the note
-    /// is not spendable as of the given height.
+    /// is not spendable as of the given height. When `include_locked` is `false`, locked
+    /// notes are also excluded.
     fn get_spendable_note(
         &self,
         txid: &TxId,
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
+        include_locked: bool,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error>;
 
     /// Returns a list of spendable notes sufficient to cover the specified target value, if
     /// possible. Only spendable notes corresponding to the specified shielded protocol will
-    /// be included.
+    /// be included. When `include_locked` is `false`, locked notes are excluded.
+    #[allow(clippy::too_many_arguments)]
     fn select_spendable_notes(
         &self,
         account: Self::AccountId,
@@ -1680,16 +1683,18 @@ pub trait InputSource {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
 
     /// Returns the list of notes belonging to the wallet that are unspent as of the specified
-    /// target height.
+    /// target height. When `include_locked` is `false`, locked notes are excluded.
     fn select_unspent_notes(
         &self,
         account: Self::AccountId,
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
 
     /// Returns metadata describing the structure of the wallet for the specified account.
@@ -1698,6 +1703,7 @@ pub trait InputSource {
     /// - notes that are not considered spendable as of the given `target_height`
     /// - unspent notes excluded by the provided selector;
     /// - unspent notes identified in the given `exclude` list.
+    /// - when `include_locked` is `false`, locked notes.
     ///
     /// Implementations of this method may limit the complexity of supported queries. Such
     /// limitations should be clearly documented for the implementing type.
@@ -1707,6 +1713,7 @@ pub trait InputSource {
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<AccountMeta, Self::Error>;
 
     /// Fetches the transparent output corresponding to the provided `outpoint` if it is considered
@@ -1714,11 +1721,13 @@ pub trait InputSource {
     ///
     /// Returns `Ok(None)` if the UTXO is not known to belong to the wallet or would not be
     /// spendable in a transaction mined in the block at the target height.
+    /// When `include_locked` is `false`, locked outputs are also excluded.
     #[cfg(feature = "transparent-inputs")]
     fn get_unspent_transparent_output(
         &self,
         _outpoint: &OutPoint,
         _target_height: TargetHeight,
+        _include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         unimplemented!(
             "InputSource::get_spendable_transparent_output must be overridden for wallets to use the `transparent-inputs` feature"
@@ -1738,6 +1747,7 @@ pub trait InputSource {
     ///
     /// Any output that is potentially spent by an unmined transaction in the mempool should be
     /// excluded unless the spending transaction will be expired at `target_height`.
+    /// When `include_locked` is `false`, locked outputs are also excluded.
     #[cfg(feature = "transparent-inputs")]
     fn get_spendable_transparent_outputs(
         &self,
@@ -1745,6 +1755,7 @@ pub trait InputSource {
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _output_filter: CoinbaseFilter,
+        _include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         unimplemented!(
             "InputSource::get_spendable_transparent_outputs must be overridden for wallets to use the `transparent-inputs` feature"
@@ -1771,6 +1782,7 @@ pub trait InputSource {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         let mut outputs = Vec::new();
         for address in addresses {
@@ -1779,6 +1791,7 @@ pub trait InputSource {
                 target_height,
                 confirmations_policy,
                 output_filter,
+                include_locked,
             )?);
         }
         Ok(outputs)
@@ -1838,6 +1851,7 @@ pub trait InputSource {
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         let _ = (
             account,
@@ -1848,6 +1862,7 @@ pub trait InputSource {
             target_value,
             max_inputs,
             fee_rule,
+            include_locked,
         );
         unimplemented!(
             "InputSource::select_spendable_transparent_outputs must be overridden for \

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -97,7 +97,7 @@ use self::{
 use crate::{
     data_api::{
         error::{LockError, RewindError},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     decrypt::DecryptedOutput,
     proto::service::TreeState,
@@ -1696,20 +1696,24 @@ pub trait InputSource {
     /// specified shielded protocol.
     ///
     /// Returns `Ok(None)` if the note is not known to belong to the wallet or if the note
-    /// is not spendable as of the given height. When `include_locked` is `false`, locked
-    /// notes are also excluded.
+    /// is not spendable as of the given height. Locked outputs are selected according to
+    /// `lock_filter` (see [`LockFilter`]; a [`LockFilter::Policy`] carrying the default
+    /// [`LockedInputPolicy::Exclude`] selects none).
+    ///
+    /// [`LockedInputPolicy::Exclude`]: crate::data_api::wallet::input_selection::LockedInputPolicy::Exclude
     fn get_spendable_note(
         &self,
         txid: &TxId,
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error>;
 
     /// Returns a list of spendable notes sufficient to cover the specified target value, if
     /// possible. Only spendable notes corresponding to the specified shielded protocol will
-    /// be included. When `include_locked` is `false`, locked notes are excluded.
+    /// be included. Locked outputs are selected according to `lock_filter` (see [`LockFilter`];
+    /// a [`LockFilter::Policy`] carrying the default `Exclude` selects none).
     #[allow(clippy::too_many_arguments)]
     fn select_spendable_notes(
         &self,
@@ -1719,18 +1723,19 @@ pub trait InputSource {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
 
     /// Returns the list of notes belonging to the wallet that are unspent as of the specified
-    /// target height. When `include_locked` is `false`, locked notes are excluded.
+    /// target height. Locked outputs are selected according to `lock_filter` (see [`LockFilter`];
+    /// a [`LockFilter::Policy`] carrying the default `Exclude` selects none).
     fn select_unspent_notes(
         &self,
         account: Self::AccountId,
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
 
     /// Returns metadata describing the structure of the wallet for the specified account.
@@ -1739,7 +1744,8 @@ pub trait InputSource {
     /// - notes that are not considered spendable as of the given `target_height`
     /// - unspent notes excluded by the provided selector;
     /// - unspent notes identified in the given `exclude` list.
-    /// - when `include_locked` is `false`, locked notes.
+    /// - locked notes not admitted by `lock_filter` (see [`LockFilter`]; a [`LockFilter::Policy`]
+    ///   carrying the default `Exclude` admits none).
     ///
     /// Implementations of this method may limit the complexity of supported queries. Such
     /// limitations should be clearly documented for the implementing type.
@@ -1749,7 +1755,7 @@ pub trait InputSource {
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<AccountMeta, Self::Error>;
 
     /// Fetches the transparent output corresponding to the provided `outpoint` if it is considered
@@ -1757,13 +1763,14 @@ pub trait InputSource {
     ///
     /// Returns `Ok(None)` if the UTXO is not known to belong to the wallet or would not be
     /// spendable in a transaction mined in the block at the target height.
-    /// When `include_locked` is `false`, locked outputs are also excluded.
+    /// Locked outputs are selected according to `lock_filter` (see [`LockFilter`]; a
+    /// [`LockFilter::Policy`] carrying the default `Exclude` selects none).
     #[cfg(feature = "transparent-inputs")]
     fn get_unspent_transparent_output(
         &self,
         _outpoint: &OutPoint,
         _target_height: TargetHeight,
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         unimplemented!(
             "InputSource::get_spendable_transparent_output must be overridden for wallets to use the `transparent-inputs` feature"
@@ -1783,7 +1790,8 @@ pub trait InputSource {
     ///
     /// Any output that is potentially spent by an unmined transaction in the mempool should be
     /// excluded unless the spending transaction will be expired at `target_height`.
-    /// When `include_locked` is `false`, locked outputs are also excluded.
+    /// Locked outputs are selected according to `lock_filter` (see [`LockFilter`]; a
+    /// [`LockFilter::Policy`] carrying the default `Exclude` selects none).
     #[cfg(feature = "transparent-inputs")]
     fn get_spendable_transparent_outputs(
         &self,
@@ -1791,7 +1799,7 @@ pub trait InputSource {
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _output_filter: CoinbaseFilter,
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         unimplemented!(
             "InputSource::get_spendable_transparent_outputs must be overridden for wallets to use the `transparent-inputs` feature"
@@ -1818,7 +1826,7 @@ pub trait InputSource {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         let mut outputs = Vec::new();
         for address in addresses {
@@ -1827,7 +1835,7 @@ pub trait InputSource {
                 target_height,
                 confirmations_policy,
                 output_filter,
-                include_locked,
+                lock_filter,
             )?);
         }
         Ok(outputs)
@@ -1887,7 +1895,7 @@ pub trait InputSource {
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         let _ = (
             account,
@@ -1898,7 +1906,7 @@ pub trait InputSource {
             target_value,
             max_inputs,
             fee_rule,
-            include_locked,
+            lock_filter,
         );
         unimplemented!(
             "InputSource::select_spendable_transparent_outputs must be overridden for \

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3649,8 +3649,16 @@ pub trait WalletWrite: WalletRead {
     /// [`ConfirmationsPolicy::trusted`] confirmations even if the output is not wallet-internal.
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error>;
 
-    /// Locks the specified outputs on behalf of `owner`, preventing them from being selected
-    /// for spending at any height less than or equal to the given height.
+    /// Locks the specified outputs on behalf of `owner` so that, by default, they are not
+    /// selected for spending at any height less than or equal to the given height.
+    ///
+    /// Locks are advisory. Input selection excludes locked outputs by default, but a caller may
+    /// deliberately draw on them by supplying an owner-scoped
+    /// [`LockedInputPolicy`](crate::data_api::wallet::input_selection::LockedInputPolicy) (via
+    /// [`SpendPolicy::with_locked_input_policy`](crate::data_api::wallet::input_selection::SpendPolicy::with_locked_input_policy)),
+    /// scoped to the lock owners it names; doing so spends through the lock during selection but
+    /// never releases it. A locked output can be released only via [`Self::unlock_output`] (by its
+    /// owner) or [`Self::clear_locked_outputs`].
     ///
     /// Returns the number of row updates performed on success (equal to the number of provided
     /// references; a duplicated reference is counted per occurrence), or a [`LockError`] on
@@ -3668,8 +3676,8 @@ pub trait WalletWrite: WalletRead {
     /// provided output on success, or fail completely leaving all lock state unmodified if any
     /// of the outputs is actively locked by a different owner.
     ///
-    /// This is the mechanism by which overlapping proposals for the same account are prevented
-    /// from selecting the same inputs. Because note selection and locking cannot be performed as a
+    /// This is the mechanism by which overlapping proposals for the same account avoid selecting
+    /// the same inputs by default. Because note selection and locking cannot be performed as a
     /// single atomic step above the storage layer, two callers may independently select an
     /// overlapping set of outputs before either locks them (a time-of-check/time-of-use race); the
     /// conflict is resolved here, at the storage layer, where the second caller's `lock_outputs`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3657,9 +3657,17 @@ pub trait WalletWrite: WalletRead {
     /// conflict is resolved here, at the storage layer, where the second caller's `lock_outputs`
     /// fails with [`LockError::LockFailure`] naming the already-locked output. Callers that lock
     /// via a proposal-creation function surface this as
-    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend). The
+    /// [`ProposalError::InputsLocked`](crate::proposal::ProposalError::InputsLocked). The
     /// losing caller has not partially locked anything and should treat the failure as "the
     /// account is busy" and retry.
+    ///
+    /// The provided output references must be distinct: because a live lock cannot be
+    /// re-acquired, a duplicated reference fails on its second occurrence as if a concurrent
+    /// caller held the lock. (Inputs of a valid [`Proposal`] are always distinct; proposal
+    /// construction rejects duplicates as
+    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend).)
+    ///
+    /// [`Proposal`]: crate::proposal::Proposal
     fn lock_outputs(
         &mut self,
         outputs: impl Iterator<Item = OutputRef>,
@@ -3681,6 +3689,13 @@ pub trait WalletWrite: WalletRead {
     /// operating system before the corresponding transactions could be built). By clearing all
     /// locks for the account, the caller declares that it has no pending proposals holding those
     /// outputs.
+    ///
+    /// # Warning
+    ///
+    /// This releases every lock for the account, including locks held by proposals that are
+    /// still legitimately in flight; those proposals' inputs immediately become selectable by
+    /// new proposals, re-creating the conflict that locking exists to prevent. Only call this
+    /// when no in-flight proposal or PCZT for the account remains.
     ///
     /// Returns the number of outputs that were unlocked.
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error>;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3649,6 +3649,17 @@ pub trait WalletWrite: WalletRead {
     /// provided output on success, or fail completely leaving all lock state unmodified if any of
     /// the outputs were already locked. Existing locks that have expired as of the chain tip
     /// should be replaced with new locks.
+    ///
+    /// This is the mechanism by which overlapping proposals for the same account are prevented
+    /// from selecting the same inputs. Because note selection and locking cannot be performed as a
+    /// single atomic step above the storage layer, two callers may independently select an
+    /// overlapping set of outputs before either locks them (a time-of-check/time-of-use race); the
+    /// conflict is resolved here, at the storage layer, where the second caller's `lock_outputs`
+    /// fails with [`LockError::LockFailure`] naming the already-locked output. Callers that lock
+    /// via a proposal-creation function surface this as
+    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend). The
+    /// losing caller has not partially locked anything and should treat the failure as "the
+    /// account is busy" and retry.
     fn lock_outputs(
         &mut self,
         outputs: impl Iterator<Item = OutputRef>,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -4218,6 +4218,168 @@ pub trait WalletCommitmentTrees {
     }
 }
 
+/// Property tests for the [`Balance`] bucket arithmetic.
+///
+/// These pin the accounting semantics the locked-value bucket joined: every bucket except
+/// `uneconomic_value` participates in [`Balance::total`] and in the shared overflow guard,
+/// while `uneconomic_value` is guarded only against its own overflow and never contributes
+/// to the total.
+#[cfg(test)]
+mod balance_tests {
+    use proptest::prelude::*;
+    use zcash_protocol::value::{BalanceError, MAX_MONEY, Zatoshis};
+
+    use super::Balance;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Bucket {
+        Spendable = 0,
+        Locked = 1,
+        PendingChange = 2,
+        PendingSpendable = 3,
+        Uneconomic = 4,
+    }
+    use Bucket::*;
+
+    const ALL_BUCKETS: [Bucket; 5] = [
+        Spendable,
+        Locked,
+        PendingChange,
+        PendingSpendable,
+        Uneconomic,
+    ];
+    /// The buckets that participate in `Balance::total` and its overflow guard.
+    const TOTAL_BUCKETS: [Bucket; 4] = [Spendable, Locked, PendingChange, PendingSpendable];
+
+    fn apply(balance: &mut Balance, bucket: Bucket, value: Zatoshis) -> Result<(), BalanceError> {
+        match bucket {
+            Spendable => balance.add_spendable_value(value),
+            Locked => balance.add_locked_value(value),
+            PendingChange => balance.add_pending_change_value(value),
+            PendingSpendable => balance.add_pending_spendable_value(value),
+            Uneconomic => balance.add_uneconomic_value(value),
+        }
+    }
+
+    fn get(balance: &Balance, bucket: Bucket) -> Zatoshis {
+        match bucket {
+            Spendable => balance.spendable_value(),
+            Locked => balance.locked_value(),
+            PendingChange => balance.change_pending_confirmation(),
+            PendingSpendable => balance.value_pending_spendability(),
+            Uneconomic => balance.uneconomic_value(),
+        }
+    }
+
+    fn arb_bucket() -> impl Strategy<Value = Bucket> {
+        prop_oneof![
+            Just(Spendable),
+            Just(Locked),
+            Just(PendingChange),
+            Just(PendingSpendable),
+            Just(Uneconomic),
+        ]
+    }
+
+    /// A bucket and a value to add to it. Values are mostly small (so most sequences stay
+    /// within `MAX_MONEY`) with occasional near-cap draws to exercise the overflow guards.
+    fn arb_add() -> impl Strategy<Value = (Bucket, u64)> {
+        (
+            arb_bucket(),
+            prop_oneof![
+                3 => 0u64..=1_000_000,
+                1 => 0u64..=MAX_MONEY,
+            ],
+        )
+    }
+
+    proptest! {
+        /// Bucket adds succeed exactly while their overflow guard permits, mutate only the
+        /// requested bucket, and leave the balance untouched on failure. `total()` is always
+        /// the sum of the four participating buckets. (In particular this establishes that
+        /// the `unwrap` inside each guarded add is unreachable.)
+        #[test]
+        fn add_total_consistency(adds in proptest::collection::vec(arb_add(), 0..12)) {
+            let mut balance = Balance::ZERO;
+            // The model: per-bucket totals, indexed by bucket discriminant.
+            let mut model = [0u64; 5];
+
+            for (bucket, v) in adds {
+                let value = Zatoshis::from_u64(v).unwrap();
+                let before = balance;
+                let result = apply(&mut balance, bucket, value);
+
+                let total: u64 = TOTAL_BUCKETS.iter().map(|b| model[*b as usize]).sum();
+                let expect_ok = match bucket {
+                    Uneconomic => model[Uneconomic as usize] + v <= MAX_MONEY,
+                    _ => total + v <= MAX_MONEY,
+                };
+                if expect_ok {
+                    prop_assert!(result.is_ok());
+                    model[bucket as usize] += v;
+                } else {
+                    prop_assert!(result.is_err());
+                    prop_assert_eq!(
+                        balance, before,
+                        "a failed add must leave the balance unchanged"
+                    );
+                }
+
+                let total: u64 = TOTAL_BUCKETS.iter().map(|b| model[*b as usize]).sum();
+                prop_assert_eq!(balance.total(), Zatoshis::from_u64(total).unwrap());
+                for b in ALL_BUCKETS {
+                    prop_assert_eq!(
+                        get(&balance, b),
+                        Zatoshis::from_u64(model[b as usize]).unwrap()
+                    );
+                }
+            }
+        }
+
+        /// `Balance + Balance` is componentwise addition: it succeeds exactly when the
+        /// combined total and the combined uneconomic value each remain within `MAX_MONEY`,
+        /// and on success every bucket of the sum is the sum of the corresponding buckets.
+        #[test]
+        fn balance_addition_is_componentwise(
+            a in proptest::collection::vec(arb_add(), 0..6),
+            b in proptest::collection::vec(arb_add(), 0..6),
+        ) {
+            let build = |adds: &[(Bucket, u64)]| {
+                let mut balance = Balance::ZERO;
+                for (bucket, v) in adds {
+                    let _ = apply(&mut balance, *bucket, Zatoshis::from_u64(*v).unwrap());
+                }
+                balance
+            };
+            let ba = build(&a);
+            let bb = build(&b);
+
+            let combined_total = u64::from(ba.total()) + u64::from(bb.total());
+            let combined_uneconomic =
+                u64::from(ba.uneconomic_value()) + u64::from(bb.uneconomic_value());
+            match ba + bb {
+                Ok(sum) => {
+                    prop_assert!(combined_total <= MAX_MONEY);
+                    prop_assert!(combined_uneconomic <= MAX_MONEY);
+                    for bucket in ALL_BUCKETS {
+                        prop_assert_eq!(
+                            u64::from(get(&sum, bucket)),
+                            u64::from(get(&ba, bucket)) + u64::from(get(&bb, bucket))
+                        );
+                    }
+                    prop_assert_eq!(u64::from(sum.total()), combined_total);
+                }
+                Err(_) => {
+                    prop_assert!(
+                        combined_total > MAX_MONEY || combined_uneconomic > MAX_MONEY,
+                        "balance addition failed although no component overflows"
+                    );
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3662,6 +3662,18 @@ pub trait WalletWrite: WalletRead {
     /// output exists.
     fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error>;
 
+    /// Unlocks every currently-locked output belonging to the specified account, regardless of
+    /// lock expiry height.
+    ///
+    /// This is intended as a recovery mechanism for callers that have lost track of their
+    /// in-flight proposals or PCZTs (for example, because the application was terminated by the
+    /// operating system before the corresponding transactions could be built). By clearing all
+    /// locks for the account, the caller declares that it has no pending proposals holding those
+    /// outputs.
+    ///
+    /// Returns the number of outputs that were unlocked.
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error>;
+
     /// Saves information about transactions constructed by the wallet to the persistent
     /// wallet store.
     ///

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -214,6 +214,7 @@ pub enum MaxSpendMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Balance {
     spendable_value: Zatoshis,
+    locked_value: Zatoshis,
     change_pending_confirmation: Zatoshis,
     value_pending_spendability: Zatoshis,
     uneconomic_value: Zatoshis,
@@ -223,6 +224,7 @@ impl Balance {
     /// The [`Balance`] value having zero values for all its fields.
     pub const ZERO: Self = Self {
         spendable_value: Zatoshis::ZERO,
+        locked_value: Zatoshis::ZERO,
         change_pending_confirmation: Zatoshis::ZERO,
         value_pending_spendability: Zatoshis::ZERO,
         uneconomic_value: Zatoshis::ZERO,
@@ -230,6 +232,7 @@ impl Balance {
 
     fn check_total_adding(&self, value: Zatoshis) -> Result<Zatoshis, BalanceError> {
         (self.spendable_value
+            + self.locked_value
             + self.change_pending_confirmation
             + self.value_pending_spendability
             + value)
@@ -243,10 +246,25 @@ impl Balance {
         self.spendable_value
     }
 
+    /// Returns the value in the account that is currently "locked".
+    ///
+    /// The outputs that comprise this balance are seen by the wallet as being committed to be
+    /// spent by a transaction proposal or PCZT.
+    pub fn locked_value(&self) -> Zatoshis {
+        self.locked_value
+    }
+
     /// Adds the specified value to the spendable total, checking for overflow.
     pub fn add_spendable_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
         self.check_total_adding(value)?;
         self.spendable_value = (self.spendable_value + value).unwrap();
+        Ok(())
+    }
+
+    /// Adds the specified value to the locked total, checking for overflow.
+    pub fn add_locked_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
+        self.check_total_adding(value)?;
+        self.locked_value = (self.locked_value + value).unwrap();
         Ok(())
     }
 
@@ -291,7 +309,10 @@ impl Balance {
 
     /// Returns the total value of funds represented by this [`Balance`].
     pub fn total(&self) -> Zatoshis {
-        (self.spendable_value + self.change_pending_confirmation + self.value_pending_spendability)
+        (self.spendable_value
+            + self.locked_value
+            + self.change_pending_confirmation
+            + self.value_pending_spendability)
             .expect("Balance cannot overflow MAX_MONEY")
     }
 }
@@ -303,6 +324,7 @@ impl core::ops::Add<Balance> for Balance {
         let result = Balance {
             spendable_value: (self.spendable_value + rhs.spendable_value)
                 .ok_or(BalanceError::Overflow)?,
+            locked_value: (self.locked_value + rhs.locked_value).ok_or(BalanceError::Overflow)?,
             change_pending_confirmation: (self.change_pending_confirmation
                 + rhs.change_pending_confirmation)
                 .ok_or(BalanceError::Overflow)?,
@@ -497,6 +519,17 @@ impl AccountBalance {
             + self.orchard_balance.spendable_value
             + self.ironwood_balance.spendable_value)
             .expect("Account balance cannot overflow MAX_MONEY")
+    }
+
+    /// Returns the total value of notes and UTXOs that are locked, having been committed to
+    /// an in-flight transaction proposal or PCZT.
+    pub fn locked_value(&self) -> Zatoshis {
+        (self.sapling_balance.locked_value()
+            + self.orchard_balance.locked_value()
+            + self.ironwood_balance.locked_value()
+            + self.unshielded_regular_balance.locked_value()
+            + self.unshielded_coinbase_balance.locked_value())
+        .expect("Account balance cannot overflow MAX_MONEY")
     }
 
     /// Returns the total value of change and/or shielding transaction outputs that are awaiting

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -96,12 +96,12 @@ use self::{
 };
 use crate::{
     data_api::{
-        error::RewindError,
+        error::{LockError, RewindError},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     decrypt::DecryptedOutput,
     proto::service::TreeState,
-    wallet::{Note, NoteId, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
+    wallet::{Note, NoteId, OutputRef, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -2284,6 +2284,15 @@ pub trait WalletRead {
 #[cfg(any(test, feature = "test-dependencies"))]
 #[cfg_attr(feature = "test-dependencies", delegatable_trait)]
 pub trait WalletTest: InputSource + WalletRead {
+    /// Returns the set of currently locked outputs for the given account.
+    ///
+    /// Locked outputs are excluded from note selection, and are tallied separately in balance
+    /// computations.
+    fn get_locked_outputs(
+        &self,
+        account: <Self as WalletRead>::AccountId,
+    ) -> Result<Vec<OutputRef>, <Self as WalletRead>::Error>;
+
     /// Returns a vector of transaction summaries.
     ///
     /// Currently test-only, as production use could return a very large number of results; either
@@ -3580,6 +3589,30 @@ pub trait WalletWrite: WalletRead {
     /// The outputs of a trusted transaction will be available for spending with
     /// [`ConfirmationsPolicy::trusted`] confirmations even if the output is not wallet-internal.
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error>;
+
+    /// Locks the specified outputs, preventing it from being selected for spending at any height
+    /// less than or equal to the given height.
+    ///
+    /// Returns the number of outputs locked by the operation on success, or a [`LockError`] on
+    /// failure, wrapping either an error from the underlying storage backend or the first output
+    /// that could not be locked.
+    ///
+    /// Implementations of this method must either succeed completely, successfully locking each
+    /// provided output on success, or fail completely leaving all lock state unmodified if any of
+    /// the outputs were already locked. Existing locks that have expired as of the chain tip
+    /// should be replaced with new locks.
+    fn lock_outputs(
+        &mut self,
+        outputs: impl Iterator<Item = OutputRef>,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>>;
+
+    /// Unlocks the specified output, making it once again available for spending and balance
+    /// computations.
+    ///
+    /// Returns `true` if the output was found and unlocked, `false` if no matching
+    /// output exists.
+    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error>;
 
     /// Saves information about transactions constructed by the wallet to the persistent
     /// wallet store.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -101,7 +101,10 @@ use crate::{
     },
     decrypt::DecryptedOutput,
     proto::service::TreeState,
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
+    wallet::{
+        LockOwner, Note, NoteId, OutputRef, ReceivedNote, Recipient, WalletTransparentOutput,
+        WalletTx,
+    },
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -3638,17 +3641,24 @@ pub trait WalletWrite: WalletRead {
     /// [`ConfirmationsPolicy::trusted`] confirmations even if the output is not wallet-internal.
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error>;
 
-    /// Locks the specified outputs, preventing it from being selected for spending at any height
-    /// less than or equal to the given height.
+    /// Locks the specified outputs on behalf of `owner`, preventing them from being selected
+    /// for spending at any height less than or equal to the given height.
     ///
-    /// Returns the number of outputs locked by the operation on success, or a [`LockError`] on
+    /// Returns the number of row updates performed on success (equal to the number of provided
+    /// references; a duplicated reference is counted per occurrence), or a [`LockError`] on
     /// failure, wrapping either an error from the underlying storage backend or the first output
     /// that could not be locked.
     ///
+    /// A lock may be acquired when the output holds no lock, when its existing lock has expired
+    /// as of the chain tip, or when its existing lock is held by the *same* `owner`; in the
+    /// latter case the lock's expiry height is updated. Same-owner re-locking makes the
+    /// operation idempotent, so a caller that crashes between locking and persisting its
+    /// proposal can safely retry the flow under the same [`LockOwner`]. Acquisition fails only
+    /// when an unexpired lock is held by a different owner.
+    ///
     /// Implementations of this method must either succeed completely, successfully locking each
-    /// provided output on success, or fail completely leaving all lock state unmodified if any of
-    /// the outputs were already locked. Existing locks that have expired as of the chain tip
-    /// should be replaced with new locks.
+    /// provided output on success, or fail completely leaving all lock state unmodified if any
+    /// of the outputs is actively locked by a different owner.
     ///
     /// This is the mechanism by which overlapping proposals for the same account are prevented
     /// from selecting the same inputs. Because note selection and locking cannot be performed as a
@@ -3660,26 +3670,21 @@ pub trait WalletWrite: WalletRead {
     /// [`ProposalError::InputsLocked`](crate::proposal::ProposalError::InputsLocked). The
     /// losing caller has not partially locked anything and should treat the failure as "the
     /// account is busy" and retry.
-    ///
-    /// The provided output references must be distinct: because a live lock cannot be
-    /// re-acquired, a duplicated reference fails on its second occurrence as if a concurrent
-    /// caller held the lock. (Inputs of a valid [`Proposal`] are always distinct; proposal
-    /// construction rejects duplicates as
-    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend).)
-    ///
-    /// [`Proposal`]: crate::proposal::Proposal
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>>;
 
-    /// Unlocks the specified output, making it once again available for spending and balance
-    /// computations.
+    /// Unlocks the specified output if it is locked by the given `owner`, making it once again
+    /// available for spending and balance computations.
     ///
-    /// Returns `true` if the output was found and unlocked, `false` if no matching
-    /// output exists.
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error>;
+    /// Returns `true` if a lock held by `owner` (whether or not it had already expired) was
+    /// removed from the output, and `false` otherwise: in particular, a lock held by a
+    /// different owner is left in place, so one flow cannot accidentally release another's
+    /// locks.
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error>;
 
     /// Unlocks every currently-locked output belonging to the specified account, regardless of
     /// lock expiry height.
@@ -3692,10 +3697,10 @@ pub trait WalletWrite: WalletRead {
     ///
     /// # Warning
     ///
-    /// This releases every lock for the account, including locks held by proposals that are
-    /// still legitimately in flight; those proposals' inputs immediately become selectable by
-    /// new proposals, re-creating the conflict that locking exists to prevent. Only call this
-    /// when no in-flight proposal or PCZT for the account remains.
+    /// This releases every lock for the account regardless of its owner, including locks held
+    /// by proposals that are still legitimately in flight; those proposals' inputs immediately
+    /// become selectable by new proposals, re-creating the conflict that locking exists to
+    /// prevent. Only call this when no in-flight proposal or PCZT for the account remains.
     ///
     /// Returns the number of outputs that were unlocked.
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error>;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3669,6 +3669,11 @@ pub trait WalletWrite: WalletRead {
     ///
     /// Transactions that have been stored by this method should be retransmitted while it
     /// is still possible that they could be mined.
+    ///
+    /// Implementations must unlock any locked outputs that are recorded as spent by the
+    /// stored transactions. Once spend records exist, the outputs are protected from
+    /// double-selection by the spend tracking mechanism, so the explicit locks are no
+    /// longer needed.
     fn store_transactions_to_be_sent(
         &mut self,
         transactions: &[SentTransaction<Self::AccountId>],

--- a/zcash_client_backend/src/data_api/error.rs
+++ b/zcash_client_backend/src/data_api/error.rs
@@ -15,6 +15,7 @@ use zcash_protocol::{
     value::{BalanceError, Zatoshis},
 };
 
+use crate::wallet::OutputRef;
 use crate::{
     data_api::wallet::input_selection::InputSelectorError, fees::ChangeError,
     proposal::ProposalError, wallet::NoteId,
@@ -551,6 +552,38 @@ impl<E: error::Error + 'static> error::Error for FindAccountForAddressError<E> {
         match self {
             FindAccountForAddressError::Backend(e) => Some(e),
             FindAccountForAddressError::UnifiedAddressConflict => None,
+        }
+    }
+}
+
+/// Errors that occur when attempting to lock an output.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LockError<S> {
+    /// Wrapper for storage errors.
+    Storage(S),
+    /// The wrapped output reference was not found, or the output it refers to was already locked.
+    LockFailure(OutputRef),
+}
+
+impl<S: Display> Display for LockError<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LockError::Storage(e) => write!(f, "Note locking failed: {e}"),
+            LockError::LockFailure(output) => {
+                write!(
+                    f,
+                    "Lock conflict or missing output for reference {output:?}"
+                )
+            }
+        }
+    }
+}
+
+impl<S: error::Error + 'static> error::Error for LockError<S> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            LockError::Storage(e) => Some(e),
+            LockError::LockFailure(_) => None,
         }
     }
 }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -75,7 +75,9 @@ use crate::{
     proto::compact_formats::{
         self, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },
-    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote, WalletTransparentOutput},
+    wallet::{
+        LockOwner, Note, NoteId, OutputRef, OvkPolicy, ReceivedNote, WalletTransparentOutput,
+    },
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -1306,6 +1308,7 @@ where
             to_address,
             memo,
             limit,
+            None,
         )
     }
 
@@ -3382,13 +3385,18 @@ impl WalletWrite for MockWalletDb {
 
     fn lock_outputs(
         &mut self,
-        _outputs: impl Iterator<Item = OutputRef>,
+        _outputs: &[OutputRef],
+        _owner: LockOwner,
         _lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
         Ok(0)
     }
 
-    fn unlock_output(&mut self, _output: &OutputRef) -> Result<bool, Self::Error> {
+    fn unlock_output(
+        &mut self,
+        _output: &OutputRef,
+        _owner: LockOwner,
+    ) -> Result<bool, Self::Error> {
         Ok(false)
     }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -3392,6 +3392,10 @@ impl WalletWrite for MockWalletDb {
         Ok(false)
     }
 
+    fn clear_locked_outputs(&mut self, _account: Self::AccountId) -> Result<usize, Self::Error> {
+        Ok(0)
+    }
+
     fn store_transactions_to_be_sent(
         &mut self,
         _transactions: &[SentTransaction<Self::AccountId>],

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -57,7 +57,7 @@ use super::{
     scanning::ScanRange,
     wallet::{
         ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
-        input_selection::{GreedyInputSelector, InputSelector, SpendPolicy},
+        input_selection::{GreedyInputSelector, InputSelector, LockFilter, SpendPolicy},
         propose_send_max_transfer, propose_standard_transfer_to_address, propose_transfer,
     },
 };
@@ -3028,7 +3028,7 @@ impl InputSource for MockWalletDb {
         _protocol: ShieldedPool,
         _index: u32,
         _target_height: TargetHeight,
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         Ok(None)
     }
@@ -3041,7 +3041,7 @@ impl InputSource for MockWalletDb {
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::empty())
     }
@@ -3052,7 +3052,7 @@ impl InputSource for MockWalletDb {
         _sources: &[ShieldedPool],
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Err(())
     }
@@ -3063,7 +3063,7 @@ impl InputSource for MockWalletDb {
         _selector: &NoteFilter,
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<AccountMeta, Self::Error> {
         Err(())
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -62,7 +62,11 @@ use super::{
     },
 };
 use crate::{
-    data_api::{MaxSpendMode, TargetValue, error::RewindError, wallet::TargetHeight},
+    data_api::{
+        MaxSpendMode, TargetValue,
+        error::{LockError, RewindError},
+        wallet::TargetHeight,
+    },
     fees::{
         ChangeStrategy, DustOutputPolicy, StandardFeeRule,
         standard::{self, SingleOutputChangeStrategy},
@@ -71,7 +75,7 @@ use crate::{
     proto::compact_formats::{
         self, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },
-    wallet::{Note, NoteId, OvkPolicy, ReceivedNote, WalletTransparentOutput},
+    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote, WalletTransparentOutput},
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -3357,6 +3361,18 @@ impl WalletWrite for MockWalletDb {
 
     fn set_tx_trust(&mut self, _txid: TxId, _trusted: bool) -> Result<(), Self::Error> {
         Ok(())
+    }
+
+    fn lock_outputs(
+        &mut self,
+        _outputs: impl Iterator<Item = OutputRef>,
+        _lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        Ok(0)
+    }
+
+    fn unlock_output(&mut self, _output: &OutputRef) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
     fn store_transactions_to_be_sent(

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -3012,6 +3012,7 @@ impl InputSource for MockWalletDb {
         _protocol: ShieldedPool,
         _index: u32,
         _target_height: TargetHeight,
+        _include_locked: bool,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         Ok(None)
     }
@@ -3024,6 +3025,7 @@ impl InputSource for MockWalletDb {
         _target_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
         _exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::empty())
     }
@@ -3034,6 +3036,7 @@ impl InputSource for MockWalletDb {
         _sources: &[ShieldedPool],
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Err(())
     }
@@ -3044,6 +3047,7 @@ impl InputSource for MockWalletDb {
         _selector: &NoteFilter,
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<AccountMeta, Self::Error> {
         Err(())
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -57,7 +57,9 @@ use super::{
     scanning::ScanRange,
     wallet::{
         ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
-        input_selection::{GreedyInputSelector, InputSelector, LockFilter, SpendPolicy},
+        input_selection::{
+            GreedyInputSelector, InputSelector, LockFilter, LockedInputPolicy, SpendPolicy,
+        },
         propose_send_max_transfer, propose_standard_transfer_to_address, propose_transfer,
     },
 };
@@ -1181,6 +1183,7 @@ where
             memo,
             mode,
             confirmations_policy,
+            &LockedInputPolicy::Exclude,
             None,
         )
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1065,6 +1065,7 @@ where
             confirmations_policy,
             &SpendPolicy::default(),
             None,
+            None,
         )?;
 
         create_proposed_transactions(
@@ -1107,6 +1108,7 @@ where
             confirmations_policy,
             &SpendPolicy::default(),
             None,
+            None,
         )
     }
 
@@ -1145,6 +1147,7 @@ where
             confirmations_policy,
             spend_policy,
             None,
+            None,
         )
     }
 
@@ -1176,6 +1179,7 @@ where
             memo,
             mode,
             confirmations_policy,
+            None,
         )
     }
 
@@ -1213,6 +1217,7 @@ where
             memo,
             change_memo,
             fallback_change_pool,
+            None,
             None,
         );
 
@@ -1260,6 +1265,7 @@ where
             to_account,
             confirmations_policy,
             output_filter,
+            None,
         )
     }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1451,6 +1451,13 @@ where
         self.with_account_balance(account, ConfirmationsPolicy::MIN, |balance| balance.total())
     }
 
+    /// Returns the locked balance in the given account at this point in the test.
+    pub fn get_locked_balance(&self, account: AccountIdT) -> Zatoshis {
+        self.with_account_balance(account, ConfirmationsPolicy::MIN, |balance| {
+            balance.locked_value()
+        })
+    }
+
     /// Returns the balance in the given account that is spendable with the given number
     /// of confirmations at this point in the test.
     pub fn get_spendable_balance(

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -27,7 +27,10 @@ use crate::{
         WalletTest,
         chain::{CommitmentTreeRoot, ScanSummary},
         testing::{TestState, pool::ShieldedPoolTester},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{
+            ConfirmationsPolicy, TargetHeight,
+            input_selection::{LockFilter, LockedInputPolicy},
+        },
     },
     wallet::{Note, ReceivedNote},
 };
@@ -138,7 +141,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
                 target_height,
                 confirmations_policy,
                 exclude,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map(|n| n.take_orchard())
     }
@@ -155,7 +158,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
                 &[ShieldedPool::Orchard],
                 target_height,
                 exclude,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map(|n| n.take_orchard())
     }

--- a/zcash_client_backend/src/data_api/testing/orchard.rs
+++ b/zcash_client_backend/src/data_api/testing/orchard.rs
@@ -138,6 +138,7 @@ impl ShieldedPoolTester for OrchardPoolTester {
                 target_height,
                 confirmations_policy,
                 exclude,
+                false,
             )
             .map(|n| n.take_orchard())
     }
@@ -149,7 +150,13 @@ impl ShieldedPoolTester for OrchardPoolTester {
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
-            .select_unspent_notes(account, &[ShieldedPool::Orchard], target_height, exclude)
+            .select_unspent_notes(
+                account,
+                &[ShieldedPool::Orchard],
+                target_height,
+                exclude,
+                false,
+            )
             .map(|n| n.take_orchard())
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -44,8 +44,8 @@ use crate::{
             single_output_change_strategy,
         },
         wallet::{
-            ConfirmationsPolicy, TargetHeight, TransferErrT, decrypt_and_store_transaction,
-            input_selection::GreedyInputSelector,
+            ConfirmationsPolicy, LockRequest, TargetHeight, TransferErrT,
+            decrypt_and_store_transaction, input_selection::GreedyInputSelector,
         },
     },
     decrypt_transaction,
@@ -54,7 +54,7 @@ use crate::{
         standard::{self, SingleOutputChangeStrategy},
     },
     scanning::ScanError,
-    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote},
+    wallet::{LockOwner, Note, NoteId, OutputRef, OvkPolicy, ReceivedNote},
 };
 
 use super::{DataStoreFactory, Reset, TestCache, TestFvk, TestState};
@@ -3400,9 +3400,10 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 
     // Lock the note with a far-future expiry so it's active during the test
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[output_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3433,7 +3434,7 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 
     // Unlock the note
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    assert!(st.wallet_mut().unlock_output(&output_ref, owner).unwrap());
 
     // Balance should be restored: spendable equals the full value, locked is zero
     assert_eq!(st.get_total_balance(account_id), value);
@@ -3501,9 +3502,10 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
     );
 
     // Lock with expiry exactly at the target height: the output must be treated as locked.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), target_height)
+            .lock_outputs(&[output_ref], owner, target_height)
             .unwrap(),
         1
     );
@@ -3517,12 +3519,12 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
         vec![output_ref]
     );
 
-    // Re-lock with expiry one block below the target height. Because the existing lock is not
-    // yet expired as of the chain tip, we must first unlock it explicitly.
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    // Re-lock with expiry one block below the target height. The existing lock is not yet
+    // expired as of the chain tip, but the same owner may re-acquire (and here, shorten) its
+    // own lock directly, with no explicit unlock.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), target_height - 1)
+            .lock_outputs(&[output_ref], owner, target_height - 1)
             .unwrap(),
         1
     );
@@ -3569,9 +3571,10 @@ pub fn clear_locked_outputs<T: ShieldedPoolTester>(
     );
 
     // Lock the note with a far-future expiry.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[output_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3582,7 +3585,7 @@ pub fn clear_locked_outputs<T: ShieldedPoolTester>(
     );
 
     // Clearing all locks for the account unlocks the output even though its expiry height is far
-    // in the future.
+    // in the future (and regardless of its owner).
     assert_eq!(st.wallet_mut().clear_locked_outputs(account_id).unwrap(), 1);
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
     assert_eq!(
@@ -3638,6 +3641,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -3647,7 +3651,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -3695,7 +3699,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     );
     assert_matches!(
         st.wallet_mut()
-            .lock_outputs([unknown].into_iter(), BlockHeight::from(u32::MAX)),
+            .lock_outputs(&[unknown], owner, BlockHeight::from(u32::MAX)),
         Err(LockError::LockFailure(r)) if r == unknown
     );
 
@@ -3706,7 +3710,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     // tightening of the contract is a visible, deliberate change.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([funding_note_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[funding_note_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3716,7 +3720,11 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         vec![funding_note_ref]
     );
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
-    assert!(st.wallet_mut().unlock_output(&funding_note_ref).unwrap());
+    assert!(
+        st.wallet_mut()
+            .unlock_output(&funding_note_ref, owner)
+            .unwrap()
+    );
 }
 
 /// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its
@@ -3753,6 +3761,7 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -3762,7 +3771,7 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -3815,10 +3824,11 @@ pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
     );
 
     // Lock the note until three blocks past the current tip.
+    let owner = LockOwner::new([1; 32]);
     let expiry = tip + 3;
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), expiry)
+            .lock_outputs(&[output_ref], owner, expiry)
             .unwrap(),
         1
     );
@@ -3868,12 +3878,14 @@ pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
     )
     .expect("an expired lock must not block proposal creation");
 
-    // The expired lock is replaceable: a fresh lock_outputs call succeeds without an explicit
-    // unlock, overwriting the stale expiry value.
+    // The expired lock is replaceable, even by a DIFFERENT owner: a fresh lock_outputs call
+    // succeeds without an explicit unlock, overwriting the stale expiry value and taking over
+    // ownership of the lock.
+    let other_owner = LockOwner::new([2; 32]);
     let new_tip = st.latest_cached_block().unwrap().height();
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), new_tip + 5)
+            .lock_outputs(&[output_ref], other_owner, new_tip + 5)
             .unwrap(),
         1
     );
@@ -3919,26 +3931,41 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
     let r1 = output_ref(value1);
     let r2 = output_ref(value2);
 
+    let owner_a = LockOwner::new([0xA1; 32]);
+    let owner_b = LockOwner::new([0xB2; 32]);
+
     // The first lock on a note succeeds.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([r1].into_iter(), far_expiry)
+            .lock_outputs(&[r1], owner_a, far_expiry)
             .unwrap(),
         1
     );
 
-    // A second lock on the same note fails while the first lock is active, even from the same
-    // caller: an active lock cannot be re-acquired, extended, or shortened without an explicit
-    // unlock first.
+    // Re-locking under the SAME owner succeeds while the lock is active: acquisition is
+    // idempotent for the holding flow (this is the crash-retry path), and may extend or
+    // shorten the expiry.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs(&[r1], owner_a, far_expiry)
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1]
+    );
+
+    // A lock by a DIFFERENT owner fails while the first lock is active.
     assert_matches!(
-        st.wallet_mut().lock_outputs([r1].into_iter(), far_expiry),
+        st.wallet_mut().lock_outputs(&[r1], owner_b, far_expiry),
         Err(LockError::LockFailure(r)) if r == r1
     );
 
-    // A batch containing a conflicting output fails all-or-nothing: r2 precedes the conflicting
-    // r1 in the batch, but the failure must leave r2 unlocked.
+    // A batch containing a foreign-locked output fails all-or-nothing: r2 precedes the
+    // conflicting r1 in the batch, but the failure must leave r2 unlocked.
     assert_matches!(
-        st.wallet_mut().lock_outputs([r2, r1].into_iter(), far_expiry),
+        st.wallet_mut().lock_outputs(&[r2, r1], owner_b, far_expiry),
         Err(LockError::LockFailure(r)) if r == r1
     );
     assert_eq!(
@@ -3952,35 +3979,47 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
         value2
     );
 
-    // A batch containing the same output twice fails on the duplicate: the first occurrence
-    // takes a live lock, which the second occurrence then conflicts with. Atomicity applies
-    // here too: the failed batch leaves r2 unlocked.
-    assert_matches!(
-        st.wallet_mut().lock_outputs([r2, r2].into_iter(), far_expiry),
-        Err(LockError::LockFailure(r)) if r == r2
-    );
+    // A batch containing the same output twice under one owner succeeds: the second occurrence
+    // re-acquires the lock taken by the first (both row updates are counted).
     assert_eq!(
-        st.wallet().get_locked_outputs(account_id).unwrap(),
-        vec![r1]
+        st.wallet_mut()
+            .lock_outputs(&[r2, r2], owner_b, far_expiry)
+            .unwrap(),
+        2
     );
+    {
+        let mut locked = st.wallet().get_locked_outputs(account_id).unwrap();
+        locked.sort();
+        let mut expected = vec![r1, r2];
+        expected.sort();
+        assert_eq!(locked, expected);
+    }
 
-    // Unlocking an existing output that holds no lock reports `true` (the output was found;
-    // its lock state is NULL afterwards either way); unlocking an unknown output reports
-    // `false`.
-    assert!(st.wallet_mut().unlock_output(&r2).unwrap());
+    // Unlocking is owner-scoped: owner A cannot release owner B's lock on r2, and unlocking
+    // an unknown output reports `false`.
+    assert!(!st.wallet_mut().unlock_output(&r2, owner_a).unwrap());
+    assert_eq!(
+        st.get_locked_balance(account_id),
+        (value1 + value2).unwrap()
+    );
     let unknown = OutputRef::new(
         TxId::from_bytes([0xEE; 32]),
         PoolType::Shielded(T::SHIELDED_PROTOCOL),
         0,
     );
-    assert!(!st.wallet_mut().unlock_output(&unknown).unwrap());
+    assert!(!st.wallet_mut().unlock_output(&unknown, owner_a).unwrap());
 
-    // After unlocking r1, both notes are spendable again and a fresh lock succeeds.
-    assert!(st.wallet_mut().unlock_output(&r1).unwrap());
+    // Each owner releases its own lock; unlocking an output that holds no lock reports
+    // `false`.
+    assert!(st.wallet_mut().unlock_output(&r2, owner_b).unwrap());
+    assert!(!st.wallet_mut().unlock_output(&r2, owner_b).unwrap());
+    assert!(st.wallet_mut().unlock_output(&r1, owner_a).unwrap());
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+
+    // With everything released, a single owner can lock both notes in one batch.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([r1, r2].into_iter(), far_expiry)
+            .lock_outputs(&[r1, r2], owner_a, far_expiry)
             .unwrap(),
         2
     );
@@ -3991,8 +4030,8 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
 }
 
 /// Verifies that [`unlock_proposal_inputs`] releases the locks taken by a proposal created with
-/// `lock_for_blocks: Some(_)`, restoring spendability for a subsequent proposal (the
-/// abandoned-proposal recovery path).
+/// a [`LockRequest`], restoring spendability for a subsequent proposal (the abandoned-proposal
+/// recovery path), and that the release is scoped to the owner that took the locks.
 ///
 /// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
 pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
@@ -4021,6 +4060,7 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -4030,7 +4070,7 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -4051,8 +4091,16 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
         Err(data_api::error::Error::InsufficientFunds { .. })
     );
 
-    // Abandon the proposal: releasing its inputs restores spendable balance...
-    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    // Attempting to release the locks under the WRONG owner is a no-op: the locks are scoped
+    // to the owner that took them.
+    let other_owner = LockOwner::new([2; 32]);
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, other_owner)
+        .unwrap();
+    assert_eq!(st.get_locked_balance(account_id), value);
+
+    // Abandon the proposal: releasing its inputs under the correct owner restores spendable
+    // balance...
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, owner).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
     assert_eq!(
         st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
@@ -4079,44 +4127,57 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     .expect("released inputs must be selectable by a new proposal");
 
     // Releasing an already-released proposal is a no-op.
-    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, owner).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
 }
 
 /// An operation in the note-locking model test; see [`check_note_locking_model`].
 #[derive(Clone, Debug)]
 pub enum LockOp {
-    /// Attempt to lock the notes at the given indices (duplicates permitted, and meaningful:
-    /// a duplicated index conflicts with the lock taken by its own first occurrence unless
-    /// that lock is already expired) with expiry height `chain_tip + expiry_delta`.
+    /// Attempt to lock the notes at the given indices on behalf of the given owner
+    /// (duplicates permitted: a duplicated index re-acquires the lock taken by its own first
+    /// occurrence, which succeeds because it is held by the same owner) with expiry height
+    /// `chain_tip + expiry_delta`.
     ///
     /// An `expiry_delta` of zero produces a lock that is expired from the moment it is taken:
     /// balance and selection evaluate locks against `target_height = chain_tip + 1`.
     Lock {
         notes: Vec<usize>,
+        owner: usize,
         expiry_delta: u32,
     },
-    /// Unlock the note at the given index, whether or not it is locked.
-    Unlock { note: usize },
-    /// Clear every lock for the account, regardless of expiry.
+    /// Unlock the note at the given index on behalf of the given owner; only a lock held by
+    /// that owner is released.
+    Unlock { note: usize, owner: usize },
+    /// Clear every lock for the account, regardless of expiry or owner.
     ClearLocked,
     /// Mine the given number of empty blocks, advancing the chain tip (and thereby expiring
     /// any lock whose expiry height the tip reaches).
     MineBlocks { count: usize },
 }
 
+/// The owner-index pool used by [`arb_lock_ops`] and [`check_note_locking_model`].
+const MODEL_OWNERS: [LockOwner; 2] = [LockOwner::new([0xA1; 32]), LockOwner::new([0xB2; 32])];
+
 /// A `proptest` strategy over sequences of [`LockOp`] for a wallet holding `n_notes` notes.
 ///
 /// Expiry deltas and mining counts are drawn from small ranges so that sequences routinely
 /// cross lock-expiry boundaries.
 pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec<LockOp>> {
+    let n_owners = MODEL_OWNERS.len();
     let op = prop_oneof![
         3 => (
             proptest::collection::vec(0..n_notes, 1..=n_notes + 1),
+            0..n_owners,
             0u32..=4,
         )
-            .prop_map(|(notes, expiry_delta)| LockOp::Lock { notes, expiry_delta }),
-        2 => (0..n_notes).prop_map(|note| LockOp::Unlock { note }),
+            .prop_map(|(notes, owner, expiry_delta)| LockOp::Lock {
+                notes,
+                owner,
+                expiry_delta
+            }),
+        2 => (0..n_notes, 0..n_owners)
+            .prop_map(|(note, owner)| LockOp::Unlock { note, owner }),
         1 => Just(LockOp::ClearLocked),
         2 => (1usize..=3).prop_map(|count| LockOp::MineBlocks { count }),
     ];
@@ -4126,11 +4187,12 @@ pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec
 /// Model-based test of the note-locking storage operations.
 ///
 /// Funds a wallet with three notes, then applies the given operation sequence both to the real
-/// data store and to a trivial in-memory model (per-note `Option<lock_expiry_height>` plus the
-/// chain tip). After every operation, the store must agree with the model on:
+/// data store and to a trivial in-memory model (per-note `Option<(lock_expiry_height, owner)>`
+/// plus the chain tip). After every operation, the store must agree with the model on:
 ///
 /// - the outcome of the operation itself, including the all-or-nothing failure of a `Lock`
-///   batch containing a conflict (an active, unexpired lock on any requested note);
+///   batch containing a conflict (an active, unexpired lock held by a different owner on any
+///   requested note), same-owner re-lock idempotency, and owner-scoped unlocking;
 /// - the set reported by `get_locked_outputs` (a note is locked while
 ///   `lock_expiry_height >= chain_tip + 1`);
 /// - the account balance decomposition: locked value is exactly the sum of model-locked note
@@ -4174,34 +4236,39 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
         })
         .collect();
 
-    // The model: per-note lock expiry height, and the chain tip.
-    let mut model: Vec<Option<u32>> = vec![None; refs.len()];
+    // The model: per-note lock expiry height and owner index, and the chain tip.
+    let mut model: Vec<Option<(u32, usize)>> = vec![None; refs.len()];
     let mut tip = u32::from(st.latest_cached_block().unwrap().height());
 
     for op in ops {
         match op {
             LockOp::Lock {
                 notes,
+                owner,
                 expiry_delta,
             } => {
                 let expiry = tip + expiry_delta;
                 // Predict the outcome by simulating the store's sequential update: each
-                // requested note may be locked when it holds no lock or its lock has expired
-                // as of the chain tip; the first conflict fails the whole batch.
+                // requested note may be locked when it holds no lock, when its lock has
+                // expired as of the chain tip, or when its lock is held by the requesting
+                // owner; the first conflict (an active foreign lock) fails the whole batch.
                 let mut scratch = model.clone();
                 let mut conflict = None;
                 for &i in notes {
-                    if scratch[i].is_none_or(|h| h <= tip) {
-                        scratch[i] = Some(expiry);
+                    if scratch[i].is_none_or(|(h, o)| h <= tip || o == *owner) {
+                        scratch[i] = Some((expiry, *owner));
                     } else {
                         conflict = Some(i);
                         break;
                     }
                 }
 
-                let result = st
-                    .wallet_mut()
-                    .lock_outputs(notes.iter().map(|&i| refs[i]), BlockHeight::from(expiry));
+                let batch: Vec<OutputRef> = notes.iter().map(|&i| refs[i]).collect();
+                let result = st.wallet_mut().lock_outputs(
+                    &batch,
+                    MODEL_OWNERS[*owner],
+                    BlockHeight::from(expiry),
+                );
                 match conflict {
                     None => {
                         assert_matches!(result, Ok(n) if n == notes.len());
@@ -4214,14 +4281,23 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
                     }
                 }
             }
-            LockOp::Unlock { note } => {
-                // The note exists, so unlock reports `true` regardless of prior lock state.
-                assert!(st.wallet_mut().unlock_output(&refs[*note]).unwrap());
-                model[*note] = None;
+            LockOp::Unlock { note, owner } => {
+                // Unlocking releases only a lock held by the requesting owner (expired or
+                // not), and reports whether one was released.
+                let expected = model[*note].is_some_and(|(_, o)| o == *owner);
+                assert_eq!(
+                    st.wallet_mut()
+                        .unlock_output(&refs[*note], MODEL_OWNERS[*owner])
+                        .unwrap(),
+                    expected
+                );
+                if expected {
+                    model[*note] = None;
+                }
             }
             LockOp::ClearLocked => {
-                // Clearing removes every lock record, expired or not, and reports how many
-                // rows it touched.
+                // Clearing removes every lock record, expired or not and regardless of
+                // owner, and reports how many rows it touched.
                 let expected = model.iter().filter(|h| h.is_some()).count();
                 assert_eq!(
                     st.wallet_mut().clear_locked_outputs(account_id).unwrap(),
@@ -4241,14 +4317,14 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
         let locked_value = model
             .iter()
             .zip(values.iter())
-            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .filter(|(h, _)| h.is_some_and(|(h, _)| h >= target))
             .try_fold(Zatoshis::ZERO, |acc, (_, v)| acc + *v)
             .unwrap();
 
         let mut expected_locked: Vec<OutputRef> = model
             .iter()
             .zip(refs.iter())
-            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .filter(|(h, _)| h.is_some_and(|(h, _)| h >= target))
             .map(|(_, r)| *r)
             .collect();
         expected_locked.sort();

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3674,6 +3674,72 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     );
 }
 
+/// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its
+/// serialized (proto) form.
+///
+/// A locking proposal locks its own inputs, and decoding re-retrieves each input from the wallet.
+/// Input retrieval during decoding must therefore not filter out locked outputs; otherwise a
+/// wallet that persists a locking proposal (for example around an app restart, while a PCZT is
+/// out for signing) could never decode it again.
+pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(15000),
+    )])
+    .unwrap();
+
+    let network = *st.network();
+    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
+        Some(100), // lock_for_blocks
+        None,
+    )
+    .unwrap();
+
+    // The proposal's input is locked.
+    assert!(
+        !st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty(),
+        "the proposal's input must be locked before the round-trip"
+    );
+
+    // The serialized proposal must decode back to an identical proposal even though its inputs
+    // are locked (a proposal legitimately references its own locked inputs).
+    let proto = crate::proto::proposal::Proposal::from_standard_proposal(&proposal);
+    let decoded = proto
+        .try_into_standard_proposal(&network, st.wallet())
+        .expect("a proposal with locked inputs must decode from its serialized form");
+    assert_eq!(decoded, proposal);
+}
+
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(
     ds_factory: Dsf,
     cache: impl TestCache,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4132,6 +4132,140 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
 }
 
+/// Verifies that `SpendPolicy::with_locked_input_policy` actually reaches note selection in
+/// `GreedyInputSelector::propose_transaction`, end to end.
+///
+/// With the default policy (`LockedInputPolicy::Exclude`), a proposal that needs more than the
+/// unlocked balance fails with `InsufficientFunds`, even though a locked note could cover it.
+/// With `LockedInputPolicy::PreferUnlocked` naming the lock's owner, the same proposal succeeds
+/// and its selected inputs include the note that owner locked. A note locked by a DIFFERENT
+/// owner — one the policy does not name — is never selected, under either policy.
+pub fn spend_policy_locked_input_policy_reaches_selection<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    use crate::data_api::wallet::input_selection::{
+        LockedInputPolicy, NonEmptyBTreeSet, SpendPolicy,
+    };
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Fund the account with three notes of distinct values in a single block, so that each can
+    // be identified by its value below: `unlocked_value` is left unlocked, `locked_a_value` is
+    // locked by owner A, and `locked_b_value` is locked by a DIFFERENT owner B.
+    let unlocked_value = Zatoshis::const_from_u64(20_000);
+    let locked_a_value = Zatoshis::const_from_u64(60_000);
+    let locked_b_value = Zatoshis::const_from_u64(70_000);
+    st.add_notes_checking_balance([[unlocked_value, locked_a_value, locked_b_value]]);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 3);
+    let output_ref = |value: Zatoshis| {
+        let note = notes
+            .iter()
+            .find(|n| n.note().value() == value)
+            .expect("a note with the requested value exists");
+        OutputRef::new(
+            *note.txid(),
+            PoolType::Shielded(note.note().pool()),
+            u32::from(note.output_index()),
+        )
+    };
+    let locked_a_ref = output_ref(locked_a_value);
+    let locked_b_ref = output_ref(locked_b_value);
+
+    let owner_a = LockOwner::new([0xA1; 32]);
+    let owner_b = LockOwner::new([0xB2; 32]);
+    let far_expiry = BlockHeight::from(u32::MAX);
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs(&[locked_a_ref], owner_a, far_expiry)
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs(&[locked_b_ref], owner_b, far_expiry)
+            .unwrap(),
+        1
+    );
+
+    // The unlocked note alone cannot cover this request (plus fee); a locked note is required.
+    let request_amount = Zatoshis::const_from_u64(50_000);
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        request_amount,
+    )])
+    .unwrap();
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    // With the default `Exclude` policy, both locked notes are ineligible, and the unlocked
+    // note alone is insufficient: the A-locked note is NOT drawn upon.
+    assert_matches!(
+        st.propose_transfer_with_policy(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request.clone(),
+            ConfirmationsPolicy::MIN,
+            &SpendPolicy::default(),
+        ),
+        Err(data_api::error::Error::InsufficientFunds { .. })
+    );
+
+    // With `PreferUnlocked` naming owner A, the proposal succeeds and draws on the note owner A
+    // locked, but never on the note locked by owner B (who the policy does not name).
+    let policy = SpendPolicy::default().with_locked_input_policy(
+        LockedInputPolicy::PreferUnlocked(NonEmptyBTreeSet::singleton(owner_a)),
+    );
+    let proposal = st
+        .propose_transfer_with_policy(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+            &policy,
+        )
+        .expect("a note locked by a permitted owner must be selectable to cover the request");
+
+    assert_eq!(proposal.steps().len(), 1);
+    let selected_values: Vec<Zatoshis> = proposal
+        .steps()
+        .head
+        .shielded_inputs()
+        .expect("the proposal must spend shielded notes")
+        .notes()
+        .iter()
+        .map(|rn| rn.note().value())
+        .collect();
+    assert!(
+        selected_values.contains(&locked_a_value),
+        "the note locked by the permitted owner must be selected: {selected_values:?}"
+    );
+    assert!(
+        !selected_values.contains(&locked_b_value),
+        "a note locked by a different owner must never be selected: {selected_values:?}"
+    );
+
+    // The owner-B lock is untouched by this proposal.
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .contains(&locked_b_ref)
+    );
+}
+
 /// An operation in the note-locking model test; see [`check_note_locking_model`].
 #[derive(Clone, Debug)]
 pub enum LockOp {

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8098,6 +8098,7 @@ pub fn propose_v5_payment_to_orchard_receiver_is_rejected<Dsf>(
         request,
         ConfirmationsPolicy::MIN,
         &SpendPolicy::default(),
+        None,
         Some(TxVersion::V5),
     );
 
@@ -8560,6 +8561,7 @@ where
         request,
         ConfirmationsPolicy::MIN,
         &SpendPolicy::default(),
+        None,
         Some(TxVersion::V5),
     )
     .expect("proposal construction succeeds");

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3466,6 +3466,79 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 }
 
+/// Exercises the exact height boundary of the note-locking semantics.
+///
+/// A lock with `lock_expiry_height == target_height` must keep the output locked (excluded from
+/// selection, counted as locked balance), whereas a lock with `lock_expiry_height ==
+/// target_height - 1` must leave the output spendable. Balance computation uses
+/// `target_height = chain_tip + 1`, so we derive the boundary from the current chain tip.
+pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    // Balance computation targets `chain_tip + 1`.
+    let chain_tip = st.latest_cached_block().unwrap().height();
+    let target_height = chain_tip + 1;
+
+    // Find the received note and construct an OutputRef for it
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let note = &notes[0];
+    let output_ref = OutputRef::new(
+        *note.txid(),
+        PoolType::Shielded(note.note().pool()),
+        u32::from(note.output_index()),
+    );
+
+    // Lock with expiry exactly at the target height: the output must be treated as locked.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), target_height)
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // Re-lock with expiry one block below the target height. Because the existing lock is not
+    // yet expired as of the chain tip, we must first unlock it explicitly.
+    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), target_height - 1)
+            .unwrap(),
+        1
+    );
+
+    // With expiry strictly below the target height, the output is spendable again.
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+}
 pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     ds_factory: impl DataStoreFactory,
     cache: impl TestCache,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8,6 +8,7 @@ use std::{
 
 use assert_matches::assert_matches;
 use incrementalmerkletree::{Level, Position, frontier::Frontier};
+use proptest::prelude::{Just, Strategy, prop_oneof};
 use rand::{Rng, RngCore};
 use secrecy::Secret;
 use shardtree::error::ShardTreeError;
@@ -4036,6 +4037,200 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     // Releasing an already-released proposal is a no-op.
     crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+}
+
+/// An operation in the note-locking model test; see [`check_note_locking_model`].
+#[derive(Clone, Debug)]
+pub enum LockOp {
+    /// Attempt to lock the notes at the given indices (duplicates permitted, and meaningful:
+    /// a duplicated index conflicts with the lock taken by its own first occurrence unless
+    /// that lock is already expired) with expiry height `chain_tip + expiry_delta`.
+    ///
+    /// An `expiry_delta` of zero produces a lock that is expired from the moment it is taken:
+    /// balance and selection evaluate locks against `target_height = chain_tip + 1`.
+    Lock {
+        notes: Vec<usize>,
+        expiry_delta: u32,
+    },
+    /// Unlock the note at the given index, whether or not it is locked.
+    Unlock { note: usize },
+    /// Clear every lock for the account, regardless of expiry.
+    ClearLocked,
+    /// Mine the given number of empty blocks, advancing the chain tip (and thereby expiring
+    /// any lock whose expiry height the tip reaches).
+    MineBlocks { count: usize },
+}
+
+/// A `proptest` strategy over sequences of [`LockOp`] for a wallet holding `n_notes` notes.
+///
+/// Expiry deltas and mining counts are drawn from small ranges so that sequences routinely
+/// cross lock-expiry boundaries.
+pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec<LockOp>> {
+    let op = prop_oneof![
+        3 => (
+            proptest::collection::vec(0..n_notes, 1..=n_notes + 1),
+            0u32..=4,
+        )
+            .prop_map(|(notes, expiry_delta)| LockOp::Lock { notes, expiry_delta }),
+        2 => (0..n_notes).prop_map(|note| LockOp::Unlock { note }),
+        1 => Just(LockOp::ClearLocked),
+        2 => (1usize..=3).prop_map(|count| LockOp::MineBlocks { count }),
+    ];
+    proptest::collection::vec(op, 1..=max_ops)
+}
+
+/// Model-based test of the note-locking storage operations.
+///
+/// Funds a wallet with three notes, then applies the given operation sequence both to the real
+/// data store and to a trivial in-memory model (per-note `Option<lock_expiry_height>` plus the
+/// chain tip). After every operation, the store must agree with the model on:
+///
+/// - the outcome of the operation itself, including the all-or-nothing failure of a `Lock`
+///   batch containing a conflict (an active, unexpired lock on any requested note);
+/// - the set reported by `get_locked_outputs` (a note is locked while
+///   `lock_expiry_height >= chain_tip + 1`);
+/// - the account balance decomposition: locked value is exactly the sum of model-locked note
+///   values, spendable value is the remainder, and the total is unaffected by lock state.
+pub fn check_note_locking_model<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+    ops: &[LockOp],
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Fund the wallet with three notes of distinct values in a single block, so that notes can
+    // be matched to model indices by value.
+    let values = [
+        Zatoshis::const_from_u64(60000),
+        Zatoshis::const_from_u64(70000),
+        Zatoshis::const_from_u64(80000),
+    ];
+    st.add_notes_checking_balance([values]);
+    let total = values
+        .iter()
+        .try_fold(Zatoshis::ZERO, |acc, v| acc + *v)
+        .unwrap();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), values.len());
+    let refs: Vec<OutputRef> = values
+        .iter()
+        .map(|value| {
+            let note = notes
+                .iter()
+                .find(|n| n.note().value() == *value)
+                .expect("a note with the requested value exists");
+            OutputRef::new(
+                *note.txid(),
+                PoolType::Shielded(note.note().pool()),
+                u32::from(note.output_index()),
+            )
+        })
+        .collect();
+
+    // The model: per-note lock expiry height, and the chain tip.
+    let mut model: Vec<Option<u32>> = vec![None; refs.len()];
+    let mut tip = u32::from(st.latest_cached_block().unwrap().height());
+
+    for op in ops {
+        match op {
+            LockOp::Lock {
+                notes,
+                expiry_delta,
+            } => {
+                let expiry = tip + expiry_delta;
+                // Predict the outcome by simulating the store's sequential update: each
+                // requested note may be locked when it holds no lock or its lock has expired
+                // as of the chain tip; the first conflict fails the whole batch.
+                let mut scratch = model.clone();
+                let mut conflict = None;
+                for &i in notes {
+                    if scratch[i].is_none_or(|h| h <= tip) {
+                        scratch[i] = Some(expiry);
+                    } else {
+                        conflict = Some(i);
+                        break;
+                    }
+                }
+
+                let result = st
+                    .wallet_mut()
+                    .lock_outputs(notes.iter().map(|&i| refs[i]), BlockHeight::from(expiry));
+                match conflict {
+                    None => {
+                        assert_matches!(result, Ok(n) if n == notes.len());
+                        model = scratch;
+                    }
+                    Some(i) => {
+                        // The batch fails naming the conflicting note, and (checked by the
+                        // post-operation invariants below) locks nothing.
+                        assert_matches!(result, Err(LockError::LockFailure(r)) if r == refs[i]);
+                    }
+                }
+            }
+            LockOp::Unlock { note } => {
+                // The note exists, so unlock reports `true` regardless of prior lock state.
+                assert!(st.wallet_mut().unlock_output(&refs[*note]).unwrap());
+                model[*note] = None;
+            }
+            LockOp::ClearLocked => {
+                // Clearing removes every lock record, expired or not, and reports how many
+                // rows it touched.
+                let expected = model.iter().filter(|h| h.is_some()).count();
+                assert_eq!(
+                    st.wallet_mut().clear_locked_outputs(account_id).unwrap(),
+                    expected
+                );
+                model.iter_mut().for_each(|h| *h = None);
+            }
+            LockOp::MineBlocks { count } => {
+                st.add_empty_blocks(*count);
+                tip += *count as u32;
+            }
+        }
+
+        // Invariants, checked after every operation. Balance and selection evaluate lock
+        // state against the next block to be mined.
+        let target = tip + 1;
+        let locked_value = model
+            .iter()
+            .zip(values.iter())
+            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .try_fold(Zatoshis::ZERO, |acc, (_, v)| acc + *v)
+            .unwrap();
+
+        let mut expected_locked: Vec<OutputRef> = model
+            .iter()
+            .zip(refs.iter())
+            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .map(|(_, r)| *r)
+            .collect();
+        expected_locked.sort();
+        let mut actual_locked = st.wallet().get_locked_outputs(account_id).unwrap();
+        actual_locked.sort();
+        assert_eq!(
+            actual_locked, expected_locked,
+            "locked-output set diverged from the model after {op:?}"
+        );
+
+        assert_eq!(
+            st.get_locked_balance(account_id),
+            locked_value,
+            "locked balance diverged from the model after {op:?}"
+        );
+        assert_eq!(
+            st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+            (total - locked_value).unwrap(),
+            "spendable balance diverged from the model after {op:?}"
+        );
+        assert_eq!(
+            st.get_total_balance(account_id),
+            total,
+            "lock state must never change the total balance (after {op:?})"
+        );
+    }
 }
 
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -45,7 +45,8 @@ use crate::{
         },
         wallet::{
             ConfirmationsPolicy, LockRequest, TargetHeight, TransferErrT,
-            decrypt_and_store_transaction, input_selection::GreedyInputSelector,
+            decrypt_and_store_transaction,
+            input_selection::{GreedyInputSelector, LockFilter},
         },
     },
     decrypt_transaction,
@@ -7669,7 +7670,13 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
     let test_meta = |st: &TestState<TC, Dsf::DataStore, LocalNetwork>, query, expected_count| {
         let metadata = st
             .wallet()
-            .get_account_metadata(account.id(), &query, target_height, &[], true)
+            .get_account_metadata(
+                account.id(),
+                &query,
+                target_height,
+                &[],
+                LockFilter::Unfiltered,
+            )
             .unwrap();
 
         assert_eq!(metadata.note_count(T::SHIELDED_PROTOCOL), expected_count);
@@ -8174,6 +8181,8 @@ pub fn immature_coinbase_outputs_are_excluded_from_note_selection<T: ShieldedPoo
     dsf: impl DataStoreFactory,
     cache: impl TestCache,
 ) {
+    use crate::data_api::wallet::input_selection::LockedInputPolicy;
+
     let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
 
     // Get the default transparent address
@@ -8210,7 +8219,7 @@ pub fn immature_coinbase_outputs_are_excluded_from_note_selection<T: ShieldedPoo
                 TargetHeight::from(h + i),
                 ConfirmationsPolicy::default(),
                 CoinbaseFilter::AllTransparentOutputs,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap();
         let confirmations = latest_block_height - h;
@@ -8234,7 +8243,7 @@ pub fn immature_coinbase_outputs_are_excluded_from_note_selection<T: ShieldedPoo
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert!(
@@ -8270,6 +8279,7 @@ where
     Dsf: DataStoreFactory,
     <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
 {
+    use crate::data_api::wallet::input_selection::LockedInputPolicy;
     use std::collections::BTreeSet;
 
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
@@ -8324,7 +8334,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(
@@ -8350,7 +8360,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::CoinbaseOnly,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(
@@ -8371,7 +8381,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::NonCoinbaseOnly,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3539,6 +3539,66 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
             .is_empty()
     );
 }
+
+/// Verifies that [`WalletWrite::clear_locked_outputs`] unlocks every locked output for an account
+/// regardless of expiry height, as required by the lost-proposal recovery path.
+///
+/// [`WalletWrite::clear_locked_outputs`]: crate::data_api::WalletWrite::clear_locked_outputs
+pub fn clear_locked_outputs<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    // Find the received note and construct an OutputRef for it
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let note = &notes[0];
+    let output_ref = OutputRef::new(
+        *note.txid(),
+        PoolType::Shielded(note.note().pool()),
+        u32::from(note.output_index()),
+    );
+
+    // Lock the note with a far-future expiry.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // Clearing all locks for the account unlocks the output even though its expiry height is far
+    // in the future.
+    assert_eq!(st.wallet_mut().clear_locked_outputs(account_id).unwrap(), 1);
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // Clearing again is a no-op and reports zero unlocked outputs.
+    assert_eq!(st.wallet_mut().clear_locked_outputs(account_id).unwrap(), 0);
+}
+
 pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     ds_factory: impl DataStoreFactory,
     cache: impl TestCache,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6683,7 +6683,7 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
     let test_meta = |st: &TestState<TC, Dsf::DataStore, LocalNetwork>, query, expected_count| {
         let metadata = st
             .wallet()
-            .get_account_metadata(account.id(), &query, target_height, &[])
+            .get_account_metadata(account.id(), &query, target_height, &[], false)
             .unwrap();
 
         assert_eq!(metadata.note_count(T::SHIELDED_PROTOCOL), expected_count);
@@ -7224,6 +7224,7 @@ pub fn immature_coinbase_outputs_are_excluded_from_note_selection<T: ShieldedPoo
                 TargetHeight::from(h + i),
                 ConfirmationsPolicy::default(),
                 CoinbaseFilter::AllTransparentOutputs,
+                false,
             )
             .unwrap();
         let confirmations = latest_block_height - h;
@@ -7247,6 +7248,7 @@ pub fn immature_coinbase_outputs_are_excluded_from_note_selection<T: ShieldedPoo
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert!(
@@ -7336,6 +7338,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -7361,6 +7364,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::CoinbaseOnly,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -7381,6 +7385,7 @@ where
             target_height,
             ConfirmationsPolicy::default(),
             CoinbaseFilter::NonCoinbaseOnly,
+            false,
         )
         .unwrap();
     assert_eq!(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3617,6 +3617,16 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
 
+    // Remember the funding note's reference; it is spent at the end of this test, where the
+    // lock-a-spent-note behavior is pinned.
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let funding_note_ref = OutputRef::new(
+        *notes[0].txid(),
+        PoolType::Shielded(notes[0].note().pool()),
+        u32::from(notes[0].output_index()),
+    );
+
     // Create a proposal with lock_for_blocks: Some(100) using propose_transfer
     let input_selector = GreedyInputSelector::new();
     let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
@@ -3673,6 +3683,40 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         locked.is_empty(),
         "all notes should be unlocked after create_proposed_transactions"
     );
+
+    // Pin two lock-target edge behaviors:
+    //
+    // Locking an output the wallet does not know fails with `LockFailure` (the "not found"
+    // and "already locked" cases are deliberately indistinguishable to the caller).
+    let unknown = OutputRef::new(
+        TxId::from_bytes([0xEE; 32]),
+        PoolType::Shielded(T::SHIELDED_PROTOCOL),
+        0,
+    );
+    assert_matches!(
+        st.wallet_mut()
+            .lock_outputs([unknown].into_iter(), BlockHeight::from(u32::MAX)),
+        Err(LockError::LockFailure(r)) if r == unknown
+    );
+
+    // Locking an already-spent note currently SUCCEEDS: `lock_outputs` checks only for an
+    // existing active lock, not for spend status. This is harmless in the proposal flow
+    // (spent notes never enter selection, and the lock has no balance effect because balance
+    // computation only considers unspent notes), but it is pinned here so that any future
+    // tightening of the contract is a visible, deliberate change.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([funding_note_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .unwrap(),
+        1
+    );
+    // The stale lock is visible in the raw lock listing but has no balance effect.
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![funding_note_ref]
+    );
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert!(st.wallet_mut().unlock_output(&funding_note_ref).unwrap());
 }
 
 /// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -53,7 +53,7 @@ use crate::{
         standard::{self, SingleOutputChangeStrategy},
     },
     scanning::ScanError,
-    wallet::{Note, NoteId, OvkPolicy, ReceivedNote},
+    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote},
 };
 
 use super::{DataStoreFactory, Reset, TestCache, TestFvk, TestState};
@@ -76,7 +76,6 @@ use {
     zcash_protocol::{TxId, value::ZatBalance},
 };
 
-#[cfg(feature = "orchard")]
 use zcash_protocol::PoolType;
 
 #[cfg(feature = "pczt")]
@@ -3364,6 +3363,181 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     assert_eq!(
         st.get_total_balance(account_id),
         (value - (amount_sent2 + Zatoshis::from_u64(10000).unwrap()).unwrap()).unwrap()
+    );
+}
+
+pub fn explicit_note_locking<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    // Find the received note and construct an OutputRef for it
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let note = &notes[0];
+    let output_ref = OutputRef::new(
+        *note.txid(),
+        PoolType::Shielded(note.note().pool()),
+        u32::from(note.output_index()),
+    );
+
+    // Balance is available before locking
+    assert_eq!(st.get_total_balance(account_id), value);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+
+    // Lock the note with a far-future expiry so it's active during the test
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .unwrap(),
+        1
+    );
+
+    // Total balance is unchanged, but spendable is zero and locked equals the full value
+    assert_eq!(st.get_total_balance(account_id), value);
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO
+    );
+
+    // Proposal should fail because there are no spendable notes
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+    assert_matches!(
+        st.propose_standard_transfer::<Infallible>(
+            account_id,
+            fee_rule,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(15000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        ),
+        Err(data_api::error::Error::InsufficientFunds { .. })
+    );
+
+    // Unlock the note
+    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+
+    // Balance should be restored: spendable equals the full value, locked is zero
+    assert_eq!(st.get_total_balance(account_id), value);
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+
+    // Proposal should now succeed
+    let proposal = st
+        .propose_standard_transfer::<Infallible>(
+            account_id,
+            fee_rule,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(15000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        )
+        .unwrap();
+
+    assert_matches!(
+        st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        ),
+        Ok(txids) if txids.len() == 1
+    );
+}
+
+pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+
+    // Create a proposal with lock_for_blocks: Some(100) using propose_transfer
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(15000),
+    )])
+    .unwrap();
+
+    let network = *st.network();
+    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
+        Some(100), // lock_for_blocks
+        None,
+    )
+    .unwrap();
+
+    // Notes should now be locked; a second proposal should fail
+    assert_matches!(
+        st.propose_standard_transfer::<Infallible>(
+            account_id,
+            fee_rule,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(2000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        ),
+        Err(data_api::error::Error::InsufficientFunds { .. })
+    );
+
+    // Execute the proposal; this should unlock the notes (they become spent)
+    assert_matches!(
+        st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        ),
+        Ok(txids) if txids.len() == 1
+    );
+
+    // All notes should now be unlocked (spent via spends table, lock cleared)
+    let locked = st.wallet().get_locked_outputs(account_id).unwrap();
+    assert!(
+        locked.is_empty(),
+        "all notes should be unlocked after create_proposed_transactions"
     );
 }
 
@@ -6683,7 +6857,7 @@ pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
     let test_meta = |st: &TestState<TC, Dsf::DataStore, LocalNetwork>, query, expected_count| {
         let metadata = st
             .wallet()
-            .get_account_metadata(account.id(), &query, target_height, &[], false)
+            .get_account_metadata(account.id(), &query, target_height, &[], true)
             .unwrap();
 
         assert_eq!(metadata.note_count(T::SHIELDED_PROTOCOL), expected_count);

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -37,7 +37,7 @@ use crate::{
         MaxSpendMode, NoteFilter, Ratio, TargetValue, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletTest, WalletWrite,
         chain::{self, ChainState, CommitmentTreeRoot, ScanSummary},
-        error::Error,
+        error::{Error, LockError},
         testing::{
             AddressType, CacheInsertionResult, FakeCompactOutput, InitialChainState, TestBuilder,
             single_output_change_strategy,
@@ -73,10 +73,10 @@ use {
         keys::{NonHardenedChildIndex, TransparentKeyScope},
     },
     zcash_primitives::transaction::fees::zip317,
-    zcash_protocol::{TxId, value::ZatBalance},
+    zcash_protocol::value::ZatBalance,
 };
 
-use zcash_protocol::PoolType;
+use zcash_protocol::{PoolType, TxId};
 
 #[cfg(feature = "pczt")]
 use {
@@ -3738,6 +3738,304 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
         .try_into_standard_proposal(&network, st.wallet())
         .expect("a proposal with locked inputs must decode from its serialized form");
     assert_eq!(decoded, proposal);
+}
+
+/// Exercises the passed-expiry semantics of note locking under chain advance.
+///
+/// A lock names an expiry height `h`; balance and selection evaluate it against
+/// `target_height = chain_tip + 1`, so the note stays locked while `chain_tip < h` and becomes
+/// spendable again, with no unlock call, as soon as the chain tip reaches `h`. The stale
+/// `lock_expiry_height` value remains in the row, and a subsequent `lock_outputs` replaces it
+/// (the expired-lock branch of the lock-acquisition guard).
+pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account_id = st.test_account().unwrap().id();
+    let tip = st.latest_cached_block().unwrap().height();
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let note = &notes[0];
+    let output_ref = OutputRef::new(
+        *note.txid(),
+        PoolType::Shielded(note.note().pool()),
+        u32::from(note.output_index()),
+    );
+
+    // Lock the note until three blocks past the current tip.
+    let expiry = tip + 3;
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), expiry)
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+
+    // Advance the chain to two blocks below the expiry... still locked: the balance target
+    // height is now `expiry` itself, and a lock covers its expiry height inclusively.
+    st.add_empty_blocks(2);
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // One more block reaches the expiry height: the lock has now been passed, and the note is
+    // spendable again without any unlock call. The stale lock_expiry_height column value is
+    // simply ignored by selection and balance.
+    st.add_empty_blocks(1);
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // A spend proposal succeeds now that the lock has expired.
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+    st.propose_standard_transfer::<Infallible>(
+        account_id,
+        StandardFeeRule::Zip317,
+        ConfirmationsPolicy::MIN,
+        &to,
+        Zatoshis::const_from_u64(15000),
+        None,
+        None,
+        T::SHIELDED_PROTOCOL,
+    )
+    .expect("an expired lock must not block proposal creation");
+
+    // The expired lock is replaceable: a fresh lock_outputs call succeeds without an explicit
+    // unlock, overwriting the stale expiry value.
+    let new_tip = st.latest_cached_block().unwrap().height();
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), new_tip + 5)
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+}
+
+/// Exercises lock-conflict detection and the all-or-nothing batch contract of
+/// [`WalletWrite::lock_outputs`], along with the `unlock_output` return-value semantics.
+///
+/// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
+pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Fund the wallet with two notes of distinct values in a single block, so that each note
+    // can be identified by its value below.
+    let value1 = Zatoshis::const_from_u64(60000);
+    let value2 = Zatoshis::const_from_u64(40000);
+    st.add_notes_checking_balance([[value1, value2]]);
+
+    let account_id = st.test_account().unwrap().id();
+    let far_expiry = BlockHeight::from(u32::MAX);
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 2);
+    let output_ref = |value: Zatoshis| {
+        let note = notes
+            .iter()
+            .find(|n| n.note().value() == value)
+            .expect("a note with the requested value exists");
+        OutputRef::new(
+            *note.txid(),
+            PoolType::Shielded(note.note().pool()),
+            u32::from(note.output_index()),
+        )
+    };
+    let r1 = output_ref(value1);
+    let r2 = output_ref(value2);
+
+    // The first lock on a note succeeds.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([r1].into_iter(), far_expiry)
+            .unwrap(),
+        1
+    );
+
+    // A second lock on the same note fails while the first lock is active, even from the same
+    // caller: an active lock cannot be re-acquired, extended, or shortened without an explicit
+    // unlock first.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r1].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r1
+    );
+
+    // A batch containing a conflicting output fails all-or-nothing: r2 precedes the conflicting
+    // r1 in the batch, but the failure must leave r2 unlocked.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r2, r1].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r1
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1],
+        "a failed batch lock must not leave any of its outputs locked"
+    );
+    assert_eq!(st.get_locked_balance(account_id), value1);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value2
+    );
+
+    // A batch containing the same output twice fails on the duplicate: the first occurrence
+    // takes a live lock, which the second occurrence then conflicts with. Atomicity applies
+    // here too: the failed batch leaves r2 unlocked.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r2, r2].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r2
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1]
+    );
+
+    // Unlocking an existing output that holds no lock reports `true` (the output was found;
+    // its lock state is NULL afterwards either way); unlocking an unknown output reports
+    // `false`.
+    assert!(st.wallet_mut().unlock_output(&r2).unwrap());
+    let unknown = OutputRef::new(
+        TxId::from_bytes([0xEE; 32]),
+        PoolType::Shielded(T::SHIELDED_PROTOCOL),
+        0,
+    );
+    assert!(!st.wallet_mut().unlock_output(&unknown).unwrap());
+
+    // After unlocking r1, both notes are spendable again and a fresh lock succeeds.
+    assert!(st.wallet_mut().unlock_output(&r1).unwrap());
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([r1, r2].into_iter(), far_expiry)
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        st.get_locked_balance(account_id),
+        (value1 + value2).unwrap()
+    );
+}
+
+/// Verifies that [`unlock_proposal_inputs`] releases the locks taken by a proposal created with
+/// `lock_for_blocks: Some(_)`, restoring spendability for a subsequent proposal (the
+/// abandoned-proposal recovery path).
+///
+/// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
+pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account_id = st.test_account().unwrap().id();
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(15000),
+    )])
+    .unwrap();
+
+    let network = *st.network();
+    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
+        Some(100), // lock_for_blocks
+        None,
+    )
+    .unwrap();
+
+    // The proposal's input is locked; a competing proposal cannot be created.
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_matches!(
+        st.propose_standard_transfer::<Infallible>(
+            account_id,
+            fee_rule,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(2000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        ),
+        Err(data_api::error::Error::InsufficientFunds { .. })
+    );
+
+    // Abandon the proposal: releasing its inputs restores spendable balance...
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // ... and a subsequent proposal can select the released inputs.
+    st.propose_standard_transfer::<Infallible>(
+        account_id,
+        fee_rule,
+        ConfirmationsPolicy::MIN,
+        &to,
+        Zatoshis::const_from_u64(2000),
+        None,
+        None,
+        T::SHIELDED_PROTOCOL,
+    )
+    .expect("released inputs must be selectable by a new proposal");
+
+    // Releasing an already-released proposal is a no-op.
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
 }
 
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -122,6 +122,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
                 target_height,
                 confirmations_policy,
                 exclude,
+                false,
             )
             .map(|n| n.take_sapling())
     }
@@ -133,7 +134,13 @@ impl ShieldedPoolTester for SaplingPoolTester {
         exclude: &[DbT::NoteRef],
     ) -> Result<Vec<ReceivedNote<DbT::NoteRef, Self::Note>>, <DbT as InputSource>::Error> {
         st.wallet()
-            .select_unspent_notes(account, &[ShieldedPool::Sapling], target_height, exclude)
+            .select_unspent_notes(
+                account,
+                &[ShieldedPool::Sapling],
+                target_height,
+                exclude,
+                false,
+            )
             .map(|n| n.take_sapling())
     }
 

--- a/zcash_client_backend/src/data_api/testing/sapling.rs
+++ b/zcash_client_backend/src/data_api/testing/sapling.rs
@@ -21,7 +21,10 @@ use crate::{
         DecryptedTransaction, InputSource, TargetValue, WalletCommitmentTrees, WalletSummary,
         WalletTest,
         chain::{CommitmentTreeRoot, ScanSummary},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{
+            ConfirmationsPolicy, TargetHeight,
+            input_selection::{LockFilter, LockedInputPolicy},
+        },
     },
     wallet::{Note, ReceivedNote},
 };
@@ -122,7 +125,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
                 target_height,
                 confirmations_policy,
                 exclude,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map(|n| n.take_sapling())
     }
@@ -139,7 +142,7 @@ impl ShieldedPoolTester for SaplingPoolTester {
                 &[ShieldedPool::Sapling],
                 target_height,
                 exclude,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map(|n| n.take_sapling())
     }

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -167,11 +167,8 @@ where
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            utxo.outpoint(),
-            target_height,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
-        ),
+        st.wallet()
+            .get_unspent_transparent_output(utxo.outpoint(), target_height),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
@@ -208,11 +205,8 @@ where
 
     // We can still look up the specific output, and it has the expected height.
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            utxo2.outpoint(),
-            target_height,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
-        ),
+        st.wallet()
+            .get_unspent_transparent_output(utxo2.outpoint(), target_height),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo2.outpoint(), utxo2.txout(), Some(height_2))
     );
@@ -237,10 +231,11 @@ where
 
 /// Exercises note locking for transparent outputs.
 ///
-/// A locked UTXO is excluded from single-output retrieval and from spendable-output listing
-/// unless the query passes `LockFilter::Unfiltered`, is reported as locked (not spendable) value
-/// in the per-address balances, conflicts with a second lock, and returns to spendability when
-/// the chain tip passes the lock expiry height, with no unlock call.
+/// A locked UTXO is still returned by a by-outpoint lookup (which is not a selection query and
+/// so does not filter by lock state), but is excluded from spendable-output listing unless the
+/// query passes `LockFilter::Unfiltered`, is reported as locked (not spendable) value in the
+/// per-address balances, conflicts with a second lock, and returns to spendability when the
+/// chain tip passes the lock expiry height, with no unlock call.
 pub fn transparent_note_locking<DSF>(dsf: DSF)
 where
     DSF: DataStoreFactory,
@@ -289,11 +284,8 @@ where
 
     // The output is retrievable and spendable before locking.
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            &outpoint,
-            target_height,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
-        ),
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height),
         Ok(Some(_))
     );
 
@@ -313,21 +305,12 @@ where
         Err(LockError::LockFailure(r)) if r == output_ref
     );
 
-    // The locked output is excluded from single-output retrieval unless the query is unfiltered.
+    // A by-outpoint lookup of a known output is not a selection query, so it does not filter by
+    // lock state: the output is still returned even though it is locked. Lock exclusion is
+    // verified via `get_spendable_transparent_outputs`, below.
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            &outpoint,
-            target_height,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
-        ),
-        Ok(None)
-    );
-    assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            &outpoint,
-            target_height,
-            LockFilter::Unfiltered
-        ),
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height),
         Ok(Some(_))
     );
 
@@ -379,14 +362,6 @@ where
     // Advancing the chain tip to the expiry height restores spendability with no unlock call.
     st.wallet_mut().update_chain_tip(height + 10).unwrap();
     let expired_target = TargetHeight::from(height + 11);
-    assert_matches!(
-        st.wallet().get_unspent_transparent_output(
-            &outpoint,
-            expired_target,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
-        ),
-        Ok(Some(_))
-    );
     let balances = st
         .wallet()
         .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -39,7 +39,10 @@ use crate::{
         testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
-            input_selection::{GreedyInputSelector, SpendPolicy, TransparentSpendPolicy},
+            input_selection::{
+                GreedyInputSelector, LockFilter, LockedInputPolicy, SpendPolicy,
+                TransparentSpendPolicy,
+            },
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
@@ -90,7 +93,7 @@ fn check_balance<DSF>(
                 target_height,
                 confirmations_policy,
                 CoinbaseFilter::AllTransparentOutputs,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap()
             .into_iter()
@@ -158,13 +161,17 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         ).as_deref(),
         Ok([ret])
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(utxo.outpoint(), target_height, false),
+        st.wallet().get_unspent_transparent_output(
+            utxo.outpoint(),
+            target_height,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
@@ -193,7 +200,7 @@ where
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
-                false
+                LockFilter::Policy(&LockedInputPolicy::Exclude)
             )
             .as_deref(),
         Ok(&[])
@@ -201,7 +208,11 @@ where
 
     // We can still look up the specific output, and it has the expected height.
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(utxo2.outpoint(), target_height, false),
+        st.wallet().get_unspent_transparent_output(
+            utxo2.outpoint(),
+            target_height,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo2.outpoint(), utxo2.txout(), Some(height_2))
     );
@@ -209,7 +220,7 @@ where
     // If we include `height_2` then the output is returned.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN, CoinbaseFilter::AllTransparentOutputs, false)
+            .get_spendable_transparent_outputs(taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN, CoinbaseFilter::AllTransparentOutputs, LockFilter::Policy(&LockedInputPolicy::Exclude))
             .as_deref(),
         Ok([ret]) if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_2))
     );
@@ -227,9 +238,9 @@ where
 /// Exercises note locking for transparent outputs.
 ///
 /// A locked UTXO is excluded from single-output retrieval and from spendable-output listing
-/// unless `include_locked` is set, is reported as locked (not spendable) value in the
-/// per-address balances, conflicts with a second lock, and returns to spendability when the
-/// chain tip passes the lock expiry height, with no unlock call.
+/// unless the query passes `LockFilter::Unfiltered`, is reported as locked (not spendable) value
+/// in the per-address balances, conflicts with a second lock, and returns to spendability when
+/// the chain tip passes the lock expiry height, with no unlock call.
 pub fn transparent_note_locking<DSF>(dsf: DSF)
 where
     DSF: DataStoreFactory,
@@ -278,8 +289,11 @@ where
 
     // The output is retrievable and spendable before locking.
     assert_matches!(
-        st.wallet()
-            .get_unspent_transparent_output(&outpoint, target_height, false),
+        st.wallet().get_unspent_transparent_output(
+            &outpoint,
+            target_height,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ),
         Ok(Some(_))
     );
 
@@ -299,19 +313,25 @@ where
         Err(LockError::LockFailure(r)) if r == output_ref
     );
 
-    // The locked output is excluded from single-output retrieval unless `include_locked`.
+    // The locked output is excluded from single-output retrieval unless the query is unfiltered.
     assert_matches!(
-        st.wallet()
-            .get_unspent_transparent_output(&outpoint, target_height, false),
+        st.wallet().get_unspent_transparent_output(
+            &outpoint,
+            target_height,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ),
         Ok(None)
     );
     assert_matches!(
-        st.wallet()
-            .get_unspent_transparent_output(&outpoint, target_height, true),
+        st.wallet().get_unspent_transparent_output(
+            &outpoint,
+            target_height,
+            LockFilter::Unfiltered
+        ),
         Ok(Some(_))
     );
 
-    // ... and from the spendable-outputs listing unless `include_locked`.
+    // ... and from the spendable-outputs listing unless the query is unfiltered.
     assert_matches!(
         st.wallet()
             .get_spendable_transparent_outputs(
@@ -319,7 +339,7 @@ where
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .as_deref(),
         Ok(&[])
@@ -331,7 +351,7 @@ where
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
-                true,
+                LockFilter::Unfiltered,
             )
             .as_deref(),
         Ok([_])
@@ -360,8 +380,11 @@ where
     st.wallet_mut().update_chain_tip(height + 10).unwrap();
     let expired_target = TargetHeight::from(height + 11);
     assert_matches!(
-        st.wallet()
-            .get_unspent_transparent_output(&outpoint, expired_target, false),
+        st.wallet().get_unspent_transparent_output(
+            &outpoint,
+            expired_target,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ),
         Ok(Some(_))
     );
     let balances = st
@@ -711,7 +734,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(all.len(), 3);
@@ -730,7 +753,7 @@ where
                     target_height,
                     ConfirmationsPolicy::MIN,
                     CoinbaseFilter::AllTransparentOutputs,
-                    false,
+                    LockFilter::Policy(&LockedInputPolicy::Exclude),
                 )
                 .unwrap(),
         );
@@ -748,7 +771,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(subset.len(), 1);
@@ -762,7 +785,7 @@ where
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap()
             .is_empty()
@@ -1587,7 +1610,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(utxos.len(), 1);
@@ -1934,7 +1957,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .unwrap();
     assert_eq!(utxos.len(), 1);
@@ -2544,7 +2567,7 @@ where
             TargetValue::AtLeast(payment_amount),
             usize::MAX,
             &StandardFeeRule::Zip317,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .expect("initial gather should succeed");
     let initial_gather_value: Zatoshis = initial_gather
@@ -2858,7 +2881,7 @@ where
             TargetValue::AtLeast(target),
             usize::MAX,
             &StandardFeeRule::Zip317,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .expect("value-bounded gather should succeed");
 
@@ -2907,7 +2930,7 @@ where
             TargetValue::AllFunds(MaxSpendMode::MaxSpendable),
             usize::MAX,
             &StandardFeeRule::Zip317,
-            false,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .expect("AllFunds gather should succeed");
     assert_eq!(all.len(), n_dust);

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -43,7 +43,7 @@ use crate::{
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
-    wallet::{OutputRef, WalletTransparentOutput},
+    wallet::{LockOwner, OutputRef, WalletTransparentOutput},
 };
 
 /// Checks whether the transparent balance of the given test `account` is as `expected`
@@ -284,16 +284,18 @@ where
     );
 
     // Lock the UTXO until ten blocks past the tip.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), height + 10)
+            .lock_outputs(&[output_ref], owner, height + 10)
             .unwrap(),
         1
     );
 
-    // A second lock conflicts while the first is active.
+    // A lock by a different owner conflicts while the first is active.
+    let other_owner = LockOwner::new([2; 32]);
     assert_matches!(
-        st.wallet_mut().lock_outputs([output_ref].into_iter(), height + 20),
+        st.wallet_mut().lock_outputs(&[output_ref], other_owner, height + 20),
         Err(LockError::LockFailure(r)) if r == output_ref
     );
 
@@ -378,15 +380,19 @@ where
             .is_empty()
     );
 
-    // The expired lock is replaceable without an explicit unlock, and unlocking then reports
-    // the output as found.
+    // The expired lock is replaceable without an explicit unlock, even by a different owner,
+    // and the new holder can then release it.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), height + 30)
+            .lock_outputs(&[output_ref], other_owner, height + 30)
             .unwrap(),
         1
     );
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    assert!(
+        st.wallet_mut()
+            .unlock_output(&output_ref, other_owner)
+            .unwrap()
+    );
     let balances = st
         .wallet()
         .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -87,7 +87,8 @@ fn check_balance<DSF>(
                 taddr,
                 target_height,
                 confirmations_policy,
-                CoinbaseFilter::AllTransparentOutputs
+                CoinbaseFilter::AllTransparentOutputs,
+                false,
             )
             .unwrap()
             .into_iter()
@@ -155,12 +156,13 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         ).as_deref(),
         Ok([ret])
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(utxo.outpoint(), target_height),
+        st.wallet().get_unspent_transparent_output(utxo.outpoint(), target_height, false),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_1))
     );
@@ -188,7 +190,8 @@ where
                 taddr,
                 target_height,
                 ConfirmationsPolicy::MIN,
-                CoinbaseFilter::AllTransparentOutputs
+                CoinbaseFilter::AllTransparentOutputs,
+                false
             )
             .as_deref(),
         Ok(&[])
@@ -196,7 +199,7 @@ where
 
     // We can still look up the specific output, and it has the expected height.
     assert_matches!(
-        st.wallet().get_unspent_transparent_output(utxo2.outpoint(), target_height),
+        st.wallet().get_unspent_transparent_output(utxo2.outpoint(), target_height, false),
         Ok(Some(ret))
         if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo2.outpoint(), utxo2.txout(), Some(height_2))
     );
@@ -204,7 +207,7 @@ where
     // If we include `height_2` then the output is returned.
     assert_matches!(
         st.wallet()
-            .get_spendable_transparent_outputs(taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN, CoinbaseFilter::AllTransparentOutputs)
+            .get_spendable_transparent_outputs(taddr, TargetHeight::from(height_2 + 1), ConfirmationsPolicy::MIN, CoinbaseFilter::AllTransparentOutputs, false)
             .as_deref(),
         Ok([ret]) if (ret.outpoint(), ret.txout(), ret.mined_height()) == (utxo.outpoint(), utxo.txout(), Some(height_2))
     );
@@ -527,6 +530,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert_eq!(all.len(), 3);
@@ -545,6 +549,7 @@ where
                     target_height,
                     ConfirmationsPolicy::MIN,
                     CoinbaseFilter::AllTransparentOutputs,
+                    false,
                 )
                 .unwrap(),
         );
@@ -562,6 +567,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert_eq!(subset.len(), 1);
@@ -575,6 +581,7 @@ where
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
+                false,
             )
             .unwrap()
             .is_empty()
@@ -1399,6 +1406,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert_eq!(utxos.len(), 1);
@@ -1745,6 +1753,7 @@ where
             target_height,
             ConfirmationsPolicy::MIN,
             CoinbaseFilter::AllTransparentOutputs,
+            false,
         )
         .unwrap();
     assert_eq!(utxos.len(), 1);
@@ -2354,6 +2363,7 @@ where
             TargetValue::AtLeast(payment_amount),
             usize::MAX,
             &StandardFeeRule::Zip317,
+            false,
         )
         .expect("initial gather should succeed");
     let initial_gather_value: Zatoshis = initial_gather
@@ -2667,6 +2677,7 @@ where
             TargetValue::AtLeast(target),
             usize::MAX,
             &StandardFeeRule::Zip317,
+            false,
         )
         .expect("value-bounded gather should succeed");
 
@@ -2715,6 +2726,7 @@ where
             TargetValue::AllFunds(MaxSpendMode::MaxSpendable),
             usize::MAX,
             &StandardFeeRule::Zip317,
+            false,
         )
         .expect("AllFunds gather should succeed");
     assert_eq!(all.len(), n_dust);

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -17,6 +17,7 @@ use zcash_primitives::{
     transaction::{Transaction, TransactionData, TxVersion, fees::zip317},
 };
 use zcash_protocol::{
+    PoolType, TxId,
     consensus::{BlockHeight, BranchId, COINBASE_MATURITY_BLOCKS},
     local_consensus::LocalNetwork,
     value::Zatoshis,
@@ -34,6 +35,7 @@ use crate::{
     data_api::{
         Account as _, AccountBalance, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode,
         TargetValue, WalletRead as _, WalletTest as _, WalletWrite,
+        error::LockError,
         testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
@@ -41,7 +43,7 @@ use crate::{
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
-    wallet::WalletTransparentOutput,
+    wallet::{OutputRef, WalletTransparentOutput},
 };
 
 /// Checks whether the transparent balance of the given test `account` is as `expected`
@@ -220,6 +222,179 @@ where
         ),
         Ok(h) if h.get(taddr).map(|(_, b)| b.spendable_value()) == Some(value)
     );
+}
+
+/// Exercises note locking for transparent outputs.
+///
+/// A locked UTXO is excluded from single-output retrieval and from spendable-output listing
+/// unless `include_locked` is set, is reported as locked (not spendable) value in the
+/// per-address balances, conflicts with a second lock, and returns to spendability when the
+/// chain tip passes the lock expiry height, with no unlock call.
+pub fn transparent_note_locking<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let birthday = st.test_account().unwrap().birthday().height();
+    let account_id = st.test_account().unwrap().id();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    let height = birthday + 12345;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+
+    // Create a fake transparent output mined at `height`.
+    let value = Zatoshis::const_from_u64(100000);
+    let outpoint = OutPoint::fake();
+    let txout = TxOut::new(value, taddr.script().into());
+    let utxo = WalletTransparentOutput::from_parts(
+        outpoint.clone(),
+        txout,
+        Some(height),
+        Some(account_id),
+        Some(TransparentKeyScope::EXTERNAL),
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    let target_height = TargetHeight::from(height + 1);
+    let output_ref = OutputRef::new(
+        TxId::from_bytes(*outpoint.hash()),
+        PoolType::TRANSPARENT,
+        outpoint.n(),
+    );
+
+    // The output is retrievable and spendable before locking.
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, false),
+        Ok(Some(_))
+    );
+
+    // Lock the UTXO until ten blocks past the tip.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), height + 10)
+            .unwrap(),
+        1
+    );
+
+    // A second lock conflicts while the first is active.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([output_ref].into_iter(), height + 20),
+        Err(LockError::LockFailure(r)) if r == output_ref
+    );
+
+    // The locked output is excluded from single-output retrieval unless `include_locked`.
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, false),
+        Ok(None)
+    );
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, true),
+        Ok(Some(_))
+    );
+
+    // ... and from the spendable-outputs listing unless `include_locked`.
+    assert_matches!(
+        st.wallet()
+            .get_spendable_transparent_outputs(
+                taddr,
+                target_height,
+                ConfirmationsPolicy::MIN,
+                CoinbaseFilter::AllTransparentOutputs,
+                false,
+            )
+            .as_deref(),
+        Ok(&[])
+    );
+    assert_matches!(
+        st.wallet()
+            .get_spendable_transparent_outputs(
+                taddr,
+                target_height,
+                ConfirmationsPolicy::MIN,
+                CoinbaseFilter::AllTransparentOutputs,
+                true,
+            )
+            .as_deref(),
+        Ok([_])
+    );
+
+    // The per-address balances report the value as locked, not spendable; the total is
+    // unaffected by lock state.
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, target_height, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.locked_value(), value);
+    assert_eq!(bal.spendable_value(), Zatoshis::ZERO);
+    assert_eq!(bal.total(), value);
+
+    // The locked-outputs listing includes the transparent lock.
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // Advancing the chain tip to the expiry height restores spendability with no unlock call.
+    st.wallet_mut().update_chain_tip(height + 10).unwrap();
+    let expired_target = TargetHeight::from(height + 11);
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, expired_target, false),
+        Ok(Some(_))
+    );
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.spendable_value(), value);
+    assert_eq!(bal.locked_value(), Zatoshis::ZERO);
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // The expired lock is replaceable without an explicit unlock, and unlocking then reports
+    // the output as found.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), height + 30)
+            .unwrap(),
+        1
+    );
+    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.spendable_value(), value);
 }
 
 pub fn transparent_balance_across_shielding<DSF>(dsf: DSF, cache: impl TestCache)

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -716,9 +716,12 @@ where
     }
 }
 
+/// Unlocks all inputs selected by the given proposal, reversing the locks acquired when the
+/// proposal was created with a non-`None` `lock_for_blocks` argument.
 ///
-/// This is useful when a proposal is rejected or abandoned after its inputs
-/// were locked via [`lock_proposal_inputs`].
+/// This is useful when a proposal is rejected or abandoned after its inputs were locked, so that
+/// the outputs become available for selection and balance computation once again. Outputs that are
+/// not currently locked are left unchanged.
 pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -47,7 +47,8 @@ use super::InputSource;
 use crate::{
     data_api::{
         Account, MaxSpendMode, NoteCommitmentTree, SentTransaction, SentTransactionOutput,
-        WalletCommitmentTrees, WalletRead, WalletWrite, error::Error,
+        WalletCommitmentTrees, WalletRead, WalletWrite,
+        error::{Error, LockError},
         wallet::input_selection::propose_send_max,
     },
     decrypt_transaction,
@@ -55,7 +56,7 @@ use crate::{
         ChangeStrategy, DustOutputPolicy, StandardFeeRule, standard::SingleOutputChangeStrategy,
     },
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
-    wallet::{Note, OvkPolicy, Recipient},
+    wallet::{Note, OutputRef, OvkPolicy, Recipient},
 };
 use sapling::{
     note_encryption::{PreparedIncomingViewingKey, try_sapling_note_decryption},
@@ -668,6 +669,69 @@ impl ConfirmationsPolicy {
     }
 }
 
+/// Returns the set of [`OutputRef`]s for all inputs selected by the given proposal.
+fn proposal_input_refs<FeeRuleT, NoteRef>(
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+) -> impl Iterator<Item = OutputRef> {
+    proposal.steps().iter().flat_map(|step| {
+        step.shielded_inputs()
+            .into_iter()
+            .flat_map(|shielded_inputs| {
+                shielded_inputs.notes().iter().map(|note| {
+                    OutputRef::new(
+                        *note.txid(),
+                        PoolType::Shielded(note.note().pool()),
+                        u32::from(note.output_index()),
+                    )
+                })
+            })
+            .chain(step.transparent_inputs().iter().map(|utxo| {
+                let outpoint = utxo.outpoint();
+                OutputRef::new(
+                    TxId::from_bytes(*outpoint.hash()),
+                    PoolType::TRANSPARENT,
+                    outpoint.n(),
+                )
+            }))
+    })
+}
+
+/// Locks all inputs selected by the given proposal, preventing them from being
+/// selected by subsequent proposals. The lock expires at the given height.
+#[allow(clippy::type_complexity)]
+fn lock_proposal_inputs<DbT, FeeRuleT, NoteRef, TE, SE, FE, CE>(
+    wallet_db: &mut DbT,
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+    lock_expiry_height: BlockHeight,
+) -> Result<(), Error<DbT::Error, TE, SE, FE, CE, NoteRef>>
+where
+    DbT: WalletWrite,
+{
+    match wallet_db.lock_outputs(proposal_input_refs(proposal), lock_expiry_height) {
+        Ok(_) => Ok(()),
+        Err(LockError::LockFailure(out_ref)) => {
+            Err(Error::Proposal(ProposalError::ChainDoubleSpend(out_ref)))
+        }
+        Err(LockError::Storage(e)) => Err(Error::DataSource(e)),
+    }
+}
+
+///
+/// This is useful when a proposal is rejected or abandoned after its inputs
+/// were locked via [`lock_proposal_inputs`].
+pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
+    wallet_db: &mut DbT,
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+) -> Result<(), DbT::Error>
+where
+    DbT: WalletWrite,
+{
+    for output_ref in proposal_input_refs(proposal) {
+        wallet_db.unlock_output(&output_ref)?;
+    }
+    Ok(())
+}
+
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that can then be authorized and made ready for submission to the network with
 /// [`create_proposed_transactions`].
@@ -682,13 +746,14 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     request: zip321::TransactionRequest,
     confirmations_policy: ConfirmationsPolicy,
     spend_policy: &input_selection::SpendPolicy,
+    lock_for_blocks: Option<u32>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
     ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
 >
 where
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
     <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
     ParamsT: consensus::Parameters + Clone,
     InputsT: InputSelector<InputSource = DbT>,
@@ -716,6 +781,11 @@ where
         spend_policy,
         proposed_version,
     )?;
+    if let Some(n) = lock_for_blocks {
+        let lock_expiry_height = target_height + n;
+        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    }
+
     // Record the requested version on the proposal so that it is carried through to transaction
     // building; when `None`, building falls back to the version implied by the target height.
     Ok(proposal.with_proposed_version(proposed_version))
@@ -759,6 +829,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
+    lock_for_blocks: Option<u32>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<StandardFeeRule, DbT::NoteRef>,
@@ -772,7 +843,10 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
 where
     ParamsT: consensus::Parameters + Clone,
     DbT: InputSource,
-    DbT: WalletRead<Error = <DbT as InputSource>::Error, AccountId = <DbT as InputSource>::AccountId>,
+    DbT: WalletWrite<
+            Error = <DbT as InputSource>::Error,
+            AccountId = <DbT as InputSource>::AccountId,
+        >,
     DbT::NoteRef: Copy + Eq + Ord,
 {
     let request = zip321::TransactionRequest::new(vec![
@@ -807,6 +881,7 @@ where
         request,
         confirmations_policy,
         &input_selection::SpendPolicy::default(),
+        lock_for_blocks,
         proposed_version,
     )
 }
@@ -826,12 +901,13 @@ pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     mode: MaxSpendMode,
     confirmations_policy: ConfirmationsPolicy,
+    lock_for_blocks: Option<u32>,
 ) -> Result<
     Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
     ProposeSendMaxErrT<DbT, CommitmentTreeErrT, FeeRuleT>,
 >
 where
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
     <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
     ParamsT: consensus::Parameters + Clone,
     FeeRuleT: FeeRule + Clone,
@@ -859,6 +935,11 @@ where
         memo,
     )?;
 
+    if let Some(n) = lock_for_blocks {
+        let lock_expiry_height = target_height + n;
+        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    }
+
     Ok(proposal)
 }
 
@@ -880,13 +961,14 @@ pub fn propose_shielding<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     to_account: <DbT as InputSource>::AccountId,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
+    lock_for_blocks: Option<u32>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, Infallible>,
     ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
 >
 where
     ParamsT: consensus::Parameters,
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
     InputsT: ShieldingSelector<InputSource = DbT>,
     ChangeT: ChangeStrategy<MetaSource = DbT>,
 {
@@ -895,7 +977,7 @@ where
         .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
-    input_selector
+    let proposal = input_selector
         .propose_shielding(
             params,
             wallet_db,
@@ -908,7 +990,14 @@ where
             confirmations_policy,
             output_filter,
         )
-        .map_err(Error::from)
+        .map_err(Error::from)?;
+
+    if let Some(n) = lock_for_blocks {
+        let lock_expiry_height = target_height + n;
+        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    }
+
+    Ok(proposal)
 }
 
 /// Errors that may be generated in construction of proposals for shielding coinbase
@@ -3464,6 +3553,7 @@ where
         to_account,
         confirmations_policy,
         CoinbaseFilter::AllTransparentOutputs,
+        None,
     )?;
 
     create_proposed_transactions(

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -56,7 +56,7 @@ use crate::{
         ChangeStrategy, DustOutputPolicy, StandardFeeRule, standard::SingleOutputChangeStrategy,
     },
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
-    wallet::{Note, OutputRef, OvkPolicy, Recipient},
+    wallet::{LockOwner, Note, OutputRef, OvkPolicy, Recipient},
 };
 use sapling::{
     note_encryption::{PreparedIncomingViewingKey, try_sapling_note_decryption},
@@ -677,28 +677,67 @@ impl ConfirmationsPolicy {
 /// by that creating transaction's id, which is the stable identity the lock tables are keyed on.
 fn proposal_input_refs<FeeRuleT, NoteRef>(
     proposal: &Proposal<FeeRuleT, NoteRef>,
-) -> impl Iterator<Item = OutputRef> {
-    proposal.steps().iter().flat_map(|step| {
-        step.shielded_inputs()
-            .into_iter()
-            .flat_map(|shielded_inputs| {
-                shielded_inputs.notes().iter().map(|note| {
-                    OutputRef::new(
-                        *note.txid(),
-                        PoolType::Shielded(note.note().pool()),
-                        u32::from(note.output_index()),
-                    )
+) -> Vec<OutputRef> {
+    proposal
+        .steps()
+        .iter()
+        .flat_map(|step| {
+            step.shielded_inputs()
+                .into_iter()
+                .flat_map(|shielded_inputs| {
+                    shielded_inputs.notes().iter().map(|note| {
+                        OutputRef::new(
+                            *note.txid(),
+                            PoolType::Shielded(note.note().pool()),
+                            u32::from(note.output_index()),
+                        )
+                    })
                 })
-            })
-            .chain(step.transparent_inputs().iter().map(|utxo| {
-                let outpoint = utxo.outpoint();
-                OutputRef::new(
-                    TxId::from_bytes(*outpoint.hash()),
-                    PoolType::TRANSPARENT,
-                    outpoint.n(),
-                )
-            }))
-    })
+                .chain(step.transparent_inputs().iter().map(|utxo| {
+                    let outpoint = utxo.outpoint();
+                    OutputRef::new(
+                        TxId::from_bytes(*outpoint.hash()),
+                        PoolType::TRANSPARENT,
+                        outpoint.n(),
+                    )
+                }))
+        })
+        .collect()
+}
+
+/// A request to lock the inputs selected by a proposal, made when calling one of the
+/// proposal-creation functions ([`propose_transfer`] and friends).
+///
+/// The caller supplies the [`LockOwner`] under which the locks are taken and must retain it: the
+/// owner token is what authorizes releasing the locks with [`unlock_proposal_inputs`], and what
+/// allows the same flow to re-lock its own inputs when retrying after a crash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LockRequest {
+    owner: LockOwner,
+    for_blocks: u32,
+}
+
+impl LockRequest {
+    /// Constructs a request to lock the proposal's inputs on behalf of `owner` until
+    /// `for_blocks` blocks past the proposal's target height.
+    ///
+    /// Choose `for_blocks` conservatively with respect to the worst-case time between proposal
+    /// creation and transaction storage: once the lock expires, a concurrent proposal may
+    /// select the same inputs.
+    pub fn new(owner: LockOwner, for_blocks: u32) -> Self {
+        Self { owner, for_blocks }
+    }
+
+    /// Returns the owner under which the locks will be taken.
+    pub fn owner(&self) -> LockOwner {
+        self.owner
+    }
+
+    /// Returns the number of blocks past the proposal's target height at which the locks will
+    /// expire.
+    pub fn for_blocks(&self) -> u32 {
+        self.for_blocks
+    }
 }
 
 /// Locks all inputs selected by the given proposal, preventing them from being
@@ -707,12 +746,13 @@ fn proposal_input_refs<FeeRuleT, NoteRef>(
 fn lock_proposal_inputs<DbT, FeeRuleT, NoteRef, TE, SE, FE, CE>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
+    owner: LockOwner,
     lock_expiry_height: BlockHeight,
 ) -> Result<(), Error<DbT::Error, TE, SE, FE, CE, NoteRef>>
 where
     DbT: WalletWrite,
 {
-    match wallet_db.lock_outputs(proposal_input_refs(proposal), lock_expiry_height) {
+    match wallet_db.lock_outputs(&proposal_input_refs(proposal), owner, lock_expiry_height) {
         Ok(_) => Ok(()),
         Err(LockError::LockFailure(out_ref)) => {
             Err(Error::Proposal(ProposalError::InputsLocked(out_ref)))
@@ -722,28 +762,22 @@ where
 }
 
 /// Unlocks all inputs selected by the given proposal, reversing the locks acquired when the
-/// proposal was created with a non-`None` `lock_for_blocks` argument.
+/// proposal was created with a [`LockRequest`] under the same `owner`.
 ///
 /// This is useful when a proposal is rejected or abandoned after its inputs were locked, so that
-/// the outputs become available for selection and balance computation once again. Outputs that are
-/// not currently locked are left unchanged.
-///
-/// # Warning
-///
-/// Locks do not record which proposal acquired them, so this function must only be called for
-/// proposals that were created with `lock_for_blocks: Some(_)`. Calling it for an unlocked
-/// proposal that happens to share inputs with a concurrently-created locked proposal (possible
-/// when the two proposals selected inputs before either lock was taken) would release the other
-/// proposal's locks while it is still in flight.
+/// the outputs become available for selection and balance computation once again. Because
+/// unlocking is scoped to `owner`, inputs that are not locked, or whose locks are held by a
+/// different owner (for example a concurrently-created proposal), are left unchanged.
 pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
+    owner: LockOwner,
 ) -> Result<(), DbT::Error>
 where
     DbT: WalletWrite,
 {
     for output_ref in proposal_input_refs(proposal) {
-        wallet_db.unlock_output(&output_ref)?;
+        wallet_db.unlock_output(&output_ref, owner)?;
     }
     Ok(())
 }
@@ -752,31 +786,33 @@ where
 /// of transactions that can then be authorized and made ready for submission to the network with
 /// [`create_proposed_transactions`].
 ///
-/// When `lock_for_blocks` is `Some(n)`, every input selected by the returned proposal is locked
-/// via [`WalletWrite::lock_outputs`] with an expiry height of `target_height + n`, so that the
-/// inputs are excluded from selection by subsequent proposals until that height is reached (or
-/// until they are explicitly released; see below). When it is `None`, no locking is performed.
+/// When `lock_inputs` is `Some(request)`, every input selected by the returned proposal is
+/// locked via [`WalletWrite::lock_outputs`] on behalf of the request's [`LockOwner`], with an
+/// expiry height of `target_height + request.for_blocks()`, so that the inputs are excluded from
+/// selection by subsequent proposals until that height is reached (or until they are explicitly
+/// released; see below). When it is `None`, no locking is performed.
 ///
-/// This is the height-based generalization of the `lock_notes: bool` parameter originally
-/// proposed in [zcash/librustzcash#2161]: `Some(n)` corresponds to "lock" with an explicit expiry
-/// window, and `None` to "do not lock".
+/// This is the owner- and height-based generalization of the `lock_notes: bool` parameter
+/// originally proposed in [zcash/librustzcash#2161].
 ///
 /// # Concurrency
 ///
 /// Locking is how overlapping proposals for the same account are kept from selecting the same
-/// inputs. If a concurrent caller has already locked one of the inputs this proposal selected
-/// (a check-then-lock race resolved at the storage layer), locking fails and the error surfaces
-/// as [`ProposalError::InputsLocked`] identifying the conflicting output; the losing caller
-/// should treat this as "the account is busy" and retry. A caller that abandons a proposal whose
-/// inputs it locked should release them with [`unlock_proposal_inputs`]; locks are otherwise
-/// cleared automatically when the inputs are recorded as spent by
+/// inputs. If a concurrent caller (a different [`LockOwner`]) has already locked one of the
+/// inputs this proposal selected (a check-then-lock race resolved at the storage layer), locking
+/// fails and the error surfaces as [`ProposalError::InputsLocked`] identifying the conflicting
+/// output; the losing caller should treat this as "the account is busy" and retry. Re-locking
+/// under the SAME owner succeeds (an idempotent acquire/extend), so a flow that crashed after
+/// locking may safely retry with its original owner token. A caller that abandons a proposal
+/// whose inputs it locked should release them with [`unlock_proposal_inputs`] under the same
+/// owner; locks are otherwise cleared automatically when the inputs are recorded as spent by
 /// [`WalletWrite::store_transactions_to_be_sent`], when their expiry height is reached, or via
 /// [`WalletWrite::clear_locked_outputs`].
 ///
 /// Note that expiry re-opens the race the lock exists to prevent: if building and proving the
-/// transaction takes longer than `n` blocks, the lock expires and a concurrent proposal may
-/// select and spend the same inputs. Choose `n` conservatively with respect to the worst-case
-/// time between proposal creation and transaction storage.
+/// transaction takes longer than the requested lock window, the lock expires and a concurrent
+/// proposal may select and spend the same inputs. Choose the window conservatively with respect
+/// to the worst-case time between proposal creation and transaction storage.
 ///
 /// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
 /// [`WalletWrite::store_transactions_to_be_sent`]: crate::data_api::WalletWrite::store_transactions_to_be_sent
@@ -793,7 +829,7 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     request: zip321::TransactionRequest,
     confirmations_policy: ConfirmationsPolicy,
     spend_policy: &input_selection::SpendPolicy,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
@@ -828,9 +864,9 @@ where
         spend_policy,
         proposed_version,
     )?;
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     // Record the requested version on the proposal so that it is carried through to transaction
@@ -863,10 +899,10 @@ where
 /// * `change_memo`: A memo to be included in any change output that is created.
 /// * `fallback_change_pool`: The shielded pool to which change should be sent if
 ///   automatic change pool determination fails.
-/// * `lock_for_blocks`: When `Some(n)`, the inputs selected by the proposal are locked until
-///   `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-///   locking is performed. See [`propose_transfer`] for the full semantics and concurrency
-///   behavior.
+/// * `lock_inputs`: When `Some(request)`, the inputs selected by the proposal are locked on
+///   behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+///   concurrent proposals from selecting them; when `None`, no locking is performed. See
+///   [`propose_transfer`] for the full semantics and concurrency behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
@@ -880,7 +916,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<StandardFeeRule, DbT::NoteRef>,
@@ -932,7 +968,7 @@ where
         request,
         confirmations_policy,
         &input_selection::SpendPolicy::default(),
-        lock_for_blocks,
+        lock_inputs,
         proposed_version,
     )
 }
@@ -941,9 +977,10 @@ where
 /// of transactions that would spend all available funds from the given `spend_pool`s that can then
 /// be authorized and made ready for submission to the network with [`create_proposed_transactions`].
 ///
-/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
-/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
+/// When `lock_inputs` is `Some(request)`, the inputs selected by the proposal are locked on
+/// behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+/// concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
@@ -956,7 +993,7 @@ pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     mode: MaxSpendMode,
     confirmations_policy: ConfirmationsPolicy,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
     ProposeSendMaxErrT<DbT, CommitmentTreeErrT, FeeRuleT>,
@@ -990,9 +1027,9 @@ where
         memo,
     )?;
 
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     Ok(proposal)
@@ -1004,9 +1041,10 @@ where
 /// The `output_filter` parameter controls which transparent outputs are eligible for
 /// inclusion in the proposal. See [`CoinbaseFilter`] for details.
 ///
-/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
-/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
+/// When `lock_inputs` is `Some(request)`, the inputs selected by the proposal are locked on
+/// behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+/// concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
 #[cfg(feature = "transparent-inputs")]
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
@@ -1020,7 +1058,7 @@ pub fn propose_shielding<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     to_account: <DbT as InputSource>::AccountId,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, Infallible>,
     ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
@@ -1051,9 +1089,9 @@ where
         )
         .map_err(Error::from)?;
 
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     Ok(proposal)
@@ -1091,6 +1129,11 @@ pub type ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT
 ///   outpoint). `Some(0)` selects no inputs and therefore returns
 ///   [`InputSelectorError::InsufficientFunds`].
 ///
+/// When `lock_inputs` is `Some(request)`, the coinbase inputs selected by the proposal are
+/// locked on behalf of the request's owner until `target_height + request.for_blocks()` to
+/// prevent concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
+///
 /// The resulting proposal carries an explicit ZIP-321 payment to `to_address` for
 /// `input_total - fee`. **No change is produced**, in either the transparent or any
 /// shielded pool: a shielded change output would let the recipient (or any chain
@@ -1112,13 +1155,14 @@ pub fn propose_shielding_coinbase<DbT, ParamsT, InputsT, FeeRuleT, CommitmentTre
     to_address: ZcashAddress,
     memo: Option<MemoBytes>,
     limit: Option<usize>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<FeeRuleT, Infallible>,
     ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT>,
 >
 where
     ParamsT: consensus::Parameters,
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
     InputsT: ShieldingSelector<InputSource = DbT>,
     FeeRuleT: FeeRule + Clone,
 {
@@ -1127,7 +1171,7 @@ where
         .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
-    input_selector
+    let proposal = input_selector
         .propose_shielding_coinbase(
             params,
             wallet_db,
@@ -1140,7 +1184,14 @@ where
             target_height,
             anchor_height,
         )
-        .map_err(Error::from)
+        .map_err(Error::from)?;
+
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
+    }
+
+    Ok(proposal)
 }
 
 struct StepResult<AccountId> {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -738,6 +738,32 @@ where
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that can then be authorized and made ready for submission to the network with
 /// [`create_proposed_transactions`].
+///
+/// When `lock_for_blocks` is `Some(n)`, every input selected by the returned proposal is locked
+/// via [`WalletWrite::lock_outputs`] with an expiry height of `target_height + n`, so that the
+/// inputs are excluded from selection by subsequent proposals until that height is reached (or
+/// until they are explicitly released; see below). When it is `None`, no locking is performed.
+///
+/// This is the height-based generalization of the `lock_notes: bool` parameter originally
+/// proposed in [zcash/librustzcash#2161]: `Some(n)` corresponds to "lock" with an explicit expiry
+/// window, and `None` to "do not lock".
+///
+/// # Concurrency
+///
+/// Locking is how overlapping proposals for the same account are kept from selecting the same
+/// inputs. If a concurrent caller has already locked one of the inputs this proposal selected
+/// (a check-then-lock race resolved at the storage layer), locking fails and the error surfaces
+/// as [`ProposalError::ChainDoubleSpend`] identifying the conflicting output; the losing caller
+/// should treat this as "the account is busy" and retry. A caller that abandons a proposal whose
+/// inputs it locked should release them with [`unlock_proposal_inputs`]; locks are otherwise
+/// cleared automatically when the inputs are recorded as spent by
+/// [`WalletWrite::store_transactions_to_be_sent`], when their expiry height is reached, or via
+/// [`WalletWrite::clear_locked_outputs`].
+///
+/// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
+/// [`WalletWrite::store_transactions_to_be_sent`]: crate::data_api::WalletWrite::store_transactions_to_be_sent
+/// [`WalletWrite::clear_locked_outputs`]: crate::data_api::WalletWrite::clear_locked_outputs
+/// [zcash/librustzcash#2161]: https://github.com/zcash/librustzcash/issues/2161
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
@@ -819,6 +845,10 @@ where
 /// * `change_memo`: A memo to be included in any change output that is created.
 /// * `fallback_change_pool`: The shielded pool to which change should be sent if
 ///   automatic change pool determination fails.
+/// * `lock_for_blocks`: When `Some(n)`, the inputs selected by the proposal are locked until
+///   `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
+///   locking is performed. See [`propose_transfer`] for the full semantics and concurrency
+///   behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
@@ -892,6 +922,10 @@ where
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that would spend all available funds from the given `spend_pool`s that can then
 /// be authorized and made ready for submission to the network with [`create_proposed_transactions`].
+///
+/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
+/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
+/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
@@ -951,6 +985,10 @@ where
 ///
 /// The `output_filter` parameter controls which transparent outputs are eligible for
 /// inclusion in the proposal. See [`CoinbaseFilter`] for details.
+///
+/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
+/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
+/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
 #[cfg(feature = "transparent-inputs")]
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -981,6 +981,11 @@ where
 /// behalf of the request's owner until `target_height + request.for_blocks()` to prevent
 /// concurrent proposals from selecting them; when `None`, no locking is performed. See
 /// [`propose_transfer`] for the full semantics and concurrency behavior.
+///
+/// `locked_input_policy` controls whether a locked note may be drawn upon to reach the
+/// requested amount, exactly as [`input_selection::SpendPolicy::locked_input_policy`] does for
+/// [`propose_transfer`]; pass `&LockedInputPolicy::Exclude` (its default) to never select a
+/// locked note.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
@@ -993,6 +998,7 @@ pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     mode: MaxSpendMode,
     confirmations_policy: ConfirmationsPolicy,
+    locked_input_policy: &input_selection::LockedInputPolicy,
     lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
@@ -1025,6 +1031,7 @@ where
         confirmations_policy,
         recipient,
         memo,
+        locked_input_policy,
     )?;
 
     if let Some(request) = lock_inputs {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -669,7 +669,12 @@ impl ConfirmationsPolicy {
     }
 }
 
-/// Returns the set of [`OutputRef`]s for all inputs selected by the given proposal.
+/// Returns the [`OutputRef`] identifying each output that the given proposal consumes as an
+/// input.
+///
+/// Each note or UTXO selected for spending is an *input* to the proposal's transaction, but is at
+/// the same time an *output* of the earlier transaction that created it; an [`OutputRef`] names it
+/// by that creating transaction's id, which is the stable identity the lock tables are keyed on.
 fn proposal_input_refs<FeeRuleT, NoteRef>(
     proposal: &Proposal<FeeRuleT, NoteRef>,
 ) -> impl Iterator<Item = OutputRef> {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -715,7 +715,7 @@ where
     match wallet_db.lock_outputs(proposal_input_refs(proposal), lock_expiry_height) {
         Ok(_) => Ok(()),
         Err(LockError::LockFailure(out_ref)) => {
-            Err(Error::Proposal(ProposalError::ChainDoubleSpend(out_ref)))
+            Err(Error::Proposal(ProposalError::InputsLocked(out_ref)))
         }
         Err(LockError::Storage(e)) => Err(Error::DataSource(e)),
     }
@@ -727,6 +727,14 @@ where
 /// This is useful when a proposal is rejected or abandoned after its inputs were locked, so that
 /// the outputs become available for selection and balance computation once again. Outputs that are
 /// not currently locked are left unchanged.
+///
+/// # Warning
+///
+/// Locks do not record which proposal acquired them, so this function must only be called for
+/// proposals that were created with `lock_for_blocks: Some(_)`. Calling it for an unlocked
+/// proposal that happens to share inputs with a concurrently-created locked proposal (possible
+/// when the two proposals selected inputs before either lock was taken) would release the other
+/// proposal's locks while it is still in flight.
 pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
@@ -758,12 +766,17 @@ where
 /// Locking is how overlapping proposals for the same account are kept from selecting the same
 /// inputs. If a concurrent caller has already locked one of the inputs this proposal selected
 /// (a check-then-lock race resolved at the storage layer), locking fails and the error surfaces
-/// as [`ProposalError::ChainDoubleSpend`] identifying the conflicting output; the losing caller
+/// as [`ProposalError::InputsLocked`] identifying the conflicting output; the losing caller
 /// should treat this as "the account is busy" and retry. A caller that abandons a proposal whose
 /// inputs it locked should release them with [`unlock_proposal_inputs`]; locks are otherwise
 /// cleared automatically when the inputs are recorded as spent by
 /// [`WalletWrite::store_transactions_to_be_sent`], when their expiry height is reached, or via
 /// [`WalletWrite::clear_locked_outputs`].
+///
+/// Note that expiry re-opens the race the lock exists to prevent: if building and proving the
+/// transaction takes longer than `n` blocks, the lock expires and a concurrent proposal may
+/// select and spend the same inputs. Choose `n` conservatively with respect to the worst-case
+/// time between proposal creation and transaction storage.
 ///
 /// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
 /// [`WalletWrite::store_transactions_to_be_sent`]: crate::data_api::WalletWrite::store_transactions_to_be_sent

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     fees::{ChangeError, ChangeStrategy, EphemeralBalance, TransactionBalance, sapling},
     proposal::{Proposal, ProposalError, ShieldedInputs},
-    wallet::WalletTransparentOutput,
+    wallet::{LockOwner, WalletTransparentOutput},
 };
 
 use super::ConfirmationsPolicy;
@@ -428,7 +428,6 @@ impl orchard_fees::OutputView for OrchardPayment {
 #[cfg(feature = "transparent-inputs")]
 const DEFAULT_SHIELDING_BLOCK_SPACE_PERCENT: u32 = 10;
 
-#[cfg(feature = "transparent-inputs")]
 /// A `BTreeSet` that is guaranteed to contain at least one element.
 ///
 /// Non-emptiness is maintained by construction: every constructor requires at least one
@@ -436,7 +435,6 @@ const DEFAULT_SHIELDING_BLOCK_SPACE_PERCENT: u32 = 10;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NonEmptyBTreeSet<T>(BTreeSet<T>);
 
-#[cfg(feature = "transparent-inputs")]
 impl<T: Ord> NonEmptyBTreeSet<T> {
     /// Constructs a set containing only the given element.
     pub fn singleton(value: T) -> Self {
@@ -455,7 +453,6 @@ impl<T: Ord> NonEmptyBTreeSet<T> {
     }
 }
 
-#[cfg(feature = "transparent-inputs")]
 impl<T> NonEmptyBTreeSet<T> {
     /// Returns a reference to the wrapped set.
     pub fn as_set(&self) -> &BTreeSet<T> {
@@ -533,6 +530,48 @@ impl SpendPolicy {
     #[cfg(feature = "transparent-inputs")]
     pub fn transparent(&self) -> Option<&TransparentSpendPolicy> {
         self.transparent.as_ref()
+    }
+}
+
+/// Governs whether input selection may draw on locked outputs, and with what preference.
+///
+/// Locks are advisory. The default, [`Self::Exclude`], never selects a locked output. The
+/// overriding variants each carry the set of lock owners whose locks may be drawn upon; a locked
+/// output whose owner is not in that set is never selected, regardless of variant. This keeps an
+/// override scoped to a known reason (e.g. the wallet's own pool-migration PCZTs) and leaves every
+/// other flow's locks intact. Overriding here only *spends through* a lock during selection; it
+/// never releases the lock.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum LockedInputPolicy {
+    /// Never select locked outputs.
+    #[default]
+    Exclude,
+    /// Prefer unlocked outputs; draw on outputs locked by one of these owners only as needed to
+    /// reach the target value.
+    PreferUnlocked(NonEmptyBTreeSet<LockOwner>),
+    /// Prefer outputs locked by one of these owners; draw on unlocked outputs only as needed to
+    /// reach the target value.
+    PreferLocked(NonEmptyBTreeSet<LockOwner>),
+}
+
+impl LockedInputPolicy {
+    /// The set of lock owners whose locked outputs this policy admits (empty for `Exclude`).
+    pub fn overridable_owners(&self) -> &BTreeSet<LockOwner> {
+        static EMPTY: BTreeSet<LockOwner> = BTreeSet::new();
+        match self {
+            LockedInputPolicy::Exclude => &EMPTY,
+            LockedInputPolicy::PreferUnlocked(o) | LockedInputPolicy::PreferLocked(o) => o.as_set(),
+        }
+    }
+
+    /// Whether locked (overridable) outputs are preferred ahead of unlocked ones.
+    pub fn prefers_locked(&self) -> bool {
+        matches!(self, LockedInputPolicy::PreferLocked(_))
+    }
+
+    /// Whether any locked outputs may be selected at all.
+    pub fn admits_locked(&self) -> bool {
+        !matches!(self, LockedInputPolicy::Exclude)
     }
 }
 
@@ -2481,5 +2520,24 @@ mod spend_policy_tests {
         let policy = policy.with_coinbase(CoinbasePolicy::OnlyCoinbase);
         assert_eq!(policy.coinbase(), CoinbasePolicy::OnlyCoinbase);
         assert!(matches!(policy.source(), TransparentSource::AnyAccountAddr));
+    }
+
+    // Each variant's accessors agree with the meaning of the variant: `Exclude` admits no
+    // owners at all, while `PreferUnlocked`/`PreferLocked` admit exactly the given owners and
+    // differ only in whether locked outputs are preferred.
+    #[test]
+    fn locked_input_policy_accessors() {
+        let owner = LockOwner::new([7u8; 32]);
+        let set = BTreeSet::from([owner]);
+        let owners = NonEmptyBTreeSet::from_set(set.clone()).unwrap();
+        assert_eq!(LockedInputPolicy::default(), LockedInputPolicy::Exclude);
+        assert!(LockedInputPolicy::Exclude.overridable_owners().is_empty());
+        assert!(!LockedInputPolicy::Exclude.admits_locked());
+        let pu = LockedInputPolicy::PreferUnlocked(owners.clone());
+        assert!(pu.admits_locked() && !pu.prefers_locked());
+        assert_eq!(pu.overridable_owners(), &set);
+        let pl = LockedInputPolicy::PreferLocked(owners.clone());
+        assert!(pl.admits_locked() && pl.prefers_locked());
+        assert_eq!(pl.overridable_owners(), &set);
     }
 }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -484,6 +484,7 @@ pub struct SpendPolicy {
     shielded: BTreeSet<ShieldedPool>,
     #[cfg(feature = "transparent-inputs")]
     transparent: Option<TransparentSpendPolicy>,
+    locked_input_policy: LockedInputPolicy,
 }
 
 impl Default for SpendPolicy {
@@ -506,6 +507,7 @@ impl SpendPolicy {
             shielded: pools.into_iter().collect(),
             #[cfg(feature = "transparent-inputs")]
             transparent: None,
+            locked_input_policy: LockedInputPolicy::Exclude,
         }
     }
 
@@ -530,6 +532,17 @@ impl SpendPolicy {
     #[cfg(feature = "transparent-inputs")]
     pub fn transparent(&self) -> Option<&TransparentSpendPolicy> {
         self.transparent.as_ref()
+    }
+
+    /// Sets how input selection treats locked outputs (default: `LockedInputPolicy::Exclude`).
+    pub fn with_locked_input_policy(mut self, policy: LockedInputPolicy) -> Self {
+        self.locked_input_policy = policy;
+        self
+    }
+
+    /// Returns the policy governing selection of locked outputs.
+    pub fn locked_input_policy(&self) -> &LockedInputPolicy {
+        &self.locked_input_policy
     }
 }
 
@@ -2539,5 +2552,20 @@ mod spend_policy_tests {
         let pl = LockedInputPolicy::PreferLocked(owners.clone());
         assert!(pl.admits_locked() && pl.prefers_locked());
         assert_eq!(pl.overridable_owners(), &set);
+    }
+
+    // The default `SpendPolicy` excludes locked inputs, and `with_locked_input_policy` overrides
+    // that choice.
+    #[test]
+    fn spend_policy_locked_input_policy_roundtrips() {
+        let default = SpendPolicy::default();
+        assert_eq!(default.locked_input_policy(), &LockedInputPolicy::Exclude);
+        let owners = NonEmptyBTreeSet::singleton(LockOwner::new([9u8; 32]));
+        let policy = SpendPolicy::default()
+            .with_locked_input_policy(LockedInputPolicy::PreferLocked(owners.clone()));
+        assert_eq!(
+            policy.locked_input_policy(),
+            &LockedInputPolicy::PreferLocked(owners)
+        );
     }
 }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -756,6 +756,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
                 &StandardFeeRule::Zip317,
+                false,
             )
             .map_err(InputSelectorError::DataSource)?
             .into_iter()
@@ -1331,6 +1332,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                                 TargetValue::AtLeast(required),
                                 shielding_max_inputs(self.shielding_block_space_percent),
                                 &StandardFeeRule::Zip317,
+                                false,
                             )
                             .map_err(InputSelectorError::DataSource)?
                             .into_iter()
@@ -1362,6 +1364,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     target_height,
                     confirmations_policy,
                     &exclude,
+                    false,
                 )
                 .map_err(InputSelectorError::DataSource)?;
 
@@ -1493,6 +1496,7 @@ where
             target_height,
             confirmations_policy,
             &[],
+            false,
         )
         .map_err(InputSelectorError::DataSource)?;
 
@@ -2178,6 +2182,7 @@ where
             target_height,
             confirmations_policy,
             output_filter,
+            false,
         )
         .map_err(InputSelectorError::DataSource)?;
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -603,17 +603,6 @@ pub enum LockFilter<'a> {
     Unfiltered,
 }
 
-impl LockFilter<'_> {
-    /// Whether any locked output is admitted under this filter (the boolean the current
-    /// selection SQL still keys on; owner-scoping is a later task).
-    pub fn admits_locked(&self) -> bool {
-        match self {
-            LockFilter::Unfiltered => true,
-            LockFilter::Policy(p) => p.admits_locked(),
-        }
-    }
-}
-
 /// The caller's choice of which coinbase transparent outputs a transparent spend may draw upon.
 ///
 /// Consensus requires coinbase funds to be spent to a single shielded output with no change and

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -588,6 +588,32 @@ impl LockedInputPolicy {
     }
 }
 
+/// How a query filters candidate outputs by lock state.
+///
+/// Input selection for a proposal passes [`Self::Policy`], carrying the caller's owner-scoped
+/// [`LockedInputPolicy`]. Retrieval/decoding paths that must expose wallet contents regardless of
+/// locks (proposal decoding, low-level and test accessors) pass [`Self::Unfiltered`]. Keeping the
+/// two separate means a `SpendPolicy` can only ever request an owner-scoped override, never an
+/// unscoped "ignore all locks".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LockFilter<'a> {
+    /// Apply the given owner-scoped selection policy.
+    Policy(&'a LockedInputPolicy),
+    /// Ignore lock state entirely; every matching output is eligible.
+    Unfiltered,
+}
+
+impl LockFilter<'_> {
+    /// Whether any locked output is admitted under this filter (the boolean the current
+    /// selection SQL still keys on; owner-scoping is a later task).
+    pub fn admits_locked(&self) -> bool {
+        match self {
+            LockFilter::Unfiltered => true,
+            LockFilter::Policy(p) => p.admits_locked(),
+        }
+    }
+}
+
 /// The caller's choice of which coinbase transparent outputs a transparent spend may draw upon.
 ///
 /// Consensus requires coinbase funds to be spent to a single shielded output with no change and
@@ -801,7 +827,6 @@ impl<DbT> GreedyInputSelector<DbT> {
         // Input selection must never draw on locked outputs: a locked output belongs to
         // another in-flight proposal, and spending it would recreate the conflict that
         // locking exists to prevent.
-        let include_locked = false;
         Ok(wallet_db
             .select_spendable_transparent_outputs(
                 account,
@@ -812,7 +837,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
                 &StandardFeeRule::Zip317,
-                include_locked,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map_err(InputSelectorError::DataSource)?
             .into_iter()
@@ -1381,7 +1406,6 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         // Input selection must never draw on locked outputs: a locked output belongs to
                         // another in-flight proposal, and spending it would recreate the conflict that
                         // locking exists to prevent.
-                        let include_locked = false;
                         transparent_inputs = wallet_db
                             .select_spendable_transparent_outputs(
                                 account,
@@ -1392,7 +1416,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                                 TargetValue::AtLeast(required),
                                 shielding_max_inputs(self.shielding_block_space_percent),
                                 &StandardFeeRule::Zip317,
-                                include_locked,
+                                LockFilter::Policy(&LockedInputPolicy::Exclude),
                             )
                             .map_err(InputSelectorError::DataSource)?
                             .into_iter()
@@ -1419,7 +1443,6 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // Input selection must never draw on locked outputs: a locked output belongs to
             // another in-flight proposal, and spending it would recreate the conflict that
             // locking exists to prevent.
-            let include_locked = false;
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
@@ -1428,7 +1451,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     target_height,
                     confirmations_policy,
                     &exclude,
-                    include_locked,
+                    LockFilter::Policy(&LockedInputPolicy::Exclude),
                 )
                 .map_err(InputSelectorError::DataSource)?;
 
@@ -1555,7 +1578,6 @@ where
     // Input selection must never draw on locked outputs: a locked output belongs to
     // another in-flight proposal, and spending it would recreate the conflict that
     // locking exists to prevent.
-    let include_locked = false;
     let spendable_notes = wallet_db
         .select_spendable_notes(
             source_account,
@@ -1564,7 +1586,7 @@ where
             target_height,
             confirmations_policy,
             &[],
-            include_locked,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .map_err(InputSelectorError::DataSource)?;
 
@@ -2247,14 +2269,13 @@ where
     // Input selection must never draw on locked outputs: a locked output belongs to
     // another in-flight proposal, and spending it would recreate the conflict that
     // locking exists to prevent.
-    let include_locked = false;
     let mut utxos = wallet_db
         .get_spendable_transparent_outputs_for_addresses(
             source_addrs,
             target_height,
             confirmations_policy,
             output_filter,
-            include_locked,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
         .map_err(InputSelectorError::DataSource)?;
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -746,6 +746,10 @@ impl<DbT> GreedyInputSelector<DbT> {
             ),
         };
         *amount_at_transparent_gather = amount_at_gather;
+        // Input selection must never draw on locked outputs: a locked output belongs to
+        // another in-flight proposal, and spending it would recreate the conflict that
+        // locking exists to prevent.
+        let include_locked = false;
         Ok(wallet_db
             .select_spendable_transparent_outputs(
                 account,
@@ -756,7 +760,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
                 &StandardFeeRule::Zip317,
-                false,
+                include_locked,
             )
             .map_err(InputSelectorError::DataSource)?
             .into_iter()
@@ -1322,6 +1326,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         && required > amount_at_transparent_gather
                     {
                         let address_allow_list = transparent.address_allow_list();
+                        // Input selection must never draw on locked outputs: a locked output belongs to
+                        // another in-flight proposal, and spending it would recreate the conflict that
+                        // locking exists to prevent.
+                        let include_locked = false;
                         transparent_inputs = wallet_db
                             .select_spendable_transparent_outputs(
                                 account,
@@ -1332,7 +1340,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                                 TargetValue::AtLeast(required),
                                 shielding_max_inputs(self.shielding_block_space_percent),
                                 &StandardFeeRule::Zip317,
-                                false,
+                                include_locked,
                             )
                             .map_err(InputSelectorError::DataSource)?
                             .into_iter()
@@ -1356,6 +1364,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // by one policy: pool crossing is minimized, and a payment to an Orchard
             // receiver draws on the pool its output is constructed in (the Ironwood
             // pool once NU6.3 is active).
+            // Input selection must never draw on locked outputs: a locked output belongs to
+            // another in-flight proposal, and spending it would recreate the conflict that
+            // locking exists to prevent.
+            let include_locked = false;
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
@@ -1364,7 +1376,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     target_height,
                     confirmations_policy,
                     &exclude,
-                    false,
+                    include_locked,
                 )
                 .map_err(InputSelectorError::DataSource)?;
 
@@ -1488,6 +1500,10 @@ where
     InputSourceT: InputSource,
     FeeRuleT: FeeRule + Clone,
 {
+    // Input selection must never draw on locked outputs: a locked output belongs to
+    // another in-flight proposal, and spending it would recreate the conflict that
+    // locking exists to prevent.
+    let include_locked = false;
     let spendable_notes = wallet_db
         .select_spendable_notes(
             source_account,
@@ -1496,7 +1512,7 @@ where
             target_height,
             confirmations_policy,
             &[],
-            false,
+            include_locked,
         )
         .map_err(InputSelectorError::DataSource)?;
 
@@ -2176,13 +2192,17 @@ where
     // one query per address (including for the many addresses that have no spendable outputs),
     // which is prohibitively expensive for wallets that hold large numbers of transparent
     // addresses.
+    // Input selection must never draw on locked outputs: a locked output belongs to
+    // another in-flight proposal, and spending it would recreate the conflict that
+    // locking exists to prevent.
+    let include_locked = false;
     let mut utxos = wallet_db
         .get_spendable_transparent_outputs_for_addresses(
             source_addrs,
             target_height,
             confirmations_policy,
             output_filter,
-            false,
+            include_locked,
         )
         .map_err(InputSelectorError::DataSource)?;
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -719,6 +719,15 @@ pub struct GreedyInputSelector<DbT> {
     /// transfers when the active [`TransparentSpendPolicy`] requires it.
     #[cfg(feature = "transparent-inputs")]
     shielding_block_space_percent: u32,
+    /// The policy governing whether the transparent UTXOs gathered by
+    /// [`ShieldingSelector::propose_shielding`] and
+    /// [`ShieldingSelector::propose_shielding_coinbase`] may be drawn from locked outputs.
+    /// Defaults to [`LockedInputPolicy::Exclude`]. Unlike [`SpendPolicy::locked_input_policy`],
+    /// which a caller supplies per call to [`InputSelector::propose_transaction`], shielding has
+    /// no per-call policy argument, so this is configured once on the selector instance via
+    /// [`Self::with_locked_input_policy`].
+    #[cfg(feature = "transparent-inputs")]
+    locked_input_policy: LockedInputPolicy,
     _ds_type: PhantomData<DbT>,
 }
 
@@ -736,6 +745,8 @@ impl<DbT> GreedyInputSelector<DbT> {
         GreedyInputSelector {
             #[cfg(feature = "transparent-inputs")]
             shielding_block_space_percent: DEFAULT_SHIELDING_BLOCK_SPACE_PERCENT,
+            #[cfg(feature = "transparent-inputs")]
+            locked_input_policy: LockedInputPolicy::Exclude,
             _ds_type: PhantomData,
         }
     }
@@ -757,6 +768,18 @@ impl<DbT> GreedyInputSelector<DbT> {
         self
     }
 
+    /// Sets the policy governing whether shielding (via
+    /// [`ShieldingSelector::propose_shielding`] and
+    /// [`ShieldingSelector::propose_shielding_coinbase`]) may draw on transparent UTXOs locked
+    /// by one of the given policy's owners (default: [`LockedInputPolicy::Exclude`], which never
+    /// selects a locked output). This overrides a lock only for the purpose of *selecting through*
+    /// it during shielding; it does not release the lock.
+    #[cfg(feature = "transparent-inputs")]
+    pub fn with_locked_input_policy(mut self, policy: LockedInputPolicy) -> Self {
+        self.locked_input_policy = policy;
+        self
+    }
+
     #[cfg(feature = "transparent-inputs")]
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
@@ -773,6 +796,7 @@ impl<DbT> GreedyInputSelector<DbT> {
         coinbase: CoinbaseFilter,
         transaction_request: &TransactionRequest,
         amount_at_transparent_gather: &mut Zatoshis,
+        locked_input_policy: &LockedInputPolicy,
     ) -> Result<
         Vec<WalletTransparentOutput<()>>,
         InputSelectorError<
@@ -813,9 +837,11 @@ impl<DbT> GreedyInputSelector<DbT> {
             ),
         };
         *amount_at_transparent_gather = amount_at_gather;
-        // Input selection must never draw on locked outputs: a locked output belongs to
-        // another in-flight proposal, and spending it would recreate the conflict that
-        // locking exists to prevent.
+        // Input selection honors the caller's `SpendPolicy::locked_input_policy`: by default
+        // (`Exclude`) a locked output is never drawn upon, since it belongs to another in-flight
+        // proposal and spending it would recreate the conflict that locking exists to prevent; the
+        // `PreferUnlocked`/`PreferLocked` overrides let a caller draw through a lock it recognizes
+        // (e.g. its own pool-migration PCZTs).
         Ok(wallet_db
             .select_spendable_transparent_outputs(
                 account,
@@ -826,7 +852,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
                 &StandardFeeRule::Zip317,
-                LockFilter::Policy(&LockedInputPolicy::Exclude),
+                LockFilter::Policy(locked_input_policy),
             )
             .map_err(InputSelectorError::DataSource)?
             .into_iter()
@@ -1031,6 +1057,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     transparent.coinbase().into(),
                     &transaction_request,
                     &mut amount_at_transparent_gather,
+                    spend_policy.locked_input_policy(),
                 )?
             }
         };
@@ -1392,9 +1419,8 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         && required > amount_at_transparent_gather
                     {
                         let address_allow_list = transparent.address_allow_list();
-                        // Input selection must never draw on locked outputs: a locked output belongs to
-                        // another in-flight proposal, and spending it would recreate the conflict that
-                        // locking exists to prevent.
+                        // Honor the caller's `SpendPolicy::locked_input_policy`, as at the
+                        // initial gather above.
                         transparent_inputs = wallet_db
                             .select_spendable_transparent_outputs(
                                 account,
@@ -1405,7 +1431,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                                 TargetValue::AtLeast(required),
                                 shielding_max_inputs(self.shielding_block_space_percent),
                                 &StandardFeeRule::Zip317,
-                                LockFilter::Policy(&LockedInputPolicy::Exclude),
+                                LockFilter::Policy(spend_policy.locked_input_policy()),
                             )
                             .map_err(InputSelectorError::DataSource)?
                             .into_iter()
@@ -1429,9 +1455,11 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // by one policy: pool crossing is minimized, and a payment to an Orchard
             // receiver draws on the pool its output is constructed in (the Ironwood
             // pool once NU6.3 is active).
-            // Input selection must never draw on locked outputs: a locked output belongs to
-            // another in-flight proposal, and spending it would recreate the conflict that
-            // locking exists to prevent.
+            // Input selection honors the caller's `SpendPolicy::locked_input_policy`: by default
+            // (`Exclude`) a locked output is never drawn upon, since it belongs to another
+            // in-flight proposal and spending it would recreate the conflict that locking exists
+            // to prevent; the `PreferUnlocked`/`PreferLocked` overrides let a caller draw through
+            // a lock it recognizes (e.g. its own pool-migration PCZTs).
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
@@ -1440,7 +1468,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     target_height,
                     confirmations_policy,
                     &exclude,
-                    LockFilter::Policy(&LockedInputPolicy::Exclude),
+                    LockFilter::Policy(spend_policy.locked_input_policy()),
                 )
                 .map_err(InputSelectorError::DataSource)?;
 
@@ -1550,6 +1578,7 @@ pub(crate) fn propose_send_max<ParamsT, InputSourceT, FeeRuleT>(
     confirmations_policy: ConfirmationsPolicy,
     recipient: ZcashAddress,
     memo: Option<MemoBytes>,
+    locked_input_policy: &LockedInputPolicy,
 ) -> Result<
     Proposal<FeeRuleT, InputSourceT::NoteRef>,
     InputSelectorError<
@@ -1564,9 +1593,11 @@ where
     InputSourceT: InputSource,
     FeeRuleT: FeeRule + Clone,
 {
-    // Input selection must never draw on locked outputs: a locked output belongs to
-    // another in-flight proposal, and spending it would recreate the conflict that
-    // locking exists to prevent.
+    // Input selection honors the caller's `locked_input_policy`: by default (`Exclude`) a
+    // locked output is never drawn upon, since it belongs to another in-flight proposal and
+    // spending it would recreate the conflict that locking exists to prevent; the
+    // `PreferUnlocked`/`PreferLocked` overrides let a caller draw through a lock it recognizes
+    // (e.g. its own pool-migration PCZTs).
     let spendable_notes = wallet_db
         .select_spendable_notes(
             source_account,
@@ -1575,7 +1606,7 @@ where
             target_height,
             confirmations_policy,
             &[],
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
+            LockFilter::Policy(locked_input_policy),
         )
         .map_err(InputSelectorError::DataSource)?;
 
@@ -2013,6 +2044,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             confirmations_policy,
             output_filter,
             shielding_max_inputs(self.shielding_block_space_percent),
+            &self.locked_input_policy,
         )?;
 
         let wallet_meta = change_strategy
@@ -2092,6 +2124,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             limit
                 .unwrap_or(usize::MAX)
                 .min(shielding_max_inputs(self.shielding_block_space_percent)),
+            &self.locked_input_policy,
         )?;
 
         let destination_pool = resolve_shielded_destination::<DbT, FeeRuleT::Error, ParamsT>(
@@ -2237,6 +2270,7 @@ fn gather_shielding_inputs<DbT, ChangeErrT>(
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
     max_inputs: usize,
+    locked_input_policy: &LockedInputPolicy,
 ) -> Result<
     Vec<WalletTransparentOutput<()>>,
     InputSelectorError<
@@ -2255,16 +2289,17 @@ where
     // one query per address (including for the many addresses that have no spendable outputs),
     // which is prohibitively expensive for wallets that hold large numbers of transparent
     // addresses.
-    // Input selection must never draw on locked outputs: a locked output belongs to
-    // another in-flight proposal, and spending it would recreate the conflict that
-    // locking exists to prevent.
+    // Input selection honors the selector's configured `locked_input_policy` (see
+    // `GreedyInputSelector::with_locked_input_policy`): by default (`Exclude`) a locked output is
+    // never drawn upon, since it belongs to another in-flight proposal and spending it would
+    // recreate the conflict that locking exists to prevent.
     let mut utxos = wallet_db
         .get_spendable_transparent_outputs_for_addresses(
             source_addrs,
             target_height,
             confirmations_policy,
             output_filter,
-            LockFilter::Policy(&LockedInputPolicy::Exclude),
+            LockFilter::Policy(locked_input_policy),
         )
         .map_err(InputSelectorError::DataSource)?;
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -318,7 +318,17 @@ where
                 .unwrap_or(SplitPolicy::MIN_NOTE_VALUE),
         );
 
-        meta_source.get_account_metadata(account, &note_selector, target_height, exclude, false)
+        // Account metadata feeds change-splitting decisions, which reason about the
+        // notes that selection can actually draw on; locked notes are excluded from
+        // selection, so they are excluded here as well.
+        let include_locked = false;
+        meta_source.get_account_metadata(
+            account,
+            &note_selector,
+            target_height,
+            exclude,
+            include_locked,
+        )
     }
 
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -14,7 +14,13 @@ use zcash_protocol::{
 };
 
 use crate::{
-    data_api::{AccountMeta, InputSource, NoteFilter, wallet::TargetHeight},
+    data_api::{
+        AccountMeta, InputSource, NoteFilter,
+        wallet::{
+            TargetHeight,
+            input_selection::{LockFilter, LockedInputPolicy},
+        },
+    },
     fees::StandardFeeRule,
 };
 
@@ -321,13 +327,12 @@ where
         // Account metadata feeds change-splitting decisions, which reason about the
         // notes that selection can actually draw on; locked notes are excluded from
         // selection, so they are excluded here as well.
-        let include_locked = false;
         meta_source.get_account_metadata(
             account,
             &note_selector,
             target_height,
             exclude,
-            include_locked,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
         )
     }
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -318,7 +318,7 @@ where
                 .unwrap_or(SplitPolicy::MIN_NOTE_VALUE),
         );
 
-        meta_source.get_account_metadata(account, &note_selector, target_height, exclude)
+        meta_source.get_account_metadata(account, &note_selector, target_height, exclude, false)
     }
 
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -17,7 +17,7 @@ use zip321::{TransactionRequest, Zip321Error};
 use crate::{
     data_api::wallet::{ConfirmationsPolicy, TargetHeight},
     fees::TransactionBalance,
-    wallet::{Note, ReceivedNote, WalletTransparentOutput},
+    wallet::{Note, OutputRef, ReceivedNote, WalletTransparentOutput},
 };
 
 /// Errors that can occur in construction of a [`Step`].
@@ -51,7 +51,7 @@ pub enum ProposalError {
     /// An attempted double-spend of a prior step output was detected.
     StepDoubleSpend(StepOutput),
     /// An attempted double-spend of an output belonging to the wallet was detected.
-    ChainDoubleSpend(PoolType, TxId, u32),
+    ChainDoubleSpend(OutputRef),
     /// There was a mismatch between the payments in the proposal's transaction request
     /// and the payment pool selection values.
     PaymentPoolsMismatch,
@@ -141,9 +141,12 @@ impl Display for ProposalError {
                 f,
                 "The proposal uses the output of step {r:?} in more than one place."
             ),
-            ProposalError::ChainDoubleSpend(pool, txid, index) => write!(
+            ProposalError::ChainDoubleSpend(output_ref) => write!(
                 f,
-                "The proposal attempts to spend the same output twice: {pool}, {txid}, {index}"
+                "The proposal attempts to spend the same output twice: {}, {}, {}",
+                output_ref.pool(),
+                output_ref.txid(),
+                output_ref.output_index()
             ),
             ProposalError::PaymentPoolsMismatch => write!(
                 f,
@@ -266,7 +269,7 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
         confirmations_policy: ConfirmationsPolicy,
         steps: NonEmpty<Step<NoteRef>>,
     ) -> Result<Self, ProposalError> {
-        let mut consumed_chain_inputs: BTreeSet<(PoolType, TxId, u32)> = BTreeSet::new();
+        let mut consumed_chain_inputs: BTreeSet<OutputRef> = BTreeSet::new();
         let mut consumed_prior_inputs: BTreeSet<StepOutput> = BTreeSet::new();
 
         for (i, step) in steps.iter().enumerate() {
@@ -296,24 +299,24 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
             }
 
             for t_out in step.transparent_inputs() {
-                let key = (
-                    PoolType::TRANSPARENT,
+                let output_ref = OutputRef::new(
                     TxId::from_bytes(*t_out.outpoint().hash()),
+                    PoolType::TRANSPARENT,
                     t_out.outpoint().n(),
                 );
-                if !consumed_chain_inputs.insert(key) {
-                    return Err(ProposalError::ChainDoubleSpend(key.0, key.1, key.2));
+                if !consumed_chain_inputs.insert(output_ref) {
+                    return Err(ProposalError::ChainDoubleSpend(output_ref));
                 }
             }
 
             for s_out in step.shielded_inputs().iter().flat_map(|i| i.notes().iter()) {
-                let key = (
-                    PoolType::Shielded(s_out.note().pool()),
+                let output_ref = OutputRef::new(
                     *s_out.txid(),
+                    PoolType::Shielded(s_out.note().pool()),
                     s_out.output_index().into(),
                 );
-                if !consumed_chain_inputs.insert(key) {
-                    return Err(ProposalError::ChainDoubleSpend(key.0, key.1, key.2));
+                if !consumed_chain_inputs.insert(output_ref) {
+                    return Err(ProposalError::ChainDoubleSpend(output_ref));
                 }
             }
         }

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -52,6 +52,15 @@ pub enum ProposalError {
     StepDoubleSpend(StepOutput),
     /// An attempted double-spend of an output belonging to the wallet was detected.
     ChainDoubleSpend(OutputRef),
+    /// An input selected by the proposal could not be locked, because a concurrent
+    /// proposal or PCZT already holds a lock on it.
+    ///
+    /// This is a transient condition, not a defect in the proposal itself: the wrapped
+    /// output was spendable when it was selected, but another in-flight proposal locked
+    /// it first. Callers should treat this as "the account is busy" and retry proposal
+    /// creation; the retry will select around the locked output (or fail with an
+    /// insufficient-funds error if no other outputs are available).
+    InputsLocked(OutputRef),
     /// There was a mismatch between the payments in the proposal's transaction request
     /// and the payment pool selection values.
     PaymentPoolsMismatch,
@@ -144,6 +153,13 @@ impl Display for ProposalError {
             ProposalError::ChainDoubleSpend(output_ref) => write!(
                 f,
                 "The proposal attempts to spend the same output twice: {}, {}, {}",
+                output_ref.pool(),
+                output_ref.txid(),
+                output_ref.output_index()
+            ),
+            ProposalError::InputsLocked(output_ref) => write!(
+                f,
+                "A selected input is locked by a concurrent proposal (retry later): {}, {}, {}",
                 output_ref.pool(),
                 output_ref.txid(),
                 output_ref.output_index()

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -875,6 +875,7 @@ impl proposal::Proposal {
                                                     .get_unspent_transparent_output(
                                                         &outpoint,
                                                         target_height,
+                                                        false,
                                                     )
                                                     .map_err(ProposalDecodingError::InputRetrieval)?
                                                     .ok_or({
@@ -895,6 +896,7 @@ impl proposal::Proposal {
                                                 protocol,
                                                 out.index,
                                                 target_height,
+                                                false,
                                             )
                                             .map_err(ProposalDecodingError::InputRetrieval)
                                             .and_then(|opt| {

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -805,6 +805,14 @@ impl proposal::Proposal {
                 };
 
                 let target_height = TargetHeight::from(self.min_target_height);
+
+                // A proposal created with `lock_for_blocks` locks its own inputs, so
+                // input retrieval during decoding must not filter locked outputs;
+                // otherwise a locked proposal would fail to round-trip through its
+                // serialized form. Double-spend protection is enforced when the
+                // proposal's transactions are created, not here.
+                let include_locked = true;
+
                 // Steps are checked against the Orchard turnstile when Ironwood is
                 // active at the height for which the proposal was constructed.
                 #[cfg(feature = "orchard")]
@@ -875,7 +883,7 @@ impl proposal::Proposal {
                                                     .get_unspent_transparent_output(
                                                         &outpoint,
                                                         target_height,
-                                                        false,
+                                                        include_locked,
                                                     )
                                                     .map_err(ProposalDecodingError::InputRetrieval)?
                                                     .ok_or({
@@ -896,7 +904,7 @@ impl proposal::Proposal {
                                                 protocol,
                                                 out.index,
                                                 target_height,
-                                                false,
+                                                include_locked,
                                             )
                                             .map_err(ProposalDecodingError::InputRetrieval)
                                             .and_then(|opt| {

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -883,7 +883,6 @@ impl proposal::Proposal {
                                                     .get_unspent_transparent_output(
                                                         &outpoint,
                                                         target_height,
-                                                        lock_filter,
                                                     )
                                                     .map_err(ProposalDecodingError::InputRetrieval)?
                                                     .ok_or({

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -30,7 +30,7 @@ use crate::{
     data_api::{
         InputSource,
         chain::ChainState,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     fees::{ChangeValue, StandardFeeRule, TransactionBalance},
     proposal::{
@@ -811,7 +811,7 @@ impl proposal::Proposal {
                 // otherwise a locked proposal would fail to round-trip through its
                 // serialized form. Double-spend protection is enforced when the
                 // proposal's transactions are created, not here.
-                let include_locked = true;
+                let lock_filter = LockFilter::Unfiltered;
 
                 // Steps are checked against the Orchard turnstile when Ironwood is
                 // active at the height for which the proposal was constructed.
@@ -883,7 +883,7 @@ impl proposal::Proposal {
                                                     .get_unspent_transparent_output(
                                                         &outpoint,
                                                         target_height,
-                                                        include_locked,
+                                                        lock_filter,
                                                     )
                                                     .map_err(ProposalDecodingError::InputRetrieval)?
                                                     .ok_or({
@@ -904,7 +904,7 @@ impl proposal::Proposal {
                                                 protocol,
                                                 out.index,
                                                 target_height,
-                                                include_locked,
+                                                lock_filter,
                                             )
                                             .map_err(ProposalDecodingError::InputRetrieval)
                                             .and_then(|opt| {

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -150,6 +150,24 @@ impl LockOwner {
     }
 }
 
+/// A transaction id may serve as a lock owner.
+///
+/// This is the right owner choice for flows that hold a durable transaction identity while
+/// their locks are alive; most notably a persisted PCZT, whose v5 txid is fixed once its
+/// effecting data is final. Deriving the owner from the txid lets such a flow re-derive its
+/// token after a restart and release (or re-acquire) exactly its own locks.
+///
+/// It is NOT a suitable owner for proposal-time locking in general: at proposal creation no
+/// transaction exists yet, a multi-step proposal builds several transactions, and a
+/// transaction rebuilt after a crash generally has a different txid, which would defeat the
+/// idempotent same-owner re-lock. Flows without a durable transaction identity should use
+/// [`LockOwner::random`] and retain the token.
+impl From<TxId> for LockOwner {
+    fn from(txid: TxId) -> Self {
+        Self(txid.into())
+    }
+}
+
 /// A type that represents the recipient of a transaction output.
 ///
 /// Variants vary along two independent axes:
@@ -1299,6 +1317,15 @@ mod output_ref_tests {
             let other_txid = OutputRef::new(TxId::from_bytes(txid), a.pool(), a.output_index());
             prop_assert_ne!(a, other_txid);
             prop_assert_ne!(a.cmp(&other_txid), std::cmp::Ordering::Equal);
+        }
+
+        /// A txid-derived [`super::LockOwner`] preserves the txid bytes, so two owners
+        /// derived from distinct transactions are distinct (a persisted PCZT re-derives
+        /// exactly its own token after a restart).
+        #[test]
+        fn lock_owner_from_txid_preserves_bytes(txid in any::<[u8; 32]>()) {
+            let owner = super::LockOwner::from(TxId::from_bytes(txid));
+            prop_assert_eq!(*owner.as_bytes(), txid);
         }
 
         /// Two independently drawn references are equal exactly when all three components

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -109,6 +109,47 @@ impl From<NoteId> for OutputRef {
     }
 }
 
+/// An opaque token identifying the holder of an output lock.
+///
+/// A caller that locks outputs (directly via [`WalletWrite::lock_outputs`], or through a
+/// proposal-creation function's lock request) supplies an owner token and must retain it: the
+/// token is what authorizes releasing the locks ([`WalletWrite::unlock_output`],
+/// [`unlock_proposal_inputs`]) and what makes re-locking idempotent (an owner may re-acquire or
+/// extend its own active lock, for example when retrying a flow after a crash, while a different
+/// owner's lock attempt fails until the lock expires).
+///
+/// The token is not a cryptographic secret: everything that can reach the wallet database can
+/// read it. It exists to prevent *accidental* cross-flow interference between concurrent
+/// in-process operations, not to protect against an adversary with database access.
+///
+/// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
+/// [`WalletWrite::unlock_output`]: crate::data_api::WalletWrite::unlock_output
+/// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LockOwner([u8; 32]);
+
+impl LockOwner {
+    /// Constructs a `LockOwner` from the given bytes.
+    ///
+    /// Callers that persist their own operation state may derive a stable token from it; all
+    /// others should prefer [`LockOwner::random`].
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Generates a fresh random `LockOwner`.
+    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Returns the byte representation of this token.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
 /// A type that represents the recipient of a transaction output.
 ///
 /// Variants vary along two independent axes:

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -1175,3 +1175,99 @@ impl TransparentAddressSource {
         }
     }
 }
+
+/// Property tests for [`OutputRef`], whose identity (txid, pool, output index) is the key the
+/// note-locking tables and the proposal double-spend check operate on.
+#[cfg(test)]
+mod output_ref_tests {
+    use proptest::prelude::*;
+    use zcash_protocol::{PoolType, ShieldedPool, TxId};
+
+    use super::{NoteId, OutputRef};
+
+    fn arb_shielded_pool() -> impl Strategy<Value = ShieldedPool> {
+        prop_oneof![
+            Just(ShieldedPool::Sapling),
+            Just(ShieldedPool::Orchard),
+            Just(ShieldedPool::Ironwood),
+        ]
+    }
+
+    fn arb_pool_type() -> impl Strategy<Value = PoolType> {
+        prop_oneof![
+            Just(PoolType::Transparent),
+            arb_shielded_pool().prop_map(PoolType::Shielded),
+        ]
+    }
+
+    fn arb_output_ref() -> impl Strategy<Value = OutputRef> {
+        (any::<[u8; 32]>(), arb_pool_type(), any::<u32>())
+            .prop_map(|(txid, pool, idx)| OutputRef::new(TxId::from_bytes(txid), pool, idx))
+    }
+
+    proptest! {
+        /// Converting a `NoteId` preserves every component: the note's pool maps into the
+        /// shielded arm of `PoolType`, and the `u16` output index widens losslessly.
+        #[test]
+        fn from_note_id_preserves_fields(
+            txid in any::<[u8; 32]>(),
+            pool in arb_shielded_pool(),
+            idx in any::<u16>(),
+        ) {
+            let txid = TxId::from_bytes(txid);
+            let output_ref = OutputRef::from(NoteId::new(txid, pool, idx));
+            prop_assert_eq!(output_ref.txid(), &txid);
+            prop_assert_eq!(output_ref.pool(), PoolType::Shielded(pool));
+            prop_assert_eq!(output_ref.output_index(), u32::from(idx));
+        }
+
+        /// Identity is exactly the (txid, pool, output index) triple: a reference equals
+        /// itself, differs from any single-field mutation of itself, and `Ord` agrees with
+        /// `Eq` (the `BTreeSet` double-spend check in proposal construction and the lock
+        /// tables both rely on this).
+        #[test]
+        fn identity_is_the_full_triple(a in arb_output_ref()) {
+            prop_assert_eq!(a, a);
+            prop_assert_eq!(a.cmp(&a), std::cmp::Ordering::Equal);
+
+            // A different output index is a different output.
+            let other_index = OutputRef::new(
+                *a.txid(),
+                a.pool(),
+                a.output_index().wrapping_add(1),
+            );
+            prop_assert_ne!(a, other_index);
+            prop_assert_ne!(a.cmp(&other_index), std::cmp::Ordering::Equal);
+
+            // A different pool is a different output, even at the same (txid, index): the
+            // same transaction may have outputs at the same index in several pools.
+            let other_pool = OutputRef::new(
+                *a.txid(),
+                match a.pool() {
+                    PoolType::Transparent => PoolType::SAPLING,
+                    PoolType::Shielded(_) => PoolType::Transparent,
+                },
+                a.output_index(),
+            );
+            prop_assert_ne!(a, other_pool);
+            prop_assert_ne!(a.cmp(&other_pool), std::cmp::Ordering::Equal);
+
+            // A different transaction is a different output.
+            let mut txid = <[u8; 32]>::from(*a.txid());
+            txid[0] = txid[0].wrapping_add(1);
+            let other_txid = OutputRef::new(TxId::from_bytes(txid), a.pool(), a.output_index());
+            prop_assert_ne!(a, other_txid);
+            prop_assert_ne!(a.cmp(&other_txid), std::cmp::Ordering::Equal);
+        }
+
+        /// Two independently drawn references are equal exactly when all three components
+        /// match.
+        #[test]
+        fn equality_is_component_wise(a in arb_output_ref(), b in arb_output_ref()) {
+            let components_equal = a.txid() == b.txid()
+                && a.pool() == b.pool()
+                && a.output_index() == b.output_index();
+            prop_assert_eq!(a == b, components_equal);
+        }
+    }
+}

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -65,6 +65,50 @@ impl NoteId {
     }
 }
 
+/// A reference to a transaction output received by the wallet, across all pools.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OutputRef {
+    txid: TxId,
+    pool: PoolType,
+    output_index: u32,
+}
+
+impl OutputRef {
+    /// Constructs a new `OutputRef` from its parts.
+    pub fn new(txid: TxId, pool: PoolType, output_index: u32) -> Self {
+        Self {
+            txid,
+            pool,
+            output_index,
+        }
+    }
+
+    /// Returns the ID of the transaction containing this output.
+    pub fn txid(&self) -> &TxId {
+        &self.txid
+    }
+
+    /// Returns the pool type of this output.
+    pub fn pool(&self) -> PoolType {
+        self.pool
+    }
+
+    /// Returns the index of this output within its transaction.
+    pub fn output_index(&self) -> u32 {
+        self.output_index
+    }
+}
+
+impl From<NoteId> for OutputRef {
+    fn from(note_id: NoteId) -> Self {
+        Self {
+            txid: note_id.txid,
+            pool: PoolType::Shielded(note_id.protocol),
+            output_index: note_id.output_index.into(),
+        }
+    }
+}
+
 /// A type that represents the recipient of a transaction output.
 ///
 /// Variants vary along two independent axes:

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,6 +33,12 @@ workspace.
   `PoolMigrations::for_account`, scoped to the account whose migration it
   tracks; the underlying `orchard_ironwood_migrations` table enforces at most
   one migration per account.
+- `zcash_client_sqlite::pool_migration::PoolMigrations::migration_lock_owners`
+  returns the set of `LockOwner`s under which an account's in-progress pool
+  migration has reserved notes. A proposal can pass this set to a
+  `LockedInputPolicy` override (`SpendPolicy::with_locked_input_policy`) so it
+  may draw on the migration's own locked notes without disturbing any other
+  flow's locks.
 - A database migration adds `lock_expiry_height` and `lock_owner` columns to the
   `sapling_received_notes`, `orchard_received_notes`, `ironwood_received_notes`,
   and `transparent_received_outputs` tables to support explicit note locking

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,6 +33,10 @@ workspace.
   `PoolMigrations::for_account`, scoped to the account whose migration it
   tracks; the underlying `orchard_ironwood_migrations` table enforces at most
   one migration per account.
+- A database migration adds `lock_expiry_height` columns to the
+  `sapling_received_notes`, `orchard_received_notes`, `ironwood_received_notes`,
+  and `transparent_received_outputs` tables to support explicit note locking
+  during concurrent proposal creation.
 
 ### Fixed
 - The `zewif` importer no longer marks transparent addresses that have no

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -45,7 +45,7 @@ workspace.
   locked by an in-flight shielding proposal was still reported as spendable,
   even though note selection (correctly) refused to select it.
 - The `InputSource::get_unspent_transparent_output` implementation now honors
-  its `include_locked` parameter; previously the parameter was ignored and
+  its `lock_filter` parameter; previously the lock state was ignored and
   locked transparent outputs were returned regardless, diverging from the
   trait contract and from the shielded `get_spendable_note` behavior.
 - The `zewif` importer no longer marks transparent addresses that have no

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -50,10 +50,6 @@ workspace.
   locked value into `Balance::locked_value`: previously a mature coinbase UTXO
   locked by an in-flight shielding proposal was still reported as spendable,
   even though note selection (correctly) refused to select it.
-- The `InputSource::get_unspent_transparent_output` implementation now honors
-  its `lock_filter` parameter; previously the lock state was ignored and
-  locked transparent outputs were returned regardless, diverging from the
-  trait contract and from the shielded `get_spendable_note` behavior.
 - The `zewif` importer no longer marks transparent addresses that have no
   recorded exposure height (`zewif::Address::exposed_at_height() == None`, e.g.
   zcashd keypool reserves) as exposed unconditionally. Previously every such

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,12 +33,17 @@ workspace.
   `PoolMigrations::for_account`, scoped to the account whose migration it
   tracks; the underlying `orchard_ironwood_migrations` table enforces at most
   one migration per account.
-- A database migration adds `lock_expiry_height` columns to the
+- A database migration adds `lock_expiry_height` and `lock_owner` columns to the
   `sapling_received_notes`, `orchard_received_notes`, `ironwood_received_notes`,
   and `transparent_received_outputs` tables to support explicit note locking
-  during concurrent proposal creation.
+  during concurrent proposal creation: `lock_expiry_height` bounds how long a
+  lock lasts, and `lock_owner` records the flow that acquired it.
 
 ### Fixed
+- The coinbase branch of the transparent account-balance tally now classifies
+  locked value into `Balance::locked_value`: previously a mature coinbase UTXO
+  locked by an in-flight shielding proposal was still reported as spendable,
+  even though note selection (correctly) refused to select it.
 - The `InputSource::get_unspent_transparent_output` implementation now honors
   its `include_locked` parameter; previously the parameter was ignored and
   locked transparent outputs were returned regardless, diverging from the

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,6 +39,10 @@ workspace.
   during concurrent proposal creation.
 
 ### Fixed
+- The `InputSource::get_unspent_transparent_output` implementation now honors
+  its `include_locked` parameter; previously the parameter was ignored and
+  locked transparent outputs were returned regardless, diverging from the
+  trait contract and from the shielded `get_spendable_note` behavior.
 - The `zewif` importer no longer marks transparent addresses that have no
   recorded exposure height (`zewif::Address::exposed_at_height() == None`, e.g.
   zcashd keypool reserves) as exposed unconditionally. Previously every such

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -17,6 +17,7 @@ use zcash_address::ParseError;
 use zcash_client_backend::data_api::NoteFilter;
 use zcash_client_backend::data_api::ll;
 use zcash_client_backend::data_api::ll::wallet::PutBlocksError;
+use zcash_client_backend::wallet::OutputRef;
 use zcash_keys::address::UnifiedAddress;
 use zcash_keys::keys::AddressGenerationError;
 use zcash_protocol::{PoolType, ShieldedPool, TxId, consensus::BlockHeight, value::BalanceError};
@@ -564,5 +565,32 @@ impl From<PutBlocksError<SqliteClientError, commitment_tree::Error>> for SqliteC
 impl ErrUnsupportedPool for SqliteClientError {
     fn unsupported_pool_type(pool_type: PoolType) -> Self {
         SqliteClientError::UnsupportedPoolType(pool_type)
+    }
+}
+
+/// A local LockError type for which we can write a From<rusqlite::Error> impl.
+pub(crate) enum LockError {
+    /// Wrapper for storage errors.
+    Storage(rusqlite::Error),
+    /// The wrapped output reference was not found, or the output it refers to was already locked.
+    LockFailure(OutputRef),
+}
+
+impl From<rusqlite::Error> for LockError {
+    fn from(value: rusqlite::Error) -> Self {
+        LockError::Storage(value)
+    }
+}
+
+impl From<LockError> for zcash_client_backend::data_api::error::LockError<SqliteClientError> {
+    fn from(value: LockError) -> Self {
+        match value {
+            LockError::Storage(error) => zcash_client_backend::data_api::error::LockError::Storage(
+                SqliteClientError::from(error),
+            ),
+            LockError::LockFailure(output) => {
+                zcash_client_backend::data_api::error::LockError::LockFailure(output)
+            }
+        }
     }
 }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1700,6 +1700,10 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output))
     }
 
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
+        self.transactionally(|wdb| wallet::clear_locked_outputs(wdb.conn.0, account))
+    }
+
     fn store_transactions_to_be_sent(
         &mut self,
         transactions: &[SentTransaction<Self::AccountId>],
@@ -2104,6 +2108,10 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
 
     fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
         wallet::unlock_output(self.conn.0, output)
+    }
+
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
+        wallet::clear_locked_outputs(self.conn.0, account)
     }
 
     fn store_transactions_to_be_sent(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -71,7 +71,7 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     proto::compact_formats::CompactBlock,
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
+    wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
 };
 use zcash_keys::{
     address::UnifiedAddress,
@@ -1693,15 +1693,17 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
 
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
-        Ok(self
-            .transactionally(|wdb| wallet::lock_outputs(wdb.conn.0, outputs, lock_expiry_height))?)
+        Ok(self.transactionally(|wdb| {
+            wallet::lock_outputs(wdb.conn.0, outputs, owner, lock_expiry_height)
+        })?)
     }
 
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
-        self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output))
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output, owner))
     }
 
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
@@ -2100,7 +2102,8 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
 
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
         // This impl operates within an enclosing database transaction, so the
@@ -2112,12 +2115,13 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         Ok(wallet::lock_outputs(
             self.conn.0,
             outputs,
+            owner,
             lock_expiry_height,
         )?)
     }
 
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
-        wallet::unlock_output(self.conn.0, output)
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        wallet::unlock_output(self.conn.0, output, owner)
     }
 
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2103,6 +2103,12 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         outputs: impl Iterator<Item = OutputRef>,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
+        // This impl operates within an enclosing database transaction, so the
+        // all-or-nothing contract of `WalletWrite::lock_outputs` holds only if a
+        // returned error causes the enclosing transaction to be rolled back: on a
+        // mid-batch `LockFailure`, locks taken for earlier outputs in the batch
+        // remain pending in the transaction. `WalletDb::transactionally` (used by
+        // the non-transactional impl above) provides that rollback.
         Ok(wallet::lock_outputs(
             self.conn.0,
             outputs,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -673,6 +673,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
+        _include_locked: bool,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         match protocol {
             ShieldedPool::Sapling => wallet::sapling::get_spendable_sapling_note(
@@ -736,6 +737,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -788,6 +790,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -845,6 +848,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
+        _include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
@@ -860,6 +864,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
+        _include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -878,6 +883,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
+        _include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs_for_addresses(
             self.conn.borrow(),
@@ -900,6 +906,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
+        _include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::select_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -922,6 +929,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        _include_locked: bool,
     ) -> Result<AccountMeta, Self::Error> {
         let sapling_pool_meta = unspent_notes_meta(
             self.conn.borrow(),
@@ -1496,6 +1504,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
                         protocol,
                         output_index,
                         target_height,
+                        true,
                     )
                     .unwrap()
                     .unwrap();

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -62,7 +62,7 @@ use zcash_client_backend::{
         SeedRelevance, SentTransaction, TargetValue, TransactionDataRequest, WalletCommitmentTrees,
         WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
-        error::{FindAccountForAddressError, RewindError},
+        error::{FindAccountForAddressError, LockError, RewindError},
         ll::{
             self, LowLevelWalletRead, LowLevelWalletWrite, ReceivedSaplingOutput,
             wallet::store_decrypted_tx,
@@ -71,7 +71,7 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     proto::compact_formats::CompactBlock,
-    wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput, WalletTx},
+    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
 };
 use zcash_keys::{
     address::UnifiedAddress,
@@ -1326,6 +1326,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
 impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTest
     for WalletDb<C, P, CL, R>
 {
+    fn get_locked_outputs(
+        &self,
+        account: <Self as WalletRead>::AccountId,
+    ) -> Result<Vec<OutputRef>, <Self as WalletRead>::Error> {
+        wallet::get_locked_outputs(self.conn.borrow(), account)
+    }
+
     fn get_tx_history(
         &self,
     ) -> Result<Vec<TransactionSummary<<Self as WalletRead>::AccountId>>, <Self as WalletRead>::Error>
@@ -1654,6 +1661,19 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
 
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error> {
         self.transactionally(|wdb| wdb.set_tx_trust(txid, trusted))
+    }
+
+    fn lock_outputs(
+        &mut self,
+        outputs: impl Iterator<Item = OutputRef>,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        Ok(self
+            .transactionally(|wdb| wallet::lock_outputs(wdb.conn.0, outputs, lock_expiry_height))?)
+    }
+
+    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
+        self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output))
     }
 
     fn store_transactions_to_be_sent(
@@ -2044,6 +2064,22 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
 
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error> {
         wallet::set_tx_trust(self.conn.0, txid, trusted)
+    }
+
+    fn lock_outputs(
+        &mut self,
+        outputs: impl Iterator<Item = OutputRef>,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        Ok(wallet::lock_outputs(
+            self.conn.0,
+            outputs,
+            lock_expiry_height,
+        )?)
+    }
+
+    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
+        wallet::unlock_output(self.conn.0, output)
     }
 
     fn store_transactions_to_be_sent(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -857,13 +857,11 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-        lock_filter: LockFilter<'_>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             Some(target_height),
-            lock_filter,
         )
     }
 
@@ -1480,13 +1478,10 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
         Option<WalletTransparentOutput<<Self as InputSource>::AccountId>>,
         <Self as InputSource>::Error,
     > {
-        // The test accessor inspects wallet contents irrespective of lock state.
-        let lock_filter = LockFilter::Unfiltered;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
-            lock_filter,
         )
     }
 
@@ -2389,14 +2384,10 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         outpoint: &OutPoint,
         target_height: Option<TargetHeight>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
-        // The low-level accessor exposes wallet contents irrespective of lock
-        // state; locks only constrain input selection for new proposals.
-        let lock_filter = LockFilter::Unfiltered;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
-            lock_filter,
         )
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -673,7 +673,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         match protocol {
             ShieldedPool::Sapling => wallet::sapling::get_spendable_sapling_note(
@@ -682,6 +682,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 txid,
                 index,
                 target_height,
+                include_locked,
             )
             .map(|opt| opt.map(|n| n.map_note(Note::Sapling))),
             ShieldedPool::Orchard => {
@@ -692,6 +693,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     txid,
                     index,
                     target_height,
+                    include_locked,
                 )
                 .map(|opt| {
                     opt.map(|n| {
@@ -713,6 +715,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     txid,
                     index,
                     target_height,
+                    include_locked,
                 )
                 .map(|opt| {
                     opt.map(|n| {
@@ -737,7 +740,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -749,6 +752,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -763,6 +767,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -777,6 +782,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -790,7 +796,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -804,6 +810,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Sapling,
                     wallet::sapling::to_received_note,
                     wallet::common::NoteRequest::Unspent,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -820,6 +827,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Orchard,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -836,6 +844,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Ironwood,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
+                    include_locked,
                 )?
             } else {
                 vec![]
@@ -864,7 +873,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -873,6 +882,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_height,
             confirmations_policy,
             output_filter,
+            include_locked,
         )
     }
 
@@ -883,7 +893,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs_for_addresses(
             self.conn.borrow(),
@@ -892,6 +902,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_height,
             confirmations_policy,
             output_filter,
+            include_locked,
         )
     }
 
@@ -906,7 +917,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::select_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -919,6 +930,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_value,
             max_inputs,
             fee_rule,
+            include_locked,
         )
     }
 
@@ -929,7 +941,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<AccountMeta, Self::Error> {
         let sapling_pool_meta = unspent_notes_meta(
             self.conn.borrow(),
@@ -938,6 +950,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
+            include_locked,
         )?;
 
         #[cfg(feature = "orchard")]
@@ -948,6 +961,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
+            include_locked,
         )?;
         #[cfg(not(feature = "orchard"))]
         let orchard_pool_meta = None;
@@ -960,6 +974,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
+            include_locked,
         )?;
         #[cfg(not(feature = "orchard"))]
         let ironwood_pool_meta = None;

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -857,12 +857,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             Some(target_height),
+            include_locked,
         )
     }
 
@@ -1479,10 +1480,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
         Option<WalletTransparentOutput<<Self as InputSource>::AccountId>>,
         <Self as InputSource>::Error,
     > {
+        // The test accessor inspects wallet contents irrespective of lock state.
+        let include_locked = true;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
+            include_locked,
         )
     }
 
@@ -2373,10 +2377,14 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         outpoint: &OutPoint,
         target_height: Option<TargetHeight>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+        // The low-level accessor exposes wallet contents irrespective of lock
+        // state; locks only constrain input selection for new proposals.
+        let include_locked = true;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
+            include_locked,
         )
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -68,7 +68,7 @@ use zcash_client_backend::{
             wallet::store_decrypted_tx,
         },
         scanning::{ScanPriority, ScanRange},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     proto::compact_formats::CompactBlock,
     wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
@@ -673,7 +673,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         match protocol {
             ShieldedPool::Sapling => wallet::sapling::get_spendable_sapling_note(
@@ -682,7 +682,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 txid,
                 index,
                 target_height,
-                include_locked,
+                lock_filter,
             )
             .map(|opt| opt.map(|n| n.map_note(Note::Sapling))),
             ShieldedPool::Orchard => {
@@ -693,7 +693,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     txid,
                     index,
                     target_height,
-                    include_locked,
+                    lock_filter,
                 )
                 .map(|opt| {
                     opt.map(|n| {
@@ -715,7 +715,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     txid,
                     index,
                     target_height,
-                    include_locked,
+                    lock_filter,
                 )
                 .map(|opt| {
                     opt.map(|n| {
@@ -740,7 +740,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -752,7 +752,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -767,7 +767,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -782,7 +782,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     target_height,
                     confirmations_policy,
                     exclude,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -796,7 +796,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         Ok(ReceivedNotes::new(
             if sources.contains(&ShieldedPool::Sapling) {
@@ -810,7 +810,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Sapling,
                     wallet::sapling::to_received_note,
                     wallet::common::NoteRequest::Unspent,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -827,7 +827,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Orchard,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -844,7 +844,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                     ShieldedPool::Ironwood,
                     wallet::orchard::to_received_note,
                     wallet::common::NoteRequest::Unspent,
-                    include_locked,
+                    lock_filter,
                 )?
             } else {
                 vec![]
@@ -857,13 +857,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             Some(target_height),
-            include_locked,
+            lock_filter,
         )
     }
 
@@ -874,7 +874,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -883,7 +883,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_height,
             confirmations_policy,
             output_filter,
-            include_locked,
+            lock_filter,
         )
     }
 
@@ -894,7 +894,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_spendable_transparent_outputs_for_addresses(
             self.conn.borrow(),
@@ -903,7 +903,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_height,
             confirmations_policy,
             output_filter,
-            include_locked,
+            lock_filter,
         )
     }
 
@@ -918,7 +918,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::select_spendable_transparent_outputs(
             self.conn.borrow(),
@@ -931,7 +931,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             target_value,
             max_inputs,
             fee_rule,
-            include_locked,
+            lock_filter,
         )
     }
 
@@ -942,7 +942,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<AccountMeta, Self::Error> {
         let sapling_pool_meta = unspent_notes_meta(
             self.conn.borrow(),
@@ -951,7 +951,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
-            include_locked,
+            lock_filter,
         )?;
 
         #[cfg(feature = "orchard")]
@@ -962,7 +962,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
-            include_locked,
+            lock_filter,
         )?;
         #[cfg(not(feature = "orchard"))]
         let orchard_pool_meta = None;
@@ -975,7 +975,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
             account_id,
             selector,
             exclude,
-            include_locked,
+            lock_filter,
         )?;
         #[cfg(not(feature = "orchard"))]
         let ironwood_pool_meta = None;
@@ -1481,12 +1481,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
         <Self as InputSource>::Error,
     > {
         // The test accessor inspects wallet contents irrespective of lock state.
-        let include_locked = true;
+        let lock_filter = LockFilter::Unfiltered;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
-            include_locked,
+            lock_filter,
         )
     }
 
@@ -1518,14 +1518,14 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
                 let txid: [u8; 32] = row.get("txid")?;
                 let output_index: u32 = row.get(output_index_col)?;
                 // The test accessor inspects wallet contents irrespective of lock state.
-                let include_locked = true;
+                let lock_filter = LockFilter::Unfiltered;
                 let note = self
                     .get_spendable_note(
                         &TxId::from_bytes(txid),
                         protocol,
                         output_index,
                         target_height,
-                        include_locked,
+                        lock_filter,
                     )
                     .unwrap()
                     .unwrap();
@@ -2391,12 +2391,12 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         // The low-level accessor exposes wallet contents irrespective of lock
         // state; locks only constrain input selection for new proposals.
-        let include_locked = true;
+        let lock_filter = LockFilter::Unfiltered;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
-            include_locked,
+            lock_filter,
         )
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1517,13 +1517,15 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
             .query_map([], |row| {
                 let txid: [u8; 32] = row.get("txid")?;
                 let output_index: u32 = row.get(output_index_col)?;
+                // The test accessor inspects wallet contents irrespective of lock state.
+                let include_locked = true;
                 let note = self
                     .get_spendable_note(
                         &TxId::from_bytes(txid),
                         protocol,
                         output_index,
                         target_height,
-                        true,
+                        include_locked,
                     )
                     .unwrap()
                     .unwrap();

--- a/zcash_client_sqlite/src/pool_migration.rs
+++ b/zcash_client_sqlite/src/pool_migration.rs
@@ -9,8 +9,9 @@
 //! The schema is fully NORMALIZED: every structured value (the note-split plan, the preparation
 //! plan's transaction inputs/outputs and direct-funding notes, the transaction kind, and the
 //! dependency graph) is stored in typed columns and child tables, so it can be queried directly.
-//! The only `BLOB` column is the pre-signed transaction (`pczt`), which is genuinely unstructured,
-//! already-versioned bytes; all amounts are zatoshi `INTEGER` columns and the broadcast `txid` is
+//! The `BLOB` columns are the pre-signed transaction (`pczt`), which is genuinely unstructured,
+//! already-versioned bytes, and the transaction's `lock_owner` (an opaque fixed-size token, not a
+//! structured value); all amounts are zatoshi `INTEGER` columns and the broadcast `txid` is
 //! hex `TEXT`. It is also MINIMAL: values derivable from other columns get no tables of their own
 //! (the funding-note values are the crossing values plus the fee buffer, and the preparation
 //! plan's layers/transactions grid is implied by the input and output rows' `(layer, tx_index)`

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -166,6 +166,84 @@ mod tests {
         assert_empty_is_none(&fresh_store());
     }
 
+    /// A transaction's `lock_owner` round-trips exactly through the store's `BLOB` column: a
+    /// `Some` token comes back byte-for-byte and a `None` comes back as `None`, not a zeroed or
+    /// otherwise substituted token. This pins the two cases the column must distinguish; the
+    /// general `put_then_get_round_trips` property (whose generator also produces `lock_owner`)
+    /// covers the type more broadly.
+    #[test]
+    fn lock_owner_round_trips() {
+        use zcash_pool_migration_backend::engine::{
+            MigrationState, MigrationStatus, MigrationTransaction, MigrationTxKind,
+        };
+        use zcash_pool_migration_backend::note_splitting::NoteSplitPlan;
+        use zcash_pool_migration_backend::preparation::PreparationPlan;
+        use zcash_protocol::consensus::BlockHeight;
+        use zcash_protocol::value::Zatoshis;
+
+        let note_split = NoteSplitPlan::from_stored_parts(
+            Vec::new(),
+            Zatoshis::ZERO,
+            None,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+        )
+        .expect("an empty stored plan reconstructs");
+
+        let owner_bytes = [7u8; 32];
+        let locked = MigrationTransaction::from_parts(
+            MigrationTxId::new(0),
+            MigrationTxKind::Preparation { layer: 0, index: 0 },
+            vec![1, 2, 3],
+            Vec::new(),
+            BlockHeight::from_u32(100),
+            BlockHeight::from_u32(200),
+            None,
+            MigrationTxState::Signed,
+            Some(owner_bytes),
+        );
+        let unlocked = MigrationTransaction::from_parts(
+            MigrationTxId::new(1),
+            MigrationTxKind::Transfer { crossing: 0 },
+            vec![4, 5, 6],
+            Vec::new(),
+            BlockHeight::from_u32(100),
+            BlockHeight::from_u32(200),
+            None,
+            MigrationTxState::Signed,
+            None,
+        );
+        let state = MigrationState::from_parts(
+            MigrationStatus::Committed,
+            note_split,
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            vec![locked, unlocked],
+        );
+
+        let mut store = fresh_store();
+        store.replace_migration(&state).expect("write succeeds");
+        let loaded = store
+            .get_migration()
+            .expect("read succeeds")
+            .expect("a migration is stored");
+
+        assert_eq!(
+            loaded, state,
+            "the whole migration, including lock_owner, must round-trip unchanged"
+        );
+        assert_eq!(
+            loaded.transactions()[0].lock_owner(),
+            Some(owner_bytes),
+            "a `Some` lock_owner must survive exactly"
+        );
+        assert_eq!(
+            loaded.transactions()[1].lock_owner(),
+            None,
+            "a `None` lock_owner must round-trip as `None`"
+        );
+    }
+
     /// A state with an empty preparation layer is rejected on write rather than silently
     /// renumbered: the layers/transactions grid is stored only through the input and output rows,
     /// so an empty layer would leave no trace (and the engine never produces one).

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -7,9 +7,11 @@
 //! migration runs. The generic store type never leaks into this API.
 
 use std::borrow::{Borrow, BorrowMut};
+use std::collections::BTreeSet;
 
 use rusqlite::{Connection, OptionalExtension};
 
+use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration_backend::engine::{
     MigrationState, MigrationTxId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
@@ -76,6 +78,20 @@ impl<C> PoolMigrations<C> {
     /// Recover the wrapped connection borrow.
     pub fn into_inner(self) -> C {
         self.0.into_inner()
+    }
+}
+
+impl<C: Borrow<Connection>> PoolMigrations<C> {
+    /// Returns the set of [`LockOwner`]s under which this account's in-progress pool migration
+    /// has locked notes (empty if there is no migration, or it holds no locks).
+    ///
+    /// This is the set a caller passes to a `LockedInputPolicy::PreferUnlocked` /
+    /// `PreferLocked` override so a proposal may draw on the migration's own locked notes
+    /// without disturbing any other flow's locks. It is not part of [`PoolMigrationRead`]: that
+    /// trait is shared with the pool-agnostic migration engine, which has no notion of
+    /// [`LockOwner`] (a wallet-level concept).
+    pub fn migration_lock_owners(&self) -> Result<BTreeSet<LockOwner>, Error> {
+        self.0.migration_lock_owners()
     }
 }
 
@@ -241,6 +257,79 @@ mod tests {
             loaded.transactions()[1].lock_owner(),
             None,
             "a `None` lock_owner must round-trip as `None`"
+        );
+    }
+
+    /// `migration_lock_owners` returns exactly the distinct, non-`None` lock owners across an
+    /// account's migration transactions: an account with no migration returns the empty set,
+    /// a `None` lock_owner contributes nothing, and repeated owners collapse to one entry.
+    #[test]
+    fn migration_lock_owners_collects_distinct_non_none_owners() {
+        use std::collections::BTreeSet;
+
+        use zcash_client_backend::wallet::LockOwner;
+        use zcash_pool_migration_backend::engine::{
+            MigrationState, MigrationStatus, MigrationTransaction, MigrationTxKind,
+        };
+        use zcash_pool_migration_backend::note_splitting::NoteSplitPlan;
+        use zcash_pool_migration_backend::preparation::PreparationPlan;
+        use zcash_protocol::consensus::BlockHeight;
+        use zcash_protocol::value::Zatoshis;
+
+        let mut store = fresh_store();
+        assert_eq!(
+            store.migration_lock_owners().expect("read succeeds"),
+            BTreeSet::new(),
+            "an account with no migration must report no lock owners"
+        );
+
+        let owner_a_bytes = [0xA1u8; 32];
+        let owner_b_bytes = [0xB2u8; 32];
+
+        let note_split = NoteSplitPlan::from_stored_parts(
+            Vec::new(),
+            Zatoshis::ZERO,
+            None,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+        )
+        .expect("an empty stored plan reconstructs");
+
+        let tx = |id: u32, crossing: usize, lock_owner: Option<[u8; 32]>| {
+            MigrationTransaction::from_parts(
+                MigrationTxId::new(id),
+                MigrationTxKind::Transfer { crossing },
+                vec![id as u8],
+                Vec::new(),
+                BlockHeight::from_u32(100),
+                BlockHeight::from_u32(200),
+                None,
+                MigrationTxState::Signed,
+                lock_owner,
+            )
+        };
+
+        let state = MigrationState::from_parts(
+            MigrationStatus::Committed,
+            note_split,
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            vec![
+                tx(0, 0, Some(owner_a_bytes)),
+                tx(1, 1, Some(owner_b_bytes)),
+                tx(2, 2, None),
+                // A second transaction locked by A, to prove duplicates collapse.
+                tx(3, 3, Some(owner_a_bytes)),
+            ],
+        );
+
+        store.replace_migration(&state).expect("write succeeds");
+
+        let owners = store.migration_lock_owners().expect("read succeeds");
+        assert_eq!(
+            owners,
+            BTreeSet::from([LockOwner::new(owner_a_bytes), LockOwner::new(owner_b_bytes)]),
+            "must contain exactly the distinct non-None lock owners, deduped"
         );
     }
 

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -24,9 +24,11 @@
 //! [`PoolMigrationWrite`]: zcash_pool_migration_backend::engine::PoolMigrationWrite
 
 use std::borrow::{Borrow, BorrowMut};
+use std::collections::BTreeSet;
 
 use rusqlite::{Connection, OptionalExtension, named_params, params};
 
+use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration_backend::engine::{
     MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
     MigrationTxState,
@@ -257,6 +259,13 @@ impl<C> Store<C> {
 impl<C: Borrow<Connection>> Store<C> {
     pub(crate) fn get_migration(&self) -> Result<Option<MigrationState>, Error> {
         read_migration(self.conn.borrow(), self.tables, self.account_id)
+    }
+
+    /// Returns the set of [`LockOwner`]s under which this account's in-progress migration has
+    /// locked notes (empty if the account has no migration, or none of its transactions hold a
+    /// lock).
+    pub(crate) fn migration_lock_owners(&self) -> Result<BTreeSet<LockOwner>, Error> {
+        read_lock_owners(self.conn.borrow(), self.tables, self.account_id)
     }
 }
 
@@ -609,6 +618,31 @@ fn read_transactions(
             state,
             r.lock_owner,
         ));
+    }
+    Ok(out)
+}
+
+/// Returns the distinct [`LockOwner`]s recorded on `account`'s migration transactions (empty if
+/// the account has no migration, or none of its transactions hold a lock). A direct `DISTINCT`
+/// query over the transactions table, scoped by the account's resolved migration id, so this
+/// avoids reconstructing the whole migration (with its preparation plan and every transaction)
+/// just to inspect which locks it holds.
+fn read_lock_owners(
+    conn: &Connection,
+    t: &Tables,
+    account: AccountRef,
+) -> Result<BTreeSet<LockOwner>, Error> {
+    let Some(migration_id) = resolve_migration_id(conn, t, account)? else {
+        return Ok(BTreeSet::new());
+    };
+    let mut stmt = conn.prepare(&format!(
+        "SELECT DISTINCT lock_owner FROM {} WHERE migration_id = ? AND lock_owner IS NOT NULL",
+        t.transactions
+    ))?;
+    let rows = stmt.query_map(params![migration_id], |row| row.get::<_, [u8; 32]>(0))?;
+    let mut out = BTreeSet::new();
+    for r in rows {
+        out.insert(LockOwner::new(r?));
     }
     Ok(out)
 }

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -4,8 +4,11 @@
 //! (the DDL builders and the [`Store`] type that carries the [`PoolMigrationRead`] /
 //! [`PoolMigrationWrite`] SQL logic), parameterized over the table names in [`Tables`]. The schema is
 //! fully NORMALIZED: every structured value is stored in typed columns and child-table rows, so the
-//! store maps the engine types to and from columns directly. The only `BLOB` column is the pre-signed
-//! transaction (`pczt`), which is genuinely unstructured, already-versioned bytes. All amounts are
+//! store maps the engine types to and from columns directly. The `BLOB` columns are the pre-signed
+//! transaction (`pczt`), which is genuinely unstructured, already-versioned bytes, and each
+//! transaction's `lock_owner`, an opaque fixed-size token read and written directly as
+//! `Option<[u8; 32]>` (no codec: `rusqlite`'s fixed-size-array `FromSql`/`ToSql` impls handle it,
+//! and reject a non-NULL blob that is not exactly 32 bytes). All amounts are
 //! zatoshi `INTEGER` columns; the broadcast `txid` is stored as hex `TEXT`.
 //!
 //! The preparation plan's layers/transactions grid has no tables of its own: each input and output
@@ -165,6 +168,7 @@ fn create_transactions_sql(t: &Tables) -> String {
             state TEXT NOT NULL,
             txid TEXT,
             mined_height INTEGER,
+            lock_owner BLOB,
             PRIMARY KEY (migration_id, tx_id)
         )",
         t.transactions, t.migrations
@@ -540,7 +544,8 @@ fn read_transactions(
     let rows: Vec<TxRow> = {
         let mut stmt = conn.prepare(&format!(
             "SELECT tx_id, kind, kind_layer, kind_index, kind_crossing, pczt,
-                    scheduled_height, expiry_height, anchor_boundary, state, txid, mined_height
+                    scheduled_height, expiry_height, anchor_boundary, state, txid, mined_height,
+                    lock_owner
                FROM {}
               WHERE migration_id = ?
               ORDER BY tx_id",
@@ -560,6 +565,7 @@ fn read_transactions(
                 state: row.get(9)?,
                 txid: row.get(10)?,
                 mined_height: row.get(11)?,
+                lock_owner: row.get(12)?,
             })
         })?;
         mapped.collect::<Result<_, _>>()?
@@ -601,6 +607,7 @@ fn read_transactions(
             BlockHeight::from_u32(r.expiry_height),
             r.anchor_boundary.map(BlockHeight::from_u32),
             state,
+            r.lock_owner,
         ));
     }
     Ok(out)
@@ -620,6 +627,10 @@ struct TxRow {
     state: String,
     txid: Option<String>,
     mined_height: Option<u32>,
+    /// The stored lock-owner token, read directly as a fixed-size blob: `rusqlite`'s `[u8; 32]`
+    /// `FromSql` impl errors cleanly (`InvalidBlobSize`) if a non-NULL blob is not exactly 32
+    /// bytes, so a corrupt row is rejected rather than silently truncated or panicking.
+    lock_owner: Option<[u8; 32]>,
 }
 
 fn read_deps(
@@ -806,10 +817,10 @@ fn replace_migration(
             &format!(
                 "INSERT INTO {} (migration_id, tx_id, kind, kind_layer, kind_index, kind_crossing,
                                  pczt, scheduled_height, expiry_height, anchor_boundary, state, txid,
-                                 mined_height)
+                                 mined_height, lock_owner)
                  VALUES (:migration_id, :tx_id, :kind, :kind_layer, :kind_index, :kind_crossing,
                          :pczt, :scheduled_height, :expiry_height, :anchor_boundary, :state, :txid,
-                         :mined_height)",
+                         :mined_height, :lock_owner)",
                 t.transactions
             ),
             named_params! {
@@ -826,6 +837,7 @@ fn replace_migration(
                 ":state": tx_state.as_ref(),
                 ":txid": tx_state.broadcast_txid().map(hex::encode),
                 ":mined_height": tx_state.mined_height().map(u32::from),
+                ":lock_owner": mtx.lock_owner(),
             },
         )?;
         for (ordinal, dep) in mtx.depends_on().iter().enumerate() {

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -120,6 +120,12 @@ impl TestDb {
         self.data_file
     }
 
+    /// Returns the path of the backing database file, so that tests can open additional
+    /// independent connections to the same wallet database.
+    pub(crate) fn data_file_path(&self) -> &std::path::Path {
+        self.data_file.path()
+    }
+
     /// Dump the schema and contents of the given database table, in
     /// sqlite3 ".dump" format. The name of the table must be a static
     /// string. This assumes that `sqlite3` is on your path and that it

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -120,8 +120,7 @@ impl TestDb {
         self.data_file
     }
 
-    /// Returns the path of the backing database file, so that tests can open additional
-    /// independent connections to the same wallet database.
+    #[allow(dead_code)]
     pub(crate) fn data_file_path(&self) -> &std::path::Path {
         self.data_file.path()
     }

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -26,7 +26,7 @@ use zcash_client_backend::{
         error::{LockError, RewindError},
         scanning::ScanRange,
         testing::{DataStoreFactory, Reset, TestState},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
         *,
     },
     wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -29,7 +29,7 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
         *,
     },
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},
+    wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},
 };
 use zcash_keys::{
     address::UnifiedAddress,

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -23,13 +23,13 @@ use zcash_client_backend::{
     data_api::{
         TargetValue,
         chain::{ChainState, CommitmentTreeRoot},
-        error::RewindError,
+        error::{LockError, RewindError},
         scanning::ScanRange,
         testing::{DataStoreFactory, Reset, TestState},
         wallet::{ConfirmationsPolicy, TargetHeight},
         *,
     },
-    wallet::{Note, NoteId, ReceivedNote, WalletTransparentOutput},
+    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},
 };
 use zcash_keys::{
     address::UnifiedAddress,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -238,6 +238,13 @@ pub(crate) fn explicit_note_locking<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn note_locking_height_boundary<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::note_locking_height_boundary::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn proposal_level_note_locking<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::proposal_level_note_locking::<T>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -983,3 +983,154 @@ pub(crate) fn proposal_records_and_serializes_proposed_version() {
         BlockCache::new(),
     );
 }
+
+#[cfg(test)]
+mod concurrency_tests {
+    use assert_matches::assert_matches;
+
+    use zcash_client_backend::{
+        data_api::{
+            Account as _, InputSource as _, WalletRead as _, WalletTest as _, WalletWrite as _,
+            error::LockError,
+            testing::{
+                AddressType, TestBuilder, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+            },
+            wallet::TargetHeight,
+        },
+        wallet::OutputRef,
+    };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
+
+    use crate::{
+        WalletDb,
+        testing::{
+            BlockCache,
+            db::{TestDbFactory, test_clock, test_rng},
+        },
+    };
+
+    /// Two independent `WalletDb` connections to the same wallet database resolve a lock race
+    /// at the storage layer: both handles observe the same spendable note (the shared
+    /// select-before-lock state of the TOCTOU window), only the first `lock_outputs` succeeds,
+    /// the loser's failure names the contested note, and lock state changes are immediately
+    /// visible across handles. Also pins the ownerless-lock property across connections: the
+    /// losing handle is able to release the winner's lock.
+    #[test]
+    fn concurrent_handles_resolve_lock_conflict() {
+        let mut st = TestBuilder::new()
+            .with_block_cache(BlockCache::new())
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        // Fund the wallet with a single note.
+        let dfvk = SaplingPoolTester::test_account_fvk(&st);
+        let value = Zatoshis::const_from_u64(60000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        let account_id = st.test_account().unwrap().id();
+        let notes = st.wallet().get_notes(ShieldedPool::Sapling).unwrap();
+        assert_eq!(notes.len(), 1);
+        let note = &notes[0];
+        let txid = *note.txid();
+        let output_index = u32::from(note.output_index());
+        let output_ref = OutputRef::new(txid, PoolType::SAPLING, output_index);
+
+        let tip = st.wallet().chain_height().unwrap().unwrap();
+        let target_height = TargetHeight::from(tip + 1);
+
+        // Open a second, independent connection to the same wallet database file.
+        let network = *st.network();
+        let mut db2 = WalletDb::for_path(
+            st.wallet().data_file_path(),
+            network,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        // Both handles observe the note as spendable: this is the shared state from which two
+        // concurrent proposal flows would each select the same input.
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db2.get_spendable_note(
+                &txid,
+                ShieldedPool::Sapling,
+                output_index,
+                target_height,
+                false
+            )
+            .unwrap()
+            .is_some()
+        );
+
+        // The second handle locks first...
+        assert_eq!(
+            db2.lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .unwrap(),
+            1
+        );
+
+        // ... so the first handle's lock fails, naming the contested output: the race is
+        // resolved at the storage layer, across connections.
+        assert_matches!(
+            st.wallet_mut()
+                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX)),
+            Err(LockError::LockFailure(r)) if r == output_ref
+        );
+
+        // The winner's lock is immediately visible to the losing handle.
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            st.wallet().get_locked_outputs(account_id).unwrap(),
+            vec![output_ref]
+        );
+
+        // Locks carry no owner, so the losing handle can release the winner's lock; the
+        // release is visible to the winning handle.
+        assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+        assert!(
+            db2.get_spendable_note(
+                &txid,
+                ShieldedPool::Sapling,
+                output_index,
+                target_height,
+                false
+            )
+            .unwrap()
+            .is_some()
+        );
+
+        // With the note unlocked, the losing handle's retry succeeds.
+        assert_eq!(
+            st.wallet_mut()
+                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -231,6 +231,20 @@ pub(crate) fn spend_fails_on_locked_notes<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn explicit_note_locking<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::explicit_note_locking::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn proposal_level_note_locking<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::proposal_level_note_locking::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -259,6 +259,13 @@ pub(crate) fn proposal_level_note_locking<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::locked_proposal_proto_roundtrip::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -997,7 +997,7 @@ mod concurrency_tests {
             },
             wallet::TargetHeight,
         },
-        wallet::OutputRef,
+        wallet::{LockOwner, OutputRef},
     };
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
@@ -1077,18 +1077,20 @@ mod concurrency_tests {
             .is_some()
         );
 
-        // The second handle locks first...
+        // The second handle locks first, under its own owner...
+        let owner_a = LockOwner::new([0xA1; 32]);
+        let owner_b = LockOwner::new([0xB2; 32]);
         assert_eq!(
-            db2.lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            db2.lock_outputs(&[output_ref], owner_b, BlockHeight::from(u32::MAX))
                 .unwrap(),
             1
         );
 
-        // ... so the first handle's lock fails, naming the contested output: the race is
-        // resolved at the storage layer, across connections.
+        // ... so the first handle's lock (under a different owner) fails, naming the
+        // contested output: the race is resolved at the storage layer, across connections.
         assert_matches!(
             st.wallet_mut()
-                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX)),
+                .lock_outputs(&[output_ref], owner_a, BlockHeight::from(u32::MAX)),
             Err(LockError::LockFailure(r)) if r == output_ref
         );
 
@@ -1110,9 +1112,25 @@ mod concurrency_tests {
             vec![output_ref]
         );
 
-        // Locks carry no owner, so the losing handle can release the winner's lock; the
-        // release is visible to the winning handle.
-        assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+        // Locks are owner-scoped, so the losing handle CANNOT release the winner's lock:
+        // its unlock is a no-op and the note stays locked.
+        assert!(!st.wallet_mut().unlock_output(&output_ref, owner_a).unwrap());
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_none()
+        );
+
+        // The winning handle releases its own lock; the release is visible to the losing
+        // handle, whose retry then succeeds.
+        assert!(db2.unlock_output(&output_ref, owner_b).unwrap());
         assert!(
             db2.get_spendable_note(
                 &txid,
@@ -1124,11 +1142,9 @@ mod concurrency_tests {
             .unwrap()
             .is_some()
         );
-
-        // With the note unlocked, the losing handle's retry succeeds.
         assert_eq!(
             st.wallet_mut()
-                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .lock_outputs(&[output_ref], owner_a, BlockHeight::from(u32::MAX))
                 .unwrap(),
             1
         );

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -995,7 +995,10 @@ mod concurrency_tests {
             testing::{
                 AddressType, TestBuilder, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
             },
-            wallet::TargetHeight,
+            wallet::{
+                TargetHeight,
+                input_selection::{LockFilter, LockedInputPolicy},
+            },
         },
         wallet::{LockOwner, OutputRef},
     };
@@ -1060,7 +1063,7 @@ mod concurrency_tests {
                     ShieldedPool::Sapling,
                     output_index,
                     target_height,
-                    false
+                    LockFilter::Policy(&LockedInputPolicy::Exclude)
                 )
                 .unwrap()
                 .is_some()
@@ -1071,7 +1074,7 @@ mod concurrency_tests {
                 ShieldedPool::Sapling,
                 output_index,
                 target_height,
-                false
+                LockFilter::Policy(&LockedInputPolicy::Exclude)
             )
             .unwrap()
             .is_some()
@@ -1102,7 +1105,7 @@ mod concurrency_tests {
                     ShieldedPool::Sapling,
                     output_index,
                     target_height,
-                    false
+                    LockFilter::Policy(&LockedInputPolicy::Exclude)
                 )
                 .unwrap()
                 .is_none()
@@ -1122,7 +1125,7 @@ mod concurrency_tests {
                     ShieldedPool::Sapling,
                     output_index,
                     target_height,
-                    false
+                    LockFilter::Policy(&LockedInputPolicy::Exclude)
                 )
                 .unwrap()
                 .is_none()
@@ -1137,7 +1140,7 @@ mod concurrency_tests {
                 ShieldedPool::Sapling,
                 output_index,
                 target_height,
-                false
+                LockFilter::Policy(&LockedInputPolicy::Exclude)
             )
             .unwrap()
             .is_some()

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -287,6 +287,13 @@ pub(crate) fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn spend_policy_locked_input_policy_reaches_selection<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::spend_policy_locked_input_policy_reaches_selection::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn check_note_locking_model<T: ShieldedPoolTester>(
     ops: &[zcash_client_backend::data_api::testing::pool::LockOp],
 ) {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -287,6 +287,16 @@ pub(crate) fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn check_note_locking_model<T: ShieldedPoolTester>(
+    ops: &[zcash_client_backend::data_api::testing::pool::LockOp],
+) {
+    zcash_client_backend::data_api::testing::pool::check_note_locking_model::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+        ops,
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -266,6 +266,27 @@ pub(crate) fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn lock_expiry_restores_spendability<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::lock_expiry_restores_spendability::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::lock_conflict_and_batch_atomicity::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::unlock_proposal_inputs_releases_locks::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -245,6 +245,13 @@ pub(crate) fn note_locking_height_boundary<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn clear_locked_outputs<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::clear_locked_outputs::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn proposal_level_note_locking<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::proposal_level_note_locking::<T>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5413,6 +5413,11 @@ pub(crate) fn lock_outputs(
     outputs: impl Iterator<Item = OutputRef>,
     lock_expiry_height: BlockHeight,
 ) -> Result<usize, LockError> {
+    // When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the
+    // `lock_expiry_height <= :chain_tip` clause evaluates to NULL (falsy). In that case only
+    // outputs that are not already locked (`lock_expiry_height IS NULL`) can be locked; an
+    // existing lock cannot be treated as expired because we have no height against which to
+    // judge expiry. This is the conservative choice: locking generally requires a synced wallet.
     let chain_tip = chain_tip_height(conn)?.map(u32::from);
 
     let mut rows_updated = 0;
@@ -5534,6 +5539,37 @@ pub(crate) fn unlock_output(
         )?,
     };
     Ok(rows_updated > 0)
+}
+
+/// Unlocks every currently-locked output belonging to the given account, across all pools,
+/// regardless of lock expiry height. Returns the total number of outputs unlocked.
+///
+/// This is the storage-layer implementation of [`WalletWrite::clear_locked_outputs`], and is
+/// intended as a recovery mechanism for callers that have lost track of their in-flight proposals.
+///
+/// [`WalletWrite::clear_locked_outputs`]: zcash_client_backend::data_api::WalletWrite::clear_locked_outputs
+pub(crate) fn clear_locked_outputs(
+    conn: &rusqlite::Transaction,
+    account: AccountUuid,
+) -> Result<usize, SqliteClientError> {
+    let mut rows_updated = 0;
+    for table in [
+        "sapling_received_notes",
+        "orchard_received_notes",
+        "ironwood_received_notes",
+        "transparent_received_outputs",
+    ] {
+        rows_updated += conn.execute(
+            &format!(
+                "UPDATE {table} SET lock_expiry_height = NULL
+                 WHERE lock_expiry_height IS NOT NULL
+                   AND account_id = (SELECT id FROM accounts WHERE uuid = :account_uuid)"
+            ),
+            named_params![":account_uuid": account.0],
+        )?;
+    }
+
+    Ok(rows_updated)
 }
 
 /// Unlocks all notes that have been recorded as spent by the given transaction.

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -98,7 +98,7 @@ use zcash_client_backend::{
         scanning::{ScanPriority, ScanRange},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
-    wallet::{Note, NoteId, OutputRef, Recipient, WalletTx},
+    wallet::{LockOwner, Note, NoteId, OutputRef, Recipient, WalletTx},
 };
 use zcash_keys::{
     address::{Address, Receiver, UnifiedAddress},
@@ -5339,14 +5339,16 @@ pub(crate) fn get_locked_outputs(
 
 pub(crate) fn lock_outputs(
     conn: &rusqlite::Transaction,
-    outputs: impl Iterator<Item = OutputRef>,
+    outputs: &[OutputRef],
+    owner: LockOwner,
     lock_expiry_height: BlockHeight,
 ) -> Result<usize, LockError> {
     // When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the
     // `lock_expiry_height <= :chain_tip` clause evaluates to NULL (falsy). In that case only
-    // outputs that are not already locked (`lock_expiry_height IS NULL`) can be locked; an
-    // existing lock cannot be treated as expired because we have no height against which to
-    // judge expiry. This is the conservative choice: locking generally requires a synced wallet.
+    // outputs that are not already locked (`lock_expiry_height IS NULL`) or whose lock is
+    // already held by the requesting owner can be locked; an existing lock cannot be treated
+    // as expired because we have no height against which to judge expiry. This is the
+    // conservative choice: locking generally requires a synced wallet.
     let chain_tip = chain_tip_height(conn)?.map(u32::from);
 
     let mut rows_updated = 0;
@@ -5355,7 +5357,9 @@ pub(crate) fn lock_outputs(
         let updated = conn
             .execute(
                 &format!(
-                    "UPDATE {table} SET lock_expiry_height = :expiry_height
+                    "UPDATE {table} SET
+                        lock_expiry_height = :expiry_height,
+                        lock_owner = :owner
                     WHERE {index_col} = :idx
                     AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
                     AND ({})",
@@ -5363,6 +5367,7 @@ pub(crate) fn lock_outputs(
                 ),
                 named_params![
                     ":expiry_height": u32::from(lock_expiry_height),
+                    ":owner": owner.as_bytes(),
                     ":idx": output.output_index(),
                     ":txid": output.txid().as_ref(),
                     ":chain_tip": chain_tip
@@ -5371,7 +5376,7 @@ pub(crate) fn lock_outputs(
             .map_err(LockError::Storage)?;
 
         if updated == 0 {
-            return Err(LockError::LockFailure(output));
+            return Err(LockError::LockFailure(*output));
         } else {
             rows_updated += updated;
         }
@@ -5393,17 +5398,23 @@ fn received_outputs_table(pool: PoolType) -> (&'static str, &'static str) {
 pub(crate) fn unlock_output(
     conn: &rusqlite::Transaction,
     output: &OutputRef,
+    owner: LockOwner,
 ) -> Result<bool, SqliteClientError> {
     let (table, index_col) = received_outputs_table(output.pool());
+    // Unlocking is scoped to the owner: a lock held by a different owner is left in place, so
+    // one flow cannot accidentally release another's locks. An expired lock held by the owner
+    // is still cleared (and reported as such), tidying the stale row.
     let rows_updated = conn.execute(
         &format!(
-            "UPDATE {table} SET lock_expiry_height = NULL
+            "UPDATE {table} SET lock_expiry_height = NULL, lock_owner = NULL
              WHERE {index_col} = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)"
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+               AND lock_owner = :owner"
         ),
         named_params![
             ":idx": output.output_index(),
             ":txid": output.txid().as_ref(),
+            ":owner": owner.as_bytes(),
         ],
     )?;
     Ok(rows_updated > 0)
@@ -5429,7 +5440,7 @@ pub(crate) fn clear_locked_outputs(
     ] {
         rows_updated += conn.execute(
             &format!(
-                "UPDATE {table} SET lock_expiry_height = NULL
+                "UPDATE {table} SET lock_expiry_height = NULL, lock_owner = NULL
                  WHERE lock_expiry_height IS NOT NULL
                    AND account_id = (SELECT id FROM accounts WHERE uuid = :account_uuid)"
             ),
@@ -5445,7 +5456,7 @@ pub(crate) fn clear_locked_outputs(
 /// since the spend records now prevent them from being selected by subsequent proposals.
 fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), SqliteClientError> {
     conn.execute(
-        "UPDATE sapling_received_notes SET lock_expiry_height = NULL
+        "UPDATE sapling_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT sapling_received_note_id FROM sapling_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5454,7 +5465,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE orchard_received_notes SET lock_expiry_height = NULL
+        "UPDATE orchard_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT orchard_received_note_id FROM orchard_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5463,7 +5474,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
+        "UPDATE ironwood_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT ironwood_received_note_id FROM ironwood_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5472,7 +5483,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
+        "UPDATE transparent_received_outputs SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT transparent_received_output_id FROM transparent_received_output_spends
              WHERE transaction_id = :tx_ref

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -98,7 +98,7 @@ use zcash_client_backend::{
         scanning::{ScanPriority, ScanRange},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
-    wallet::{Note, NoteId, Recipient, WalletTx},
+    wallet::{Note, NoteId, OutputRef, Recipient, WalletTx},
 };
 use zcash_keys::{
     address::{Address, Receiver, UnifiedAddress},
@@ -128,7 +128,7 @@ use self::{
 use crate::{
     AccountRef, AccountUuid, AddressRef, PRUNING_DEPTH, SqlTransaction, TransferType, TxRef,
     WalletCommitmentTrees, WalletDb,
-    error::SqliteClientError,
+    error::{LockError, SqliteClientError},
     util::Clock,
     wallet::{
         commitment_tree::{SqliteShardStore, get_max_checkpointed_height},
@@ -5262,6 +5262,256 @@ pub(crate) fn get_block_range(
         },
     )
     .map_err(SqliteClientError::from)
+}
+
+#[cfg(any(test, feature = "test-dependencies"))]
+pub(crate) fn get_locked_outputs(
+    conn: &rusqlite::Connection,
+    account: AccountUuid,
+) -> Result<Vec<OutputRef>, SqliteClientError> {
+    let chain_tip = chain_tip_height(conn)?
+        .map(u32::from)
+        .ok_or(SqliteClientError::ChainHeightUnknown)?;
+
+    let mut result = Vec::new();
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT t.txid, sn.output_index
+         FROM sapling_received_notes sn
+         JOIN transactions t ON t.id_tx = sn.transaction_id
+         JOIN accounts a ON a.id = sn.account_id
+         WHERE sn.lock_expiry_height > :chain_tip
+         AND a.uuid = :account_uuid",
+    )?;
+    let rows = stmt.query_map(
+        named_params![
+            ":account_uuid": account.0,
+            ":chain_tip": chain_tip
+        ],
+        |row| {
+            let txid: [u8; 32] = row.get(0)?;
+            let output_index: u32 = row.get(1)?;
+            Ok(OutputRef::new(
+                TxId::from_bytes(txid),
+                PoolType::SAPLING,
+                output_index,
+            ))
+        },
+    )?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT t.txid, orn.action_index
+         FROM orchard_received_notes orn
+         JOIN transactions t ON t.id_tx = orn.transaction_id
+         JOIN accounts a ON a.id = orn.account_id
+         WHERE orn.lock_expiry_height > :chain_tip
+         AND a.uuid = :account_uuid",
+    )?;
+    let rows = stmt.query_map(
+        named_params![
+            ":account_uuid": account.0,
+            ":chain_tip": chain_tip
+        ],
+        |row| {
+            let txid: [u8; 32] = row.get(0)?;
+            let output_index: u32 = row.get(1)?;
+            Ok(OutputRef::new(
+                TxId::from_bytes(txid),
+                PoolType::ORCHARD,
+                output_index,
+            ))
+        },
+    )?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT t.txid, irn.action_index
+         FROM ironwood_received_notes irn
+         JOIN transactions t ON t.id_tx = irn.transaction_id
+         JOIN accounts a ON a.id = irn.account_id
+         WHERE irn.lock_expiry_height > :chain_tip
+         AND a.uuid = :account_uuid",
+    )?;
+    let rows = stmt.query_map(
+        named_params![
+            ":account_uuid": account.0,
+            ":chain_tip": chain_tip
+        ],
+        |row| {
+            let txid: [u8; 32] = row.get(0)?;
+            let output_index: u32 = row.get(1)?;
+            Ok(OutputRef::new(
+                TxId::from_bytes(txid),
+                PoolType::IRONWOOD,
+                output_index,
+            ))
+        },
+    )?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT t.txid, tro.output_index
+         FROM transparent_received_outputs tro
+         JOIN transactions t ON t.id_tx = tro.transaction_id
+         JOIN accounts a ON a.id = tro.account_id
+         WHERE tro.lock_expiry_height > :chain_tip
+         AND a.uuid = :account_uuid",
+    )?;
+    let rows = stmt.query_map(
+        named_params![
+            ":account_uuid": account.0,
+            ":chain_tip": chain_tip
+        ],
+        |row| {
+            let txid: [u8; 32] = row.get(0)?;
+            let output_index: u32 = row.get(1)?;
+            Ok(OutputRef::new(
+                TxId::from_bytes(txid),
+                PoolType::TRANSPARENT,
+                output_index,
+            ))
+        },
+    )?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    Ok(result)
+}
+
+pub(crate) fn lock_outputs(
+    conn: &rusqlite::Transaction,
+    outputs: impl Iterator<Item = OutputRef>,
+    lock_expiry_height: BlockHeight,
+) -> Result<usize, LockError> {
+    let chain_tip = chain_tip_height(conn)?.map(u32::from);
+
+    let mut rows_updated = 0;
+    for output in outputs {
+        let updated = match output.pool() {
+            PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
+                "UPDATE sapling_received_notes SET lock_expiry_height = :expiry_height
+                WHERE output_index = :idx
+                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                AND (
+                    lock_expiry_height IS NULL
+                    OR lock_expiry_height <= :chain_tip
+                )",
+                named_params![
+                    ":expiry_height": u32::from(lock_expiry_height),
+                    ":idx": output.output_index(),
+                    ":txid": output.txid().as_ref(),
+                    ":chain_tip": chain_tip
+                ],
+            ),
+            PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
+                "UPDATE orchard_received_notes SET lock_expiry_height = :expiry_height
+                WHERE action_index = :idx
+                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                AND (
+                    lock_expiry_height IS NULL
+                    OR lock_expiry_height <= :chain_tip
+                )",
+                named_params![
+                    ":expiry_height": u32::from(lock_expiry_height),
+                    ":idx": output.output_index(),
+                    ":txid": output.txid().as_ref(),
+                    ":chain_tip": chain_tip
+                ],
+            ),
+            PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
+                "UPDATE ironwood_received_notes SET lock_expiry_height = :expiry_height
+                WHERE action_index = :idx
+                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                AND (
+                    lock_expiry_height IS NULL
+                    OR lock_expiry_height <= :chain_tip
+                )",
+                named_params![
+                    ":expiry_height": u32::from(lock_expiry_height),
+                    ":idx": output.output_index(),
+                    ":txid": output.txid().as_ref(),
+                    ":chain_tip": chain_tip
+                ],
+            ),
+            PoolType::Transparent => conn.execute(
+                "UPDATE transparent_received_outputs SET lock_expiry_height = :expiry_height
+                WHERE output_index = :idx
+                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                AND (
+                    lock_expiry_height IS NULL
+                    OR lock_expiry_height <= :chain_tip
+                )",
+                named_params![
+                    ":expiry_height": u32::from(lock_expiry_height),
+                    ":idx": output.output_index(),
+                    ":txid": output.txid().as_ref(),
+                    ":chain_tip": chain_tip
+                ],
+            ),
+        }
+        .map_err(|e| LockError::Storage(e))?;
+
+        if updated == 0 {
+            return Err(LockError::LockFailure(output));
+        } else {
+            rows_updated += updated;
+        }
+    }
+
+    Ok(rows_updated)
+}
+
+pub(crate) fn unlock_output(
+    conn: &rusqlite::Transaction,
+    output: &OutputRef,
+) -> Result<bool, SqliteClientError> {
+    let rows_updated = match output.pool() {
+        PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
+            "UPDATE sapling_received_notes SET lock_expiry_height = NULL
+             WHERE output_index = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
+            named_params![
+                ":idx": output.output_index(),
+                ":txid": output.txid().as_ref(),
+            ],
+        )?,
+        PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
+            "UPDATE orchard_received_notes SET lock_expiry_height = NULL
+             WHERE action_index = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
+            named_params![
+                ":idx": output.output_index(),
+                ":txid": output.txid().as_ref(),
+            ],
+        )?,
+        PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
+            "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
+             WHERE action_index = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
+            named_params![
+                ":idx": output.output_index(),
+                ":txid": output.txid().as_ref(),
+            ],
+        )?,
+        PoolType::Transparent => conn.execute(
+            "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
+             WHERE output_index = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
+            named_params![
+                ":idx": output.output_index(),
+                ":txid": output.txid().as_ref(),
+            ],
+        )?,
+    };
+    Ok(rows_updated > 0)
 }
 
 pub(crate) fn get_received_outputs(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5422,69 +5422,24 @@ pub(crate) fn lock_outputs(
 
     let mut rows_updated = 0;
     for output in outputs {
-        let updated = match output.pool() {
-            PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
-                "UPDATE sapling_received_notes SET lock_expiry_height = :expiry_height
-                WHERE output_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
+        let (table, index_col) = received_outputs_table(output.pool());
+        let updated = conn
+            .execute(
+                &format!(
+                    "UPDATE {table} SET lock_expiry_height = :expiry_height
+                    WHERE {index_col} = :idx
+                    AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                    AND ({})",
+                    common::output_lockable_condition(),
+                ),
                 named_params![
                     ":expiry_height": u32::from(lock_expiry_height),
                     ":idx": output.output_index(),
                     ":txid": output.txid().as_ref(),
                     ":chain_tip": chain_tip
                 ],
-            ),
-            PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
-                "UPDATE orchard_received_notes SET lock_expiry_height = :expiry_height
-                WHERE action_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-            PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
-                "UPDATE ironwood_received_notes SET lock_expiry_height = :expiry_height
-                WHERE action_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-            PoolType::Transparent => conn.execute(
-                "UPDATE transparent_received_outputs SET lock_expiry_height = :expiry_height
-                WHERE output_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-        }
-        .map_err(LockError::Storage)?;
+            )
+            .map_err(LockError::Storage)?;
 
         if updated == 0 {
             return Err(LockError::LockFailure(output));
@@ -5496,48 +5451,32 @@ pub(crate) fn lock_outputs(
     Ok(rows_updated)
 }
 
+/// Returns the received notes/outputs table and its output-index column for the given pool.
+fn received_outputs_table(pool: PoolType) -> (&'static str, &'static str) {
+    match pool {
+        PoolType::Shielded(ShieldedPool::Sapling) => ("sapling_received_notes", "output_index"),
+        PoolType::Shielded(ShieldedPool::Orchard) => ("orchard_received_notes", "action_index"),
+        PoolType::Shielded(ShieldedPool::Ironwood) => ("ironwood_received_notes", "action_index"),
+        PoolType::Transparent => ("transparent_received_outputs", "output_index"),
+    }
+}
+
 pub(crate) fn unlock_output(
     conn: &rusqlite::Transaction,
     output: &OutputRef,
 ) -> Result<bool, SqliteClientError> {
-    let rows_updated = match output.pool() {
-        PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
-            "UPDATE sapling_received_notes SET lock_expiry_height = NULL
-             WHERE output_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
-            "UPDATE orchard_received_notes SET lock_expiry_height = NULL
-             WHERE action_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
-            "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
-             WHERE action_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Transparent => conn.execute(
-            "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
-             WHERE output_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-    };
+    let (table, index_col) = received_outputs_table(output.pool());
+    let rows_updated = conn.execute(
+        &format!(
+            "UPDATE {table} SET lock_expiry_height = NULL
+             WHERE {index_col} = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)"
+        ),
+        named_params![
+            ":idx": output.output_index(),
+            ":txid": output.txid().as_ref(),
+        ],
+    )?;
     Ok(rows_updated > 0)
 }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2604,6 +2604,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
             Zatoshis,
             Zatoshis,
             Zatoshis,
+            Zatoshis,
         ) -> Result<(), SqliteClientError>,
     {
         let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
@@ -2645,7 +2646,8 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
                     t.mined_height,
                     IFNULL(t.trust_status, 0) AS trust_status,
                     MAX(tt.mined_height) AS max_shielding_input_height,
-                    MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust
+                    MIN(IFNULL(tt.trust_status, 0)) AS min_shielding_input_trust,
+                    rn.lock_expiry_height
              FROM {table_prefix}_received_notes rn
              INNER JOIN accounts ON accounts.id = rn.account_id
              INNER JOIN transactions t ON t.id_tx = rn.transaction_id
@@ -2663,11 +2665,12 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
              AND rn.id NOT IN ({}) -- and the received note is unspent
              GROUP BY rn.id",
             common::tx_unexpired_condition("t"),
-            common::spent_notes_clause(table_prefix)
+            common::spent_notes_clause(table_prefix),
         ))?;
 
-        let mut rows =
-            stmt_select_notes.query(named_params![":target_height": u32::from(target_height)])?;
+        let mut rows = stmt_select_notes.query(named_params![
+            ":target_height": u32::from(target_height),
+        ])?;
         while let Some(row) = rows.next()? {
             let account = AccountUuid(row.get::<_, Uuid>("uuid")?);
 
@@ -2714,6 +2717,11 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
 
+            let is_locked = row
+                .get::<_, Option<u32>>("lock_expiry_height")?
+                .iter()
+                .any(|h| *h >= u32::from(target_height));
+
             // A stabilized note is unconditionally spendable. Its originating transaction has been
             // confirmed well beyond any reasonable confirmation policy, and its witness data
             // cannot be removed by truncation.
@@ -2740,19 +2748,22 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
 
             let (
                 spendable_value,
+                locked_value,
                 change_pending_confirmation,
                 value_pending_spendability,
                 uneconomic_value,
             ) = {
                 let zero = Zatoshis::ZERO;
                 if value <= zip317::MARGINAL_FEE {
-                    (zero, zero, zero, value)
+                    (zero, zero, zero, zero, value)
+                } else if is_spendable && is_locked {
+                    (zero, value, zero, zero, zero)
                 } else if is_spendable {
-                    (value, zero, zero, zero)
+                    (value, zero, zero, zero, zero)
                 } else if is_pending_change {
-                    (zero, value, zero, zero)
+                    (zero, zero, value, zero, zero)
                 } else {
-                    (zero, zero, value, zero)
+                    (zero, zero, zero, value, zero)
                 }
             };
 
@@ -2760,6 +2771,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
                 with_pool_balance(
                     balances,
                     spendable_value,
+                    locked_value,
                     change_pending_confirmation,
                     value_pending_spendability,
                     uneconomic_value,
@@ -2781,11 +2793,13 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
             ShieldedPool::Orchard,
             |balances,
              spendable_value,
+             locked_value,
              change_pending_confirmation,
              value_pending_spendability,
              uneconomic_value| {
                 balances.with_orchard_balance_mut::<_, SqliteClientError>(|bal| {
                     bal.add_spendable_value(spendable_value)?;
+                    bal.add_locked_value(locked_value)?;
                     bal.add_pending_change_value(change_pending_confirmation)?;
                     bal.add_pending_spendable_value(value_pending_spendability)?;
                     bal.add_uneconomic_value(uneconomic_value)?;
@@ -2808,11 +2822,13 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
             ShieldedPool::Ironwood,
             |balances,
              spendable_value,
+             locked_value,
              change_pending_confirmation,
              value_pending_spendability,
              uneconomic_value| {
                 balances.with_ironwood_balance_mut::<_, SqliteClientError>(|bal| {
                     bal.add_spendable_value(spendable_value)?;
+                    bal.add_locked_value(locked_value)?;
                     bal.add_pending_change_value(change_pending_confirmation)?;
                     bal.add_pending_spendable_value(value_pending_spendability)?;
                     bal.add_uneconomic_value(uneconomic_value)?;
@@ -2833,11 +2849,13 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         ShieldedPool::Sapling,
         |balances,
          spendable_value,
+         locked_value,
          change_pending_confirmation,
          value_pending_spendability,
          uneconomic_value| {
             balances.with_sapling_balance_mut::<_, SqliteClientError>(|bal| {
                 bal.add_spendable_value(spendable_value)?;
+                bal.add_locked_value(locked_value)?;
                 bal.add_pending_change_value(change_pending_confirmation)?;
                 bal.add_pending_spendable_value(value_pending_spendability)?;
                 bal.add_uneconomic_value(uneconomic_value)?;

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2757,6 +2757,10 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
                 if value <= zip317::MARGINAL_FEE {
                     (zero, zero, zero, zero, value)
                 } else if is_spendable && is_locked {
+                    // Only notes that would otherwise be spendable are counted as locked; a
+                    // locked note that is still pending confirmations is deliberately reported
+                    // in the pending buckets below, since locking only matters once the note
+                    // would enter selection. This mirrors the transparent balance computation.
                     (zero, value, zero, zero, zero)
                 } else if is_spendable {
                     (value, zero, zero, zero, zero)
@@ -5297,112 +5301,37 @@ pub(crate) fn get_locked_outputs(
 
     let mut result = Vec::new();
 
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, sn.output_index
-         FROM sapling_received_notes sn
-         JOIN transactions t ON t.id_tx = sn.transaction_id
-         JOIN accounts a ON a.id = sn.account_id
-         WHERE sn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::SAPLING,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, orn.action_index
-         FROM orchard_received_notes orn
-         JOIN transactions t ON t.id_tx = orn.transaction_id
-         JOIN accounts a ON a.id = orn.account_id
-         WHERE orn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::ORCHARD,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, irn.action_index
-         FROM ironwood_received_notes irn
-         JOIN transactions t ON t.id_tx = irn.transaction_id
-         JOIN accounts a ON a.id = irn.account_id
-         WHERE irn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::IRONWOOD,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, tro.output_index
-         FROM transparent_received_outputs tro
-         JOIN transactions t ON t.id_tx = tro.transaction_id
-         JOIN accounts a ON a.id = tro.account_id
-         WHERE tro.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::TRANSPARENT,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
+    // `lock_expiry_height > chain_tip` is `lock_expiry_height >= chain_tip + 1`, i.e. the
+    // locked-balance condition evaluated at the standard target height.
+    for pool in [
+        PoolType::SAPLING,
+        PoolType::ORCHARD,
+        PoolType::IRONWOOD,
+        PoolType::TRANSPARENT,
+    ] {
+        let (table, index_col) = received_outputs_table(pool);
+        let mut stmt = conn.prepare_cached(&format!(
+            "SELECT t.txid, rn.{index_col}
+             FROM {table} rn
+             JOIN transactions t ON t.id_tx = rn.transaction_id
+             JOIN accounts a ON a.id = rn.account_id
+             WHERE rn.lock_expiry_height > :chain_tip
+             AND a.uuid = :account_uuid"
+        ))?;
+        let rows = stmt.query_map(
+            named_params![
+                ":account_uuid": account.0,
+                ":chain_tip": chain_tip
+            ],
+            |row| {
+                let txid: [u8; 32] = row.get(0)?;
+                let output_index: u32 = row.get(1)?;
+                Ok(OutputRef::new(TxId::from_bytes(txid), pool, output_index))
+            },
+        )?;
+        for row in rows {
+            result.push(row?);
+        }
     }
 
     Ok(result)

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3516,6 +3516,10 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
         transparent::mark_transparent_utxo_spent(conn, tx_ref, utxo_outpoint)?;
     }
 
+    // Unlock any notes that were locked for this transaction, since the spend records
+    // now prevent them from being selected by subsequent proposals.
+    unlock_spent_notes(conn, tx_ref)?;
+
     for output in sent_tx.outputs() {
         insert_sent_output(conn, params, tx_ref, *sent_tx.funding_account(), output)?;
 
@@ -5530,6 +5534,49 @@ pub(crate) fn unlock_output(
         )?,
     };
     Ok(rows_updated > 0)
+}
+
+/// Unlocks all notes that have been recorded as spent by the given transaction.
+/// This is called after marking notes as spent in `store_transaction_to_be_sent`,
+/// since the spend records now prevent them from being selected by subsequent proposals.
+fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), SqliteClientError> {
+    conn.execute(
+        "UPDATE sapling_received_notes SET lock_expiry_height = NULL
+         WHERE id IN (
+             SELECT sapling_received_note_id FROM sapling_received_note_spends
+             WHERE transaction_id = :tx_ref
+         )",
+        named_params![":tx_ref": tx_ref.0],
+    )?;
+
+    conn.execute(
+        "UPDATE orchard_received_notes SET lock_expiry_height = NULL
+         WHERE id IN (
+             SELECT orchard_received_note_id FROM orchard_received_note_spends
+             WHERE transaction_id = :tx_ref
+         )",
+        named_params![":tx_ref": tx_ref.0],
+    )?;
+
+    conn.execute(
+        "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
+         WHERE id IN (
+             SELECT ironwood_received_note_id FROM ironwood_received_note_spends
+             WHERE transaction_id = :tx_ref
+         )",
+        named_params![":tx_ref": tx_ref.0],
+    )?;
+
+    conn.execute(
+        "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
+         WHERE id IN (
+             SELECT transparent_received_output_id FROM transparent_received_output_spends
+             WHERE transaction_id = :tx_ref
+         )",
+        named_params![":tx_ref": tx_ref.0],
+    )?;
+
+    Ok(())
 }
 
 pub(crate) fn get_received_outputs(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5457,7 +5457,7 @@ pub(crate) fn lock_outputs(
                 ],
             ),
         }
-        .map_err(|e| LockError::Storage(e))?;
+        .map_err(LockError::Storage)?;
 
         if updated == 0 {
             return Err(LockError::LockFailure(output));

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -141,15 +141,21 @@ pub(crate) fn spent_notes_clause(table_prefix: &str) -> String {
 
 /// Generates an SQL condition that filters out locked notes/outputs.
 ///
-/// A note is considered locked when its `lock_expiry_height` is set and greater than the
-/// target height. Locks expire automatically when the chain advances past the expiry height.
+/// A note is considered locked when its `lock_expiry_height` is set and greater than or equal
+/// to the target height; equivalently, an output is only selectable once the target height has
+/// advanced strictly beyond its `lock_expiry_height`. This matches the [`WalletWrite::lock_outputs`]
+/// contract, which prevents selection "at any height less than or equal to" the lock expiry
+/// height, and is the exact complement of the locked-balance condition (`lock_expiry_height >=
+/// target_height`) used in balance computation.
 ///
 /// # Usage requirements
 /// - `tbl` must be set to the SQL alias for the received notes/outputs table.
 /// - The parent must provide `:target_height` and `:include_locked` as named arguments.
+///
+/// [`WalletWrite::lock_outputs`]: zcash_client_backend::data_api::WalletWrite::lock_outputs
 pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
     format!(
-        "{tbl}.lock_expiry_height IS NULL OR {tbl}.lock_expiry_height <= :target_height OR :include_locked"
+        "{tbl}.lock_expiry_height IS NULL OR {tbl}.lock_expiry_height < :target_height OR :include_locked"
     )
 }
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -1171,7 +1171,7 @@ mod lock_predicate_tests {
     /// The balance-side model: an output is counted as locked value while its lock expiry
     /// height has not been passed as of the target height.
     fn model_locked(lock_expiry_height: Option<u32>, target_height: u32) -> bool {
-        lock_expiry_height.map_or(false, |h| h >= target_height)
+        lock_expiry_height.is_some_and(|h| h >= target_height)
     }
 
     /// A height strategy biased toward the boundary around the given height, where the
@@ -1228,7 +1228,7 @@ mod lock_predicate_tests {
         ) {
             let expected = match lock {
                 None => true,
-                Some(h) => tip.map_or(false, |tip| h <= tip),
+                Some(h) => tip.is_some_and(|tip| h <= tip),
             };
             prop_assert_eq!(sql_lockable(lock, tip), expected);
         }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -159,6 +159,26 @@ pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
     )
 }
 
+/// Generates the SQL condition under which an output's lock may be (re)acquired.
+///
+/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`) or when the existing
+/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`). Because balance and
+/// selection evaluate lock state against `target_height = chain_tip + 1`, "expired as of the
+/// chain tip" (`h <= chain_tip`) is exactly "not locked for selection" (`h < target_height`):
+/// a lock can never be stolen while the output is still excluded from selection.
+///
+/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the comparison evaluates to
+/// NULL (falsy), so only outputs with no existing lock can be locked; an existing lock cannot be
+/// judged expired without a height to compare against.
+///
+/// # Usage requirements
+/// - This condition uses the bare `lock_expiry_height` column name, so it must be used in a
+///   single-table statement (such as the `UPDATE`s in `lock_outputs`).
+/// - The parent must provide `:chain_tip` as a named argument (possibly NULL).
+pub(crate) fn output_lockable_condition() -> &'static str {
+    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip"
+}
+
 fn unscanned_tip_exists(
     conn: &Connection,
     anchor_height: BlockHeight,
@@ -1076,5 +1096,156 @@ mod tests {
         .unwrap();
 
         assert_eq!(unspent_note_meta.len(), 1);
+    }
+}
+
+/// Property tests for the lock-state SQL predicates.
+///
+/// These pin the semantics of `lock_expiry_height` against executable models, evaluating the
+/// actual SQL fragments in SQLite (including their NULL behavior) rather than a Rust
+/// re-implementation of them:
+///
+/// - An output is LOCKED for balance purposes while `lock_expiry_height >= target_height`.
+/// - An output is SELECTABLE when it has no lock or `lock_expiry_height < target_height`;
+///   once the lock expiry height is passed, an expired lock is indistinguishable from no
+///   lock for selection and balance, even though the stale column value remains until it is
+///   replaced or cleared.
+/// - A lock may be (re)acquired only when no lock exists or the existing lock has expired as
+///   of the chain tip (`lock_expiry_height <= chain_tip`); with an unknown chain tip only
+///   unlocked outputs may be locked.
+/// - No lock stealing: whenever a lock is replaceable, the output is already selectable at
+///   the next target height, so replacing an expired lock never removes protection from a
+///   still-protected output.
+#[cfg(test)]
+mod lock_predicate_tests {
+    use proptest::prelude::*;
+    use rusqlite::{Connection, named_params};
+
+    use super::{output_lockable_condition, output_unlocked_condition};
+
+    fn lock_state_db(lock_expiry_height: Option<u32>) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER)")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO t (lock_expiry_height) VALUES (:h)",
+            named_params![":h": lock_expiry_height],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// Evaluates `output_unlocked_condition` in SQLite. A NULL result is falsy, as it would
+    /// be in the enclosing `WHERE` clauses.
+    fn sql_unlocked(
+        lock_expiry_height: Option<u32>,
+        target_height: u32,
+        include_locked: bool,
+    ) -> bool {
+        let conn = lock_state_db(lock_expiry_height);
+        conn.query_row(
+            &format!("SELECT ({}) FROM t", output_unlocked_condition("t")),
+            named_params![
+                ":target_height": target_height,
+                ":include_locked": include_locked,
+            ],
+            |row| row.get::<_, Option<bool>>(0),
+        )
+        .unwrap()
+        .unwrap_or(false)
+    }
+
+    /// Evaluates `output_lockable_condition` in SQLite. A NULL result is falsy, as it would
+    /// be in the `UPDATE ... WHERE` clause of `lock_outputs`.
+    fn sql_lockable(lock_expiry_height: Option<u32>, chain_tip: Option<u32>) -> bool {
+        let conn = lock_state_db(lock_expiry_height);
+        conn.query_row(
+            &format!("SELECT ({}) FROM t", output_lockable_condition()),
+            named_params![":chain_tip": chain_tip],
+            |row| row.get::<_, Option<bool>>(0),
+        )
+        .unwrap()
+        .unwrap_or(false)
+    }
+
+    /// The balance-side model: an output is counted as locked value while its lock expiry
+    /// height has not been passed as of the target height.
+    fn model_locked(lock_expiry_height: Option<u32>, target_height: u32) -> bool {
+        lock_expiry_height.map_or(false, |h| h >= target_height)
+    }
+
+    /// A height strategy biased toward the boundary around the given height, where the
+    /// interesting semantics (expiry exactly at the target, one below, one above) live.
+    fn arb_height_near(height: u32) -> impl Strategy<Value = u32> {
+        prop_oneof![
+            3 => height.saturating_sub(3)..=height.saturating_add(3),
+            1 => any::<u32>(),
+        ]
+    }
+
+    fn arb_lock_expiry(target_height: u32) -> impl Strategy<Value = Option<u32>> {
+        prop_oneof![
+            1 => Just(None),
+            4 => arb_height_near(target_height).prop_map(Some),
+        ]
+    }
+
+    proptest! {
+        /// `include_locked: true` disables lock filtering entirely.
+        #[test]
+        fn include_locked_ignores_lock_state(
+            target in any::<u32>(),
+            lock in prop::option::of(any::<u32>()),
+        ) {
+            prop_assert!(sql_unlocked(lock, target, true));
+        }
+
+        /// The selection predicate is the exact complement of the locked-balance predicate:
+        /// an output is never both selectable and counted as locked value, and never
+        /// neither. In particular, once the target height passes the lock expiry height the
+        /// output is selectable again with no unlock call, while the stale column value is
+        /// ignored.
+        #[test]
+        fn selection_is_complement_of_locked_balance(
+            (target, lock) in any::<u32>().prop_flat_map(|t| (Just(t), arb_lock_expiry(t))),
+        ) {
+            let selectable = sql_unlocked(lock, target, false);
+            let locked = model_locked(lock, target);
+            prop_assert!(
+                selectable ^ locked,
+                "selectable = {selectable}, locked = {locked} for lock {lock:?}, target {target}"
+            );
+        }
+
+        /// The lock-acquisition predicate matches its model: a lock slot is free when no
+        /// lock exists or the existing lock has expired as of the chain tip; when the chain
+        /// tip is unknown an existing lock can never be judged expired.
+        #[test]
+        fn lockable_matches_model(
+            (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
+            }),
+        ) {
+            let expected = match lock {
+                None => true,
+                Some(h) => tip.map_or(false, |tip| h <= tip),
+            };
+            prop_assert_eq!(sql_lockable(lock, tip), expected);
+        }
+
+        /// No lock stealing: whenever an existing lock may be replaced (as of chain tip
+        /// `tip`), the output is already selectable at the corresponding target height
+        /// `tip + 1`. Acquiring a lock therefore never displaces a lock that still protects
+        /// its output.
+        #[test]
+        fn lockable_implies_selectable(
+            (tip, lock) in (0..u32::MAX).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip))
+            }),
+        ) {
+            if sql_lockable(lock, Some(tip)) {
+                prop_assert!(sql_unlocked(lock, tip + 1, false));
+            }
+        }
     }
 }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -1,7 +1,7 @@
 //! Functions common to Sapling and Orchard support in the wallet.
 
 use incrementalmerkletree::Position;
-use rusqlite::{Connection, Row, named_params, types::Value};
+use rusqlite::{Connection, Row, ToSql, named_params, types::Value};
 use std::{num::NonZeroU64, rc::Rc};
 
 use zcash_client_backend::{
@@ -139,24 +139,129 @@ pub(crate) fn spent_notes_clause(table_prefix: &str) -> String {
     )
 }
 
-/// Generates an SQL condition that filters out locked notes/outputs.
+/// Generates the SQL condition under which an output is eligible for selection, given the
+/// active [`LockFilter`].
 ///
-/// A note is considered locked when its `lock_expiry_height` is set and greater than or equal
-/// to the target height; equivalently, an output is only selectable once the target height has
-/// advanced strictly beyond its `lock_expiry_height`. This matches the [`WalletWrite::lock_outputs`]
-/// contract, which prevents selection "at any height less than or equal to" the lock expiry
-/// height, and is the exact complement of the locked-balance condition (`lock_expiry_height >=
-/// target_height`) used in balance computation.
+/// An output is *locked for selection* when its `lock_expiry_height` is set and greater than or
+/// equal to the target height; equivalently, it becomes selectable again once the target height
+/// has advanced strictly beyond its `lock_expiry_height`. This matches the
+/// [`WalletWrite::lock_outputs`] contract, which prevents selection "at any height less than or
+/// equal to" the lock expiry height, and is the exact complement of the locked-balance condition
+/// (`lock_expiry_height >= target_height`) used in balance computation.
+///
+/// - [`LockFilter::Unfiltered`] admits every output: the fragment is the constant `1`, so neither
+///   `:target_height` nor `:overridable_owners` is referenced on account of the lock filter and
+///   neither must be bound for its sake.
+/// - [`LockFilter::Policy`] admits an output when it carries no lock, when its lock has expired as
+///   of `:target_height`, or when its `lock_owner` is one of the policy's overridable owners. For
+///   [`LockedInputPolicy::Exclude`] the overridable-owner set is empty, so the `IN rarray(...)`
+///   term is always false and only unlocked outputs are eligible; for the preference variants the
+///   set carries the owners whose locks may be drawn upon. An output locked by any other owner is
+///   never eligible.
 ///
 /// # Usage requirements
 /// - `tbl` must be set to the SQL alias for the received notes/outputs table.
-/// - The parent must provide `:target_height` and `:include_locked` as named arguments.
+/// - Under a [`LockFilter::Policy`] the parent must provide `:target_height` and must bind
+///   `:overridable_owners` to the rarray produced by [`overridable_owners_rarray`]. Under
+///   [`LockFilter::Unfiltered`] neither is referenced by this fragment, and (rusqlite rejecting an
+///   unused named parameter) `:overridable_owners` must not be bound for its sake.
 ///
 /// [`WalletWrite::lock_outputs`]: zcash_client_backend::data_api::WalletWrite::lock_outputs
-pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
-    format!(
-        "{tbl}.lock_expiry_height IS NULL OR {tbl}.lock_expiry_height < :target_height OR :include_locked"
-    )
+/// [`LockedInputPolicy::Exclude`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::Exclude
+pub(crate) fn output_eligible_condition(lock_filter: LockFilter<'_>, tbl: &str) -> String {
+    match lock_filter {
+        LockFilter::Unfiltered => "1".to_string(),
+        LockFilter::Policy(_) => format!(
+            "{tbl}.lock_expiry_height IS NULL \
+             OR {tbl}.lock_expiry_height < :target_height \
+             OR {tbl}.lock_owner IN rarray(:overridable_owners)"
+        ),
+    }
+}
+
+/// Builds the `:overridable_owners` rarray for the given [`LockFilter`]: the byte strings of the
+/// lock owners whose locked outputs the filter's policy admits.
+///
+/// The set is empty under [`LockFilter::Unfiltered`] (which does not reference the parameter) and
+/// under [`LockedInputPolicy::Exclude`] (which admits no locked owner). The returned `Rc` must be
+/// kept alive and bound by reference for the duration of the query, following the same pattern as
+/// the `:exclude` rarray.
+///
+/// [`LockedInputPolicy::Exclude`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::Exclude
+pub(crate) fn overridable_owners_rarray(lock_filter: LockFilter<'_>) -> Rc<Vec<Value>> {
+    let owners = match lock_filter {
+        LockFilter::Unfiltered => Vec::new(),
+        LockFilter::Policy(policy) => policy
+            .overridable_owners()
+            .iter()
+            .map(|owner| Value::from(owner.as_bytes().to_vec()))
+            .collect(),
+    };
+    Rc::new(owners)
+}
+
+/// Appends the lock-filter-dependent named parameters that [`output_eligible_condition`]
+/// references to a selection query's parameter list.
+///
+/// This is the single source of truth pairing the eligibility SQL with its bindings: it binds
+/// `:overridable_owners` (to the `overridable_owners` rarray from [`overridable_owners_rarray`],
+/// which must outlive the query) exactly when the fragment references it, i.e. under a
+/// [`LockFilter::Policy`]. Because rusqlite rejects a provided-but-unreferenced named parameter,
+/// keeping this in lockstep with [`output_eligible_condition`] in one place — rather than repeating
+/// the `matches!` and the `:overridable_owners` literal at each call site — prevents the SQL and
+/// its bindings from silently drifting apart.
+///
+/// `:target_height` is deliberately NOT handled here: every query that uses the eligibility
+/// fragment also references `:target_height` independently of the lock filter (via
+/// `spent_notes_clause` / `tx_unexpired_condition` and the like), so it is always present in the
+/// SQL and is bound unconditionally by the caller.
+pub(crate) fn push_lock_params<'a>(
+    params: &mut Vec<(&'a str, &'a dyn ToSql)>,
+    lock_filter: LockFilter<'_>,
+    overridable_owners: &'a Rc<Vec<Value>>,
+) {
+    if matches!(lock_filter, LockFilter::Policy(_)) {
+        params.push((":overridable_owners", overridable_owners as &dyn ToSql));
+    }
+}
+
+/// Returns the tier-preference sort key `(<lock tier>) ASC|DESC` for a [`LockFilter`] that prefers
+/// one lock tier over the other, or `None` when no tier preference applies
+/// ([`LockedInputPolicy::Exclude`] and [`LockFilter::Unfiltered`], which draw on a single admitted
+/// tier or apply no lock filtering).
+///
+/// The tier expression evaluates to `1` for an output that is locked for selection as of
+/// `:target_height` and `0` otherwise. [`LockedInputPolicy::PreferUnlocked`] sorts it ascending
+/// (unlocked first) and [`LockedInputPolicy::PreferLocked`] descending (owned-locked first).
+/// Because a [`LockFilter::Policy`] `WHERE` clause (see [`output_eligible_condition`]) has already
+/// excluded foreign-owner locks, the `1` tier contains only owned-locked outputs.
+///
+/// This key is a *preference* over an eligible set: callers must combine it with the existing
+/// within-tier ordering (age or value) as a secondary key so that ordering is preserved within
+/// each tier.
+///
+/// # Usage requirements
+/// - `tbl` must be set to the SQL alias for the received notes/outputs table.
+/// - When this returns `Some(_)`, the parent must provide `:target_height`.
+///
+/// [`LockedInputPolicy::Exclude`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::Exclude
+/// [`LockedInputPolicy::PreferUnlocked`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::PreferUnlocked
+/// [`LockedInputPolicy::PreferLocked`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::PreferLocked
+pub(crate) fn locked_tier_order_key(lock_filter: LockFilter<'_>, tbl: &str) -> Option<String> {
+    match lock_filter {
+        LockFilter::Policy(policy) if policy.admits_locked() => {
+            let direction = if policy.prefers_locked() {
+                "DESC"
+            } else {
+                "ASC"
+            };
+            Some(format!(
+                "(CASE WHEN {tbl}.lock_expiry_height IS NOT NULL \
+                  AND {tbl}.lock_expiry_height >= :target_height THEN 1 ELSE 0 END) {direction}"
+            ))
+        }
+        _ => None,
+    }
 }
 
 /// Generates the SQL condition under which an output's lock may be (re)acquired.
@@ -287,6 +392,16 @@ where
         ..
     } = table_constants::<SqliteClientError>(protocol)?;
 
+    let txid_bytes = txid.as_ref();
+    let target_height_arg = u32::from(target_height);
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":txid", &txid_bytes),
+        (":output_index", &index),
+        (":target_height", &target_height_arg),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
+
     let result = conn.query_row_and_then(
         &format!(
             "SELECT rn.id, t.txid, rn.{output_index_col},
@@ -311,17 +426,12 @@ where
              AND rn.nf IS NOT NULL
              AND rn.commitment_tree_position IS NOT NULL
              AND rn.id NOT IN ({}) -- the note is unspent
-             AND ({}) -- the note is not locked
+             AND ({}) -- the note is eligible under the lock filter
              GROUP BY rn.id",
             spent_notes_clause(table_prefix),
-            output_unlocked_condition("rn"),
+            output_eligible_condition(lock_filter, "rn"),
         ),
-        named_params![
-           ":txid": txid.as_ref(),
-           ":output_index": index,
-           ":target_height": u32::from(target_height),
-           ":include_locked": lock_filter.admits_locked(),
-        ],
+        &sql_params[..],
         |row| to_spendable_note(params, protocol, row),
     );
 
@@ -491,11 +601,11 @@ where
          AND ({})  -- the transaction is unexpired
          AND rn.id NOT IN rarray(:exclude)  -- the note is not excluded
          AND rn.id NOT IN ({})  -- the note is unspent
-         AND ({}) -- the note is not locked
+         AND ({}) -- the note is eligible under the lock filter
          GROUP BY rn.id",
         tx_unexpired_condition("t"),
         spent_notes_clause(table_prefix),
-        output_unlocked_condition("rn")
+        output_eligible_condition(lock_filter, "rn")
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -510,14 +620,20 @@ where
         .collect();
     let excluded_ptr = Rc::new(excluded);
 
+    let account_uuid = account.0;
+    let target_height_arg = u32::from(target_height);
+    let min_value = u64::from(zip317::MARGINAL_FEE);
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":account_uuid", &account_uuid),
+        (":target_height", &target_height_arg),
+        (":exclude", &excluded_ptr),
+        (":min_value", &min_value),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
+
     let row_results = stmt_select_notes.query_and_then(
-        named_params![
-            ":account_uuid": account.0,
-            ":target_height": &u32::from(target_height),
-            ":exclude": &excluded_ptr,
-            ":min_value": u64::from(zip317::MARGINAL_FEE),
-            ":include_locked": lock_filter.admits_locked(),
-        ],
+        &sql_params[..],
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, protocol, row)?;
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
@@ -642,13 +758,33 @@ where
     // 3) Select all notes for which the running sum was less than the required value, as
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
+    //
+    // A `LockFilter::Policy` that prefers one lock tier (`PreferUnlocked`/`PreferLocked`)
+    // accumulates the running sum in tier order (via the window `ORDER BY`) so that the
+    // preferred tier is drawn upon first; the age order (`rn.id`) is retained as a secondary
+    // key so that within each tier the oldest notes are still selected first. Because the
+    // tiered window order need not match the CTE's physical output order, the threshold-
+    // crossing note is chosen as the note with the smallest running sum at or above the
+    // target (`ORDER BY so_far`). For `Exclude`/`Unfiltered` the window and crossing-note
+    // selection are unchanged.
+    let tier_key = locked_tier_order_key(lock_filter, "rn");
+    let window_frame = match &tier_key {
+        Some(tier_key) => format!("ORDER BY {tier_key}, rn.id ROWS UNBOUNDED PRECEDING"),
+        None => "ROWS UNBOUNDED PRECEDING".to_string(),
+    };
+    let crossing_note_subquery = if tier_key.is_some() {
+        "SELECT * from eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1"
+    } else {
+        "SELECT * from eligible WHERE so_far >= :target_value LIMIT 1"
+    };
+    let eligible_condition = output_eligible_condition(lock_filter, "rn");
     let mut stmt_select_notes = conn.prepare_cached(&format!(
         "WITH eligible AS (
              SELECT
                  rn.id AS id, t.txid, rn.{output_index_col},
                  rn.diversifier, rn.value,
                  {note_reconstruction_cols}, rn.commitment_tree_position,
-                 SUM(value) OVER (ROWS UNBOUNDED PRECEDING) AS so_far,
+                 SUM(value) OVER ({window_frame}) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,
                  rn.witness_stabilized,
@@ -687,7 +823,7 @@ where
              )
              AND rn.id NOT IN rarray(:exclude)
              AND rn.id NOT IN ({}) -- the note is not spent
-             AND ({}) -- the note is not locked
+             AND ({eligible_condition}) -- the note is eligible under the lock filter
              GROUP BY rn.id
          )
          SELECT id, txid, {output_index_col},
@@ -702,9 +838,8 @@ where
                 ufvk, recipient_key_scope,
                 mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
-         FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
+         FROM ({crossing_note_subquery})",
         spent_notes_clause(table_prefix),
-        output_unlocked_condition("rn")
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -719,38 +854,45 @@ where
         .collect();
     let excluded_ptr = Rc::new(excluded);
 
-    let notes = stmt_select_notes.query_and_then(
-        named_params![
-            ":account_uuid": account.0,
-            ":anchor_height": &u32::from(anchor_height),
-            ":target_height": &u32::from(target_height),
-            ":target_value": &u64::from(target_value),
-            ":exclude": &excluded_ptr,
-            ":scanned_priority": priority_code(&ScanPriority::Scanned),
-            ":tip_unscanned": i64::from(tip_unscanned),
-            ":min_value": u64::from(zip317::MARGINAL_FEE),
-            ":include_locked": lock_filter.admits_locked(),
-        ],
-        |row| {
-            let tx_trust_status = row.get::<_, bool>("trust_status")?;
-            let max_shielding_input_height = row
-                .get::<_, Option<u32>>("max_shielding_input_height")?
-                .map(BlockHeight::from);
-            let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
-            let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
-            let note = to_spendable_note(params, protocol, row)?;
+    let account_uuid = account.0;
+    let anchor_height_arg = u32::from(anchor_height);
+    let target_height_arg = u32::from(target_height);
+    let target_value_arg = u64::from(target_value);
+    let scanned_priority = priority_code(&ScanPriority::Scanned);
+    let tip_unscanned_arg = i64::from(tip_unscanned);
+    let min_value = u64::from(zip317::MARGINAL_FEE);
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":account_uuid", &account_uuid),
+        (":anchor_height", &anchor_height_arg),
+        (":target_height", &target_height_arg),
+        (":target_value", &target_value_arg),
+        (":exclude", &excluded_ptr),
+        (":scanned_priority", &scanned_priority),
+        (":tip_unscanned", &tip_unscanned_arg),
+        (":min_value", &min_value),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
 
-            Ok(note.map(|n| {
-                (
-                    n,
-                    tx_trust_status,
-                    max_shielding_input_height,
-                    tx_shielding_inputs_trusted,
-                    witness_stabilized,
-                )
-            }))
-        },
-    )?;
+    let notes = stmt_select_notes.query_and_then(&sql_params[..], |row| {
+        let tx_trust_status = row.get::<_, bool>("trust_status")?;
+        let max_shielding_input_height = row
+            .get::<_, Option<u32>>("max_shielding_input_height")?
+            .map(BlockHeight::from);
+        let tx_shielding_inputs_trusted = row.get::<_, bool>("min_shielding_input_trust")?;
+        let witness_stabilized = row.get::<_, bool>("witness_stabilized")?;
+        let note = to_spendable_note(params, protocol, row)?;
+
+        Ok(note.map(|n| {
+            (
+                n,
+                tx_trust_status,
+                max_shielding_input_height,
+                tx_shielding_inputs_trusted,
+                witness_stabilized,
+            )
+        }))
+    })?;
 
     notes
         .filter_map(|result_maybe_note| {
@@ -909,7 +1051,22 @@ pub(crate) fn unspent_notes_meta(
         })
     }
 
-    let run_selection = |min_value| {
+    // This is an aggregation, not a value-target selection, so no tier ordering applies; only the
+    // eligibility filter (Part A) is imposed.
+    let eligible_condition = output_eligible_condition(lock_filter, "rn");
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let account_uuid = account.0;
+    let target_height_arg = u32::from(target_height);
+
+    let run_selection = |min_value: Zatoshis| {
+        let min_value = u64::from(min_value);
+        let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+            (":account_uuid", &account_uuid),
+            (":min_value", &min_value),
+            (":exclude", &excluded_ptr),
+            (":target_height", &target_height_arg),
+        ];
+        push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
         conn.query_row_and_then::<_, SqliteClientError, _, _>(
             &format!(
                 "SELECT COUNT(*), SUM(rn.value)
@@ -922,17 +1079,10 @@ pub(crate) fn unspent_notes_meta(
                  AND transactions.mined_height IS NOT NULL
                  AND rn.id NOT IN rarray(:exclude)
                  AND rn.id NOT IN ({}) -- the note is unspent
-                 AND ({}) -- the note is not locked",
+                 AND ({eligible_condition}) -- the note is eligible under the lock filter",
                 spent_notes_clause(table_prefix),
-                output_unlocked_condition("rn")
             ),
-            named_params![
-                ":account_uuid": account.0,
-                ":min_value": u64::from(min_value),
-                ":exclude": &excluded_ptr,
-                ":target_height": u32::from(target_height),
-                ":include_locked": lock_filter.admits_locked(),
-            ],
+            &sql_params[..],
             |row| {
                 Ok((
                     row.get::<_, usize>(0)?,
@@ -1102,17 +1252,25 @@ mod tests {
     }
 }
 
-/// Property tests for the lock-state SQL predicates.
+/// Tests for the lock-state SQL predicates.
 ///
-/// These pin the semantics of `lock_expiry_height` against executable models, evaluating the
-/// actual SQL fragments in SQLite (including their NULL behavior) rather than a Rust
-/// re-implementation of them:
+/// These pin the semantics of the lock columns against executable models, evaluating the actual
+/// SQL fragments in SQLite (including their NULL behavior, `rarray` owner matching, and window
+/// ordering) rather than a Rust re-implementation of them:
 ///
 /// - An output is LOCKED for balance purposes while `lock_expiry_height >= target_height`.
-/// - An output is SELECTABLE when it has no lock or `lock_expiry_height < target_height`;
-///   once the lock expiry height is passed, an expired lock is indistinguishable from no
-///   lock for selection and balance, even though the stale column value remains until it is
-///   replaced or cleared.
+/// - Selection eligibility (`output_eligible_condition`) is owner-scoped:
+///   - `Unfiltered` admits every output;
+///   - `Policy(Exclude)` admits only outputs with no active lock as of the target height (the
+///     exact complement of the locked-balance predicate), so once the target height passes the
+///     lock expiry height an output is eligible again with no unlock call, even though the stale
+///     column value remains until replaced or cleared;
+///   - `Policy(PreferUnlocked | PreferLocked)` additionally admits outputs whose `lock_owner` is
+///     one of the policy's overridable owners, and never an output locked by any other owner.
+/// - Greedy value-target selection is TIERED under a preference policy
+///   (`locked_tier_order_key`): `PreferUnlocked` draws unlocked outputs before owned-locked
+///   ones and `PreferLocked` the reverse, each retaining age order within a tier; `Exclude` and
+///   `Unfiltered` impose no tier preference.
 /// - A lock may be (re)acquired when no lock exists, when the existing lock has expired as of
 ///   the chain tip (`lock_expiry_height <= chain_tip`), or when the existing lock is held by
 ///   the requesting owner (idempotent same-owner re-lock); with an unknown chain tip a
@@ -1123,9 +1281,22 @@ mod tests {
 #[cfg(test)]
 mod lock_predicate_tests {
     use proptest::prelude::*;
-    use rusqlite::{Connection, named_params};
+    use rusqlite::{Connection, ToSql, named_params};
+    use zcash_client_backend::{
+        data_api::wallet::input_selection::{LockFilter, LockedInputPolicy, NonEmptyBTreeSet},
+        wallet::LockOwner,
+    };
 
-    use super::{output_lockable_condition, output_unlocked_condition};
+    use super::{
+        locked_tier_order_key, output_eligible_condition, output_lockable_condition,
+        overridable_owners_rarray, push_lock_params,
+    };
+
+    /// A distinguished lock owner whose locks the preference policies in these tests admit.
+    const OWNER_A: LockOwner = LockOwner::new([0xA1; 32]);
+    /// A distinguished lock owner NOT admitted by the policies, standing in for "some other
+    /// flow's" lock; an output it holds must never be eligible under a `Policy`.
+    const OWNER_B: LockOwner = LockOwner::new([0xB2; 32]);
 
     fn lock_state_db(lock_expiry_height: Option<u32>, lock_owner: Option<[u8; 32]>) -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -1139,24 +1310,151 @@ mod lock_predicate_tests {
         conn
     }
 
-    /// Evaluates `output_unlocked_condition` in SQLite. A NULL result is falsy, as it would
-    /// be in the enclosing `WHERE` clauses.
-    fn sql_unlocked(
+    /// A candidate output for the selection-eligibility and tiering tests: its stable `id`
+    /// (also its age order, oldest first), value, and lock state (`lock_expiry_height` set with
+    /// a `lock_owner` when locked).
+    struct Candidate {
+        id: i64,
+        value: i64,
         lock_expiry_height: Option<u32>,
-        target_height: u32,
-        include_locked: bool,
-    ) -> bool {
-        let conn = lock_state_db(lock_expiry_height, None);
-        conn.query_row(
-            &format!("SELECT ({}) FROM t", output_unlocked_condition("t")),
-            named_params![
-                ":target_height": target_height,
-                ":include_locked": include_locked,
-            ],
-            |row| row.get::<_, Option<bool>>(0),
+        lock_owner: Option<LockOwner>,
+    }
+
+    fn unlocked(id: i64, value: i64) -> Candidate {
+        Candidate {
+            id,
+            value,
+            lock_expiry_height: None,
+            lock_owner: None,
+        }
+    }
+
+    fn locked(id: i64, value: i64, expiry: u32, owner: LockOwner) -> Candidate {
+        Candidate {
+            id,
+            value,
+            lock_expiry_height: Some(expiry),
+            lock_owner: Some(owner),
+        }
+    }
+
+    /// Builds an in-memory table of candidate outputs, with the `rarray` module loaded so that
+    /// the `:overridable_owners` binding used by [`output_eligible_condition`] can be evaluated.
+    fn candidates_db(candidates: &[Candidate]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rusqlite::vtab::array::load_module(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t (
+                 id INTEGER PRIMARY KEY,
+                 value INTEGER NOT NULL,
+                 lock_expiry_height INTEGER,
+                 lock_owner BLOB
+             )",
         )
-        .unwrap()
-        .unwrap_or(false)
+        .unwrap();
+        for c in candidates {
+            conn.execute(
+                "INSERT INTO t (id, value, lock_expiry_height, lock_owner)
+                 VALUES (:id, :value, :h, :owner)",
+                named_params![
+                    ":id": c.id,
+                    ":value": c.value,
+                    ":h": c.lock_expiry_height,
+                    ":owner": c.lock_owner.map(|o| o.as_bytes().to_vec()),
+                ],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    /// A preference policy admitting only [`OWNER_A`]'s locks.
+    fn owner_a_policy(prefer_locked: bool) -> LockedInputPolicy {
+        let owners = NonEmptyBTreeSet::singleton(OWNER_A);
+        if prefer_locked {
+            LockedInputPolicy::PreferLocked(owners)
+        } else {
+            LockedInputPolicy::PreferUnlocked(owners)
+        }
+    }
+
+    /// The set of candidate ids the eligibility fragment admits under `lock_filter`, in id
+    /// order. `:target_height` and `:overridable_owners` are bound only under a `Policy`, since
+    /// the `Unfiltered` fragment (`1`) references neither and rusqlite rejects unused
+    /// parameters.
+    fn eligible_ids(
+        candidates: &[Candidate],
+        target_height: u32,
+        lock_filter: LockFilter<'_>,
+    ) -> Vec<i64> {
+        let conn = candidates_db(candidates);
+        let sql = format!(
+            "SELECT id FROM t WHERE ({}) ORDER BY id",
+            output_eligible_condition(lock_filter, "t"),
+        );
+        let overridable_owners = overridable_owners_rarray(lock_filter);
+        let mut params: Vec<(&str, &dyn ToSql)> = Vec::new();
+        // Unlike the production queries, this isolated table references `:target_height` only
+        // through the eligibility fragment, so it too is bound only under a policy.
+        if matches!(lock_filter, LockFilter::Policy(_)) {
+            params.push((":target_height", &target_height));
+        }
+        push_lock_params(&mut params, lock_filter, &overridable_owners);
+        let mut stmt = conn.prepare(&sql).unwrap();
+        stmt.query_map(&params[..], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    /// The ids selected by a greedy value-target selection composed exactly as
+    /// `select_spendable_notes_matching_value` composes it (eligibility fragment + tiered
+    /// window `so_far` + threshold-crossing note), returned in selection (running-sum) order.
+    fn selection_order(
+        candidates: &[Candidate],
+        target_height: u32,
+        target_value: i64,
+        lock_filter: LockFilter<'_>,
+    ) -> Vec<i64> {
+        let conn = candidates_db(candidates);
+        let eligible_condition = output_eligible_condition(lock_filter, "t");
+        let tier_key = locked_tier_order_key(lock_filter, "t");
+        let window_frame = match &tier_key {
+            Some(k) => format!("ORDER BY {k}, t.id ROWS UNBOUNDED PRECEDING"),
+            None => "ROWS UNBOUNDED PRECEDING".to_string(),
+        };
+        // The crossing note is wrapped in its own subquery (as in the production query) so that
+        // its `LIMIT 1` binds to the crossing selection alone, not to the whole `UNION`.
+        let crossing = if tier_key.is_some() {
+            "SELECT * FROM eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1"
+        } else {
+            "SELECT * FROM eligible WHERE so_far >= :target_value LIMIT 1"
+        };
+        let sql = format!(
+            "WITH eligible AS (
+                 SELECT t.id AS id, SUM(t.value) OVER ({window_frame}) AS so_far
+                 FROM t WHERE ({eligible_condition})
+             )
+             SELECT id FROM (
+                 SELECT id, so_far FROM eligible WHERE so_far < :target_value
+                 UNION
+                 SELECT id, so_far FROM ({crossing})
+             ) ORDER BY so_far",
+        );
+        // `:target_value` is always referenced; the isolated table references `:target_height`
+        // only through the eligibility fragment and tier window, so it is bound only under a
+        // policy.
+        let overridable_owners = overridable_owners_rarray(lock_filter);
+        let mut params: Vec<(&str, &dyn ToSql)> = vec![(":target_value", &target_value)];
+        if matches!(lock_filter, LockFilter::Policy(_)) {
+            params.push((":target_height", &target_height));
+        }
+        push_lock_params(&mut params, lock_filter, &overridable_owners);
+        let mut stmt = conn.prepare(&sql).unwrap();
+        stmt.query_map(&params[..], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 
     /// Evaluates `output_lockable_condition` in SQLite. A NULL result is falsy, as it would
@@ -1183,6 +1481,23 @@ mod lock_predicate_tests {
         lock_expiry_height.is_some_and(|h| h >= target_height)
     }
 
+    /// Whether a note with the given lock expiry height is eligible for selection under
+    /// `Policy(Exclude)` (i.e. unlocked for selection) at `target_height`. The owner is
+    /// irrelevant under `Exclude`, which admits no owner's lock, so a locked candidate records
+    /// [`OWNER_A`].
+    fn exclude_eligible(lock_expiry_height: Option<u32>, target_height: u32) -> bool {
+        let candidate = match lock_expiry_height {
+            None => unlocked(1, 100),
+            Some(h) => locked(1, 100, h, OWNER_A),
+        };
+        !eligible_ids(
+            &[candidate],
+            target_height,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .is_empty()
+    }
+
     /// A height strategy biased toward the boundary around the given height, where the
     /// interesting semantics (expiry exactly at the target, one below, one above) live.
     fn arb_height_near(height: u32) -> impl Strategy<Value = u32> {
@@ -1205,30 +1520,175 @@ mod lock_predicate_tests {
         prop_oneof![Just([0xAA; 32]), Just([0xBB; 32])]
     }
 
+    /// Two unlocked notes, two locked by [`OWNER_A`] (the admitted owner), and one locked by
+    /// [`OWNER_B`] (a foreign owner). All ids are assigned in age order (oldest first), all
+    /// values are equal, and all locks expire at 105, safely above [`TARGET_HEIGHT`], so every
+    /// locked note is "locked for selection".
+    const TARGET_HEIGHT: u32 = 100;
+
+    fn mixed_candidates() -> Vec<Candidate> {
+        vec![
+            unlocked(1, 100),
+            locked(2, 100, 105, OWNER_A),
+            unlocked(3, 100),
+            locked(4, 100, 105, OWNER_B),
+            locked(5, 100, 105, OWNER_A),
+        ]
+    }
+
+    /// `Exclude` admits only unlocked notes, regardless of owner.
+    #[test]
+    fn exclude_selects_only_unlocked() {
+        assert_eq!(
+            eligible_ids(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
+            ),
+            vec![1, 3]
+        );
+    }
+
+    /// `Unfiltered` admits every note, locked or not, by any owner.
+    #[test]
+    fn unfiltered_selects_everything() {
+        assert_eq!(
+            eligible_ids(&mixed_candidates(), TARGET_HEIGHT, LockFilter::Unfiltered),
+            vec![1, 2, 3, 4, 5]
+        );
+    }
+
+    /// Both preference policies admit unlocked notes and the admitted owner's locked notes, but
+    /// never a note locked by a foreign owner (id 4).
+    #[test]
+    fn prefer_policies_admit_unlocked_and_owned_locks_not_foreign() {
+        for prefer_locked in [false, true] {
+            let policy = owner_a_policy(prefer_locked);
+            assert_eq!(
+                eligible_ids(
+                    &mixed_candidates(),
+                    TARGET_HEIGHT,
+                    LockFilter::Policy(&policy),
+                ),
+                vec![1, 2, 3, 5],
+                "prefer_locked = {prefer_locked}"
+            );
+        }
+    }
+
+    /// `PreferUnlocked` draws the unlocked notes first (in age order), reaching into the
+    /// admitted owner's locked notes only to cross the target; the foreign lock never appears.
+    #[test]
+    fn prefer_unlocked_draws_unlocked_before_owned_locks() {
+        let policy = owner_a_policy(false);
+        assert_eq!(
+            selection_order(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                250,
+                LockFilter::Policy(&policy),
+            ),
+            vec![1, 3, 2]
+        );
+    }
+
+    /// `PreferLocked` is the mirror image: the admitted owner's locked notes are drawn first,
+    /// reaching into the unlocked notes only to cross the target; the foreign lock never appears.
+    #[test]
+    fn prefer_locked_draws_owned_locks_before_unlocked() {
+        let policy = owner_a_policy(true);
+        assert_eq!(
+            selection_order(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                250,
+                LockFilter::Policy(&policy),
+            ),
+            vec![2, 5, 1]
+        );
+    }
+
+    /// A preference is only a preference: when the preferred tier alone covers the target, the
+    /// other tier is not drawn upon at all.
+    #[test]
+    fn preference_stays_within_preferred_tier_when_sufficient() {
+        assert_eq!(
+            selection_order(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                150,
+                LockFilter::Policy(&owner_a_policy(false)),
+            ),
+            vec![1, 3],
+            "PreferUnlocked draws only unlocked notes"
+        );
+        assert_eq!(
+            selection_order(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                150,
+                LockFilter::Policy(&owner_a_policy(true)),
+            ),
+            vec![2, 5],
+            "PreferLocked draws only the admitted owner's locked notes"
+        );
+    }
+
+    /// `Unfiltered` imposes no tier preference: it draws purely in age order, so a locked note
+    /// can be selected ahead of a later unlocked one.
+    #[test]
+    fn unfiltered_draws_in_age_order() {
+        assert_eq!(
+            selection_order(
+                &mixed_candidates(),
+                TARGET_HEIGHT,
+                150,
+                LockFilter::Unfiltered
+            ),
+            vec![1, 2]
+        );
+    }
+
     proptest! {
-        /// `include_locked: true` disables lock filtering entirely.
+        /// `LockFilter::Unfiltered` ignores lock state entirely: a candidate is eligible
+        /// whatever its lock expiry height or owner.
         #[test]
-        fn include_locked_ignores_lock_state(
+        fn unfiltered_admits_all_lock_states(
             target in any::<u32>(),
             lock in prop::option::of(any::<u32>()),
         ) {
-            prop_assert!(sql_unlocked(lock, target, true));
+            let candidate = match lock {
+                None => unlocked(1, 100),
+                Some(h) => locked(1, 100, h, OWNER_A),
+            };
+            prop_assert_eq!(
+                eligible_ids(&[candidate], target, LockFilter::Unfiltered),
+                vec![1]
+            );
         }
 
-        /// The selection predicate is the exact complement of the locked-balance predicate:
-        /// an output is never both selectable and counted as locked value, and never
-        /// neither. In particular, once the target height passes the lock expiry height the
-        /// output is selectable again with no unlock call, while the stale column value is
-        /// ignored.
+        /// Under `Policy(Exclude)`, eligibility is the exact complement of the locked-balance
+        /// predicate: an output is eligible for selection iff it is not counted as locked value
+        /// at the target height. Once the target height passes the lock expiry height the output
+        /// is eligible again with no unlock call, while the stale column value is ignored.
         #[test]
-        fn selection_is_complement_of_locked_balance(
+        fn exclude_selection_is_complement_of_locked_balance(
             (target, lock) in any::<u32>().prop_flat_map(|t| (Just(t), arb_lock_expiry(t))),
         ) {
-            let selectable = sql_unlocked(lock, target, false);
-            let locked = model_locked(lock, target);
+            let candidate = match lock {
+                None => unlocked(1, 100),
+                Some(h) => locked(1, 100, h, OWNER_A),
+            };
+            let eligible = !eligible_ids(
+                &[candidate],
+                target,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
+            )
+            .is_empty();
+            let locked_balance = model_locked(lock, target);
             prop_assert!(
-                selectable ^ locked,
-                "selectable = {selectable}, locked = {locked} for lock {lock:?}, target {target}"
+                eligible ^ locked_balance,
+                "eligible = {eligible}, locked = {locked_balance} for lock {lock:?}, target {target}"
             );
         }
 
@@ -1285,7 +1745,7 @@ mod lock_predicate_tests {
         ) {
             let row_owner = lock.map(|_| [0xAA; 32]);
             if sql_lockable(lock, row_owner, Some(tip), [0xBB; 32]) {
-                prop_assert!(sql_unlocked(lock, tip + 1, false));
+                prop_assert!(exclude_eligible(lock, tip + 1));
             }
         }
     }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -8,7 +8,7 @@ use zcash_client_backend::{
     data_api::{
         MaxSpendMode, NoteFilter, NullifierQuery, PoolMeta, SAPLING_SHARD_HEIGHT, TargetValue,
         scanning::ScanPriority,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     wallet::ReceivedNote,
 };
@@ -271,7 +271,7 @@ pub(crate) fn get_spendable_note<P: consensus::Parameters, F, Note>(
     protocol: ShieldedPool,
     target_height: TargetHeight,
     to_spendable_note: F,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -320,7 +320,7 @@ where
            ":txid": txid.as_ref(),
            ":output_index": index,
            ":target_height": u32::from(target_height),
-           ":include_locked": include_locked,
+           ":include_locked": lock_filter.admits_locked(),
         ],
         |row| to_spendable_note(params, protocol, row),
     );
@@ -377,7 +377,7 @@ pub(crate) fn select_spendable_notes<P: consensus::Parameters, F, Note>(
     exclude: &[ReceivedNoteId],
     protocol: ShieldedPool,
     to_spendable_note: F,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -403,7 +403,7 @@ where
             protocol,
             &to_spendable_note,
             NoteRequest::from_max_spend_mode(mode, anchor_height),
-            include_locked,
+            lock_filter,
         ),
         TargetValue::AtLeast(zats) => select_spendable_notes_matching_value(
             conn,
@@ -416,7 +416,7 @@ where
             exclude,
             protocol,
             &to_spendable_note,
-            include_locked,
+            lock_filter,
         ),
     }
 }
@@ -442,7 +442,7 @@ pub(crate) fn select_unspent_notes<P: consensus::Parameters, F, Note>(
     protocol: ShieldedPool,
     to_received_note: F,
     note_request: NoteRequest,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -516,7 +516,7 @@ where
             ":target_height": &u32::from(target_height),
             ":exclude": &excluded_ptr,
             ":min_value": u64::from(zip317::MARGINAL_FEE),
-            ":include_locked": include_locked,
+            ":include_locked": lock_filter.admits_locked(),
         ],
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, protocol, row)?;
@@ -608,7 +608,7 @@ fn select_spendable_notes_matching_value<P: consensus::Parameters, F, Note>(
     exclude: &[ReceivedNoteId],
     protocol: ShieldedPool,
     to_spendable_note: F,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -729,7 +729,7 @@ where
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
             ":tip_unscanned": i64::from(tip_unscanned),
             ":min_value": u64::from(zip317::MARGINAL_FEE),
-            ":include_locked": include_locked,
+            ":include_locked": lock_filter.admits_locked(),
         ],
         |row| {
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
@@ -887,7 +887,7 @@ pub(crate) fn unspent_notes_meta(
     account: AccountUuid,
     filter: &NoteFilter,
     exclude: &[ReceivedNoteId],
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<PoolMeta>, SqliteClientError> {
     let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
 
@@ -931,7 +931,7 @@ pub(crate) fn unspent_notes_meta(
                 ":min_value": u64::from(min_value),
                 ":exclude": &excluded_ptr,
                 ":target_height": u32::from(target_height),
-                ":include_locked": include_locked,
+                ":include_locked": lock_filter.admits_locked(),
             ],
             |row| {
                 Ok((

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -161,22 +161,25 @@ pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
 
 /// Generates the SQL condition under which an output's lock may be (re)acquired.
 ///
-/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`) or when the existing
-/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`). Because balance and
-/// selection evaluate lock state against `target_height = chain_tip + 1`, "expired as of the
-/// chain tip" (`h <= chain_tip`) is exactly "not locked for selection" (`h < target_height`):
-/// a lock can never be stolen while the output is still excluded from selection.
+/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`), when the existing
+/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`), or when the
+/// existing lock is held by the requesting owner (`lock_owner = :owner`), which makes
+/// re-locking by the same owner idempotent. Because balance and selection evaluate lock state
+/// against `target_height = chain_tip + 1`, "expired as of the chain tip" (`h <= chain_tip`)
+/// is exactly "not locked for selection" (`h < target_height`): a lock can never be stolen by
+/// a DIFFERENT owner while the output is still excluded from selection.
 ///
-/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the comparison evaluates to
-/// NULL (falsy), so only outputs with no existing lock can be locked; an existing lock cannot be
-/// judged expired without a height to compare against.
+/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the expiry comparison
+/// evaluates to NULL (falsy), so only outputs with no existing lock, or whose lock the
+/// requesting owner already holds, can be locked; a foreign lock cannot be judged expired
+/// without a height to compare against.
 ///
 /// # Usage requirements
-/// - This condition uses the bare `lock_expiry_height` column name, so it must be used in a
-///   single-table statement (such as the `UPDATE`s in `lock_outputs`).
-/// - The parent must provide `:chain_tip` as a named argument (possibly NULL).
+/// - This condition uses the bare `lock_expiry_height` and `lock_owner` column names, so it
+///   must be used in a single-table statement (such as the `UPDATE`s in `lock_outputs`).
+/// - The parent must provide `:chain_tip` (possibly NULL) and `:owner` as named arguments.
 pub(crate) fn output_lockable_condition() -> &'static str {
-    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip"
+    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip OR lock_owner = :owner"
 }
 
 fn unscanned_tip_exists(
@@ -1110,12 +1113,13 @@ mod tests {
 ///   once the lock expiry height is passed, an expired lock is indistinguishable from no
 ///   lock for selection and balance, even though the stale column value remains until it is
 ///   replaced or cleared.
-/// - A lock may be (re)acquired only when no lock exists or the existing lock has expired as
-///   of the chain tip (`lock_expiry_height <= chain_tip`); with an unknown chain tip only
-///   unlocked outputs may be locked.
-/// - No lock stealing: whenever a lock is replaceable, the output is already selectable at
-///   the next target height, so replacing an expired lock never removes protection from a
-///   still-protected output.
+/// - A lock may be (re)acquired when no lock exists, when the existing lock has expired as of
+///   the chain tip (`lock_expiry_height <= chain_tip`), or when the existing lock is held by
+///   the requesting owner (idempotent same-owner re-lock); with an unknown chain tip a
+///   foreign lock can never be judged expired.
+/// - No lock stealing: whenever a lock held by a DIFFERENT owner is replaceable, the output
+///   is already selectable at the next target height, so replacing an expired lock never
+///   removes protection from a still-protected output.
 #[cfg(test)]
 mod lock_predicate_tests {
     use proptest::prelude::*;
@@ -1123,13 +1127,13 @@ mod lock_predicate_tests {
 
     use super::{output_lockable_condition, output_unlocked_condition};
 
-    fn lock_state_db(lock_expiry_height: Option<u32>) -> Connection {
+    fn lock_state_db(lock_expiry_height: Option<u32>, lock_owner: Option<[u8; 32]>) -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER)")
+        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER, lock_owner BLOB)")
             .unwrap();
         conn.execute(
-            "INSERT INTO t (lock_expiry_height) VALUES (:h)",
-            named_params![":h": lock_expiry_height],
+            "INSERT INTO t (lock_expiry_height, lock_owner) VALUES (:h, :owner)",
+            named_params![":h": lock_expiry_height, ":owner": lock_owner],
         )
         .unwrap();
         conn
@@ -1142,7 +1146,7 @@ mod lock_predicate_tests {
         target_height: u32,
         include_locked: bool,
     ) -> bool {
-        let conn = lock_state_db(lock_expiry_height);
+        let conn = lock_state_db(lock_expiry_height, None);
         conn.query_row(
             &format!("SELECT ({}) FROM t", output_unlocked_condition("t")),
             named_params![
@@ -1157,11 +1161,16 @@ mod lock_predicate_tests {
 
     /// Evaluates `output_lockable_condition` in SQLite. A NULL result is falsy, as it would
     /// be in the `UPDATE ... WHERE` clause of `lock_outputs`.
-    fn sql_lockable(lock_expiry_height: Option<u32>, chain_tip: Option<u32>) -> bool {
-        let conn = lock_state_db(lock_expiry_height);
+    fn sql_lockable(
+        lock_expiry_height: Option<u32>,
+        lock_owner: Option<[u8; 32]>,
+        chain_tip: Option<u32>,
+        requesting_owner: [u8; 32],
+    ) -> bool {
+        let conn = lock_state_db(lock_expiry_height, lock_owner);
         conn.query_row(
             &format!("SELECT ({}) FROM t", output_lockable_condition()),
-            named_params![":chain_tip": chain_tip],
+            named_params![":chain_tip": chain_tip, ":owner": requesting_owner],
             |row| row.get::<_, Option<bool>>(0),
         )
         .unwrap()
@@ -1188,6 +1197,12 @@ mod lock_predicate_tests {
             1 => Just(None),
             4 => arb_height_near(target_height).prop_map(Some),
         ]
+    }
+
+    /// Owners drawn from a two-element pool, so that the requesting owner frequently matches
+    /// (and frequently differs from) the owner recorded on the row.
+    fn arb_owner() -> impl Strategy<Value = [u8; 32]> {
+        prop_oneof![Just([0xAA; 32]), Just([0xBB; 32])]
     }
 
     proptest! {
@@ -1218,32 +1233,58 @@ mod lock_predicate_tests {
         }
 
         /// The lock-acquisition predicate matches its model: a lock slot is free when no
-        /// lock exists or the existing lock has expired as of the chain tip; when the chain
-        /// tip is unknown an existing lock can never be judged expired.
+        /// lock exists, when the existing lock has expired as of the chain tip, or when the
+        /// existing lock is held by the requesting owner; when the chain tip is unknown a
+        /// foreign lock can never be judged expired.
         #[test]
         fn lockable_matches_model(
             (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
                 (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
             }),
+            row_owner in arb_owner(),
+            requesting_owner in arb_owner(),
         ) {
+            // A row with a lock height always records its owner; a row without one records
+            // no owner (the invariant maintained by lock/unlock/clear).
+            let row_owner = lock.map(|_| row_owner);
             let expected = match lock {
                 None => true,
-                Some(h) => tip.is_some_and(|tip| h <= tip),
+                Some(h) => {
+                    tip.is_some_and(|tip| h <= tip) || row_owner == Some(requesting_owner)
+                }
             };
-            prop_assert_eq!(sql_lockable(lock, tip), expected);
+            prop_assert_eq!(
+                sql_lockable(lock, row_owner, tip, requesting_owner),
+                expected
+            );
         }
 
-        /// No lock stealing: whenever an existing lock may be replaced (as of chain tip
-        /// `tip`), the output is already selectable at the corresponding target height
-        /// `tip + 1`. Acquiring a lock therefore never displaces a lock that still protects
-        /// its output.
+        /// Same-owner re-locking is always permitted, regardless of expiry state and even
+        /// when the chain tip is unknown: this is what makes lock acquisition idempotent for
+        /// the flow that holds the lock.
+        #[test]
+        fn same_owner_relock_always_permitted(
+            (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
+            }),
+            owner in arb_owner(),
+        ) {
+            let row_owner = lock.map(|_| owner);
+            prop_assert!(sql_lockable(lock, row_owner, tip, owner));
+        }
+
+        /// No lock stealing: whenever an existing lock held by a DIFFERENT owner may be
+        /// replaced (as of chain tip `tip`), the output is already selectable at the
+        /// corresponding target height `tip + 1`. Acquiring a lock therefore never displaces
+        /// a foreign lock that still protects its output.
         #[test]
         fn lockable_implies_selectable(
             (tip, lock) in (0..u32::MAX).prop_flat_map(|tip| {
                 (Just(tip), arb_lock_expiry(tip))
             }),
         ) {
-            if sql_lockable(lock, Some(tip)) {
+            let row_owner = lock.map(|_| [0xAA; 32]);
+            if sql_lockable(lock, row_owner, Some(tip), [0xBB; 32]) {
                 prop_assert!(sql_unlocked(lock, tip + 1, false));
             }
         }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -139,6 +139,20 @@ pub(crate) fn spent_notes_clause(table_prefix: &str) -> String {
     )
 }
 
+/// Generates an SQL condition that filters out locked notes/outputs.
+///
+/// A note is considered locked when its `lock_expiry_height` is set and greater than the
+/// target height. Locks expire automatically when the chain advances past the expiry height.
+///
+/// # Usage requirements
+/// - `tbl` must be set to the SQL alias for the received notes/outputs table.
+/// - The parent must provide `:target_height` and `:include_locked` as named arguments.
+pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
+    format!(
+        "{tbl}.lock_expiry_height IS NULL OR {tbl}.lock_expiry_height <= :target_height OR :include_locked"
+    )
+}
+
 fn unscanned_tip_exists(
     conn: &Connection,
     anchor_height: BlockHeight,
@@ -219,6 +233,7 @@ pub(crate) fn get_nullifiers<N, F: Fn(&[u8]) -> Result<N, SqliteClientError>>(
 // (https://github.com/rust-lang/rust-clippy/issues/11308) means it fails to identify that the `result` temporary
 // is required in order to resolve the borrows involved in the `query_and_then` call.
 #[allow(clippy::let_and_return)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn get_spendable_note<P: consensus::Parameters, F, Note>(
     conn: &Connection,
     params: &P,
@@ -227,6 +242,7 @@ pub(crate) fn get_spendable_note<P: consensus::Parameters, F, Note>(
     protocol: ShieldedPool,
     target_height: TargetHeight,
     to_spendable_note: F,
+    include_locked: bool,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -265,14 +281,17 @@ where
              AND rn.recipient_key_scope IS NOT NULL
              AND rn.nf IS NOT NULL
              AND rn.commitment_tree_position IS NOT NULL
-             AND rn.id NOT IN ({})
+             AND rn.id NOT IN ({}) -- the note is unspent
+             AND ({}) -- the note is not locked
              GROUP BY rn.id",
-            spent_notes_clause(table_prefix)
+            spent_notes_clause(table_prefix),
+            output_unlocked_condition("rn"),
         ),
         named_params![
            ":txid": txid.as_ref(),
            ":output_index": index,
            ":target_height": u32::from(target_height),
+           ":include_locked": include_locked,
         ],
         |row| to_spendable_note(params, protocol, row),
     );
@@ -329,6 +348,7 @@ pub(crate) fn select_spendable_notes<P: consensus::Parameters, F, Note>(
     exclude: &[ReceivedNoteId],
     protocol: ShieldedPool,
     to_spendable_note: F,
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -354,6 +374,7 @@ where
             protocol,
             &to_spendable_note,
             NoteRequest::from_max_spend_mode(mode, anchor_height),
+            include_locked,
         ),
         TargetValue::AtLeast(zats) => select_spendable_notes_matching_value(
             conn,
@@ -366,6 +387,7 @@ where
             exclude,
             protocol,
             &to_spendable_note,
+            include_locked,
         ),
     }
 }
@@ -391,6 +413,7 @@ pub(crate) fn select_unspent_notes<P: consensus::Parameters, F, Note>(
     protocol: ShieldedPool,
     to_received_note: F,
     note_request: NoteRequest,
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -439,9 +462,11 @@ where
          AND ({})  -- the transaction is unexpired
          AND rn.id NOT IN rarray(:exclude)  -- the note is not excluded
          AND rn.id NOT IN ({})  -- the note is unspent
+         AND ({}) -- the note is not locked
          GROUP BY rn.id",
         tx_unexpired_condition("t"),
-        spent_notes_clause(table_prefix)
+        spent_notes_clause(table_prefix),
+        output_unlocked_condition("rn")
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -461,7 +486,8 @@ where
             ":account_uuid": account.0,
             ":target_height": &u32::from(target_height),
             ":exclude": &excluded_ptr,
-            ":min_value": u64::from(zip317::MARGINAL_FEE)
+            ":min_value": u64::from(zip317::MARGINAL_FEE),
+            ":include_locked": include_locked,
         ],
         |row| -> Result<_, SqliteClientError> {
             let result_note = to_received_note(params, protocol, row)?;
@@ -553,6 +579,7 @@ fn select_spendable_notes_matching_value<P: consensus::Parameters, F, Note>(
     exclude: &[ReceivedNoteId],
     protocol: ShieldedPool,
     to_spendable_note: F,
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
 where
     F: Fn(
@@ -630,7 +657,8 @@ where
                  )
              )
              AND rn.id NOT IN rarray(:exclude)
-             AND rn.id NOT IN ({})
+             AND rn.id NOT IN ({}) -- the note is not spent
+             AND ({}) -- the note is not locked
              GROUP BY rn.id
          )
          SELECT id, txid, {output_index_col},
@@ -646,7 +674,8 @@ where
                 mined_height, witness_stabilized, trust_status,
                 max_shielding_input_height, min_shielding_input_trust
          FROM (SELECT * from eligible WHERE so_far >= :target_value LIMIT 1)",
-        spent_notes_clause(table_prefix)
+        spent_notes_clause(table_prefix),
+        output_unlocked_condition("rn")
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -670,7 +699,8 @@ where
             ":exclude": &excluded_ptr,
             ":scanned_priority": priority_code(&ScanPriority::Scanned),
             ":tip_unscanned": i64::from(tip_unscanned),
-            ":min_value": u64::from(zip317::MARGINAL_FEE)
+            ":min_value": u64::from(zip317::MARGINAL_FEE),
+            ":include_locked": include_locked,
         ],
         |row| {
             let tx_trust_status = row.get::<_, bool>("trust_status")?;
@@ -828,6 +858,7 @@ pub(crate) fn unspent_notes_meta(
     account: AccountUuid,
     filter: &NoteFilter,
     exclude: &[ReceivedNoteId],
+    include_locked: bool,
 ) -> Result<Option<PoolMeta>, SqliteClientError> {
     let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
 
@@ -861,14 +892,17 @@ pub(crate) fn unspent_notes_meta(
                  AND rn.value > :min_value
                  AND transactions.mined_height IS NOT NULL
                  AND rn.id NOT IN rarray(:exclude)
-                 AND rn.id NOT IN ({})",
-                spent_notes_clause(table_prefix)
+                 AND rn.id NOT IN ({}) -- the note is unspent
+                 AND ({}) -- the note is not locked",
+                spent_notes_clause(table_prefix),
+                output_unlocked_condition("rn")
             ),
             named_params![
                 ":account_uuid": account.0,
                 ":min_value": u64::from(min_value),
                 ":exclude": &excluded_ptr,
-                ":target_height": u32::from(target_height)
+                ":target_height": u32::from(target_height),
+                ":include_locked": include_locked,
             ],
             |row| {
                 Ok((

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -382,6 +382,7 @@ CREATE TABLE "sapling_received_notes" (
     address_id INTEGER
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
+    lock_expiry_height INTEGER,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -475,6 +476,7 @@ CREATE TABLE "orchard_received_notes" (
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL DEFAULT 2,
+    lock_expiry_height INTEGER,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -549,6 +551,7 @@ CREATE TABLE ironwood_received_notes (
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL,
+    lock_expiry_height INTEGER,
     UNIQUE (transaction_id, action_index)
 )";
 pub(super) const INDEX_IRONWOOD_RECEIVED_NOTES_ACCOUNT: &str = "
@@ -744,6 +747,7 @@ CREATE TABLE "transparent_received_outputs" (
     max_observed_unspent_height INTEGER,
     address_id INTEGER NOT NULL
         REFERENCES addresses(id) ON DELETE CASCADE,
+    lock_expiry_height INTEGER,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_TRANSPARENT_RECEIVED_OUTPUTS_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -383,6 +383,7 @@ CREATE TABLE "sapling_received_notes" (
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -477,6 +478,7 @@ CREATE TABLE "orchard_received_notes" (
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL DEFAULT 2,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -552,6 +554,7 @@ CREATE TABLE ironwood_received_notes (
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, action_index)
 )";
 pub(super) const INDEX_IRONWOOD_RECEIVED_NOTES_ACCOUNT: &str = "
@@ -748,6 +751,7 @@ CREATE TABLE "transparent_received_outputs" (
     address_id INTEGER NOT NULL
         REFERENCES addresses(id) ON DELETE CASCADE,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_TRANSPARENT_RECEIVED_OUTPUTS_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -666,7 +666,8 @@ CREATE TABLE orchard_ironwood_migration_prep_direct_funding (
 )";
 /// One row per migration transaction. `kind` is `preparation` or `transfer`; `pczt` is the pre-signed
 /// transaction (an opaque, already-versioned `BLOB`); `state` is the lifecycle discriminant, with the
-/// hex broadcast `txid` and `mined_height`. Dependencies are edges in
+/// hex broadcast `txid` and `mined_height`. `lock_owner` records the `LockOwner` under which this
+/// transaction's notes are locked, if any. Dependencies are edges in
 /// `orchard_ironwood_migration_transaction_deps`.
 pub(super) const TABLE_ORCHARD_IRONWOOD_MIGRATION_TRANSACTIONS: &str = "
 CREATE TABLE orchard_ironwood_migration_transactions (
@@ -683,6 +684,7 @@ CREATE TABLE orchard_ironwood_migration_transactions (
     state TEXT NOT NULL,
     txid TEXT,
     mined_height INTEGER,
+    lock_owner BLOB,
     PRIMARY KEY (migration_id, tx_id)
 )";
 /// The dependency edges between migration transactions.

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -29,6 +29,7 @@ mod ironwood_pool_code_views;
 mod ironwood_received_notes;
 mod ironwood_shardtree;
 mod ivk_item_cache;
+mod note_locking;
 mod nullifier_map;
 mod orchard_ironwood_migration_tables;
 mod orchard_note_version;
@@ -148,10 +149,11 @@ pub(super) fn all_migrations<
     //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
     //                                                    /          \         \
     //                                                   /            \      orchard_note_version
-    //                                                  /              \         \
-    //                                                 /                \      ironwood_received_notes
-    //                                                /                  \              |
-    //                                               /                    \     ironwood_pool_code_views
+    //                                                  /              \                      \
+    //                                                 /                \               ironwood_received_notes
+    //                                                /                  \                     /           \
+    //                                               /                    \    ironwood_pool_code_views   note_locking
+    //                                              /                      \
     //                                          ivk_item_cache    add_transparent_receiver_address_index
     //
     let rng = Rc::new(Mutex::new(rng));
@@ -258,6 +260,7 @@ pub(super) fn all_migrations<
         Box::new(ironwood_pool_code_views::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
+        Box::new(note_locking::Migration),
     ]
 }
 
@@ -406,6 +409,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     ironwood_pool_code_views::MIGRATION_ID,
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
+    note_locking::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
@@ -1,0 +1,64 @@
+//! This migration adds `lock_expiry_height` columns to received note tables to support
+//! height-based note locking during proposal creation.
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::{WalletMigrationError, migrations::ironwood_received_notes};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xa1d4a28c_7582_4457_b0f4_d3f297b62a71);
+
+// This migration only appends a nullable column to each of the `sapling_received_notes`,
+// `orchard_received_notes`, `ironwood_received_notes`, and `transparent_received_outputs`
+// tables, so it need only run after the last migration that establishes the schema of those
+// tables. `ironwood_received_notes` is that migration: it transitively depends on every
+// migration that creates or rebuilds any of the four tables (the sapling/orchard/transparent
+// rebuilds all precede it via `orchard_note_version` -> `witness_stabilized_notes` ->
+// `account_delete_cascade`), and it creates the `ironwood_received_notes` table itself.
+const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds lock_expiry_height columns to received note tables for height-based note locking."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        conn.execute_batch(
+            "ALTER TABLE sapling_received_notes ADD COLUMN lock_expiry_height INTEGER;
+             ALTER TABLE orchard_received_notes ADD COLUMN lock_expiry_height INTEGER;
+             ALTER TABLE ironwood_received_notes ADD COLUMN lock_expiry_height INTEGER;
+             ALTER TABLE transparent_received_outputs ADD COLUMN lock_expiry_height INTEGER;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
@@ -1,5 +1,7 @@
-//! This migration adds `lock_expiry_height` columns to received note tables to support
-//! height-based note locking during proposal creation.
+//! This migration adds the note-locking columns to the received note/output tables. The
+//! `lock_expiry_height` column supports height-based note locking during proposal creation, and
+//! the `lock_owner` column records the flow that acquired a lock, so that unlocking is scoped to
+//! the owner and re-locking by the same owner is idempotent.
 use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
@@ -30,7 +32,7 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 
     fn description(&self) -> &'static str {
-        "Adds lock_expiry_height columns to received note tables for height-based note locking."
+        "Adds lock_expiry_height and lock_owner columns to received note tables for note locking."
     }
 }
 
@@ -42,7 +44,11 @@ impl RusqliteMigration for Migration {
             "ALTER TABLE sapling_received_notes ADD COLUMN lock_expiry_height INTEGER;
              ALTER TABLE orchard_received_notes ADD COLUMN lock_expiry_height INTEGER;
              ALTER TABLE ironwood_received_notes ADD COLUMN lock_expiry_height INTEGER;
-             ALTER TABLE transparent_received_outputs ADD COLUMN lock_expiry_height INTEGER;",
+             ALTER TABLE transparent_received_outputs ADD COLUMN lock_expiry_height INTEGER;
+             ALTER TABLE sapling_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE orchard_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE ironwood_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE transparent_received_outputs ADD COLUMN lock_owner BLOB;",
         )?;
 
         Ok(())

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -150,6 +150,7 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
+    include_locked: bool,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -159,6 +160,7 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
         ShieldedPool::Orchard,
         target_height,
         to_received_note,
+        include_locked,
     )
 }
 
@@ -171,6 +173,7 @@ pub(crate) fn get_spendable_ironwood_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
+    include_locked: bool,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -180,12 +183,14 @@ pub(crate) fn get_spendable_ironwood_note<P: consensus::Parameters>(
         ShieldedPool::Ironwood,
         target_height,
         to_received_note,
+        include_locked,
     )
 }
 
 /// Selects spendable Ironwood notes to satisfy the given target value. Ironwood notes are
 /// Orchard-shaped, so this reuses the Orchard note reconstruction; only the pool (and thus the
 /// `ironwood_received_notes` table) differs.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -194,6 +199,7 @@ pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -205,9 +211,11 @@ pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Ironwood,
         to_received_note,
+        include_locked,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -216,6 +224,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -227,6 +236,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Orchard,
         to_received_note,
+        include_locked,
     )
 }
 
@@ -2010,6 +2020,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[],
+                false,
             )
             .unwrap();
             assert_eq!(notes.len(), 2, "both Ironwood notes are spendable");
@@ -2033,6 +2044,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[excluded],
+                false,
             )
             .unwrap();
             assert!(
@@ -2221,6 +2233,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[],
+                false,
             )
             .unwrap()
             .into_iter()

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -814,6 +814,16 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn explicit_note_locking() {
+        testing::pool::explicit_note_locking::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn proposal_level_note_locking() {
+        testing::pool::proposal_level_note_locking::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -839,6 +839,21 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn lock_expiry_restores_spendability() {
+        testing::pool::lock_expiry_restores_spendability::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn lock_conflict_and_batch_atomicity() {
+        testing::pool::lock_conflict_and_batch_atomicity::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn unlock_proposal_inputs_releases_locks() {
+        testing::pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -819,6 +819,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn note_locking_height_boundary() {
+        testing::pool::note_locking_height_boundary::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn proposal_level_note_locking() {
         testing::pool::proposal_level_note_locking::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -12,7 +12,7 @@ use zcash_client_backend::{
     data_api::{
         Account as _, NullifierQuery, TargetValue,
         ll::ReceivedOrchardOutput,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     wallet::ReceivedNote,
 };
@@ -150,7 +150,7 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -160,7 +160,7 @@ pub(crate) fn get_spendable_orchard_note<P: consensus::Parameters>(
         ShieldedPool::Orchard,
         target_height,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -173,7 +173,7 @@ pub(crate) fn get_spendable_ironwood_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -183,7 +183,7 @@ pub(crate) fn get_spendable_ironwood_note<P: consensus::Parameters>(
         ShieldedPool::Ironwood,
         target_height,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -199,7 +199,7 @@ pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -211,7 +211,7 @@ pub(crate) fn select_spendable_ironwood_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Ironwood,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -224,7 +224,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -236,7 +236,7 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Orchard,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -2028,6 +2028,9 @@ pub(crate) mod tests {
             use zcash_client_backend::data_api::{TargetValue, WalletRead};
 
             use crate::wallet::orchard::select_spendable_ironwood_notes;
+            use zcash_client_backend::data_api::wallet::input_selection::{
+                LockFilter, LockedInputPolicy,
+            };
 
             let mut st = TestBuilder::new()
                 .with_network(ironwood_active_network())
@@ -2073,7 +2076,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[],
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap();
             assert_eq!(notes.len(), 2, "both Ironwood notes are spendable");
@@ -2097,7 +2100,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[excluded],
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap();
             assert!(
@@ -2247,6 +2250,9 @@ pub(crate) mod tests {
 
             use crate::error::SqliteClientError;
             use crate::wallet::orchard::select_spendable_ironwood_notes;
+            use zcash_client_backend::data_api::wallet::input_selection::{
+                LockFilter, LockedInputPolicy,
+            };
 
             let mut st = TestBuilder::new()
                 .with_network(ironwood_active_network())
@@ -2286,7 +2292,7 @@ pub(crate) mod tests {
                 target_height,
                 ConfirmationsPolicy::MIN,
                 &[],
-                false,
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .unwrap()
             .into_iter()

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -853,6 +853,19 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>()
     }
 
+    proptest::proptest! {
+        // Each case builds a fresh wallet and replays an operation sequence, so keep the
+        // case count moderate; the sequences themselves explore the expiry boundaries.
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(12))]
+
+        #[test]
+        fn note_locking_model(
+            ops in zcash_client_backend::data_api::testing::pool::arb_lock_ops(3, 10)
+        ) {
+            testing::pool::check_note_locking_model::<OrchardPoolTester>(&ops)
+        }
+    }
+
     #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -824,6 +824,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn clear_locked_outputs() {
+        testing::pool::clear_locked_outputs::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn proposal_level_note_locking() {
         testing::pool::proposal_level_note_locking::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -834,6 +834,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn locked_proposal_proto_roundtrip() {
+        testing::pool::locked_proposal_proto_roundtrip::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -853,6 +853,11 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>()
     }
 
+    #[test]
+    fn spend_policy_locked_input_policy_reaches_selection() {
+        testing::pool::spend_policy_locked_input_policy_reaches_selection::<OrchardPoolTester>()
+    }
+
     proptest::proptest! {
         // Each case builds a fresh wallet and replays an operation sequence, so keep the
         // case count moderate; the sequences themselves explore the expiry boundaries.

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -583,6 +583,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn note_locking_height_boundary() {
+        testing::pool::note_locking_height_boundary::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn proposal_level_note_locking() {
         testing::pool::proposal_level_note_locking::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -603,6 +603,21 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn lock_expiry_restores_spendability() {
+        testing::pool::lock_expiry_restores_spendability::<SaplingPoolTester>()
+    }
+
+    #[test]
+    fn lock_conflict_and_batch_atomicity() {
+        testing::pool::lock_conflict_and_batch_atomicity::<SaplingPoolTester>()
+    }
+
+    #[test]
+    fn unlock_proposal_inputs_releases_locks() {
+        testing::pool::unlock_proposal_inputs_releases_locks::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -588,6 +588,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn clear_locked_outputs() {
+        testing::pool::clear_locked_outputs::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn proposal_level_note_locking() {
         testing::pool::proposal_level_note_locking::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -139,6 +139,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
+    include_locked: bool,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -148,6 +149,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
         ShieldedPool::Sapling,
         target_height,
         to_received_note,
+        include_locked,
     )
 }
 
@@ -156,6 +158,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
 /// If the tip shard has unscanned ranges below the anchor height and greater than or equal to
 /// the wallet birthday, none of our notes can be spent because we cannot construct witnesses at
 /// the provided anchor height.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     conn: &Connection,
     params: &P,
@@ -164,6 +167,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
+    include_locked: bool,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -175,6 +179,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Sapling,
         to_received_note,
+        include_locked,
     )
 }
 

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -617,6 +617,11 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<SaplingPoolTester>()
     }
 
+    #[test]
+    fn spend_policy_locked_input_policy_reaches_selection() {
+        testing::pool::spend_policy_locked_input_policy_reaches_selection::<SaplingPoolTester>()
+    }
+
     proptest::proptest! {
         // Each case builds a fresh wallet and replays an operation sequence, so keep the
         // case count moderate; the sequences themselves explore the expiry boundaries.

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -617,6 +617,19 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<SaplingPoolTester>()
     }
 
+    proptest::proptest! {
+        // Each case builds a fresh wallet and replays an operation sequence, so keep the
+        // case count moderate; the sequences themselves explore the expiry boundaries.
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(12))]
+
+        #[test]
+        fn note_locking_model(
+            ops in zcash_client_backend::data_api::testing::pool::arb_lock_ops(3, 10)
+        ) {
+            testing::pool::check_note_locking_model::<SaplingPoolTester>(&ops)
+        }
+    }
+
     #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -578,6 +578,16 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn explicit_note_locking() {
+        testing::pool::explicit_note_locking::<SaplingPoolTester>()
+    }
+
+    #[test]
+    fn proposal_level_note_locking() {
+        testing::pool::proposal_level_note_locking::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -598,6 +598,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn locked_proposal_proto_roundtrip() {
+        testing::pool::locked_proposal_proto_roundtrip::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -11,7 +11,7 @@ use zcash_client_backend::{
     data_api::{
         Account, NullifierQuery, TargetValue,
         ll::ReceivedSaplingOutput,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     wallet::ReceivedNote,
 };
@@ -139,7 +139,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
     txid: &TxId,
     index: u32,
     target_height: TargetHeight,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::get_spendable_note(
         conn,
@@ -149,7 +149,7 @@ pub(crate) fn get_spendable_sapling_note<P: consensus::Parameters>(
         ShieldedPool::Sapling,
         target_height,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -167,7 +167,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     exclude: &[ReceivedNoteId],
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
     super::common::select_spendable_notes(
         conn,
@@ -179,7 +179,7 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         exclude,
         ShieldedPool::Sapling,
         to_received_note,
-        include_locked,
+        lock_filter,
     )
 }
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -11,7 +11,7 @@ use rand::RngCore;
 use rand_distr::Distribution;
 use rusqlite::OptionalExtension;
 use rusqlite::types::Value;
-use rusqlite::{Connection, Row, named_params};
+use rusqlite::{Connection, Row, ToSql, named_params};
 use tracing::{debug, warn};
 
 use transparent::{
@@ -72,10 +72,16 @@ use crate::{
     error::SqliteClientError,
     util::Clock,
     wallet::{
-        common::{output_unlocked_condition, tx_unexpired_condition},
+        common::{
+            output_eligible_condition, overridable_owners_rarray, push_lock_params,
+            tx_unexpired_condition,
+        },
         get_account, mempool_height,
     },
 };
+// Used only by the value-target transparent selection, which is gated on transparent inputs.
+#[cfg(feature = "transparent-inputs")]
+use crate::wallet::common::locked_tier_order_key;
 
 pub(crate) mod ephemeral;
 
@@ -1305,26 +1311,32 @@ pub(crate) fn get_wallet_transparent_output(
                  ({}) -- the transaction is unexpired
                  AND u.id NOT IN ({}) -- and the output is unspent
                  AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-                 AND ({}) -- the output is not locked
+                 AND ({}) -- the output is eligible under the lock filter
              )
          )",
         tx_unexpired_condition("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
-        output_unlocked_condition("u"),
+        output_eligible_condition(lock_filter, "u"),
     ))?;
 
+    let txid_bytes = outpoint.hash();
+    let output_index = outpoint.n();
+    let target_height_arg = target_height.map(u32::from);
+    let allow_unspendable = target_height.is_none();
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":txid", &txid_bytes),
+        (":output_index", &output_index),
+        (":target_height", &target_height_arg),
+        (":allow_unspendable", &allow_unspendable),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
+
     let result: Result<Option<WalletTransparentOutput<_>>, SqliteClientError> = stmt_select_utxo
-        .query_and_then(
-            named_params![
-                ":txid": outpoint.hash(),
-                ":output_index": outpoint.n(),
-                ":target_height": target_height.map(u32::from),
-                ":allow_unspendable": target_height.is_none(),
-                ":include_locked": lock_filter.admits_locked(),
-            ],
-            |row| to_unspent_transparent_output(conn, row),
-        )?
+        .query_and_then(&sql_params[..], |row| {
+            to_unspent_transparent_output(conn, row)
+        })?
         .next()
         .transpose();
 
@@ -1334,11 +1346,16 @@ pub(crate) fn get_wallet_transparent_output(
 /// Builds the SQL query body shared by `get_spendable_transparent_outputs[_for_addresses]`
 /// and `select_spendable_transparent_outputs`.
 ///
-/// The query body is parameterized over the address-predicate SQL fragment and the
-/// `ORDER BY` fragment, so callers can match on a single address, a set of addresses, or
-/// an account; and can order by address+index (per-address determinism) or by value
-/// descending (value-bounded selection).
-fn spendable_transparent_outputs_query(address_predicate_sql: &str, order_by_sql: &str) -> String {
+/// The query body is parameterized over the address-predicate SQL fragment, the lock-eligibility
+/// fragment (see [`output_eligible_condition`]), and the `ORDER BY` fragment, so callers can match
+/// on a single address, a set of addresses, or an account; and can order by address+index
+/// (per-address determinism) or by value descending (value-bounded selection), optionally prefixed
+/// with a lock-tier preference key.
+fn spendable_transparent_outputs_query(
+    address_predicate_sql: &str,
+    lock_eligible_sql: &str,
+    order_by_sql: &str,
+) -> String {
     format!(
         "SELECT t.txid, u.output_index, u.script,
                 u.value_zat, addresses.key_scope,
@@ -1363,13 +1380,12 @@ fn spendable_transparent_outputs_query(address_predicate_sql: &str, order_by_sql
          ) -- coinbase filter: 0 = all, 1 = coinbase-only, 2 = non-coinbase-only;
            -- unknown tx_index defaults to 1 (non-coinbase) to avoid false positives,
            -- so such outputs are excluded by CoinbaseOnly and included by NonCoinbaseOnly
-         AND ({}) -- the output is not locked
+         AND ({lock_eligible_sql}) -- the output is eligible under the lock filter
          ORDER BY {order_by_sql}",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
         excluding_immature_coinbase_outputs("t"),
-        output_unlocked_condition("u"),
     )
 }
 
@@ -1451,8 +1467,11 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
 
     let coinbase_filter = coinbase_filter_encoding(output_filter);
 
+    // This returns all matching outputs (no value target), so only the eligibility filter
+    // (Part A) applies; no lock-tier ordering is imposed.
     let mut stmt_utxos = conn.prepare_cached(&spendable_transparent_outputs_query(
         "addresses.cached_transparent_receiver_address IN rarray(:addresses)",
+        &output_eligible_condition(lock_filter, "u"),
         "addresses.cached_transparent_receiver_address, u.output_index",
     ))?;
 
@@ -1470,14 +1489,19 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
         .collect();
     let addresses_ptr = Rc::new(address_values);
 
-    let mut rows = stmt_utxos.query(named_params![
-        ":addresses": &addresses_ptr,
-        ":target_height": u32::from(target_height),
-        ":min_confirmations": min_confirmations,
-        ":min_value": u64::from(zip317::MARGINAL_FEE),
-        ":coinbase_filter": coinbase_filter,
-        ":include_locked": lock_filter.admits_locked(),
-    ])?;
+    let target_height_arg = u32::from(target_height);
+    let min_value = u64::from(zip317::MARGINAL_FEE);
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":addresses", &addresses_ptr),
+        (":target_height", &target_height_arg),
+        (":min_confirmations", &min_confirmations),
+        (":min_value", &min_value),
+        (":coinbase_filter", &coinbase_filter),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
+
+    let mut rows = stmt_utxos.query(&sql_params[..])?;
 
     let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
     while let Some(row) = rows.next()? {
@@ -1546,6 +1570,15 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
 
     let coinbase_filter = coinbase_filter_encoding(output_filter);
 
+    // This gathers outputs greedily in `ORDER BY` order until the value target is met, so a
+    // `LockFilter::Policy` that prefers one lock tier prefixes the value ordering with a lock-tier
+    // key (Part B): the preferred tier is drawn upon first, with value-descending order retained as
+    // a secondary key within each tier. For `Exclude`/`Unfiltered` the ordering is unchanged.
+    let order_by_sql = match locked_tier_order_key(lock_filter, "u") {
+        Some(tier_key) => format!("{tier_key}, u.value_zat DESC, u.output_index"),
+        None => "u.value_zat DESC, u.output_index".to_string(),
+    };
+
     // `:has_address_allow_list` and `:addresses` are always bound (the latter to an empty
     // array when there is no allow list), following the same always-bound-flag idiom as
     // `:coinbase_filter`, so that there is a single query text regardless of whether an
@@ -1556,7 +1589,8 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
              :has_address_allow_list = 0
              OR addresses.cached_transparent_receiver_address IN rarray(:addresses)
          )",
-        "u.value_zat DESC, u.output_index",
+        &output_eligible_condition(lock_filter, "u"),
+        &order_by_sql,
     ))?;
 
     // We treat all transparent UTXOs as untrusted; however, if zero-conf shielding
@@ -1574,16 +1608,23 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
         .collect();
     let addresses_ptr = Rc::new(address_values);
 
-    let mut rows = stmt_utxos.query(named_params![
-        ":account_uuid": account.0,
-        ":target_height": u32::from(target_height),
-        ":min_confirmations": min_confirmations,
-        ":min_value": u64::from(zip317::MARGINAL_FEE),
-        ":coinbase_filter": coinbase_filter,
-        ":include_locked": lock_filter.admits_locked(),
-        ":has_address_allow_list": address_allow_list.is_some(),
-        ":addresses": &addresses_ptr,
-    ])?;
+    let account_uuid = account.0;
+    let target_height_arg = u32::from(target_height);
+    let min_value = u64::from(zip317::MARGINAL_FEE);
+    let has_address_allow_list = address_allow_list.is_some();
+    let overridable_owners = overridable_owners_rarray(lock_filter);
+    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+        (":account_uuid", &account_uuid),
+        (":target_height", &target_height_arg),
+        (":min_confirmations", &min_confirmations),
+        (":min_value", &min_value),
+        (":coinbase_filter", &coinbase_filter),
+        (":has_address_allow_list", &has_address_allow_list),
+        (":addresses", &addresses_ptr),
+    ];
+    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
+
+    let mut rows = stmt_utxos.query(&sql_params[..])?;
 
     let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
     let mut accumulated_value: u64 = 0;

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1818,6 +1818,14 @@ pub(crate) fn add_transparent_account_balances(
             balance.with_unshielded_coinbase_balance_mut(|bal| {
                 if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
+                } else if lock_expiry_height
+                    .iter()
+                    .any(|h| *h >= u32::from(target_height))
+                {
+                    // A locked coinbase output (selected by an in-flight shielding
+                    // proposal) is excluded from the spendable balance, exactly like a
+                    // locked non-coinbase output.
+                    bal.add_locked_value(value)
                 } else if is_mature {
                     bal.add_spendable_value(value)
                 } else {

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1272,20 +1272,17 @@ pub(crate) fn excluding_immature_coinbase_outputs(tx: &str) -> String {
 }
 /// Get information about a transparent output controlled by the wallet.
 ///
+/// This is a direct lookup by `outpoint`, not a selection query, so it does not filter on lock
+/// state: a locked output that is otherwise unspent and unexpired is still returned.
+///
 /// # Parameters
 /// - `outpoint`: The identifier for the output to be retrieved.
 /// - `target_height`: The target height of a transaction under construction that will spend the
 ///   returned output. If this is `None`, no spendability checks are performed.
-/// - `lock_filter`: Locked outputs are selected according to this filter (see [`LockFilter`]; a
-///   [`LockFilter::Policy`] carrying the default `Exclude` treats an output whose
-///   `lock_expiry_height` has not passed as of `target_height` as unspendable and excludes it).
-///   Like the other spendability checks, the lock check is skipped entirely when `target_height`
-///   is `None`.
 pub(crate) fn get_wallet_transparent_output(
     conn: &rusqlite::Connection,
     outpoint: &OutPoint,
     target_height: Option<TargetHeight>,
-    lock_filter: LockFilter<'_>,
 ) -> Result<Option<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // This could return as unspent outputs that are actually not spendable, if they are the
     // outputs of deshielding transactions where the spend anchors have been invalidated by a
@@ -1311,27 +1308,23 @@ pub(crate) fn get_wallet_transparent_output(
                  ({}) -- the transaction is unexpired
                  AND u.id NOT IN ({}) -- and the output is unspent
                  AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-                 AND ({}) -- the output is eligible under the lock filter
              )
          )",
         tx_unexpired_condition("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
-        output_eligible_condition(lock_filter, "u"),
     ))?;
 
     let txid_bytes = outpoint.hash();
     let output_index = outpoint.n();
     let target_height_arg = target_height.map(u32::from);
     let allow_unspendable = target_height.is_none();
-    let overridable_owners = overridable_owners_rarray(lock_filter);
-    let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
+    let sql_params: Vec<(&str, &dyn ToSql)> = vec![
         (":txid", &txid_bytes),
         (":output_index", &output_index),
         (":target_height", &target_height_arg),
         (":allow_unspendable", &allow_unspendable),
     ];
-    push_lock_params(&mut sql_params, lock_filter, &overridable_owners);
 
     let result: Result<Option<WalletTransparentOutput<_>>, SqliteClientError> = stmt_select_utxo
         .query_and_then(&sql_params[..], |row| {

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -24,7 +24,7 @@ use zcash_client_backend::{
     data_api::{
         Account, AccountBalance, Balance, CoinbaseFilter, OutputStatusFilter, TargetValue,
         TransactionDataRequest, TransactionStatusFilter, TransparentBalances,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     fees::StandardFeeRule,
     wallet::{
@@ -1270,14 +1270,16 @@ pub(crate) fn excluding_immature_coinbase_outputs(tx: &str) -> String {
 /// - `outpoint`: The identifier for the output to be retrieved.
 /// - `target_height`: The target height of a transaction under construction that will spend the
 ///   returned output. If this is `None`, no spendability checks are performed.
-/// - `include_locked`: When `false`, an output whose `lock_expiry_height` has not passed as of
-///   `target_height` is treated as unspendable and excluded. Like the other spendability checks,
-///   the lock check is skipped entirely when `target_height` is `None`.
+/// - `lock_filter`: Locked outputs are selected according to this filter (see [`LockFilter`]; a
+///   [`LockFilter::Policy`] carrying the default `Exclude` treats an output whose
+///   `lock_expiry_height` has not passed as of `target_height` as unspendable and excludes it).
+///   Like the other spendability checks, the lock check is skipped entirely when `target_height`
+///   is `None`.
 pub(crate) fn get_wallet_transparent_output(
     conn: &rusqlite::Connection,
     outpoint: &OutPoint,
     target_height: Option<TargetHeight>,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Option<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // This could return as unspent outputs that are actually not spendable, if they are the
     // outputs of deshielding transactions where the spend anchors have been invalidated by a
@@ -1319,7 +1321,7 @@ pub(crate) fn get_wallet_transparent_output(
                 ":output_index": outpoint.n(),
                 ":target_height": target_height.map(u32::from),
                 ":allow_unspendable": target_height.is_none(),
-                ":include_locked": include_locked,
+                ":include_locked": lock_filter.admits_locked(),
             ],
             |row| to_unspent_transparent_output(conn, row),
         )?
@@ -1402,7 +1404,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // Defer to the batched query with a singleton address set, so that there is a single query
     // body to maintain. `transparent_received_outputs.address` is always equal to the
@@ -1417,7 +1419,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
         target_height,
         confirmations_policy,
         output_filter,
-        include_locked,
+        lock_filter,
     )
 }
 
@@ -1441,7 +1443,7 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     if addresses.is_empty() {
         return Ok(vec![]);
@@ -1474,7 +1476,7 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
         ":min_confirmations": min_confirmations,
         ":min_value": u64::from(zip317::MARGINAL_FEE),
         ":coinbase_filter": coinbase_filter,
-        ":include_locked": include_locked,
+        ":include_locked": lock_filter.admits_locked(),
     ])?;
 
     let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
@@ -1533,7 +1535,7 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
     target_value: TargetValue,
     max_inputs: usize,
     fee_rule: &StandardFeeRule,
-    include_locked: bool,
+    lock_filter: LockFilter<'_>,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // The post-fee bound for `TargetValue::AtLeast`. `TargetValue::AllFunds` has no bound; we
     // return every eligible output in that case.
@@ -1578,7 +1580,7 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
         ":min_confirmations": min_confirmations,
         ":min_value": u64::from(zip317::MARGINAL_FEE),
         ":coinbase_filter": coinbase_filter,
-        ":include_locked": include_locked,
+        ":include_locked": lock_filter.admits_locked(),
         ":has_address_allow_list": address_allow_list.is_some(),
         ":addresses": &addresses_ptr,
     ])?;

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1270,10 +1270,14 @@ pub(crate) fn excluding_immature_coinbase_outputs(tx: &str) -> String {
 /// - `outpoint`: The identifier for the output to be retrieved.
 /// - `target_height`: The target height of a transaction under construction that will spend the
 ///   returned output. If this is `None`, no spendability checks are performed.
+/// - `include_locked`: When `false`, an output whose `lock_expiry_height` has not passed as of
+///   `target_height` is treated as unspendable and excluded. Like the other spendability checks,
+///   the lock check is skipped entirely when `target_height` is `None`.
 pub(crate) fn get_wallet_transparent_output(
     conn: &rusqlite::Connection,
     outpoint: &OutPoint,
     target_height: Option<TargetHeight>,
+    include_locked: bool,
 ) -> Result<Option<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // This could return as unspent outputs that are actually not spendable, if they are the
     // outputs of deshielding transactions where the spend anchors have been invalidated by a
@@ -1299,11 +1303,13 @@ pub(crate) fn get_wallet_transparent_output(
                  ({}) -- the transaction is unexpired
                  AND u.id NOT IN ({}) -- and the output is unspent
                  AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
+                 AND ({}) -- the output is not locked
              )
          )",
         tx_unexpired_condition("t"),
         spent_utxos_clause(),
-        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
+        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        output_unlocked_condition("u"),
     ))?;
 
     let result: Result<Option<WalletTransparentOutput<_>>, SqliteClientError> = stmt_select_utxo
@@ -1313,6 +1319,7 @@ pub(crate) fn get_wallet_transparent_output(
                 ":output_index": outpoint.n(),
                 ":target_height": target_height.map(u32::from),
                 ":allow_unspendable": target_height.is_none(),
+                ":include_locked": include_locked,
             ],
             |row| to_unspent_transparent_output(conn, row),
         )?

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2848,6 +2848,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn transparent_note_locking() {
+        zcash_client_backend::data_api::testing::transparent::transparent_note_locking(
+            TestDbFactory::default(),
+        );
+    }
+
     /// Re-storing a transparent output with an unknown mined height (`None`) must not discard
     /// the mined height already recorded for its transaction. A `None` height means "we do not
     /// yet know this to have been mined" — for example, an output re-observed via the mempool

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -71,7 +71,10 @@ use crate::{
     AccountRef, AccountUuid, AddressRef, TxRef, UtxoId,
     error::SqliteClientError,
     util::Clock,
-    wallet::{common::tx_unexpired_condition, get_account, mempool_height},
+    wallet::{
+        common::{output_unlocked_condition, tx_unexpired_condition},
+        get_account, mempool_height,
+    },
 };
 
 pub(crate) mod ephemeral;
@@ -1351,11 +1354,13 @@ fn spendable_transparent_outputs_query(address_predicate_sql: &str, order_by_sql
          ) -- coinbase filter: 0 = all, 1 = coinbase-only, 2 = non-coinbase-only;
            -- unknown tx_index defaults to 1 (non-coinbase) to avoid false positives,
            -- so such outputs are excluded by CoinbaseOnly and included by NonCoinbaseOnly
+         AND ({}) -- the output is not locked
          ORDER BY {order_by_sql}",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
         excluding_immature_coinbase_outputs("t"),
+        output_unlocked_condition("u"),
     )
 }
 
@@ -1390,6 +1395,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
+    include_locked: bool,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // Defer to the batched query with a singleton address set, so that there is a single query
     // body to maintain. `transparent_received_outputs.address` is always equal to the
@@ -1404,6 +1410,7 @@ pub(crate) fn get_spendable_transparent_outputs<P: consensus::Parameters>(
         target_height,
         confirmations_policy,
         output_filter,
+        include_locked,
     )
 }
 
@@ -1427,6 +1434,7 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
     target_height: TargetHeight,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
+    include_locked: bool,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     if addresses.is_empty() {
         return Ok(vec![]);
@@ -1459,6 +1467,7 @@ pub(crate) fn get_spendable_transparent_outputs_for_addresses<P: consensus::Para
         ":min_confirmations": min_confirmations,
         ":min_value": u64::from(zip317::MARGINAL_FEE),
         ":coinbase_filter": coinbase_filter,
+        ":include_locked": include_locked,
     ])?;
 
     let mut utxos = Vec::<WalletTransparentOutput<_>>::new();
@@ -1517,6 +1526,7 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
     target_value: TargetValue,
     max_inputs: usize,
     fee_rule: &StandardFeeRule,
+    include_locked: bool,
 ) -> Result<Vec<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // The post-fee bound for `TargetValue::AtLeast`. `TargetValue::AllFunds` has no bound; we
     // return every eligible output in that case.
@@ -1561,6 +1571,7 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
         ":min_confirmations": min_confirmations,
         ":min_value": u64::from(zip317::MARGINAL_FEE),
         ":coinbase_filter": coinbase_filter,
+        ":include_locked": include_locked,
         ":has_address_allow_list": address_allow_list.is_some(),
         ":addresses": &addresses_ptr,
     ])?;
@@ -1642,19 +1653,19 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     let mut result = HashMap::new();
 
     let mut stmt_address_balances = conn.prepare(&format!(
-        "SELECT u.address, u.value_zat, addresses.key_scope
+        "SELECT u.address, u.value_zat, u.lock_expiry_height, addresses.key_scope
          FROM transparent_received_outputs u
          JOIN accounts ON accounts.id = u.account_id
          JOIN transactions t ON t.id_tx = u.transaction_id
          JOIN addresses ON addresses.id = u.address_id
          WHERE accounts.uuid = :account_uuid
          AND u.value_zat > 0
-         AND ({}) -- the transaction is mined or unexpired with minconf 0
+         AND ({}) -- the output is mined with sufficient confirmations, or is unexpired and minconf is 0
          AND u.id NOT IN ({}) -- and the output is unspent
          AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
-        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
+        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
     ))?;
 
     let mut rows = stmt_address_balances.query(named_params![
@@ -1667,20 +1678,31 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
         let taddr_str: String = row.get("address")?;
         let taddr = TransparentAddress::decode(params, &taddr_str)?;
         let value = Zatoshis::from_nonnegative_i64(row.get("value_zat")?)?;
+        let lock_expiry_height: Option<u32> = row.get("lock_expiry_height")?;
         let key_scope_code: i64 = row.get("key_scope")?;
         let key_origin = KeyScope::decode(key_scope_code)?.as_key_origin();
 
         let entry = result.entry(taddr).or_insert((key_origin, Balance::ZERO));
         if value <= zip317::MARGINAL_FEE {
             entry.1.add_uneconomic_value(value)?;
+        } else if lock_expiry_height
+            .iter()
+            .any(|h| *h >= u32::from(target_height))
+        {
+            entry.1.add_locked_value(value)?;
         } else {
             entry.1.add_spendable_value(value)?;
         }
     }
 
+    // Compute pending spendable balance.
+    //
     // Pending spendable balance for transparent UTXOs is only relevant for min_confirmations > 0;
     // with min_confirmations == 0, zero-conf spends are allowed and therefore the value will
-    // appear in the spendable balance and we don't want to double-count it.
+    // appear in the spendable balance and we don't want to also count it as pending.
+    //
+    // For pending value, we can ignore locking considerations until the balance is no longer
+    // pending, so we don't check locking here.
     if min_confirmations > 0 {
         let mut stmt_address_balances = conn.prepare(&format!(
             "SELECT u.address, u.value_zat, addresses.key_scope
@@ -1750,7 +1772,7 @@ pub(crate) fn add_transparent_account_balances(
     };
 
     let mut stmt_account_spendable_balances = conn.prepare(&format!(
-        "SELECT accounts.uuid, SUM(u.value_zat),
+        "SELECT accounts.uuid, u.lock_expiry_height, SUM(u.value_zat),
             (IFNULL(t.tx_index, 1) == 0) AS is_coinbase,
             (t.mined_height IS NOT NULL
              AND :target_height - t.mined_height >= {COINBASE_MATURITY_BLOCKS}) AS is_mature
@@ -1761,10 +1783,10 @@ pub(crate) fn add_transparent_account_balances(
          WHERE ({}) -- the transaction is mined or unexpired with minconf 0
          AND u.id NOT IN ({}) -- and the received txo is unspent
          AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-         GROUP BY accounts.uuid, is_coinbase, is_mature",
+         GROUP BY accounts.uuid, lock_expiry_height, is_coinbase, is_mature",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
-        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
+        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
     ))?;
 
     let mut rows = stmt_account_spendable_balances.query(named_params![
@@ -1774,7 +1796,8 @@ pub(crate) fn add_transparent_account_balances(
 
     while let Some(row) = rows.next()? {
         let account = AccountUuid(row.get(0)?);
-        let raw_value = row.get(1)?;
+        let lock_expiry_height: Option<u32> = row.get(1)?;
+        let raw_value = row.get(2)?;
         let value = Zatoshis::from_nonnegative_i64(raw_value).map_err(|_| {
             SqliteClientError::CorruptedData(format!("Negative UTXO value {raw_value:?}"))
         })?;
@@ -1800,6 +1823,11 @@ pub(crate) fn add_transparent_account_balances(
             balance.with_unshielded_regular_balance_mut(|bal| {
                 if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
+                } else if lock_expiry_height
+                    .iter()
+                    .any(|h| *h >= u32::from(target_height))
+                {
+                    bal.add_locked_value(value)
                 } else {
                     bal.add_spendable_value(value)
                 }
@@ -1813,7 +1841,7 @@ pub(crate) fn add_transparent_account_balances(
     // TODO (#1592): Ability to distinguish between Transparent pending change and pending non-change
     if min_confirmations > 0 {
         let mut stmt_account_unconfirmed_balances = conn.prepare(&format!(
-            "SELECT accounts.uuid, SUM(u.value_zat),
+            "SELECT accounts.uuid, u.lock_expiry_height, SUM(u.value_zat),
                 (IFNULL(t.tx_index, 1) == 0) AS is_coinbase
              FROM transparent_received_outputs u
              JOIN accounts ON accounts.id = u.account_id
@@ -1833,9 +1861,9 @@ pub(crate) fn add_transparent_account_balances(
              )
              AND u.id NOT IN ({}) -- and the received txo is unspent
              AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-             GROUP BY accounts.uuid, is_coinbase",
+             GROUP BY accounts.uuid, lock_expiry_height, is_coinbase",
             spent_utxos_clause(),
-            excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
+            excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
         ))?;
 
         let mut rows = stmt_account_unconfirmed_balances.query(named_params![
@@ -1845,7 +1873,8 @@ pub(crate) fn add_transparent_account_balances(
 
         while let Some(row) = rows.next()? {
             let account = AccountUuid(row.get(0)?);
-            let raw_value = row.get(1)?;
+            let lock_expiry_height: Option<u32> = row.get(1)?;
+            let raw_value = row.get(2)?;
             let value = Zatoshis::from_nonnegative_i64(raw_value).map_err(|_| {
                 SqliteClientError::CorruptedData(format!("Negative UTXO value {raw_value:?}"))
             })?;
@@ -1854,6 +1883,11 @@ pub(crate) fn add_transparent_account_balances(
             let add_pending = |bal: &mut Balance| {
                 if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
+                } else if lock_expiry_height
+                    .iter()
+                    .any(|h| *h >= u32::from(target_height))
+                {
+                    bal.add_locked_value(value)
                 } else {
                     bal.add_pending_spendable_value(value)
                 }

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -290,6 +290,17 @@ pub struct MigrationTransaction {
     /// The transaction's lifecycle state.
     #[getset(get_copy = "pub")]
     pub(crate) state: MigrationTxState,
+    /// The opaque lock-owner token under which this transaction's input notes are locked, or
+    /// `None` if it holds no lock. These are the raw bytes of a wallet's
+    /// `zcash_client_backend::wallet::LockOwner` (its `LockOwner::as_bytes()` /
+    /// `LockOwner::new()` round-trip) — carried here as an opaque `[u8; 32]` rather than the typed
+    /// `LockOwner` because this `orchard`-gated engine module must not depend on
+    /// `zcash_client_backend` (only `wallet`-feature code does); the conversion to/from `LockOwner`
+    /// happens at that boundary, not here. The migration flow does not yet acquire locks, so every
+    /// transaction the engine itself builds carries `None`; a store still round-trips whatever a
+    /// caller sets.
+    #[getset(get_copy = "pub")]
+    pub(crate) lock_owner: Option<[u8; 32]>,
 }
 
 impl MigrationTransaction {
@@ -306,6 +317,7 @@ impl MigrationTransaction {
         expiry_height: BlockHeight,
         anchor_boundary: Option<BlockHeight>,
         state: MigrationTxState,
+        lock_owner: Option<[u8; 32]>,
     ) -> Self {
         Self {
             id,
@@ -316,6 +328,7 @@ impl MigrationTransaction {
             expiry_height,
             anchor_boundary,
             state,
+            lock_owner,
         }
     }
 }
@@ -2171,6 +2184,9 @@ where
                     expiry_height,
                     anchor_boundary: None,
                     state: tx_state,
+                    // The engine does not yet acquire locks; a later slice that draws a
+                    // `LockOwner` for the commit would set this here.
+                    lock_owner: None,
                 });
             }
             self.layer_ids.push(this_layer_ids);
@@ -2321,6 +2337,9 @@ where
                 expiry_height: schedule.expiry_height(),
                 anchor_boundary: Some(anchor_boundary),
                 state: tx_state,
+                // The engine does not yet acquire locks; a later slice that draws a
+                // `LockOwner` for the commit would set this here.
+                lock_owner: None,
             });
             self.transfer_funding.push((id, note));
         }
@@ -2697,6 +2716,7 @@ mod tests {
             expiry_height: BlockHeight::from_u32(2_069_220),
             anchor_boundary: None,
             state: MigrationTxState::Signed,
+            lock_owner: None,
         };
         let state = MigrationState {
             status: MigrationStatus::Committed,

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -510,6 +510,7 @@ mod tests {
             expiry_height: BlockHeight::from_u32(0),
             anchor_boundary: None,
             state,
+            lock_owner: None,
         }
     }
 

--- a/zcash_pool_migration_backend/src/testing.rs
+++ b/zcash_pool_migration_backend/src/testing.rs
@@ -162,6 +162,13 @@ pub fn arb_migration_status() -> impl Strategy<Value = MigrationStatus> {
     ]
 }
 
+/// An arbitrary lock-owner token: `None` (no lock held) or the raw bytes of a
+/// `zcash_client_backend::wallet::LockOwner` (opaque here — this crate does not depend on
+/// `zcash_client_backend`).
+pub fn arb_lock_owner() -> impl Strategy<Value = Option<[u8; 32]>> {
+    prop::option::of(any::<[u8; 32]>())
+}
+
 /// An arbitrary [`MigrationTransaction`], built through [`MigrationTransaction::from_parts`]. Its id
 /// is arbitrary here; [`arb_migration_state`] re-keys the transactions it holds so their ids stay
 /// unique within a migration.
@@ -175,6 +182,7 @@ pub fn arb_migration_transaction() -> impl Strategy<Value = MigrationTransaction
         arb_block_height(),
         prop::option::of(arb_block_height()),
         arb_migration_tx_state(),
+        arb_lock_owner(),
     )
         .prop_map(
             |(
@@ -186,6 +194,7 @@ pub fn arb_migration_transaction() -> impl Strategy<Value = MigrationTransaction
                 expiry_height,
                 anchor_boundary,
                 state,
+                lock_owner,
             )| {
                 MigrationTransaction::from_parts(
                     id,
@@ -196,6 +205,7 @@ pub fn arb_migration_transaction() -> impl Strategy<Value = MigrationTransaction
                     expiry_height,
                     anchor_boundary,
                     state,
+                    lock_owner,
                 )
             },
         )
@@ -228,6 +238,7 @@ pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
                         tx.expiry_height(),
                         tx.anchor_boundary(),
                         tx.state(),
+                        tx.lock_owner(),
                     )
                 })
                 .collect();

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -35,13 +35,16 @@ use shardtree::error::ShardTreeError;
 
 use ::pczt::roles::prover::Prover;
 use ::pczt::roles::updater::{AnchorUpdateError, SpendWitnessUpdateError, Updater};
-use zcash_client_backend::data_api::wallet::TargetHeight;
-use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead};
+use zcash_client_backend::data_api::{
+    InputSource, WalletCommitmentTrees, WalletRead,
+    wallet::{
+        TargetHeight,
+        input_selection::{LockFilter, LockedInputPolicy},
+    },
+};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::builder::cached_orchard_proving_key;
-use zcash_protocol::ShieldedPool;
-use zcash_protocol::consensus::BlockHeight;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 
 use crate::build::sign_pczt;
 use crate::engine::{
@@ -161,7 +164,13 @@ where
         let target = self.selection_target()?;
         let received = self
             .wallet
-            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[], false)
+            .select_unspent_notes(
+                self.account,
+                &[ShieldedPool::Orchard],
+                target,
+                &[],
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
+            )
             .map_err(Error::InputSource)?;
         let mut notes: Vec<SpendableNote> = received
             .orchard()
@@ -475,7 +484,13 @@ where
             .ok_or(WalletProveError::ChainTipUnknown)?;
         let received = self
             .wallet
-            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
+            .select_unspent_notes(
+                self.account,
+                &[ShieldedPool::Orchard],
+                target,
+                &[],
+                LockFilter::Unfiltered,
+            )
             .map_err(WalletProveError::Notes)?;
         let positions: BTreeMap<Nullifier, Position> = received
             .orchard()

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -161,7 +161,7 @@ where
         let target = self.selection_target()?;
         let received = self
             .wallet
-            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[])
+            .select_unspent_notes(self.account, &[ShieldedPool::Orchard], target, &[], false)
             .map_err(Error::InputSource)?;
         let mut notes: Vec<SpendableNote> = received
             .orchard()

--- a/zcash_pool_migration_backend/tests/engine_plan.rs
+++ b/zcash_pool_migration_backend/tests/engine_plan.rs
@@ -237,6 +237,7 @@ fn stores_loads_and_updates_a_migration() {
         BlockHeight::from_u32(2_069_220),
         None,
         MigrationTxState::Signed,
+        None,
     );
     let state = MigrationState::from_parts(
         MigrationStatus::Committed,

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -225,6 +225,7 @@ fn set_transaction_state(stored: &mut MigrationState, id: MigrationTxId, state: 
                     t.expiry_height(),
                     t.anchor_boundary(),
                     state,
+                    t.lock_owner(),
                 )
             } else {
                 t.clone()


### PR DESCRIPTION
## Note locking

Adds a note/UTXO locking facility to `zcash_client_backend` and `zcash_client_sqlite`, allowing a wallet to reserve the inputs selected by an in-flight transaction proposal or PCZT so that concurrent proposals for the same account do not select the same outputs. This addresses the gap described in the Zallet audit, where overlapping `z_sendmany`/`z_shieldcoinbase` operations on one account could select the same inputs during the proving-long selection→store window and each build, sign, and broadcast — wasting proving work and producing a self-healing but confusing conflict.

Continues the work in #2162 (author @nuttycom); part of the ZIP 318 / Ironwood migration stack.

Closes #2161.

### What this adds

- **`OutputRef`** (`zcash_client_backend::wallet`): a cross-pool reference to a received output `(txid, pool, output_index)`, with `From<NoteId>`. `ProposalError::ChainDoubleSpend` now wraps an `OutputRef` instead of an ad-hoc `(PoolType, TxId, u32)` tuple.
- **`WalletWrite::lock_outputs` / `unlock_output` / `clear_locked_outputs`**, plus `WalletTest::get_locked_outputs`. `lock_outputs` takes a sequence and locks it atomically (all-or-nothing), failing with `LockError::LockFailure` if any output is already locked; expired locks are replaced. `clear_locked_outputs` releases every lock for an account, as a recovery path for lost proposals (e.g. the app was killed before the transaction could be built).
- A **`lock_expiry_height` column** on the four received-notes/outputs tables (`sapling`, `orchard`, `ironwood`, `transparent`), via a new migration. A note is locked while `lock_expiry_height >= target_height`; locks expire automatically as the chain advances.
- An **`include_locked: bool` parameter** on the `InputSource` selection/metadata methods, threaded through to the SQL queries so locked notes are excluded from selection (and from spendable balance) by default.
- A **`lock_for_blocks: Option<u32>` parameter** on `propose_transfer`, `propose_standard_transfer_to_address`, `propose_send_max_transfer`, and `propose_shielding`. When `Some(n)`, the proposal's inputs are locked until `target_height + n`; when `None`, no locking occurs. `unlock_proposal_inputs` releases them on the abandon/reject path.
- **Balance** gains a `locked_value` component (`Balance`, `AccountBalance`). Locked funds move out of the spendable total but remain part of `total()`.
- `store_transactions_to_be_sent` unlocks any outputs recorded as spent by the stored transactions, since the spend records then prevent re-selection.

### Design notes

- **`lock_for_blocks: Option<u32>` vs `lock_notes: bool`.** #2161 originally proposed a `lock_notes: bool`. This PR uses the height-based `Option<u32>` instead: `Some(n)` is "lock with an expiry window", `None` is "do not lock". It is strictly more expressive and matches the `lock_expiry_height` column. This is intentional and documented on `propose_transfer`.
- **Concurrency / TOCTOU.** Note selection and locking cannot be one atomic step above the storage layer, so two callers may select overlapping inputs before either locks them. The conflict is resolved at the storage layer: the second `lock_outputs` fails with `LockError::LockFailure`, surfaced through proposal creation as `ProposalError::ChainDoubleSpend`. The losing caller has locked nothing partially and should treat it as "account busy" and retry. Documented on `WalletWrite::lock_outputs` and the proposal functions.
- **Selection/balance boundary.** The selection filter (`lock_expiry_height < target_height` ⇒ selectable) is the exact complement of the locked-balance condition (`lock_expiry_height >= target_height` ⇒ locked), so a note is never simultaneously spendable and counted as locked. A boundary test exercises `lock_expiry_height == target_height` and `== target_height - 1`.
- **Atomicity.** In the SQLite backend, `lock_outputs`, `unlock_output`, and `clear_locked_outputs` each run within a single storage transaction; the batch lock is all-or-nothing.

### Breaking changes

- `InputSource` selection/metadata methods gain `include_locked: bool` (downstream `InputSource` implementers must update their signatures).
- The four `propose_*` functions gain `lock_for_blocks: Option<u32>` and now require `WalletWrite` rather than `WalletRead`.
- `ProposalError::ChainDoubleSpend` now wraps `OutputRef`.
- `Balance::total` / `AccountBalance::total` now include locked value; callers computing a total from `spendable_value` alone must add `locked_value`.

See the `zcash_client_backend` and `zcash_client_sqlite` CHANGELOGs for the full list.

### Testing

- `explicit_note_locking`, `proposal_level_note_locking`, `note_locking_height_boundary`, and `clear_locked_outputs` pool tests, run for both Sapling and Orchard, plus the migration test.
- Full `zcash_client_sqlite` and `zcash_client_backend` suites pass with `--all-features`; `clippy --all-features --all-targets` is clean; verified across `--no-default-features`, `transparent-inputs`, `orchard`, and `orchard,transparent-inputs` feature combinations.
