### PR TITLE
Add storage-trait operations needed by external sync engines

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,10 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `zcash_client_backend::data_api::WalletRead::get_wallet_recover_until`
+- `zcash_client_backend::data_api::WalletWrite::prune_scan_queue_below`
+- `zcash_client_backend::data_api::WalletCommitmentTrees::{get_sapling_subtree_root,
+  get_orchard_subtree_root, get_ironwood_subtree_root}`
 - `zcash_client_backend::data_api::wallet::{redact_pczt_for_signer,
   redact_pczt_for_batch_signer}`, which create compact signer views of a
   wallet-created PCZT. The batch variant additionally removes fields that a

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -92,7 +92,7 @@ use zip32::{DiversifierIndex, fingerprint::SeedFingerprint};
 
 use self::{
     chain::{ChainState, CommitmentTreeRoot},
-    scanning::ScanRange,
+    scanning::{ScanPriority, ScanRange},
 };
 use crate::{
     data_api::{
@@ -2057,6 +2057,15 @@ pub trait WalletRead {
     /// or `Ok(None)` if the wallet has no initialized accounts.
     fn get_wallet_birthday(&self) -> Result<Option<BlockHeight>, Self::Error>;
 
+    /// Returns the height at which the wallet as a whole will have exited recovery mode.
+    ///
+    /// This returns the latest `recover_until` height among accounts maintained by this
+    /// wallet (see [`AccountBirthday::recover_until`]), or `Ok(None)` if no account has a
+    /// recovery horizon set (for example, in a wallet whose accounts were all created at
+    /// the chain tip rather than restored from backup). Heights below the returned value,
+    /// exclusive, are in scope for wallet recovery for at least one account.
+    fn get_wallet_recover_until(&self) -> Result<Option<BlockHeight>, Self::Error>;
+
     /// Returns a [`WalletSummary`] that represents the sync status and the wallet balances as of
     /// the chain tip given the specified confirmation policy for all accounts known to the wallet,
     /// or `Ok(None)` if the wallet has no summary data available.
@@ -3614,6 +3623,40 @@ pub trait WalletWrite: WalletRead {
     /// needs to correctly prioritize scanning operations.
     fn update_chain_tip(&mut self, tip_height: BlockHeight) -> Result<(), Self::Error>;
 
+    /// Drops the scan work queued below `height`, except where retained by
+    /// `retain_with_priority`. Returns the number of queue entries removed or altered.
+    ///
+    /// If `retain_with_priority` is `None`, no entries below `height` are retained,
+    /// irrespective of their priority. If it is `Some(priority)`, entries with that
+    /// priority and greater are retained (left untouched, even where they straddle
+    /// `height`), as are entries with the bookkeeping priorities
+    /// [`ScanPriority::Scanned`] and [`ScanPriority::Ignored`] — those record which
+    /// regions of the chain the backend has already covered or deliberately skips, and
+    /// removing them would cause the backend to forget coverage state it maintains
+    /// itself (use the `None` form when that full reset is the intent). Entries with
+    /// priorities between the bookkeeping ones and the retained threshold are pruned.
+    ///
+    /// Pruning must not leave a gap in the queue's coverage: implementations are required
+    /// to preserve contiguity across whatever remains below `height`, which in general
+    /// means demoting pruned ranges to [`ScanPriority::Ignored`] rather than deleting them
+    /// outright. Only coverage below the lowest retained entry may be deleted, since that
+    /// merely raises the floor of the queue. A caller may therefore observe that the total
+    /// span of the queue is unchanged and that the pruned region is now `Ignored`.
+    ///
+    /// This is a queue-hygiene operation. The primary use case is discarding historic scan
+    /// ranges that no remaining account justifies: [`WalletWrite::delete_account`] does not
+    /// modify the scan queue, so the deep ranges queued for a since-deleted account's
+    /// birthday would otherwise still be scanned even though no remaining account can have
+    /// notes below its own birthday. In that case, pass the wallet birthday
+    /// ([`WalletRead::get_wallet_birthday`]) as `height` and retain
+    /// [`ScanPriority::OpenAdjacent`] and greater — the priorities that may legitimately
+    /// reach below the wallet birthday in service of note witnesses.
+    fn prune_scan_queue_below(
+        &mut self,
+        height: BlockHeight,
+        retain_with_priority: Option<ScanPriority>,
+    ) -> Result<u64, Self::Error>;
+
     /// Updates the state of the wallet database by persisting the provided block information,
     /// along with the note commitments that were detected when scanning the block for transactions
     /// pertaining to this wallet.
@@ -4034,6 +4077,18 @@ pub trait WalletCommitmentTrees {
         roots: &[CommitmentTreeRoot<sapling::Node>],
     ) -> Result<(), ShardTreeError<Self::Error>>;
 
+    /// Returns the stored root hash of the completed Sapling subtree with the given index,
+    /// or `Ok(None)` if no root is recorded for that subtree.
+    ///
+    /// This is the store's record of the subtree root as most recently provided via
+    /// [`WalletCommitmentTrees::put_sapling_subtree_roots`] (i.e. the chain-authoritative
+    /// root obtained from a chain data provider), or as recorded when a locally-completed
+    /// subtree was persisted.
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<sapling::Node>, ShardTreeError<Self::Error>>;
+
     /// The type of the backing [`ShardStore`] for the Orchard note commitment tree.
     #[cfg(feature = "orchard")]
     type OrchardShardStore<'a>: ShardStore<
@@ -4066,6 +4121,19 @@ pub trait WalletCommitmentTrees {
         start_index: u64,
         roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
     ) -> Result<(), ShardTreeError<Self::Error>>;
+
+    /// Returns the stored root hash of the completed Orchard subtree with the given index,
+    /// or `Ok(None)` if no root is recorded for that subtree.
+    ///
+    /// This is the store's record of the subtree root as most recently provided via
+    /// [`WalletCommitmentTrees::put_orchard_subtree_roots`] (i.e. the chain-authoritative
+    /// root obtained from a chain data provider), or as recorded when a locally-completed
+    /// subtree was persisted.
+    #[cfg(feature = "orchard")]
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>>;
 
     /// Evaluates the given callback with the Ironwood note commitment tree
     /// maintained by the wallet, if this backend has one.
@@ -4105,6 +4173,17 @@ pub trait WalletCommitmentTrees {
         _roots: &[CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         Ok(())
+    }
+
+    /// Returns the stored root hash of the completed Ironwood subtree with the given
+    /// index, or `Ok(None)` if no root is recorded for that subtree (in particular, if
+    /// this backend does not track an Ironwood tree — the default implementation).
+    #[cfg(feature = "orchard")]
+    fn get_ironwood_subtree_root(
+        &mut self,
+        _index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        Ok(None)
     }
 
     /// Applies a batch of changes — shards, an optional replacement tree cap, and a

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -54,7 +54,7 @@ use super::{
     WalletSummary, WalletTest, WalletWrite, Zip32Derivation,
     chain::{BlockSource, ChainState, CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
     error::Error,
-    scanning::ScanRange,
+    scanning::{ScanPriority, ScanRange},
     wallet::{
         ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
         input_selection::{
@@ -3154,6 +3154,10 @@ impl WalletRead for MockWalletDb {
         Ok(None)
     }
 
+    fn get_wallet_recover_until(&self) -> Result<Option<BlockHeight>, Self::Error> {
+        Ok(None)
+    }
+
     fn get_wallet_summary(
         &self,
         _confirmations_policy: ConfirmationsPolicy,
@@ -3375,6 +3379,14 @@ impl WalletWrite for MockWalletDb {
         Ok(())
     }
 
+    fn prune_scan_queue_below(
+        &mut self,
+        _height: BlockHeight,
+        _retain_with_priority: Option<ScanPriority>,
+    ) -> Result<u64, Self::Error> {
+        Ok(0)
+    }
+
     fn store_decrypted_tx(
         &mut self,
         _received_tx: DecryptedTransaction<Transaction, Self::AccountId>,
@@ -3514,6 +3526,26 @@ impl WalletCommitmentTrees for MockWalletDb {
         Ok(())
     }
 
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<::sapling::Node>, ShardTreeError<Self::Error>> {
+        use shardtree::store::ShardStore as _;
+        self.with_sapling_tree_mut(|t| {
+            let addr =
+                incrementalmerkletree::Address::from_parts(SAPLING_SHARD_HEIGHT.into(), index);
+            Ok::<_, ShardTreeError<Self::Error>>(
+                t.store()
+                    .get_shard(addr)
+                    .map_err(ShardTreeError::Storage)?
+                    .and_then(|shard| match shard.root() {
+                        tree if tree.is_leaf() => tree.leaf_value().copied(),
+                        tree => tree.annotation().and_then(|ann| ann.as_deref().copied()),
+                    }),
+            )
+        })
+    }
+
     #[cfg(feature = "orchard")]
     type OrchardShardStore<'a> = MemoryShardStore<::orchard::tree::MerkleHashOrchard, BlockHeight>;
 
@@ -3551,5 +3583,26 @@ impl WalletCommitmentTrees for MockWalletDb {
         })?;
 
         Ok(())
+    }
+
+    #[cfg(feature = "orchard")]
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<::orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        use shardtree::store::ShardStore as _;
+        self.with_orchard_tree_mut(|t| {
+            let addr =
+                incrementalmerkletree::Address::from_parts(ORCHARD_SHARD_HEIGHT.into(), index);
+            Ok::<_, ShardTreeError<Self::Error>>(
+                t.store()
+                    .get_shard(addr)
+                    .map_err(ShardTreeError::Storage)?
+                    .and_then(|shard| match shard.root() {
+                        tree if tree.is_leaf() => tree.leaf_value().copied(),
+                        tree => tree.annotation().and_then(|ann| ann.as_deref().copied()),
+                    }),
+            )
+        })
     }
 }

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1715,12 +1715,12 @@ where
     // only an Orchard receiver, in a build made without the `orchard` feature). Other
     // recipient kinds always receive an assignment above, except for TEX addresses,
     // whose payment is delivered by the ephemeral second step.
-    if payment_pools.is_empty() {
-        if let Address::Unified(addr) = &recipient_address {
-            return Err(InputSelectorError::Selection(
-                GreedyInputSelectorError::UnsupportedAddress(Box::new(addr.clone())),
-            ));
-        }
+    if payment_pools.is_empty()
+        && let Address::Unified(addr) = &recipient_address
+    {
+        return Err(InputSelectorError::Selection(
+            GreedyInputSelectorError::UnsupportedAddress(Box::new(addr.clone())),
+        ));
     }
 
     let (tr0_fee, tr1_fee) = match recipient_address {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,11 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `WalletDb` now implements the new `zcash_client_backend` storage-trait
+  methods `WalletRead::get_wallet_recover_until`,
+  `WalletWrite::prune_scan_queue_below`, and
+  `WalletCommitmentTrees::{get_sapling_subtree_root, get_orchard_subtree_root,
+  get_ironwood_subtree_root}`.
 - `WalletDb::get_unspent_ironwood_notes_at_historical_height` returns all Ironwood
   notes that existed and were unspent at a given height.
 - `WalletDb::transactionally_with_extension` performs wallet operations and writes to

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1131,6 +1131,10 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
         wallet::wallet_birthday(self.conn.borrow()).map_err(SqliteClientError::from)
     }
 
+    fn get_wallet_recover_until(&self) -> Result<Option<BlockHeight>, Self::Error> {
+        wallet::wallet_recover_until(self.conn.borrow()).map_err(SqliteClientError::from)
+    }
+
     fn get_wallet_summary(
         &self,
         confirmations_policy: ConfirmationsPolicy,
@@ -1653,6 +1657,14 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.update_chain_tip(tip_height))
     }
 
+    fn prune_scan_queue_below(
+        &mut self,
+        height: BlockHeight,
+        retain_with_priority: Option<ScanPriority>,
+    ) -> Result<u64, Self::Error> {
+        self.transactionally(|wdb| wdb.prune_scan_queue_below(height, retain_with_priority))
+    }
+
     #[tracing::instrument(skip_all, fields(height = blocks.first().map(|b| u32::from(b.height())), count = blocks.len()))]
     #[allow(clippy::type_complexity)]
     fn put_blocks(
@@ -2013,6 +2025,14 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
     fn update_chain_tip(&mut self, tip_height: BlockHeight) -> Result<(), Self::Error> {
         wallet::scanning::update_chain_tip(self.conn.0, &self.params, tip_height)?;
         Ok(())
+    }
+
+    fn prune_scan_queue_below(
+        &mut self,
+        height: BlockHeight,
+        retain_with_priority: Option<ScanPriority>,
+    ) -> Result<u64, Self::Error> {
+        wallet::scanning::prune_scan_queue_below(self.conn.0, height, retain_with_priority)
     }
 
     #[allow(clippy::type_complexity)]
@@ -2907,6 +2927,14 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL, R> Wallet
         Ok(())
     }
 
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<sapling::Node>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.borrow(), SAPLING_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
+    }
+
     #[cfg(feature = "orchard")]
     type OrchardShardStore<'a> = SqliteShardStore<
         &'a rusqlite::Transaction<'a>,
@@ -2959,6 +2987,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL, R> Wallet
     }
 
     #[cfg(feature = "orchard")]
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.borrow(), ORCHARD_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
+    }
+
+    #[cfg(feature = "orchard")]
     fn put_ironwood_subtree_roots(
         &mut self,
         start_index: u64,
@@ -2978,6 +3015,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL, R> Wallet
         tx.commit()
             .map_err(|e| ShardTreeError::Storage(commitment_tree::Error::Query(e)))?;
         Ok(())
+    }
+
+    #[cfg(feature = "orchard")]
+    fn get_ironwood_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.borrow(), IRONWOOD_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
     }
 
     #[cfg(feature = "orchard")]
@@ -3034,6 +3080,14 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
         )
     }
 
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<sapling::Node>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.0, SAPLING_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
+    }
+
     #[cfg(feature = "orchard")]
     type OrchardShardStore<'a> = crate::OrchardShardStore<&'a rusqlite::Transaction<'a>>;
 
@@ -3065,6 +3119,15 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
     }
 
     #[cfg(feature = "orchard")]
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.0, ORCHARD_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
+    }
+
+    #[cfg(feature = "orchard")]
     fn put_ironwood_subtree_roots(
         &mut self,
         start_index: u64,
@@ -3076,6 +3139,15 @@ impl<P: consensus::Parameters, CL, R> WalletCommitmentTrees
             start_index,
             roots,
         )
+    }
+
+    #[cfg(feature = "orchard")]
+    fn get_ironwood_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        wallet::commitment_tree::get_subtree_root(self.conn.0, IRONWOOD_TABLES_PREFIX, index)
+            .map_err(ShardTreeError::Storage)
     }
 
     #[cfg(feature = "orchard")]
@@ -3566,6 +3638,61 @@ mod tests {
     #[cfg(feature = "unstable")]
     use zcash_keys::keys::sapling;
     use zcash_protocol::local_consensus::LocalNetwork;
+
+    #[test]
+    fn get_wallet_recover_until_is_max_across_accounts() {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+        // The fixture account has no recovery horizon.
+        assert_eq!(st.wallet().get_wallet_recover_until().unwrap(), None);
+        // The result reflects the maximum recover_until height across accounts.
+        st.wallet_mut()
+            .conn_mut()
+            .execute("UPDATE accounts SET recover_until_height = 123456", [])
+            .unwrap();
+        assert_eq!(
+            st.wallet().get_wallet_recover_until().unwrap(),
+            Some(zcash_protocol::consensus::BlockHeight::from_u32(123456))
+        );
+    }
+
+    #[test]
+    fn get_subtree_root_round_trips_put_subtree_roots() {
+        use incrementalmerkletree::Hashable as _;
+        use zcash_client_backend::data_api::{
+            SAPLING_SHARD_HEIGHT, WalletCommitmentTrees, chain::CommitmentTreeRoot,
+        };
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let root = ::sapling::Node::empty_root(SAPLING_SHARD_HEIGHT.into());
+        st.wallet_mut()
+            .db_mut()
+            .put_sapling_subtree_roots(
+                0,
+                &[CommitmentTreeRoot::from_parts(
+                    zcash_protocol::consensus::BlockHeight::from_u32(500_000),
+                    root,
+                )],
+            )
+            .unwrap();
+        assert_eq!(
+            st.wallet_mut()
+                .db_mut()
+                .get_sapling_subtree_root(0)
+                .unwrap(),
+            Some(root)
+        );
+        assert_eq!(
+            st.wallet_mut()
+                .db_mut()
+                .get_sapling_subtree_root(1)
+                .unwrap(),
+            None
+        );
+    }
 
     /// Builds a test wallet with a single account and an application-owned extension
     /// table (`ext_test_notes`), simulating an external migration having created it.

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -24,7 +24,7 @@ use zcash_client_backend::{
         TargetValue,
         chain::{ChainState, CommitmentTreeRoot},
         error::{LockError, RewindError},
-        scanning::ScanRange,
+        scanning::{ScanPriority, ScanRange},
         testing::{DataStoreFactory, Reset, TestState},
         wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
         *,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3078,6 +3078,20 @@ pub(crate) fn wallet_birthday(
     )
 }
 
+/// Returns the maximum `recover_until` height for accounts in the wallet.
+pub(crate) fn wallet_recover_until(
+    conn: &rusqlite::Connection,
+) -> Result<Option<BlockHeight>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT MAX(recover_until_height) AS wallet_recover_until FROM accounts",
+        [],
+        |row| {
+            row.get::<_, Option<u32>>(0)
+                .map(|opt| opt.map(BlockHeight::from))
+        },
+    )
+}
+
 pub(crate) fn account_birthday(
     conn: &rusqlite::Connection,
     account_uuid: AccountUuid,

--- a/zcash_client_sqlite/src/wallet/commitment_tree.rs
+++ b/zcash_client_sqlite/src/wallet/commitment_tree.rs
@@ -409,6 +409,30 @@ impl<H: HashSer, const SHARD_HEIGHT: u8> ShardStore
     }
 }
 
+/// Returns the stored root hash of the completed subtree with the given index, as most
+/// recently written by [`put_shard_roots`] or recorded by [`put_shard`], or `Ok(None)` if
+/// no row exists for the subtree or its `root_hash` is unknown.
+pub(crate) fn get_subtree_root<H: HashSer>(
+    conn: &rusqlite::Connection,
+    table_prefix: &'static str,
+    index: u64,
+) -> Result<Option<H>, Error> {
+    conn.query_row(
+        &format!(
+            "SELECT root_hash
+             FROM {table_prefix}_tree_shards
+             WHERE shard_index = :shard_index"
+        ),
+        named_params![":shard_index": index],
+        |row| row.get::<_, Option<Vec<u8>>>(0),
+    )
+    .optional()
+    .map_err(Error::Query)?
+    .flatten()
+    .map(|bytes| H::read(Cursor::new(bytes)).map_err(Error::Serialization))
+    .transpose()
+}
+
 pub(crate) fn get_shard<H: HashSer>(
     conn: &rusqlite::Connection,
     table_prefix: &'static str,

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -58,6 +58,20 @@ pub(crate) fn parse_priority_code(code: i64) -> Option<ScanPriority> {
     }
 }
 
+/// Decodes a `scan_queue` row selected as `(block_range_start, block_range_end, priority)`.
+fn scan_range_from_row<E: WalletError>(row: &rusqlite::Row<'_>) -> Result<ScanRange, E> {
+    let start = row.get::<_, u32>(0).map_err(E::db_error)?;
+    let end = row.get::<_, u32>(1).map_err(E::db_error)?;
+    let code = row.get::<_, i64>(2).map_err(E::db_error)?;
+    let priority = parse_priority_code(code)
+        .ok_or_else(|| E::corrupt(format!("scan priority not recognized: {code}")))?;
+
+    Ok(ScanRange::from_parts(
+        BlockHeight::from(start)..BlockHeight::from(end),
+        priority,
+    ))
+}
+
 pub(crate) fn suggest_scan_ranges(
     conn: &rusqlite::Connection,
     min_priority: ScanPriority,
@@ -69,24 +83,12 @@ pub(crate) fn suggest_scan_ranges(
          ORDER BY priority DESC, block_range_end DESC",
     )?;
 
-    let mut rows =
-        stmt_scan_ranges.query(named_params![":min_priority": priority_code(&min_priority)])?;
-
-    let mut result = vec![];
-    while let Some(row) = rows.next()? {
-        let range = Range {
-            start: row.get::<_, u32>(0).map(BlockHeight::from)?,
-            end: row.get::<_, u32>(1).map(BlockHeight::from)?,
-        };
-        let code = row.get::<_, i64>(2)?;
-        let priority = parse_priority_code(code).ok_or_else(|| {
-            SqliteClientError::CorruptedData(format!("scan priority not recognized: {code}"))
-        })?;
-
-        result.push(ScanRange::from_parts(range, priority));
-    }
-
-    Ok(result)
+    stmt_scan_ranges
+        .query_and_then(
+            named_params![":min_priority": priority_code(&min_priority)],
+            scan_range_from_row::<SqliteClientError>,
+        )?
+        .collect()
 }
 
 pub(crate) fn insert_queue_entries<'a>(
@@ -173,18 +175,7 @@ pub(crate) fn replace_queue_entries<E: WalletError>(
         let mut to_create: Option<SpanningTree> = None;
         let mut to_delete_ends: Vec<Value> = vec![];
         while let Some(row) = rows.next().map_err(E::db_error)? {
-            let entry = ScanRange::from_parts(
-                Range {
-                    start: BlockHeight::from(row.get::<_, u32>(0).map_err(E::db_error)?),
-                    end: BlockHeight::from(row.get::<_, u32>(1).map_err(E::db_error)?),
-                },
-                {
-                    let code = row.get::<_, i64>(2).map_err(E::db_error)?;
-                    parse_priority_code(code).ok_or_else(|| {
-                        E::corrupt(format!("scan priority not recognized: {code}"))
-                    })?
-                },
-            );
+            let entry = scan_range_from_row::<E>(row)?;
             to_delete_ends.push(Value::from(u32::from(entry.block_range().end)));
             to_create = if let Some(cur) = to_create {
                 Some(cur.insert(entry, force_rescans))
@@ -219,6 +210,117 @@ pub(crate) fn replace_queue_entries<E: WalletError>(
     }
 
     Ok(())
+}
+
+/// Drops the scan work queued below `height`, leaving the queue's coverage contiguous.
+///
+/// This is the inverse of [`replace_queue_entries`], and cannot be expressed in terms of
+/// it: the spanning tree's dominance rule exists to stop a merge from *lowering* the
+/// priority of a queued range, which is precisely what pruning must do.
+///
+/// With `Some(priority)`, entries at or above that priority are retained whole (even where
+/// they straddle `height`), as are the `Scanned`/`Ignored` bookkeeping entries — those
+/// record which regions the store has already covered or deliberately skips. With `None`,
+/// nothing below `height` is retained, irrespective of priority.
+///
+/// Pruned coverage is only ever *relabelled*, never removed, wherever a retained entry
+/// still sits below it: such regions are rewritten as [`ScanPriority::Ignored`] and
+/// coalesced with their neighbours. Deleting them instead would leave a hole that
+/// [`replace_queue_entries`] refills as [`ScanPriority::Historic`] the next time a
+/// spanning-tree merge covers it, resurrecting the very work being pruned. Only coverage
+/// beneath the lowest retained entry is deleted outright, since raising the queue's floor
+/// cannot open an interior gap.
+///
+/// Returns the number of queue entries that were removed or altered.
+pub(crate) fn prune_scan_queue_below(
+    conn: &rusqlite::Transaction<'_>,
+    height: BlockHeight,
+    retain_with_priority: Option<ScanPriority>,
+) -> Result<u64, SqliteClientError> {
+    let is_retained = |priority: ScanPriority| {
+        retain_with_priority
+            .is_some_and(|retain| priority <= ScanPriority::Scanned || priority >= retain)
+    };
+
+    // Every entry this operation can touch starts below `height`; the queue's non-overlap
+    // invariant leaves the remainder unaffected. Reading them up front keeps the no-op
+    // case read-only, so callers probing at every wallet open never contend for the write
+    // lock.
+    let existing = {
+        let mut stmt = conn.prepare_cached(
+            "SELECT block_range_start, block_range_end, priority FROM scan_queue
+             WHERE block_range_start < :height
+             ORDER BY block_range_start",
+        )?;
+
+        stmt.query_and_then(
+            named_params![":height": u32::from(height)],
+            scan_range_from_row::<SqliteClientError>,
+        )?
+        .collect::<Result<Vec<_>, _>>()?
+    };
+
+    // The lowest retained entry is the floor of the region that must remain covered.
+    let fill_from = existing
+        .iter()
+        .find(|entry| is_retained(entry.priority()))
+        .map(|entry| entry.block_range().start);
+
+    let replacement = existing
+        .iter()
+        .flat_map(|entry| {
+            let range = entry.block_range();
+            if is_retained(entry.priority()) {
+                vec![entry.clone()]
+            } else {
+                // Only the part below `height` is pruned; any remainder keeps its priority.
+                let pruned = ScanRange::from_parts(
+                    range.start..min(range.end, height),
+                    ScanPriority::Ignored,
+                );
+                let kept = (range.end > height)
+                    .then(|| ScanRange::from_parts(height..range.end, entry.priority()));
+
+                match fill_from {
+                    Some(floor) if pruned.block_range().end > floor => {
+                        Some(pruned).into_iter().chain(kept).collect()
+                    }
+                    _ => kept.into_iter().collect(),
+                }
+            }
+        })
+        .fold(Vec::<ScanRange>::new(), |mut acc, entry| {
+            match acc.last() {
+                Some(prev)
+                    if prev.priority() == entry.priority()
+                        && prev.block_range().end == entry.block_range().start =>
+                {
+                    let merged = ScanRange::from_parts(
+                        prev.block_range().start..entry.block_range().end,
+                        prev.priority(),
+                    );
+                    acc.pop();
+                    acc.push(merged);
+                }
+                _ => acc.push(entry),
+            }
+            acc
+        });
+
+    if replacement == existing {
+        return Ok(0);
+    }
+
+    conn.execute(
+        "DELETE FROM scan_queue WHERE block_range_start < :height",
+        named_params![":height": u32::from(height)],
+    )?;
+    insert_queue_entries(conn, replacement.iter())?;
+
+    Ok(existing
+        .iter()
+        .filter(|entry| !replacement.contains(entry))
+        .count() as u64)
 }
 
 fn extend_range(
@@ -690,7 +792,9 @@ pub(crate) mod tests {
             BlockCache,
             db::{TestDb, TestDbFactory},
         },
-        wallet::scanning::{insert_queue_entries, replace_queue_entries, suggest_scan_ranges},
+        wallet::scanning::{
+            insert_queue_entries, priority_code, replace_queue_entries, suggest_scan_ranges,
+        },
     };
 
     /// `extend_range` for the Ironwood pool must query the `ironwood_tree_shards` table (rather
@@ -2183,5 +2287,246 @@ pub(crate) mod tests {
             "the ChainTip range must cover the Ironwood shard tip {low:?}, but started at \
              {chain_tip_start:?}",
         );
+    }
+
+    fn queue_contents(st: &TestState<(), TestDb, LocalNetwork>) -> Vec<(u32, u32, i64)> {
+        let mut stmt = st
+            .wallet()
+            .conn()
+            .prepare(
+                "SELECT block_range_start, block_range_end, priority FROM scan_queue
+                 ORDER BY block_range_start",
+            )
+            .unwrap();
+
+        stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, u32>(0)?,
+                r.get::<_, u32>(1)?,
+                r.get::<_, i64>(2)?,
+            ))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+    }
+
+    /// Asserts that the scan queue's coverage is contiguous. `replace_queue_entries` fills
+    /// any gap between adjacent entries with a `Historic` range, so a hole punched in the
+    /// queue silently re-queues that region for scanning at the next spanning-tree merge.
+    fn assert_queue_contiguous(st: &TestState<(), TestDb, LocalNetwork>) {
+        let entries = queue_contents(st);
+        for pair in entries.windows(2) {
+            assert_eq!(
+                pair[0].1, pair[1].0,
+                "gap in scan queue between {:?} and {:?}",
+                pair[0], pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn prune_scan_queue_below_retains_at_and_above_priority() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let floor = BlockHeight::from_u32(663_150);
+        insert_queue_entries(
+            st.wallet().conn(),
+            [
+                scan_range(419_200..450_000, ScanPriority::Ignored), // bookkeeping: kept
+                scan_range(450_000..460_000, ScanPriority::FoundNote), // retained priority: kept
+                scan_range(460_000..500_000, ScanPriority::Scanned), // bookkeeping: kept
+                scan_range(500_000..700_000, ScanPriority::Historic), // straddler: split
+                scan_range(700_000..710_000, ScanPriority::ChainTip), // above height: untouched
+            ]
+            .iter(),
+        )
+        .unwrap();
+
+        let changed = st
+            .wallet_mut()
+            .prune_scan_queue_below(floor, Some(ScanPriority::OpenAdjacent))
+            .unwrap();
+        assert_eq!(
+            changed, 1,
+            "only the straddling `Historic` entry is altered"
+        );
+
+        // The `Historic` entry's coverage below the floor is demoted rather than deleted:
+        // the `FoundNote` witness range still sits below it, so deleting would leave a gap.
+        assert_eq!(
+            queue_contents(&st),
+            vec![
+                (419_200, 450_000, priority_code(&ScanPriority::Ignored)),
+                (450_000, 460_000, priority_code(&ScanPriority::FoundNote)),
+                (460_000, 500_000, priority_code(&ScanPriority::Scanned)),
+                (500_000, 663_150, priority_code(&ScanPriority::Ignored)),
+                (663_150, 700_000, priority_code(&ScanPriority::Historic)),
+                (700_000, 710_000, priority_code(&ScanPriority::ChainTip)),
+            ]
+        );
+        assert_queue_contiguous(&st);
+    }
+
+    /// The motivating case: after the account that justified the deep `Historic` range is
+    /// deleted, pruning to the remaining wallet birthday leaves exactly the state that
+    /// account creation would have produced had the deleted account never existed — a
+    /// single `Ignored` range below the birthday.
+    #[test]
+    fn prune_scan_queue_below_coalesces_with_the_ignored_floor() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let floor = BlockHeight::from_u32(663_150);
+        insert_queue_entries(
+            st.wallet().conn(),
+            [
+                scan_range(419_200..500_000, ScanPriority::Ignored),
+                scan_range(500_000..700_000, ScanPriority::Historic),
+            ]
+            .iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            st.wallet_mut()
+                .prune_scan_queue_below(floor, Some(ScanPriority::OpenAdjacent))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            queue_contents(&st),
+            vec![
+                (419_200, 663_150, priority_code(&ScanPriority::Ignored)),
+                (663_150, 700_000, priority_code(&ScanPriority::Historic)),
+            ]
+        );
+        assert_queue_contiguous(&st);
+    }
+
+    /// Where nothing below the pruned region is retained, the queue's floor simply rises;
+    /// raising the floor cannot open an interior gap, so no `Ignored` filler is recorded.
+    #[test]
+    fn prune_scan_queue_below_raises_the_floor_when_nothing_is_retained() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let floor = BlockHeight::from_u32(663_150);
+        insert_queue_entries(
+            st.wallet().conn(),
+            [
+                scan_range(500_000..600_000, ScanPriority::Historic),
+                scan_range(600_000..700_000, ScanPriority::Historic),
+            ]
+            .iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            st.wallet_mut()
+                .prune_scan_queue_below(floor, Some(ScanPriority::OpenAdjacent))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            queue_contents(&st),
+            vec![(663_150, 700_000, priority_code(&ScanPriority::Historic))]
+        );
+        assert_queue_contiguous(&st);
+    }
+
+    /// `retain_with_priority: None` retains nothing below the height, irrespective of
+    /// priority — even a `Verify` entry is pruned, and the bookkeeping entries that would
+    /// otherwise anchor the queue's floor go with it.
+    #[test]
+    fn prune_scan_queue_below_none_retains_nothing() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let floor = BlockHeight::from_u32(663_150);
+        insert_queue_entries(
+            st.wallet().conn(),
+            [
+                scan_range(419_200..450_000, ScanPriority::Ignored), // deleted despite bookkeeping
+                scan_range(450_000..460_000, ScanPriority::Verify),  // deleted despite priority
+                scan_range(460_000..600_000, ScanPriority::Historic), // deleted
+                scan_range(600_000..700_000, ScanPriority::FoundNote), // straddler: trimmed
+            ]
+            .iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            st.wallet_mut().prune_scan_queue_below(floor, None).unwrap(),
+            4
+        );
+        assert_eq!(
+            queue_contents(&st),
+            vec![(663_150, 700_000, priority_code(&ScanPriority::FoundNote))]
+        );
+        assert_queue_contiguous(&st);
+    }
+
+    /// Pruning is a no-op when nothing below the height is prunable, and leaves the queue
+    /// untouched rather than rewriting it.
+    #[test]
+    fn prune_scan_queue_below_is_a_no_op_when_all_entries_are_retained() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let entries = [
+            scan_range(419_200..450_000, ScanPriority::Ignored),
+            scan_range(450_000..460_000, ScanPriority::Scanned),
+            scan_range(460_000..700_000, ScanPriority::FoundNote),
+        ];
+        insert_queue_entries(st.wallet().conn(), entries.iter()).unwrap();
+        let before = queue_contents(&st);
+
+        assert_eq!(
+            st.wallet_mut()
+                .prune_scan_queue_below(
+                    BlockHeight::from_u32(663_150),
+                    Some(ScanPriority::OpenAdjacent)
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(queue_contents(&st), before);
+    }
+
+    /// `block_range_end` is exclusive: an entry ending exactly at `height` covers only
+    /// heights strictly below it, so it is deleted whole rather than trimmed to an empty
+    /// range (which the schema's `start < end` constraint would reject).
+    #[test]
+    fn prune_scan_queue_below_treats_end_at_height_as_fully_below() {
+        use zcash_client_backend::data_api::WalletWrite as _;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .build();
+        let floor = BlockHeight::from_u32(663_150);
+        insert_queue_entries(
+            st.wallet().conn(),
+            [scan_range(600_000..663_150, ScanPriority::Historic)].iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            st.wallet_mut()
+                .prune_scan_queue_below(floor, Some(ScanPriority::OpenAdjacent))
+                .unwrap(),
+            1
+        );
+        let remaining: i64 = st
+            .wallet()
+            .conn()
+            .query_row("SELECT COUNT(*) FROM scan_queue", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(remaining, 0);
     }
 }

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1024,10 +1024,10 @@ fn source_pool_notes_after_run(
     for layer in preparation.layers() {
         for tx in layer {
             for input in tx.inputs() {
-                if let PrepInput::Wallet { index, .. } = input {
-                    if let Some(flag) = spent.get_mut(*index) {
-                        *flag = true;
-                    }
+                if let PrepInput::Wallet { index, .. } = input
+                    && let Some(flag) = spent.get_mut(*index)
+                {
+                    *flag = true;
                 }
             }
         }
@@ -2472,10 +2472,10 @@ mod tests {
             id: MigrationTxId,
             state: MigrationTxState,
         ) -> Result<(), Self::Error> {
-            if let Some(stored) = &mut self.stored {
-                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
-                    tx.state = state;
-                }
+            if let Some(stored) = &mut self.stored
+                && let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id)
+            {
+                tx.state = state;
             }
             Ok(())
         }
@@ -2855,10 +2855,10 @@ mod commit_tests {
             id: MigrationTxId,
             state: MigrationTxState,
         ) -> Result<(), Self::Error> {
-            if let Some(stored) = &mut self.stored {
-                if let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id) {
-                    tx.state = state;
-                }
+            if let Some(stored) = &mut self.stored
+                && let Some(tx) = stored.transactions.iter_mut().find(|t| t.id == id)
+            {
+                tx.state = state;
             }
             Ok(())
         }

--- a/zcash_pool_migration/src/note_splitting/utils.rs
+++ b/zcash_pool_migration/src/note_splitting/utils.rs
@@ -21,10 +21,10 @@ pub(crate) fn largest_one_two_five(hi: u64, floor: u64) -> u64 {
     }
     // Prefer the largest significand multiple of that power that still fits.
     for multiple in ONE_TWO_FIVE_DESCENDING {
-        if let Some(v) = pow.checked_mul(multiple) {
-            if v <= hi {
-                return v;
-            }
+        if let Some(v) = pow.checked_mul(multiple)
+            && v <= hi
+        {
+            return v;
         }
     }
     pow

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -390,21 +390,20 @@ pub fn plan_preparation(
         .filter(|(i, _)| !used[*i])
         .map(|(i, &v)| (i, v))
         .max_by_key(|&(_, v)| v)
+        && big >= subtree_cost(&remaining, fee_per_tx).1
     {
-        if big >= subtree_cost(&remaining, fee_per_tx).1 {
-            build_split(
-                PrepInput::Wallet {
-                    index: idx,
-                    value: zat(big),
-                },
-                big,
-                &remaining,
-                fee_per_tx,
-                0,
-                &mut layers,
-            );
-            remaining.clear();
-        }
+        build_split(
+            PrepInput::Wallet {
+                index: idx,
+                value: zat(big),
+            },
+            big,
+            &remaining,
+            fee_per_tx,
+            0,
+            &mut layers,
+        );
+        remaining.clear();
     }
 
     // The notes available to spend in the current layer (layer 0: the wallet's own notes not already
@@ -540,10 +539,10 @@ pub fn plan_preparation(
     for (li, layer) in layers.iter_mut().enumerate() {
         for (ti, tx) in layer.iter_mut().enumerate() {
             for (oi, out) in tx.outputs.iter_mut().enumerate() {
-                if let PrepOutput::Intermediate(v) = *out {
-                    if !spent.contains(&(li, ti, oi)) {
-                        *out = PrepOutput::Change(v);
-                    }
+                if let PrepOutput::Intermediate(v) = *out
+                    && !spent.contains(&(li, ti, oi))
+                {
+                    *out = PrepOutput::Change(v);
                 }
             }
         }
@@ -634,15 +633,15 @@ fn unconsumed_feeders(layers: &[Vec<PrepTransaction>]) -> Vec<PrepInput> {
     for (li, layer) in layers.iter().enumerate() {
         for (ti, tx) in layer.iter().enumerate() {
             for (oi, output) in tx.outputs.iter().enumerate() {
-                if let PrepOutput::Intermediate(v) = output {
-                    if !spent.contains(&(li, ti, oi)) {
-                        out.push(PrepInput::Prior {
-                            layer: li,
-                            transaction: ti,
-                            output: oi,
-                            value: *v,
-                        });
-                    }
+                if let PrepOutput::Intermediate(v) = output
+                    && !spent.contains(&(li, ti, oi))
+                {
+                    out.push(PrepInput::Prior {
+                        layer: li,
+                        transaction: ti,
+                        output: oi,
+                        value: *v,
+                    });
                 }
             }
         }

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -140,14 +140,14 @@ fn commits_a_multi_layer_migration_in_one_pass() {
         .collect();
     assert_eq!(layer0_ids.len(), 1, "one root transaction in layer 0");
     for tx in state.transactions() {
-        if let MigrationTxKind::Preparation { layer, .. } = tx.kind() {
-            if layer > 0 {
-                assert_eq!(
-                    tx.depends_on(),
-                    &layer0_ids,
-                    "a later layer broadcasts only after its predecessor mines"
-                );
-            }
+        if let MigrationTxKind::Preparation { layer, .. } = tx.kind()
+            && layer > 0
+        {
+            assert_eq!(
+                tx.depends_on(),
+                &layer0_ids,
+                "a later layer broadcasts only after its predecessor mines"
+            );
         }
     }
 


### PR DESCRIPTION
Adds three operations to the `zcash_client_backend` storage traits, with `zcash_client_sqlite` implementations. Each replaces an operation that an out-of-tree sync engine built on these crates would otherwise need direct SQL against wallet-internal tables to express:

- **`WalletRead::get_wallet_recover_until`** — the latest `recover_until` height among the wallet's accounts (the wallet-wide recovery horizon), mirroring `get_wallet_birthday`'s wallet-wide shape. Drives an "is the wallet still recovering?" signal.
- **`WalletWrite::prune_scan_queue_below`** — removes (or trims to a height floor) scan-queue entries below a given height. With `retain_with_priority: None`, nothing below the height is retained, irrespective of priority; with `Some(priority)`, entries at or above that priority are retained, as are the `Scanned`/`Ignored` bookkeeping entries (the store's own record of chain coverage — e.g. the canonical `Ignored` range spanning activation → wallet birthday — which the backend maintains itself; pruning those would make the queue shape depend on how often the wallet was opened). Primary use case: discarding `Historic` ranges that no remaining account justifies after `delete_account`, which deliberately does not modify the scan queue. The sqlite implementation keeps the common no-op case read-only (a probe inside the deferred transaction), so callers pruning at every wallet open never contend for the write lock.
- **`WalletCommitmentTrees::{get_sapling_subtree_root, get_orchard_subtree_root, get_ironwood_subtree_root}`** — paired readers for the existing `put_*_subtree_roots` methods, returning the store's record of a completed subtree's root hash, if known. The Ironwood variant has a default implementation returning `Ok(None)`, mirroring `with_ironwood_tree_mut`.

Includes mock implementations in `data_api::testing` (Ironwood mock modeling is tracked separately in #2756), unit tests for all three operations in `zcash_client_sqlite`, and changelog entries.

---
Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)