### PR TITLE
zcash_client_backend: silence build-script warnings on Windows

### DIFF
--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -1,12 +1,20 @@
+#[cfg(not(windows))]
 use std::env;
+#[cfg(not(windows))]
 use std::fs;
 use std::io;
+#[cfg(not(windows))]
 use std::path::{Path, PathBuf};
 
+// The proto machinery below is only ever exercised on non-Windows targets (see the note in
+// `main`), so gate it on `not(windows)` to avoid dead-code and unused-import warnings on Windows.
+#[cfg(not(windows))]
 const COMPACT_FORMATS_PROTO: &str = "proto/compact_formats.proto";
 
+#[cfg(not(windows))]
 const PROPOSAL_PROTO: &str = "proto/proposal.proto";
 
+#[cfg(not(windows))]
 const SERVICE_PROTO: &str = "proto/service.proto";
 
 fn main() -> io::Result<()> {
@@ -32,6 +40,7 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(not(windows))]
 fn build() -> io::Result<()> {
     let out: PathBuf = env::var_os("OUT_DIR")
         .expect("Cannot find OUT_DIR environment variable")


### PR DESCRIPTION
Closes #2732.

## Problem

On Windows, `zcash_client_backend`'s build script emitted five warnings:

```
warning: unused import: `Path`
warning: constant `COMPACT_FORMATS_PROTO` is never used
warning: constant `PROPOSAL_PROTO` is never used
warning: constant `SERVICE_PROTO` is never used
warning: function `build` is never used
```

The build script deliberately does nothing on Windows (the protobufs are
symlinks that do not resolve in default Windows git clones), so the
protoc-existence check and `build()` are already guarded by
`#[cfg(not(windows))]`. But the proto path constants, the `build()` function,
and the `Path` import were left ungated, so on Windows they were reachable by
nothing and the compiler flagged them. (`PathBuf`, `env`, and `fs` were not
flagged because they are still referenced inside the ungated-but-dead
`build()`; the unused-import lint is not transitive, while dead-code is.)

## Fix

Gate the non-Windows-only items on `#[cfg(not(windows))]`: the `Path`/`PathBuf`,
`env`, and `fs` imports, the three proto path constants, and the `build()`
function. On Windows they no longer exist; on non-Windows nothing changes.

## Verification

- **Windows target** (`x86_64-pc-windows-gnu`), which is what reproduces the
  `cfg(windows)` build-script evaluation: the unmodified build script emits the
  five warnings; the fixed build script compiles clean under `-D warnings`.
- **Non-Windows** (`cargo check -p zcash_client_backend` on macOS): builds
  successfully with no build-script warnings; behavior is unchanged.
- Formatted with the repo's pinned toolchain (`cargo +1.88 fmt`).

No behavior change on any target.

Generated with [Claude Code](https://claude.com/claude-code)
