### PR TITLE
zcash_client_backend: retain anchor checkpoints across large scan batches

### DIFF
--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1606,7 +1606,7 @@ fn should_track_nullifiers(
 
 /// The interval, in blocks, at which checkpoints are retained as durable "anchors" once anchor
 /// retention is active. At 75-second blocks this is roughly every 6 hours (4 per day).
-const ANCHOR_RETENTION_INTERVAL: u32 = 288;
+pub(crate) const ANCHOR_RETENTION_INTERVAL: u32 = 288;
 
 /// Returns whether the checkpoint at `height` should be retained as a durable anchor.
 ///

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1698,12 +1698,15 @@ where
     retain_anchor_checkpoint(tree, anchor_retention_height, frontier_height)?;
 
     for (subtree, checkpoints) in subtrees {
-        // Capture the checkpoint heights before the checkpoint map is consumed by `insert_tree`.
-        let checkpoint_heights = checkpoints.keys().copied().collect::<Vec<_>>();
-        tree.insert_tree(subtree, checkpoints)?;
-        for height in checkpoint_heights {
-            retain_anchor_checkpoint(tree, anchor_retention_height, height)?;
+        // Register anchor retention for this batch's checkpoint heights *before* `insert_tree`,
+        // which prunes down to `max_checkpoints` during insertion. A batch larger than the
+        // checkpoint budget would otherwise prune an anchor before it could be retained, so
+        // retention must be recorded first; `ShardTree::ensure_retained` accepts a checkpoint
+        // height whose checkpoint does not yet exist.
+        for height in checkpoints.keys() {
+            retain_anchor_checkpoint(tree, anchor_retention_height, *height)?;
         }
+        tree.insert_tree(subtree, checkpoints)?;
     }
 
     // Ensure we have a tree checkpoint for each checkpointed block height.

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -4358,6 +4358,194 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, Dsf: DataStoreFactory>(
     );
 }
 
+/// A wallet-level test for note-commitment-tree *anchor retention*: once NU6.3 (Ironwood) is
+/// active, checkpoints on the anchor-retention interval are retained as durable anchors, exempt
+/// from the ordinary `PRUNING_DEPTH`-checkpoint pruning budget, so that their roots and the
+/// witnesses anchored to them remain computable even after they age far behind the chain tip.
+///
+/// The retention interval and pruning depth are read from `crate::data_api::ll::wallet`, so this
+/// test tracks whatever values the implementation defines rather than assuming a particular one.
+///
+/// The test:
+/// - Activates NU6.3 from the Sapling activation height, so anchor retention is live and its
+///   floor equals the account birthday.
+/// - Receives a single note early, capturing its note-commitment-tree position.
+/// - Scans forward in a single batch until an interval-aligned anchor has aged *more than
+///   `PRUNING_DEPTH` checkpoints* behind the chain tip — so it would have been pruned to enforce
+///   the checkpoint budget had it not been retained.
+/// - Proves survival behaviorally: a witness for the received note *as of that buried anchor* is
+///   still constructible (it would be `None` if the anchor checkpoint had been pruned).
+/// - Confirms the anchors did not consume the pruning budget: the ordinary checkpoint immediately
+///   above the buried anchor *was* pruned, exactly the interval-aligned anchors at/above the floor
+///   are retained, and the full `PRUNING_DEPTH` window of checkpoints at the chain tip survives.
+pub fn anchor_checkpoints_retained_across_deep_scan<
+    T: ShieldedPoolTester,
+    Dsf: DataStoreFactory,
+>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) {
+    use std::collections::BTreeSet;
+
+    use shardtree::{ShardTree, store::ShardStore};
+
+    use crate::data_api::ll::wallet::{ANCHOR_RETENTION_INTERVAL, PRUNING_DEPTH};
+
+    // Reads, from any pool's note commitment tree, the set of surviving checkpoint heights, the
+    // set of retained-anchor heights, and whether a witness for `note_position` as of
+    // `anchor_height` is still constructible.
+    #[allow(clippy::type_complexity)]
+    fn tree_anchor_state<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+        tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
+        note_position: Position,
+        anchor_height: BlockHeight,
+    ) -> Result<(bool, BTreeSet<BlockHeight>, BTreeSet<BlockHeight>), ShardTreeError<S::Error>>
+    where
+        S: ShardStore<CheckpointId = BlockHeight>,
+        S::H: incrementalmerkletree::Hashable + Clone + PartialEq,
+    {
+        let witness_computable = tree
+            .witness_at_checkpoint_id(note_position, &anchor_height)?
+            .is_some();
+        let retained = tree
+            .store()
+            .retained_checkpoints()
+            .map_err(ShardTreeError::Storage)?;
+        let checkpoint_count = tree
+            .store()
+            .checkpoint_count()
+            .map_err(ShardTreeError::Storage)?;
+        let mut survivors = BTreeSet::new();
+        tree.store()
+            .for_each_checkpoint(checkpoint_count, |cid, _| {
+                survivors.insert(*cid);
+                Ok(())
+            })
+            .map_err(ShardTreeError::Storage)?;
+        Ok((witness_computable, survivors, retained))
+    }
+
+    // A network on which NU6.3 (Ironwood) is active from the Sapling activation height, so anchor
+    // retention is live with its floor at the account birthday.
+    let activation = BlockHeight::from_u32(100_000);
+    let ironwood_active_network = LocalNetwork {
+        nu6: Some(activation),
+        nu6_1: Some(activation),
+        nu6_2: Some(activation),
+        nu6_3: Some(activation),
+        ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<T>();
+
+    // Receive a single note; its position is captured after it is deeply confirmed, below.
+    let (received_height, _, _) =
+        st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(500_000));
+    let received = u32::from(received_height);
+    let floor = u32::from(activation);
+
+    // The first interval-aligned anchor height at or above the retention floor and strictly above
+    // the received note, so the note's position precedes the anchor's checkpoint.
+    let mut anchor = floor.div_ceil(ANCHOR_RETENTION_INTERVAL) * ANCHOR_RETENTION_INTERVAL;
+    while anchor <= received {
+        anchor += ANCHOR_RETENTION_INTERVAL;
+    }
+
+    // Scan forward in a single batch so the anchor ages more than `PRUNING_DEPTH` checkpoints
+    // behind the tip: without retention it would be pruned to enforce the checkpoint budget.
+    let tip = anchor + PRUNING_DEPTH + 10;
+
+    // Fillers pay a non-wallet key, so each block still adds a commitment (and thus a checkpoint)
+    // without changing the received note's position or the wallet's spendable set.
+    let not_our_fvk = T::sk_to_fvk(&T::sk(&[0xf5; 32]));
+    let filler_count = tip - received;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10_000),
+        );
+    }
+    st.scan_cached_blocks(received_height + 1, filler_count as usize);
+
+    // Capture the received note's commitment-tree position now that it is deeply confirmed.
+    let account_id = st.get_account().id();
+    let spendable = T::select_spendable_notes(
+        &st,
+        account_id,
+        TargetValue::AtLeast(Zatoshis::const_from_u64(1)),
+        TargetHeight::from(BlockHeight::from(tip + 1)),
+        ConfirmationsPolicy::MIN,
+        &[],
+    )
+    .unwrap();
+    let note_position = spendable
+        .first()
+        .expect("the received note is spendable")
+        .note_commitment_tree_position();
+
+    let anchor_height = BlockHeight::from(anchor);
+    let (witness_computable, survivors, retained) = match T::SHIELDED_PROTOCOL {
+        ShieldedPool::Sapling => st
+            .wallet_mut()
+            .with_sapling_tree_mut(|tree| tree_anchor_state(tree, note_position, anchor_height))
+            .unwrap(),
+        #[cfg(feature = "orchard")]
+        ShieldedPool::Orchard => st
+            .wallet_mut()
+            .with_orchard_tree_mut(|tree| tree_anchor_state(tree, note_position, anchor_height))
+            .unwrap(),
+        other => {
+            unreachable!("anchor retention test covers only Sapling and Orchard, got {other:?}")
+        }
+    };
+
+    // The witness for the received note, anchored at the buried anchor, must still be computable —
+    // impossible if that checkpoint had been pruned.
+    assert!(
+        witness_computable,
+        "a witness for the received note as of the retained anchor at height {anchor} \
+         must still be constructible",
+    );
+
+    // Exactly the interval-aligned checkpoints at or above the retention floor are retained.
+    let expected_anchors: BTreeSet<BlockHeight> = (floor..=tip)
+        .filter(|h| h % ANCHOR_RETENTION_INTERVAL == 0)
+        .map(BlockHeight::from)
+        .collect();
+    assert_eq!(
+        retained, expected_anchors,
+        "only the interval-aligned anchors at/above the NU6.3 floor should be retained",
+    );
+
+    // The buried anchor survives, but the ordinary checkpoint immediately above it was pruned — so
+    // its survival is due to retention, not to pruning having failed to run.
+    assert!(
+        survivors.contains(&anchor_height),
+        "the buried anchor checkpoint must survive",
+    );
+    assert!(
+        !survivors.contains(&BlockHeight::from(anchor + 1)),
+        "the ordinary checkpoint just above the buried anchor must have been pruned",
+    );
+
+    // The anchors did not consume the pruning budget: the full `PRUNING_DEPTH` window of
+    // checkpoints at the chain tip is still retained.
+    for h in (tip - PRUNING_DEPTH + 1)..=tip {
+        assert!(
+            survivors.contains(&BlockHeight::from(h)),
+            "checkpoint at tip-window height {h} must be retained",
+        );
+    }
+}
+
 #[cfg(feature = "orchard")]
 pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     ds_factory: impl DataStoreFactory,

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -307,6 +307,13 @@ pub(crate) fn checkpoint_gaps<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn anchor_checkpoints_retained_across_deep_scan<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::anchor_checkpoints_retained_across_deep_scan::<
+        T,
+        _,
+    >(TestDbFactory::default(), BlockCache::new())
+}
+
 #[cfg(feature = "orchard")]
 pub(crate) fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::pool_crossing_required::<P0, P1>(

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -858,6 +858,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn anchor_checkpoints_retained_across_deep_scan() {
+        testing::pool::anchor_checkpoints_retained_across_deep_scan::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn scan_cached_blocks_detects_spends_out_of_order() {
         testing::pool::scan_cached_blocks_detects_spends_out_of_order::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -627,6 +627,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn anchor_checkpoints_retained_across_deep_scan() {
+        testing::pool::anchor_checkpoints_retained_across_deep_scan::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn scan_cached_blocks_detects_spends_out_of_order() {
         testing::pool::scan_cached_blocks_detects_spends_out_of_order::<SaplingPoolTester>()
     }


### PR DESCRIPTION
`update_tree` registered anchor retention *after* `insert_tree`, but `insert_tree` prunes to `max_checkpoints` (the `PRUNING_DEPTH` checkpoint budget) during insertion. A single `put_blocks` scan batch larger than that budget — routine during initial sync and catch-up — therefore pruned an interval-aligned anchor checkpoint before its retention id was registered, leaving its root and anchored witnesses permanently unrecoverable. Anchor retention only happened to work for batches no larger than the budget, because retention was then registered before the *next* batch's prune. (Retention is dormant on mainnet until NU6.3 has an assigned activation height, so no released wallet is affected yet.)

The fix registers anchor retention for a batch's checkpoint heights before `insert_tree`, so the pruning during insertion exempts them. `ShardTree::ensure_retained` records a checkpoint id even when no checkpoint with that id yet exists, so recording it ahead of insertion is safe.

Commits (TDD, red then green):
1. Add a backend-generic, wallet-level regression test — run for Sapling and Orchard against the SQLite backend — that drives the real batched `put_blocks`/`insert_tree` path. It **fails** at that commit, demonstrating the bug. The interval and pruning depth are read from the implementation, so the test tracks whatever values it defines.
2. Reorder the retention registration to fix the bug; the test passes.

Closes #2727

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
