### PR TITLE
Reuse the shared Orchard proving key in the migration backend

### DIFF
--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6866,7 +6866,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     // modernizing the test network fixture is part of the broader Ironwood test
     // coverage work.)
     let sapling_prover = LocalTxProver::bundled();
-    let orchard_pk = ::orchard::circuit::ProvingKey::build(
+    let orchard_pk = zcash_primitives::transaction::builder::cached_orchard_proving_key(
         zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
             pczt_branch_id,
             ::orchard::ValuePool::Orchard,
@@ -6875,7 +6875,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         .circuit_version(),
     );
     let pczt_proven = Prover::new(pczt_updated)
-        .create_orchard_proof(&orchard_pk)
+        .create_orchard_proof(orchard_pk)
         .unwrap()
         .create_sapling_proofs(&sapling_prover, &sapling_prover)
         .unwrap()

--- a/zcash_pool_migration_backend/src/wallet.rs
+++ b/zcash_pool_migration_backend/src/wallet.rs
@@ -23,10 +23,9 @@
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::fmt;
-use std::sync::OnceLock;
 
 use ::orchard::Anchor;
-use ::orchard::circuit::{OrchardCircuitVersion, ProvingKey};
+use ::orchard::circuit::OrchardCircuitVersion;
 use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
 use ::orchard::note::{Note as OrchardNote, Nullifier};
 use ::orchard::tree::MerklePath;
@@ -38,6 +37,7 @@ use ::pczt::roles::updater::{AnchorUpdateError, SpendWitnessUpdateError, Updater
 use zcash_client_backend::data_api::wallet::TargetHeight;
 use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead};
 use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_primitives::transaction::builder::cached_orchard_proving_key;
 use zcash_protocol::ShieldedPool;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
@@ -258,15 +258,6 @@ where
             .update_transaction(id, state)
             .map_err(Error::Store)
     }
-}
-
-/// The single Orchard proving key used for both the source (Orchard) and destination (Ironwood)
-/// bundles of a post-NU6.3 migration transfer. Building it is expensive (it materializes the halo2
-/// circuit parameters), so it is built once and cached for the process. Ironwood proofs reuse the
-/// same key as Orchard (both are the `PostNu6_3` circuit).
-fn post_nu6_3_orchard_proving_key() -> &'static ProvingKey {
-    static PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-    PROVING_KEY.get_or_init(|| ProvingKey::build(OrchardCircuitVersion::PostNu6_3))
 }
 
 /// Why proving a migration transaction through the wallet-backed prover failed. `TE` is the
@@ -531,7 +522,7 @@ where
 
         // Prove the Orchard bundle, and the Ironwood bundle too when present, with the single
         // post-NU6.3 Orchard proving key.
-        let pk = post_nu6_3_orchard_proving_key();
+        let pk = cached_orchard_proving_key(OrchardCircuitVersion::PostNu6_3);
         let orchard_proven = Prover::new(updated)
             .create_orchard_proof(pk)
             .map_err(|e| WalletProveError::Prove(alloc::format!("orchard proof: {e:?}")))?;

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -26,6 +26,10 @@ workspace.
   note positions, so Sapling spends cannot be signed before their witnesses
   are final).
 - `zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported`
+- `zcash_primitives::transaction::builder::cached_orchard_proving_key`, the
+  process-wide, per-circuit-version Orchard proving-key cache, now public so
+  other proving code in the workspace (such as the pool-migration backend) can
+  share it instead of rebuilding the expensive proving key.
 
 ### Changed
 - `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1769,7 +1769,7 @@ impl<P: consensus::Parameters, U> Builder<P, U> {
 /// [`std::sync::OnceLock`] for thread-safe lazy initialization. Proving requires
 /// `std` in practice, so this covers the paths that actually create proofs.
 #[cfg(all(feature = "circuits", feature = "std"))]
-fn cached_orchard_proving_key(
+pub fn cached_orchard_proving_key(
     circuit_version: orchard::circuit::OrchardCircuitVersion,
 ) -> &'static orchard::circuit::ProvingKey {
     use orchard::circuit::{OrchardCircuitVersion, ProvingKey};


### PR DESCRIPTION
Closes #2731.

## Motivation

The pool-migration backend built and cached its own Orchard proving key (a
`post_nu6_3_orchard_proving_key` `OnceLock` in `wallet.rs`), duplicating the
process-wide cache `zcash_primitives` gained in #2722. Building an Orchard
proving key materializes the halo2 circuit parameters and is expensive, so the
key should be built at most once per circuit version per process across the
whole workspace, not an extra time for the migration backend.

## Changes

- **`zcash_primitives`**: make `cached_orchard_proving_key` (added in #2722)
  `pub`, so proving code elsewhere in the workspace that constructs Orchard or
  Ironwood proofs outside the transaction builder can share the same
  per-version cache. It is only compiled with `circuits` + `std` (proving needs
  both), matching where it is usable. CHANGELOG updated.
- **`zcash_pool_migration_backend`**: drop the migration-local
  `post_nu6_3_orchard_proving_key` cache and call
  `zcash_primitives::transaction::builder::cached_orchard_proving_key(
  OrchardCircuitVersion::PostNu6_3)` instead (both the Orchard source and
  Ironwood destination proofs use the same `PostNu6_3` key).
- **`zcash_client_backend`**: the PCZT proving helper in `data_api::testing`
  rebuilt the Orchard proving key on **every** call (it was not cached); point
  it at the shared cache too. This is the one test-support site that actually
  recomputed the key per call, so it directly speeds up the suites that drive
  proving through that harness.

## Reuse audit

I checked every other `ProvingKey::build` / proving-key-cache site while here:

- `zcash_primitives`'s builder already uses `cached_orchard_proving_key` under
  `std`; its `#[cfg(not(std))]` path is the correct no-`std` fallback (no
  `OnceLock` without `std`, and proving needs `std`, so it does not run when
  actually proving) and is left as-is.
- `pczt`'s tests (`tests/end_to_end.rs` and the `roles::prover::orchard` test
  module) already cache their proving keys in local `OnceLock`s, so they build
  each key at most once per test binary; nothing to remove, and `pczt` is a
  lower-level crate that only depends on `zcash_primitives` optionally, so
  routing its tests through the workspace cache would be backwards for no gain.

## Testing

- `zcash_pool_migration_backend` builds (`--features wallet`) and its
  real-proving chain simulation (`prove_chain_sim`) passes with the shared key;
  `zcash_client_backend --all-features` builds. clippy `-D warnings` and
  `cargo fmt --check` clean on the changed crates.

Generated with [Claude Code](https://claude.com/claude-code)
