### PR TITLE
zcash_pool_migration_backend: test single-quantum migration

### DIFF
--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -332,6 +332,115 @@ mod tests {
         assert_eq!(p.change(), Some(zat(below)));
     }
 
+    /// The largest reserved preparation fee the single-quantum tests sample. Kept below the smallest
+    /// gap between adjacent denominations (`RESIDUAL_MIGRATION_MIN`, the 0.01 -> 0.02 ZEC step) so
+    /// that `quantum + fee` never rounds up to the next `{1, 2, 5} * 10^k` denomination: the plan
+    /// must then pick exactly the quantum. Realistic ZIP-317 preparation fees are far smaller (a
+    /// handful of marginal fees).
+    const MAX_SINGLE_QUANTUM_PREP_FEE_ZATOSHI: u64 = COIN / 200; // 0.005 ZEC, half the minimum denom
+
+    /// Every `{1, 2, 5} * 10^k` denomination (a "quantum") within the valid range
+    /// `[RESIDUAL_MIGRATION_MIN, MIGRATION_MAX_DENOMINATION_ZEC]`, in zatoshi. These are exactly the
+    /// crossing values the strategy can emit, so a balance of one of them plus its fees is the
+    /// smallest input that migrates that denomination as a single note.
+    fn all_quanta() -> Vec<u64> {
+        let min = u64::from(RESIDUAL_MIGRATION_MIN);
+        let cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
+        let mut quanta = Vec::new();
+        let mut pow = 1u64;
+        while pow <= cap {
+            for m in [1u64, 2, 5] {
+                let q = m * pow;
+                if (min..=cap).contains(&q) {
+                    quanta.push(q);
+                }
+            }
+            match pow.checked_mul(10) {
+                Some(p) => pow = p,
+                None => break,
+            }
+        }
+        quanta
+    }
+
+    /// A single `{1, 2, 5} * 10^k` denomination drawn from [`all_quanta`].
+    fn arb_quantum() -> impl Strategy<Value = u64> {
+        prop::sample::select(all_quanta())
+    }
+
+    /// A balance of exactly one `quantum` plus its fees (the ZIP-317 transfer buffer that funds the
+    /// crossing note, and one reserved preparation-transaction fee) is the smallest input that
+    /// migrates that denomination: the plan is a single crossing note of exactly `quantum`, reserves
+    /// exactly one preparation fee, and leaves no change.
+    fn assert_one_quantum_plus_fees(quantum: u64, prep_fee: u64) {
+        let buffer = zip317_buffer();
+        let balance = quantum + buffer + prep_fee;
+        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let p = s.plan(zat(balance), zat(prep_fee), &prep_tx_count_stub, &mut rng);
+
+        assert_eq!(
+            crossings_u64(&p),
+            vec![quantum],
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(
+            p.migration_outputs()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum + buffer],
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(
+            u64::from(p.total_migratable()),
+            quantum,
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        // One prepared note is one padded preparation transaction, so exactly one fee is reserved.
+        assert_eq!(
+            u64::from(p.prep_fees()),
+            prep_fee,
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(p.change(), None, "quantum {quantum}, prep fee {prep_fee}");
+    }
+
+    /// A balance of exactly one quantum plus fees migrates that quantum as a single note, across a
+    /// few example denominations spanning the `{1, 2, 5} * 10^k` series from the 0.01 ZEC minimum to
+    /// the 10,000 ZEC cap.
+    #[test]
+    fn single_quantum_plus_fees_migrates_exactly_one_note() {
+        // A realistic reserved preparation fee: the ZIP-317 marginal fee for a few actions.
+        let prep_fee = 3 * MARGINAL_FEE.into_u64();
+        let examples = [
+            u64::from(RESIDUAL_MIGRATION_MIN), // 0.01 ZEC, the minimum denomination
+            COIN / 50,                         // 0.02 ZEC
+            COIN / 20,                         // 0.05 ZEC
+            COIN / 10,                         // 0.1 ZEC
+            COIN,                              // 1 ZEC
+            2 * COIN,                          // 2 ZEC
+            5 * COIN,                          // 5 ZEC
+            100 * COIN,                        // 100 ZEC
+            MIGRATION_MAX_DENOMINATION_ZEC * COIN, // 10,000 ZEC, the cap
+        ];
+        for quantum in examples {
+            assert_one_quantum_plus_fees(quantum, prep_fee);
+        }
+    }
+
+    proptest! {
+        /// For any valid `{1, 2, 5} * 10^k` quantum and any realistic reserved preparation fee, a
+        /// balance of exactly that quantum plus its fees migrates it as a single note with no change.
+        #[test]
+        fn single_quantum_plus_fees_is_one_note(
+            quantum in arb_quantum(),
+            prep_fee in 0u64..=MAX_SINGLE_QUANTUM_PREP_FEE_ZATOSHI,
+        ) {
+            assert_one_quantum_plus_fees(quantum, prep_fee);
+        }
+    }
+
     /// The ZIP 318 worked examples: canonical `{1, 2, 5} * 10^k` quantization.
     #[test]
     fn matches_the_zip_worked_examples() {

--- a/zcash_pool_migration_backend/tests/engine_plan.rs
+++ b/zcash_pool_migration_backend/tests/engine_plan.rs
@@ -63,6 +63,74 @@ fn empty_balance_has_nothing_to_migrate() {
     ));
 }
 
+/// The full migration pipeline (note splitting then preparation) for the smallest migratable
+/// balance: a lone source note of exactly one quantum plus its fees. A quantum is a canonical
+/// `{1, 2, 5} * 10^k` denomination; its fees are the ZIP-317 transfer buffer that funds the crossing
+/// note plus one padded preparation-transaction fee. Such a balance migrates that one denomination
+/// as a single crossing note, minted by exactly one preparation transaction in exactly one
+/// preparation layer, leaving no source-pool change.
+#[test]
+fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
+    let params = regtest_network(true);
+    let tip = 2_000_000;
+
+    // The canonical fees depend only on the network and height, not the balance. Discover them from
+    // a probe migration of a lone 0.02 ZEC note, which funds exactly one 0.01 ZEC minimum-denomination
+    // note in a single padded preparation transaction (so its reserved prep fee is one tx fee).
+    let probe = MockBackend::new(vec![2 * (COIN / 100)], tip);
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    let probe_plan = plan_migration(&params, &probe, &mut rng).expect("the probe balance plans");
+    assert_eq!(probe_plan.preparation().transaction_count(), 1);
+    let buffer = u64::from(probe_plan.note_split().note_fee_buffer());
+    let prep_tx_fee = u64::from(probe_plan.note_split().prep_fees());
+
+    // A few example quanta spanning the series from the 0.01 ZEC minimum to the 10,000 ZEC cap.
+    let quanta = [
+        COIN / 100,    // 0.01 ZEC, the minimum denomination
+        COIN / 20,     // 0.05 ZEC
+        COIN,          // 1 ZEC
+        100 * COIN,    // 100 ZEC
+        10_000 * COIN, // 10,000 ZEC, the cap
+    ];
+    for quantum in quanta {
+        let balance = quantum + buffer + prep_tx_fee;
+        let backend = MockBackend::new(vec![balance], tip);
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let plan =
+            plan_migration(&params, &backend, &mut rng).expect("a one-quantum balance plans");
+
+        // The split: one crossing of exactly the quantum, and the whole balance consumed (no change).
+        assert_eq!(
+            plan.note_split()
+                .crossing_values()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum],
+            "quantum {quantum}",
+        );
+        assert_eq!(plan.note_split().change(), None, "quantum {quantum}");
+
+        // The preparation: exactly one layer holding exactly one transaction, minting exactly the
+        // single funding note (the crossing plus its transfer buffer).
+        let prep = plan.preparation();
+        assert_eq!(prep.layer_count(), 1, "quantum {quantum}");
+        assert_eq!(prep.transaction_count(), 1, "quantum {quantum}");
+        assert_eq!(prep.layers()[0].len(), 1, "quantum {quantum}");
+        assert_eq!(
+            plan.funding_notes()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum + buffer],
+            "quantum {quantum}",
+        );
+
+        // One funding note is one scheduled transfer.
+        assert_eq!(plan.schedule().len(), 1, "quantum {quantum}");
+    }
+}
+
 /// Reconciliation on a many-equal-note source (the "exchange" wallet shape). Ten identical 5-ZEC
 /// notes (50 ZEC) decompose into `[20, 20, 5, 2, 2, 0.5, ...]`, but equal source notes cannot fund
 /// that whole split: each funding note is its crossing plus a transfer buffer and costs a


### PR DESCRIPTION
Adds test coverage for migrating a balance of exactly **one quantum + fees**,
the smallest migratable balance. A quantum is a canonical `{1, 2, 5} * 10^k`
denomination; its fees are the ZIP-317 transfer buffer that funds the crossing
note plus one padded preparation-transaction fee.

Before this PR, only `below_min_note_migrates_nothing` covered the region
around this boundary, and it only exercises the *just-below* case (migrates
nothing). Neither the split layer nor the full pipeline had an at-boundary test
pinning that exactly one quantum + fees migrates that one denomination cleanly.

### Note-split unit test (`note_splitting/strategies.rs`)

The `CanonicalOneTwoFive` split in isolation: a balance of exactly one quantum
plus its fees splits into exactly one crossing note of that denomination, with
no change.

- `single_quantum_plus_fees_migrates_exactly_one_note` — a few example quanta
  from the 0.01 ZEC minimum denomination to the 10,000 ZEC cap.
- `single_quantum_plus_fees_is_one_note` — a proptest over an `arb_quantum`
  strategy that enumerates every valid `{1, 2, 5} * 10^k` denomination, with the
  sampled preparation fee bounded below the smallest inter-denomination gap
  (`RESIDUAL_MIGRATION_MIN`) so the greedy must pick exactly the quantum.

### Full-migration integration test (`tests/engine_plan.rs`)

`full_migration_of_one_quantum_is_one_layer_one_transaction` drives the whole
`plan_migration` pipeline (note splitting then preparation) for a lone source
note of exactly one quantum plus its fees. It asserts the result is **one
preparation layer holding exactly one transaction**, minting the single funding
note, with no source-pool change and a single scheduled transfer.

The canonical fees depend only on the network and height (not the balance), so
they are discovered from a probe migration and reused to build the exact
per-quantum balance across a few example denominations.

### Verification

- Full `zcash_pool_migration_backend` suite green (unit + doc + integration).
- `cargo clippy --tests` clean.
- `cargo fmt --check` clean.

### Follow-up (separate PR)

A prover-backed full end-to-end test built on top of `prove/pool-migration-transfer`
(#2710), exercising split -> preparation -> transfer proving rather than only
planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)