### PR TITLE
Replace per-pool BundleType fields with a coinbase-free BundlePadding

### DIFF
--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -31,7 +31,7 @@ use rand_core::{OsRng, SeedableRng};
 use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use zcash_note_encryption::try_note_decryption;
 use zcash_primitives::transaction::{
-    builder::{BuildConfig, Builder, PcztResult},
+    builder::{BuildConfig, Builder, BundlePadding, PcztResult},
     fees::zip317,
     sighash::SignableInput,
     sighash_v5::v5_signature_hash,
@@ -156,8 +156,8 @@ fn transparent_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -348,8 +348,8 @@ fn transparent_p2sh_multisig_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -559,8 +559,8 @@ fn sapling_to_orchard() {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -724,8 +724,8 @@ fn orchard_to_orchard() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -946,8 +946,8 @@ fn orchard_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1123,8 +1123,8 @@ fn pczt_with_anchor(pool: ShieldedPool) -> Pczt {
             orchard_anchor: matches!(pool, ShieldedPool::Orchard).then(orchard::Anchor::empty_tree),
             ironwood_anchor: matches!(pool, ShieldedPool::Ironwood)
                 .then(orchard::Anchor::empty_tree),
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1262,8 +1262,8 @@ fn redacted_sapling_anchor_can_be_restored_after_signing() {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1423,8 +1423,8 @@ fn wallet_can_set_sapling_witness_after_signing() {
             sapling_anchor: Some(anchor),
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1622,8 +1622,8 @@ fn redacted_orchard_anchor_can_be_restored_after_signing() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1774,8 +1774,8 @@ fn wallet_can_set_orchard_witness_after_signing() {
             sapling_anchor: None,
             orchard_anchor: Some(anchor),
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -1947,8 +1947,8 @@ fn wallet_can_set_ironwood_witness_after_signing() {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: Some(anchor),
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -2121,8 +2121,8 @@ fn ironwood_low_level_signer_uses_preverified_signing_parse() {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: Some(anchor),
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     );
     builder
@@ -2405,8 +2405,8 @@ fn builder_can_defer_anchors_until_proving() {
     let mut builder = DeferredPcztBuilder::new::<zip317::FeeRule>(
         nu6_3_test_network(),
         10_000_000.into(),
-        orchard::builder::BundleType::DEFAULT,
-        orchard::builder::BundleType::DEFAULT,
+        BundlePadding::DEFAULT,
+        BundlePadding::DEFAULT,
     )
     .unwrap();
     builder
@@ -2506,8 +2506,8 @@ fn deferred_anchors_require_v6() {
         DeferredPcztBuilder::new::<zip317::FeeRule>(
             pre_nu6_3_test_network(),
             10_000_000.into(),
-            orchard::builder::BundleType::DEFAULT,
-            orchard::builder::BundleType::DEFAULT,
+            BundlePadding::DEFAULT,
+            BundlePadding::DEFAULT,
         ),
         Err(zcash_primitives::transaction::builder::Error::AnchorDeferralUnsupported(_))
     ));

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -523,10 +523,11 @@ workspace.
   other internal variant.
 - MSRV is now 1.88
 - `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` now takes an
-  `orchard_pool_bundle_type` argument (behind the `pczt` feature flag) selecting
-  the transactional bundle type for the Orchard and Ironwood bundles; it must
+  `orchard_pool_padding` argument (behind the `pczt` feature flag) selecting
+  the transactional bundle padding for the Orchard and Ironwood bundles; it must
   match the change strategy used to create the proposal. Pass
-  `orchard::builder::BundleType::DEFAULT` for the previous (padded) behavior.
+  `zcash_primitives::transaction::builder::BundlePadding::DEFAULT` for the
+  previous (padded) behavior.
 - The `proposed_version: Option<TxVersion>` parameter of
   `zcash_client_backend::data_api::wallet::propose_transfer`,
   `propose_standard_transfer_to_address`, and

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1370,7 +1370,7 @@ where
             ovk_policy,
             proposal,
             expiry_height,
-            ::orchard::builder::BundleType::DEFAULT,
+            ::zcash_primitives::transaction::builder::BundlePadding::DEFAULT,
         )
     }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -70,7 +70,7 @@ use zcash_keys::{
 };
 use zcash_primitives::transaction::{
     Transaction, TxId,
-    builder::{BuildConfig, BuildResult, Builder},
+    builder::{BuildConfig, BuildResult, Builder, BundlePadding},
     components::sapling::zip212_enforcement,
     fees::FeeRule,
 };
@@ -83,7 +83,6 @@ use zcash_protocol::{
 use zip32::Scope;
 use zip321::Payment;
 
-use orchard::builder::BundleType;
 #[cfg(feature = "transparent-inputs")]
 use {
     super::CoinbaseFilter,
@@ -1533,9 +1532,10 @@ fn build_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N>
         (TransparentAddress, OutPoint),
     >,
     proposed_version: Option<TxVersion>,
-    // The transactional bundle type for the Orchard and Ironwood bundles; the PCZT path
-    // threads the proposal's configured type here, other callers pass `BundleType::DEFAULT`.
-    orchard_pool_bundle_type: BundleType,
+    // The transactional bundle padding for the Orchard and Ironwood bundles; the PCZT path
+    // threads the proposal's configured padding here, other callers pass
+    // `BundlePadding::DEFAULT`.
+    orchard_pool_padding: BundlePadding,
     // Overrides the builder-derived expiry height, when set. Applied immediately after
     // `Builder::new` below, before any inputs are added or signatures/proofs are produced.
     expiry_height: Option<BlockHeight>,
@@ -1743,8 +1743,8 @@ where
             sapling_anchor,
             orchard_anchor,
             ironwood_anchor,
-            orchard_bundle_type: orchard_pool_bundle_type,
-            ironwood_bundle_type: orchard_pool_bundle_type,
+            orchard_padding: orchard_pool_padding,
+            ironwood_padding: orchard_pool_padding,
         },
     );
     if let Some(expiry_height) = expiry_height {
@@ -2387,7 +2387,7 @@ where
         unused_transparent_outputs,
         proposed_version,
         // The non-PCZT path always builds padded Orchard-pool bundles.
-        BundleType::DEFAULT,
+        BundlePadding::DEFAULT,
         expiry_height,
     )?;
 
@@ -2642,11 +2642,12 @@ where
 /// [`Error::ExpiryHeightBelowTargetHeight`]. An `expiry_height` of zero,
 /// which disables expiry, is exempt from this check.
 ///
-/// `orchard_pool_bundle_type` selects the transactional bundle type for the Orchard
+/// `orchard_pool_padding` selects the transactional bundle padding for the Orchard
 /// and Ironwood bundles, and must match the change strategy used to create
 /// `proposal` (see
 /// `zip317::SingleOutputChangeStrategy::with_unpadded_orchard_pool_bundles`); pass
-/// [`BundleType::DEFAULT`](orchard::builder::BundleType) otherwise.
+/// [`BundlePadding::DEFAULT`](zcash_primitives::transaction::builder::BundlePadding)
+/// otherwise.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "pczt")]
@@ -2657,7 +2658,7 @@ pub fn create_pczt_from_proposal<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
     expiry_height: Option<BlockHeight>,
-    orchard_pool_bundle_type: BundleType,
+    orchard_pool_padding: BundlePadding,
 ) -> Result<pczt::Pczt, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
@@ -2713,7 +2714,7 @@ where
         #[cfg(feature = "transparent-inputs")]
         unused_transparent_outputs,
         proposed_version,
-        orchard_pool_bundle_type,
+        orchard_pool_padding,
         // This path applies `expiry_height` after the PCZT is built instead (below),
         // since overriding it via the builder would be redundant with that existing mechanism.
         None,

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -301,7 +301,7 @@ mod tests {
         block::BlockHash,
         transaction::{
             Transaction,
-            builder::{BuildConfig, BuildResult, Builder},
+            builder::{BuildConfig, BuildResult, Builder, BundlePadding},
             fees::fixed,
         },
     };
@@ -363,8 +363,8 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         let mut transparent_signing_set = TransparentSigningSet::new();

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -2248,7 +2248,7 @@ pub(crate) mod tests {
                 wallet::{TargetHeight, decrypt_and_store_transaction},
             };
             use zcash_primitives::transaction::{
-                builder::{BuildConfig, Builder},
+                builder::{BuildConfig, Builder, BundlePadding},
                 fees::zip317,
             };
             use zcash_protocol::memo::MemoBytes;
@@ -2342,8 +2342,8 @@ pub(crate) mod tests {
                     sapling_anchor: None,
                     orchard_anchor: None,
                     ironwood_anchor: Some(anchor),
-                    orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                    ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                    orchard_padding: BundlePadding::DEFAULT,
+                    ironwood_padding: BundlePadding::DEFAULT,
                 },
             );
             builder

--- a/zcash_pool_migration/src/build/prep.rs
+++ b/zcash_pool_migration/src/build/prep.rs
@@ -55,9 +55,8 @@ use alloc::vec::Vec;
 
 use rand_core::{CryptoRng, RngCore};
 
-use orchard::builder::BundleType;
 use orchard::keys::{FullViewingKey, Scope};
-use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+use zcash_primitives::transaction::builder::{BundlePadding, DeferredPcztBuilder};
 use zcash_primitives::transaction::fees::zip317::{
     FeeError as Zip317FeeError, FeeRule as Zip317FeeRule,
 };
@@ -148,11 +147,11 @@ where
     let mut builder = DeferredPcztBuilder::new::<Zip317FeeError>(
         params.clone(),
         BlockHeight::from_u32(target_height),
-        BundleType::Transactional {
+        BundlePadding {
             bundle_required: false,
             pad_to_minimum: Some(PREP_TX_ACTIONS as u8),
         },
-        BundleType::DEFAULT,
+        BundlePadding::DEFAULT,
     )
     .map_err(|e| BuildError::Build(format!("preparation: builder: {e}")))?
     .with_expiry_height(BlockHeight::from_u32(expiry_height));

--- a/zcash_pool_migration/src/build/transfer.rs
+++ b/zcash_pool_migration/src/build/transfer.rs
@@ -23,9 +23,8 @@
 
 use rand_core::{CryptoRng, RngCore};
 
-use orchard::builder::BundleType;
 use orchard::keys::{FullViewingKey, Scope};
-use zcash_primitives::transaction::builder::DeferredPcztBuilder;
+use zcash_primitives::transaction::builder::{BundlePadding, DeferredPcztBuilder};
 use zcash_primitives::transaction::fees::zip317::{
     FeeError as Zip317FeeError, FeeRule as Zip317FeeRule,
 };
@@ -35,11 +34,11 @@ use zcash_protocol::value::Zatoshis;
 
 use super::{BuildError, finalize_pczt};
 
-/// The transfer's destination-pool bundle type: a SINGLE unpadded Ironwood action. The canonical
+/// The transfer's destination-pool bundle padding: a SINGLE unpadded Ironwood action. The canonical
 /// transfer carries exactly one Ironwood output, and since every migration transfer shares this
 /// canonical shape the one-action bundle reveals nothing extra, while saving proving bandwidth on
 /// hardware signers.
-const IRONWOOD_TRANSFER_BUNDLE_TYPE: BundleType = BundleType::Transactional {
+const IRONWOOD_TRANSFER_PADDING: BundlePadding = BundlePadding {
     bundle_required: false,
     pad_to_minimum: Some(1),
 };
@@ -83,8 +82,8 @@ where
     let mut builder = DeferredPcztBuilder::new::<Zip317FeeError>(
         params.clone(),
         BlockHeight::from_u32(target_height),
-        BundleType::DEFAULT,
-        IRONWOOD_TRANSFER_BUNDLE_TYPE,
+        BundlePadding::DEFAULT,
+        IRONWOOD_TRANSFER_PADDING,
     )
     .map_err(|e| BuildError::Build(format!("transfer: builder: {e}")))?
     .with_expiry_height(BlockHeight::from_u32(expiry_height));

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -30,13 +30,21 @@ workspace.
   process-wide, per-circuit-version Orchard proving-key cache, now public so
   other proving code in the workspace (such as the pool-migration engine) can
   share it instead of rebuilding the expensive proving key.
+- `zcash_primitives::transaction::builder::BundlePadding`, the transactional
+  bundle padding (`bundle_required` / `pad_to_minimum`) for an Orchard-family
+  pool, with `BundlePadding::{DEFAULT, UNPADDED}` matching the corresponding
+  `orchard::builder::BundleType` constants. Unlike `BundleType` it cannot
+  express a coinbase bundle.
 
 ### Changed
 - `zcash_primitives::transaction::builder::BuildConfig::Standard` now carries
-  separate `orchard_bundle_type` and `ironwood_bundle_type` fields in place of
-  `orchard_pool_bundle_type`, selecting the transactional bundle type
-  independently for each Orchard protocol value pool. Set both fields to the
-  same value to keep the previous behavior.
+  separate `orchard_padding` and `ironwood_padding` fields (of the new
+  `BundlePadding` type) in place of `orchard_pool_bundle_type`, selecting the
+  transactional bundle padding independently for each Orchard protocol value
+  pool. `BundlePadding`, unlike `orchard::builder::BundleType`, cannot select a
+  coinbase bundle: whether a transaction is coinbase is a property of the whole
+  transaction, chosen by the `BuildConfig` variant, so it can no longer be set
+  per pool. Set both fields to the same value to pad both pools alike.
 - `zcash_primitives::transaction::builder::Builder::build` no longer
   reconstructs the Orchard proving key on every call. When the `std` feature is
   enabled the key is now built lazily and cached process-wide (keyed by circuit

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -262,6 +262,52 @@ impl Progress {
     }
 }
 
+/// The padding policy for a transactional Orchard-family (Orchard or Ironwood) bundle.
+///
+/// This selects only the parameters that vary between transactional bundles: whether a
+/// bundle is produced even when empty, and the minimum action count it is padded to. It
+/// deliberately cannot express an [`orchard::builder::BundleType::Coinbase`] bundle:
+/// coinbase construction is a property of the whole transaction, selected by
+/// [`BuildConfig::Coinbase`], never of an individual pool. Storing padding here rather
+/// than a full `BundleType` keeps the per-pool coinbase state unrepresentable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BundlePadding {
+    /// Produce a bundle even when no spends or outputs have been added; the resulting
+    /// bundle then consists entirely of dummy actions.
+    pub bundle_required: bool,
+    /// The minimum number of actions to pad the bundle to. `None` uses the orchard
+    /// builder's default 2-action minimum; `Some(1)` leaves the bundle unpadded, so its
+    /// action count reveals the transaction shape (acceptable when that shape is already
+    /// public, e.g. pool migrations).
+    pub pad_to_minimum: Option<u8>,
+}
+
+impl BundlePadding {
+    /// The default padding, matching [`orchard::builder::BundleType::DEFAULT`]: an empty
+    /// bundle is not produced, and a non-empty bundle is padded to the default minimum.
+    pub const DEFAULT: BundlePadding = BundlePadding {
+        bundle_required: false,
+        pad_to_minimum: None,
+    };
+
+    /// Unpadded transactional padding, matching [`orchard::builder::BundleType::UNPADDED`]:
+    /// the bundle is padded only to the one-action consensus minimum, so it contains
+    /// exactly the requested actions.
+    pub const UNPADDED: BundlePadding = BundlePadding {
+        bundle_required: false,
+        pad_to_minimum: Some(1),
+    };
+
+    /// Returns the orchard [`BundleType`](orchard::builder::BundleType) selecting this
+    /// padding. The result is always a `Transactional` bundle type.
+    pub fn bundle_type(self) -> orchard::builder::BundleType {
+        orchard::builder::BundleType::Transactional {
+            bundle_required: self.bundle_required,
+            pad_to_minimum: self.pad_to_minimum,
+        }
+    }
+}
+
 /// Rules for how the builder should be configured for each shielded pool or coinbase tx.
 #[derive(Clone)]
 pub enum BuildConfig {
@@ -269,8 +315,8 @@ pub enum BuildConfig {
         sapling_anchor: Option<sapling::Anchor>,
         orchard_anchor: Option<orchard::Anchor>,
         ironwood_anchor: Option<orchard::Anchor>,
-        orchard_bundle_type: orchard::builder::BundleType,
-        ironwood_bundle_type: orchard::builder::BundleType,
+        orchard_padding: BundlePadding,
+        ironwood_padding: BundlePadding,
     },
     Coinbase {
         miner_data: Option<PushValue>,
@@ -301,16 +347,16 @@ impl BuildConfig {
         match self {
             BuildConfig::Standard {
                 orchard_anchor,
-                orchard_bundle_type,
+                orchard_padding,
                 ..
             } => orchard_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    *orchard_bundle_type,
+                    orchard_padding.bundle_type(),
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
                 )
-                .expect("the default flags are always representable for a transactional bundle")
+                .expect("a transactional bundle type with default flags is always representable")
             }),
             BuildConfig::Coinbase { .. }
                 if bundle_version == orchard::bundle::BundleVersion::orchard_v3() =>
@@ -338,16 +384,16 @@ impl BuildConfig {
         match self {
             BuildConfig::Standard {
                 ironwood_anchor,
-                ironwood_bundle_type,
+                ironwood_padding,
                 ..
             } => ironwood_anchor.as_ref().map(|a| {
                 orchard::builder::Builder::new(
-                    *ironwood_bundle_type,
+                    ironwood_padding.bundle_type(),
                     bundle_version,
                     bundle_version.default_flags(),
                     *a,
                 )
-                .expect("the default flags are always representable for an Ironwood bundle")
+                .expect("a transactional bundle type with default flags is always representable")
             }),
             BuildConfig::Coinbase { .. } => Some(
                 orchard::builder::Builder::new(
@@ -433,7 +479,7 @@ pub struct DeferredPcztBuilder<P> {
 
 impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
     /// Creates a builder targeting the block at `target_height`, with the given
-    /// transactional bundle type for each Orchard-family pool.
+    /// transactional bundle padding for each Orchard-family pool.
     ///
     /// The expiry height defaults to `target_height` plus the default transaction expiry
     /// delta; override it with [`Self::with_expiry_height`].
@@ -445,8 +491,8 @@ impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
     pub fn new<FE>(
         params: P,
         target_height: BlockHeight,
-        orchard_bundle_type: orchard::builder::BundleType,
-        ironwood_bundle_type: orchard::builder::BundleType,
+        orchard_padding: BundlePadding,
+        ironwood_padding: BundlePadding,
     ) -> Result<Self, Error<FE>> {
         let consensus_branch_id = BranchId::for_height(&params, target_height);
         let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
@@ -457,7 +503,7 @@ impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
             bundle_version_for_branch(consensus_branch_id, orchard::ValuePool::Orchard)
                 .expect("a branch with the V6 format supports the Orchard pool");
         let orchard_builder = orchard::builder::Builder::new_with_anchor_deferred(
-            orchard_bundle_type,
+            orchard_padding.bundle_type(),
             orchard_bundle_version,
             orchard_bundle_version.default_flags(),
             orchard::bundle::TxVersion::V6,
@@ -465,7 +511,7 @@ impl<P: consensus::Parameters> DeferredPcztBuilder<P> {
         .map_err(Error::OrchardBuild)?;
         let ironwood_bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
         let ironwood_builder = orchard::builder::Builder::new_with_anchor_deferred(
-            ironwood_bundle_type,
+            ironwood_padding.bundle_type(),
             ironwood_bundle_version,
             ironwood_bundle_version.default_flags(),
             orchard::bundle::TxVersion::V6,
@@ -1863,7 +1909,7 @@ mod tests {
     #[cfg(feature = "circuits")]
     use {
         super::{Builder, Error},
-        crate::transaction::builder::BuildConfig,
+        crate::transaction::builder::{BuildConfig, BundlePadding},
         ::sapling::{Node, Rseed, zip32::ExtendedSpendingKey},
         ::transparent::{address::TransparentAddress, builder::TransparentSigningSet},
         assert_matches::assert_matches,
@@ -1940,8 +1986,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
 
@@ -1962,8 +2008,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
 
@@ -2078,8 +2124,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         builder
@@ -2136,8 +2182,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         let recipient = orchard::keys::FullViewingKey::from(
@@ -2172,8 +2218,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         builder
@@ -2261,8 +2307,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         let (fvk, note, merkle_path) = ironwood_note_with_version(orchard::note::NoteVersion::V2);
@@ -2339,29 +2385,29 @@ mod tests {
         );
     }
 
-    /// `BuildConfig::Standard`'s `orchard_bundle_type` controls padding: the
+    /// `BuildConfig::Standard`'s `orchard_padding` controls padding: the
     /// padded default counts a single-output bundle as 2 actions, while
     /// `UNPADDED` counts exactly the requested single action.
     #[test]
     #[cfg(feature = "circuits")]
-    fn orchard_bundle_type_controls_padding() {
+    fn orchard_padding_controls_padding() {
         let recipient = orchard::keys::FullViewingKey::from(
             &orchard::keys::SpendingKey::from_bytes([0; 32]).unwrap(),
         )
         .address_at(0u32, orchard::keys::Scope::External);
 
-        let config_with = |bundle_type| BuildConfig::Standard {
+        let config_with = |padding| BuildConfig::Standard {
             sapling_anchor: None,
             orchard_anchor: Some(orchard::Anchor::empty_tree()),
             ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-            orchard_bundle_type: bundle_type,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: padding,
+            ironwood_padding: BundlePadding::DEFAULT,
         };
 
         // `orchard_v2` here: the NU6.3 `orchard_v3` version disables cross-address
         // transfers, so a bare output cannot be added.
-        let count_for = |bundle_type| {
-            let config = config_with(bundle_type);
+        let count_for = |padding| {
+            let config = config_with(padding);
             let mut builder = config
                 .orchard_builder(orchard::bundle::BundleVersion::orchard_v2())
                 .unwrap();
@@ -2381,16 +2427,16 @@ mod tests {
             .unwrap()
         };
 
-        assert_eq!(count_for(orchard::builder::BundleType::DEFAULT), 2);
-        assert_eq!(count_for(orchard::builder::BundleType::UNPADDED), 1);
+        assert_eq!(count_for(BundlePadding::DEFAULT), 2);
+        assert_eq!(count_for(BundlePadding::UNPADDED), 1);
     }
 
-    /// Each Orchard protocol value pool's builder takes its bundle type from its
+    /// Each Orchard protocol value pool's builder takes its padding from its
     /// own `BuildConfig::Standard` field.
     #[test]
     #[cfg(feature = "circuits")]
-    fn orchard_protocol_bundle_types_are_per_pool() {
-        let bundle_types = |orchard_bundle_type, ironwood_bundle_type| {
+    fn orchard_protocol_padding_is_per_pool() {
+        let bundle_types = |orchard_padding, ironwood_padding| {
             let builder = Builder::new(
                 nu6_3_test_network(),
                 zcash_protocol::consensus::BlockHeight::from_u32(10),
@@ -2398,8 +2444,8 @@ mod tests {
                     sapling_anchor: None,
                     orchard_anchor: Some(orchard::Anchor::empty_tree()),
                     ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                    orchard_bundle_type,
-                    ironwood_bundle_type,
+                    orchard_padding,
+                    ironwood_padding,
                 },
             );
 
@@ -2409,21 +2455,18 @@ mod tests {
             )
         };
 
-        for config in [
-            (
-                orchard::builder::BundleType::DEFAULT,
-                orchard::builder::BundleType::DEFAULT,
-            ),
-            (
-                orchard::builder::BundleType::UNPADDED,
-                orchard::builder::BundleType::DEFAULT,
-            ),
-            (
-                orchard::builder::BundleType::DEFAULT,
-                orchard::builder::BundleType::UNPADDED,
-            ),
+        for (orchard_padding, ironwood_padding) in [
+            (BundlePadding::DEFAULT, BundlePadding::DEFAULT),
+            (BundlePadding::UNPADDED, BundlePadding::DEFAULT),
+            (BundlePadding::DEFAULT, BundlePadding::UNPADDED),
         ] {
-            assert_eq!(bundle_types(config.0, config.1), config);
+            assert_eq!(
+                bundle_types(orchard_padding, ironwood_padding),
+                (
+                    orchard_padding.bundle_type(),
+                    ironwood_padding.bundle_type()
+                ),
+            );
         }
     }
 
@@ -2460,8 +2503,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard_anchor),
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::UNPADDED,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::UNPADDED,
             },
         );
         builder
@@ -2507,8 +2550,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
         );
         let fvk = orchard::keys::FullViewingKey::from(
@@ -2555,8 +2598,8 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             },
             target_height: sapling_activation_height,
             expiry_height: sapling_activation_height + DEFAULT_TX_EXPIRY_DELTA,
@@ -2617,8 +2660,8 @@ mod tests {
             sapling_anchor: None,
             orchard_anchor: None,
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         };
         let mut builder =
             Builder::new(TEST_NETWORK, tx_height, build_config).with_expiry_height(0u32.into());
@@ -2707,8 +2750,8 @@ mod tests {
             sapling_anchor: Some(witness1.root().into()),
             orchard_anchor: None,
             ironwood_anchor: None,
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         };
         let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
 
@@ -2751,8 +2794,8 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             assert_matches!(
@@ -2774,8 +2817,8 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2800,8 +2843,8 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2825,8 +2868,8 @@ mod tests {
                 sapling_anchor: Some(sapling::Anchor::empty_tree()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder.set_zip233_amount(Zatoshis::const_from_u64(50000));
@@ -2854,8 +2897,8 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2893,8 +2936,8 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2941,8 +2984,8 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder
@@ -2992,8 +3035,8 @@ mod tests {
                 sapling_anchor: Some(witness1.root().into()),
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
-                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(TEST_NETWORK, tx_height, build_config);
             builder


### PR DESCRIPTION
## Summary

`BuildConfig::Standard` (and `DeferredPcztBuilder::new`) selected each Orchard-family pool's transactional bundle with an `orchard::builder::BundleType`, which also admits `BundleType::Coinbase`. With a separate field per pool, the type could express states that cannot occur:

- a coinbase bundle inside a `Standard` (non-coinbase) transaction, and
- one pool coinbase while the other is not.

Whether a transaction is coinbase is a property of the *whole* transaction — already chosen by the `BuildConfig` variant — so it must not be selectable per pool. The assertion that had previously rejected a coinbase override was removed when the per-pool fields were introduced, leaving only a misleading `.expect()` that would panic with a message claiming the flags were the problem.

## Changes

- Add `zcash_primitives::transaction::builder::BundlePadding`, carrying only the transactional padding axis (`bundle_required` / `pad_to_minimum`), with `DEFAULT` / `UNPADDED` constants mirroring the corresponding `BundleType` values and a `bundle_type()` bridge that always yields a `Transactional` bundle type.
- `BuildConfig::Standard` now stores `orchard_padding` / `ironwood_padding: BundlePadding`, and `DeferredPcztBuilder::new` takes two `BundlePadding`s. The per-pool coinbase state is now unrepresentable, and the two builder `.expect()`s are genuinely unreachable (relabeled to say so).
- Propagate the type through `zcash_client_backend::data_api::wallet::create_pczt_from_proposal` (`orchard_pool_padding`), closing the same hole at the public boundary.
- The `fees` module keeps its internal `BundleType` locals: they are needed for `num_actions` fee counting and never construct a coinbase bundle.

Per-pool *padding* remains supported (pool migration builds a padded Orchard source bundle alongside an unpadded Ironwood destination); only the nonsensical per-pool *coinbase* selection is removed.

## Testing

- `cargo check --workspace --tests`
- `cargo test -p zcash_primitives --features circuits,transparent-inputs` (the per-pool padding builder tests)
- `cargo test -p pczt`

---
🤖 Filed with [Claude Code](https://claude.com/claude-code) assistance.
