### PR TITLE
zcash_client_backend: reduce the anchor retention interval to 144 blocks

### DIFF
--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1605,8 +1605,8 @@ fn should_track_nullifiers(
 }
 
 /// The interval, in blocks, at which checkpoints are retained as durable "anchors" once anchor
-/// retention is active. At 75-second blocks this is roughly every 6 hours (4 per day).
-pub(crate) const ANCHOR_RETENTION_INTERVAL: u32 = 288;
+/// retention is active. At 75-second blocks this is roughly every 3 hours (8 per day).
+pub(crate) const ANCHOR_RETENTION_INTERVAL: u32 = 144;
 
 /// Returns whether the checkpoint at `height` should be retained as a durable anchor.
 ///


### PR DESCRIPTION
Halve the anchor retention interval from 288 to 144 blocks (~every 3 hours at 75-second blocks, 8 per day), and update the doc comment to match.

Stacked on #2728 (the anchor-retention pruning fix); this PR targets that branch, so its diff is just the interval change. It should be rebased onto `main` once #2728 merges.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
