### PR TITLE
zcash_pool_migration: prove the minimal one-quantum migration end to end

### DIFF
--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -332,6 +332,115 @@ mod tests {
         assert_eq!(p.change(), Some(zat(below)));
     }
 
+    /// The largest reserved preparation fee the single-quantum tests sample. Kept below the smallest
+    /// gap between adjacent denominations (`RESIDUAL_MIGRATION_MIN`, the 0.01 -> 0.02 ZEC step) so
+    /// that `quantum + fee` never rounds up to the next `{1, 2, 5} * 10^k` denomination: the plan
+    /// must then pick exactly the quantum. Realistic ZIP-317 preparation fees are far smaller (a
+    /// handful of marginal fees).
+    const MAX_SINGLE_QUANTUM_PREP_FEE_ZATOSHI: u64 = COIN / 200; // 0.005 ZEC, half the minimum denom
+
+    /// Every `{1, 2, 5} * 10^k` denomination (a "quantum") within the valid range
+    /// `[RESIDUAL_MIGRATION_MIN, MIGRATION_MAX_DENOMINATION_ZEC]`, in zatoshi. These are exactly the
+    /// crossing values the strategy can emit, so a balance of one of them plus its fees is the
+    /// smallest input that migrates that denomination as a single note.
+    fn all_quanta() -> Vec<u64> {
+        let min = u64::from(RESIDUAL_MIGRATION_MIN);
+        let cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
+        let mut quanta = Vec::new();
+        let mut pow = 1u64;
+        while pow <= cap {
+            for m in [1u64, 2, 5] {
+                let q = m * pow;
+                if (min..=cap).contains(&q) {
+                    quanta.push(q);
+                }
+            }
+            match pow.checked_mul(10) {
+                Some(p) => pow = p,
+                None => break,
+            }
+        }
+        quanta
+    }
+
+    /// A single `{1, 2, 5} * 10^k` denomination drawn from [`all_quanta`].
+    fn arb_quantum() -> impl Strategy<Value = u64> {
+        prop::sample::select(all_quanta())
+    }
+
+    /// A balance of exactly one `quantum` plus its fees (the ZIP-317 transfer buffer that funds the
+    /// crossing note, and one reserved preparation-transaction fee) is the smallest input that
+    /// migrates that denomination: the plan is a single crossing note of exactly `quantum`, reserves
+    /// exactly one preparation fee, and leaves no change.
+    fn assert_one_quantum_plus_fees(quantum: u64, prep_fee: u64) {
+        let buffer = zip317_buffer();
+        let balance = quantum + buffer + prep_fee;
+        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let p = s.plan(zat(balance), zat(prep_fee), &prep_tx_count_stub, &mut rng);
+
+        assert_eq!(
+            crossings_u64(&p),
+            vec![quantum],
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(
+            p.migration_outputs()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum + buffer],
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(
+            u64::from(p.total_migratable()),
+            quantum,
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        // One prepared note is one padded preparation transaction, so exactly one fee is reserved.
+        assert_eq!(
+            u64::from(p.prep_fees()),
+            prep_fee,
+            "quantum {quantum}, prep fee {prep_fee}",
+        );
+        assert_eq!(p.change(), None, "quantum {quantum}, prep fee {prep_fee}");
+    }
+
+    /// A balance of exactly one quantum plus fees migrates that quantum as a single note, across a
+    /// few example denominations spanning the `{1, 2, 5} * 10^k` series from the 0.01 ZEC minimum to
+    /// the 10,000 ZEC cap.
+    #[test]
+    fn single_quantum_plus_fees_migrates_exactly_one_note() {
+        // A realistic reserved preparation fee: the ZIP-317 marginal fee for a few actions.
+        let prep_fee = 3 * MARGINAL_FEE.into_u64();
+        let examples = [
+            u64::from(RESIDUAL_MIGRATION_MIN), // 0.01 ZEC, the minimum denomination
+            COIN / 50,                         // 0.02 ZEC
+            COIN / 20,                         // 0.05 ZEC
+            COIN / 10,                         // 0.1 ZEC
+            COIN,                              // 1 ZEC
+            2 * COIN,                          // 2 ZEC
+            5 * COIN,                          // 5 ZEC
+            100 * COIN,                        // 100 ZEC
+            MIGRATION_MAX_DENOMINATION_ZEC * COIN, // 10,000 ZEC, the cap
+        ];
+        for quantum in examples {
+            assert_one_quantum_plus_fees(quantum, prep_fee);
+        }
+    }
+
+    proptest! {
+        /// For any valid `{1, 2, 5} * 10^k` quantum and any realistic reserved preparation fee, a
+        /// balance of exactly that quantum plus its fees migrates it as a single note with no change.
+        #[test]
+        fn single_quantum_plus_fees_is_one_note(
+            quantum in arb_quantum(),
+            prep_fee in 0u64..=MAX_SINGLE_QUANTUM_PREP_FEE_ZATOSHI,
+        ) {
+            assert_one_quantum_plus_fees(quantum, prep_fee);
+        }
+    }
+
     /// The ZIP 318 worked examples: canonical `{1, 2, 5} * 10^k` quantization.
     #[test]
     fn matches_the_zip_worked_examples() {

--- a/zcash_pool_migration_backend/tests/engine_plan.rs
+++ b/zcash_pool_migration_backend/tests/engine_plan.rs
@@ -63,6 +63,74 @@ fn empty_balance_has_nothing_to_migrate() {
     ));
 }
 
+/// The full migration pipeline (note splitting then preparation) for the smallest migratable
+/// balance: a lone source note of exactly one quantum plus its fees. A quantum is a canonical
+/// `{1, 2, 5} * 10^k` denomination; its fees are the ZIP-317 transfer buffer that funds the crossing
+/// note plus one padded preparation-transaction fee. Such a balance migrates that one denomination
+/// as a single crossing note, minted by exactly one preparation transaction in exactly one
+/// preparation layer, leaving no source-pool change.
+#[test]
+fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
+    let params = regtest_network(true);
+    let tip = 2_000_000;
+
+    // The canonical fees depend only on the network and height, not the balance. Discover them from
+    // a probe migration of a lone 0.02 ZEC note, which funds exactly one 0.01 ZEC minimum-denomination
+    // note in a single padded preparation transaction (so its reserved prep fee is one tx fee).
+    let probe = MockBackend::new(vec![2 * (COIN / 100)], tip);
+    let mut rng = ChaCha8Rng::seed_from_u64(1);
+    let probe_plan = plan_migration(&params, &probe, &mut rng).expect("the probe balance plans");
+    assert_eq!(probe_plan.preparation().transaction_count(), 1);
+    let buffer = u64::from(probe_plan.note_split().note_fee_buffer());
+    let prep_tx_fee = u64::from(probe_plan.note_split().prep_fees());
+
+    // A few example quanta spanning the series from the 0.01 ZEC minimum to the 10,000 ZEC cap.
+    let quanta = [
+        COIN / 100,    // 0.01 ZEC, the minimum denomination
+        COIN / 20,     // 0.05 ZEC
+        COIN,          // 1 ZEC
+        100 * COIN,    // 100 ZEC
+        10_000 * COIN, // 10,000 ZEC, the cap
+    ];
+    for quantum in quanta {
+        let balance = quantum + buffer + prep_tx_fee;
+        let backend = MockBackend::new(vec![balance], tip);
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let plan =
+            plan_migration(&params, &backend, &mut rng).expect("a one-quantum balance plans");
+
+        // The split: one crossing of exactly the quantum, and the whole balance consumed (no change).
+        assert_eq!(
+            plan.note_split()
+                .crossing_values()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum],
+            "quantum {quantum}",
+        );
+        assert_eq!(plan.note_split().change(), None, "quantum {quantum}");
+
+        // The preparation: exactly one layer holding exactly one transaction, minting exactly the
+        // single funding note (the crossing plus its transfer buffer).
+        let prep = plan.preparation();
+        assert_eq!(prep.layer_count(), 1, "quantum {quantum}");
+        assert_eq!(prep.transaction_count(), 1, "quantum {quantum}");
+        assert_eq!(prep.layers()[0].len(), 1, "quantum {quantum}");
+        assert_eq!(
+            plan.funding_notes()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![quantum + buffer],
+            "quantum {quantum}",
+        );
+
+        // One funding note is one scheduled transfer.
+        assert_eq!(plan.schedule().len(), 1, "quantum {quantum}");
+    }
+}
+
 /// Reconciliation on a many-equal-note source (the "exchange" wallet shape). Ten identical 5-ZEC
 /// notes (50 ZEC) decompose into `[20, 20, 5, 2, 2, 0.5, ...]`, but equal source notes cannot fund
 /// that whole split: each funding note is its crossing plus a transfer buffer and costs a

--- a/zcash_pool_migration_backend/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration_backend/tests/prove_chain_sim.rs
@@ -49,10 +49,14 @@ use zcash_pool_migration_backend::engine::{
     PoolMigrationWrite,
 };
 use zcash_pool_migration_backend::wallet::{WalletMigration, WalletMigrationProver};
+use zcash_pool_migration_memory::{MockBackend, regtest_network};
 
 /// Every network upgrade (through NU6.3, which activates the Ironwood pool) is active from this
 /// height, so a migration built at or above it is post-NU6.3 and its transfers cross into Ironwood.
 const ACTIVATION: u32 = 100_000;
+/// The single quantum the minimal end-to-end migration moves: the 0.01 ZEC minimum denomination
+/// (the smallest `{1, 2, 5} * 10^k` value the note-split planner emits).
+const SINGLE_QUANTUM_ZATOSHI: u64 = COIN / 100;
 /// Empty blocks scanned after a note is received so its commitment-tree shard completes and an
 /// anchor at that height is available.
 const SHARD_COMPLETION_BLOCKS: usize = 5;
@@ -544,4 +548,186 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
     for scenario in scenarios() {
         scenario.prove_end_to_end();
     }
+}
+
+/// The minimal migration proven end to end: a wallet funded with exactly one quantum plus its fees.
+///
+/// This is the prover-backed companion to the planner-only
+/// `full_migration_of_one_quantum_is_one_layer_one_transaction` (in `tests/engine_plan.rs`): where
+/// that test asserts the PLAN shape, this one funds a real wallet with exactly that balance and
+/// proves the resulting single preparation and single transfer end to end against the wallet's own
+/// Orchard commitment tree. A quantum is a canonical `{1, 2, 5} * 10^k` denomination; its fees are
+/// the ZIP-317 transfer buffer that funds the crossing note plus one padded preparation-transaction
+/// fee, so the whole balance migrates as one crossing note with no source-pool change.
+#[test]
+fn single_quantum_migration_proves_end_to_end() {
+    let network = nu63_network();
+
+    // The canonical ZIP-317 fees use a fixed fee rule, so they are network- and height-independent:
+    // discover them from a cheap probe migration of a lone 0.02 ZEC note, which funds exactly one
+    // 0.01 ZEC minimum-denomination note in a single padded preparation transaction (its reserved
+    // prep fee is then one transaction fee). The wallet is funded with one quantum plus these fees.
+    let mut probe_rng = ChaCha8Rng::seed_from_u64(0);
+    let probe = MockBackend::new(vec![2 * SINGLE_QUANTUM_ZATOSHI], 2_000_000);
+    let probe_plan = engine::plan_migration(&regtest_network(true), &probe, &mut probe_rng)
+        .expect("the probe migration plans");
+    assert_eq!(probe_plan.preparation().transaction_count(), 1);
+    let buffer = u64::from(probe_plan.note_split().note_fee_buffer());
+    let prep_tx_fee = u64::from(probe_plan.note_split().prep_fees());
+    let funding = Zatoshis::from_u64(SINGLE_QUANTUM_ZATOSHI + buffer + prep_tx_fee)
+        .expect("the funding amount is a valid value");
+
+    let mut st = TestBuilder::new()
+        .with_network(network)
+        .with_data_store_factory(TestDbFactory::default())
+        .with_block_cache(BlockCache::new())
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().expect("the test account exists");
+    let account_id = account.id();
+    let usk = account.usk().clone();
+    let fvk = OrchardPoolTester::test_account_fvk(&st);
+
+    // Fund the account with a single spendable Orchard note of exactly one quantum plus its fees,
+    // then let its shard complete so an anchor is available at the tip.
+    let (fund_height, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, funding);
+    st.scan_cached_blocks(fund_height, 1);
+    assert_eq!(st.get_total_balance(account_id), funding);
+    for _ in 0..SHARD_COMPLETION_BLOCKS {
+        let (h, _) = st.generate_empty_block();
+        st.scan_cached_blocks(h, 1);
+    }
+
+    let tip = st
+        .wallet()
+        .chain_height()
+        .expect("reads the chain height")
+        .expect("the wallet has a chain tip");
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut state = {
+        let adapter =
+            WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
+        let plan =
+            engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+
+        // The whole balance migrates as one quantum-sized crossing note, minted by a single
+        // preparation transaction in a single layer, with no source-pool change.
+        assert_eq!(
+            plan.note_split()
+                .crossing_values()
+                .iter()
+                .map(|&v| u64::from(v))
+                .collect::<Vec<u64>>(),
+            vec![SINGLE_QUANTUM_ZATOSHI],
+        );
+        assert_eq!(plan.note_split().change(), None);
+        assert_eq!(plan.preparation().layer_count(), 1);
+        assert_eq!(plan.preparation().transaction_count(), 1);
+
+        let mut adapter = adapter;
+        let (state, _funding_notes) =
+            engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
+                .expect("commits the migration");
+        state
+    };
+
+    // Exactly one preparation transaction and one transfer, each Signed with anchor and witnesses
+    // deferred.
+    let prep_ids: Vec<MigrationTxId> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .map(|t| t.id())
+        .collect();
+    let transfer_ids: Vec<MigrationTxId> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+        .map(|t| t.id())
+        .collect();
+    assert_eq!(prep_ids.len(), 1, "one preparation transaction");
+    assert_eq!(transfer_ids.len(), 1, "one transfer");
+    for tx in state.transactions() {
+        assert!(matches!(tx.state(), MigrationTxState::Signed));
+    }
+    let prep_id = prep_ids[0];
+    let transfer_id = transfer_ids[0];
+
+    // Prove the single preparation against the current tip, extract it (Orchard-only), mine it, and
+    // scan it, so its minted funding note becomes a spendable received note in the wallet.
+    let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
+        .expect("a rooted Orchard checkpoint exists");
+    {
+        let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+        engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+            .expect("proves the preparation transaction");
+    }
+    let proven_prep = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == prep_id)
+        .expect("the preparation transaction is present");
+    assert!(matches!(proven_prep.state(), MigrationTxState::Proved));
+    let prep_tx = TransactionExtractor::new(
+        pczt::Pczt::parse(proven_prep.pczt()).expect("parses the proven preparation PCZT"),
+    )
+    .extract()
+    .expect("extracts and verifies the preparation transaction");
+    assert!(
+        prep_tx.orchard_bundle().is_some(),
+        "the preparation has an Orchard bundle"
+    );
+    assert!(
+        prep_tx.ironwood_bundle().is_none(),
+        "the preparation has no Ironwood bundle"
+    );
+    let (prep_height, _) = st.generate_next_block_from_tx(1, &prep_tx);
+    st.scan_cached_blocks(prep_height, 1);
+
+    // Advance (scanning empty blocks) until the tip is strictly past the transfer's drawn boundary,
+    // so its checkpoint is settled and rooted, then prove the single transfer and assert BOTH its
+    // Orchard and Ironwood bundles verify.
+    let boundary = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == transfer_id)
+        .and_then(|t| t.anchor_boundary())
+        .expect("the transfer carries a drawn boundary");
+    loop {
+        let tip = st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        if tip > boundary {
+            break;
+        }
+        let (h, _) = st.generate_empty_block();
+        st.scan_cached_blocks(h, 1);
+    }
+    {
+        let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+        engine::prove_transfer(&mut prover, &mut state, transfer_id)
+            .expect("proves the transfer against its drawn boundary");
+    }
+    let proven_transfer = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == transfer_id)
+        .expect("the transfer is present");
+    assert!(matches!(proven_transfer.state(), MigrationTxState::Proved));
+    let transfer_tx = TransactionExtractor::new(
+        pczt::Pczt::parse(proven_transfer.pczt()).expect("parses the proven transfer PCZT"),
+    )
+    .extract()
+    .expect("extracts and verifies the transfer's Orchard and Ironwood proofs");
+    assert!(
+        transfer_tx.orchard_bundle().is_some(),
+        "the transfer has an Orchard bundle"
+    );
+    assert!(
+        transfer_tx.ironwood_bundle().is_some(),
+        "the transfer has an Ironwood bundle"
+    );
 }


### PR DESCRIPTION
**Stacked PR** (draft). Depends on, and is based on:
- #2710 (`prove/pool-migration-transfer`) — the real Orchard+Ironwood transfer proving and the E2E chain-simulation harness this builds on.
- #2717 (`test/migration-single-quantum`) — the planner-only single-quantum tests, cherry-picked here so this branch has both. Its two commits appear in this PR's range and will drop out once #2717 merges.

Base is set to `prove/pool-migration-transfer` so the diff shows only the incremental work. Once #2710 (and #2717) merge, this will be rebased onto `main` and retargeted.

### What this adds

The prover-backed companion to #2717's planner-only
`full_migration_of_one_quantum_is_one_layer_one_transaction`: a wallet funded
with exactly **one quantum plus its fees** migrates that one denomination as a
single preparation transaction and a single transfer, proven end to end against
the wallet's own Orchard commitment tree.

A quantum is a canonical `{1, 2, 5} * 10^k` denomination; its fees are the
ZIP-317 transfer buffer that funds the crossing note plus one padded
preparation-transaction fee.

`single_quantum_migration_proves_end_to_end` (in #2710's
`tests/prove_chain_sim.rs`) reuses the chain-simulation harness (wallet factory,
block cache, migration store, prove/mine/scan helpers) and:

1. Discovers the canonical ZIP-317 fees from a cheap `MockBackend` probe (the
   fees use a fixed fee rule, so they are network- and height-independent, and
   `canonical_fees` is private), then funds a real in-memory `WalletDb` with
   exactly `quantum + transfer_buffer + prep_tx_fee`.
2. Asserts the plan is one crossing of exactly the quantum, no source-pool
   change, one preparation layer, one transaction.
3. Proves the single preparation (asserts Orchard-only), mines and scans it,
   advances to the transfer's drawn boundary, proves the transfer, and asserts
   both its Orchard and Ironwood bundles verify.

### Verification

- Both E2E proving tests pass (`2 passed`, ~33s with real halo2 proving).
- `cargo clippy --test prove_chain_sim` clean.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)