### PR TITLE
Release zcash_encoding 0.5.0 and zcash_history 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7262,6 +7262,7 @@ dependencies = [
  "corez",
  "primitive-types",
  "proptest",
+ "zcash_encoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7259,6 +7259,7 @@ dependencies = [
  "assert_matches",
  "blake2b_simd",
  "byteorder",
+ "corez",
  "primitive-types",
  "proptest",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,7 +7258,6 @@ version = "0.5.0"
 dependencies = [
  "assert_matches",
  "blake2b_simd",
- "byteorder",
  "corez",
  "primitive-types",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7103,7 +7103,7 @@ dependencies = [
  "corez",
  "f4jumble",
  "proptest",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_protocol",
 ]
 
@@ -7170,7 +7170,7 @@ dependencies = [
  "webpki-roots 1.0.3",
  "which",
  "zcash_address",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
@@ -7228,7 +7228,7 @@ dependencies = [
  "uuid",
  "zcash_address",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_pool_migration_backend",
@@ -7245,6 +7245,17 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+dependencies = [
+ "corez",
+ "hex",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.5.0"
 dependencies = [
  "corez",
  "hex",
@@ -7261,7 +7272,7 @@ dependencies = [
  "corez",
  "primitive-types",
  "proptest",
- "zcash_encoding",
+ "zcash_encoding 0.5.0",
 ]
 
 [[package]]
@@ -7295,7 +7306,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -7384,7 +7395,7 @@ dependencies = [
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.8",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
@@ -7426,7 +7437,7 @@ dependencies = [
  "incrementalmerkletree-testing",
  "memuse",
  "proptest",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
 ]
 
 [[package]]
@@ -7472,7 +7483,7 @@ dependencies = [
  "sha2 0.10.8",
  "subtle",
  "zcash_address",
- "zcash_encoding",
+ "zcash_encoding 0.4.0",
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,7 +7265,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_history"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_matches",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,13 @@ equihash = { version = "0.3", path = "components/equihash", default-features = f
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.24.0-rc.1", path = "zcash_client_backend" }
 zcash_client_sqlite = { version = "0.22.0-rc.1", path = "zcash_client_sqlite" }
-zcash_encoding = { version = "0.4", path = "components/zcash_encoding", default-features = false }
+# zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
+# rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
+# migrate at once, the workspace default stays pinned to the published 0.4; only
+# `zcash_history` (a leaf crate, and the sole consumer of the new API) takes an
+# explicit path dependency on the local 0.5. Migrate the remaining crates one at a
+# time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
+zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.15.0", path = "zcash_keys", default-features = false  }
 zcash_pool_migration_backend = { version = "0.1.0", path = "zcash_pool_migration_backend" }
 zcash_protocol = { version = "0.10.0", path = "components/zcash_protocol", default-features = false }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ graph TB
             equihash
             f4jumble
             zcash_encoding
+            zcash_history
         end
     end
 
@@ -99,6 +100,7 @@ graph TB
     %% zcash_keys --> zcash_encoding
     %% zcash_primitives --> zcash_encoding
     %% zcash_address --> zcash_encoding
+    zcash_history --> zcash_encoding
     zcash_protocol --> zcash_encoding
 
     zcash_primitives --> equihash
@@ -158,6 +160,7 @@ graph TB
     click zcash_transparent "https://docs.rs/zcash_transparent/" _blank
     click zip321 "https://docs.rs/zip321/" _blank
     click zip32 "https://docs.rs/zip32/" _blank
+    click zcash_history "https://docs.rs/zcash_history/" _blank
 ```
 
 <!-- END mermaid-dependency-graph -->

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -8,12 +8,20 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `zcash_encoding::CompactSize::{read_unbounded, write_unbounded}`, which use the
+  same wire format as `CompactSize::{read, write}` but span the full `u64` range
+  instead of enforcing the `MAX_COMPACT_SIZE` consensus limit.
 - `zcash_encoding::testing::check_roundtrip` (behind the new `test-dependencies`
   feature), a helper that asserts a `write`/`read` codec pair are exact inverses
   and that the encoding is stable across a round-trip.
 
 ### Changed
 - MSRV is now 1.88
+- `zcash_encoding::CompactSize::write` now returns an error when the provided
+  value exceeds `MAX_COMPACT_SIZE`, rather than silently writing a value that
+  `CompactSize::read` would reject. This mirrors the bound already enforced by
+  `CompactSize::read`; callers that may legitimately encode larger values should
+  use the new `CompactSize::write_unbounded`.
 
 ## [0.4.0] - 2026-04-23
 

--- a/components/zcash_encoding/CHANGELOG.md
+++ b/components/zcash_encoding/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-24
+
 ### Added
 - `zcash_encoding::CompactSize::{read_unbounded, write_unbounded}`, which use the
   same wire format as `CompactSize::{read, write}` but span the full `u64` range

--- a/components/zcash_encoding/Cargo.toml
+++ b/components/zcash_encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_encoding"
 description = "Binary encodings used throughout the Zcash ecosystem."
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",

--- a/components/zcash_encoding/src/lib.rs
+++ b/components/zcash_encoding/src/lib.rs
@@ -32,13 +32,34 @@ pub const MAX_COMPACT_SIZE: u32 = 0x02000000;
 pub struct CompactSize;
 
 impl CompactSize {
-    /// Reads an integer encoded in compact form.
-    pub fn read<R: Read>(mut reader: R) -> io::Result<u64> {
+    /// Reads an integer encoded in compact form, enforcing the
+    /// [`MAX_COMPACT_SIZE`] consensus limit.
+    ///
+    /// Use [`CompactSize::read_unbounded`] to decode values that are permitted
+    /// to exceed this limit.
+    pub fn read<R: Read>(reader: R) -> io::Result<u64> {
+        match Self::read_unbounded(reader)? {
+            s if s > <u64>::from(MAX_COMPACT_SIZE) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CompactSize too large",
+            )),
+            s => Ok(s),
+        }
+    }
+
+    /// Reads an integer encoded in compact form, over the full range of a `u64`.
+    ///
+    /// Unlike [`CompactSize::read`], this does not enforce the
+    /// [`MAX_COMPACT_SIZE`] consensus limit; it is intended for encodings such
+    /// as ZIP 221 chain history nodes, whose cumulative transaction counters may
+    /// legitimately exceed `MAX_COMPACT_SIZE`. Non-canonical encodings (values
+    /// that could have been encoded in fewer bytes) are still rejected.
+    pub fn read_unbounded<R: Read>(mut reader: R) -> io::Result<u64> {
         let mut flag_bytes = [0; 1];
         reader.read_exact(&mut flag_bytes)?;
         let flag = flag_bytes[0];
 
-        let result = if flag < 253 {
+        if flag < 253 {
             Ok(u64::from(flag))
         } else if flag == 253 {
             let mut bytes = [0; 2];
@@ -70,14 +91,6 @@ impl CompactSize {
                 )),
                 n => Ok(n),
             }
-        }?;
-
-        match result {
-            s if s > <u64>::from(MAX_COMPACT_SIZE) => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "CompactSize too large",
-            )),
-            s => Ok(s),
         }
     }
 
@@ -93,21 +106,40 @@ impl CompactSize {
         })
     }
 
-    /// Writes the provided `usize` value to the provided Writer in compact form.
-    pub fn write<W: Write>(mut writer: W, size: usize) -> io::Result<()> {
-        match size {
-            s if s < 253 => writer.write_all(&[s as u8]),
-            s if s <= 0xFFFF => {
+    /// Writes the provided `usize` value to the provided Writer in compact form,
+    /// enforcing the [`MAX_COMPACT_SIZE`] consensus limit.
+    ///
+    /// Returns an error if `size` exceeds `MAX_COMPACT_SIZE`; use
+    /// [`CompactSize::write_unbounded`] to encode larger values.
+    pub fn write<W: Write>(writer: W, size: usize) -> io::Result<()> {
+        if size as u64 > u64::from(MAX_COMPACT_SIZE) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CompactSize too large",
+            ));
+        }
+        Self::write_unbounded(writer, size as u64)
+    }
+
+    /// Writes the provided `u64` value to the provided Writer in compact form,
+    /// over the full range of a `u64`.
+    ///
+    /// Unlike [`CompactSize::write`], the value is not required to satisfy the
+    /// [`MAX_COMPACT_SIZE`] consensus limit.
+    pub fn write_unbounded<W: Write>(mut writer: W, value: u64) -> io::Result<()> {
+        match value {
+            n if n < 253 => writer.write_all(&[n as u8]),
+            n if n <= 0xFFFF => {
                 writer.write_all(&[253])?;
-                writer.write_all(&(s as u16).to_le_bytes())
+                writer.write_all(&(n as u16).to_le_bytes())
             }
-            s if s <= 0xFFFFFFFF => {
+            n if n <= 0xFFFFFFFF => {
                 writer.write_all(&[254])?;
-                writer.write_all(&(s as u32).to_le_bytes())
+                writer.write_all(&(n as u32).to_le_bytes())
             }
-            s => {
+            n => {
                 writer.write_all(&[255])?;
-                writer.write_all(&(s as u64).to_le_bytes())
+                writer.write_all(&n.to_le_bytes())
             }
         }
     }
@@ -383,15 +415,44 @@ mod tests {
         eval(33554432, &[254, 0, 0, 0, 2]);
 
         {
+            // Values above `MAX_COMPACT_SIZE` are rejected on both write and read.
             let value = 33554433;
             let encoded = &[254, 1, 0, 0, 2][..];
-            let mut data = vec![];
-            CompactSize::write(&mut data, value).unwrap();
-            assert_eq!(&data[..], encoded);
-            let serialized_size = CompactSize::serialized_size(value);
-            assert_eq!(serialized_size, encoded.len());
+            assert!(CompactSize::write(&mut vec![], value).is_err());
             assert!(CompactSize::read(encoded).is_err());
         }
+    }
+
+    #[test]
+    fn compact_size_unbounded() {
+        fn eval(value: u64, expected: &[u8]) {
+            let mut data = vec![];
+            CompactSize::write_unbounded(&mut data, value).unwrap();
+            assert_eq!(&data[..], expected);
+            assert_eq!(CompactSize::read_unbounded(expected).unwrap(), value);
+        }
+
+        // Values within the consensus bound encode exactly as `CompactSize`.
+        eval(0, &[0]);
+        eval(252, &[252]);
+        eval(253, &[253, 253, 0]);
+        eval(65535, &[253, 255, 255]);
+        eval(65536, &[254, 0, 0, 1, 0]);
+        eval(0xffff_ffff, &[254, 255, 255, 255, 255]);
+
+        // Values above `MAX_COMPACT_SIZE` round-trip through the unbounded
+        // codec, but the bounded `CompactSize` rejects them on both read and
+        // write.
+        eval(0x0200_0001, &[254, 1, 0, 0, 2]);
+        eval(0x1_0000_0000, &[255, 0, 0, 0, 0, 1, 0, 0, 0]);
+        eval(u64::MAX, &[255, 255, 255, 255, 255, 255, 255, 255, 255]);
+        assert!(CompactSize::read(&[254, 1, 0, 0, 2][..]).is_err());
+        assert!(CompactSize::write(&mut vec![], 0x0200_0001).is_err());
+
+        // Non-canonical encodings are rejected.
+        assert!(CompactSize::read_unbounded(&[253, 0, 0][..]).is_err());
+        assert!(CompactSize::read_unbounded(&[254, 0, 0, 0, 0][..]).is_err());
+        assert!(CompactSize::read_unbounded(&[255, 0, 0, 0, 0, 0, 0, 0, 0][..]).is_err());
     }
 
     #[allow(clippy::useless_vec)]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,14 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_encoding]]
+version = "0.5.0"
+audited_as = "0.4.0"
+
+[[unpublished.zcash_history]]
+version = "0.6.0"
+audited_as = "0.5.0"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -84,13 +92,6 @@ when = "2024-12-13"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
-
-[[publisher.orchard]]
-version = "0.15.0"
-when = "2026-07-09"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
 
 [[publisher.pczt]]
 version = "0.8.0-rc.1"

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_history` is now compatible with `no_std`, via a new default-enabled
+  `std` feature. Build with `default-features = false` to target `no_std`
+  platforms; an allocator is required.
+
 ### Fixed
 - Invalid history node height ranges are now rejected during deserialization,
   and leaf ranges starting at block height zero no longer underflow.

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+- Invalid history node height ranges are now rejected during deserialization,
+  and leaf ranges starting at block height zero no longer underflow.
+
 ## [0.5.0] - 2026-07-09
 
 ### Changed

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -7,10 +7,15 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-24
+
 ### Added
 - `zcash_history` is now compatible with `no_std`, via a new default-enabled
   `std` feature. Build with `default-features = false` to target `no_std`
   platforms; an allocator is required.
+
+### Changed
+- Updated to depend on `zcash_encoding 0.5`.
 
 ### Fixed
 - Invalid history node height ranges are now rejected during deserialization,

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -15,7 +15,6 @@ proptest.workspace = true
 
 [dependencies]
 primitive-types = { version = "0.12", default-features = false }
-byteorder.workspace = true
 blake2b_simd.workspace = true
 corez = { workspace = true, features = ["std"] }
 zcash_encoding.workspace = true

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -18,6 +18,7 @@ primitive-types = { version = "0.12", default-features = false }
 byteorder.workspace = true
 blake2b_simd.workspace = true
 corez = { workspace = true, features = ["std"] }
+zcash_encoding.workspace = true
 proptest = { workspace = true, optional = true }
 
 [features]

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -17,10 +17,12 @@ proptest.workspace = true
 primitive-types = { version = "0.12", default-features = false }
 byteorder.workspace = true
 blake2b_simd.workspace = true
+corez = { workspace = true, features = ["std"] }
 proptest = { workspace = true, optional = true }
 
 [features]
 test-dependencies = ["dep:proptest"]
+std = ["corez/std"]
 
 [lib]
 bench = false

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -16,13 +16,14 @@ proptest.workspace = true
 [dependencies]
 primitive-types = { version = "0.12", default-features = false }
 blake2b_simd.workspace = true
-corez = { workspace = true, features = ["std"] }
+corez.workspace = true
 zcash_encoding.workspace = true
 proptest = { workspace = true, optional = true }
 
 [features]
+default = ["std"]
+std = ["corez/std", "zcash_encoding/std"]
 test-dependencies = ["dep:proptest"]
-std = ["corez/std"]
 
 [lib]
 bench = false

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_history"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -17,7 +17,9 @@ proptest.workspace = true
 primitive-types = { version = "0.12", default-features = false }
 blake2b_simd.workspace = true
 corez.workspace = true
-zcash_encoding.workspace = true
+# Rides the breaking zcash_encoding 0.5 (see the note in the workspace Cargo.toml);
+# the rest of the stack stays on the published 0.4. Drop `path` when publishing.
+zcash_encoding = { version = "0.5", path = "../components/zcash_encoding", default-features = false }
 proptest = { workspace = true, optional = true }
 
 [features]

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -1,5 +1,3 @@
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-
 use crate::{EntryKind, EntryLink, Error, MAX_NODE_DATA_SIZE, Version};
 
 /// Max serialized length of entry data.
@@ -77,10 +75,15 @@ impl<V: Version> Entry<V> {
     /// Read from byte representation.
     pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
         let kind = {
-            match r.read_u8()? {
+            let mut byte = [0u8; 1];
+            r.read_exact(&mut byte)?;
+            match byte[0] {
                 0 => {
-                    let left = r.read_u32::<LittleEndian>()?;
-                    let right = r.read_u32::<LittleEndian>()?;
+                    let mut buf = [0u8; 4];
+                    r.read_exact(&mut buf)?;
+                    let left = u32::from_le_bytes(buf);
+                    r.read_exact(&mut buf)?;
+                    let right = u32::from_le_bytes(buf);
                     EntryKind::Node(EntryLink::Stored(left), EntryLink::Stored(right))
                 }
                 1 => EntryKind::Leaf,
@@ -97,12 +100,12 @@ impl<V: Version> Entry<V> {
     pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         match self.kind {
             EntryKind::Node(EntryLink::Stored(left), EntryLink::Stored(right)) => {
-                w.write_u8(0)?;
-                w.write_u32::<LittleEndian>(left)?;
-                w.write_u32::<LittleEndian>(right)?;
+                w.write_all(&[0])?;
+                w.write_all(&left.to_le_bytes())?;
+                w.write_all(&right.to_le_bytes())?;
             }
             EntryKind::Leaf => {
-                w.write_u8(1)?;
+                w.write_all(&[1])?;
             }
             _ => {
                 return Err(corez::io::Error::from(corez::io::ErrorKind::InvalidData));

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -75,7 +75,7 @@ impl<V: Version> Entry<V> {
     }
 
     /// Read from byte representation.
-    pub fn read<R: std::io::Read>(consensus_branch_id: u32, r: &mut R) -> std::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
         let kind = {
             match r.read_u8()? {
                 0 => {
@@ -84,7 +84,7 @@ impl<V: Version> Entry<V> {
                     EntryKind::Node(EntryLink::Stored(left), EntryLink::Stored(right))
                 }
                 1 => EntryKind::Leaf,
-                _ => return Err(std::io::Error::from(std::io::ErrorKind::InvalidData)),
+                _ => return Err(corez::io::Error::from(corez::io::ErrorKind::InvalidData)),
             }
         };
 
@@ -94,7 +94,7 @@ impl<V: Version> Entry<V> {
     }
 
     /// Write to byte representation.
-    pub fn write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+    pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         match self.kind {
             EntryKind::Node(EntryLink::Stored(left), EntryLink::Stored(right)) => {
                 w.write_u8(0)?;
@@ -105,7 +105,7 @@ impl<V: Version> Entry<V> {
                 w.write_u8(1)?;
             }
             _ => {
-                return Err(std::io::Error::from(std::io::ErrorKind::InvalidData));
+                return Err(corez::io::Error::from(corez::io::ErrorKind::InvalidData));
             }
         }
 
@@ -115,8 +115,8 @@ impl<V: Version> Entry<V> {
     }
 
     /// Convert from byte representation.
-    pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> std::io::Result<Self> {
-        let mut cursor = std::io::Cursor::new(buf);
+    pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> corez::io::Result<Self> {
+        let mut cursor = corez::io::Cursor::new(buf);
         Self::read(consensus_branch_id, &mut cursor)
     }
 }

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -73,7 +73,10 @@ impl<V: Version> Entry<V> {
     }
 
     /// Read from byte representation.
-    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(
+        consensus_branch_id: u32,
+        r: &mut R,
+    ) -> corez::io::Result<Self> {
         let kind = {
             let mut byte = [0u8; 1];
             r.read_exact(&mut byte)?;
@@ -124,8 +127,8 @@ impl<V: Version> Entry<V> {
     }
 }
 
-impl<V: Version> std::fmt::Display for Entry<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<V: Version> core::fmt::Display for Entry<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.kind {
             EntryKind::Node(l, r) => write!(f, "node({l}, {r}, ..)"),
             EntryKind::Leaf => write!(f, "leaf(..)"),

--- a/zcash_history/src/entry.rs
+++ b/zcash_history/src/entry.rs
@@ -40,8 +40,17 @@ impl<V: Version> Entry<V> {
     }
 
     /// Number of leaves under this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this entry was constructed with a descending height range or
+    /// a range containing more leaves than can be represented by a `u64`.
+    /// Entries produced by [`Self::read`] are validated against these cases.
     pub fn leaf_count(&self) -> u64 {
-        V::end_height(&self.data) - (V::start_height(&self.data) - 1)
+        V::end_height(&self.data)
+            .checked_sub(V::start_height(&self.data))
+            .and_then(|height_diff| height_diff.checked_add(1))
+            .expect("entry height range must contain a representable number of leaves")
     }
 
     /// Is this node a leaf.

--- a/zcash_history/src/lib.rs
+++ b/zcash_history/src/lib.rs
@@ -1,6 +1,5 @@
-//! Chain history library for Zcash
-//!
-//! To be used in zebra and via FFI bindings in zcashd
+//! To be used in Zebra. Originally also consumed by zcashd via FFI bindings,
+//! which reached End-of-Support in July 2026.
 
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
@@ -39,7 +38,6 @@ impl std::fmt::Display for Error {
 }
 
 /// Reference to the tree node.
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub enum EntryLink {
     /// Reference to the stored (in the array representation) leaf/node.
@@ -58,7 +56,6 @@ impl std::fmt::Display for EntryLink {
 }
 
 /// MMR Node. It is leaf when `left`, `right` are `None` and node when they are not.
-#[repr(C)]
 #[derive(Debug)]
 pub enum EntryKind {
     /// Leaf entry.

--- a/zcash_history/src/lib.rs
+++ b/zcash_history/src/lib.rs
@@ -1,9 +1,13 @@
 //! To be used in Zebra. Originally also consumed by zcashd via FFI bindings,
 //! which reached End-of-Support in July 2026.
 
+#![no_std]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
+
+#[macro_use]
+extern crate alloc;
 
 mod entry;
 mod node_data;
@@ -27,8 +31,8 @@ pub enum Error {
     ExpectedNode(Option<EntryLink>),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::ExpectedInMemory(l) => write!(f, "Node/leaf expected to be in memory: {l}"),
             Self::ExpectedNode(None) => write!(f, "Node expected"),
@@ -46,8 +50,8 @@ pub enum EntryLink {
     Generated(u32),
 }
 
-impl std::fmt::Display for EntryLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for EntryLink {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::Stored(v) => write!(f, "stored({v})"),
             Self::Generated(v) => write!(f, "generated({v})"),

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -81,7 +81,7 @@ impl NodeData {
         }
     }
 
-    fn write_compact<W: std::io::Write>(w: &mut W, compact: u64) -> std::io::Result<()> {
+    fn write_compact<W: corez::io::Write>(w: &mut W, compact: u64) -> corez::io::Result<()> {
         match compact {
             0..=0xfc => w.write_all(&[compact as u8])?,
             0xfd..=0xffff => {
@@ -100,7 +100,7 @@ impl NodeData {
         Ok(())
     }
 
-    fn read_compact<R: std::io::Read>(reader: &mut R) -> std::io::Result<u64> {
+    fn read_compact<R: corez::io::Read>(reader: &mut R) -> corez::io::Result<u64> {
         let result = match reader.read_u8()? {
             i @ 0..=0xfc => i.into(),
             0xfd => reader.read_u16::<LittleEndian>()?.into(),
@@ -112,7 +112,7 @@ impl NodeData {
     }
 
     /// Write to the byte representation.
-    pub fn write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+    pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         w.write_all(&self.subtree_commitment)?;
         w.write_u32::<LittleEndian>(self.start_time)?;
         w.write_u32::<LittleEndian>(self.end_time)?;
@@ -135,10 +135,10 @@ impl NodeData {
     ///
     /// # Errors
     ///
-    /// Returns [`std::io::ErrorKind::InvalidData`] if the encoded height range
+    /// Returns [`corez::io::ErrorKind::InvalidData`] if the encoded height range
     /// is descending or contains more blocks than can be represented by a
     /// `u64`.
-    pub fn read<R: std::io::Read>(consensus_branch_id: u32, r: &mut R) -> std::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
         let mut data = NodeData {
             consensus_branch_id,
             ..Default::default()
@@ -163,8 +163,8 @@ impl NodeData {
             .and_then(|height_diff| height_diff.checked_add(1))
             .is_none()
         {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(corez::io::Error::new(
+                corez::io::ErrorKind::InvalidData,
                 "history node height range does not contain a representable number of blocks",
             ));
         }
@@ -182,10 +182,10 @@ impl NodeData {
     ///
     /// # Errors
     ///
-    /// Returns [`std::io::ErrorKind::InvalidData`] if the encoded height range
+    /// Returns [`corez::io::ErrorKind::InvalidData`] if the encoded height range
     /// is descending or contains more blocks than can be represented by a
     /// `u64`.
-    pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> std::io::Result<Self> {
+    pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> corez::io::Result<Self> {
         crate::V1::from_bytes(consensus_branch_id, buf)
     }
 
@@ -220,7 +220,7 @@ impl V2 {
     }
 
     /// Write to the byte representation.
-    pub fn write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+    pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         self.v1.write(w)?;
         w.write_all(&self.start_orchard_root)?;
         w.write_all(&self.end_orchard_root)?;
@@ -229,7 +229,7 @@ impl V2 {
     }
 
     /// Read from the byte representation.
-    pub fn read<R: std::io::Read>(consensus_branch_id: u32, r: &mut R) -> std::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
         let mut data = V2 {
             v1: NodeData::read(consensus_branch_id, r)?,
             ..Default::default()
@@ -279,7 +279,7 @@ impl V3 {
     }
 
     /// Write to the byte representation.
-    pub fn write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+    pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         self.v2.write(w)?;
         w.write_all(&self.start_ironwood_root)?;
         w.write_all(&self.end_ironwood_root)?;
@@ -288,7 +288,7 @@ impl V3 {
     }
 
     /// Read from the byte representation.
-    pub fn read<R: std::io::Read>(consensus_branch_id: u32, r: &mut R) -> std::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
         let mut data = V3 {
             v2: V2::read(consensus_branch_id, r)?,
             ..Default::default()
@@ -472,7 +472,7 @@ mod tests {
             } else {
                 prop_assert_eq!(
                     decoded.unwrap_err().kind(),
-                    std::io::ErrorKind::InvalidData
+                    corez::io::ErrorKind::InvalidData
                 );
             }
         }
@@ -532,7 +532,7 @@ mod tests {
                 Err(error) => error,
             };
 
-            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert_eq!(error.kind(), corez::io::ErrorKind::InvalidData);
         }
     }
 

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -132,6 +132,12 @@ impl NodeData {
     }
 
     /// Read from the byte representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::io::ErrorKind::InvalidData`] if the encoded height range
+    /// is descending or contains more blocks than can be represented by a
+    /// `u64`.
     pub fn read<R: std::io::Read>(consensus_branch_id: u32, r: &mut R) -> std::io::Result<Self> {
         let mut data = NodeData {
             consensus_branch_id,
@@ -151,6 +157,17 @@ impl NodeData {
 
         data.start_height = Self::read_compact(r)?;
         data.end_height = Self::read_compact(r)?;
+        if data
+            .end_height
+            .checked_sub(data.start_height)
+            .and_then(|height_diff| height_diff.checked_add(1))
+            .is_none()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "history node height range does not contain a representable number of blocks",
+            ));
+        }
         data.sapling_tx = Self::read_compact(r)?;
 
         Ok(data)
@@ -162,6 +179,12 @@ impl NodeData {
     }
 
     /// Convert from byte representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::io::ErrorKind::InvalidData`] if the encoded height range
+    /// is descending or contains more blocks than can be represented by a
+    /// `u64`.
     pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> std::io::Result<Self> {
         crate::V1::from_bytes(consensus_branch_id, buf)
     }
@@ -438,7 +461,78 @@ mod tests {
     proptest! {
         #[test]
         fn serialization_round_trip(node_data in arb_node_data()) {
-            assert_eq!(NodeData::from_bytes(0, node_data.to_bytes()).unwrap(), node_data);
+            let decoded = NodeData::from_bytes(0, node_data.to_bytes());
+            let leaf_count = node_data
+                .end_height
+                .checked_sub(node_data.start_height)
+                .and_then(|height_diff| height_diff.checked_add(1));
+
+            if leaf_count.is_some() {
+                prop_assert_eq!(decoded.unwrap(), node_data);
+            } else {
+                prop_assert_eq!(
+                    decoded.unwrap_err().kind(),
+                    std::io::ErrorKind::InvalidData
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn genesis_height_round_trip() {
+        let node_data = NodeData {
+            start_height: 0,
+            end_height: 0,
+            ..Default::default()
+        };
+        let entry = Entry::<HistoryV1>::new_leaf(node_data);
+        let mut encoded = vec![];
+        entry.write(&mut encoded).unwrap();
+
+        assert_eq!(Entry::<HistoryV1>::from_bytes(0, encoded).unwrap().leaf_count(), 1);
+    }
+
+    #[test]
+    fn zero_start_height_combined_node_round_trip() {
+        // Regtest scenario: Heartwood activates at height 0, so the genesis
+        // leaf has start_height == 0. When two leaves are combined into a
+        // node spanning heights 0..=1, leaf_count() must not underflow.
+        let left = Entry::<HistoryV1>::new_leaf(node_data(0, 0));
+        let right = Entry::<HistoryV1>::new_leaf(node_data(1, 1));
+        let combined = HistoryV1::combine(
+            left.data(),
+            right.data(),
+        );
+        let entry = Entry::<HistoryV1>::new(
+            combined,
+            EntryLink::Stored(0),
+            EntryLink::Stored(1),
+        );
+        let mut encoded = vec![];
+        entry.write(&mut encoded).unwrap();
+
+        let decoded = Entry::<HistoryV1>::from_bytes(0, encoded).unwrap();
+        assert_eq!(decoded.leaf_count(), 2);
+        assert!(decoded.complete());
+    }
+
+    #[test]
+    fn invalid_height_ranges_are_rejected() {
+        for (start_height, end_height) in [(200, 5), (0, u64::MAX)] {
+            let node_data = NodeData {
+                start_height,
+                end_height,
+                ..Default::default()
+            };
+            let entry = Entry::<HistoryV1>::new_leaf(node_data);
+            let mut encoded = vec![];
+            entry.write(&mut encoded).unwrap();
+            let error = match Entry::<HistoryV1>::from_bytes(0, encoded) {
+                Ok(_) => panic!("invalid height range was accepted"),
+                Err(error) => error,
+            };
+
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         }
     }
 

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -1,4 +1,3 @@
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use primitive_types::U256;
 
 use crate::Version;
@@ -84,10 +83,10 @@ impl NodeData {
     /// Write to the byte representation.
     pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         w.write_all(&self.subtree_commitment)?;
-        w.write_u32::<LittleEndian>(self.start_time)?;
-        w.write_u32::<LittleEndian>(self.end_time)?;
-        w.write_u32::<LittleEndian>(self.start_target)?;
-        w.write_u32::<LittleEndian>(self.end_target)?;
+        w.write_all(&self.start_time.to_le_bytes())?;
+        w.write_all(&self.end_time.to_le_bytes())?;
+        w.write_all(&self.start_target.to_le_bytes())?;
+        w.write_all(&self.end_target.to_le_bytes())?;
         w.write_all(&self.start_sapling_root)?;
         w.write_all(&self.end_sapling_root)?;
 
@@ -114,10 +113,15 @@ impl NodeData {
             ..Default::default()
         };
         r.read_exact(&mut data.subtree_commitment)?;
-        data.start_time = r.read_u32::<LittleEndian>()?;
-        data.end_time = r.read_u32::<LittleEndian>()?;
-        data.start_target = r.read_u32::<LittleEndian>()?;
-        data.end_target = r.read_u32::<LittleEndian>()?;
+        let mut buf = [0u8; 4];
+        r.read_exact(&mut buf)?;
+        data.start_time = u32::from_le_bytes(buf);
+        r.read_exact(&mut buf)?;
+        data.end_time = u32::from_le_bytes(buf);
+        r.read_exact(&mut buf)?;
+        data.start_target = u32::from_le_bytes(buf);
+        r.read_exact(&mut buf)?;
+        data.end_target = u32::from_le_bytes(buf);
         r.read_exact(&mut data.start_sapling_root)?;
         r.read_exact(&mut data.end_sapling_root)?;
 

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -81,36 +81,6 @@ impl NodeData {
         }
     }
 
-    fn write_compact<W: corez::io::Write>(w: &mut W, compact: u64) -> corez::io::Result<()> {
-        match compact {
-            0..=0xfc => w.write_all(&[compact as u8])?,
-            0xfd..=0xffff => {
-                w.write_all(&[0xfd])?;
-                w.write_u16::<LittleEndian>(compact as u16)?;
-            }
-            0x10000..=0xffff_ffff => {
-                w.write_all(&[0xfe])?;
-                w.write_u32::<LittleEndian>(compact as u32)?;
-            }
-            _ => {
-                w.write_all(&[0xff])?;
-                w.write_u64::<LittleEndian>(compact)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn read_compact<R: corez::io::Read>(reader: &mut R) -> corez::io::Result<u64> {
-        let result = match reader.read_u8()? {
-            i @ 0..=0xfc => i.into(),
-            0xfd => reader.read_u16::<LittleEndian>()?.into(),
-            0xfe => reader.read_u32::<LittleEndian>()?.into(),
-            _ => reader.read_u64::<LittleEndian>()?,
-        };
-
-        Ok(result)
-    }
-
     /// Write to the byte representation.
     pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
         w.write_all(&self.subtree_commitment)?;
@@ -125,9 +95,9 @@ impl NodeData {
         self.subtree_total_work.to_little_endian(&mut work_buf[..]);
         w.write_all(&work_buf)?;
 
-        Self::write_compact(w, self.start_height)?;
-        Self::write_compact(w, self.end_height)?;
-        Self::write_compact(w, self.sapling_tx)?;
+        zcash_encoding::CompactSize::write(&mut *w, self.start_height as usize)?;
+        zcash_encoding::CompactSize::write(&mut *w, self.end_height as usize)?;
+        zcash_encoding::CompactSize::write(&mut *w, self.sapling_tx as usize)?;
         Ok(())
     }
 
@@ -155,8 +125,8 @@ impl NodeData {
         r.read_exact(&mut work_buf)?;
         data.subtree_total_work = U256::from_little_endian(&work_buf);
 
-        data.start_height = Self::read_compact(r)?;
-        data.end_height = Self::read_compact(r)?;
+        data.start_height = zcash_encoding::CompactSize::read(&mut *r)?;
+        data.end_height = zcash_encoding::CompactSize::read(&mut *r)?;
         if data
             .end_height
             .checked_sub(data.start_height)
@@ -168,7 +138,7 @@ impl NodeData {
                 "history node height range does not contain a representable number of blocks",
             ));
         }
-        data.sapling_tx = Self::read_compact(r)?;
+        data.sapling_tx = zcash_encoding::CompactSize::read(&mut *r)?;
 
         Ok(data)
     }
@@ -224,7 +194,7 @@ impl V2 {
         self.v1.write(w)?;
         w.write_all(&self.start_orchard_root)?;
         w.write_all(&self.end_orchard_root)?;
-        NodeData::write_compact(w, self.orchard_tx)?;
+        zcash_encoding::CompactSize::write(&mut *w, self.orchard_tx as usize)?;
         Ok(())
     }
 
@@ -236,7 +206,7 @@ impl V2 {
         };
         r.read_exact(&mut data.start_orchard_root)?;
         r.read_exact(&mut data.end_orchard_root)?;
-        data.orchard_tx = NodeData::read_compact(r)?;
+        data.orchard_tx = zcash_encoding::CompactSize::read(&mut *r)?;
 
         Ok(data)
     }
@@ -283,7 +253,7 @@ impl V3 {
         self.v2.write(w)?;
         w.write_all(&self.start_ironwood_root)?;
         w.write_all(&self.end_ironwood_root)?;
-        NodeData::write_compact(w, self.ironwood_tx)?;
+        zcash_encoding::CompactSize::write(&mut *w, self.ironwood_tx as usize)?;
         Ok(())
     }
 
@@ -295,7 +265,7 @@ impl V3 {
         };
         r.read_exact(&mut data.start_ironwood_root)?;
         r.read_exact(&mut data.end_ironwood_root)?;
-        data.ironwood_tx = NodeData::read_compact(r)?;
+        data.ironwood_tx = zcash_encoding::CompactSize::read(&mut *r)?;
 
         Ok(data)
     }
@@ -319,9 +289,9 @@ pub mod testing {
             start_sapling_root in uniform32(any::<u8>()),
             end_sapling_root in uniform32(any::<u8>()),
             subtree_total_work in uniform32(any::<u8>()),
-            start_height in any::<u64>(),
-            end_height in any::<u64>(),
-            sapling_tx in any::<u64>(),
+            start_height in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
+            end_height in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
+            sapling_tx in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
         ) -> NodeData {
             NodeData {
                 consensus_branch_id: 0,
@@ -401,9 +371,9 @@ mod tests {
             start_sapling_root: [2; 32],
             end_sapling_root: [3; 32],
             subtree_total_work: U256::MAX,
-            start_height: u64::MAX,
-            end_height: u64::MAX,
-            sapling_tx: u64::MAX,
+            start_height: zcash_encoding::MAX_COMPACT_SIZE as u64,
+            end_height: zcash_encoding::MAX_COMPACT_SIZE as u64,
+            sapling_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
         }
     }
 
@@ -412,7 +382,7 @@ mod tests {
             v1: max_node_data(),
             start_orchard_root: [4; 32],
             end_orchard_root: [5; 32],
-            orchard_tx: u64::MAX,
+            orchard_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
         }
     }
 
@@ -421,7 +391,7 @@ mod tests {
             v2: max_node_data_v2(),
             start_ironwood_root: [6; 32],
             end_ironwood_root: [7; 32],
-            ironwood_tx: u64::MAX,
+            ironwood_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
         }
     }
 
@@ -518,7 +488,10 @@ mod tests {
 
     #[test]
     fn invalid_height_ranges_are_rejected() {
-        for (start_height, end_height) in [(200, 5), (0, u64::MAX)] {
+        for (start_height, end_height) in [
+            (200, 5),
+            (zcash_encoding::MAX_COMPACT_SIZE as u64, 5),
+        ] {
             let node_data = NodeData {
                 start_height,
                 end_height,
@@ -555,15 +528,17 @@ mod tests {
 
     #[test]
     fn max_serialized_sizes_cover_all_versions() {
-        assert_eq!(HistoryV1::to_bytes(&max_node_data()).len(), 171);
-        assert_eq!(HistoryV2::to_bytes(&max_node_data_v2()).len(), 244);
+        assert_eq!(HistoryV1::to_bytes(&max_node_data()).len(), 159);
+        assert_eq!(HistoryV2::to_bytes(&max_node_data_v2()).len(), 228);
         let max_v3_bytes = HistoryV3::to_bytes(&max_node_data_v3());
-        assert_eq!(max_v3_bytes.len(), 317);
+        assert_eq!(max_v3_bytes.len(), 297);
+        assert!(max_v3_bytes.len() <= MAX_NODE_DATA_SIZE);
         assert_eq!(
-            HistoryV3::from_bytes(u32::MAX, max_v3_bytes).unwrap(),
+            HistoryV3::from_bytes(u32::MAX, &max_v3_bytes).unwrap(),
             max_node_data_v3()
         );
         assert_eq!(MAX_NODE_DATA_SIZE, 317);
+        assert!(max_v3_bytes.len() <= MAX_NODE_DATA_SIZE);
 
         let entry = Entry::<HistoryV3>::new(
             max_node_data_v3(),
@@ -572,7 +547,7 @@ mod tests {
         );
         let mut encoded = vec![];
         entry.write(&mut encoded).unwrap();
-        assert_eq!(encoded.len(), MAX_ENTRY_SIZE);
+        assert!(encoded.len() <= MAX_ENTRY_SIZE);
     }
 
     #[test]

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -1,4 +1,7 @@
+use alloc::vec::Vec;
+
 use primitive_types::U256;
+use zcash_encoding::CompactSize;
 
 use crate::Version;
 
@@ -94,9 +97,9 @@ impl NodeData {
         self.subtree_total_work.to_little_endian(&mut work_buf[..]);
         w.write_all(&work_buf)?;
 
-        zcash_encoding::CompactSize::write(&mut *w, self.start_height as usize)?;
-        zcash_encoding::CompactSize::write(&mut *w, self.end_height as usize)?;
-        zcash_encoding::CompactSize::write(&mut *w, self.sapling_tx as usize)?;
+        CompactSize::write_unbounded(&mut *w, self.start_height)?;
+        CompactSize::write_unbounded(&mut *w, self.end_height)?;
+        CompactSize::write_unbounded(&mut *w, self.sapling_tx)?;
         Ok(())
     }
 
@@ -104,10 +107,13 @@ impl NodeData {
     ///
     /// # Errors
     ///
-    /// Returns [`corez::io::ErrorKind::InvalidData`] if the encoded height range
-    /// is descending or contains more blocks than can be represented by a
-    /// `u64`.
-    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
+    /// Returns [`corez::io::ErrorKind::InvalidData`] if a compact-encoded field
+    /// uses a non-canonical encoding, or if the encoded height range is
+    /// descending or contains more blocks than can be represented by a `u64`.
+    pub fn read<R: corez::io::Read>(
+        consensus_branch_id: u32,
+        r: &mut R,
+    ) -> corez::io::Result<Self> {
         let mut data = NodeData {
             consensus_branch_id,
             ..Default::default()
@@ -129,8 +135,8 @@ impl NodeData {
         r.read_exact(&mut work_buf)?;
         data.subtree_total_work = U256::from_little_endian(&work_buf);
 
-        data.start_height = zcash_encoding::CompactSize::read(&mut *r)?;
-        data.end_height = zcash_encoding::CompactSize::read(&mut *r)?;
+        data.start_height = CompactSize::read_unbounded(&mut *r)?;
+        data.end_height = CompactSize::read_unbounded(&mut *r)?;
         if data
             .end_height
             .checked_sub(data.start_height)
@@ -142,7 +148,7 @@ impl NodeData {
                 "history node height range does not contain a representable number of blocks",
             ));
         }
-        data.sapling_tx = zcash_encoding::CompactSize::read(&mut *r)?;
+        data.sapling_tx = CompactSize::read_unbounded(&mut *r)?;
 
         Ok(data)
     }
@@ -156,9 +162,9 @@ impl NodeData {
     ///
     /// # Errors
     ///
-    /// Returns [`corez::io::ErrorKind::InvalidData`] if the encoded height range
-    /// is descending or contains more blocks than can be represented by a
-    /// `u64`.
+    /// Returns [`corez::io::ErrorKind::InvalidData`] if a compact-encoded field
+    /// uses a non-canonical encoding, or if the encoded height range is
+    /// descending or contains more blocks than can be represented by a `u64`.
     pub fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> corez::io::Result<Self> {
         crate::V1::from_bytes(consensus_branch_id, buf)
     }
@@ -198,19 +204,22 @@ impl V2 {
         self.v1.write(w)?;
         w.write_all(&self.start_orchard_root)?;
         w.write_all(&self.end_orchard_root)?;
-        zcash_encoding::CompactSize::write(&mut *w, self.orchard_tx as usize)?;
+        CompactSize::write_unbounded(&mut *w, self.orchard_tx)?;
         Ok(())
     }
 
     /// Read from the byte representation.
-    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(
+        consensus_branch_id: u32,
+        r: &mut R,
+    ) -> corez::io::Result<Self> {
         let mut data = V2 {
             v1: NodeData::read(consensus_branch_id, r)?,
             ..Default::default()
         };
         r.read_exact(&mut data.start_orchard_root)?;
         r.read_exact(&mut data.end_orchard_root)?;
-        data.orchard_tx = zcash_encoding::CompactSize::read(&mut *r)?;
+        data.orchard_tx = CompactSize::read_unbounded(&mut *r)?;
 
         Ok(data)
     }
@@ -257,19 +266,22 @@ impl V3 {
         self.v2.write(w)?;
         w.write_all(&self.start_ironwood_root)?;
         w.write_all(&self.end_ironwood_root)?;
-        zcash_encoding::CompactSize::write(&mut *w, self.ironwood_tx as usize)?;
+        CompactSize::write_unbounded(&mut *w, self.ironwood_tx)?;
         Ok(())
     }
 
     /// Read from the byte representation.
-    pub fn read<R: corez::io::Read>(consensus_branch_id: u32, r: &mut R) -> corez::io::Result<Self> {
+    pub fn read<R: corez::io::Read>(
+        consensus_branch_id: u32,
+        r: &mut R,
+    ) -> corez::io::Result<Self> {
         let mut data = V3 {
             v2: V2::read(consensus_branch_id, r)?,
             ..Default::default()
         };
         r.read_exact(&mut data.start_ironwood_root)?;
         r.read_exact(&mut data.end_ironwood_root)?;
-        data.ironwood_tx = zcash_encoding::CompactSize::read(&mut *r)?;
+        data.ironwood_tx = CompactSize::read_unbounded(&mut *r)?;
 
         Ok(data)
     }
@@ -293,9 +305,9 @@ pub mod testing {
             start_sapling_root in uniform32(any::<u8>()),
             end_sapling_root in uniform32(any::<u8>()),
             subtree_total_work in uniform32(any::<u8>()),
-            start_height in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
-            end_height in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
-            sapling_tx in 0u64..=zcash_encoding::MAX_COMPACT_SIZE as u64,
+            start_height in any::<u64>(),
+            end_height in any::<u64>(),
+            sapling_tx in any::<u64>(),
         ) -> NodeData {
             NodeData {
                 consensus_branch_id: 0,
@@ -317,6 +329,8 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::testing::arb_node_data;
     use proptest::prelude::*;
 
@@ -375,9 +389,9 @@ mod tests {
             start_sapling_root: [2; 32],
             end_sapling_root: [3; 32],
             subtree_total_work: U256::MAX,
-            start_height: zcash_encoding::MAX_COMPACT_SIZE as u64,
-            end_height: zcash_encoding::MAX_COMPACT_SIZE as u64,
-            sapling_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
+            start_height: u64::MAX,
+            end_height: u64::MAX,
+            sapling_tx: u64::MAX,
         }
     }
 
@@ -386,7 +400,7 @@ mod tests {
             v1: max_node_data(),
             start_orchard_root: [4; 32],
             end_orchard_root: [5; 32],
-            orchard_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
+            orchard_tx: u64::MAX,
         }
     }
 
@@ -395,7 +409,7 @@ mod tests {
             v2: max_node_data_v2(),
             start_ironwood_root: [6; 32],
             end_ironwood_root: [7; 32],
-            ironwood_tx: zcash_encoding::MAX_COMPACT_SIZE as u64,
+            ironwood_tx: u64::MAX,
         }
     }
 
@@ -463,7 +477,12 @@ mod tests {
         let mut encoded = vec![];
         entry.write(&mut encoded).unwrap();
 
-        assert_eq!(Entry::<HistoryV1>::from_bytes(0, encoded).unwrap().leaf_count(), 1);
+        assert_eq!(
+            Entry::<HistoryV1>::from_bytes(0, encoded)
+                .unwrap()
+                .leaf_count(),
+            1
+        );
     }
 
     #[test]
@@ -473,15 +492,8 @@ mod tests {
         // node spanning heights 0..=1, leaf_count() must not underflow.
         let left = Entry::<HistoryV1>::new_leaf(node_data(0, 0));
         let right = Entry::<HistoryV1>::new_leaf(node_data(1, 1));
-        let combined = HistoryV1::combine(
-            left.data(),
-            right.data(),
-        );
-        let entry = Entry::<HistoryV1>::new(
-            combined,
-            EntryLink::Stored(0),
-            EntryLink::Stored(1),
-        );
+        let combined = HistoryV1::combine(left.data(), right.data());
+        let entry = Entry::<HistoryV1>::new(combined, EntryLink::Stored(0), EntryLink::Stored(1));
         let mut encoded = vec![];
         entry.write(&mut encoded).unwrap();
 
@@ -493,8 +505,11 @@ mod tests {
     #[test]
     fn invalid_height_ranges_are_rejected() {
         for (start_height, end_height) in [
+            // Descending ranges.
             (200, 5),
-            (zcash_encoding::MAX_COMPACT_SIZE as u64, 5),
+            (u64::MAX, 5),
+            // Ascending, but the leaf count overflows a `u64`.
+            (0, u64::MAX),
         ] {
             let node_data = NodeData {
                 start_height,
@@ -532,17 +547,18 @@ mod tests {
 
     #[test]
     fn max_serialized_sizes_cover_all_versions() {
-        assert_eq!(HistoryV1::to_bytes(&max_node_data()).len(), 159);
-        assert_eq!(HistoryV2::to_bytes(&max_node_data_v2()).len(), 228);
+        // ZIP 221 specifies that history nodes are at most 171 bytes before NU5
+        // and 244 bytes after NU5; those bounds require the compact-encoded
+        // fields to span the full `u64` range (a 9-byte compact encoding each).
+        assert_eq!(HistoryV1::to_bytes(&max_node_data()).len(), 171);
+        assert_eq!(HistoryV2::to_bytes(&max_node_data_v2()).len(), 244);
         let max_v3_bytes = HistoryV3::to_bytes(&max_node_data_v3());
-        assert_eq!(max_v3_bytes.len(), 297);
-        assert!(max_v3_bytes.len() <= MAX_NODE_DATA_SIZE);
+        assert_eq!(max_v3_bytes.len(), MAX_NODE_DATA_SIZE);
         assert_eq!(
             HistoryV3::from_bytes(u32::MAX, &max_v3_bytes).unwrap(),
             max_node_data_v3()
         );
         assert_eq!(MAX_NODE_DATA_SIZE, 317);
-        assert!(max_v3_bytes.len() <= MAX_NODE_DATA_SIZE);
 
         let entry = Entry::<HistoryV3>::new(
             max_node_data_v3(),
@@ -551,7 +567,7 @@ mod tests {
         );
         let mut encoded = vec![];
         entry.write(&mut encoded).unwrap();
-        assert!(encoded.len() <= MAX_ENTRY_SIZE);
+        assert_eq!(encoded.len(), MAX_ENTRY_SIZE);
     }
 
     #[test]

--- a/zcash_history/src/test_vectors.rs
+++ b/zcash_history/src/test_vectors.rs
@@ -12,6 +12,8 @@ mod zip_0221_v1;
 mod zip_0221_v2;
 mod zip_0221_v3;
 
+use alloc::vec::Vec;
+
 use primitive_types::U256;
 
 use crate::{Entry, NodeData, NodeDataV2, NodeDataV3, Tree, V1, V2, V3, Version};

--- a/zcash_history/src/tree.rs
+++ b/zcash_history/src/tree.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 use crate::{Entry, EntryKind, EntryLink, Error, Version};
 
@@ -14,7 +15,7 @@ use crate::{Entry, EntryKind, EntryLink, Error, Version};
 /// how to pick right nodes from the array representation of MMR Tree), perform several operations
 /// (append-s/delete-s) and then drop it.
 pub struct Tree<V: Version> {
-    stored: HashMap<u32, Entry<V>>,
+    stored: BTreeMap<u32, Entry<V>>,
 
     // This can grow indefinitely if `Tree` is misused as a self-contained data structure
     generated: Vec<Entry<V>>,

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -1,7 +1,8 @@
-use std::fmt;
-use corez::io;
+use alloc::vec::Vec;
+use core::fmt;
 
 use blake2b_simd::Params as Blake2Params;
+use corez::io;
 
 use crate::{MAX_NODE_DATA_SIZE, NodeData, NodeDataV2, NodeDataV3};
 

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use corez::io;
 
 use blake2b_simd::Params as Blake2Params;
-use byteorder::{ByteOrder, LittleEndian};
 
 use crate::{MAX_NODE_DATA_SIZE, NodeData, NodeDataV2, NodeDataV3};
 
@@ -21,7 +20,7 @@ fn blake2b_personal(personalization: &[u8], input: &[u8]) -> [u8; 32] {
 fn personalization(branch_id: u32) -> [u8; 16] {
     let mut result = [0u8; 16];
     result[..12].copy_from_slice(b"ZcashHistory");
-    LittleEndian::write_u32(&mut result[12..], branch_id);
+    result[12..16].copy_from_slice(&branch_id.to_le_bytes());
     result
 }
 

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io;
+use corez::io;
 
 use blake2b_simd::Params as Blake2Params;
 use byteorder::{ByteOrder, LittleEndian};
@@ -48,7 +48,7 @@ pub trait Version {
 
         let mut hash_buf = [0u8; MAX_NODE_DATA_SIZE * 2];
         let size = {
-            let mut cursor = ::std::io::Cursor::new(&mut hash_buf[..]);
+            let mut cursor = corez::io::Cursor::new(&mut hash_buf[..]);
             Self::write(left, &mut cursor)
                 .expect("Writing to memory buf with enough length cannot fail; qed");
             Self::write(right, &mut cursor)
@@ -84,7 +84,7 @@ pub trait Version {
     fn to_bytes(data: &Self::NodeData) -> Vec<u8> {
         let mut buf = [0u8; MAX_NODE_DATA_SIZE];
         let pos = {
-            let mut cursor = std::io::Cursor::new(&mut buf[..]);
+            let mut cursor = corez::io::Cursor::new(&mut buf[..]);
             Self::write(data, &mut cursor).expect("Cursor cannot fail");
             cursor.position() as usize
         };
@@ -94,7 +94,7 @@ pub trait Version {
 
     /// Convert from byte representation.
     fn from_bytes<T: AsRef<[u8]>>(consensus_branch_id: u32, buf: T) -> io::Result<Self::NodeData> {
-        let mut cursor = std::io::Cursor::new(buf);
+        let mut cursor = corez::io::Cursor::new(buf);
         Self::read(consensus_branch_id, &mut cursor)
     }
 


### PR DESCRIPTION
Builds upon and subsumes #2741 