### PR TITLE
zcash_pool_migration_backend: return a struct from the commit pass

### DIFF
--- a/zcash_pool_migration_backend/src/engine.rs
+++ b/zcash_pool_migration_backend/src/engine.rs
@@ -1856,7 +1856,7 @@ where
         rng,
         Signing::InProcess,
     )
-    .map(|(state, _unsigned, _funding)| state)
+    .map(|output| output.state)
 }
 
 /// Commit a planned migration for an EXTERNAL signer: build EVERY transaction exactly as
@@ -1890,7 +1890,7 @@ where
     R: RngCore + rand_core::CryptoRng,
 {
     commit_preparation_inner(params, target_height, backend, plan, rng, Signing::External)
-        .map(|(state, unsigned, _funding)| (state, unsigned))
+        .map(|output| (output.state, output.unsigned))
 }
 
 /// Shared body of [`commit_preparation`] (with [`Signing::InProcess`]) and
@@ -1919,11 +1919,11 @@ where
     committer.build_transfers(plan)?;
     // `into_state` consumes the committer, releasing its `&mut backend` reborrow, so the store
     // write below can borrow `backend` again.
-    let (state, unsigned, transfer_funding) = committer.into_state(plan);
+    let output = committer.into_state(plan);
     backend
-        .replace_migration(&state)
+        .replace_migration(&output.state)
         .map_err(CommitError::Backend)?;
-    Ok((state, unsigned, transfer_funding))
+    Ok(output)
 }
 
 /// Commit a planned migration in-process (as [`commit_preparation`]) and additionally return each
@@ -1955,7 +1955,7 @@ where
         rng,
         Signing::InProcess,
     )
-    .map(|(state, _unsigned, funding)| (state, funding))
+    .map(|output| (output.state, output.transfer_funding))
 }
 
 /// Hosts the shared mutable state that building a whole committed migration threads through its
@@ -2356,7 +2356,11 @@ where
             preparation: plan.preparation().clone(),
             transactions: self.transactions,
         };
-        (state, self.unsigned, self.transfer_funding)
+        CommitOutput {
+            state,
+            unsigned: self.unsigned,
+            transfer_funding: self.transfer_funding,
+        }
     }
 }
 
@@ -2366,11 +2370,14 @@ where
 #[cfg(feature = "orchard")]
 type TransferFunding = Vec<(MigrationTxId, orchard::note::Note)>;
 
-/// What one commit pass produces: the persisted [`MigrationState`], the unsigned PCZTs (empty for
-/// the in-process signing path), and each transfer paired with the funding note it spends. The
-/// public commit entry points drop the parts they do not surface.
+/// What one commit pass produces. The public commit entry points drop the parts they do not
+/// surface.
 #[cfg(feature = "orchard")]
-type CommitOutput = (MigrationState, Vec<UnsignedMigrationTx>, TransferFunding);
+struct CommitOutput {
+    state: MigrationState,
+    unsigned: Vec<UnsignedMigrationTx>,
+    transfer_funding: TransferFunding,
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
`commit_preparation_inner` returned a bare 3-tuple aliased as `CommitOutput`
(`(MigrationState, Vec<UnsignedMigrationTx>, TransferFunding)`), and each public
entry point destructured it positionally (`|(state, _unsigned, _funding)| ...`).
Promote it to a struct with named fields so the three commit outputs are
self-documenting at every call site.

Addresses the agreed follow-up from PR #2710 (the "bespoke struct for the
commit output" thread).

## Change

- `CommitOutput` is now a `struct { state, unsigned, transfer_funding }` instead
  of a tuple type alias.
- `Committer::into_state` builds the struct; `commit_preparation`,
  `build_preparation_unsigned`, and `commit_preparation_with_funding` read named
  fields.

Pure internal refactor: `CommitOutput` is a private type and there is no
behavior or public-API change, so no CHANGELOG entry (the crate is pre-release).

## Testing

116 lib + 3 `engine_commit` tests pass; `prove_chain_sim` E2E running.