### PR TITLE
zcash_pool_migration_backend: detect and rebuild expired migration transactions

### DIFF
--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -274,8 +274,11 @@ pub struct MigrationTransaction {
     /// dependencies to mine and a boundary to pass rather than a fixed height).
     #[getset(get_copy = "pub")]
     pub(crate) scheduled_height: BlockHeight,
-    /// The height after which the transaction is invalid and must be rebuilt
-    /// (rebuild-on-expiry is grown by a later slice, alongside reconciliation-on-launch).
+    /// The height after which the transaction can no longer be mined (ZIP 203) and its part must
+    /// be carried by an entirely new, freshly signed transaction: a transfer via
+    /// [`rebuild_expired_transfer`] / [`rebuild_expired_transfer_unsigned`] (detection via
+    /// [`MigrationState::expired_transactions`]); an expired preparation awaits its own
+    /// remediation slice.
     #[getset(get_copy = "pub")]
     pub(crate) expiry_height: BlockHeight,
     /// The boundary height whose tree state the transaction proves against. For a transfer this is
@@ -455,8 +458,9 @@ pub struct MigrationState {
     #[getset(get = "pub")]
     pub(crate) note_split: NoteSplitPlan,
     /// The preparation plan (its layers and direct-funding notes), retained for auditability and
-    /// for the rebuild-on-expiry slice. A `Preparation { layer, index }` transaction's spends
-    /// resolve against `preparation.layers()[layer][index]`.
+    /// for rebuilding expired PREPARATION transactions (a follow-on slice). A
+    /// `Preparation { layer, index }` transaction's spends resolve against
+    /// `preparation.layers()[layer][index]`.
     #[getset(get = "pub")]
     pub(crate) preparation: PreparationPlan,
     /// Every migration transaction, in dependency order.
@@ -1339,6 +1343,345 @@ where
 
     state.set_transaction_proved(id, bytes);
     Ok(())
+}
+
+/// Why rebuilding an expired migration transfer failed.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+pub enum RebuildError<E> {
+    /// No transaction with the given id belongs to the migration.
+    UnknownTransaction(MigrationTxId),
+    /// The transaction is a preparation transaction, not a transfer. Only a transfer — a leaf of
+    /// the dependency graph — is rebuilt this way (with a fresh boundary anchor and canonical
+    /// expiry). An expired preparation has no single-transaction rebuild: its dependents'
+    /// pre-signatures commit to the notes it would have minted, so its remediation (re-signing the
+    /// affected subtree) is a follow-on slice.
+    NotATransfer(MigrationTxId),
+    /// The transaction has not expired at the current chain tip, so there is nothing to rebuild: it is
+    /// still valid, or it has already mined. Guards against reissuing a live transaction as a second,
+    /// double-spending copy.
+    NotExpired(MigrationTxId),
+    /// The stored migration state is internally inconsistent: the note split carries no crossing or
+    /// funding value for this transfer's crossing index, or the transfer's stored PCZT is
+    /// malformed.
+    InconsistentPlan(alloc::string::String),
+    /// The transfer's funding note — the EXACT note its expired PCZT spends, matched by nullifier
+    /// among the wallet's spendable notes — is no longer available. It should still be unspent
+    /// (the expired transfer never mined); if it is gone (spent outside the migration), the
+    /// remaining balance must be re-planned instead of this part rebuilt. A different spendable
+    /// note of coincidentally equal value is deliberately not substituted: denominations repeat,
+    /// so it may be a sibling transfer's funding note, and spending it would make the rebuilt
+    /// transfer a double-spend of that still-valid sibling.
+    FundingNoteUnavailable(Zatoshis),
+    /// NU6.3 is not active on this network, so there is no destination pool and no boundary grid to
+    /// draw an anchor from.
+    Nu63NotActive,
+    /// No candidate anchor boundary exists for the rebuilt schedule (the same stale condition
+    /// [`CommitError::StalePlan`] models at commit time): the migration must be re-planned.
+    NoCandidateAnchor,
+    /// Building the fresh transfer PCZT failed.
+    Build(crate::build::BuildError),
+    /// Serializing the rebuilt PCZT failed.
+    Serialize(pczt::EncodingError),
+    /// A wallet backend or signing operation failed.
+    Backend(E),
+}
+
+#[cfg(feature = "orchard")]
+impl<E: fmt::Display> fmt::Display for RebuildError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RebuildError::UnknownTransaction(id) => {
+                write!(f, "no migration transaction with id {}", u32::from(*id))
+            }
+            RebuildError::NotATransfer(id) => write!(
+                f,
+                "transaction {} is a preparation transaction, not a transfer",
+                u32::from(*id)
+            ),
+            RebuildError::NotExpired(id) => write!(
+                f,
+                "transaction {} has not expired; there is nothing to rebuild",
+                u32::from(*id)
+            ),
+            RebuildError::InconsistentPlan(m) => {
+                write!(f, "the migration plan is internally inconsistent: {m}")
+            }
+            RebuildError::FundingNoteUnavailable(v) => write!(
+                f,
+                "the transfer's funding note (funding value {}) is no longer spendable; the \
+                 remaining balance must be re-planned",
+                u64::from(*v)
+            ),
+            RebuildError::Nu63NotActive => f.write_str("NU6.3 is not active on this network"),
+            RebuildError::NoCandidateAnchor => f.write_str(
+                "no candidate anchor boundary exists for the rebuilt schedule; the migration must \
+                 be re-planned",
+            ),
+            RebuildError::Build(e) => write!(f, "rebuilding the transfer failed: {e}"),
+            RebuildError::Serialize(e) => {
+                write!(f, "serializing the rebuilt transfer failed: {e:?}")
+            }
+            RebuildError::Backend(e) => write!(f, "wallet backend error: {e}"),
+        }
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl<E: core::error::Error> core::error::Error for RebuildError<E> {}
+
+/// Rebuild an EXPIRED migration transfer as an entirely NEW pre-signed transaction, signed anew
+/// IN-PROCESS with the wallet's spend authority and stored back in the transfer's slot as
+/// [`Signed`](MigrationTxState::Signed), with a fresh boundary anchor and canonical expiry and an
+/// unchanged denomination.
+///
+/// A transfer can only be included in a block at or below its expiry height (ZIP 203); once the
+/// chain passes it, the pre-signed transaction is dead and
+/// [`next_step`](MigrationState::next_step) surfaces it as
+/// [`AdvanceStep::Rebuild`](crate::state::AdvanceStep::Rebuild). NOTHING of the expired artifact is
+/// reusable — the signature hash covers the expiry height, so its signatures cannot authorize any
+/// rescheduled copy. This is ZIP 318's expired-transaction handling: "a new transaction with a
+/// fresh anchor and expiry is constructed for the affected part, with its denomination unchanged".
+/// This function performs that reconstruction: it reschedules the part from the current tip with a
+/// fresh memoryless delay, derives the new canonical expiry, draws a fresh boundary anchor, builds
+/// a new transfer PCZT against the same funding note and crossing value, signs it anew, and
+/// replaces the stored PCZT. Anchors and witnesses stay DEFERRED (ZIP 374): the fresh anchor is
+/// installed at proving time, exactly as for an originally committed transfer.
+///
+/// Signing anew is what distinguishes this step from proving and broadcasting: it needs the
+/// account's SPEND AUTHORITY, not just the viewing key and the network. This entry point signs
+/// in-process via [`MigrationCrypto::sign`], for a wallet that holds the spend authority; a
+/// migration signed by an EXTERNAL (hardware or offline) signer uses
+/// [`rebuild_expired_transfer_unsigned`] instead, which leaves the rebuilt transfer awaiting the
+/// device's signature.
+///
+/// The funding note is recovered by IDENTITY, not by value: the expired PCZT's one real spend
+/// reveals the note's nullifier, which is matched among the wallet's spendable Orchard notes. The
+/// note is still unspent (the expired transfer never mined), so the rebuilt transfer re-spends
+/// exactly it — never a different spendable note of coincidentally equal value, which (since
+/// denominations repeat) could be a sibling transfer's funding note and would make the rebuild a
+/// double-spend of that sibling. If the exact note is gone (spent outside the migration), this
+/// returns [`RebuildError::FundingNoteUnavailable`] and the remaining balance should be re-planned
+/// rather than this part rebuilt.
+///
+/// The caller persists the updated state afterwards (`replace_migration`), exactly as after proving.
+#[cfg(feature = "orchard")]
+pub fn rebuild_expired_transfer<P, B, R>(
+    params: &P,
+    backend: &B,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+    rng: &mut R,
+) -> Result<(), RebuildError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    R: RngCore + rand_core::CryptoRng,
+{
+    rebuild_expired_transfer_inner(params, backend, state, id, rng, Signing::InProcess).map(|_| ())
+}
+
+/// Rebuild an EXPIRED migration transfer for an EXTERNAL signer: construct the same entirely new
+/// transaction as [`rebuild_expired_transfer`], but leave it UNSIGNED in the
+/// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) state and return it as an
+/// [`UnsignedMigrationTx`] to route to the signing device (split device-sized sessions with
+/// [`batch_unsigned_by_action_budget`]), mirroring [`build_preparation_unsigned`].
+///
+/// An expired transaction must be signed ANEW — its signature hash covers the expiry height — and
+/// for an externally signed migration the spend authority is on the device, not in-process: the
+/// rebuild therefore requires a new signing session, unlike proving and broadcasting.
+/// [`MigrationCrypto::sign`] is never called. After the device signs, call
+/// [`MigrationState::apply_signature`] with the returned PCZT (matched by
+/// [`UnsignedMigrationTx::id`]) to move the transfer to [`Signed`](MigrationTxState::Signed), and
+/// persist with `replace_migration`.
+#[cfg(feature = "orchard")]
+pub fn rebuild_expired_transfer_unsigned<P, B, R>(
+    params: &P,
+    backend: &B,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+    rng: &mut R,
+) -> Result<UnsignedMigrationTx, RebuildError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    R: RngCore + rand_core::CryptoRng,
+{
+    rebuild_expired_transfer_inner(params, backend, state, id, rng, Signing::External)
+        .map(|unsigned| unsigned.expect("the external signing path always returns the unsigned tx"))
+}
+
+/// Shared body of [`rebuild_expired_transfer`] (with [`Signing::InProcess`]) and
+/// [`rebuild_expired_transfer_unsigned`] (with [`Signing::External`]). Returns the
+/// [`UnsignedMigrationTx`] for the external path, `None` for the in-process path.
+#[cfg(feature = "orchard")]
+fn rebuild_expired_transfer_inner<P, B, R>(
+    params: &P,
+    backend: &B,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+    rng: &mut R,
+    signing: Signing,
+) -> Result<Option<UnsignedMigrationTx>, RebuildError<<B as MigrationBackend>::Error>>
+where
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
+    R: RngCore + rand_core::CryptoRng,
+{
+    // The height of the next block this transfer could be mined into, against which expiry is judged.
+    let target_height = backend.chain_tip_height().map_err(RebuildError::Backend)? + 1;
+
+    // Read everything the rebuild needs from the persisted state before the mutable borrow below.
+    let tx = state
+        .transactions
+        .iter()
+        .find(|t| t.id == id)
+        .ok_or(RebuildError::UnknownTransaction(id))?;
+    let crossing = match tx.kind {
+        MigrationTxKind::Transfer { crossing } => crossing,
+        MigrationTxKind::Preparation { .. } => return Err(RebuildError::NotATransfer(id)),
+    };
+    // Only an expired, not-yet-mined transfer is rebuilt (the same condition the state machine reports
+    // as expired): a still-valid or already-mined transfer is a typed error, not a silently reissued
+    // double spend.
+    let expiry = u32::from(tx.expiry_height);
+    let expired = !matches!(tx.state, MigrationTxState::Mined { .. })
+        && expiry != 0
+        && expiry < u32::from(target_height);
+    if !expired {
+        return Err(RebuildError::NotExpired(id));
+    }
+    let nu63_activation = params
+        .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
+        .ok_or(RebuildError::Nu63NotActive)?;
+    // The candidate anchor set starts at or after the funding note's creation height: the height its
+    // producing preparation mined, or the NU6.3 activation for a wallet note used directly (no
+    // producer).
+    let funding_creation = tx
+        .depends_on
+        .iter()
+        .filter_map(|dep| state.transactions.iter().find(|t| t.id == *dep))
+        .filter_map(|producer| match producer.state {
+            MigrationTxState::Mined { height } => Some(height),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(nu63_activation);
+
+    let crossing_value = *state
+        .note_split
+        .crossing_values()
+        .get(crossing)
+        .ok_or_else(|| {
+            RebuildError::InconsistentPlan(format!("no crossing value for transfer {crossing}"))
+        })?;
+    let funding_value = *state
+        .note_split
+        .migration_outputs()
+        .get(crossing)
+        .ok_or_else(|| {
+            RebuildError::InconsistentPlan(format!("no funding value for transfer {crossing}"))
+        })?;
+
+    // Recover the funding note's IDENTITY from the expired PCZT itself: its one real spend (the
+    // action with no witness; ZIP 374 deferral leaves the padding dummy its arbitrary witness)
+    // reveals the nullifier of the exact note this part is funded by. Denominations repeat across
+    // a migration, so matching the wallet's spendable notes by value alone could grab a sibling
+    // transfer's funding note and turn the rebuilt transfer into a double-spend of that
+    // still-valid sibling.
+    let stored_pczt = pczt::Pczt::parse(&tx.pczt).map_err(|e| {
+        RebuildError::InconsistentPlan(format!("the stored transfer PCZT does not parse: {e:?}"))
+    })?;
+    let mut real_spend_nullifiers = stored_pczt
+        .orchard()
+        .actions()
+        .iter()
+        .filter(|a| a.spend().witness().is_none())
+        .map(|a| *a.spend().nullifier());
+    let funding_nullifier = match (real_spend_nullifiers.next(), real_spend_nullifiers.next()) {
+        (Some(nf), None) => nf,
+        _ => {
+            return Err(RebuildError::InconsistentPlan(
+                "the stored transfer PCZT does not have exactly one real (unwitnessed) spend"
+                    .into(),
+            ));
+        }
+    };
+
+    // The exact note must still be among the wallet's spendable notes; if it is gone (spent
+    // outside the migration), the remaining balance must be re-planned rather than this part
+    // rebuilt, so a different note of coincidentally equal value is deliberately NOT substituted.
+    let fvk = backend.orchard_fvk().map_err(RebuildError::Backend)?;
+    let spendable_values = backend
+        .spendable_orchard_note_values()
+        .map_err(RebuildError::Backend)?;
+    let mut note = None;
+    for (index, value) in spendable_values.iter().enumerate() {
+        if *value != funding_value {
+            continue;
+        }
+        let candidate = backend
+            .resolve_wallet_note(index)
+            .map_err(RebuildError::Backend)?;
+        if candidate.nullifier(&fvk).to_bytes() == funding_nullifier {
+            note = Some(candidate);
+            break;
+        }
+    }
+    let note = note.ok_or(RebuildError::FundingNoteUnavailable(funding_value))?;
+
+    // Reschedule the part with a fresh memoryless delay from the current tip, and derive its new
+    // canonical expiry and a fresh boundary anchor for that schedule.
+    let scheduled_height = target_height + scheduling::draw_delay(&mut *rng);
+    let expiry_height = scheduling::expiry_height(scheduled_height);
+    let anchor_boundary =
+        scheduling::draw_anchor_boundary(nu63_activation, funding_creation, scheduled_height, rng)
+            .ok_or(RebuildError::NoCandidateAnchor)?;
+
+    // Build the entirely new transfer against the same funding note and crossing value; anchors
+    // and witnesses stay deferred (installed at proving time, ZIP 374). The expired artifact
+    // contributes nothing: the new expiry is covered by the signature hash, so the transaction is
+    // signed anew below (in-process) or by the external signer.
+    let pczt = crate::build::build_transfer_pczt(
+        params,
+        u32::from(target_height),
+        u32::from(expiry_height),
+        &fvk,
+        note,
+        crossing_value,
+        &mut *rng,
+    )
+    .map_err(RebuildError::Build)?;
+    let (bytes, new_state, unsigned) = match signing {
+        Signing::InProcess => {
+            let signed = backend.sign(pczt).map_err(RebuildError::Backend)?;
+            let bytes = signed.serialize().map_err(RebuildError::Serialize)?;
+            (bytes, MigrationTxState::Signed, None)
+        }
+        Signing::External => {
+            let bytes = pczt.serialize().map_err(RebuildError::Serialize)?;
+            let unsigned = UnsignedMigrationTx {
+                id,
+                pczt: bytes.clone(),
+                actions: crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
+                    + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER,
+            };
+            (bytes, MigrationTxState::AwaitingSignature, Some(unsigned))
+        }
+    };
+
+    // Replace the expired transaction's PCZT and reschedule it on the fresh schedule.
+    let tx = state
+        .transactions
+        .iter_mut()
+        .find(|t| t.id == id)
+        .expect("the transaction was found above");
+    tx.pczt = bytes;
+    tx.scheduled_height = scheduled_height;
+    tx.expiry_height = expiry_height;
+    tx.anchor_boundary = Some(anchor_boundary);
+    tx.state = new_state;
+    Ok(unsigned)
 }
 
 /// How a freshly built migration PCZT is finished by the commit functions: signed in-process with the
@@ -2402,7 +2745,9 @@ mod commit_tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
     };
-    use crate::note_splitting::NoteSplitPlan;
+    use crate::note_splitting::{
+        DESTINATION_ACTIONS_PER_TRANSFER, NoteSplitPlan, SOURCE_ACTIONS_PER_TRANSFER,
+    };
     use crate::preparation::{PREP_TX_ACTIONS, plan_preparation};
 
     /// The canonical fees on the regtest network at the build height, computed exactly as
@@ -2425,6 +2770,7 @@ mod commit_tests {
         fvk: FullViewingKey,
         ask: SpendAuthorizingKey,
         stored: Option<MigrationState>,
+        tip: BlockHeight,
     }
 
     impl CommitMock {
@@ -2442,6 +2788,7 @@ mod commit_tests {
                 fvk,
                 ask: SpendAuthorizingKey::from(&sk),
                 stored: None,
+                tip: BlockHeight::from_u32(2_000_000),
             }
         }
     }
@@ -2458,7 +2805,7 @@ mod commit_tests {
         }
 
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
-            Ok(BlockHeight::from_u32(2_000_000))
+            Ok(self.tip)
         }
     }
 
@@ -2644,6 +2991,349 @@ mod commit_tests {
         assert!(backend.get_migration().unwrap().is_some());
     }
 
+    /// An expired transfer is rebuilt in place: rescheduled forward with a fresh boundary anchor and
+    /// canonical expiry and re-signed against the same funding note, its denomination unchanged, and
+    /// moved back to `Signed` ready to prove and broadcast on the new schedule (ZIP 318 error
+    /// handling). A wallet holding exactly one funding note funds the transfer DIRECTLY (no
+    /// preparation), so the note stays spendable for the rebuild to re-resolve by value.
+    #[test]
+    fn rebuild_expired_transfer_reschedules_and_resigns_in_place() {
+        let seed = 99u64;
+        let params = regtest_network(true);
+        let buffer = u64::from(commit_test_fees().1);
+        let funding_note = COIN + buffer; // one 1-ZEC crossing plus its fee buffer
+        let mut backend = CommitMock::new(seed, &[funding_note]);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        // Direct funding: exactly one transfer, no preparation transactions.
+        assert_eq!(
+            plan.preparation()
+                .layers()
+                .iter()
+                .map(|l| l.len())
+                .sum::<usize>(),
+            0,
+            "the wallet note funds the transfer directly"
+        );
+        assert_eq!(plan.funding_notes().len(), 1);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+        assert_eq!(state.transactions.len(), 1);
+        let id = state.transactions[0].id;
+        let old = state.transactions[0].clone();
+        assert_eq!(old.state, MigrationTxState::Signed);
+        assert!(
+            old.depends_on.is_empty(),
+            "a directly funded transfer has no producer"
+        );
+
+        // Advance the chain tip past the transfer's expiry, so it can no longer be mined.
+        backend.tip = old.expiry_height + 1;
+        let target = backend.chain_tip_height().unwrap() + 1;
+        assert!(
+            state.expired_transactions(target).contains(&id),
+            "the transfer has expired at the new tip"
+        );
+
+        // Rebuild it.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng)
+            .expect("rebuilds the expired transfer");
+
+        let new = &state.transactions[0];
+        // Same denomination and kind, back to Signed, with a fresh schedule, expiry, anchor, and PCZT.
+        assert_eq!(
+            new.kind, old.kind,
+            "the denomination (crossing) is unchanged"
+        );
+        assert_eq!(new.state, MigrationTxState::Signed);
+        assert!(
+            new.scheduled_height > old.scheduled_height,
+            "rescheduled forward from the new tip"
+        );
+        assert!(
+            new.expiry_height > old.expiry_height,
+            "a fresh, later canonical expiry"
+        );
+        assert_ne!(new.pczt, old.pczt, "a freshly built and re-signed PCZT");
+        // The fresh anchor boundary is on the grid and within the rebuilt schedule's candidate set.
+        let boundary = u32::from(
+            new.anchor_boundary
+                .expect("the rebuilt transfer carries a boundary"),
+        );
+        assert_eq!(boundary % crate::scheduling::BOUNDARY_MODULUS, 0);
+        assert!(
+            boundary
+                < u32::from(crate::scheduling::most_recent_boundary(
+                    new.scheduled_height
+                ))
+        );
+
+        // The rebuilt PCZT is a valid pre-signed transfer with deferred anchors and the new expiry.
+        let parsed = pczt::Pczt::parse(&new.pczt).expect("the rebuilt PCZT parses");
+        assert!(parsed.orchard().anchor().is_none());
+        assert!(parsed.ironwood().anchor().is_none());
+        assert_eq!(
+            *parsed.global().expiry_height(),
+            u32::from(new.expiry_height)
+        );
+
+        // It is no longer expired at the tip it was rebuilt against.
+        assert!(!state.expired_transactions(target).contains(&id));
+    }
+
+    /// The nullifier of the one real spend (the action with no witness; ZIP 374 deferral leaves
+    /// the padding dummy its arbitrary witness) of a stored transfer PCZT.
+    fn real_spend_nullifier(pczt_bytes: &[u8]) -> [u8; 32] {
+        let parsed = pczt::Pczt::parse(pczt_bytes).expect("the stored PCZT parses");
+        let real: Vec<[u8; 32]> = parsed
+            .orchard()
+            .actions()
+            .iter()
+            .filter(|a| a.spend().witness().is_none())
+            .map(|a| *a.spend().nullifier())
+            .collect();
+        assert_eq!(real.len(), 1, "a transfer has exactly one real spend");
+        real[0]
+    }
+
+    /// Rebuilding re-funds the transfer with EXACTLY the note its expired PCZT spends (matched by
+    /// nullifier), not whichever spendable note happens to share its value: migration
+    /// denominations repeat, and re-funding from a sibling transfer's identical-value note would
+    /// make the rebuilt transfer a double-spend of that still-valid sibling.
+    #[test]
+    fn rebuild_resolves_the_exact_funding_note_not_an_equal_value_sibling() {
+        let seed = 103u64;
+        let params = regtest_network(true);
+        let buffer = u64::from(commit_test_fees().1);
+        let funding_note = COIN + buffer;
+        // TWO identical-denomination funding notes: two transfers of the same funding value.
+        let mut backend = CommitMock::new(seed, &[funding_note, funding_note]);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+        // Direct funding: two transfers, no preparation transactions.
+        assert_eq!(state.transactions.len(), 2);
+        let victim = state
+            .transactions
+            .iter()
+            .find(|t| matches!(t.kind, MigrationTxKind::Transfer { crossing: 1 }))
+            .expect("the second crossing's transfer exists")
+            .clone();
+
+        // Expire every transfer.
+        let latest_expiry = state
+            .transactions
+            .iter()
+            .map(|t| t.expiry_height)
+            .max()
+            .expect("transactions exist");
+        backend.tip = latest_expiry + 1;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        rebuild_expired_transfer(&params, &backend, &mut state, victim.id, &mut rng)
+            .expect("rebuilds the expired transfer");
+
+        let rebuilt = state
+            .transactions
+            .iter()
+            .find(|t| t.id == victim.id)
+            .expect("the rebuilt transfer is still stored");
+        assert_eq!(
+            real_spend_nullifier(&rebuilt.pczt),
+            real_spend_nullifier(&victim.pczt),
+            "the rebuilt transfer spends the same funding note its expired PCZT spent"
+        );
+    }
+
+    /// When the exact funding note is gone (spent outside the migration), rebuilding fails with
+    /// `FundingNoteUnavailable` even if the wallet holds a DIFFERENT spendable note of equal
+    /// value: re-funding a part from an arbitrary note is re-planning, not a rebuild.
+    #[test]
+    fn rebuild_rejects_a_replaced_funding_note_of_equal_value() {
+        let seed = 105u64;
+        let params = regtest_network(true);
+        let buffer = u64::from(commit_test_fees().1);
+        let funding_note = COIN + buffer;
+        let mut backend = CommitMock::new(seed, &[funding_note]);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+        let tx = state.transactions[0].clone();
+
+        // Replace the funding note with a different note of the SAME value, as if the original
+        // was spent outside the migration and equal-value change arrived in its place.
+        let replacement = single_note_witness(&backend.fvk, funding_note, seed + 777).0;
+        backend.wallet_notes[0] = replacement;
+        backend.tip = tx.expiry_height + 1;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, tx.id, &mut rng),
+            Err(RebuildError::FundingNoteUnavailable(v))
+                if v == Zatoshis::from_u64(funding_note).expect("test value is valid")
+        ));
+    }
+
+    /// For an EXTERNALLY signed migration (a hardware or offline signer), an expired transfer is
+    /// rebuilt UNSIGNED, mirroring [`build_preparation_unsigned`]: it moves to
+    /// `AwaitingSignature` holding the fresh unsigned PCZT, the same bytes come back as an
+    /// [`UnsignedMigrationTx`] to route to the device (batchable by action budget), and
+    /// [`MigrationState::apply_signature`] completes it to `Signed`. In-process signing never
+    /// runs: the spend authority stays on the device.
+    #[test]
+    fn rebuild_expired_transfer_unsigned_awaits_the_external_signature() {
+        let seed = 107u64;
+        let params = regtest_network(true);
+        let buffer = u64::from(commit_test_fees().1);
+        let funding_note = COIN + buffer;
+        let mut backend = CommitMock::new(seed, &[funding_note]);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (mut state, unsigned) = build_preparation_unsigned(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("builds the migration unsigned");
+        // Sign out of band and apply, exactly as the external-signing caller does.
+        for u in unsigned {
+            let (id, bytes) = u.into_parts();
+            let signed = sign_pczt(
+                pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses"),
+                &backend.ask,
+            )
+            .expect("the external signer signs");
+            assert!(state.apply_signature(id, signed.serialize().expect("serializes")));
+        }
+        let old = state.transactions[0].clone();
+        assert_eq!(old.state, MigrationTxState::Signed);
+
+        // Expire the transfer, then rebuild it UNSIGNED.
+        backend.tip = old.expiry_height + 1;
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        let unsigned_rebuild =
+            rebuild_expired_transfer_unsigned(&params, &backend, &mut state, old.id, &mut rng)
+                .expect("rebuilds the expired transfer unsigned");
+
+        // The transfer awaits the external signature, holding the fresh UNSIGNED bytes that were
+        // also returned for routing to the signer.
+        let rebuilt = state.transactions[0].clone();
+        assert_eq!(rebuilt.state, MigrationTxState::AwaitingSignature);
+        assert_eq!(unsigned_rebuild.id(), old.id);
+        assert_eq!(*unsigned_rebuild.pczt(), rebuilt.pczt);
+        assert_eq!(
+            unsigned_rebuild.actions(),
+            SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER
+        );
+        let parsed = pczt::Pczt::parse(&rebuilt.pczt).expect("the rebuilt PCZT parses");
+        assert_eq!(
+            *parsed.global().expiry_height(),
+            u32::from(rebuilt.expiry_height)
+        );
+        assert!(
+            rebuilt.expiry_height > old.expiry_height,
+            "a fresh, later canonical expiry"
+        );
+        // The builder signs its fabricated dummy spends with their throwaway keys; the account's
+        // one REAL spend (the unwitnessed one, ZIP 374) is what must await the external signer.
+        assert!(
+            parsed
+                .orchard()
+                .actions()
+                .iter()
+                .filter(|a| a.spend().witness().is_none())
+                .all(|a| a.spend().spend_auth_sig().is_none()),
+            "the account's spend authorization was not attached in-process"
+        );
+        assert_eq!(
+            real_spend_nullifier(&rebuilt.pczt),
+            real_spend_nullifier(&old.pczt),
+            "the same funding note funds the rebuilt transfer"
+        );
+
+        // The externally produced signature completes it back to Signed.
+        let signed = sign_pczt(parsed, &backend.ask).expect("the external signer signs");
+        assert!(state.apply_signature(old.id, signed.serialize().expect("serializes")));
+        assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
+    }
+
+    /// Rebuilding rejects a transaction that has not expired, a preparation transaction, and an
+    /// unknown id, so a caller cannot reissue a still-valid transfer as a double-spending copy.
+    #[test]
+    fn rebuild_expired_transfer_rejects_ineligible_transactions() {
+        let seed = 101u64;
+        let params = regtest_network(true);
+        let buffer = u64::from(commit_test_fees().1);
+        let mut backend = CommitMock::new(seed, &[COIN + buffer]);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+        let id = state.transactions[0].id;
+
+        // Not expired yet (the tip is far below the expiry): rejected.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            Err(RebuildError::NotExpired(rejected)) if rejected == id
+        ));
+        // An unknown id: rejected.
+        let unknown = MigrationTxId::new(9999);
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, unknown, &mut rng),
+            Err(RebuildError::UnknownTransaction(rejected)) if rejected == unknown
+        ));
+
+        // A preparation transaction, even an expired one: rejected. Only a transfer (a leaf of the
+        // dependency graph) is rebuilt this way; an expired preparation invalidates its dependents'
+        // pre-signatures and needs its own remediation.
+        state.transactions[0].kind = MigrationTxKind::Preparation { layer: 0, index: 0 };
+        backend.tip = state.transactions[0].expiry_height + 1;
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            Err(RebuildError::NotATransfer(rejected)) if rejected == id
+        ));
+    }
+
     /// A lone whale fanning out into more funding notes than one transaction holds needs a
     /// MULTI-LAYER preparation — and it still signs in the SAME single pass: the later layer's
     /// feeder spends and the transfers' funding notes are recovered from the earlier layers'
@@ -2733,6 +3423,7 @@ mod commit_tests {
             fvk,
             ask: SpendAuthorizingKey::from(&sk),
             stored: None,
+            tip: BlockHeight::from_u32(2_000_000),
         };
         let params = regtest_network(true);
         let prep_count = plan.preparation().transaction_count();

--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -2776,7 +2776,15 @@ mod commit_tests {
         // only once layer 0 mines; each transfer once its own funding note's producer mines (here
         // the whole last layer is mined at once, so every transfer becomes broadcastable).
         let mut state = state;
-        let target = BlockHeight::from_u32(2_100_000);
+        // A height past every scheduled broadcast (so each transaction is due, not blocked on the
+        // schedule) but within every expiry window (so none is expired and offered for rebuild): the
+        // latest scheduled height. This exercises the dependency-ordering walk, not expiry handling.
+        let target = state
+            .transactions
+            .iter()
+            .map(|t| t.scheduled_height)
+            .max()
+            .expect("the committed migration has transactions");
         match state.next_step(target) {
             crate::state::AdvanceStep::Prove { id }
             | crate::state::AdvanceStep::Broadcast { id } => {
@@ -2948,7 +2956,15 @@ mod commit_tests {
         // The state machine broadcasts each preparation layer in order — a layer only once its
         // predecessor has mined — then, once the last layer mines, the transfers.
         let mut state = state;
-        let target = BlockHeight::from_u32(2_100_000);
+        // A height past every scheduled broadcast (so each transaction is due, not blocked on the
+        // schedule) but within every expiry window (so none is expired and offered for rebuild): the
+        // latest scheduled height. This exercises the dependency-ordering walk, not expiry handling.
+        let target = state
+            .transactions
+            .iter()
+            .map(|t| t.scheduled_height)
+            .max()
+            .expect("the committed migration has transactions");
         let mut height = 2_000_000u32;
         for layer in 0..layer_count {
             let ids = layer_ids(&state, layer);

--- a/zcash_pool_migration_backend/src/state.rs
+++ b/zcash_pool_migration_backend/src/state.rs
@@ -50,6 +50,24 @@ pub enum AdvanceStep {
         /// The transaction to broadcast.
         id: MigrationTxId,
     },
+    /// Rebuild this TRANSFER: its [`expiry_height`](MigrationTransaction::expiry_height) has passed
+    /// without it mining, so it can no longer be included in a block (ZIP 203). The pre-signed
+    /// artifact is dead — the signature hash covers the expiry height, so no part of it can be
+    /// reused — and an entirely new transaction must be constructed and SIGNED ANEW with a fresh
+    /// anchor and expiry, its denomination unchanged. Unlike proving and broadcasting (which need
+    /// only the viewing key, the commitment tree, and the network), acting on this step needs the
+    /// account's SPEND AUTHORITY: in-process where the wallet holds it, or a new external signing
+    /// session for a hardware or offline signer.
+    ///
+    /// Only a transfer is surfaced: it is a leaf of the dependency graph, so it can be rebuilt on
+    /// its own. An expired PREPARATION is reported via [`Blocker::Expired`] but never as this step
+    /// (see [`MigrationState::expired_transactions`]). A migration is never stuck silently on an
+    /// expired transfer: this step is returned in preference to [`Waiting`](Self::Waiting) whenever
+    /// one is holding up the schedule.
+    Rebuild {
+        /// The transaction to rebuild.
+        id: MigrationTxId,
+    },
     /// Nothing to do now: waiting for one or more transactions to mine, for an anchor boundary to
     /// settle, or for a scheduled height to arrive.
     Waiting,
@@ -89,6 +107,16 @@ pub enum Blocker {
     /// [`MigrationState::apply_signature`](MigrationState::apply_signature) stores the signed PCZT
     /// returned by the device.
     Signature,
+    /// Its [`expiry_height`](MigrationTransaction::expiry_height) has passed without it mining, so it
+    /// can no longer be included in a block (ZIP 203): the pre-signed artifact is dead, and an
+    /// entirely new transaction must be constructed and signed anew (with a fresh anchor and
+    /// expiry, its denomination unchanged) before this part can advance. For a TRANSFER the
+    /// consumer performs that rebuild when [`next_step`](MigrationState::next_step) returns
+    /// [`AdvanceStep::Rebuild`]. For a PREPARATION no single-transaction rebuild exists (its
+    /// dependents' pre-signatures commit to the notes it would have minted), so this blocker is the
+    /// signal that the migration needs a new signing ceremony over the affected subtree. Reported
+    /// so a wallet can show the transaction as needing attention rather than as merely waiting.
+    Expired,
 }
 
 /// The status of one migration transaction, as a wallet renders it and decides the next step. This is
@@ -113,6 +141,11 @@ pub struct TransactionStatus {
     /// The height at or after which it is due to broadcast.
     #[getset(get_copy = "pub")]
     pub(crate) scheduled_height: BlockHeight,
+    /// The height after which the transaction can no longer be mined (ZIP 203); `0` means it never
+    /// expires. Surfaced so a wallet can show how close a transaction is to expiring, and recognize
+    /// the [`Blocker::Expired`] state.
+    #[getset(get_copy = "pub")]
+    pub(crate) expiry_height: BlockHeight,
     /// Whether the wallet can act on it right now.
     #[getset(get_copy = "pub")]
     pub(crate) ready: bool,
@@ -142,6 +175,51 @@ impl MigrationState {
         })
     }
 
+    /// Whether transaction `t` can no longer be mined at `target_height` (`chain_tip + 1`, the height
+    /// of the next block it could be included in) and so must be rebuilt. A transaction may be mined
+    /// only in a block whose height is at or below its
+    /// [`expiry_height`](MigrationTransaction::expiry_height) (ZIP 203), so it is expired once
+    /// `expiry_height < target_height`. An `expiry_height` of `0` disables expiry (the transaction
+    /// never expires), and an already-`Mined` transaction is never expired: it was included before its
+    /// expiry and is final.
+    fn is_expired(t: &MigrationTransaction, target_height: BlockHeight) -> bool {
+        if matches!(t.state, MigrationTxState::Mined { .. }) {
+            return false;
+        }
+        let expiry = u32::from(t.expiry_height);
+        expiry != 0 && expiry < u32::from(target_height)
+    }
+
+    /// The ids of every transaction that has expired at `target_height` (`chain_tip + 1`) without
+    /// mining. This is the detection a wallet runs on launch to reconcile a schedule whose
+    /// broadcast windows were missed: each id it returns is a pre-signed transaction the node would
+    /// now reject, whose part must be carried by an entirely new transaction, constructed and
+    /// signed anew with a fresh anchor and expiry while keeping its denomination. A TRANSFER here
+    /// is also surfaced as [`AdvanceStep::Rebuild`]; a PREPARATION is not (rebuilding it means
+    /// re-signing its whole dependent subtree, a remediation beyond a single advance step), so a
+    /// wallet uses this list to tell the user the migration needs a new signing ceremony.
+    pub fn expired_transactions(&self, target_height: BlockHeight) -> Vec<MigrationTxId> {
+        self.transactions
+            .iter()
+            .filter(|t| Self::is_expired(t, target_height))
+            .map(|t| t.id)
+            .collect()
+    }
+
+    /// The id of the next TRANSFER that must be rebuilt because it has expired (see
+    /// [`Self::is_expired`]). Only a transfer is surfaced: it is a leaf of the dependency graph, so
+    /// it can be reconstructed and signed anew on its own. An expired PREPARATION has no
+    /// single-transaction remediation — its dependents' pre-signatures commit to the notes it would
+    /// have minted, so rebuilding it means re-signing the whole dependent subtree (a follow-on
+    /// slice); it stays visible through [`Blocker::Expired`] and [`Self::expired_transactions`].
+    fn next_rebuildable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+        self.transactions
+            .iter()
+            .filter(|t| matches!(t.kind, MigrationTxKind::Transfer { .. }))
+            .find(|t| Self::is_expired(t, target_height))
+            .map(|t| t.id)
+    }
+
     /// Whether transaction `t` is ready to PROVE at `target_height` (`chain_tip + 1`): its
     /// dependencies are mined and its Orchard anchor is resolvable from the wallet's commitment tree
     /// right now.
@@ -155,6 +233,12 @@ impl MigrationState {
     /// anchors to a fresh checkpoint at the tip when proved, so it is prove-ready once its
     /// dependencies are mined and its scheduled height has arrived.
     fn prove_ready(&self, t: &MigrationTransaction, target_height: BlockHeight) -> bool {
+        // An expired transaction can never be mined, so proving it is wasted work: it must be rebuilt
+        // (with a fresh anchor and expiry) first. Guarding here keeps `next_provable` from ever
+        // offering an expired transaction.
+        if Self::is_expired(t, target_height) {
+            return false;
+        }
         if !self.deps_mined(&t.depends_on) {
             return false;
         }
@@ -189,6 +273,10 @@ impl MigrationState {
                 matches!(t.state, MigrationTxState::Proved)
                     && t.scheduled_height <= target_height
                     && self.deps_mined(&t.depends_on)
+                    // An expired proven transaction would be rejected by the node; it must be rebuilt,
+                    // not broadcast. This is what stops a wallet resumed after its broadcast windows
+                    // lapsed from broadcasting a stale, no-longer-includable transaction.
+                    && !Self::is_expired(t, target_height)
             })
             .map(|t| t.id)
     }
@@ -296,6 +384,13 @@ impl MigrationState {
         if let Some(id) = self.next_broadcastable(target_height) {
             return AdvanceStep::Broadcast { id };
         }
+        // Make progress on still-valid transactions first (above), then surface any expired
+        // transfer for rebuild. Reporting Rebuild in preference to Waiting is what stops the
+        // migration stalling forever on a transfer whose broadcast window lapsed: nothing else
+        // will ever make it broadcastable again.
+        if let Some(id) = self.next_rebuildable(target_height) {
+            return AdvanceStep::Rebuild { id };
+        }
         if !self.transactions.is_empty()
             && self
                 .transactions
@@ -320,44 +415,53 @@ impl MigrationState {
             .iter()
             .map(|t| {
                 let deps_ok = self.deps_mined(&t.depends_on);
-                // `Signed`/`Proved` transactions are actionable only once their dependencies (the
-                // preparation layers that mint their inputs) are mined and they are due.
-                let (ready, action, blocked_on) = match t.state {
-                    // Built for an external signer and waiting for its signed PCZT; the wallet's
-                    // automatic driver takes no action (the external-signing caller drives it via
-                    // `apply_signature`), so it is neither ready nor blocked on the chain.
-                    MigrationTxState::AwaitingSignature => (false, None, Some(Blocker::Signature)),
-                    // Pre-signed and awaiting proof: ready to PROVE once its anchor is resolvable (a
-                    // transfer's boundary has settled, or a preparation is due). Not yet proved, so
-                    // not yet broadcast.
-                    MigrationTxState::Signed => {
-                        if !deps_ok {
-                            (false, None, Some(Blocker::Dependencies))
-                        } else if self.prove_ready(t, target_height) {
-                            (true, Some(NextAction::Prove), None)
-                        } else {
-                            // Deps mined but not prove-ready: a transfer waiting for its anchor
-                            // boundary to settle, or a preparation not yet due on its schedule.
-                            let blocker = match t.anchor_boundary {
-                                Some(_) => Blocker::AnchorBoundary,
-                                None => Blocker::Schedule,
-                            };
-                            (false, None, Some(blocker))
+                // An expired transaction (not yet mined, past its expiry height) can never be mined and
+                // must be rebuilt; report that ahead of any other blocker, so a wallet shows it as
+                // needing attention rather than as waiting on a dependency or the schedule.
+                let (ready, action, blocked_on) = if Self::is_expired(t, target_height) {
+                    (false, None, Some(Blocker::Expired))
+                } else {
+                    // `Signed`/`Proved` transactions are actionable only once their dependencies (the
+                    // preparation layers that mint their inputs) are mined and they are due.
+                    match t.state {
+                        // Built for an external signer and waiting for its signed PCZT; the wallet's
+                        // automatic driver takes no action (the external-signing caller drives it via
+                        // `apply_signature`), so it is neither ready nor blocked on the chain.
+                        MigrationTxState::AwaitingSignature => {
+                            (false, None, Some(Blocker::Signature))
                         }
-                    }
-                    // Proved and awaiting broadcast: ready to BROADCAST once its scheduled height has
-                    // arrived, otherwise waiting on the broadcast schedule.
-                    MigrationTxState::Proved => {
-                        if !deps_ok {
-                            (false, None, Some(Blocker::Dependencies))
-                        } else if t.scheduled_height <= target_height {
-                            (true, Some(NextAction::Broadcast), None)
-                        } else {
-                            (false, None, Some(Blocker::Schedule))
+                        // Pre-signed and awaiting proof: ready to PROVE once its anchor is resolvable (a
+                        // transfer's boundary has settled, or a preparation is due). Not yet proved, so
+                        // not yet broadcast.
+                        MigrationTxState::Signed => {
+                            if !deps_ok {
+                                (false, None, Some(Blocker::Dependencies))
+                            } else if self.prove_ready(t, target_height) {
+                                (true, Some(NextAction::Prove), None)
+                            } else {
+                                // Deps mined but not prove-ready: a transfer waiting for its anchor
+                                // boundary to settle, or a preparation not yet due on its schedule.
+                                let blocker = match t.anchor_boundary {
+                                    Some(_) => Blocker::AnchorBoundary,
+                                    None => Blocker::Schedule,
+                                };
+                                (false, None, Some(blocker))
+                            }
                         }
+                        // Proved and awaiting broadcast: ready to BROADCAST once its scheduled height has
+                        // arrived, otherwise waiting on the broadcast schedule.
+                        MigrationTxState::Proved => {
+                            if !deps_ok {
+                                (false, None, Some(Blocker::Dependencies))
+                            } else if t.scheduled_height <= target_height {
+                                (true, Some(NextAction::Broadcast), None)
+                            } else {
+                                (false, None, Some(Blocker::Schedule))
+                            }
+                        }
+                        MigrationTxState::Broadcast { .. } => (false, None, None),
+                        MigrationTxState::Mined { .. } => (false, None, None),
                     }
-                    MigrationTxState::Broadcast { .. } => (false, None, None),
-                    MigrationTxState::Mined { .. } => (false, None, None),
                 };
                 let txid = match t.state {
                     MigrationTxState::Broadcast { txid } => Some(txid),
@@ -373,6 +477,7 @@ impl MigrationState {
                     state: t.state,
                     depends_on: t.depends_on.clone(),
                     scheduled_height: t.scheduled_height,
+                    expiry_height: t.expiry_height,
                     ready,
                     action,
                     blocked_on,
@@ -748,6 +853,189 @@ mod tests {
             AdvanceStep::Broadcast {
                 id: MigrationTxId(1)
             }
+        );
+    }
+
+    // A transaction with the given id/kind/state, no dependencies, scheduled at 0, expiring after
+    // `expiry`. An `expiry` of 0 means the transaction never expires.
+    fn tx_expiring(
+        id: u32,
+        kind: MigrationTxKind,
+        state: MigrationTxState,
+        expiry: u32,
+    ) -> MigrationTransaction {
+        let mut t = tx(id, kind, state);
+        t.expiry_height = BlockHeight::from_u32(expiry);
+        t
+    }
+
+    #[test]
+    fn zero_expiry_height_never_expires() {
+        // The default `tx` helper uses expiry_height 0; at any target the transaction is not expired,
+        // preserving the pre-expiry behaviour of every other test in this module.
+        let s = state_with(vec![tx(0, transfer(0), MigrationTxState::Proved)]);
+        assert!(
+            s.expired_transactions(BlockHeight::from_u32(1_000_000))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn expired_transaction_is_not_broadcast_or_proved() {
+        // A proved transfer valid only up to height 50. `target_height` is `tip + 1`, i.e. the height
+        // of the next block it could be mined into.
+        let mut xfer = tx_expiring(1, transfer(0), MigrationTxState::Proved, 50);
+        xfer.scheduled_height = BlockHeight::from_u32(40);
+        let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
+
+        // At target 50 (tip 49) it can still be mined -> broadcastable.
+        assert_eq!(
+            s.next_broadcastable(BlockHeight::from_u32(50)),
+            Some(MigrationTxId(1))
+        );
+        // At target 51 (tip 50) expiry has passed (51 > 50) -> not broadcastable, must be rebuilt.
+        assert_eq!(s.next_broadcastable(BlockHeight::from_u32(51)), None);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(51)),
+            AdvanceStep::Rebuild {
+                id: MigrationTxId(1)
+            }
+        );
+
+        // The same holds for a still-`Signed` (unproved) expired transfer: it is not provable either.
+        s.transactions[1].state = MigrationTxState::Signed;
+        assert_eq!(s.next_provable(BlockHeight::from_u32(51)), None);
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(51)),
+            AdvanceStep::Rebuild {
+                id: MigrationTxId(1)
+            }
+        );
+    }
+
+    #[test]
+    fn expired_transaction_reports_blocker_and_expiry_height() {
+        let xfer = tx_expiring(1, transfer(0), MigrationTxState::Proved, 50);
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
+
+        let v = s.transaction_statuses(BlockHeight::from_u32(51));
+        assert!(!v[1].ready);
+        assert_eq!(v[1].action, None);
+        assert_eq!(v[1].blocked_on, Some(Blocker::Expired));
+        assert_eq!(v[1].expiry_height, BlockHeight::from_u32(50));
+        assert_eq!(
+            s.expired_transactions(BlockHeight::from_u32(51)),
+            vec![MigrationTxId(1)]
+        );
+    }
+
+    #[test]
+    fn mined_transaction_past_expiry_is_not_expired() {
+        // A transaction that already mined is final even once the chain passes its expiry height: it
+        // was included in time and must never be reported as expired or offered for rebuild.
+        let s = state_with(vec![tx_expiring(0, transfer(0), mined(40), 50)]);
+        assert!(
+            s.expired_transactions(BlockHeight::from_u32(1_000))
+                .is_empty()
+        );
+        let v = s.transaction_statuses(BlockHeight::from_u32(1_000));
+        assert_eq!(v[0].blocked_on, None);
+    }
+
+    #[test]
+    fn valid_work_precedes_rebuild() {
+        // One transfer is provable now; an independent, already-proved transfer has expired. The
+        // migration makes progress on the valid transfer first, and only surfaces the rebuild once no
+        // valid prove/broadcast work remains.
+        let prep0 = tx(0, prep(0, 0), mined(10));
+        let provable = tx(1, transfer(0), MigrationTxState::Signed);
+        let expired = tx_expiring(2, transfer(1), MigrationTxState::Proved, 50);
+        let mut s = state_with(vec![prep0, provable, expired]);
+
+        // Target 51: transfer 1 is provable (no boundary, deps mined, due), transfer 2 is expired.
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(51)),
+            AdvanceStep::Prove {
+                id: MigrationTxId(1)
+            }
+        );
+        // Once the valid transfer is proved and broadcast, the expired one is surfaced for rebuild.
+        s.transactions[1].state = MigrationTxState::Broadcast {
+            txid: TxId::from_bytes([3; 32]),
+        };
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(51)),
+            AdvanceStep::Rebuild {
+                id: MigrationTxId(2)
+            }
+        );
+    }
+
+    #[test]
+    fn expired_preparation_is_not_offered_for_rebuild() {
+        // An expired preparation cannot be rebuilt in isolation: its dependents' pre-signatures
+        // commit to the notes it would have minted, so its remediation (rebuilding and re-signing
+        // the whole dependent subtree) is a new signing ceremony, not a single advance step.
+        // `next_step` reports Waiting rather than an unactionable Rebuild, while the expiry stays
+        // visible through `Blocker::Expired` and `expired_transactions`.
+        let expired_prep = tx_expiring(
+            0,
+            prep(0, 0),
+            MigrationTxState::Broadcast {
+                txid: TxId::from_bytes([7; 32]),
+            },
+            50,
+        );
+        let mut dependent = tx(1, transfer(0), MigrationTxState::Signed);
+        dependent.depends_on = vec![MigrationTxId(0)];
+        let s = state_with(vec![expired_prep, dependent]);
+
+        assert_eq!(s.next_step(BlockHeight::from_u32(51)), AdvanceStep::Waiting);
+        let v = s.transaction_statuses(BlockHeight::from_u32(51));
+        assert_eq!(v[0].blocked_on, Some(Blocker::Expired));
+        assert_eq!(
+            s.expired_transactions(BlockHeight::from_u32(51)),
+            vec![MigrationTxId(0)]
+        );
+    }
+
+    #[test]
+    fn rebuild_surfaces_an_expired_transfer_past_an_expired_preparation() {
+        // When both a preparation and a transfer have expired, the rebuild decision surfaces the
+        // TRANSFER (the engine can rebuild it), not the preparation listed before it.
+        let expired_prep = tx_expiring(
+            0,
+            prep(0, 0),
+            MigrationTxState::Broadcast {
+                txid: TxId::from_bytes([7; 32]),
+            },
+            50,
+        );
+        let expired_xfer = tx_expiring(1, transfer(0), MigrationTxState::Proved, 50);
+        let s = state_with(vec![expired_prep, expired_xfer]);
+
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(51)),
+            AdvanceStep::Rebuild {
+                id: MigrationTxId(1)
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_migration_is_not_offered_for_rebuild() {
+        // A cancelled (Failed) migration with an expired transaction must stay terminal: next_step
+        // reports Complete, never Rebuild, so a cancelled migration is never driven further.
+        let mut s = state_with(vec![tx_expiring(
+            0,
+            transfer(0),
+            MigrationTxState::Proved,
+            50,
+        )]);
+        s.status = MigrationStatus::Failed;
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(1_000)),
+            AdvanceStep::Complete
         );
     }
 }

--- a/zcash_pool_migration_backend/tests/engine_commit.rs
+++ b/zcash_pool_migration_backend/tests/engine_commit.rs
@@ -154,7 +154,15 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     // The state machine walks the broadcasts in dependency order: layer 0 first; layer 1 only once
     // layer 0 mines; the transfers only once the whole preparation mines.
     let mut state = state;
-    let target = BlockHeight::from_u32(2_100_000);
+    // A height past every scheduled broadcast (so each transaction is due, not blocked on the
+    // schedule) but within every expiry window (so none is expired and offered for rebuild): the
+    // latest scheduled height. This exercises the dependency-ordering walk, not expiry handling.
+    let target = state
+        .transactions()
+        .iter()
+        .map(|t| t.scheduled_height())
+        .max()
+        .expect("the committed migration has transactions");
     match state.next_step(target) {
         AdvanceStep::Prove { id } | AdvanceStep::Broadcast { id } => {
             assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")


### PR DESCRIPTION
## Motivation

A ZIP 318 audit of the migration code flagged that the state machine ignores
transaction expiry. A pre-signed migration transaction can only be mined in a
block at or below its expiry height (ZIP 203), and the migration's expiry
window is a rolling one-to-two months. Two concrete gaps followed:

- `next_broadcastable` offered an **expired** transaction for broadcast. A
  wallet resumed after its broadcast windows lapsed (dormant past the expiry
  window) would be told to broadcast a transaction the node rejects, with no
  recovery path.
- `next_step` had no way to express "this transaction must be rebuilt", so an
  expired transaction blocking its dependents would leave the migration on
  `Waiting` indefinitely.

This PR closes both halves of that finding: the pure state machine now
**detects** expiry and surfaces a rebuild decision, and the engine now
**rebuilds** the expired transfer to act on it.

Review of an earlier revision surfaced the constraint that shapes the
solution: the transaction signature hash covers the expiry height, so nothing
of an expired artifact is reusable — the part must be carried by an entirely
new transaction, **signed anew**. Signing needs the account's spend authority
(unlike proving and broadcasting, which need only the viewing key, the
commitment tree, and the network), which drives both the in-process/external
split of the rebuild API and the restriction of the advance step to transfers.

## Changes

### Detection and advance decision (`zcash_pool_migration_backend/src/state.rs`)

- `is_expired(tx, target_height)`: a not-yet-mined transaction is expired once
  `expiry_height < target_height`. An `expiry_height` of `0` never expires; a
  `Mined` transaction is never expired (it was included in time). Expiry is
  **computed** from the persisted height and the tip, not stored as a
  `MigrationTxState` variant, so it cannot go stale as the chain advances.
- `next_provable` and `next_broadcastable` skip expired transactions.
- `next_step` returns a new `AdvanceStep::Rebuild { id }` for an expired
  **transfer**, after any still-valid prove/broadcast work and in preference
  to `Waiting`, so the migration surfaces the rebuild rather than stalling.
  Only a transfer — a leaf of the dependency graph — is surfaced: an expired
  **preparation** has no single-transaction remediation (its dependents'
  pre-signatures commit to the notes it would have minted, so rebuilding it
  means re-signing the whole dependent subtree, a follow-on slice); it stays
  visible through `Blocker::Expired` and `expired_transactions`.
- `transaction_statuses` reports a new `Blocker::Expired` and exposes each
  transaction's `expiry_height`, so a wallet UI can show "needs rebuild" and
  expiry proximity.
- `expired_transactions(target_height)`: the on-launch detection a wallet runs
  to list the transactions whose parts must be re-carried.

### Rebuild (`zcash_pool_migration_backend/src/engine.rs`)

- `rebuild_expired_transfer` makes the `AdvanceStep::Rebuild` signal
  actionable by constructing an entirely **new** transaction for the part: it
  reschedules the transfer forward from the current tip with a fresh
  memoryless delay, derives the new canonical expiry, draws a fresh boundary
  anchor, builds a new PCZT against the same funding note and crossing value,
  and signs it **anew in-process**, storing it back as `Signed`. This is
  ZIP 318's expired-transaction handling: a new transaction with a fresh
  anchor and expiry for the affected part, its denomination unchanged.
- `rebuild_expired_transfer_unsigned` serves migrations signed by an
  **external** (hardware or offline) signer, whose spend authority is not
  available in-process: it constructs the same new transaction but leaves it
  in `AwaitingSignature` and returns an `UnsignedMigrationTx` to route to the
  device (batchable by action budget), with `apply_signature` completing it to
  `Signed` — mirroring `commit_preparation` / `build_preparation_unsigned`.
- The funding note is recovered by **identity**, not value: the expired PCZT's
  one real spend reveals the note's nullifier, which is matched among the
  wallet's spendable Orchard notes. Denominations repeat across a migration,
  so a value-based match could grab a sibling transfer's funding note and turn
  the rebuilt transfer into a double-spend of that still-valid sibling.
  Anchors and witnesses stay deferred (ZIP 374): the fresh anchor is installed
  at proving time, exactly as for an originally committed transfer. The caller
  persists the updated state afterwards, as after proving.
- A typed `RebuildError` rejects a still-valid, mined, or non-transfer
  transaction, and reports (via `FundingNoteUnavailable`) a funding note that
  is gone (spent outside the migration) so the caller re-plans the remaining
  balance instead of rebuilding the part — never substituting a different
  spendable note of coincidentally equal value.

## Scope

This is the detection, reporting, advance-decision, and rebuild slice of the
audit's "error-handling states" finding, all in the pure/backend-agnostic state
module and the engine, so it is testable without a chain and usable by every
consumer (a mobile wallet using the crates directly, or Zallet). Expired
**preparation** remediation (re-signing the affected subtree), invalid
(spent-outside-the-migration) input detection, reorg handling, and the
one-overdue-per-open throttle remain separate follow-on slices.

## Testing

- Detection: an expired transaction is not proved or broadcast; `next_step`
  returns `Rebuild` for an expired transfer after still-valid work, and never
  for an expired preparation (reported via `Blocker::Expired` /
  `expired_transactions` instead); `Blocker::Expired` and `expiry_height` are
  surfaced; a mined-past-expiry transaction is not expired; a terminal
  (cancelled) migration is never offered for rebuild; and
  `expiry_height == 0` never expires.
- Rebuild: `rebuild_expired_transfer` reschedules, re-anchors, and re-signs an
  expired transfer back to `Signed`; the rebuilt transfer spends exactly the
  note its expired PCZT spent (matched by nullifier) even when a sibling
  transfer's funding note has the same value; a same-value-but-different note
  yields `FundingNoteUnavailable`; `rebuild_expired_transfer_unsigned` leaves
  the rebuilt transfer awaiting the external signature (no in-process
  authorization of the account's spend) and round-trips through
  `apply_signature`; `RebuildError` rejects a still-valid, unknown, or
  non-transfer transaction.
- Two engine lifecycle tests used a target height past the schedule's expiry
  window purely to mean "everything is due"; they now derive their target from
  the latest scheduled height, so they exercise dependency ordering rather
  than tripping the expiry path.
- `cargo test -p zcash_pool_migration_backend --all-features` green (109 unit
  tests, the integration walk, and the real-proving chain simulation); clippy
  `-D warnings` clean; `zcash_pool_migration_memory` and `zcash_client_sqlite`
  build clean.

Stacked on `prove/pool-migration-transfer`.

Generated with [Claude Code](https://claude.com/claude-code)
