### PR TITLE
Note locking: review fixes, SQL predicate proptests, and scenario tests

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -28,6 +28,15 @@ workspace.
 - `zcash_client_backend::data_api::error::LockError`
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
+- `zcash_client_backend::wallet::LockOwner`, an opaque token identifying the
+  holder of an output lock. Locks record their owner: unlocking is scoped to
+  the owner that took the lock, and re-locking by the same owner is an
+  idempotent acquire/extend (supporting crash-retry of a flow that had already
+  locked its inputs), while an active lock held by a different owner cannot be
+  acquired or released until it expires.
+- `zcash_client_backend::data_api::wallet::LockRequest`, the
+  `(owner, for_blocks)` pair accepted by the proposal-creation functions to
+  lock the proposal's inputs.
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
 - `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
   proposal-creation functions when an input selected by the proposal is already
@@ -84,16 +93,24 @@ workspace.
   required to unlock any locked outputs that are recorded as spent by
   the stored transactions.
 - `zcash_client_backend::data_api::WalletWrite` has added methods
-  `lock_outputs`, `unlock_output`, and `clear_locked_outputs`.
+  `lock_outputs`, `unlock_output`, and `clear_locked_outputs`. Locks are keyed
+  by a `LockOwner` token: `lock_outputs` takes the outputs as a slice together
+  with the owner and fails only on an active lock held by a different owner;
+  `unlock_output` releases only a lock held by the given owner;
+  `clear_locked_outputs` releases every lock for an account regardless of
+  owner, as a recovery mechanism.
 - `zcash_client_backend::data_api::WalletTest` has added method
   `get_locked_outputs`.
 - The following `zcash_client_backend::data_api::wallet::` proposal creation
-  functions now take a `lock_for_blocks: Option<u32>` parameter and require
-  `WalletWrite` instead of `WalletRead`:
+  functions now take a `lock_inputs: Option<LockRequest>` parameter and require
+  `WalletWrite` instead of `WalletRead`; `Some(request)` locks the proposal's
+  inputs on behalf of the request's owner until `target_height +
+  request.for_blocks()`:
   - `propose_transfer`
   - `propose_standard_transfer_to_address`
   - `propose_send_max_transfer`
   - `propose_shielding`
+  - `propose_shielding_coinbase` (under `transparent-inputs`)
 - `zcash_client_backend::data_api::wallet::ProposeSendMaxErrT` now uses
   `GreedyInputSelectorError` (instead of `BalanceError`) as its note-selection
   error type, so that `propose_send_max_transfer` can report

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -113,6 +113,12 @@ workspace.
   feature.
 
 ### Fixed
+- Proposal decoding (`proto::proposal::Proposal::try_into_standard_proposal`)
+  now retrieves inputs with `include_locked: true`. A proposal created with
+  `lock_for_blocks: Some(_)` locks its own inputs, so the previous behavior
+  made such a proposal fail to decode from its serialized form with
+  `ProposalDecodingError::InputNotFound` for every locked shielded input,
+  breaking persist-and-restore of in-flight locking proposals.
 - `zcash_client_backend::data_api::wallet::propose_send_max_transfer` now
   correctly constructs proposals paying a transparent (non-TEX) recipient — a
   bare transparent address, or a unified address having no shielded receiver.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -37,6 +37,10 @@ workspace.
 - `zcash_client_backend::data_api::wallet::LockRequest`, the
   `(owner, for_blocks)` pair accepted by the proposal-creation functions to
   lock the proposal's inputs.
+- `impl From<TxId> for zcash_client_backend::wallet::LockOwner`, for flows
+  that hold a durable transaction identity while their locks are alive (such
+  as a persisted PCZT with final effecting data), enabling the owner token to
+  be re-derived after a restart.
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
 - `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
   proposal-creation functions when an input selected by the proposal is already

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -29,6 +29,12 @@ workspace.
 - `zcash_client_backend::wallet::OutputRef`
 - `impl From<zcash_client_backend::wallet::NoteId> for zcash_client_backend::wallet::OutputRef`
 - `zcash_client_backend::data_api::wallet::unlock_proposal_inputs`
+- `zcash_client_backend::proposal::ProposalError::InputsLocked`, returned by the
+  proposal-creation functions when an input selected by the proposal is already
+  locked by a concurrent proposal or PCZT. This is a transient "account busy"
+  condition that callers should respond to by retrying, distinct from
+  `ProposalError::ChainDoubleSpend`, which continues to indicate a proposal
+  that attempts to spend the same output twice.
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3657,9 +3657,17 @@ pub trait WalletWrite: WalletRead {
     /// conflict is resolved here, at the storage layer, where the second caller's `lock_outputs`
     /// fails with [`LockError::LockFailure`] naming the already-locked output. Callers that lock
     /// via a proposal-creation function surface this as
-    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend). The
+    /// [`ProposalError::InputsLocked`](crate::proposal::ProposalError::InputsLocked). The
     /// losing caller has not partially locked anything and should treat the failure as "the
     /// account is busy" and retry.
+    ///
+    /// The provided output references must be distinct: because a live lock cannot be
+    /// re-acquired, a duplicated reference fails on its second occurrence as if a concurrent
+    /// caller held the lock. (Inputs of a valid [`Proposal`] are always distinct; proposal
+    /// construction rejects duplicates as
+    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend).)
+    ///
+    /// [`Proposal`]: crate::proposal::Proposal
     fn lock_outputs(
         &mut self,
         outputs: impl Iterator<Item = OutputRef>,
@@ -3681,6 +3689,13 @@ pub trait WalletWrite: WalletRead {
     /// operating system before the corresponding transactions could be built). By clearing all
     /// locks for the account, the caller declares that it has no pending proposals holding those
     /// outputs.
+    ///
+    /// # Warning
+    ///
+    /// This releases every lock for the account, including locks held by proposals that are
+    /// still legitimately in flight; those proposals' inputs immediately become selectable by
+    /// new proposals, re-creating the conflict that locking exists to prevent. Only call this
+    /// when no in-flight proposal or PCZT for the account remains.
     ///
     /// Returns the number of outputs that were unlocked.
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error>;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -4218,6 +4218,168 @@ pub trait WalletCommitmentTrees {
     }
 }
 
+/// Property tests for the [`Balance`] bucket arithmetic.
+///
+/// These pin the accounting semantics the locked-value bucket joined: every bucket except
+/// `uneconomic_value` participates in [`Balance::total`] and in the shared overflow guard,
+/// while `uneconomic_value` is guarded only against its own overflow and never contributes
+/// to the total.
+#[cfg(test)]
+mod balance_tests {
+    use proptest::prelude::*;
+    use zcash_protocol::value::{BalanceError, MAX_MONEY, Zatoshis};
+
+    use super::Balance;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Bucket {
+        Spendable = 0,
+        Locked = 1,
+        PendingChange = 2,
+        PendingSpendable = 3,
+        Uneconomic = 4,
+    }
+    use Bucket::*;
+
+    const ALL_BUCKETS: [Bucket; 5] = [
+        Spendable,
+        Locked,
+        PendingChange,
+        PendingSpendable,
+        Uneconomic,
+    ];
+    /// The buckets that participate in `Balance::total` and its overflow guard.
+    const TOTAL_BUCKETS: [Bucket; 4] = [Spendable, Locked, PendingChange, PendingSpendable];
+
+    fn apply(balance: &mut Balance, bucket: Bucket, value: Zatoshis) -> Result<(), BalanceError> {
+        match bucket {
+            Spendable => balance.add_spendable_value(value),
+            Locked => balance.add_locked_value(value),
+            PendingChange => balance.add_pending_change_value(value),
+            PendingSpendable => balance.add_pending_spendable_value(value),
+            Uneconomic => balance.add_uneconomic_value(value),
+        }
+    }
+
+    fn get(balance: &Balance, bucket: Bucket) -> Zatoshis {
+        match bucket {
+            Spendable => balance.spendable_value(),
+            Locked => balance.locked_value(),
+            PendingChange => balance.change_pending_confirmation(),
+            PendingSpendable => balance.value_pending_spendability(),
+            Uneconomic => balance.uneconomic_value(),
+        }
+    }
+
+    fn arb_bucket() -> impl Strategy<Value = Bucket> {
+        prop_oneof![
+            Just(Spendable),
+            Just(Locked),
+            Just(PendingChange),
+            Just(PendingSpendable),
+            Just(Uneconomic),
+        ]
+    }
+
+    /// A bucket and a value to add to it. Values are mostly small (so most sequences stay
+    /// within `MAX_MONEY`) with occasional near-cap draws to exercise the overflow guards.
+    fn arb_add() -> impl Strategy<Value = (Bucket, u64)> {
+        (
+            arb_bucket(),
+            prop_oneof![
+                3 => 0u64..=1_000_000,
+                1 => 0u64..=MAX_MONEY,
+            ],
+        )
+    }
+
+    proptest! {
+        /// Bucket adds succeed exactly while their overflow guard permits, mutate only the
+        /// requested bucket, and leave the balance untouched on failure. `total()` is always
+        /// the sum of the four participating buckets. (In particular this establishes that
+        /// the `unwrap` inside each guarded add is unreachable.)
+        #[test]
+        fn add_total_consistency(adds in proptest::collection::vec(arb_add(), 0..12)) {
+            let mut balance = Balance::ZERO;
+            // The model: per-bucket totals, indexed by bucket discriminant.
+            let mut model = [0u64; 5];
+
+            for (bucket, v) in adds {
+                let value = Zatoshis::from_u64(v).unwrap();
+                let before = balance;
+                let result = apply(&mut balance, bucket, value);
+
+                let total: u64 = TOTAL_BUCKETS.iter().map(|b| model[*b as usize]).sum();
+                let expect_ok = match bucket {
+                    Uneconomic => model[Uneconomic as usize] + v <= MAX_MONEY,
+                    _ => total + v <= MAX_MONEY,
+                };
+                if expect_ok {
+                    prop_assert!(result.is_ok());
+                    model[bucket as usize] += v;
+                } else {
+                    prop_assert!(result.is_err());
+                    prop_assert_eq!(
+                        balance, before,
+                        "a failed add must leave the balance unchanged"
+                    );
+                }
+
+                let total: u64 = TOTAL_BUCKETS.iter().map(|b| model[*b as usize]).sum();
+                prop_assert_eq!(balance.total(), Zatoshis::from_u64(total).unwrap());
+                for b in ALL_BUCKETS {
+                    prop_assert_eq!(
+                        get(&balance, b),
+                        Zatoshis::from_u64(model[b as usize]).unwrap()
+                    );
+                }
+            }
+        }
+
+        /// `Balance + Balance` is componentwise addition: it succeeds exactly when the
+        /// combined total and the combined uneconomic value each remain within `MAX_MONEY`,
+        /// and on success every bucket of the sum is the sum of the corresponding buckets.
+        #[test]
+        fn balance_addition_is_componentwise(
+            a in proptest::collection::vec(arb_add(), 0..6),
+            b in proptest::collection::vec(arb_add(), 0..6),
+        ) {
+            let build = |adds: &[(Bucket, u64)]| {
+                let mut balance = Balance::ZERO;
+                for (bucket, v) in adds {
+                    let _ = apply(&mut balance, *bucket, Zatoshis::from_u64(*v).unwrap());
+                }
+                balance
+            };
+            let ba = build(&a);
+            let bb = build(&b);
+
+            let combined_total = u64::from(ba.total()) + u64::from(bb.total());
+            let combined_uneconomic =
+                u64::from(ba.uneconomic_value()) + u64::from(bb.uneconomic_value());
+            match ba + bb {
+                Ok(sum) => {
+                    prop_assert!(combined_total <= MAX_MONEY);
+                    prop_assert!(combined_uneconomic <= MAX_MONEY);
+                    for bucket in ALL_BUCKETS {
+                        prop_assert_eq!(
+                            u64::from(get(&sum, bucket)),
+                            u64::from(get(&ba, bucket)) + u64::from(get(&bb, bucket))
+                        );
+                    }
+                    prop_assert_eq!(u64::from(sum.total()), combined_total);
+                }
+                Err(_) => {
+                    prop_assert!(
+                        combined_total > MAX_MONEY || combined_uneconomic > MAX_MONEY,
+                        "balance addition failed although no component overflows"
+                    );
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -101,7 +101,10 @@ use crate::{
     },
     decrypt::DecryptedOutput,
     proto::service::TreeState,
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, Recipient, WalletTransparentOutput, WalletTx},
+    wallet::{
+        LockOwner, Note, NoteId, OutputRef, ReceivedNote, Recipient, WalletTransparentOutput,
+        WalletTx,
+    },
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -3638,17 +3641,24 @@ pub trait WalletWrite: WalletRead {
     /// [`ConfirmationsPolicy::trusted`] confirmations even if the output is not wallet-internal.
     fn set_tx_trust(&mut self, txid: TxId, trusted: bool) -> Result<(), Self::Error>;
 
-    /// Locks the specified outputs, preventing it from being selected for spending at any height
-    /// less than or equal to the given height.
+    /// Locks the specified outputs on behalf of `owner`, preventing them from being selected
+    /// for spending at any height less than or equal to the given height.
     ///
-    /// Returns the number of outputs locked by the operation on success, or a [`LockError`] on
+    /// Returns the number of row updates performed on success (equal to the number of provided
+    /// references; a duplicated reference is counted per occurrence), or a [`LockError`] on
     /// failure, wrapping either an error from the underlying storage backend or the first output
     /// that could not be locked.
     ///
+    /// A lock may be acquired when the output holds no lock, when its existing lock has expired
+    /// as of the chain tip, or when its existing lock is held by the *same* `owner`; in the
+    /// latter case the lock's expiry height is updated. Same-owner re-locking makes the
+    /// operation idempotent, so a caller that crashes between locking and persisting its
+    /// proposal can safely retry the flow under the same [`LockOwner`]. Acquisition fails only
+    /// when an unexpired lock is held by a different owner.
+    ///
     /// Implementations of this method must either succeed completely, successfully locking each
-    /// provided output on success, or fail completely leaving all lock state unmodified if any of
-    /// the outputs were already locked. Existing locks that have expired as of the chain tip
-    /// should be replaced with new locks.
+    /// provided output on success, or fail completely leaving all lock state unmodified if any
+    /// of the outputs is actively locked by a different owner.
     ///
     /// This is the mechanism by which overlapping proposals for the same account are prevented
     /// from selecting the same inputs. Because note selection and locking cannot be performed as a
@@ -3660,26 +3670,21 @@ pub trait WalletWrite: WalletRead {
     /// [`ProposalError::InputsLocked`](crate::proposal::ProposalError::InputsLocked). The
     /// losing caller has not partially locked anything and should treat the failure as "the
     /// account is busy" and retry.
-    ///
-    /// The provided output references must be distinct: because a live lock cannot be
-    /// re-acquired, a duplicated reference fails on its second occurrence as if a concurrent
-    /// caller held the lock. (Inputs of a valid [`Proposal`] are always distinct; proposal
-    /// construction rejects duplicates as
-    /// [`ProposalError::ChainDoubleSpend`](crate::proposal::ProposalError::ChainDoubleSpend).)
-    ///
-    /// [`Proposal`]: crate::proposal::Proposal
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>>;
 
-    /// Unlocks the specified output, making it once again available for spending and balance
-    /// computations.
+    /// Unlocks the specified output if it is locked by the given `owner`, making it once again
+    /// available for spending and balance computations.
     ///
-    /// Returns `true` if the output was found and unlocked, `false` if no matching
-    /// output exists.
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error>;
+    /// Returns `true` if a lock held by `owner` (whether or not it had already expired) was
+    /// removed from the output, and `false` otherwise: in particular, a lock held by a
+    /// different owner is left in place, so one flow cannot accidentally release another's
+    /// locks.
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error>;
 
     /// Unlocks every currently-locked output belonging to the specified account, regardless of
     /// lock expiry height.
@@ -3692,10 +3697,10 @@ pub trait WalletWrite: WalletRead {
     ///
     /// # Warning
     ///
-    /// This releases every lock for the account, including locks held by proposals that are
-    /// still legitimately in flight; those proposals' inputs immediately become selectable by
-    /// new proposals, re-creating the conflict that locking exists to prevent. Only call this
-    /// when no in-flight proposal or PCZT for the account remains.
+    /// This releases every lock for the account regardless of its owner, including locks held
+    /// by proposals that are still legitimately in flight; those proposals' inputs immediately
+    /// become selectable by new proposals, re-creating the conflict that locking exists to
+    /// prevent. Only call this when no in-flight proposal or PCZT for the account remains.
     ///
     /// Returns the number of outputs that were unlocked.
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error>;

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -75,7 +75,9 @@ use crate::{
     proto::compact_formats::{
         self, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
     },
-    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote, WalletTransparentOutput},
+    wallet::{
+        LockOwner, Note, NoteId, OutputRef, OvkPolicy, ReceivedNote, WalletTransparentOutput,
+    },
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -1306,6 +1308,7 @@ where
             to_address,
             memo,
             limit,
+            None,
         )
     }
 
@@ -3382,13 +3385,18 @@ impl WalletWrite for MockWalletDb {
 
     fn lock_outputs(
         &mut self,
-        _outputs: impl Iterator<Item = OutputRef>,
+        _outputs: &[OutputRef],
+        _owner: LockOwner,
         _lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
         Ok(0)
     }
 
-    fn unlock_output(&mut self, _output: &OutputRef) -> Result<bool, Self::Error> {
+    fn unlock_output(
+        &mut self,
+        _output: &OutputRef,
+        _owner: LockOwner,
+    ) -> Result<bool, Self::Error> {
         Ok(false)
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -44,8 +44,8 @@ use crate::{
             single_output_change_strategy,
         },
         wallet::{
-            ConfirmationsPolicy, TargetHeight, TransferErrT, decrypt_and_store_transaction,
-            input_selection::GreedyInputSelector,
+            ConfirmationsPolicy, LockRequest, TargetHeight, TransferErrT,
+            decrypt_and_store_transaction, input_selection::GreedyInputSelector,
         },
     },
     decrypt_transaction,
@@ -54,7 +54,7 @@ use crate::{
         standard::{self, SingleOutputChangeStrategy},
     },
     scanning::ScanError,
-    wallet::{Note, NoteId, OutputRef, OvkPolicy, ReceivedNote},
+    wallet::{LockOwner, Note, NoteId, OutputRef, OvkPolicy, ReceivedNote},
 };
 
 use super::{DataStoreFactory, Reset, TestCache, TestFvk, TestState};
@@ -3400,9 +3400,10 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 
     // Lock the note with a far-future expiry so it's active during the test
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[output_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3433,7 +3434,7 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 
     // Unlock the note
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    assert!(st.wallet_mut().unlock_output(&output_ref, owner).unwrap());
 
     // Balance should be restored: spendable equals the full value, locked is zero
     assert_eq!(st.get_total_balance(account_id), value);
@@ -3501,9 +3502,10 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
     );
 
     // Lock with expiry exactly at the target height: the output must be treated as locked.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), target_height)
+            .lock_outputs(&[output_ref], owner, target_height)
             .unwrap(),
         1
     );
@@ -3517,12 +3519,12 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
         vec![output_ref]
     );
 
-    // Re-lock with expiry one block below the target height. Because the existing lock is not
-    // yet expired as of the chain tip, we must first unlock it explicitly.
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    // Re-lock with expiry one block below the target height. The existing lock is not yet
+    // expired as of the chain tip, but the same owner may re-acquire (and here, shorten) its
+    // own lock directly, with no explicit unlock.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), target_height - 1)
+            .lock_outputs(&[output_ref], owner, target_height - 1)
             .unwrap(),
         1
     );
@@ -3569,9 +3571,10 @@ pub fn clear_locked_outputs<T: ShieldedPoolTester>(
     );
 
     // Lock the note with a far-future expiry.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[output_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3582,7 +3585,7 @@ pub fn clear_locked_outputs<T: ShieldedPoolTester>(
     );
 
     // Clearing all locks for the account unlocks the output even though its expiry height is far
-    // in the future.
+    // in the future (and regardless of its owner).
     assert_eq!(st.wallet_mut().clear_locked_outputs(account_id).unwrap(), 1);
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
     assert_eq!(
@@ -3638,6 +3641,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -3647,7 +3651,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -3695,7 +3699,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     );
     assert_matches!(
         st.wallet_mut()
-            .lock_outputs([unknown].into_iter(), BlockHeight::from(u32::MAX)),
+            .lock_outputs(&[unknown], owner, BlockHeight::from(u32::MAX)),
         Err(LockError::LockFailure(r)) if r == unknown
     );
 
@@ -3706,7 +3710,7 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     // tightening of the contract is a visible, deliberate change.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([funding_note_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .lock_outputs(&[funding_note_ref], owner, BlockHeight::from(u32::MAX))
             .unwrap(),
         1
     );
@@ -3716,7 +3720,11 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         vec![funding_note_ref]
     );
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
-    assert!(st.wallet_mut().unlock_output(&funding_note_ref).unwrap());
+    assert!(
+        st.wallet_mut()
+            .unlock_output(&funding_note_ref, owner)
+            .unwrap()
+    );
 }
 
 /// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its
@@ -3753,6 +3761,7 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -3762,7 +3771,7 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -3815,10 +3824,11 @@ pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
     );
 
     // Lock the note until three blocks past the current tip.
+    let owner = LockOwner::new([1; 32]);
     let expiry = tip + 3;
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), expiry)
+            .lock_outputs(&[output_ref], owner, expiry)
             .unwrap(),
         1
     );
@@ -3868,12 +3878,14 @@ pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
     )
     .expect("an expired lock must not block proposal creation");
 
-    // The expired lock is replaceable: a fresh lock_outputs call succeeds without an explicit
-    // unlock, overwriting the stale expiry value.
+    // The expired lock is replaceable, even by a DIFFERENT owner: a fresh lock_outputs call
+    // succeeds without an explicit unlock, overwriting the stale expiry value and taking over
+    // ownership of the lock.
+    let other_owner = LockOwner::new([2; 32]);
     let new_tip = st.latest_cached_block().unwrap().height();
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), new_tip + 5)
+            .lock_outputs(&[output_ref], other_owner, new_tip + 5)
             .unwrap(),
         1
     );
@@ -3919,26 +3931,41 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
     let r1 = output_ref(value1);
     let r2 = output_ref(value2);
 
+    let owner_a = LockOwner::new([0xA1; 32]);
+    let owner_b = LockOwner::new([0xB2; 32]);
+
     // The first lock on a note succeeds.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([r1].into_iter(), far_expiry)
+            .lock_outputs(&[r1], owner_a, far_expiry)
             .unwrap(),
         1
     );
 
-    // A second lock on the same note fails while the first lock is active, even from the same
-    // caller: an active lock cannot be re-acquired, extended, or shortened without an explicit
-    // unlock first.
+    // Re-locking under the SAME owner succeeds while the lock is active: acquisition is
+    // idempotent for the holding flow (this is the crash-retry path), and may extend or
+    // shorten the expiry.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs(&[r1], owner_a, far_expiry)
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1]
+    );
+
+    // A lock by a DIFFERENT owner fails while the first lock is active.
     assert_matches!(
-        st.wallet_mut().lock_outputs([r1].into_iter(), far_expiry),
+        st.wallet_mut().lock_outputs(&[r1], owner_b, far_expiry),
         Err(LockError::LockFailure(r)) if r == r1
     );
 
-    // A batch containing a conflicting output fails all-or-nothing: r2 precedes the conflicting
-    // r1 in the batch, but the failure must leave r2 unlocked.
+    // A batch containing a foreign-locked output fails all-or-nothing: r2 precedes the
+    // conflicting r1 in the batch, but the failure must leave r2 unlocked.
     assert_matches!(
-        st.wallet_mut().lock_outputs([r2, r1].into_iter(), far_expiry),
+        st.wallet_mut().lock_outputs(&[r2, r1], owner_b, far_expiry),
         Err(LockError::LockFailure(r)) if r == r1
     );
     assert_eq!(
@@ -3952,35 +3979,47 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
         value2
     );
 
-    // A batch containing the same output twice fails on the duplicate: the first occurrence
-    // takes a live lock, which the second occurrence then conflicts with. Atomicity applies
-    // here too: the failed batch leaves r2 unlocked.
-    assert_matches!(
-        st.wallet_mut().lock_outputs([r2, r2].into_iter(), far_expiry),
-        Err(LockError::LockFailure(r)) if r == r2
-    );
+    // A batch containing the same output twice under one owner succeeds: the second occurrence
+    // re-acquires the lock taken by the first (both row updates are counted).
     assert_eq!(
-        st.wallet().get_locked_outputs(account_id).unwrap(),
-        vec![r1]
+        st.wallet_mut()
+            .lock_outputs(&[r2, r2], owner_b, far_expiry)
+            .unwrap(),
+        2
     );
+    {
+        let mut locked = st.wallet().get_locked_outputs(account_id).unwrap();
+        locked.sort();
+        let mut expected = vec![r1, r2];
+        expected.sort();
+        assert_eq!(locked, expected);
+    }
 
-    // Unlocking an existing output that holds no lock reports `true` (the output was found;
-    // its lock state is NULL afterwards either way); unlocking an unknown output reports
-    // `false`.
-    assert!(st.wallet_mut().unlock_output(&r2).unwrap());
+    // Unlocking is owner-scoped: owner A cannot release owner B's lock on r2, and unlocking
+    // an unknown output reports `false`.
+    assert!(!st.wallet_mut().unlock_output(&r2, owner_a).unwrap());
+    assert_eq!(
+        st.get_locked_balance(account_id),
+        (value1 + value2).unwrap()
+    );
     let unknown = OutputRef::new(
         TxId::from_bytes([0xEE; 32]),
         PoolType::Shielded(T::SHIELDED_PROTOCOL),
         0,
     );
-    assert!(!st.wallet_mut().unlock_output(&unknown).unwrap());
+    assert!(!st.wallet_mut().unlock_output(&unknown, owner_a).unwrap());
 
-    // After unlocking r1, both notes are spendable again and a fresh lock succeeds.
-    assert!(st.wallet_mut().unlock_output(&r1).unwrap());
+    // Each owner releases its own lock; unlocking an output that holds no lock reports
+    // `false`.
+    assert!(st.wallet_mut().unlock_output(&r2, owner_b).unwrap());
+    assert!(!st.wallet_mut().unlock_output(&r2, owner_b).unwrap());
+    assert!(st.wallet_mut().unlock_output(&r1, owner_a).unwrap());
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+
+    // With everything released, a single owner can lock both notes in one batch.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([r1, r2].into_iter(), far_expiry)
+            .lock_outputs(&[r1, r2], owner_a, far_expiry)
             .unwrap(),
         2
     );
@@ -3991,8 +4030,8 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
 }
 
 /// Verifies that [`unlock_proposal_inputs`] releases the locks taken by a proposal created with
-/// `lock_for_blocks: Some(_)`, restoring spendability for a subsequent proposal (the
-/// abandoned-proposal recovery path).
+/// a [`LockRequest`], restoring spendability for a subsequent proposal (the abandoned-proposal
+/// recovery path), and that the release is scoped to the owner that took the locks.
 ///
 /// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
 pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
@@ -4021,6 +4060,7 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     .unwrap();
 
     let network = *st.network();
+    let owner = LockOwner::new([1; 32]);
     let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
         st.wallet_mut(),
         &network,
@@ -4030,7 +4070,7 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
         request,
         ConfirmationsPolicy::MIN,
         &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(100), // lock_for_blocks
+        Some(LockRequest::new(owner, 100)),
         None,
     )
     .unwrap();
@@ -4051,8 +4091,16 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
         Err(data_api::error::Error::InsufficientFunds { .. })
     );
 
-    // Abandon the proposal: releasing its inputs restores spendable balance...
-    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    // Attempting to release the locks under the WRONG owner is a no-op: the locks are scoped
+    // to the owner that took them.
+    let other_owner = LockOwner::new([2; 32]);
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, other_owner)
+        .unwrap();
+    assert_eq!(st.get_locked_balance(account_id), value);
+
+    // Abandon the proposal: releasing its inputs under the correct owner restores spendable
+    // balance...
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, owner).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
     assert_eq!(
         st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
@@ -4079,44 +4127,57 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     .expect("released inputs must be selectable by a new proposal");
 
     // Releasing an already-released proposal is a no-op.
-    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal, owner).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
 }
 
 /// An operation in the note-locking model test; see [`check_note_locking_model`].
 #[derive(Clone, Debug)]
 pub enum LockOp {
-    /// Attempt to lock the notes at the given indices (duplicates permitted, and meaningful:
-    /// a duplicated index conflicts with the lock taken by its own first occurrence unless
-    /// that lock is already expired) with expiry height `chain_tip + expiry_delta`.
+    /// Attempt to lock the notes at the given indices on behalf of the given owner
+    /// (duplicates permitted: a duplicated index re-acquires the lock taken by its own first
+    /// occurrence, which succeeds because it is held by the same owner) with expiry height
+    /// `chain_tip + expiry_delta`.
     ///
     /// An `expiry_delta` of zero produces a lock that is expired from the moment it is taken:
     /// balance and selection evaluate locks against `target_height = chain_tip + 1`.
     Lock {
         notes: Vec<usize>,
+        owner: usize,
         expiry_delta: u32,
     },
-    /// Unlock the note at the given index, whether or not it is locked.
-    Unlock { note: usize },
-    /// Clear every lock for the account, regardless of expiry.
+    /// Unlock the note at the given index on behalf of the given owner; only a lock held by
+    /// that owner is released.
+    Unlock { note: usize, owner: usize },
+    /// Clear every lock for the account, regardless of expiry or owner.
     ClearLocked,
     /// Mine the given number of empty blocks, advancing the chain tip (and thereby expiring
     /// any lock whose expiry height the tip reaches).
     MineBlocks { count: usize },
 }
 
+/// The owner-index pool used by [`arb_lock_ops`] and [`check_note_locking_model`].
+const MODEL_OWNERS: [LockOwner; 2] = [LockOwner::new([0xA1; 32]), LockOwner::new([0xB2; 32])];
+
 /// A `proptest` strategy over sequences of [`LockOp`] for a wallet holding `n_notes` notes.
 ///
 /// Expiry deltas and mining counts are drawn from small ranges so that sequences routinely
 /// cross lock-expiry boundaries.
 pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec<LockOp>> {
+    let n_owners = MODEL_OWNERS.len();
     let op = prop_oneof![
         3 => (
             proptest::collection::vec(0..n_notes, 1..=n_notes + 1),
+            0..n_owners,
             0u32..=4,
         )
-            .prop_map(|(notes, expiry_delta)| LockOp::Lock { notes, expiry_delta }),
-        2 => (0..n_notes).prop_map(|note| LockOp::Unlock { note }),
+            .prop_map(|(notes, owner, expiry_delta)| LockOp::Lock {
+                notes,
+                owner,
+                expiry_delta
+            }),
+        2 => (0..n_notes, 0..n_owners)
+            .prop_map(|(note, owner)| LockOp::Unlock { note, owner }),
         1 => Just(LockOp::ClearLocked),
         2 => (1usize..=3).prop_map(|count| LockOp::MineBlocks { count }),
     ];
@@ -4126,11 +4187,12 @@ pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec
 /// Model-based test of the note-locking storage operations.
 ///
 /// Funds a wallet with three notes, then applies the given operation sequence both to the real
-/// data store and to a trivial in-memory model (per-note `Option<lock_expiry_height>` plus the
-/// chain tip). After every operation, the store must agree with the model on:
+/// data store and to a trivial in-memory model (per-note `Option<(lock_expiry_height, owner)>`
+/// plus the chain tip). After every operation, the store must agree with the model on:
 ///
 /// - the outcome of the operation itself, including the all-or-nothing failure of a `Lock`
-///   batch containing a conflict (an active, unexpired lock on any requested note);
+///   batch containing a conflict (an active, unexpired lock held by a different owner on any
+///   requested note), same-owner re-lock idempotency, and owner-scoped unlocking;
 /// - the set reported by `get_locked_outputs` (a note is locked while
 ///   `lock_expiry_height >= chain_tip + 1`);
 /// - the account balance decomposition: locked value is exactly the sum of model-locked note
@@ -4174,34 +4236,39 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
         })
         .collect();
 
-    // The model: per-note lock expiry height, and the chain tip.
-    let mut model: Vec<Option<u32>> = vec![None; refs.len()];
+    // The model: per-note lock expiry height and owner index, and the chain tip.
+    let mut model: Vec<Option<(u32, usize)>> = vec![None; refs.len()];
     let mut tip = u32::from(st.latest_cached_block().unwrap().height());
 
     for op in ops {
         match op {
             LockOp::Lock {
                 notes,
+                owner,
                 expiry_delta,
             } => {
                 let expiry = tip + expiry_delta;
                 // Predict the outcome by simulating the store's sequential update: each
-                // requested note may be locked when it holds no lock or its lock has expired
-                // as of the chain tip; the first conflict fails the whole batch.
+                // requested note may be locked when it holds no lock, when its lock has
+                // expired as of the chain tip, or when its lock is held by the requesting
+                // owner; the first conflict (an active foreign lock) fails the whole batch.
                 let mut scratch = model.clone();
                 let mut conflict = None;
                 for &i in notes {
-                    if scratch[i].is_none_or(|h| h <= tip) {
-                        scratch[i] = Some(expiry);
+                    if scratch[i].is_none_or(|(h, o)| h <= tip || o == *owner) {
+                        scratch[i] = Some((expiry, *owner));
                     } else {
                         conflict = Some(i);
                         break;
                     }
                 }
 
-                let result = st
-                    .wallet_mut()
-                    .lock_outputs(notes.iter().map(|&i| refs[i]), BlockHeight::from(expiry));
+                let batch: Vec<OutputRef> = notes.iter().map(|&i| refs[i]).collect();
+                let result = st.wallet_mut().lock_outputs(
+                    &batch,
+                    MODEL_OWNERS[*owner],
+                    BlockHeight::from(expiry),
+                );
                 match conflict {
                     None => {
                         assert_matches!(result, Ok(n) if n == notes.len());
@@ -4214,14 +4281,23 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
                     }
                 }
             }
-            LockOp::Unlock { note } => {
-                // The note exists, so unlock reports `true` regardless of prior lock state.
-                assert!(st.wallet_mut().unlock_output(&refs[*note]).unwrap());
-                model[*note] = None;
+            LockOp::Unlock { note, owner } => {
+                // Unlocking releases only a lock held by the requesting owner (expired or
+                // not), and reports whether one was released.
+                let expected = model[*note].is_some_and(|(_, o)| o == *owner);
+                assert_eq!(
+                    st.wallet_mut()
+                        .unlock_output(&refs[*note], MODEL_OWNERS[*owner])
+                        .unwrap(),
+                    expected
+                );
+                if expected {
+                    model[*note] = None;
+                }
             }
             LockOp::ClearLocked => {
-                // Clearing removes every lock record, expired or not, and reports how many
-                // rows it touched.
+                // Clearing removes every lock record, expired or not and regardless of
+                // owner, and reports how many rows it touched.
                 let expected = model.iter().filter(|h| h.is_some()).count();
                 assert_eq!(
                     st.wallet_mut().clear_locked_outputs(account_id).unwrap(),
@@ -4241,14 +4317,14 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
         let locked_value = model
             .iter()
             .zip(values.iter())
-            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .filter(|(h, _)| h.is_some_and(|(h, _)| h >= target))
             .try_fold(Zatoshis::ZERO, |acc, (_, v)| acc + *v)
             .unwrap();
 
         let mut expected_locked: Vec<OutputRef> = model
             .iter()
             .zip(refs.iter())
-            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .filter(|(h, _)| h.is_some_and(|(h, _)| h >= target))
             .map(|(_, r)| *r)
             .collect();
         expected_locked.sort();

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3674,6 +3674,72 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     );
 }
 
+/// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its
+/// serialized (proto) form.
+///
+/// A locking proposal locks its own inputs, and decoding re-retrieves each input from the wallet.
+/// Input retrieval during decoding must therefore not filter out locked outputs; otherwise a
+/// wallet that persists a locking proposal (for example around an app restart, while a PCZT is
+/// out for signing) could never decode it again.
+pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(15000),
+    )])
+    .unwrap();
+
+    let network = *st.network();
+    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
+        Some(100), // lock_for_blocks
+        None,
+    )
+    .unwrap();
+
+    // The proposal's input is locked.
+    assert!(
+        !st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty(),
+        "the proposal's input must be locked before the round-trip"
+    );
+
+    // The serialized proposal must decode back to an identical proposal even though its inputs
+    // are locked (a proposal legitimately references its own locked inputs).
+    let proto = crate::proto::proposal::Proposal::from_standard_proposal(&proposal);
+    let decoded = proto
+        .try_into_standard_proposal(&network, st.wallet())
+        .expect("a proposal with locked inputs must decode from its serialized form");
+    assert_eq!(decoded, proposal);
+}
+
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(
     ds_factory: Dsf,
     cache: impl TestCache,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8,6 +8,7 @@ use std::{
 
 use assert_matches::assert_matches;
 use incrementalmerkletree::{Level, Position, frontier::Frontier};
+use proptest::prelude::{Just, Strategy, prop_oneof};
 use rand::{Rng, RngCore};
 use secrecy::Secret;
 use shardtree::error::ShardTreeError;
@@ -4036,6 +4037,200 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     // Releasing an already-released proposal is a no-op.
     crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
     assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+}
+
+/// An operation in the note-locking model test; see [`check_note_locking_model`].
+#[derive(Clone, Debug)]
+pub enum LockOp {
+    /// Attempt to lock the notes at the given indices (duplicates permitted, and meaningful:
+    /// a duplicated index conflicts with the lock taken by its own first occurrence unless
+    /// that lock is already expired) with expiry height `chain_tip + expiry_delta`.
+    ///
+    /// An `expiry_delta` of zero produces a lock that is expired from the moment it is taken:
+    /// balance and selection evaluate locks against `target_height = chain_tip + 1`.
+    Lock {
+        notes: Vec<usize>,
+        expiry_delta: u32,
+    },
+    /// Unlock the note at the given index, whether or not it is locked.
+    Unlock { note: usize },
+    /// Clear every lock for the account, regardless of expiry.
+    ClearLocked,
+    /// Mine the given number of empty blocks, advancing the chain tip (and thereby expiring
+    /// any lock whose expiry height the tip reaches).
+    MineBlocks { count: usize },
+}
+
+/// A `proptest` strategy over sequences of [`LockOp`] for a wallet holding `n_notes` notes.
+///
+/// Expiry deltas and mining counts are drawn from small ranges so that sequences routinely
+/// cross lock-expiry boundaries.
+pub fn arb_lock_ops(n_notes: usize, max_ops: usize) -> impl Strategy<Value = Vec<LockOp>> {
+    let op = prop_oneof![
+        3 => (
+            proptest::collection::vec(0..n_notes, 1..=n_notes + 1),
+            0u32..=4,
+        )
+            .prop_map(|(notes, expiry_delta)| LockOp::Lock { notes, expiry_delta }),
+        2 => (0..n_notes).prop_map(|note| LockOp::Unlock { note }),
+        1 => Just(LockOp::ClearLocked),
+        2 => (1usize..=3).prop_map(|count| LockOp::MineBlocks { count }),
+    ];
+    proptest::collection::vec(op, 1..=max_ops)
+}
+
+/// Model-based test of the note-locking storage operations.
+///
+/// Funds a wallet with three notes, then applies the given operation sequence both to the real
+/// data store and to a trivial in-memory model (per-note `Option<lock_expiry_height>` plus the
+/// chain tip). After every operation, the store must agree with the model on:
+///
+/// - the outcome of the operation itself, including the all-or-nothing failure of a `Lock`
+///   batch containing a conflict (an active, unexpired lock on any requested note);
+/// - the set reported by `get_locked_outputs` (a note is locked while
+///   `lock_expiry_height >= chain_tip + 1`);
+/// - the account balance decomposition: locked value is exactly the sum of model-locked note
+///   values, spendable value is the remainder, and the total is unaffected by lock state.
+pub fn check_note_locking_model<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+    ops: &[LockOp],
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Fund the wallet with three notes of distinct values in a single block, so that notes can
+    // be matched to model indices by value.
+    let values = [
+        Zatoshis::const_from_u64(60000),
+        Zatoshis::const_from_u64(70000),
+        Zatoshis::const_from_u64(80000),
+    ];
+    st.add_notes_checking_balance([values]);
+    let total = values
+        .iter()
+        .try_fold(Zatoshis::ZERO, |acc, v| acc + *v)
+        .unwrap();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), values.len());
+    let refs: Vec<OutputRef> = values
+        .iter()
+        .map(|value| {
+            let note = notes
+                .iter()
+                .find(|n| n.note().value() == *value)
+                .expect("a note with the requested value exists");
+            OutputRef::new(
+                *note.txid(),
+                PoolType::Shielded(note.note().pool()),
+                u32::from(note.output_index()),
+            )
+        })
+        .collect();
+
+    // The model: per-note lock expiry height, and the chain tip.
+    let mut model: Vec<Option<u32>> = vec![None; refs.len()];
+    let mut tip = u32::from(st.latest_cached_block().unwrap().height());
+
+    for op in ops {
+        match op {
+            LockOp::Lock {
+                notes,
+                expiry_delta,
+            } => {
+                let expiry = tip + expiry_delta;
+                // Predict the outcome by simulating the store's sequential update: each
+                // requested note may be locked when it holds no lock or its lock has expired
+                // as of the chain tip; the first conflict fails the whole batch.
+                let mut scratch = model.clone();
+                let mut conflict = None;
+                for &i in notes {
+                    if scratch[i].is_none_or(|h| h <= tip) {
+                        scratch[i] = Some(expiry);
+                    } else {
+                        conflict = Some(i);
+                        break;
+                    }
+                }
+
+                let result = st
+                    .wallet_mut()
+                    .lock_outputs(notes.iter().map(|&i| refs[i]), BlockHeight::from(expiry));
+                match conflict {
+                    None => {
+                        assert_matches!(result, Ok(n) if n == notes.len());
+                        model = scratch;
+                    }
+                    Some(i) => {
+                        // The batch fails naming the conflicting note, and (checked by the
+                        // post-operation invariants below) locks nothing.
+                        assert_matches!(result, Err(LockError::LockFailure(r)) if r == refs[i]);
+                    }
+                }
+            }
+            LockOp::Unlock { note } => {
+                // The note exists, so unlock reports `true` regardless of prior lock state.
+                assert!(st.wallet_mut().unlock_output(&refs[*note]).unwrap());
+                model[*note] = None;
+            }
+            LockOp::ClearLocked => {
+                // Clearing removes every lock record, expired or not, and reports how many
+                // rows it touched.
+                let expected = model.iter().filter(|h| h.is_some()).count();
+                assert_eq!(
+                    st.wallet_mut().clear_locked_outputs(account_id).unwrap(),
+                    expected
+                );
+                model.iter_mut().for_each(|h| *h = None);
+            }
+            LockOp::MineBlocks { count } => {
+                st.add_empty_blocks(*count);
+                tip += *count as u32;
+            }
+        }
+
+        // Invariants, checked after every operation. Balance and selection evaluate lock
+        // state against the next block to be mined.
+        let target = tip + 1;
+        let locked_value = model
+            .iter()
+            .zip(values.iter())
+            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .try_fold(Zatoshis::ZERO, |acc, (_, v)| acc + *v)
+            .unwrap();
+
+        let mut expected_locked: Vec<OutputRef> = model
+            .iter()
+            .zip(refs.iter())
+            .filter(|(h, _)| h.is_some_and(|h| h >= target))
+            .map(|(_, r)| *r)
+            .collect();
+        expected_locked.sort();
+        let mut actual_locked = st.wallet().get_locked_outputs(account_id).unwrap();
+        actual_locked.sort();
+        assert_eq!(
+            actual_locked, expected_locked,
+            "locked-output set diverged from the model after {op:?}"
+        );
+
+        assert_eq!(
+            st.get_locked_balance(account_id),
+            locked_value,
+            "locked balance diverged from the model after {op:?}"
+        );
+        assert_eq!(
+            st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+            (total - locked_value).unwrap(),
+            "spendable balance diverged from the model after {op:?}"
+        );
+        assert_eq!(
+            st.get_total_balance(account_id),
+            total,
+            "lock state must never change the total balance (after {op:?})"
+        );
+    }
 }
 
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3617,6 +3617,16 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
 
+    // Remember the funding note's reference; it is spent at the end of this test, where the
+    // lock-a-spent-note behavior is pinned.
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let funding_note_ref = OutputRef::new(
+        *notes[0].txid(),
+        PoolType::Shielded(notes[0].note().pool()),
+        u32::from(notes[0].output_index()),
+    );
+
     // Create a proposal with lock_for_blocks: Some(100) using propose_transfer
     let input_selector = GreedyInputSelector::new();
     let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
@@ -3673,6 +3683,40 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
         locked.is_empty(),
         "all notes should be unlocked after create_proposed_transactions"
     );
+
+    // Pin two lock-target edge behaviors:
+    //
+    // Locking an output the wallet does not know fails with `LockFailure` (the "not found"
+    // and "already locked" cases are deliberately indistinguishable to the caller).
+    let unknown = OutputRef::new(
+        TxId::from_bytes([0xEE; 32]),
+        PoolType::Shielded(T::SHIELDED_PROTOCOL),
+        0,
+    );
+    assert_matches!(
+        st.wallet_mut()
+            .lock_outputs([unknown].into_iter(), BlockHeight::from(u32::MAX)),
+        Err(LockError::LockFailure(r)) if r == unknown
+    );
+
+    // Locking an already-spent note currently SUCCEEDS: `lock_outputs` checks only for an
+    // existing active lock, not for spend status. This is harmless in the proposal flow
+    // (spent notes never enter selection, and the lock has no balance effect because balance
+    // computation only considers unspent notes), but it is pinned here so that any future
+    // tightening of the contract is a visible, deliberate change.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([funding_note_ref].into_iter(), BlockHeight::from(u32::MAX))
+            .unwrap(),
+        1
+    );
+    // The stale lock is visible in the raw lock listing but has no balance effect.
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![funding_note_ref]
+    );
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert!(st.wallet_mut().unlock_output(&funding_note_ref).unwrap());
 }
 
 /// Verifies that a proposal created with `lock_for_blocks: Some(_)` round-trips through its

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -37,7 +37,7 @@ use crate::{
         MaxSpendMode, NoteFilter, Ratio, TargetValue, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletTest, WalletWrite,
         chain::{self, ChainState, CommitmentTreeRoot, ScanSummary},
-        error::Error,
+        error::{Error, LockError},
         testing::{
             AddressType, CacheInsertionResult, FakeCompactOutput, InitialChainState, TestBuilder,
             single_output_change_strategy,
@@ -73,10 +73,10 @@ use {
         keys::{NonHardenedChildIndex, TransparentKeyScope},
     },
     zcash_primitives::transaction::fees::zip317,
-    zcash_protocol::{TxId, value::ZatBalance},
+    zcash_protocol::value::ZatBalance,
 };
 
-use zcash_protocol::PoolType;
+use zcash_protocol::{PoolType, TxId};
 
 #[cfg(feature = "pczt")]
 use {
@@ -3738,6 +3738,304 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
         .try_into_standard_proposal(&network, st.wallet())
         .expect("a proposal with locked inputs must decode from its serialized form");
     assert_eq!(decoded, proposal);
+}
+
+/// Exercises the passed-expiry semantics of note locking under chain advance.
+///
+/// A lock names an expiry height `h`; balance and selection evaluate it against
+/// `target_height = chain_tip + 1`, so the note stays locked while `chain_tip < h` and becomes
+/// spendable again, with no unlock call, as soon as the chain tip reaches `h`. The stale
+/// `lock_expiry_height` value remains in the row, and a subsequent `lock_outputs` replaces it
+/// (the expired-lock branch of the lock-acquisition guard).
+pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account_id = st.test_account().unwrap().id();
+    let tip = st.latest_cached_block().unwrap().height();
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 1);
+    let note = &notes[0];
+    let output_ref = OutputRef::new(
+        *note.txid(),
+        PoolType::Shielded(note.note().pool()),
+        u32::from(note.output_index()),
+    );
+
+    // Lock the note until three blocks past the current tip.
+    let expiry = tip + 3;
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), expiry)
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+
+    // Advance the chain to two blocks below the expiry... still locked: the balance target
+    // height is now `expiry` itself, and a lock covers its expiry height inclusively.
+    st.add_empty_blocks(2);
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        Zatoshis::ZERO
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // One more block reaches the expiry height: the lock has now been passed, and the note is
+    // spendable again without any unlock call. The stale lock_expiry_height column value is
+    // simply ignored by selection and balance.
+    st.add_empty_blocks(1);
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // A spend proposal succeeds now that the lock has expired.
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+    st.propose_standard_transfer::<Infallible>(
+        account_id,
+        StandardFeeRule::Zip317,
+        ConfirmationsPolicy::MIN,
+        &to,
+        Zatoshis::const_from_u64(15000),
+        None,
+        None,
+        T::SHIELDED_PROTOCOL,
+    )
+    .expect("an expired lock must not block proposal creation");
+
+    // The expired lock is replaceable: a fresh lock_outputs call succeeds without an explicit
+    // unlock, overwriting the stale expiry value.
+    let new_tip = st.latest_cached_block().unwrap().height();
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), new_tip + 5)
+            .unwrap(),
+        1
+    );
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+}
+
+/// Exercises lock-conflict detection and the all-or-nothing batch contract of
+/// [`WalletWrite::lock_outputs`], along with the `unlock_output` return-value semantics.
+///
+/// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
+pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Fund the wallet with two notes of distinct values in a single block, so that each note
+    // can be identified by its value below.
+    let value1 = Zatoshis::const_from_u64(60000);
+    let value2 = Zatoshis::const_from_u64(40000);
+    st.add_notes_checking_balance([[value1, value2]]);
+
+    let account_id = st.test_account().unwrap().id();
+    let far_expiry = BlockHeight::from(u32::MAX);
+
+    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+    assert_eq!(notes.len(), 2);
+    let output_ref = |value: Zatoshis| {
+        let note = notes
+            .iter()
+            .find(|n| n.note().value() == value)
+            .expect("a note with the requested value exists");
+        OutputRef::new(
+            *note.txid(),
+            PoolType::Shielded(note.note().pool()),
+            u32::from(note.output_index()),
+        )
+    };
+    let r1 = output_ref(value1);
+    let r2 = output_ref(value2);
+
+    // The first lock on a note succeeds.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([r1].into_iter(), far_expiry)
+            .unwrap(),
+        1
+    );
+
+    // A second lock on the same note fails while the first lock is active, even from the same
+    // caller: an active lock cannot be re-acquired, extended, or shortened without an explicit
+    // unlock first.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r1].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r1
+    );
+
+    // A batch containing a conflicting output fails all-or-nothing: r2 precedes the conflicting
+    // r1 in the batch, but the failure must leave r2 unlocked.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r2, r1].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r1
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1],
+        "a failed batch lock must not leave any of its outputs locked"
+    );
+    assert_eq!(st.get_locked_balance(account_id), value1);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value2
+    );
+
+    // A batch containing the same output twice fails on the duplicate: the first occurrence
+    // takes a live lock, which the second occurrence then conflicts with. Atomicity applies
+    // here too: the failed batch leaves r2 unlocked.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([r2, r2].into_iter(), far_expiry),
+        Err(LockError::LockFailure(r)) if r == r2
+    );
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![r1]
+    );
+
+    // Unlocking an existing output that holds no lock reports `true` (the output was found;
+    // its lock state is NULL afterwards either way); unlocking an unknown output reports
+    // `false`.
+    assert!(st.wallet_mut().unlock_output(&r2).unwrap());
+    let unknown = OutputRef::new(
+        TxId::from_bytes([0xEE; 32]),
+        PoolType::Shielded(T::SHIELDED_PROTOCOL),
+        0,
+    );
+    assert!(!st.wallet_mut().unlock_output(&unknown).unwrap());
+
+    // After unlocking r1, both notes are spendable again and a fresh lock succeeds.
+    assert!(st.wallet_mut().unlock_output(&r1).unwrap());
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([r1, r2].into_iter(), far_expiry)
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        st.get_locked_balance(account_id),
+        (value1 + value2).unwrap()
+    );
+}
+
+/// Verifies that [`unlock_proposal_inputs`] releases the locks taken by a proposal created with
+/// `lock_for_blocks: Some(_)`, restoring spendability for a subsequent proposal (the
+/// abandoned-proposal recovery path).
+///
+/// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
+pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(50000);
+    let (_, _, _) = st.add_a_single_note_checking_balance(value);
+
+    let account_id = st.test_account().unwrap().id();
+    let extsk2 = T::sk(&[0xf5; 32]);
+    let to = T::sk_default_address(&extsk2);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
+
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(15000),
+    )])
+    .unwrap();
+
+    let network = *st.network();
+    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
+        st.wallet_mut(),
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::MIN,
+        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
+        Some(100), // lock_for_blocks
+        None,
+    )
+    .unwrap();
+
+    // The proposal's input is locked; a competing proposal cannot be created.
+    assert_eq!(st.get_locked_balance(account_id), value);
+    assert_matches!(
+        st.propose_standard_transfer::<Infallible>(
+            account_id,
+            fee_rule,
+            ConfirmationsPolicy::MIN,
+            &to,
+            Zatoshis::const_from_u64(2000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        ),
+        Err(data_api::error::Error::InsufficientFunds { .. })
+    );
+
+    // Abandon the proposal: releasing its inputs restores spendable balance...
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // ... and a subsequent proposal can select the released inputs.
+    st.propose_standard_transfer::<Infallible>(
+        account_id,
+        fee_rule,
+        ConfirmationsPolicy::MIN,
+        &to,
+        Zatoshis::const_from_u64(2000),
+        None,
+        None,
+        T::SHIELDED_PROTOCOL,
+    )
+    .expect("released inputs must be selectable by a new proposal");
+
+    // Releasing an already-released proposal is a no-op.
+    crate::data_api::wallet::unlock_proposal_inputs(st.wallet_mut(), &proposal).unwrap();
+    assert_eq!(st.get_locked_balance(account_id), Zatoshis::ZERO);
 }
 
 pub fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester, Dsf>(

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -43,7 +43,7 @@ use crate::{
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
-    wallet::{OutputRef, WalletTransparentOutput},
+    wallet::{LockOwner, OutputRef, WalletTransparentOutput},
 };
 
 /// Checks whether the transparent balance of the given test `account` is as `expected`
@@ -284,16 +284,18 @@ where
     );
 
     // Lock the UTXO until ten blocks past the tip.
+    let owner = LockOwner::new([1; 32]);
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), height + 10)
+            .lock_outputs(&[output_ref], owner, height + 10)
             .unwrap(),
         1
     );
 
-    // A second lock conflicts while the first is active.
+    // A lock by a different owner conflicts while the first is active.
+    let other_owner = LockOwner::new([2; 32]);
     assert_matches!(
-        st.wallet_mut().lock_outputs([output_ref].into_iter(), height + 20),
+        st.wallet_mut().lock_outputs(&[output_ref], other_owner, height + 20),
         Err(LockError::LockFailure(r)) if r == output_ref
     );
 
@@ -378,15 +380,19 @@ where
             .is_empty()
     );
 
-    // The expired lock is replaceable without an explicit unlock, and unlocking then reports
-    // the output as found.
+    // The expired lock is replaceable without an explicit unlock, even by a different owner,
+    // and the new holder can then release it.
     assert_eq!(
         st.wallet_mut()
-            .lock_outputs([output_ref].into_iter(), height + 30)
+            .lock_outputs(&[output_ref], other_owner, height + 30)
             .unwrap(),
         1
     );
-    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    assert!(
+        st.wallet_mut()
+            .unlock_output(&output_ref, other_owner)
+            .unwrap()
+    );
     let balances = st
         .wallet()
         .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -17,6 +17,7 @@ use zcash_primitives::{
     transaction::{Transaction, TransactionData, TxVersion, fees::zip317},
 };
 use zcash_protocol::{
+    PoolType, TxId,
     consensus::{BlockHeight, BranchId, COINBASE_MATURITY_BLOCKS},
     local_consensus::LocalNetwork,
     value::Zatoshis,
@@ -34,6 +35,7 @@ use crate::{
     data_api::{
         Account as _, AccountBalance, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode,
         TargetValue, WalletRead as _, WalletTest as _, WalletWrite,
+        error::LockError,
         testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
@@ -41,7 +43,7 @@ use crate::{
         },
     },
     fees::{DustOutputPolicy, StandardFeeRule, standard},
-    wallet::WalletTransparentOutput,
+    wallet::{OutputRef, WalletTransparentOutput},
 };
 
 /// Checks whether the transparent balance of the given test `account` is as `expected`
@@ -220,6 +222,179 @@ where
         ),
         Ok(h) if h.get(taddr).map(|(_, b)| b.spendable_value()) == Some(value)
     );
+}
+
+/// Exercises note locking for transparent outputs.
+///
+/// A locked UTXO is excluded from single-output retrieval and from spendable-output listing
+/// unless `include_locked` is set, is reported as locked (not spendable) value in the
+/// per-address balances, conflicts with a second lock, and returns to spendability when the
+/// chain tip passes the lock expiry height, with no unlock call.
+pub fn transparent_note_locking<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let birthday = st.test_account().unwrap().birthday().height();
+    let account_id = st.test_account().unwrap().id();
+    let uaddr = st
+        .wallet()
+        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap();
+    let taddr = uaddr.transparent().unwrap();
+
+    let height = birthday + 12345;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+
+    // Create a fake transparent output mined at `height`.
+    let value = Zatoshis::const_from_u64(100000);
+    let outpoint = OutPoint::fake();
+    let txout = TxOut::new(value, taddr.script().into());
+    let utxo = WalletTransparentOutput::from_parts(
+        outpoint.clone(),
+        txout,
+        Some(height),
+        Some(account_id),
+        Some(TransparentKeyScope::EXTERNAL),
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    let target_height = TargetHeight::from(height + 1);
+    let output_ref = OutputRef::new(
+        TxId::from_bytes(*outpoint.hash()),
+        PoolType::TRANSPARENT,
+        outpoint.n(),
+    );
+
+    // The output is retrievable and spendable before locking.
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, false),
+        Ok(Some(_))
+    );
+
+    // Lock the UTXO until ten blocks past the tip.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), height + 10)
+            .unwrap(),
+        1
+    );
+
+    // A second lock conflicts while the first is active.
+    assert_matches!(
+        st.wallet_mut().lock_outputs([output_ref].into_iter(), height + 20),
+        Err(LockError::LockFailure(r)) if r == output_ref
+    );
+
+    // The locked output is excluded from single-output retrieval unless `include_locked`.
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, false),
+        Ok(None)
+    );
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height, true),
+        Ok(Some(_))
+    );
+
+    // ... and from the spendable-outputs listing unless `include_locked`.
+    assert_matches!(
+        st.wallet()
+            .get_spendable_transparent_outputs(
+                taddr,
+                target_height,
+                ConfirmationsPolicy::MIN,
+                CoinbaseFilter::AllTransparentOutputs,
+                false,
+            )
+            .as_deref(),
+        Ok(&[])
+    );
+    assert_matches!(
+        st.wallet()
+            .get_spendable_transparent_outputs(
+                taddr,
+                target_height,
+                ConfirmationsPolicy::MIN,
+                CoinbaseFilter::AllTransparentOutputs,
+                true,
+            )
+            .as_deref(),
+        Ok([_])
+    );
+
+    // The per-address balances report the value as locked, not spendable; the total is
+    // unaffected by lock state.
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, target_height, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.locked_value(), value);
+    assert_eq!(bal.spendable_value(), Zatoshis::ZERO);
+    assert_eq!(bal.total(), value);
+
+    // The locked-outputs listing includes the transparent lock.
+    assert_eq!(
+        st.wallet().get_locked_outputs(account_id).unwrap(),
+        vec![output_ref]
+    );
+
+    // Advancing the chain tip to the expiry height restores spendability with no unlock call.
+    st.wallet_mut().update_chain_tip(height + 10).unwrap();
+    let expired_target = TargetHeight::from(height + 11);
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, expired_target, false),
+        Ok(Some(_))
+    );
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.spendable_value(), value);
+    assert_eq!(bal.locked_value(), Zatoshis::ZERO);
+    assert!(
+        st.wallet()
+            .get_locked_outputs(account_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // The expired lock is replaceable without an explicit unlock, and unlocking then reports
+    // the output as found.
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs([output_ref].into_iter(), height + 30)
+            .unwrap(),
+        1
+    );
+    assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, expired_target, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (_, bal) = balances
+        .get(taddr)
+        .expect("the address has a balance entry");
+    assert_eq!(bal.spendable_value(), value);
 }
 
 pub fn transparent_balance_across_shielding<DSF>(dsf: DSF, cache: impl TestCache)

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -56,7 +56,7 @@ use crate::{
         ChangeStrategy, DustOutputPolicy, StandardFeeRule, standard::SingleOutputChangeStrategy,
     },
     proposal::{Proposal, ProposalError, Step, StepOutputIndex},
-    wallet::{Note, OutputRef, OvkPolicy, Recipient},
+    wallet::{LockOwner, Note, OutputRef, OvkPolicy, Recipient},
 };
 use sapling::{
     note_encryption::{PreparedIncomingViewingKey, try_sapling_note_decryption},
@@ -677,28 +677,67 @@ impl ConfirmationsPolicy {
 /// by that creating transaction's id, which is the stable identity the lock tables are keyed on.
 fn proposal_input_refs<FeeRuleT, NoteRef>(
     proposal: &Proposal<FeeRuleT, NoteRef>,
-) -> impl Iterator<Item = OutputRef> {
-    proposal.steps().iter().flat_map(|step| {
-        step.shielded_inputs()
-            .into_iter()
-            .flat_map(|shielded_inputs| {
-                shielded_inputs.notes().iter().map(|note| {
-                    OutputRef::new(
-                        *note.txid(),
-                        PoolType::Shielded(note.note().pool()),
-                        u32::from(note.output_index()),
-                    )
+) -> Vec<OutputRef> {
+    proposal
+        .steps()
+        .iter()
+        .flat_map(|step| {
+            step.shielded_inputs()
+                .into_iter()
+                .flat_map(|shielded_inputs| {
+                    shielded_inputs.notes().iter().map(|note| {
+                        OutputRef::new(
+                            *note.txid(),
+                            PoolType::Shielded(note.note().pool()),
+                            u32::from(note.output_index()),
+                        )
+                    })
                 })
-            })
-            .chain(step.transparent_inputs().iter().map(|utxo| {
-                let outpoint = utxo.outpoint();
-                OutputRef::new(
-                    TxId::from_bytes(*outpoint.hash()),
-                    PoolType::TRANSPARENT,
-                    outpoint.n(),
-                )
-            }))
-    })
+                .chain(step.transparent_inputs().iter().map(|utxo| {
+                    let outpoint = utxo.outpoint();
+                    OutputRef::new(
+                        TxId::from_bytes(*outpoint.hash()),
+                        PoolType::TRANSPARENT,
+                        outpoint.n(),
+                    )
+                }))
+        })
+        .collect()
+}
+
+/// A request to lock the inputs selected by a proposal, made when calling one of the
+/// proposal-creation functions ([`propose_transfer`] and friends).
+///
+/// The caller supplies the [`LockOwner`] under which the locks are taken and must retain it: the
+/// owner token is what authorizes releasing the locks with [`unlock_proposal_inputs`], and what
+/// allows the same flow to re-lock its own inputs when retrying after a crash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LockRequest {
+    owner: LockOwner,
+    for_blocks: u32,
+}
+
+impl LockRequest {
+    /// Constructs a request to lock the proposal's inputs on behalf of `owner` until
+    /// `for_blocks` blocks past the proposal's target height.
+    ///
+    /// Choose `for_blocks` conservatively with respect to the worst-case time between proposal
+    /// creation and transaction storage: once the lock expires, a concurrent proposal may
+    /// select the same inputs.
+    pub fn new(owner: LockOwner, for_blocks: u32) -> Self {
+        Self { owner, for_blocks }
+    }
+
+    /// Returns the owner under which the locks will be taken.
+    pub fn owner(&self) -> LockOwner {
+        self.owner
+    }
+
+    /// Returns the number of blocks past the proposal's target height at which the locks will
+    /// expire.
+    pub fn for_blocks(&self) -> u32 {
+        self.for_blocks
+    }
 }
 
 /// Locks all inputs selected by the given proposal, preventing them from being
@@ -707,12 +746,13 @@ fn proposal_input_refs<FeeRuleT, NoteRef>(
 fn lock_proposal_inputs<DbT, FeeRuleT, NoteRef, TE, SE, FE, CE>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
+    owner: LockOwner,
     lock_expiry_height: BlockHeight,
 ) -> Result<(), Error<DbT::Error, TE, SE, FE, CE, NoteRef>>
 where
     DbT: WalletWrite,
 {
-    match wallet_db.lock_outputs(proposal_input_refs(proposal), lock_expiry_height) {
+    match wallet_db.lock_outputs(&proposal_input_refs(proposal), owner, lock_expiry_height) {
         Ok(_) => Ok(()),
         Err(LockError::LockFailure(out_ref)) => {
             Err(Error::Proposal(ProposalError::InputsLocked(out_ref)))
@@ -722,28 +762,22 @@ where
 }
 
 /// Unlocks all inputs selected by the given proposal, reversing the locks acquired when the
-/// proposal was created with a non-`None` `lock_for_blocks` argument.
+/// proposal was created with a [`LockRequest`] under the same `owner`.
 ///
 /// This is useful when a proposal is rejected or abandoned after its inputs were locked, so that
-/// the outputs become available for selection and balance computation once again. Outputs that are
-/// not currently locked are left unchanged.
-///
-/// # Warning
-///
-/// Locks do not record which proposal acquired them, so this function must only be called for
-/// proposals that were created with `lock_for_blocks: Some(_)`. Calling it for an unlocked
-/// proposal that happens to share inputs with a concurrently-created locked proposal (possible
-/// when the two proposals selected inputs before either lock was taken) would release the other
-/// proposal's locks while it is still in flight.
+/// the outputs become available for selection and balance computation once again. Because
+/// unlocking is scoped to `owner`, inputs that are not locked, or whose locks are held by a
+/// different owner (for example a concurrently-created proposal), are left unchanged.
 pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
+    owner: LockOwner,
 ) -> Result<(), DbT::Error>
 where
     DbT: WalletWrite,
 {
     for output_ref in proposal_input_refs(proposal) {
-        wallet_db.unlock_output(&output_ref)?;
+        wallet_db.unlock_output(&output_ref, owner)?;
     }
     Ok(())
 }
@@ -752,31 +786,33 @@ where
 /// of transactions that can then be authorized and made ready for submission to the network with
 /// [`create_proposed_transactions`].
 ///
-/// When `lock_for_blocks` is `Some(n)`, every input selected by the returned proposal is locked
-/// via [`WalletWrite::lock_outputs`] with an expiry height of `target_height + n`, so that the
-/// inputs are excluded from selection by subsequent proposals until that height is reached (or
-/// until they are explicitly released; see below). When it is `None`, no locking is performed.
+/// When `lock_inputs` is `Some(request)`, every input selected by the returned proposal is
+/// locked via [`WalletWrite::lock_outputs`] on behalf of the request's [`LockOwner`], with an
+/// expiry height of `target_height + request.for_blocks()`, so that the inputs are excluded from
+/// selection by subsequent proposals until that height is reached (or until they are explicitly
+/// released; see below). When it is `None`, no locking is performed.
 ///
-/// This is the height-based generalization of the `lock_notes: bool` parameter originally
-/// proposed in [zcash/librustzcash#2161]: `Some(n)` corresponds to "lock" with an explicit expiry
-/// window, and `None` to "do not lock".
+/// This is the owner- and height-based generalization of the `lock_notes: bool` parameter
+/// originally proposed in [zcash/librustzcash#2161].
 ///
 /// # Concurrency
 ///
 /// Locking is how overlapping proposals for the same account are kept from selecting the same
-/// inputs. If a concurrent caller has already locked one of the inputs this proposal selected
-/// (a check-then-lock race resolved at the storage layer), locking fails and the error surfaces
-/// as [`ProposalError::InputsLocked`] identifying the conflicting output; the losing caller
-/// should treat this as "the account is busy" and retry. A caller that abandons a proposal whose
-/// inputs it locked should release them with [`unlock_proposal_inputs`]; locks are otherwise
-/// cleared automatically when the inputs are recorded as spent by
+/// inputs. If a concurrent caller (a different [`LockOwner`]) has already locked one of the
+/// inputs this proposal selected (a check-then-lock race resolved at the storage layer), locking
+/// fails and the error surfaces as [`ProposalError::InputsLocked`] identifying the conflicting
+/// output; the losing caller should treat this as "the account is busy" and retry. Re-locking
+/// under the SAME owner succeeds (an idempotent acquire/extend), so a flow that crashed after
+/// locking may safely retry with its original owner token. A caller that abandons a proposal
+/// whose inputs it locked should release them with [`unlock_proposal_inputs`] under the same
+/// owner; locks are otherwise cleared automatically when the inputs are recorded as spent by
 /// [`WalletWrite::store_transactions_to_be_sent`], when their expiry height is reached, or via
 /// [`WalletWrite::clear_locked_outputs`].
 ///
 /// Note that expiry re-opens the race the lock exists to prevent: if building and proving the
-/// transaction takes longer than `n` blocks, the lock expires and a concurrent proposal may
-/// select and spend the same inputs. Choose `n` conservatively with respect to the worst-case
-/// time between proposal creation and transaction storage.
+/// transaction takes longer than the requested lock window, the lock expires and a concurrent
+/// proposal may select and spend the same inputs. Choose the window conservatively with respect
+/// to the worst-case time between proposal creation and transaction storage.
 ///
 /// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
 /// [`WalletWrite::store_transactions_to_be_sent`]: crate::data_api::WalletWrite::store_transactions_to_be_sent
@@ -793,7 +829,7 @@ pub fn propose_transfer<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     request: zip321::TransactionRequest,
     confirmations_policy: ConfirmationsPolicy,
     spend_policy: &input_selection::SpendPolicy,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
@@ -828,9 +864,9 @@ where
         spend_policy,
         proposed_version,
     )?;
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     // Record the requested version on the proposal so that it is carried through to transaction
@@ -863,10 +899,10 @@ where
 /// * `change_memo`: A memo to be included in any change output that is created.
 /// * `fallback_change_pool`: The shielded pool to which change should be sent if
 ///   automatic change pool determination fails.
-/// * `lock_for_blocks`: When `Some(n)`, the inputs selected by the proposal are locked until
-///   `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-///   locking is performed. See [`propose_transfer`] for the full semantics and concurrency
-///   behavior.
+/// * `lock_inputs`: When `Some(request)`, the inputs selected by the proposal are locked on
+///   behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+///   concurrent proposals from selecting them; when `None`, no locking is performed. See
+///   [`propose_transfer`] for the full semantics and concurrency behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
@@ -880,7 +916,7 @@ pub fn propose_standard_transfer_to_address<DbT, ParamsT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedPool,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
     proposed_version: Option<TxVersion>,
 ) -> Result<
     Proposal<StandardFeeRule, DbT::NoteRef>,
@@ -932,7 +968,7 @@ where
         request,
         confirmations_policy,
         &input_selection::SpendPolicy::default(),
-        lock_for_blocks,
+        lock_inputs,
         proposed_version,
     )
 }
@@ -941,9 +977,10 @@ where
 /// of transactions that would spend all available funds from the given `spend_pool`s that can then
 /// be authorized and made ready for submission to the network with [`create_proposed_transactions`].
 ///
-/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
-/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
+/// When `lock_inputs` is `Some(request)`, the inputs selected by the proposal are locked on
+/// behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+/// concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
@@ -956,7 +993,7 @@ pub fn propose_send_max_transfer<DbT, ParamsT, FeeRuleT, CommitmentTreeErrT>(
     memo: Option<MemoBytes>,
     mode: MaxSpendMode,
     confirmations_policy: ConfirmationsPolicy,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
     ProposeSendMaxErrT<DbT, CommitmentTreeErrT, FeeRuleT>,
@@ -990,9 +1027,9 @@ where
         memo,
     )?;
 
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     Ok(proposal)
@@ -1004,9 +1041,10 @@ where
 /// The `output_filter` parameter controls which transparent outputs are eligible for
 /// inclusion in the proposal. See [`CoinbaseFilter`] for details.
 ///
-/// When `lock_for_blocks` is `Some(n)`, the inputs selected by the proposal are locked until
-/// `target_height + n` to prevent concurrent proposals from selecting them; when `None`, no
-/// locking is performed. See [`propose_transfer`] for the full semantics and concurrency behavior.
+/// When `lock_inputs` is `Some(request)`, the inputs selected by the proposal are locked on
+/// behalf of the request's owner until `target_height + request.for_blocks()` to prevent
+/// concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
 #[cfg(feature = "transparent-inputs")]
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
@@ -1020,7 +1058,7 @@ pub fn propose_shielding<DbT, ParamsT, InputsT, ChangeT, CommitmentTreeErrT>(
     to_account: <DbT as InputSource>::AccountId,
     confirmations_policy: ConfirmationsPolicy,
     output_filter: CoinbaseFilter,
-    lock_for_blocks: Option<u32>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<ChangeT::FeeRule, Infallible>,
     ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT>,
@@ -1051,9 +1089,9 @@ where
         )
         .map_err(Error::from)?;
 
-    if let Some(n) = lock_for_blocks {
-        let lock_expiry_height = target_height + n;
-        lock_proposal_inputs(wallet_db, &proposal, lock_expiry_height)?;
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
     }
 
     Ok(proposal)
@@ -1091,6 +1129,11 @@ pub type ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT
 ///   outpoint). `Some(0)` selects no inputs and therefore returns
 ///   [`InputSelectorError::InsufficientFunds`].
 ///
+/// When `lock_inputs` is `Some(request)`, the coinbase inputs selected by the proposal are
+/// locked on behalf of the request's owner until `target_height + request.for_blocks()` to
+/// prevent concurrent proposals from selecting them; when `None`, no locking is performed. See
+/// [`propose_transfer`] for the full semantics and concurrency behavior.
+///
 /// The resulting proposal carries an explicit ZIP-321 payment to `to_address` for
 /// `input_total - fee`. **No change is produced**, in either the transparent or any
 /// shielded pool: a shielded change output would let the recipient (or any chain
@@ -1112,13 +1155,14 @@ pub fn propose_shielding_coinbase<DbT, ParamsT, InputsT, FeeRuleT, CommitmentTre
     to_address: ZcashAddress,
     memo: Option<MemoBytes>,
     limit: Option<usize>,
+    lock_inputs: Option<LockRequest>,
 ) -> Result<
     Proposal<FeeRuleT, Infallible>,
     ProposeShieldingCoinbaseErrT<DbT, CommitmentTreeErrT, InputsT, FeeRuleT>,
 >
 where
     ParamsT: consensus::Parameters,
-    DbT: WalletRead + InputSource<Error = <DbT as WalletRead>::Error>,
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
     InputsT: ShieldingSelector<InputSource = DbT>,
     FeeRuleT: FeeRule + Clone,
 {
@@ -1127,7 +1171,7 @@ where
         .map_err(|e| Error::from(InputSelectorError::DataSource(e)))?
         .ok_or_else(|| Error::from(InputSelectorError::SyncRequired))?;
 
-    input_selector
+    let proposal = input_selector
         .propose_shielding_coinbase(
             params,
             wallet_db,
@@ -1140,7 +1184,14 @@ where
             target_height,
             anchor_height,
         )
-        .map_err(Error::from)
+        .map_err(Error::from)?;
+
+    if let Some(request) = lock_inputs {
+        let lock_expiry_height = target_height + request.for_blocks();
+        lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
+    }
+
+    Ok(proposal)
 }
 
 struct StepResult<AccountId> {

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -715,7 +715,7 @@ where
     match wallet_db.lock_outputs(proposal_input_refs(proposal), lock_expiry_height) {
         Ok(_) => Ok(()),
         Err(LockError::LockFailure(out_ref)) => {
-            Err(Error::Proposal(ProposalError::ChainDoubleSpend(out_ref)))
+            Err(Error::Proposal(ProposalError::InputsLocked(out_ref)))
         }
         Err(LockError::Storage(e)) => Err(Error::DataSource(e)),
     }
@@ -727,6 +727,14 @@ where
 /// This is useful when a proposal is rejected or abandoned after its inputs were locked, so that
 /// the outputs become available for selection and balance computation once again. Outputs that are
 /// not currently locked are left unchanged.
+///
+/// # Warning
+///
+/// Locks do not record which proposal acquired them, so this function must only be called for
+/// proposals that were created with `lock_for_blocks: Some(_)`. Calling it for an unlocked
+/// proposal that happens to share inputs with a concurrently-created locked proposal (possible
+/// when the two proposals selected inputs before either lock was taken) would release the other
+/// proposal's locks while it is still in flight.
 pub fn unlock_proposal_inputs<DbT, FeeRuleT, NoteRef>(
     wallet_db: &mut DbT,
     proposal: &Proposal<FeeRuleT, NoteRef>,
@@ -758,12 +766,17 @@ where
 /// Locking is how overlapping proposals for the same account are kept from selecting the same
 /// inputs. If a concurrent caller has already locked one of the inputs this proposal selected
 /// (a check-then-lock race resolved at the storage layer), locking fails and the error surfaces
-/// as [`ProposalError::ChainDoubleSpend`] identifying the conflicting output; the losing caller
+/// as [`ProposalError::InputsLocked`] identifying the conflicting output; the losing caller
 /// should treat this as "the account is busy" and retry. A caller that abandons a proposal whose
 /// inputs it locked should release them with [`unlock_proposal_inputs`]; locks are otherwise
 /// cleared automatically when the inputs are recorded as spent by
 /// [`WalletWrite::store_transactions_to_be_sent`], when their expiry height is reached, or via
 /// [`WalletWrite::clear_locked_outputs`].
+///
+/// Note that expiry re-opens the race the lock exists to prevent: if building and proving the
+/// transaction takes longer than `n` blocks, the lock expires and a concurrent proposal may
+/// select and spend the same inputs. Choose `n` conservatively with respect to the worst-case
+/// time between proposal creation and transaction storage.
 ///
 /// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
 /// [`WalletWrite::store_transactions_to_be_sent`]: crate::data_api::WalletWrite::store_transactions_to_be_sent

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -746,6 +746,10 @@ impl<DbT> GreedyInputSelector<DbT> {
             ),
         };
         *amount_at_transparent_gather = amount_at_gather;
+        // Input selection must never draw on locked outputs: a locked output belongs to
+        // another in-flight proposal, and spending it would recreate the conflict that
+        // locking exists to prevent.
+        let include_locked = false;
         Ok(wallet_db
             .select_spendable_transparent_outputs(
                 account,
@@ -756,7 +760,7 @@ impl<DbT> GreedyInputSelector<DbT> {
                 target_value,
                 shielding_max_inputs(self.shielding_block_space_percent),
                 &StandardFeeRule::Zip317,
-                false,
+                include_locked,
             )
             .map_err(InputSelectorError::DataSource)?
             .into_iter()
@@ -1322,6 +1326,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                         && required > amount_at_transparent_gather
                     {
                         let address_allow_list = transparent.address_allow_list();
+                        // Input selection must never draw on locked outputs: a locked output belongs to
+                        // another in-flight proposal, and spending it would recreate the conflict that
+                        // locking exists to prevent.
+                        let include_locked = false;
                         transparent_inputs = wallet_db
                             .select_spendable_transparent_outputs(
                                 account,
@@ -1332,7 +1340,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                                 TargetValue::AtLeast(required),
                                 shielding_max_inputs(self.shielding_block_space_percent),
                                 &StandardFeeRule::Zip317,
-                                false,
+                                include_locked,
                             )
                             .map_err(InputSelectorError::DataSource)?
                             .into_iter()
@@ -1356,6 +1364,10 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // by one policy: pool crossing is minimized, and a payment to an Orchard
             // receiver draws on the pool its output is constructed in (the Ironwood
             // pool once NU6.3 is active).
+            // Input selection must never draw on locked outputs: a locked output belongs to
+            // another in-flight proposal, and spending it would recreate the conflict that
+            // locking exists to prevent.
+            let include_locked = false;
             shielded_inputs = wallet_db
                 .select_spendable_notes(
                     account,
@@ -1364,7 +1376,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     target_height,
                     confirmations_policy,
                     &exclude,
-                    false,
+                    include_locked,
                 )
                 .map_err(InputSelectorError::DataSource)?;
 
@@ -1488,6 +1500,10 @@ where
     InputSourceT: InputSource,
     FeeRuleT: FeeRule + Clone,
 {
+    // Input selection must never draw on locked outputs: a locked output belongs to
+    // another in-flight proposal, and spending it would recreate the conflict that
+    // locking exists to prevent.
+    let include_locked = false;
     let spendable_notes = wallet_db
         .select_spendable_notes(
             source_account,
@@ -1496,7 +1512,7 @@ where
             target_height,
             confirmations_policy,
             &[],
-            false,
+            include_locked,
         )
         .map_err(InputSelectorError::DataSource)?;
 
@@ -2176,13 +2192,17 @@ where
     // one query per address (including for the many addresses that have no spendable outputs),
     // which is prohibitively expensive for wallets that hold large numbers of transparent
     // addresses.
+    // Input selection must never draw on locked outputs: a locked output belongs to
+    // another in-flight proposal, and spending it would recreate the conflict that
+    // locking exists to prevent.
+    let include_locked = false;
     let mut utxos = wallet_db
         .get_spendable_transparent_outputs_for_addresses(
             source_addrs,
             target_height,
             confirmations_policy,
             output_filter,
-            false,
+            include_locked,
         )
         .map_err(InputSelectorError::DataSource)?;
 

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -318,7 +318,17 @@ where
                 .unwrap_or(SplitPolicy::MIN_NOTE_VALUE),
         );
 
-        meta_source.get_account_metadata(account, &note_selector, target_height, exclude, false)
+        // Account metadata feeds change-splitting decisions, which reason about the
+        // notes that selection can actually draw on; locked notes are excluded from
+        // selection, so they are excluded here as well.
+        let include_locked = false;
+        meta_source.get_account_metadata(
+            account,
+            &note_selector,
+            target_height,
+            exclude,
+            include_locked,
+        )
     }
 
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -52,6 +52,15 @@ pub enum ProposalError {
     StepDoubleSpend(StepOutput),
     /// An attempted double-spend of an output belonging to the wallet was detected.
     ChainDoubleSpend(OutputRef),
+    /// An input selected by the proposal could not be locked, because a concurrent
+    /// proposal or PCZT already holds a lock on it.
+    ///
+    /// This is a transient condition, not a defect in the proposal itself: the wrapped
+    /// output was spendable when it was selected, but another in-flight proposal locked
+    /// it first. Callers should treat this as "the account is busy" and retry proposal
+    /// creation; the retry will select around the locked output (or fail with an
+    /// insufficient-funds error if no other outputs are available).
+    InputsLocked(OutputRef),
     /// There was a mismatch between the payments in the proposal's transaction request
     /// and the payment pool selection values.
     PaymentPoolsMismatch,
@@ -144,6 +153,13 @@ impl Display for ProposalError {
             ProposalError::ChainDoubleSpend(output_ref) => write!(
                 f,
                 "The proposal attempts to spend the same output twice: {}, {}, {}",
+                output_ref.pool(),
+                output_ref.txid(),
+                output_ref.output_index()
+            ),
+            ProposalError::InputsLocked(output_ref) => write!(
+                f,
+                "A selected input is locked by a concurrent proposal (retry later): {}, {}, {}",
                 output_ref.pool(),
                 output_ref.txid(),
                 output_ref.output_index()

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -805,6 +805,14 @@ impl proposal::Proposal {
                 };
 
                 let target_height = TargetHeight::from(self.min_target_height);
+
+                // A proposal created with `lock_for_blocks` locks its own inputs, so
+                // input retrieval during decoding must not filter locked outputs;
+                // otherwise a locked proposal would fail to round-trip through its
+                // serialized form. Double-spend protection is enforced when the
+                // proposal's transactions are created, not here.
+                let include_locked = true;
+
                 // Steps are checked against the Orchard turnstile when Ironwood is
                 // active at the height for which the proposal was constructed.
                 #[cfg(feature = "orchard")]
@@ -875,7 +883,7 @@ impl proposal::Proposal {
                                                     .get_unspent_transparent_output(
                                                         &outpoint,
                                                         target_height,
-                                                        false,
+                                                        include_locked,
                                                     )
                                                     .map_err(ProposalDecodingError::InputRetrieval)?
                                                     .ok_or({
@@ -896,7 +904,7 @@ impl proposal::Proposal {
                                                 protocol,
                                                 out.index,
                                                 target_height,
-                                                false,
+                                                include_locked,
                                             )
                                             .map_err(ProposalDecodingError::InputRetrieval)
                                             .and_then(|opt| {

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -150,6 +150,24 @@ impl LockOwner {
     }
 }
 
+/// A transaction id may serve as a lock owner.
+///
+/// This is the right owner choice for flows that hold a durable transaction identity while
+/// their locks are alive; most notably a persisted PCZT, whose v5 txid is fixed once its
+/// effecting data is final. Deriving the owner from the txid lets such a flow re-derive its
+/// token after a restart and release (or re-acquire) exactly its own locks.
+///
+/// It is NOT a suitable owner for proposal-time locking in general: at proposal creation no
+/// transaction exists yet, a multi-step proposal builds several transactions, and a
+/// transaction rebuilt after a crash generally has a different txid, which would defeat the
+/// idempotent same-owner re-lock. Flows without a durable transaction identity should use
+/// [`LockOwner::random`] and retain the token.
+impl From<TxId> for LockOwner {
+    fn from(txid: TxId) -> Self {
+        Self(txid.into())
+    }
+}
+
 /// A type that represents the recipient of a transaction output.
 ///
 /// Variants vary along two independent axes:
@@ -1299,6 +1317,15 @@ mod output_ref_tests {
             let other_txid = OutputRef::new(TxId::from_bytes(txid), a.pool(), a.output_index());
             prop_assert_ne!(a, other_txid);
             prop_assert_ne!(a.cmp(&other_txid), std::cmp::Ordering::Equal);
+        }
+
+        /// A txid-derived [`super::LockOwner`] preserves the txid bytes, so two owners
+        /// derived from distinct transactions are distinct (a persisted PCZT re-derives
+        /// exactly its own token after a restart).
+        #[test]
+        fn lock_owner_from_txid_preserves_bytes(txid in any::<[u8; 32]>()) {
+            let owner = super::LockOwner::from(TxId::from_bytes(txid));
+            prop_assert_eq!(*owner.as_bytes(), txid);
         }
 
         /// Two independently drawn references are equal exactly when all three components

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -109,6 +109,47 @@ impl From<NoteId> for OutputRef {
     }
 }
 
+/// An opaque token identifying the holder of an output lock.
+///
+/// A caller that locks outputs (directly via [`WalletWrite::lock_outputs`], or through a
+/// proposal-creation function's lock request) supplies an owner token and must retain it: the
+/// token is what authorizes releasing the locks ([`WalletWrite::unlock_output`],
+/// [`unlock_proposal_inputs`]) and what makes re-locking idempotent (an owner may re-acquire or
+/// extend its own active lock, for example when retrying a flow after a crash, while a different
+/// owner's lock attempt fails until the lock expires).
+///
+/// The token is not a cryptographic secret: everything that can reach the wallet database can
+/// read it. It exists to prevent *accidental* cross-flow interference between concurrent
+/// in-process operations, not to protect against an adversary with database access.
+///
+/// [`WalletWrite::lock_outputs`]: crate::data_api::WalletWrite::lock_outputs
+/// [`WalletWrite::unlock_output`]: crate::data_api::WalletWrite::unlock_output
+/// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LockOwner([u8; 32]);
+
+impl LockOwner {
+    /// Constructs a `LockOwner` from the given bytes.
+    ///
+    /// Callers that persist their own operation state may derive a stable token from it; all
+    /// others should prefer [`LockOwner::random`].
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Generates a fresh random `LockOwner`.
+    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Returns the byte representation of this token.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
 /// A type that represents the recipient of a transaction output.
 ///
 /// Variants vary along two independent axes:

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -1175,3 +1175,99 @@ impl TransparentAddressSource {
         }
     }
 }
+
+/// Property tests for [`OutputRef`], whose identity (txid, pool, output index) is the key the
+/// note-locking tables and the proposal double-spend check operate on.
+#[cfg(test)]
+mod output_ref_tests {
+    use proptest::prelude::*;
+    use zcash_protocol::{PoolType, ShieldedPool, TxId};
+
+    use super::{NoteId, OutputRef};
+
+    fn arb_shielded_pool() -> impl Strategy<Value = ShieldedPool> {
+        prop_oneof![
+            Just(ShieldedPool::Sapling),
+            Just(ShieldedPool::Orchard),
+            Just(ShieldedPool::Ironwood),
+        ]
+    }
+
+    fn arb_pool_type() -> impl Strategy<Value = PoolType> {
+        prop_oneof![
+            Just(PoolType::Transparent),
+            arb_shielded_pool().prop_map(PoolType::Shielded),
+        ]
+    }
+
+    fn arb_output_ref() -> impl Strategy<Value = OutputRef> {
+        (any::<[u8; 32]>(), arb_pool_type(), any::<u32>())
+            .prop_map(|(txid, pool, idx)| OutputRef::new(TxId::from_bytes(txid), pool, idx))
+    }
+
+    proptest! {
+        /// Converting a `NoteId` preserves every component: the note's pool maps into the
+        /// shielded arm of `PoolType`, and the `u16` output index widens losslessly.
+        #[test]
+        fn from_note_id_preserves_fields(
+            txid in any::<[u8; 32]>(),
+            pool in arb_shielded_pool(),
+            idx in any::<u16>(),
+        ) {
+            let txid = TxId::from_bytes(txid);
+            let output_ref = OutputRef::from(NoteId::new(txid, pool, idx));
+            prop_assert_eq!(output_ref.txid(), &txid);
+            prop_assert_eq!(output_ref.pool(), PoolType::Shielded(pool));
+            prop_assert_eq!(output_ref.output_index(), u32::from(idx));
+        }
+
+        /// Identity is exactly the (txid, pool, output index) triple: a reference equals
+        /// itself, differs from any single-field mutation of itself, and `Ord` agrees with
+        /// `Eq` (the `BTreeSet` double-spend check in proposal construction and the lock
+        /// tables both rely on this).
+        #[test]
+        fn identity_is_the_full_triple(a in arb_output_ref()) {
+            prop_assert_eq!(a, a);
+            prop_assert_eq!(a.cmp(&a), std::cmp::Ordering::Equal);
+
+            // A different output index is a different output.
+            let other_index = OutputRef::new(
+                *a.txid(),
+                a.pool(),
+                a.output_index().wrapping_add(1),
+            );
+            prop_assert_ne!(a, other_index);
+            prop_assert_ne!(a.cmp(&other_index), std::cmp::Ordering::Equal);
+
+            // A different pool is a different output, even at the same (txid, index): the
+            // same transaction may have outputs at the same index in several pools.
+            let other_pool = OutputRef::new(
+                *a.txid(),
+                match a.pool() {
+                    PoolType::Transparent => PoolType::SAPLING,
+                    PoolType::Shielded(_) => PoolType::Transparent,
+                },
+                a.output_index(),
+            );
+            prop_assert_ne!(a, other_pool);
+            prop_assert_ne!(a.cmp(&other_pool), std::cmp::Ordering::Equal);
+
+            // A different transaction is a different output.
+            let mut txid = <[u8; 32]>::from(*a.txid());
+            txid[0] = txid[0].wrapping_add(1);
+            let other_txid = OutputRef::new(TxId::from_bytes(txid), a.pool(), a.output_index());
+            prop_assert_ne!(a, other_txid);
+            prop_assert_ne!(a.cmp(&other_txid), std::cmp::Ordering::Equal);
+        }
+
+        /// Two independently drawn references are equal exactly when all three components
+        /// match.
+        #[test]
+        fn equality_is_component_wise(a in arb_output_ref(), b in arb_output_ref()) {
+            let components_equal = a.txid() == b.txid()
+                && a.pool() == b.pool()
+                && a.output_index() == b.output_index();
+            prop_assert_eq!(a == b, components_equal);
+        }
+    }
+}

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,12 +33,17 @@ workspace.
   `PoolMigrations::for_account`, scoped to the account whose migration it
   tracks; the underlying `orchard_ironwood_migrations` table enforces at most
   one migration per account.
-- A database migration adds `lock_expiry_height` columns to the
+- A database migration adds `lock_expiry_height` and `lock_owner` columns to the
   `sapling_received_notes`, `orchard_received_notes`, `ironwood_received_notes`,
   and `transparent_received_outputs` tables to support explicit note locking
-  during concurrent proposal creation.
+  during concurrent proposal creation: `lock_expiry_height` bounds how long a
+  lock lasts, and `lock_owner` records the flow that acquired it.
 
 ### Fixed
+- The coinbase branch of the transparent account-balance tally now classifies
+  locked value into `Balance::locked_value`: previously a mature coinbase UTXO
+  locked by an in-flight shielding proposal was still reported as spendable,
+  even though note selection (correctly) refused to select it.
 - The `InputSource::get_unspent_transparent_output` implementation now honors
   its `include_locked` parameter; previously the parameter was ignored and
   locked transparent outputs were returned regardless, diverging from the

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,6 +39,10 @@ workspace.
   during concurrent proposal creation.
 
 ### Fixed
+- The `InputSource::get_unspent_transparent_output` implementation now honors
+  its `include_locked` parameter; previously the parameter was ignored and
+  locked transparent outputs were returned regardless, diverging from the
+  trait contract and from the shielded `get_spendable_note` behavior.
 - The `zewif` importer no longer marks transparent addresses that have no
   recorded exposure height (`zewif::Address::exposed_at_height() == None`, e.g.
   zcashd keypool reserves) as exposed unconditionally. Previously every such

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -71,7 +71,7 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     proto::compact_formats::CompactBlock,
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
+    wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput, WalletTx},
 };
 use zcash_keys::{
     address::UnifiedAddress,
@@ -1693,15 +1693,17 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
 
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
-        Ok(self
-            .transactionally(|wdb| wallet::lock_outputs(wdb.conn.0, outputs, lock_expiry_height))?)
+        Ok(self.transactionally(|wdb| {
+            wallet::lock_outputs(wdb.conn.0, outputs, owner, lock_expiry_height)
+        })?)
     }
 
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
-        self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output))
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        self.transactionally(|wdb| wallet::unlock_output(wdb.conn.0, output, owner))
     }
 
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
@@ -2100,7 +2102,8 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
 
     fn lock_outputs(
         &mut self,
-        outputs: impl Iterator<Item = OutputRef>,
+        outputs: &[OutputRef],
+        owner: LockOwner,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
         // This impl operates within an enclosing database transaction, so the
@@ -2112,12 +2115,13 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         Ok(wallet::lock_outputs(
             self.conn.0,
             outputs,
+            owner,
             lock_expiry_height,
         )?)
     }
 
-    fn unlock_output(&mut self, output: &OutputRef) -> Result<bool, Self::Error> {
-        wallet::unlock_output(self.conn.0, output)
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        wallet::unlock_output(self.conn.0, output, owner)
     }
 
     fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2103,6 +2103,12 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         outputs: impl Iterator<Item = OutputRef>,
         lock_expiry_height: BlockHeight,
     ) -> Result<usize, LockError<Self::Error>> {
+        // This impl operates within an enclosing database transaction, so the
+        // all-or-nothing contract of `WalletWrite::lock_outputs` holds only if a
+        // returned error causes the enclosing transaction to be rolled back: on a
+        // mid-batch `LockFailure`, locks taken for earlier outputs in the batch
+        // remain pending in the transaction. `WalletDb::transactionally` (used by
+        // the non-transactional impl above) provides that rollback.
         Ok(wallet::lock_outputs(
             self.conn.0,
             outputs,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -857,12 +857,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-        _include_locked: bool,
+        include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             Some(target_height),
+            include_locked,
         )
     }
 
@@ -1479,10 +1480,13 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
         Option<WalletTransparentOutput<<Self as InputSource>::AccountId>>,
         <Self as InputSource>::Error,
     > {
+        // The test accessor inspects wallet contents irrespective of lock state.
+        let include_locked = true;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
+            include_locked,
         )
     }
 
@@ -2373,10 +2377,14 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         outpoint: &OutPoint,
         target_height: Option<TargetHeight>,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
+        // The low-level accessor exposes wallet contents irrespective of lock
+        // state; locks only constrain input selection for new proposals.
+        let include_locked = true;
         wallet::transparent::get_wallet_transparent_output(
             self.conn.borrow(),
             outpoint,
             target_height,
+            include_locked,
         )
     }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1517,13 +1517,15 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
             .query_map([], |row| {
                 let txid: [u8; 32] = row.get("txid")?;
                 let output_index: u32 = row.get(output_index_col)?;
+                // The test accessor inspects wallet contents irrespective of lock state.
+                let include_locked = true;
                 let note = self
                     .get_spendable_note(
                         &TxId::from_bytes(txid),
                         protocol,
                         output_index,
                         target_height,
-                        true,
+                        include_locked,
                     )
                     .unwrap()
                     .unwrap();

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -111,6 +111,12 @@ impl TestDb {
         self.data_file
     }
 
+    /// Returns the path of the backing database file, so that tests can open additional
+    /// independent connections to the same wallet database.
+    pub(crate) fn data_file_path(&self) -> &std::path::Path {
+        self.data_file.path()
+    }
+
     /// Dump the schema and contents of the given database table, in
     /// sqlite3 ".dump" format. The name of the table must be a static
     /// string. This assumes that `sqlite3` is on your path and that it

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -26,7 +26,7 @@ use zcash_client_backend::{
         wallet::{ConfirmationsPolicy, TargetHeight},
         *,
     },
-    wallet::{Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},
+    wallet::{LockOwner, Note, NoteId, OutputRef, ReceivedNote, WalletTransparentOutput},
 };
 use zcash_keys::{
     address::UnifiedAddress,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -976,3 +976,154 @@ pub(crate) fn proposal_records_and_serializes_proposed_version() {
         BlockCache::new(),
     );
 }
+
+#[cfg(test)]
+mod concurrency_tests {
+    use assert_matches::assert_matches;
+
+    use zcash_client_backend::{
+        data_api::{
+            Account as _, InputSource as _, WalletRead as _, WalletTest as _, WalletWrite as _,
+            error::LockError,
+            testing::{
+                AddressType, TestBuilder, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+            },
+            wallet::TargetHeight,
+        },
+        wallet::OutputRef,
+    };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
+
+    use crate::{
+        WalletDb,
+        testing::{
+            BlockCache,
+            db::{TestDbFactory, test_clock, test_rng},
+        },
+    };
+
+    /// Two independent `WalletDb` connections to the same wallet database resolve a lock race
+    /// at the storage layer: both handles observe the same spendable note (the shared
+    /// select-before-lock state of the TOCTOU window), only the first `lock_outputs` succeeds,
+    /// the loser's failure names the contested note, and lock state changes are immediately
+    /// visible across handles. Also pins the ownerless-lock property across connections: the
+    /// losing handle is able to release the winner's lock.
+    #[test]
+    fn concurrent_handles_resolve_lock_conflict() {
+        let mut st = TestBuilder::new()
+            .with_block_cache(BlockCache::new())
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        // Fund the wallet with a single note.
+        let dfvk = SaplingPoolTester::test_account_fvk(&st);
+        let value = Zatoshis::const_from_u64(60000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        let account_id = st.test_account().unwrap().id();
+        let notes = st.wallet().get_notes(ShieldedPool::Sapling).unwrap();
+        assert_eq!(notes.len(), 1);
+        let note = &notes[0];
+        let txid = *note.txid();
+        let output_index = u32::from(note.output_index());
+        let output_ref = OutputRef::new(txid, PoolType::SAPLING, output_index);
+
+        let tip = st.wallet().chain_height().unwrap().unwrap();
+        let target_height = TargetHeight::from(tip + 1);
+
+        // Open a second, independent connection to the same wallet database file.
+        let network = *st.network();
+        let mut db2 = WalletDb::for_path(
+            st.wallet().data_file_path(),
+            network,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        // Both handles observe the note as spendable: this is the shared state from which two
+        // concurrent proposal flows would each select the same input.
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db2.get_spendable_note(
+                &txid,
+                ShieldedPool::Sapling,
+                output_index,
+                target_height,
+                false
+            )
+            .unwrap()
+            .is_some()
+        );
+
+        // The second handle locks first...
+        assert_eq!(
+            db2.lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .unwrap(),
+            1
+        );
+
+        // ... so the first handle's lock fails, naming the contested output: the race is
+        // resolved at the storage layer, across connections.
+        assert_matches!(
+            st.wallet_mut()
+                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX)),
+            Err(LockError::LockFailure(r)) if r == output_ref
+        );
+
+        // The winner's lock is immediately visible to the losing handle.
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            st.wallet().get_locked_outputs(account_id).unwrap(),
+            vec![output_ref]
+        );
+
+        // Locks carry no owner, so the losing handle can release the winner's lock; the
+        // release is visible to the winning handle.
+        assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+        assert!(
+            db2.get_spendable_note(
+                &txid,
+                ShieldedPool::Sapling,
+                output_index,
+                target_height,
+                false
+            )
+            .unwrap()
+            .is_some()
+        );
+
+        // With the note unlocked, the losing handle's retry succeeds.
+        assert_eq!(
+            st.wallet_mut()
+                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -259,6 +259,13 @@ pub(crate) fn proposal_level_note_locking<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::locked_proposal_proto_roundtrip::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -287,6 +287,16 @@ pub(crate) fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn check_note_locking_model<T: ShieldedPoolTester>(
+    ops: &[zcash_client_backend::data_api::testing::pool::LockOp],
+) {
+    zcash_client_backend::data_api::testing::pool::check_note_locking_model::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+        ops,
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -266,6 +266,27 @@ pub(crate) fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn lock_expiry_restores_spendability<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::lock_expiry_restores_spendability::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::lock_conflict_and_batch_atomicity::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+pub(crate) fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::unlock_proposal_inputs_releases_locks::<T>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 pub(crate) fn ovk_policy_prevents_recovery_from_chain<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::ovk_policy_prevents_recovery_from_chain::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -990,7 +990,7 @@ mod concurrency_tests {
             },
             wallet::TargetHeight,
         },
-        wallet::OutputRef,
+        wallet::{LockOwner, OutputRef},
     };
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
@@ -1070,18 +1070,20 @@ mod concurrency_tests {
             .is_some()
         );
 
-        // The second handle locks first...
+        // The second handle locks first, under its own owner...
+        let owner_a = LockOwner::new([0xA1; 32]);
+        let owner_b = LockOwner::new([0xB2; 32]);
         assert_eq!(
-            db2.lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+            db2.lock_outputs(&[output_ref], owner_b, BlockHeight::from(u32::MAX))
                 .unwrap(),
             1
         );
 
-        // ... so the first handle's lock fails, naming the contested output: the race is
-        // resolved at the storage layer, across connections.
+        // ... so the first handle's lock (under a different owner) fails, naming the
+        // contested output: the race is resolved at the storage layer, across connections.
         assert_matches!(
             st.wallet_mut()
-                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX)),
+                .lock_outputs(&[output_ref], owner_a, BlockHeight::from(u32::MAX)),
             Err(LockError::LockFailure(r)) if r == output_ref
         );
 
@@ -1103,9 +1105,25 @@ mod concurrency_tests {
             vec![output_ref]
         );
 
-        // Locks carry no owner, so the losing handle can release the winner's lock; the
-        // release is visible to the winning handle.
-        assert!(st.wallet_mut().unlock_output(&output_ref).unwrap());
+        // Locks are owner-scoped, so the losing handle CANNOT release the winner's lock:
+        // its unlock is a no-op and the note stays locked.
+        assert!(!st.wallet_mut().unlock_output(&output_ref, owner_a).unwrap());
+        assert!(
+            st.wallet()
+                .get_spendable_note(
+                    &txid,
+                    ShieldedPool::Sapling,
+                    output_index,
+                    target_height,
+                    false
+                )
+                .unwrap()
+                .is_none()
+        );
+
+        // The winning handle releases its own lock; the release is visible to the losing
+        // handle, whose retry then succeeds.
+        assert!(db2.unlock_output(&output_ref, owner_b).unwrap());
         assert!(
             db2.get_spendable_note(
                 &txid,
@@ -1117,11 +1135,9 @@ mod concurrency_tests {
             .unwrap()
             .is_some()
         );
-
-        // With the note unlocked, the losing handle's retry succeeds.
         assert_eq!(
             st.wallet_mut()
-                .lock_outputs([output_ref].into_iter(), BlockHeight::from(u32::MAX))
+                .lock_outputs(&[output_ref], owner_a, BlockHeight::from(u32::MAX))
                 .unwrap(),
             1
         );

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5425,69 +5425,24 @@ pub(crate) fn lock_outputs(
 
     let mut rows_updated = 0;
     for output in outputs {
-        let updated = match output.pool() {
-            PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
-                "UPDATE sapling_received_notes SET lock_expiry_height = :expiry_height
-                WHERE output_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
+        let (table, index_col) = received_outputs_table(output.pool());
+        let updated = conn
+            .execute(
+                &format!(
+                    "UPDATE {table} SET lock_expiry_height = :expiry_height
+                    WHERE {index_col} = :idx
+                    AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+                    AND ({})",
+                    common::output_lockable_condition(),
+                ),
                 named_params![
                     ":expiry_height": u32::from(lock_expiry_height),
                     ":idx": output.output_index(),
                     ":txid": output.txid().as_ref(),
                     ":chain_tip": chain_tip
                 ],
-            ),
-            PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
-                "UPDATE orchard_received_notes SET lock_expiry_height = :expiry_height
-                WHERE action_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-            PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
-                "UPDATE ironwood_received_notes SET lock_expiry_height = :expiry_height
-                WHERE action_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-            PoolType::Transparent => conn.execute(
-                "UPDATE transparent_received_outputs SET lock_expiry_height = :expiry_height
-                WHERE output_index = :idx
-                AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
-                AND (
-                    lock_expiry_height IS NULL
-                    OR lock_expiry_height <= :chain_tip
-                )",
-                named_params![
-                    ":expiry_height": u32::from(lock_expiry_height),
-                    ":idx": output.output_index(),
-                    ":txid": output.txid().as_ref(),
-                    ":chain_tip": chain_tip
-                ],
-            ),
-        }
-        .map_err(LockError::Storage)?;
+            )
+            .map_err(LockError::Storage)?;
 
         if updated == 0 {
             return Err(LockError::LockFailure(output));
@@ -5499,48 +5454,32 @@ pub(crate) fn lock_outputs(
     Ok(rows_updated)
 }
 
+/// Returns the received notes/outputs table and its output-index column for the given pool.
+fn received_outputs_table(pool: PoolType) -> (&'static str, &'static str) {
+    match pool {
+        PoolType::Shielded(ShieldedPool::Sapling) => ("sapling_received_notes", "output_index"),
+        PoolType::Shielded(ShieldedPool::Orchard) => ("orchard_received_notes", "action_index"),
+        PoolType::Shielded(ShieldedPool::Ironwood) => ("ironwood_received_notes", "action_index"),
+        PoolType::Transparent => ("transparent_received_outputs", "output_index"),
+    }
+}
+
 pub(crate) fn unlock_output(
     conn: &rusqlite::Transaction,
     output: &OutputRef,
 ) -> Result<bool, SqliteClientError> {
-    let rows_updated = match output.pool() {
-        PoolType::Shielded(ShieldedPool::Sapling) => conn.execute(
-            "UPDATE sapling_received_notes SET lock_expiry_height = NULL
-             WHERE output_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Shielded(ShieldedPool::Orchard) => conn.execute(
-            "UPDATE orchard_received_notes SET lock_expiry_height = NULL
-             WHERE action_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Shielded(ShieldedPool::Ironwood) => conn.execute(
-            "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
-             WHERE action_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-        PoolType::Transparent => conn.execute(
-            "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
-             WHERE output_index = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)",
-            named_params![
-                ":idx": output.output_index(),
-                ":txid": output.txid().as_ref(),
-            ],
-        )?,
-    };
+    let (table, index_col) = received_outputs_table(output.pool());
+    let rows_updated = conn.execute(
+        &format!(
+            "UPDATE {table} SET lock_expiry_height = NULL
+             WHERE {index_col} = :idx
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)"
+        ),
+        named_params![
+            ":idx": output.output_index(),
+            ":txid": output.txid().as_ref(),
+        ],
+    )?;
     Ok(rows_updated > 0)
 }
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -98,7 +98,7 @@ use zcash_client_backend::{
         scanning::{ScanPriority, ScanRange},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
-    wallet::{Note, NoteId, OutputRef, Recipient, WalletTx},
+    wallet::{LockOwner, Note, NoteId, OutputRef, Recipient, WalletTx},
 };
 use zcash_keys::{
     address::{Address, Receiver, UnifiedAddress},
@@ -5342,14 +5342,16 @@ pub(crate) fn get_locked_outputs(
 
 pub(crate) fn lock_outputs(
     conn: &rusqlite::Transaction,
-    outputs: impl Iterator<Item = OutputRef>,
+    outputs: &[OutputRef],
+    owner: LockOwner,
     lock_expiry_height: BlockHeight,
 ) -> Result<usize, LockError> {
     // When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the
     // `lock_expiry_height <= :chain_tip` clause evaluates to NULL (falsy). In that case only
-    // outputs that are not already locked (`lock_expiry_height IS NULL`) can be locked; an
-    // existing lock cannot be treated as expired because we have no height against which to
-    // judge expiry. This is the conservative choice: locking generally requires a synced wallet.
+    // outputs that are not already locked (`lock_expiry_height IS NULL`) or whose lock is
+    // already held by the requesting owner can be locked; an existing lock cannot be treated
+    // as expired because we have no height against which to judge expiry. This is the
+    // conservative choice: locking generally requires a synced wallet.
     let chain_tip = chain_tip_height(conn)?.map(u32::from);
 
     let mut rows_updated = 0;
@@ -5358,7 +5360,9 @@ pub(crate) fn lock_outputs(
         let updated = conn
             .execute(
                 &format!(
-                    "UPDATE {table} SET lock_expiry_height = :expiry_height
+                    "UPDATE {table} SET
+                        lock_expiry_height = :expiry_height,
+                        lock_owner = :owner
                     WHERE {index_col} = :idx
                     AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
                     AND ({})",
@@ -5366,6 +5370,7 @@ pub(crate) fn lock_outputs(
                 ),
                 named_params![
                     ":expiry_height": u32::from(lock_expiry_height),
+                    ":owner": owner.as_bytes(),
                     ":idx": output.output_index(),
                     ":txid": output.txid().as_ref(),
                     ":chain_tip": chain_tip
@@ -5374,7 +5379,7 @@ pub(crate) fn lock_outputs(
             .map_err(LockError::Storage)?;
 
         if updated == 0 {
-            return Err(LockError::LockFailure(output));
+            return Err(LockError::LockFailure(*output));
         } else {
             rows_updated += updated;
         }
@@ -5396,17 +5401,23 @@ fn received_outputs_table(pool: PoolType) -> (&'static str, &'static str) {
 pub(crate) fn unlock_output(
     conn: &rusqlite::Transaction,
     output: &OutputRef,
+    owner: LockOwner,
 ) -> Result<bool, SqliteClientError> {
     let (table, index_col) = received_outputs_table(output.pool());
+    // Unlocking is scoped to the owner: a lock held by a different owner is left in place, so
+    // one flow cannot accidentally release another's locks. An expired lock held by the owner
+    // is still cleared (and reported as such), tidying the stale row.
     let rows_updated = conn.execute(
         &format!(
-            "UPDATE {table} SET lock_expiry_height = NULL
+            "UPDATE {table} SET lock_expiry_height = NULL, lock_owner = NULL
              WHERE {index_col} = :idx
-               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)"
+               AND transaction_id = (SELECT id_tx FROM transactions WHERE txid = :txid)
+               AND lock_owner = :owner"
         ),
         named_params![
             ":idx": output.output_index(),
             ":txid": output.txid().as_ref(),
+            ":owner": owner.as_bytes(),
         ],
     )?;
     Ok(rows_updated > 0)
@@ -5432,7 +5443,7 @@ pub(crate) fn clear_locked_outputs(
     ] {
         rows_updated += conn.execute(
             &format!(
-                "UPDATE {table} SET lock_expiry_height = NULL
+                "UPDATE {table} SET lock_expiry_height = NULL, lock_owner = NULL
                  WHERE lock_expiry_height IS NOT NULL
                    AND account_id = (SELECT id FROM accounts WHERE uuid = :account_uuid)"
             ),
@@ -5448,7 +5459,7 @@ pub(crate) fn clear_locked_outputs(
 /// since the spend records now prevent them from being selected by subsequent proposals.
 fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), SqliteClientError> {
     conn.execute(
-        "UPDATE sapling_received_notes SET lock_expiry_height = NULL
+        "UPDATE sapling_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT sapling_received_note_id FROM sapling_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5457,7 +5468,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE orchard_received_notes SET lock_expiry_height = NULL
+        "UPDATE orchard_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT orchard_received_note_id FROM orchard_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5466,7 +5477,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE ironwood_received_notes SET lock_expiry_height = NULL
+        "UPDATE ironwood_received_notes SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT ironwood_received_note_id FROM ironwood_received_note_spends
              WHERE transaction_id = :tx_ref
@@ -5475,7 +5486,7 @@ fn unlock_spent_notes(conn: &rusqlite::Connection, tx_ref: TxRef) -> Result<(), 
     )?;
 
     conn.execute(
-        "UPDATE transparent_received_outputs SET lock_expiry_height = NULL
+        "UPDATE transparent_received_outputs SET lock_expiry_height = NULL, lock_owner = NULL
          WHERE id IN (
              SELECT transparent_received_output_id FROM transparent_received_output_spends
              WHERE transaction_id = :tx_ref

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2760,6 +2760,10 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
                 if value <= zip317::MARGINAL_FEE {
                     (zero, zero, zero, zero, value)
                 } else if is_spendable && is_locked {
+                    // Only notes that would otherwise be spendable are counted as locked; a
+                    // locked note that is still pending confirmations is deliberately reported
+                    // in the pending buckets below, since locking only matters once the note
+                    // would enter selection. This mirrors the transparent balance computation.
                     (zero, value, zero, zero, zero)
                 } else if is_spendable {
                     (value, zero, zero, zero, zero)
@@ -5300,112 +5304,37 @@ pub(crate) fn get_locked_outputs(
 
     let mut result = Vec::new();
 
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, sn.output_index
-         FROM sapling_received_notes sn
-         JOIN transactions t ON t.id_tx = sn.transaction_id
-         JOIN accounts a ON a.id = sn.account_id
-         WHERE sn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::SAPLING,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, orn.action_index
-         FROM orchard_received_notes orn
-         JOIN transactions t ON t.id_tx = orn.transaction_id
-         JOIN accounts a ON a.id = orn.account_id
-         WHERE orn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::ORCHARD,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, irn.action_index
-         FROM ironwood_received_notes irn
-         JOIN transactions t ON t.id_tx = irn.transaction_id
-         JOIN accounts a ON a.id = irn.account_id
-         WHERE irn.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::IRONWOOD,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
-    }
-
-    let mut stmt = conn.prepare_cached(
-        "SELECT t.txid, tro.output_index
-         FROM transparent_received_outputs tro
-         JOIN transactions t ON t.id_tx = tro.transaction_id
-         JOIN accounts a ON a.id = tro.account_id
-         WHERE tro.lock_expiry_height > :chain_tip
-         AND a.uuid = :account_uuid",
-    )?;
-    let rows = stmt.query_map(
-        named_params![
-            ":account_uuid": account.0,
-            ":chain_tip": chain_tip
-        ],
-        |row| {
-            let txid: [u8; 32] = row.get(0)?;
-            let output_index: u32 = row.get(1)?;
-            Ok(OutputRef::new(
-                TxId::from_bytes(txid),
-                PoolType::TRANSPARENT,
-                output_index,
-            ))
-        },
-    )?;
-    for row in rows {
-        result.push(row?);
+    // `lock_expiry_height > chain_tip` is `lock_expiry_height >= chain_tip + 1`, i.e. the
+    // locked-balance condition evaluated at the standard target height.
+    for pool in [
+        PoolType::SAPLING,
+        PoolType::ORCHARD,
+        PoolType::IRONWOOD,
+        PoolType::TRANSPARENT,
+    ] {
+        let (table, index_col) = received_outputs_table(pool);
+        let mut stmt = conn.prepare_cached(&format!(
+            "SELECT t.txid, rn.{index_col}
+             FROM {table} rn
+             JOIN transactions t ON t.id_tx = rn.transaction_id
+             JOIN accounts a ON a.id = rn.account_id
+             WHERE rn.lock_expiry_height > :chain_tip
+             AND a.uuid = :account_uuid"
+        ))?;
+        let rows = stmt.query_map(
+            named_params![
+                ":account_uuid": account.0,
+                ":chain_tip": chain_tip
+            ],
+            |row| {
+                let txid: [u8; 32] = row.get(0)?;
+                let output_index: u32 = row.get(1)?;
+                Ok(OutputRef::new(TxId::from_bytes(txid), pool, output_index))
+            },
+        )?;
+        for row in rows {
+            result.push(row?);
+        }
     }
 
     Ok(result)

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -1171,7 +1171,7 @@ mod lock_predicate_tests {
     /// The balance-side model: an output is counted as locked value while its lock expiry
     /// height has not been passed as of the target height.
     fn model_locked(lock_expiry_height: Option<u32>, target_height: u32) -> bool {
-        lock_expiry_height.map_or(false, |h| h >= target_height)
+        lock_expiry_height.is_some_and(|h| h >= target_height)
     }
 
     /// A height strategy biased toward the boundary around the given height, where the
@@ -1228,7 +1228,7 @@ mod lock_predicate_tests {
         ) {
             let expected = match lock {
                 None => true,
-                Some(h) => tip.map_or(false, |tip| h <= tip),
+                Some(h) => tip.is_some_and(|tip| h <= tip),
             };
             prop_assert_eq!(sql_lockable(lock, tip), expected);
         }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -159,6 +159,26 @@ pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
     )
 }
 
+/// Generates the SQL condition under which an output's lock may be (re)acquired.
+///
+/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`) or when the existing
+/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`). Because balance and
+/// selection evaluate lock state against `target_height = chain_tip + 1`, "expired as of the
+/// chain tip" (`h <= chain_tip`) is exactly "not locked for selection" (`h < target_height`):
+/// a lock can never be stolen while the output is still excluded from selection.
+///
+/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the comparison evaluates to
+/// NULL (falsy), so only outputs with no existing lock can be locked; an existing lock cannot be
+/// judged expired without a height to compare against.
+///
+/// # Usage requirements
+/// - This condition uses the bare `lock_expiry_height` column name, so it must be used in a
+///   single-table statement (such as the `UPDATE`s in `lock_outputs`).
+/// - The parent must provide `:chain_tip` as a named argument (possibly NULL).
+pub(crate) fn output_lockable_condition() -> &'static str {
+    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip"
+}
+
 fn unscanned_tip_exists(
     conn: &Connection,
     anchor_height: BlockHeight,
@@ -1076,5 +1096,156 @@ mod tests {
         .unwrap();
 
         assert_eq!(unspent_note_meta.len(), 1);
+    }
+}
+
+/// Property tests for the lock-state SQL predicates.
+///
+/// These pin the semantics of `lock_expiry_height` against executable models, evaluating the
+/// actual SQL fragments in SQLite (including their NULL behavior) rather than a Rust
+/// re-implementation of them:
+///
+/// - An output is LOCKED for balance purposes while `lock_expiry_height >= target_height`.
+/// - An output is SELECTABLE when it has no lock or `lock_expiry_height < target_height`;
+///   once the lock expiry height is passed, an expired lock is indistinguishable from no
+///   lock for selection and balance, even though the stale column value remains until it is
+///   replaced or cleared.
+/// - A lock may be (re)acquired only when no lock exists or the existing lock has expired as
+///   of the chain tip (`lock_expiry_height <= chain_tip`); with an unknown chain tip only
+///   unlocked outputs may be locked.
+/// - No lock stealing: whenever a lock is replaceable, the output is already selectable at
+///   the next target height, so replacing an expired lock never removes protection from a
+///   still-protected output.
+#[cfg(test)]
+mod lock_predicate_tests {
+    use proptest::prelude::*;
+    use rusqlite::{Connection, named_params};
+
+    use super::{output_lockable_condition, output_unlocked_condition};
+
+    fn lock_state_db(lock_expiry_height: Option<u32>) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER)")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO t (lock_expiry_height) VALUES (:h)",
+            named_params![":h": lock_expiry_height],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// Evaluates `output_unlocked_condition` in SQLite. A NULL result is falsy, as it would
+    /// be in the enclosing `WHERE` clauses.
+    fn sql_unlocked(
+        lock_expiry_height: Option<u32>,
+        target_height: u32,
+        include_locked: bool,
+    ) -> bool {
+        let conn = lock_state_db(lock_expiry_height);
+        conn.query_row(
+            &format!("SELECT ({}) FROM t", output_unlocked_condition("t")),
+            named_params![
+                ":target_height": target_height,
+                ":include_locked": include_locked,
+            ],
+            |row| row.get::<_, Option<bool>>(0),
+        )
+        .unwrap()
+        .unwrap_or(false)
+    }
+
+    /// Evaluates `output_lockable_condition` in SQLite. A NULL result is falsy, as it would
+    /// be in the `UPDATE ... WHERE` clause of `lock_outputs`.
+    fn sql_lockable(lock_expiry_height: Option<u32>, chain_tip: Option<u32>) -> bool {
+        let conn = lock_state_db(lock_expiry_height);
+        conn.query_row(
+            &format!("SELECT ({}) FROM t", output_lockable_condition()),
+            named_params![":chain_tip": chain_tip],
+            |row| row.get::<_, Option<bool>>(0),
+        )
+        .unwrap()
+        .unwrap_or(false)
+    }
+
+    /// The balance-side model: an output is counted as locked value while its lock expiry
+    /// height has not been passed as of the target height.
+    fn model_locked(lock_expiry_height: Option<u32>, target_height: u32) -> bool {
+        lock_expiry_height.map_or(false, |h| h >= target_height)
+    }
+
+    /// A height strategy biased toward the boundary around the given height, where the
+    /// interesting semantics (expiry exactly at the target, one below, one above) live.
+    fn arb_height_near(height: u32) -> impl Strategy<Value = u32> {
+        prop_oneof![
+            3 => height.saturating_sub(3)..=height.saturating_add(3),
+            1 => any::<u32>(),
+        ]
+    }
+
+    fn arb_lock_expiry(target_height: u32) -> impl Strategy<Value = Option<u32>> {
+        prop_oneof![
+            1 => Just(None),
+            4 => arb_height_near(target_height).prop_map(Some),
+        ]
+    }
+
+    proptest! {
+        /// `include_locked: true` disables lock filtering entirely.
+        #[test]
+        fn include_locked_ignores_lock_state(
+            target in any::<u32>(),
+            lock in prop::option::of(any::<u32>()),
+        ) {
+            prop_assert!(sql_unlocked(lock, target, true));
+        }
+
+        /// The selection predicate is the exact complement of the locked-balance predicate:
+        /// an output is never both selectable and counted as locked value, and never
+        /// neither. In particular, once the target height passes the lock expiry height the
+        /// output is selectable again with no unlock call, while the stale column value is
+        /// ignored.
+        #[test]
+        fn selection_is_complement_of_locked_balance(
+            (target, lock) in any::<u32>().prop_flat_map(|t| (Just(t), arb_lock_expiry(t))),
+        ) {
+            let selectable = sql_unlocked(lock, target, false);
+            let locked = model_locked(lock, target);
+            prop_assert!(
+                selectable ^ locked,
+                "selectable = {selectable}, locked = {locked} for lock {lock:?}, target {target}"
+            );
+        }
+
+        /// The lock-acquisition predicate matches its model: a lock slot is free when no
+        /// lock exists or the existing lock has expired as of the chain tip; when the chain
+        /// tip is unknown an existing lock can never be judged expired.
+        #[test]
+        fn lockable_matches_model(
+            (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
+            }),
+        ) {
+            let expected = match lock {
+                None => true,
+                Some(h) => tip.map_or(false, |tip| h <= tip),
+            };
+            prop_assert_eq!(sql_lockable(lock, tip), expected);
+        }
+
+        /// No lock stealing: whenever an existing lock may be replaced (as of chain tip
+        /// `tip`), the output is already selectable at the corresponding target height
+        /// `tip + 1`. Acquiring a lock therefore never displaces a lock that still protects
+        /// its output.
+        #[test]
+        fn lockable_implies_selectable(
+            (tip, lock) in (0..u32::MAX).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip))
+            }),
+        ) {
+            if sql_lockable(lock, Some(tip)) {
+                prop_assert!(sql_unlocked(lock, tip + 1, false));
+            }
+        }
     }
 }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -161,22 +161,25 @@ pub(crate) fn output_unlocked_condition(tbl: &str) -> String {
 
 /// Generates the SQL condition under which an output's lock may be (re)acquired.
 ///
-/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`) or when the existing
-/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`). Because balance and
-/// selection evaluate lock state against `target_height = chain_tip + 1`, "expired as of the
-/// chain tip" (`h <= chain_tip`) is exactly "not locked for selection" (`h < target_height`):
-/// a lock can never be stolen while the output is still excluded from selection.
+/// A lock may be taken when no lock exists (`lock_expiry_height IS NULL`), when the existing
+/// lock has expired as of the chain tip (`lock_expiry_height <= :chain_tip`), or when the
+/// existing lock is held by the requesting owner (`lock_owner = :owner`), which makes
+/// re-locking by the same owner idempotent. Because balance and selection evaluate lock state
+/// against `target_height = chain_tip + 1`, "expired as of the chain tip" (`h <= chain_tip`)
+/// is exactly "not locked for selection" (`h < target_height`): a lock can never be stolen by
+/// a DIFFERENT owner while the output is still excluded from selection.
 ///
-/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the comparison evaluates to
-/// NULL (falsy), so only outputs with no existing lock can be locked; an existing lock cannot be
-/// judged expired without a height to compare against.
+/// When the chain tip is unknown, `:chain_tip` binds to SQL NULL and the expiry comparison
+/// evaluates to NULL (falsy), so only outputs with no existing lock, or whose lock the
+/// requesting owner already holds, can be locked; a foreign lock cannot be judged expired
+/// without a height to compare against.
 ///
 /// # Usage requirements
-/// - This condition uses the bare `lock_expiry_height` column name, so it must be used in a
-///   single-table statement (such as the `UPDATE`s in `lock_outputs`).
-/// - The parent must provide `:chain_tip` as a named argument (possibly NULL).
+/// - This condition uses the bare `lock_expiry_height` and `lock_owner` column names, so it
+///   must be used in a single-table statement (such as the `UPDATE`s in `lock_outputs`).
+/// - The parent must provide `:chain_tip` (possibly NULL) and `:owner` as named arguments.
 pub(crate) fn output_lockable_condition() -> &'static str {
-    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip"
+    "lock_expiry_height IS NULL OR lock_expiry_height <= :chain_tip OR lock_owner = :owner"
 }
 
 fn unscanned_tip_exists(
@@ -1110,12 +1113,13 @@ mod tests {
 ///   once the lock expiry height is passed, an expired lock is indistinguishable from no
 ///   lock for selection and balance, even though the stale column value remains until it is
 ///   replaced or cleared.
-/// - A lock may be (re)acquired only when no lock exists or the existing lock has expired as
-///   of the chain tip (`lock_expiry_height <= chain_tip`); with an unknown chain tip only
-///   unlocked outputs may be locked.
-/// - No lock stealing: whenever a lock is replaceable, the output is already selectable at
-///   the next target height, so replacing an expired lock never removes protection from a
-///   still-protected output.
+/// - A lock may be (re)acquired when no lock exists, when the existing lock has expired as of
+///   the chain tip (`lock_expiry_height <= chain_tip`), or when the existing lock is held by
+///   the requesting owner (idempotent same-owner re-lock); with an unknown chain tip a
+///   foreign lock can never be judged expired.
+/// - No lock stealing: whenever a lock held by a DIFFERENT owner is replaceable, the output
+///   is already selectable at the next target height, so replacing an expired lock never
+///   removes protection from a still-protected output.
 #[cfg(test)]
 mod lock_predicate_tests {
     use proptest::prelude::*;
@@ -1123,13 +1127,13 @@ mod lock_predicate_tests {
 
     use super::{output_lockable_condition, output_unlocked_condition};
 
-    fn lock_state_db(lock_expiry_height: Option<u32>) -> Connection {
+    fn lock_state_db(lock_expiry_height: Option<u32>, lock_owner: Option<[u8; 32]>) -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER)")
+        conn.execute_batch("CREATE TABLE t (lock_expiry_height INTEGER, lock_owner BLOB)")
             .unwrap();
         conn.execute(
-            "INSERT INTO t (lock_expiry_height) VALUES (:h)",
-            named_params![":h": lock_expiry_height],
+            "INSERT INTO t (lock_expiry_height, lock_owner) VALUES (:h, :owner)",
+            named_params![":h": lock_expiry_height, ":owner": lock_owner],
         )
         .unwrap();
         conn
@@ -1142,7 +1146,7 @@ mod lock_predicate_tests {
         target_height: u32,
         include_locked: bool,
     ) -> bool {
-        let conn = lock_state_db(lock_expiry_height);
+        let conn = lock_state_db(lock_expiry_height, None);
         conn.query_row(
             &format!("SELECT ({}) FROM t", output_unlocked_condition("t")),
             named_params![
@@ -1157,11 +1161,16 @@ mod lock_predicate_tests {
 
     /// Evaluates `output_lockable_condition` in SQLite. A NULL result is falsy, as it would
     /// be in the `UPDATE ... WHERE` clause of `lock_outputs`.
-    fn sql_lockable(lock_expiry_height: Option<u32>, chain_tip: Option<u32>) -> bool {
-        let conn = lock_state_db(lock_expiry_height);
+    fn sql_lockable(
+        lock_expiry_height: Option<u32>,
+        lock_owner: Option<[u8; 32]>,
+        chain_tip: Option<u32>,
+        requesting_owner: [u8; 32],
+    ) -> bool {
+        let conn = lock_state_db(lock_expiry_height, lock_owner);
         conn.query_row(
             &format!("SELECT ({}) FROM t", output_lockable_condition()),
-            named_params![":chain_tip": chain_tip],
+            named_params![":chain_tip": chain_tip, ":owner": requesting_owner],
             |row| row.get::<_, Option<bool>>(0),
         )
         .unwrap()
@@ -1188,6 +1197,12 @@ mod lock_predicate_tests {
             1 => Just(None),
             4 => arb_height_near(target_height).prop_map(Some),
         ]
+    }
+
+    /// Owners drawn from a two-element pool, so that the requesting owner frequently matches
+    /// (and frequently differs from) the owner recorded on the row.
+    fn arb_owner() -> impl Strategy<Value = [u8; 32]> {
+        prop_oneof![Just([0xAA; 32]), Just([0xBB; 32])]
     }
 
     proptest! {
@@ -1218,32 +1233,58 @@ mod lock_predicate_tests {
         }
 
         /// The lock-acquisition predicate matches its model: a lock slot is free when no
-        /// lock exists or the existing lock has expired as of the chain tip; when the chain
-        /// tip is unknown an existing lock can never be judged expired.
+        /// lock exists, when the existing lock has expired as of the chain tip, or when the
+        /// existing lock is held by the requesting owner; when the chain tip is unknown a
+        /// foreign lock can never be judged expired.
         #[test]
         fn lockable_matches_model(
             (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
                 (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
             }),
+            row_owner in arb_owner(),
+            requesting_owner in arb_owner(),
         ) {
+            // A row with a lock height always records its owner; a row without one records
+            // no owner (the invariant maintained by lock/unlock/clear).
+            let row_owner = lock.map(|_| row_owner);
             let expected = match lock {
                 None => true,
-                Some(h) => tip.is_some_and(|tip| h <= tip),
+                Some(h) => {
+                    tip.is_some_and(|tip| h <= tip) || row_owner == Some(requesting_owner)
+                }
             };
-            prop_assert_eq!(sql_lockable(lock, tip), expected);
+            prop_assert_eq!(
+                sql_lockable(lock, row_owner, tip, requesting_owner),
+                expected
+            );
         }
 
-        /// No lock stealing: whenever an existing lock may be replaced (as of chain tip
-        /// `tip`), the output is already selectable at the corresponding target height
-        /// `tip + 1`. Acquiring a lock therefore never displaces a lock that still protects
-        /// its output.
+        /// Same-owner re-locking is always permitted, regardless of expiry state and even
+        /// when the chain tip is unknown: this is what makes lock acquisition idempotent for
+        /// the flow that holds the lock.
+        #[test]
+        fn same_owner_relock_always_permitted(
+            (tip, lock) in prop::option::of(any::<u32>()).prop_flat_map(|tip| {
+                (Just(tip), arb_lock_expiry(tip.unwrap_or(u32::MAX / 2)))
+            }),
+            owner in arb_owner(),
+        ) {
+            let row_owner = lock.map(|_| owner);
+            prop_assert!(sql_lockable(lock, row_owner, tip, owner));
+        }
+
+        /// No lock stealing: whenever an existing lock held by a DIFFERENT owner may be
+        /// replaced (as of chain tip `tip`), the output is already selectable at the
+        /// corresponding target height `tip + 1`. Acquiring a lock therefore never displaces
+        /// a foreign lock that still protects its output.
         #[test]
         fn lockable_implies_selectable(
             (tip, lock) in (0..u32::MAX).prop_flat_map(|tip| {
                 (Just(tip), arb_lock_expiry(tip))
             }),
         ) {
-            if sql_lockable(lock, Some(tip)) {
+            let row_owner = lock.map(|_| [0xAA; 32]);
+            if sql_lockable(lock, row_owner, Some(tip), [0xBB; 32]) {
                 prop_assert!(sql_unlocked(lock, tip + 1, false));
             }
         }

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -383,6 +383,7 @@ CREATE TABLE "sapling_received_notes" (
         REFERENCES addresses(id) ON DELETE CASCADE,
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_SAPLING_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -477,6 +478,7 @@ CREATE TABLE "orchard_received_notes" (
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL DEFAULT 2,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, action_index)
 )"#;
 pub(super) const INDEX_ORCHARD_RECEIVED_NOTES_ACCOUNT: &str = r#"
@@ -552,6 +554,7 @@ CREATE TABLE ironwood_received_notes (
     witness_stabilized INTEGER NOT NULL DEFAULT 0,
     note_version INTEGER NOT NULL,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, action_index)
 )";
 pub(super) const INDEX_IRONWOOD_RECEIVED_NOTES_ACCOUNT: &str = "
@@ -748,6 +751,7 @@ CREATE TABLE "transparent_received_outputs" (
     address_id INTEGER NOT NULL
         REFERENCES addresses(id) ON DELETE CASCADE,
     lock_expiry_height INTEGER,
+    lock_owner BLOB,
     UNIQUE (transaction_id, output_index)
 )"#;
 pub(super) const INDEX_TRANSPARENT_RECEIVED_OUTPUTS_ACCOUNT: &str = r#"

--- a/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
@@ -1,5 +1,7 @@
-//! This migration adds `lock_expiry_height` columns to received note tables to support
-//! height-based note locking during proposal creation.
+//! This migration adds the note-locking columns to the received note/output tables. The
+//! `lock_expiry_height` column supports height-based note locking during proposal creation, and
+//! the `lock_owner` column records the flow that acquired a lock, so that unlocking is scoped to
+//! the owner and re-locking by the same owner is idempotent.
 use std::collections::HashSet;
 
 use schemerz_rusqlite::RusqliteMigration;
@@ -30,7 +32,7 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 
     fn description(&self) -> &'static str {
-        "Adds lock_expiry_height columns to received note tables for height-based note locking."
+        "Adds lock_expiry_height and lock_owner columns to received note tables for note locking."
     }
 }
 
@@ -42,7 +44,11 @@ impl RusqliteMigration for Migration {
             "ALTER TABLE sapling_received_notes ADD COLUMN lock_expiry_height INTEGER;
              ALTER TABLE orchard_received_notes ADD COLUMN lock_expiry_height INTEGER;
              ALTER TABLE ironwood_received_notes ADD COLUMN lock_expiry_height INTEGER;
-             ALTER TABLE transparent_received_outputs ADD COLUMN lock_expiry_height INTEGER;",
+             ALTER TABLE transparent_received_outputs ADD COLUMN lock_expiry_height INTEGER;
+             ALTER TABLE sapling_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE orchard_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE ironwood_received_notes ADD COLUMN lock_owner BLOB;
+             ALTER TABLE transparent_received_outputs ADD COLUMN lock_owner BLOB;",
         )?;
 
         Ok(())

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -839,6 +839,21 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn lock_expiry_restores_spendability() {
+        testing::pool::lock_expiry_restores_spendability::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn lock_conflict_and_batch_atomicity() {
+        testing::pool::lock_conflict_and_batch_atomicity::<OrchardPoolTester>()
+    }
+
+    #[test]
+    fn unlock_proposal_inputs_releases_locks() {
+        testing::pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -853,6 +853,19 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>()
     }
 
+    proptest::proptest! {
+        // Each case builds a fresh wallet and replays an operation sequence, so keep the
+        // case count moderate; the sequences themselves explore the expiry boundaries.
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(12))]
+
+        #[test]
+        fn note_locking_model(
+            ops in zcash_client_backend::data_api::testing::pool::arb_lock_ops(3, 10)
+        ) {
+            testing::pool::check_note_locking_model::<OrchardPoolTester>(&ops)
+        }
+    }
+
     #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -834,6 +834,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn locked_proposal_proto_roundtrip() {
+        testing::pool::locked_proposal_proto_roundtrip::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -603,6 +603,21 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn lock_expiry_restores_spendability() {
+        testing::pool::lock_expiry_restores_spendability::<SaplingPoolTester>()
+    }
+
+    #[test]
+    fn lock_conflict_and_batch_atomicity() {
+        testing::pool::lock_conflict_and_batch_atomicity::<SaplingPoolTester>()
+    }
+
+    #[test]
+    fn unlock_proposal_inputs_releases_locks() {
+        testing::pool::unlock_proposal_inputs_releases_locks::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -617,6 +617,19 @@ pub(crate) mod tests {
         testing::pool::unlock_proposal_inputs_releases_locks::<SaplingPoolTester>()
     }
 
+    proptest::proptest! {
+        // Each case builds a fresh wallet and replays an operation sequence, so keep the
+        // case count moderate; the sequences themselves explore the expiry boundaries.
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(12))]
+
+        #[test]
+        fn note_locking_model(
+            ops in zcash_client_backend::data_api::testing::pool::arb_lock_ops(3, 10)
+        ) {
+            testing::pool::check_note_locking_model::<SaplingPoolTester>(&ops)
+        }
+    }
+
     #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -598,6 +598,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn locked_proposal_proto_roundtrip() {
+        testing::pool::locked_proposal_proto_roundtrip::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1818,6 +1818,14 @@ pub(crate) fn add_transparent_account_balances(
             balance.with_unshielded_coinbase_balance_mut(|bal| {
                 if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
+                } else if lock_expiry_height
+                    .iter()
+                    .any(|h| *h >= u32::from(target_height))
+                {
+                    // A locked coinbase output (selected by an in-flight shielding
+                    // proposal) is excluded from the spendable balance, exactly like a
+                    // locked non-coinbase output.
+                    bal.add_locked_value(value)
                 } else if is_mature {
                     bal.add_spendable_value(value)
                 } else {

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1270,10 +1270,14 @@ pub(crate) fn excluding_immature_coinbase_outputs(tx: &str) -> String {
 /// - `outpoint`: The identifier for the output to be retrieved.
 /// - `target_height`: The target height of a transaction under construction that will spend the
 ///   returned output. If this is `None`, no spendability checks are performed.
+/// - `include_locked`: When `false`, an output whose `lock_expiry_height` has not passed as of
+///   `target_height` is treated as unspendable and excluded. Like the other spendability checks,
+///   the lock check is skipped entirely when `target_height` is `None`.
 pub(crate) fn get_wallet_transparent_output(
     conn: &rusqlite::Connection,
     outpoint: &OutPoint,
     target_height: Option<TargetHeight>,
+    include_locked: bool,
 ) -> Result<Option<WalletTransparentOutput<AccountUuid>>, SqliteClientError> {
     // This could return as unspent outputs that are actually not spendable, if they are the
     // outputs of deshielding transactions where the spend anchors have been invalidated by a
@@ -1299,11 +1303,13 @@ pub(crate) fn get_wallet_transparent_output(
                  ({}) -- the transaction is unexpired
                  AND u.id NOT IN ({}) -- and the output is unspent
                  AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
+                 AND ({}) -- the output is not locked
              )
          )",
         tx_unexpired_condition("t"),
         spent_utxos_clause(),
-        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts")
+        excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        output_unlocked_condition("u"),
     ))?;
 
     let result: Result<Option<WalletTransparentOutput<_>>, SqliteClientError> = stmt_select_utxo
@@ -1313,6 +1319,7 @@ pub(crate) fn get_wallet_transparent_output(
                 ":output_index": outpoint.n(),
                 ":target_height": target_height.map(u32::from),
                 ":allow_unspendable": target_height.is_none(),
+                ":include_locked": include_locked,
             ],
             |row| to_unspent_transparent_output(conn, row),
         )?

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2848,6 +2848,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn transparent_note_locking() {
+        zcash_client_backend::data_api::testing::transparent::transparent_note_locking(
+            TestDbFactory::default(),
+        );
+    }
+
     /// Re-storing a transparent output with an unknown mined height (`None`) must not discard
     /// the mined height already recorded for its transaction. A `None` height means "we do not
     /// yet know this to have been mined" — for example, an output re-observed via the mempool


### PR DESCRIPTION
Builds on #2716 (targets `schell/note-locking`) with fixes and test hardening from a deep review of the note-locking feature. Work in progress; opened as draft so progress is visible.

## Fixes

- **Locked proposals now round-trip through their serialized form.** `try_into_standard_proposal` retrieved inputs with `include_locked: false`, so a proposal created with `lock_for_blocks: Some(_)` (which locks its own inputs) failed to decode with `InputNotFound` for every locked shielded input; this broke the persist-and-restore flow the locking feature exists to support. Decoding now retrieves inputs with `include_locked: true`; a `locked_proposal_proto_roundtrip` regression test was verified to fail against the previous behavior.
- **SQLite `get_unspent_transparent_output` now honors `include_locked`.** The impl accepted the parameter but ignored it, violating the trait contract and diverging from the shielded path.
- **`ProposalError::InputsLocked`.** Lock conflicts during proposal creation previously surfaced as `ChainDoubleSpend` ("attempts to spend the same output twice"), which is misleading for a transient account-busy condition; they now surface as a dedicated variant callers can match on for retry logic.

## Documentation

- `lock_outputs`: inputs must be distinct; the transaction-scoped SQLite impl relies on caller rollback for the all-or-nothing contract.
- `clear_locked_outputs` / `unlock_proposal_inputs`: locks record no owner, so these can release locks held by still-in-flight proposals; documented when they are safe to call.
- `propose_*`: lock expiry re-opens the selection race if proving outlasts the lock window; choose `lock_for_blocks` conservatively.

## Tests

Property-based (proptest), evaluating the actual SQL fragments in SQLite against executable models:

- `include_locked: true` disables lock filtering entirely.
- The selection predicate is the exact complement of the locked-balance predicate: an output is never both selectable and counted as locked, and never neither. This pins the passed-expiry semantics: once `target_height` exceeds `lock_expiry_height`, the output is selectable again with no unlock call.
- The lock-acquisition guard matches its model, including the NULL-chain-tip case.
- No lock stealing: a replaceable lock is always already expired for selection at `target_height = chain_tip + 1`.

Deterministic pool tests (Sapling + Orchard):

- `locked_proposal_proto_roundtrip`: regression test for the decoding fix.
- `lock_expiry_restores_spendability`: chain advance past the expiry restores spendability with no unlock call, and an expired lock is replaced by a fresh `lock_outputs`.
- `lock_conflict_and_batch_atomicity`: `LockFailure` on active locks (including same-caller re-lock and duplicated refs in one batch); a failed batch locks nothing; `unlock_output` return-value semantics.
- `unlock_proposal_inputs_releases_locks`: the abandoned-proposal recovery path.

The four per-pool `UPDATE` statements in `lock_outputs`/`unlock_output` were also deduplicated via a shared `received_outputs_table` lookup and `output_lockable_condition` helper (which is what makes the acquisition guard property-testable).

## More property-based tests

- **Model-based stateful proptest** (`note_locking_model`, Sapling + Orchard): random sequences of `lock`/`unlock`/`clear`/`mine` operations (expiry deltas and mining counts drawn small so sequences routinely cross expiry boundaries) run against both the real store and a trivial in-memory model of per-note lock expiry plus the chain tip. After every operation the store must agree with the model on the operation outcome (including all-or-nothing failure of conflicting batches), the `get_locked_outputs` set, and the balance decomposition (locked value = sum of model-locked notes, spendable = remainder, total unaffected by lock state).
- **`Balance` bucket invariants**: adds succeed exactly while the overflow guard permits, mutate only the requested bucket, and leave the balance unchanged on failure; `total()` is always the sum of the four participating buckets (uneconomic value never contributes and is guarded only against its own overflow); `Balance + Balance` is componentwise with the equivalent overflow condition.
- **`OutputRef` identity**: `From<NoteId>` preserves every component; identity is exactly the (txid, pool, output index) triple with `Ord` consistent with `Eq` (the `BTreeSet` double-spend check and the lock tables key on this).

## Transparent path

- `transparent_note_locking`: a locked UTXO is excluded from `get_unspent_transparent_output` and `get_spendable_transparent_outputs` unless `include_locked` is set (regression test for the fixed parameter, verified to fail against the old behavior), is reported as locked value in the per-address balances with an unchanged total, conflicts with a second lock, and returns to spendability once the chain tip passes the expiry height.

## Cross-connection concurrency

- `concurrent_handles_resolve_lock_conflict`: two independent `WalletDb` connections to the same database file, simulating the shared select-before-lock state of two concurrent proposal flows. Both handles observe the same spendable note; only the first lock succeeds; the loser's failure names the contested note; lock/unlock changes are immediately visible across handles; and the ownerless-lock property is pinned across connections.

## Edge behaviors pinned

- Locking an unknown output fails with `LockFailure`; locking an already-spent note currently succeeds with no balance effect (pinned so any future tightening of the contract is a deliberate change).
- CHANGELOG "Fixed" entries added for the two behavior fixes.

## Owner-keyed locking (`LockOwner` / `LockRequest`)

Locks now record the flow that acquired them, via an opaque caller-held `LockOwner` token stored in a `lock_owner` column (added by a second migration):

- A lock may be acquired when the output holds no lock, when the existing lock has expired as of the chain tip, or when the existing lock is held by the **same owner** (an idempotent acquire/extend, making crash-retry of a flow that already locked its inputs safe). Acquisition fails only on an active lock held by a **different** owner, preserving the no-stealing invariant (property-tested: a foreign lock is replaceable exactly when it is already expired for selection).
- `unlock_output` / `unlock_proposal_inputs` release only locks held by the given owner, closing the release-another-proposal's-locks hazard. `clear_locked_outputs` remains the owner-agnostic recovery hammer.
- The `propose_*` functions take `lock_inputs: Option<LockRequest>` (owner + expiry window) in place of `lock_for_blocks: Option<u32>`, and `propose_shielding_coinbase` gains the same parameter (it previously offered no locking, forcing Zallet to re-implement it).
- `lock_outputs` now takes `&[OutputRef]` instead of `impl Iterator`, restoring dyn-compatibility of `WalletWrite`.
- All predicate proptests, the model-based stateful proptest, and the deterministic/cross-connection tests gained an owner dimension (same-owner re-lock, cross-owner conflict and atomicity, owner-scoped unlock, owner takeover of expired locks).

Also fixed here, found by the integration suite below: the **coinbase branch of the transparent balance tally ignored locks**; a mature coinbase UTXO locked by an in-flight shielding proposal was reported as spendable while selection refused it.

## Downstream: Zallet integration and Python end-to-end suite

- **Zallet**: zcash/zallet#672 ([branch `danny/note-locking-zallet`](https://github.com/zcash/wallet/tree/danny/note-locking-zallet)) wires locking into the spend RPCs (`builder.note_lock_blocks` config, default 40 blocks; one `LockOwner` per operation with `LockRequest` into the propose calls; retryable "account is busy" error mapping; owner-scoped unlock-on-failure guards; a `z_clearlockedoutputs` recovery RPC; `lockedZat` in `z_getbalanceforaccount`). The Zallet branch is based on Zallet `main` and pins this PR's branch directly; the note-locking integration is fully independent of the pool-migration work.
- **Integration tests**: [`zcash/integration-tests` branch `danny/note-locking-integration`](https://github.com/zcash/integration-tests/tree/danny/note-locking-integration) (PR zcash/integration-tests#180) adds ten note-locking scenarios across five `qa/rpc-tests` suites (locked-balance visibility, concurrent-send double-spend prevention, unlock-on-broadcast, expiry restoring funds, locks surviving a SIGKILL restart, clear-locks recovery, account isolation, all-notes-locked errors, shielding with locking, and the short-lock-window self-heal trade-off). Both downstream branches are based on their repos' `main` and are independent of the pool-migration work. **All ten scenarios pass live** against the owner-keyed API, e.g. `ZALLET_BACKEND=zebra uv run ./qa/rpc-tests/wallet_note_locking.py`; the shielding suite behaviorally confirms the locked-coinbase balance fix.

Note for consumers pinning this branch: its `zcash_primitives` builds against the ZIP 374 deferred-anchor `orchard` builder API, so downstream manifests must mirror the workspace's git `orchard` entry (rev `3bd2b736`) in `[patch.crates-io]` alongside the librustzcash pins.

## Note for reviewers

`cargo test --release -p zcash_client_backend --all-features` has one pre-existing failure unrelated to this branch: `proposal::tests::orchard_pool_payment_with_ironwood_active_is_a_programming_error` expects a `debug_assert!` panic, which is compiled out under `--release`. It passes in debug mode and fails identically on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
