### PR TITLE
zcash_pool_migration_backend: require CryptoRng for planning randomness

### DIFF
--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -642,7 +642,7 @@ pub fn plan_migration<P, B, R>(
 where
     P: zcash_protocol::consensus::Parameters,
     B: MigrationBackend,
-    R: RngCore,
+    R: RngCore + rand_core::CryptoRng,
 {
     let notes = backend
         .spendable_orchard_note_values()
@@ -913,7 +913,7 @@ pub fn estimate_migration_runs<P, B, R>(
 where
     P: zcash_protocol::consensus::Parameters,
     B: MigrationBackend,
-    R: RngCore,
+    R: RngCore + rand_core::CryptoRng,
 {
     let height = backend
         .chain_tip_height()

--- a/zcash_pool_migration_backend/src/note_splitting.rs
+++ b/zcash_pool_migration_backend/src/note_splitting.rs
@@ -119,7 +119,7 @@
 
 use alloc::vec::Vec;
 
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 use zcash_protocol::value::{BalanceError, COIN, Zatoshis};
 
@@ -310,8 +310,9 @@ pub trait DenominationStrategy {
     /// mint that multiset at all. The engine backs it with the preparation planner, so the
     /// decomposition reserves the TRUE preparation cost (consolidation, fan-out layers, and all) as
     /// it grows, instead of a fixed guess repaired after the fact. `rng` is used by randomized
-    /// strategies and ignored by deterministic ones.
-    fn plan<R: RngCore>(
+    /// strategies and ignored by deterministic ones; it is bound as [`CryptoRng`] because a
+    /// randomized strategy's draws decide the on-chain crossing values, which are privacy-relevant.
+    fn plan<R: RngCore + CryptoRng>(
         &self,
         total_input: Zatoshis,
         prep_tx_fee: Zatoshis,
@@ -329,7 +330,7 @@ pub(crate) fn zat(value: u64) -> Zatoshis {
 
 /// Convenience wrapper: plan with the recommended [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
 /// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
-pub fn plan_note_split<R: RngCore>(
+pub fn plan_note_split<R: RngCore + CryptoRng>(
     total_input: Zatoshis,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,

--- a/zcash_pool_migration_backend/src/note_splitting/strategies.rs
+++ b/zcash_pool_migration_backend/src/note_splitting/strategies.rs
@@ -9,7 +9,7 @@
 
 use alloc::vec::Vec;
 
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 use zcash_protocol::value::COIN;
 
@@ -73,7 +73,7 @@ impl CanonicalOneTwoFive {
 }
 
 impl DenominationStrategy for CanonicalOneTwoFive {
-    fn plan<R: RngCore>(
+    fn plan<R: RngCore + CryptoRng>(
         &self,
         total_input: Zatoshis,
         prep_tx_fee: Zatoshis,

--- a/zcash_pool_migration_backend/src/scheduling.rs
+++ b/zcash_pool_migration_backend/src/scheduling.rs
@@ -3,8 +3,10 @@
 //!
 //! This module is pool-agnostic and pure arithmetic plus RNG draws (no cryptography, no note tree,
 //! no I/O); it works only in block heights and part indices. All randomness comes from a caller-
-//! supplied `rng` (a CSPRNG in production; the tests pass a seeded `rand_chacha::ChaCha8Rng`).
-//! Every function is deterministic given its `rng`.
+//! supplied `rng`, which the public functions bound as [`CryptoRng`]: the draws decide the
+//! privacy-relevant observables (broadcast order, delays, anchors), so a predictable generator
+//! would let an observer reconstruct them (the tests pass a seeded `rand_chacha::ChaCha8Rng`,
+//! which is a `CryptoRng`). Every function is deterministic given its `rng`.
 //!
 //! # The problem
 //!
@@ -62,7 +64,7 @@
 
 use alloc::vec::Vec;
 
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 use zcash_protocol::consensus::BlockHeight;
 
 /// Mean of the exponential inter-arrival delay between successive transfers, in blocks. Also the
@@ -192,14 +194,14 @@ fn draw_delay_with<R: RngCore>(mean: u32, cap: u32, rng: &mut R) -> u32 {
 /// Draw one TRANSFER inter-arrival delay in blocks from the truncated exponential distribution:
 /// mean [`MEAN_DELAY`], discard-and-redraw above [`MAX_DELAY`] (ZIP 318 "Transfer scheduling"
 /// MUST). The return is always in `[0, MAX_DELAY]`.
-pub fn draw_delay<R: RngCore>(rng: &mut R) -> u32 {
+pub fn draw_delay<R: RngCore + CryptoRng>(rng: &mut R) -> u32 {
     draw_delay_with(MEAN_DELAY, MAX_DELAY, rng)
 }
 
 /// Draw one PREPARATION inter-arrival delay in blocks: mean [`PREP_MEAN_DELAY`],
 /// discard-and-redraw above [`PREP_MAX_DELAY`]. See [`PREP_MEAN_DELAY`] for why preparations are
 /// spaced tighter than transfers. The return is always in `[0, PREP_MAX_DELAY]`.
-pub fn draw_prep_delay<R: RngCore>(rng: &mut R) -> u32 {
+pub fn draw_prep_delay<R: RngCore + CryptoRng>(rng: &mut R) -> u32 {
     draw_delay_with(PREP_MEAN_DELAY, PREP_MAX_DELAY, rng)
 }
 
@@ -208,7 +210,7 @@ pub fn draw_prep_delay<R: RngCore>(rng: &mut R) -> u32 {
 /// quantized parts so the broadcast ORDER of denominations is independent of the balance.
 ///
 /// Returns the identity for `n == 0` or `n == 1`.
-pub fn shuffle_indices<R: RngCore>(n: usize, rng: &mut R) -> Vec<usize> {
+pub fn shuffle_indices<R: RngCore + CryptoRng>(n: usize, rng: &mut R) -> Vec<usize> {
     let mut indices: Vec<usize> = (0..n).collect();
     shuffle_in_place(&mut indices, rng);
     indices
@@ -217,7 +219,7 @@ pub fn shuffle_indices<R: RngCore>(n: usize, rng: &mut R) -> Vec<usize> {
 /// In-place uniform Fisher-Yates shuffle of `slice` using `rng` (ZIP 318 SHUFFLE MUST). Iterates
 /// from the top, swapping each element with a uniformly chosen one at or below it, so every
 /// permutation is equally likely. Leaves the multiset of elements unchanged.
-pub fn shuffle_in_place<T, R: RngCore>(slice: &mut [T], rng: &mut R) {
+pub fn shuffle_in_place<T, R: RngCore + CryptoRng>(slice: &mut [T], rng: &mut R) {
     let len = slice.len();
     if len < 2 {
         return;
@@ -276,7 +278,7 @@ fn cumulative_broadcast_heights<R: RngCore>(
 /// height by an independently drawn [`draw_delay`] for each of the `n_parts` transfers (ZIP 318
 /// CUMULATIVE MUST). The returned vector has length `n_parts`, is non-decreasing, and every entry is
 /// `>= commit_height`. Heights saturate at `u32::MAX` rather than overflowing.
-pub fn schedule_broadcast_heights<R: RngCore>(
+pub fn schedule_broadcast_heights<R: RngCore + CryptoRng>(
     commit_height: BlockHeight,
     n_parts: usize,
     rng: &mut R,
@@ -290,7 +292,7 @@ pub fn schedule_broadcast_heights<R: RngCore>(
 /// is `>= start`; heights saturate at `u32::MAX`. The caller (the engine) bases each later layer's
 /// `start` past the previous layer's last scheduled height plus a mining margin, so layers stay
 /// serialized while the transactions within and across layers remain temporally decoupled.
-pub fn schedule_prep_broadcast_heights<R: RngCore>(
+pub fn schedule_prep_broadcast_heights<R: RngCore + CryptoRng>(
     start: BlockHeight,
     n_txs: usize,
     rng: &mut R,
@@ -315,7 +317,7 @@ pub fn expiry_height(current_height: BlockHeight) -> BlockHeight {
 /// Assemble a [`Schedule`] for each part: draw the cumulative broadcast heights from `commit_height`
 /// (see [`schedule_broadcast_heights`]) and pair each with its canonical [`expiry_height`]. Returns
 /// one [`Schedule`] per part, in the (already shuffled) part order the caller passes.
-pub fn schedule<R: RngCore>(
+pub fn schedule<R: RngCore + CryptoRng>(
     commit_height: BlockHeight,
     n_parts: usize,
     rng: &mut R,
@@ -366,7 +368,7 @@ fn draw_anchor_age<R: RngCore>(rng: &mut R) -> u32 {
 /// is `most_recent_boundary(chain_tip_height) - a * BOUNDARY_MODULUS`; a draw exceeding
 /// [`ANCHOR_AGE_CAP`] or landing outside the candidate set is discarded and redrawn. Because age is
 /// always `>= 1`, the chosen boundary is always strictly below the most recent boundary.
-pub fn draw_anchor_boundary<R: RngCore>(
+pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
     nu63_activation: BlockHeight,
     funding_creation_height: BlockHeight,
     chain_tip_height: BlockHeight,


### PR DESCRIPTION
## Summary

Closes a type-level gap found in a security review of the pool-migration
randomness: the commit/build entry points already bound their RNG as
`RngCore + CryptoRng`, but the planning surface accepted any `RngCore` and
enforced the documented "must be a cryptographically secure RNG" requirement
only in prose.

The planning draws decide the privacy-relevant observables of a migration:
the broadcast order (ZIP 318 SHUFFLE), the exponential inter-arrival delays,
the anchor-boundary selection, and (for a randomized strategy) the crossing
denominations. A predictable generator there would let a chain observer
reconstruct the schedule, so the `CryptoRng` marker bound is now required on
the public planning API:

- `engine::plan_migration` and `engine::estimate_migration_runs`
- `scheduling::{draw_delay, draw_prep_delay, shuffle_indices, shuffle_in_place, schedule_broadcast_heights, schedule_prep_broadcast_heights, schedule, draw_anchor_boundary}`
- `note_splitting::plan_note_split` and `note_splitting::DenominationStrategy::plan`

Private helpers keep the plain `RngCore` bound; they are reachable only
through the bounded public functions.

No behavior change and no caller changes: the crate's tests already use
`rand_chacha::ChaCha8Rng`, which implements `CryptoRng`. The crate is
unreleased, so no changelog entry beyond the existing "Initial release"
section.

## Verification

- `cargo build --release -p zcash_pool_migration_backend --all-features`
- `cargo test --release -p zcash_pool_migration_backend --all-features` (106 passed)
- `cargo clippy --release -p zcash_pool_migration_backend -p zcash_pool_migration_memory --all-features --all-targets` (clean)
- `cargo build --release -p zcash_client_sqlite --all-features`
- `cargo fmt -p zcash_pool_migration_backend -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)