### PR TITLE
README: document `zcash_pool_migration`, and style its feature-gated edge.

### DIFF
--- a/.github/helpers/check-dep-graph.py
+++ b/.github/helpers/check-dep-graph.py
@@ -44,11 +44,13 @@ def main():
             line = f.readline()
         line = f.readline()
         while not 'END mermaid-dependency-graph' in line:
-            if '-->' in line:
+            if '-->' in line or '-.->' in line:
                 # Include commented-out edges for linting purposes.
                 line = line.strip()
                 if line.startswith('%% '):
                     line = line[3:]
+                # Treat dashed (feature-gated) edges the same as solid ones.
+                line = line.replace(' -.-> ', ' --> ')
                 (crate, dependency) = line.strip().split(' --> ', 1)
                 if crate in CRATES_IN_GRAPH and dependency in CRATES_IN_GRAPH:
                     readme_edges.append((crate, dependency))

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ graph TB
 
     zcash_client_sqlite --> zcash_pool_migration
 
-    zcash_pool_migration --> zcash_client_backend
+    %% The `zcash_client_backend` dependency is gated on the `wallet` feature.
+    zcash_pool_migration -.-> zcash_client_backend
 
     zcash_client_backend --> pczt
-    %% zcash_pool_migration --> pczt
+    zcash_pool_migration --> pczt
 
     %% zcash_client_sqlite --> zcash_keys
     zcash_client_backend --> zcash_keys
@@ -216,12 +217,19 @@ graph TB
   - fee calculation
   - transaction proposals & high-level transaction construction APIs
 * `zcash_client_sqlite`: SQLite-based implementation of `zcash_client_backend` storage APIs
+* `zcash_pool_migration`: Backend-agnostic engine for migrating wallet funds between value pools (first used for the NU6.3 Orchard → Ironwood migration)
+  - note-split planning into self-funding denominations
+  - migration PCZT construction, signing & height-based scheduling
+  - state persistence through a wallet backend
 
 #### Utilities & Common Dependencies
 
 * `f4jumble`: Encoding for Unified addresses
 * `zcash_encoding`: Bitcoin-derived transaction encoding utilities for Zcash
 * `equihash`: Proof-of-work protocol implementation
+* `zcash_history`: Zcash blockchain history tree
+  - the ZIP 221 Merkle Mountain Range over per-block metadata
+  - consumed by node implementations (Zebra, zcashd) for FlyClient proofs
 
 
 ## Security Warnings


### PR DESCRIPTION
In the dependency graph, the `zcash_client_backend` dependency is behind the `wallet` feature, so draw that edge dashed (`-.->`) to distinguish it from unconditional dependencies, and add a solid edge to `pczt`, which the always-available `orchard` feature pulls in directly rather than through `zcash_client_backend`. `check-dep-graph.py` now normalizes dashed edges to solid so they are still linted against the cargo dependency graph.

Also add `Crates` prose entries for `zcash_pool_migration` and the previously-undocumented `zcash_history`.