### PR TITLE
Make the pool-migration anchor bucketing interval configurable

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -70,8 +70,33 @@ workspace.
   `propose_shielding_coinbase` apply when gathering transparent inputs
   (default `Exclude`). Shielding has no per-call `SpendPolicy` argument, so
   this is set once on the selector instance rather than passed to each call.
+- `zcash_client_backend::data_api::anchor_retention`, containing
+  `AnchorRetentionInterval` (the block-height grid on which note commitment tree
+  checkpoints are retained as durable anchors) and `AnchorRetention` (that grid
+  paired with the height at or above which retention applies). The interval was
+  previously a hard-coded 144 blocks.
+- `zcash_client_backend::data_api::WalletRead::anchor_retention_interval`, which
+  reports the grid a backend retains. It defaults to
+  `AnchorRetentionInterval::ZIP_318`, matching the retention a backend performs
+  if it does not configure the interval; a backend that makes retention
+  configurable MUST override it, because a ZIP 318 pool migration reads the grid
+  back through this method to decide which heights its transfers may anchor to.
+- `zcash_client_backend::data_api::testing::TestBuilder::with_anchor_retention_interval`
 
 ### Changed
+- `zcash_client_backend::data_api::ll::wallet::put_blocks` and
+  `zcash_client_backend::data_api::ll::wallet::update_tree` now take
+  `Option<AnchorRetention>` in place of `anchor_retention_height:
+  Option<BlockHeight>`. Replace `Some(height)` with
+  `Some(AnchorRetention::new(height, interval))`, where `interval` is the
+  wallet's configured `AnchorRetentionInterval` (use
+  `AnchorRetentionInterval::ZIP_318` to preserve the previous behaviour);
+  `None` continues to disable anchor retention.
+- `zcash_client_backend::data_api::testing::DataStoreFactory::new_data_store`
+  takes an additional `anchor_retention_interval: Option<AnchorRetentionInterval>`
+  argument; pass `None` to keep the default grid.
+- `zcash_client_backend::data_api::testing::pool::anchor_checkpoints_retained_across_deep_scan`
+  takes the `AnchorRetentionInterval` to exercise as an additional argument.
 - Migrated to `zcash_primitives 0.30.0`, `zcash_transparent 0.10.0`,
   `zcash_proofs 0.30.0`, `pczt 0.8.0`.
 - `zcash_client_backend::data_api::wallet::create_proposed_transactions` now

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -72,9 +72,13 @@ workspace.
   this is set once on the selector instance rather than passed to each call.
 - `zcash_client_backend::data_api::anchor_retention`, containing
   `AnchorRetentionInterval` (the block-height grid on which note commitment tree
-  checkpoints are retained as durable anchors) and `AnchorRetention` (that grid
-  paired with the height at or above which retention applies). The interval was
-  previously a hard-coded 144 blocks.
+  checkpoints are retained as durable anchors) and `AnchorRetention` (the set of
+  such grids to retain, paired with the height at or above which retention
+  applies). The interval was previously a hard-coded 144 blocks. `AnchorRetention`
+  holds a set rather than a single grid because a wallet may owe retention to more
+  than one at a time: the trees are wallet-wide while a pool migration is
+  per-account, and a migration already committed under one grid must keep being
+  retained even if the wallet is later configured with a different one.
 - `zcash_client_backend::data_api::WalletRead::anchor_retention_interval`, which
   reports the grid a backend retains. It defaults to
   `AnchorRetentionInterval::ZIP_318`, matching the retention a backend performs
@@ -86,12 +90,12 @@ workspace.
 ### Changed
 - `zcash_client_backend::data_api::ll::wallet::put_blocks` and
   `zcash_client_backend::data_api::ll::wallet::update_tree` now take
-  `Option<AnchorRetention>` in place of `anchor_retention_height:
-  Option<BlockHeight>`. Replace `Some(height)` with
-  `Some(AnchorRetention::new(height, interval))`, where `interval` is the
-  wallet's configured `AnchorRetentionInterval` (use
-  `AnchorRetentionInterval::ZIP_318` to preserve the previous behaviour);
-  `None` continues to disable anchor retention.
+  `Option<&AnchorRetention>` in place of `anchor_retention_height:
+  Option<BlockHeight>`. Replace `Some(height)` with a reference to
+  `AnchorRetention::new(height, interval)`, where `interval` is the wallet's
+  configured `AnchorRetentionInterval` (use `AnchorRetentionInterval::ZIP_318` to
+  preserve the previous behaviour), or to `AnchorRetention::union(height, grids)`
+  to retain several; `None` continues to disable anchor retention.
 - `zcash_client_backend::data_api::testing::DataStoreFactory::new_data_store`
   takes an additional `anchor_retention_interval: Option<AnchorRetentionInterval>`
   argument; pass `None` to keep the default grid.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -131,6 +131,7 @@ use ambassador::delegatable_trait;
 #[cfg(any(test, feature = "test-dependencies"))]
 use zcash_protocol::consensus::NetworkUpgrade;
 
+pub mod anchor_retention;
 pub mod chain;
 pub mod defaults;
 pub mod error;
@@ -2079,6 +2080,25 @@ pub trait WalletRead {
     ///
     /// This will return `Ok(None)` if the height of the current consensus chain tip is unknown.
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error>;
+
+    /// Returns the interval on which this wallet retains note commitment tree checkpoints as
+    /// durable anchors.
+    ///
+    /// A ZIP 318 pool migration anchors each of its pool-crossing transfers to a boundary of this
+    /// interval, and proves the transfer long after that boundary has passed; the proof can only be
+    /// constructed if the wallet kept the boundary's checkpoint. Reading the grid back off the
+    /// wallet that maintains it — rather than configuring the migration separately — is what
+    /// guarantees the two agree.
+    ///
+    /// The default implementation returns [`AnchorRetentionInterval::ZIP_318`], which matches the
+    /// retention a backend performs if it does not configure the interval. A backend that DOES make
+    /// retention configurable must override this to report the interval it actually retains, or
+    /// migrations over it will draw anchors it has pruned.
+    ///
+    /// [`AnchorRetentionInterval::ZIP_318`]: anchor_retention::AnchorRetentionInterval::ZIP_318
+    fn anchor_retention_interval(&self) -> anchor_retention::AnchorRetentionInterval {
+        anchor_retention::AnchorRetentionInterval::ZIP_318
+    }
 
     /// Returns the block hash for the block at the given height, if the
     /// associated block data is available. Returns `Ok(None)` if the hash

--- a/zcash_client_backend/src/data_api/anchor_retention.rs
+++ b/zcash_client_backend/src/data_api/anchor_retention.rs
@@ -1,0 +1,222 @@
+//! Durable anchor-checkpoint retention: the block-height grid on which note commitment tree
+//! checkpoints are kept alive past the ordinary pruning window.
+//!
+//! A [ZIP 318] pool migration proves each pool-crossing transfer against the note commitment tree
+//! state at a BOUNDARY block rather than at the chain tip, so that many wallets' transfers share a
+//! small set of common anchors instead of each pinning a unique recent block. A transfer is proved
+//! long after its boundary has passed, so the boundary's checkpoint must still be present in the
+//! wallet's tree at proving time — ordinary checkpoint pruning would have discarded it. Retention
+//! exempts the boundary checkpoints from that pruning.
+//!
+//! [`AnchorRetentionInterval`] defines the grid, and owns the arithmetic that decides whether a
+//! height is a boundary. The migration scheduler MUST draw its anchors from the same grid the
+//! wallet retains: a transfer anchored to a height the wallet did not retain cannot be proved. See
+//! [`WalletRead::anchor_retention_interval`], the accessor through which a migration reads the grid
+//! back off the wallet that maintains it.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+//! [`WalletRead::anchor_retention_interval`]: super::WalletRead::anchor_retention_interval
+
+use core::num::NonZeroU32;
+
+use zcash_protocol::consensus::BlockHeight;
+
+/// The interval, in blocks, between the durable anchor checkpoints a wallet retains.
+///
+/// A height `h` is a BOUNDARY of this interval exactly when `h` is a multiple of it (see
+/// [`Self::is_boundary`]); those are the heights whose checkpoints are retained, and the only tree
+/// states a migration transfer may anchor to. The interval is a modulus, so it is necessarily
+/// non-zero.
+///
+/// The value recommended for use with this crate is supplied by the [`Default`] implementation,
+/// which is [`Self::ZIP_318`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AnchorRetentionInterval(NonZeroU32);
+
+impl AnchorRetentionInterval {
+    /// The interval specified by [ZIP 318]: 144 blocks, roughly three hours (8 per day) at the
+    /// Zcash ~75-second target block spacing.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    pub const ZIP_318: Self = Self(NonZeroU32::new(144).expect("144 is nonzero"));
+
+    /// Constructs an interval other than the [ZIP 318] one.
+    ///
+    /// A wallet on the production network MUST use [`Self::ZIP_318`]: the anonymity set a shared
+    /// anchor provides is exactly the set of transfers that chose the same boundary, so a wallet
+    /// retaining (and anchoring to) a different grid than its peers is distinguishable from them.
+    /// A shorter interval is useful on test networks, where waiting out 144-block buckets makes
+    /// exercising a migration impractical.
+    ///
+    /// This constructor is only available under the `unstable` feature, as it is not recommended
+    /// for general use.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    #[cfg(any(test, feature = "test-dependencies", feature = "unstable"))]
+    pub const fn custom(blocks: NonZeroU32) -> Self {
+        Self(blocks)
+    }
+
+    /// Returns the interval as a number of blocks.
+    pub fn block_count(&self) -> NonZeroU32 {
+        self.0
+    }
+
+    /// Returns whether `height` is a boundary of this interval, i.e. whether a checkpoint at
+    /// `height` is retained as a durable anchor.
+    pub fn is_boundary(&self, height: BlockHeight) -> bool {
+        u32::from(height) % self.0 == 0
+    }
+
+    /// Returns the greatest boundary height that does not exceed `height`, i.e. `height` rounded
+    /// DOWN to a multiple of this interval.
+    pub fn boundary_at_or_below(&self, height: BlockHeight) -> BlockHeight {
+        let h = u32::from(height);
+        BlockHeight::from_u32(h - (h % self.0))
+    }
+
+    /// Returns the least boundary height that is not below `height`, i.e. `height` rounded UP to a
+    /// multiple of this interval. Saturates at [`u32::MAX`].
+    pub fn boundary_at_or_above(&self, height: BlockHeight) -> BlockHeight {
+        let h = u32::from(height);
+        let r = h % self.0;
+        BlockHeight::from_u32(if r == 0 {
+            h
+        } else {
+            h.saturating_add(self.0.get() - r)
+        })
+    }
+}
+
+impl Default for AnchorRetentionInterval {
+    fn default() -> Self {
+        Self::ZIP_318
+    }
+}
+
+/// The anchor-retention policy in force while a range of blocks is being added to the wallet.
+///
+/// Retention applies only from [`Self::from_height`] upward: below the network upgrade that
+/// introduces the destination pool there are no migration transfers to anchor, so retaining
+/// checkpoints there would consume storage to no purpose.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AnchorRetention {
+    from_height: BlockHeight,
+    interval: AnchorRetentionInterval,
+}
+
+impl AnchorRetention {
+    /// Constructs a retention policy that retains the checkpoint at every boundary of `interval`
+    /// at or above `from_height`.
+    pub fn new(from_height: BlockHeight, interval: AnchorRetentionInterval) -> Self {
+        Self {
+            from_height,
+            interval,
+        }
+    }
+
+    /// The height at or above which anchor retention applies (the activation height of the network
+    /// upgrade that enables pool migration).
+    pub fn from_height(&self) -> BlockHeight {
+        self.from_height
+    }
+
+    /// The interval defining which heights are retained as durable anchors.
+    pub fn interval(&self) -> AnchorRetentionInterval {
+        self.interval
+    }
+
+    /// Returns whether the checkpoint at `height` should be retained as a durable anchor under this
+    /// policy: `height` is at or above [`Self::from_height`] and is a boundary of
+    /// [`Self::interval`].
+    pub fn retains(&self, height: BlockHeight) -> bool {
+        height >= self.from_height && self.interval.is_boundary(height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use proptest::prelude::*;
+
+    fn interval(blocks: u32) -> AnchorRetentionInterval {
+        AnchorRetentionInterval::custom(NonZeroU32::new(blocks).expect("nonzero"))
+    }
+
+    #[test]
+    fn zip_318_is_the_default() {
+        assert_eq!(AnchorRetentionInterval::default(), interval(144));
+        assert_eq!(AnchorRetentionInterval::ZIP_318.block_count().get(), 144);
+    }
+
+    #[test]
+    fn zip_318_boundaries() {
+        let i = AnchorRetentionInterval::ZIP_318;
+        for (height, below, above) in [
+            (0u32, 0u32, 0u32),
+            (1, 0, 144),
+            (143, 0, 144),
+            (144, 144, 144),
+            (145, 144, 288),
+            (1_000_000, 999_936, 1_000_080),
+        ] {
+            let h = BlockHeight::from_u32(height);
+            assert_eq!(
+                u32::from(i.boundary_at_or_below(h)),
+                below,
+                "below {height}"
+            );
+            assert_eq!(
+                u32::from(i.boundary_at_or_above(h)),
+                above,
+                "above {height}"
+            );
+        }
+        assert!(i.is_boundary(BlockHeight::from_u32(288)));
+        assert!(!i.is_boundary(BlockHeight::from_u32(289)));
+    }
+
+    proptest! {
+        /// Rounding down yields a boundary that does not exceed the height and is within one
+        /// interval of it; rounding up yields a boundary that is not below it, likewise within one
+        /// interval (except where the round-up saturates).
+        #[test]
+        fn boundary_rounding_props(h in 0u32..5_000_000, blocks in 1u32..10_000) {
+            let i = interval(blocks);
+            let height = BlockHeight::from_u32(h);
+
+            let below = u32::from(i.boundary_at_or_below(height));
+            prop_assert!(i.is_boundary(BlockHeight::from_u32(below)));
+            prop_assert!(below <= h);
+            prop_assert!(h - below < blocks);
+
+            let above = u32::from(i.boundary_at_or_above(height));
+            prop_assert!(i.is_boundary(BlockHeight::from_u32(above)));
+            prop_assert!(above >= h);
+            prop_assert!(above - h < blocks);
+        }
+
+        /// A height is a boundary exactly when rounding it in either direction leaves it fixed.
+        #[test]
+        fn is_boundary_agrees_with_rounding(h in 0u32..5_000_000, blocks in 1u32..10_000) {
+            let i = interval(blocks);
+            let height = BlockHeight::from_u32(h);
+            prop_assert_eq!(i.is_boundary(height), i.boundary_at_or_below(height) == height);
+            prop_assert_eq!(i.is_boundary(height), i.boundary_at_or_above(height) == height);
+        }
+
+        /// A policy retains exactly the boundaries at or above its floor.
+        #[test]
+        fn retention_policy_props(
+            floor in 0u32..1_000_000,
+            offset in 0u32..2_000,
+            blocks in 1u32..500,
+        ) {
+            let i = interval(blocks);
+            let policy = AnchorRetention::new(BlockHeight::from_u32(floor), i);
+            let h = BlockHeight::from_u32(floor.saturating_sub(1_000).saturating_add(offset));
+            prop_assert_eq!(policy.retains(h), h >= BlockHeight::from_u32(floor) && i.is_boundary(h));
+        }
+    }
+}

--- a/zcash_client_backend/src/data_api/anchor_retention.rs
+++ b/zcash_client_backend/src/data_api/anchor_retention.rs
@@ -18,6 +18,7 @@
 //! [`WalletRead::anchor_retention_interval`]: super::WalletRead::anchor_retention_interval
 
 use core::num::NonZeroU32;
+use std::collections::BTreeSet;
 
 use zcash_protocol::consensus::BlockHeight;
 
@@ -54,6 +55,16 @@ impl AnchorRetentionInterval {
     /// [ZIP 318]: https://zips.z.cash/zip-0318
     #[cfg(any(test, feature = "test-dependencies", feature = "unstable"))]
     pub const fn custom(blocks: NonZeroU32) -> Self {
+        Self(blocks)
+    }
+
+    /// Reconstructs an interval from a block count that was previously persisted, for a store
+    /// reading back its own durable state.
+    ///
+    /// This is the inverse of [`Self::block_count`], and is not a way to CHOOSE an interval: a
+    /// caller deciding what grid to retain on wants [`Self::ZIP_318`] or, deliberately and on a
+    /// test network only, [`Self::custom`].
+    pub const fn from_stored_block_count(blocks: NonZeroU32) -> Self {
         Self(blocks)
     }
 
@@ -94,15 +105,23 @@ impl Default for AnchorRetentionInterval {
     }
 }
 
-/// The anchor-retention policy in force while a range of blocks is being added to the wallet.
+/// The anchor-retention policy in force while a range of blocks is being added to the wallet: the
+/// set of grids whose boundaries are retained, and the height from which retention applies.
 ///
 /// Retention applies only from [`Self::from_height`] upward: below the network upgrade that
 /// introduces the destination pool there are no migration transfers to anchor, so retaining
 /// checkpoints there would consume storage to no purpose.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// The policy holds a SET of intervals rather than one because a wallet may owe retention to more
+/// than one grid at a time. The note commitment trees are wallet-wide while a pool migration is
+/// per-account, so two accounts migrating under different intervals each need their own boundaries
+/// kept; and a migration already committed under one grid must keep being retained even if the
+/// wallet is later configured with a different one, or the boundaries its transfers are anchored to
+/// would be pruned out from under it.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AnchorRetention {
     from_height: BlockHeight,
-    interval: AnchorRetentionInterval,
+    intervals: BTreeSet<AnchorRetentionInterval>,
 }
 
 impl AnchorRetention {
@@ -111,8 +130,22 @@ impl AnchorRetention {
     pub fn new(from_height: BlockHeight, interval: AnchorRetentionInterval) -> Self {
         Self {
             from_height,
-            interval,
+            intervals: core::iter::once(interval).collect(),
         }
+    }
+
+    /// Constructs a retention policy that retains the checkpoint at every height that is a boundary
+    /// of ANY of `intervals`, at or above `from_height`. Returns `None` if `intervals` is empty,
+    /// there then being nothing to retain.
+    pub fn union(
+        from_height: BlockHeight,
+        intervals: impl IntoIterator<Item = AnchorRetentionInterval>,
+    ) -> Option<Self> {
+        let intervals: BTreeSet<AnchorRetentionInterval> = intervals.into_iter().collect();
+        (!intervals.is_empty()).then_some(Self {
+            from_height,
+            intervals,
+        })
     }
 
     /// The height at or above which anchor retention applies (the activation height of the network
@@ -121,16 +154,16 @@ impl AnchorRetention {
         self.from_height
     }
 
-    /// The interval defining which heights are retained as durable anchors.
-    pub fn interval(&self) -> AnchorRetentionInterval {
-        self.interval
+    /// The grids whose boundaries are retained as durable anchors.
+    pub fn intervals(&self) -> &BTreeSet<AnchorRetentionInterval> {
+        &self.intervals
     }
 
     /// Returns whether the checkpoint at `height` should be retained as a durable anchor under this
-    /// policy: `height` is at or above [`Self::from_height`] and is a boundary of
-    /// [`Self::interval`].
+    /// policy: `height` is at or above [`Self::from_height`] and is a boundary of at least one of
+    /// [`Self::intervals`].
     pub fn retains(&self, height: BlockHeight) -> bool {
-        height >= self.from_height && self.interval.is_boundary(height)
+        height >= self.from_height && self.intervals.iter().any(|i| i.is_boundary(height))
     }
 }
 
@@ -142,6 +175,17 @@ mod tests {
 
     fn interval(blocks: u32) -> AnchorRetentionInterval {
         AnchorRetentionInterval::custom(NonZeroU32::new(blocks).expect("nonzero"))
+    }
+
+    /// An empty grid set means there is nothing to retain, which the constructor reports as `None`
+    /// rather than as a policy that silently retains nothing.
+    #[test]
+    fn union_of_no_intervals_is_none() {
+        assert!(AnchorRetention::union(BlockHeight::from_u32(0), []).is_none());
+        assert!(
+            AnchorRetention::union(BlockHeight::from_u32(0), [AnchorRetentionInterval::ZIP_318])
+                .is_some()
+        );
     }
 
     #[test]
@@ -217,6 +261,33 @@ mod tests {
             let policy = AnchorRetention::new(BlockHeight::from_u32(floor), i);
             let h = BlockHeight::from_u32(floor.saturating_sub(1_000).saturating_add(offset));
             prop_assert_eq!(policy.retains(h), h >= BlockHeight::from_u32(floor) && i.is_boundary(h));
+        }
+
+        /// A union policy retains a height iff ANY of its grids does, so adding a grid only ever
+        /// widens what survives pruning — a migration committed under one interval keeps its
+        /// boundaries even once the wallet is retaining on another.
+        #[test]
+        fn union_retains_every_constituent_grid(
+            floor in 0u32..100_000,
+            offset in 0u32..5_000,
+            a in 1u32..500,
+            b in 1u32..500,
+        ) {
+            let (ia, ib) = (interval(a), interval(b));
+            let f = BlockHeight::from_u32(floor);
+            let union = AnchorRetention::union(f, [ia, ib]).expect("non-empty");
+            let h = BlockHeight::from_u32(floor.saturating_add(offset));
+
+            prop_assert_eq!(
+                union.retains(h),
+                AnchorRetention::new(f, ia).retains(h) || AnchorRetention::new(f, ib).retains(h)
+            );
+            // Widening never removes anything either grid alone would have kept.
+            for single in [ia, ib] {
+                if AnchorRetention::new(f, single).retains(h) {
+                    prop_assert!(union.retains(h));
+                }
+            }
         }
     }
 }

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -628,7 +628,7 @@ pub fn put_blocks<DbT, SE, TE>(
     #[cfg(feature = "transparent-inputs")] gap_limits: GapLimits,
     from_state: &ChainState,
     blocks: Vec<ScannedBlock<<DbT as LowLevelWalletRead>::AccountId>>,
-    anchor_retention: Option<AnchorRetention>,
+    anchor_retention: Option<&AnchorRetention>,
 ) -> Result<(), PutBlocksError<SE, TE>>
 where
     DbT: PutBlocksDbT<SE, TE, <DbT as LowLevelWalletRead>::AccountRef>,
@@ -1609,14 +1609,14 @@ fn should_track_nullifiers(
 /// Returns whether the checkpoint at `height` should be retained as a durable anchor: anchor
 /// retention is enabled at all (`anchor_retention` is `Some`) and its policy
 /// [retains](AnchorRetention::retains) `height`.
-fn should_retain_anchor(anchor_retention: Option<AnchorRetention>, height: BlockHeight) -> bool {
+fn should_retain_anchor(anchor_retention: Option<&AnchorRetention>, height: BlockHeight) -> bool {
     anchor_retention.is_some_and(|retention| retention.retains(height))
 }
 
 /// Retains `height` as a durable anchor checkpoint when [`should_retain_anchor`] holds.
 fn retain_anchor_checkpoint<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
-    anchor_retention: Option<AnchorRetention>,
+    anchor_retention: Option<&AnchorRetention>,
     height: BlockHeight,
 ) -> Result<(), ShardTreeError<S::Error>>
 where
@@ -1669,7 +1669,7 @@ pub fn update_tree<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     frontier: &Frontier<S::H, DEPTH>,
     frontier_height: BlockHeight,
     tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
-    anchor_retention: Option<AnchorRetention>,
+    anchor_retention: Option<&AnchorRetention>,
     subtrees: impl Iterator<Item = (LocatedPrunableTree<S::H>, BTreeMap<BlockHeight, Position>)>,
     #[cfg(feature = "orchard")] missing_checkpoints: impl Iterator<Item = (BlockHeight, Checkpoint)>,
 ) -> Result<(), ShardTreeError<S::Error>>
@@ -1832,34 +1832,35 @@ mod tests {
         ] {
             let blocks = interval.block_count().get();
             let floor = BlockHeight::from(4 * blocks);
-            let retention = AnchorRetention::new(floor, interval);
+            let policy = AnchorRetention::new(floor, interval);
+            let retention = Some(&policy);
 
             // With retention disabled, nothing is retained, even on the interval.
             assert!(!should_retain_anchor(None, BlockHeight::from(8 * blocks)));
 
             // On the interval and at or above the floor: retained.
             assert!(should_retain_anchor(
-                Some(retention),
+                retention,
                 BlockHeight::from(4 * blocks)
             ));
             assert!(should_retain_anchor(
-                Some(retention),
+                retention,
                 BlockHeight::from(8 * blocks)
             ));
 
             // On the interval but below the floor: not retained.
             assert!(!should_retain_anchor(
-                Some(retention),
+                retention,
                 BlockHeight::from(3 * blocks)
             ));
 
             // At or above the floor but not on the interval: not retained.
             assert!(!should_retain_anchor(
-                Some(retention),
+                retention,
                 BlockHeight::from(4 * blocks + 1)
             ));
             assert!(!should_retain_anchor(
-                Some(retention),
+                retention,
                 BlockHeight::from(5 * blocks - 1)
             ));
         }

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -26,7 +26,8 @@ use crate::{
     TransferType,
     data_api::{
         DecryptedTransaction, SAPLING_SHARD_HEIGHT, ScannedBlock, TransactionStatus,
-        WalletCommitmentTrees, chain::ChainState, ll::ReceivedShieldedOutput,
+        WalletCommitmentTrees, anchor_retention::AnchorRetention, chain::ChainState,
+        ll::ReceivedShieldedOutput,
     },
     wallet::{Recipient, WalletTransparentOutput},
 };
@@ -618,15 +619,16 @@ where
 /// - `blocks`: The scanned block data to be added to the data store. This vector must contain
 ///   data for blocks in sequentially increasing height order;
 ///   [`PutBlocksError::NonSequentialBlocks`] will be returned if this invariant is violated.
-/// - `anchor_retention_height`: If `Some(h)`, checkpoints established at or above height `h` whose
-///   height falls on the [`ANCHOR_RETENTION_INTERVAL`] are retained as durable anchors, exempting
-///   them from automatic pruning of excess checkpoints. `None` disables anchor retention.
+/// - `anchor_retention`: If `Some(retention)`, the checkpoints the policy
+///   [retains](AnchorRetention::retains) — those at or above its floor that fall on its interval —
+///   are kept as durable anchors, exempting them from automatic pruning of excess checkpoints.
+///   `None` disables anchor retention.
 pub fn put_blocks<DbT, SE, TE>(
     wallet_db: &mut DbT,
     #[cfg(feature = "transparent-inputs")] gap_limits: GapLimits,
     from_state: &ChainState,
     blocks: Vec<ScannedBlock<<DbT as LowLevelWalletRead>::AccountId>>,
-    anchor_retention_height: Option<BlockHeight>,
+    anchor_retention: Option<AnchorRetention>,
 ) -> Result<(), PutBlocksError<SE, TE>>
 where
     DbT: PutBlocksDbT<SE, TE, <DbT as LowLevelWalletRead>::AccountRef>,
@@ -724,7 +726,7 @@ where
                     from_state.final_sapling_tree(),
                     from_state.block_height(),
                     sapling_tree,
-                    anchor_retention_height,
+                    anchor_retention,
                     &mut sapling_subtrees,
                     #[cfg(feature = "orchard")]
                     &mut missing_checkpoints,
@@ -748,7 +750,7 @@ where
                     from_state.final_orchard_tree(),
                     from_state.block_height(),
                     orchard_tree,
-                    anchor_retention_height,
+                    anchor_retention,
                     &mut orchard_subtrees,
                     &mut missing_checkpoints,
                 )
@@ -771,7 +773,7 @@ where
                     from_state.final_ironwood_tree(),
                     from_state.block_height(),
                     ironwood_tree,
-                    anchor_retention_height,
+                    anchor_retention,
                     &mut ironwood_subtrees,
                     &mut missing_checkpoints,
                 )
@@ -1604,31 +1606,24 @@ fn should_track_nullifiers(
     nullifier_tracking_floor.is_none_or(|floor| block_height >= floor)
 }
 
-/// The interval, in blocks, at which checkpoints are retained as durable "anchors" once anchor
-/// retention is active. At 75-second blocks this is roughly every 3 hours (8 per day).
-pub(crate) const ANCHOR_RETENTION_INTERVAL: u32 = 144;
-
-/// Returns whether the checkpoint at `height` should be retained as a durable anchor.
-///
-/// Anchor retention is active for `height` when `anchor_retention_height` is `Some` and `height`
-/// is at or above it (i.e. at or after the network upgrade that enables anchor retention), and
-/// `height` falls on the [`ANCHOR_RETENTION_INTERVAL`].
-fn should_retain_anchor(anchor_retention_height: Option<BlockHeight>, height: BlockHeight) -> bool {
-    anchor_retention_height.is_some_and(|floor| height >= floor)
-        && u32::from(height) % ANCHOR_RETENTION_INTERVAL == 0
+/// Returns whether the checkpoint at `height` should be retained as a durable anchor: anchor
+/// retention is enabled at all (`anchor_retention` is `Some`) and its policy
+/// [retains](AnchorRetention::retains) `height`.
+fn should_retain_anchor(anchor_retention: Option<AnchorRetention>, height: BlockHeight) -> bool {
+    anchor_retention.is_some_and(|retention| retention.retains(height))
 }
 
 /// Retains `height` as a durable anchor checkpoint when [`should_retain_anchor`] holds.
 fn retain_anchor_checkpoint<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
-    anchor_retention_height: Option<BlockHeight>,
+    anchor_retention: Option<AnchorRetention>,
     height: BlockHeight,
 ) -> Result<(), ShardTreeError<S::Error>>
 where
     S: ShardStore<CheckpointId = BlockHeight>,
     S::H: Clone + PartialEq + Hashable,
 {
-    if should_retain_anchor(anchor_retention_height, height) {
+    if should_retain_anchor(anchor_retention, height) {
         tree.ensure_retained(height)?;
     }
     Ok(())
@@ -1663,8 +1658,8 @@ pub fn cross_pool_ensure_heights(
 /// Updates the given note commitment tree with all newly read note commitments starting
 /// at the block `frontier_height + 1`.
 ///
-/// If `anchor_retention_height` is `Some`, every checkpoint established at or above that height
-/// whose height falls on the [`ANCHOR_RETENTION_INTERVAL`] is retained as a durable anchor.
+/// If `anchor_retention` is `Some`, every checkpoint the policy
+/// [retains](AnchorRetention::retains) is kept as a durable anchor.
 ///
 /// This is generic over the [`ShardStore`] backing the tree, so stores that maintain their note
 /// commitment trees by other means (for example, accumulating updates in memory and flushing
@@ -1674,7 +1669,7 @@ pub fn update_tree<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     frontier: &Frontier<S::H, DEPTH>,
     frontier_height: BlockHeight,
     tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
-    anchor_retention_height: Option<BlockHeight>,
+    anchor_retention: Option<AnchorRetention>,
     subtrees: impl Iterator<Item = (LocatedPrunableTree<S::H>, BTreeMap<BlockHeight, Position>)>,
     #[cfg(feature = "orchard")] missing_checkpoints: impl Iterator<Item = (BlockHeight, Checkpoint)>,
 ) -> Result<(), ShardTreeError<S::Error>>
@@ -1695,7 +1690,7 @@ where
             marking: Marking::Reference,
         },
     )?;
-    retain_anchor_checkpoint(tree, anchor_retention_height, frontier_height)?;
+    retain_anchor_checkpoint(tree, anchor_retention, frontier_height)?;
 
     for (subtree, checkpoints) in subtrees {
         // Register anchor retention for this batch's checkpoint heights *before* `insert_tree`,
@@ -1704,7 +1699,7 @@ where
         // retention must be recorded first; `ShardTree::ensure_retained` accepts a checkpoint
         // height whose checkpoint does not yet exist.
         for height in checkpoints.keys() {
-            retain_anchor_checkpoint(tree, anchor_retention_height, *height)?;
+            retain_anchor_checkpoint(tree, anchor_retention, *height)?;
         }
         tree.insert_tree(subtree, checkpoints)?;
     }
@@ -1730,7 +1725,7 @@ where
                 tree.store_mut()
                     .add_checkpoint(height, checkpoint.clone())
                     .map_err(ShardTreeError::Storage)?;
-                retain_anchor_checkpoint(tree, anchor_retention_height, height)?;
+                retain_anchor_checkpoint(tree, anchor_retention, height)?;
             }
         }
     }
@@ -1743,15 +1738,18 @@ mod tests {
     #[cfg(feature = "orchard")]
     use std::collections::BTreeSet;
 
+    use core::num::NonZeroU32;
+
     use proptest::prelude::*;
     use zcash_protocol::consensus::BlockHeight;
 
     #[cfg(feature = "orchard")]
     use super::cross_pool_ensure_heights;
     use super::{
-        ANCHOR_RETENTION_INTERVAL, NULLIFIER_MAP_RETENTION_BLOCKS, nullifier_tracking_floor,
-        should_retain_anchor, should_track_nullifiers,
+        NULLIFIER_MAP_RETENTION_BLOCKS, nullifier_tracking_floor, should_retain_anchor,
+        should_track_nullifiers,
     };
+    use crate::data_api::anchor_retention::{AnchorRetention, AnchorRetentionInterval};
 
     /// A range scanned after a gap of unscanned history (or below the frontier, or with no
     /// frontier at all) must track every nullifier: a skipped entry could belong to a note
@@ -1824,39 +1822,47 @@ mod tests {
         assert!(!should_track_nullifiers(Some(floor), BlockHeight::from(0)));
     }
 
+    /// The gating semantics hold identically at the ZIP 318 interval and at a non-default one, so
+    /// a wallet configured with a short interval retains exactly its own grid.
     #[test]
     fn anchor_retention_gating() {
-        let interval = ANCHOR_RETENTION_INTERVAL;
-        let floor = BlockHeight::from(4 * interval);
+        for interval in [
+            AnchorRetentionInterval::ZIP_318,
+            AnchorRetentionInterval::custom(NonZeroU32::new(12).expect("nonzero")),
+        ] {
+            let blocks = interval.block_count().get();
+            let floor = BlockHeight::from(4 * blocks);
+            let retention = AnchorRetention::new(floor, interval);
 
-        // With no retention floor, nothing is retained, even on the interval.
-        assert!(!should_retain_anchor(None, BlockHeight::from(8 * interval)));
+            // With retention disabled, nothing is retained, even on the interval.
+            assert!(!should_retain_anchor(None, BlockHeight::from(8 * blocks)));
 
-        // On the interval and at or above the floor: retained.
-        assert!(should_retain_anchor(
-            Some(floor),
-            BlockHeight::from(4 * interval)
-        ));
-        assert!(should_retain_anchor(
-            Some(floor),
-            BlockHeight::from(8 * interval)
-        ));
+            // On the interval and at or above the floor: retained.
+            assert!(should_retain_anchor(
+                Some(retention),
+                BlockHeight::from(4 * blocks)
+            ));
+            assert!(should_retain_anchor(
+                Some(retention),
+                BlockHeight::from(8 * blocks)
+            ));
 
-        // On the interval but below the floor: not retained.
-        assert!(!should_retain_anchor(
-            Some(floor),
-            BlockHeight::from(3 * interval)
-        ));
+            // On the interval but below the floor: not retained.
+            assert!(!should_retain_anchor(
+                Some(retention),
+                BlockHeight::from(3 * blocks)
+            ));
 
-        // At or above the floor but not on the interval: not retained.
-        assert!(!should_retain_anchor(
-            Some(floor),
-            BlockHeight::from(4 * interval + 1)
-        ));
-        assert!(!should_retain_anchor(
-            Some(floor),
-            BlockHeight::from(5 * interval - 1)
-        ));
+            // At or above the floor but not on the interval: not retained.
+            assert!(!should_retain_anchor(
+                Some(retention),
+                BlockHeight::from(4 * blocks + 1)
+            ));
+            assert!(!should_retain_anchor(
+                Some(retention),
+                BlockHeight::from(5 * blocks - 1)
+            ));
+        }
     }
 
     #[cfg(feature = "orchard")]

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -52,6 +52,7 @@ use super::{
     ReceivedNotes, ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, ScannedBlock, SeedRelevance,
     SentTransaction, TransactionDataRequest, TransactionStatus, WalletCommitmentTrees, WalletRead,
     WalletSummary, WalletTest, WalletWrite, Zip32Derivation,
+    anchor_retention::AnchorRetentionInterval,
     chain::{BlockSource, ChainState, CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
     error::Error,
     scanning::{ScanPriority, ScanRange},
@@ -1631,6 +1632,7 @@ pub trait DataStoreFactory {
     fn new_data_store(
         &self,
         network: LocalNetwork,
+        anchor_retention_interval: Option<AnchorRetentionInterval>,
         #[cfg(feature = "transparent-inputs")] gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error>;
 }
@@ -1644,6 +1646,7 @@ pub struct TestBuilder<Cache, DataStoreFactory> {
     initial_chain_state: Option<InitialChainState>,
     account_birthday: Option<AccountBirthday>,
     account_index: Option<zip32::AccountId>,
+    anchor_retention_interval: Option<AnchorRetentionInterval>,
     #[cfg(feature = "transparent-inputs")]
     gap_limits: Option<GapLimits>,
 }
@@ -1678,6 +1681,7 @@ impl TestBuilder<(), ()> {
             initial_chain_state: None,
             account_birthday: None,
             account_index: None,
+            anchor_retention_interval: None,
             #[cfg(feature = "transparent-inputs")]
             gap_limits: None,
         }
@@ -1701,6 +1705,7 @@ impl<A> TestBuilder<(), A> {
             initial_chain_state: self.initial_chain_state,
             account_birthday: self.account_birthday,
             account_index: self.account_index,
+            anchor_retention_interval: self.anchor_retention_interval,
             #[cfg(feature = "transparent-inputs")]
             gap_limits: self.gap_limits,
         }
@@ -1721,6 +1726,7 @@ impl<A> TestBuilder<A, ()> {
             initial_chain_state: self.initial_chain_state,
             account_birthday: self.account_birthday,
             account_index: self.account_index,
+            anchor_retention_interval: self.anchor_retention_interval,
             #[cfg(feature = "transparent-inputs")]
             gap_limits: self.gap_limits,
         }
@@ -1738,6 +1744,16 @@ impl<A, B> TestBuilder<A, B> {
         self
     }
 
+    /// Overrides the interval on which the wallet retains durable anchor checkpoints (the default
+    /// is [`AnchorRetentionInterval::ZIP_318`]).
+    ///
+    /// A test that must scan past a retained anchor otherwise has to generate 144 blocks per
+    /// boundary; a short interval makes the same coverage cheap.
+    pub fn with_anchor_retention_interval(mut self, interval: AnchorRetentionInterval) -> Self {
+        self.anchor_retention_interval = Some(interval);
+        self
+    }
+
     #[cfg(feature = "transparent-inputs")]
     pub fn with_gap_limits(self, gap_limits: GapLimits) -> TestBuilder<A, B> {
         TestBuilder {
@@ -1748,6 +1764,7 @@ impl<A, B> TestBuilder<A, B> {
             initial_chain_state: self.initial_chain_state,
             account_birthday: self.account_birthday,
             account_index: self.account_index,
+            anchor_retention_interval: self.anchor_retention_interval,
             gap_limits: Some(gap_limits),
         }
     }
@@ -1915,6 +1932,7 @@ impl<Cache, DsFactory: DataStoreFactory> TestBuilder<Cache, DsFactory> {
             .ds_factory
             .new_data_store(
                 self.network,
+                self.anchor_retention_interval,
                 #[cfg(feature = "transparent-inputs")]
                 self.gap_limits,
             )

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -37,6 +37,7 @@ use crate::{
         self, Account as _, AccountBirthday, BoundedU8, DecryptedTransaction, InputSource,
         MaxSpendMode, NoteFilter, Ratio, TargetValue, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletTest, WalletWrite,
+        anchor_retention::AnchorRetentionInterval,
         chain::{self, ChainState, CommitmentTreeRoot, ScanSummary},
         error::{Error, LockError},
         testing::{
@@ -5484,8 +5485,11 @@ pub fn checkpoint_gaps<T: ShieldedPoolTester, Dsf: DataStoreFactory>(
 /// from the ordinary `PRUNING_DEPTH`-checkpoint pruning budget, so that their roots and the
 /// witnesses anchored to them remain computable even after they age far behind the chain tip.
 ///
-/// The retention interval and pruning depth are read from `crate::data_api::ll::wallet`, so this
-/// test tracks whatever values the implementation defines rather than assuming a particular one.
+/// The interval is supplied by the caller (the pruning depth is read from
+/// `crate::data_api::ll::wallet`, so this test tracks whatever value the implementation defines).
+/// Passing a short interval keeps the test cheap: the scan must reach a boundary more than
+/// `PRUNING_DEPTH` checkpoints behind the tip, which at the ZIP 318 interval means generating
+/// several hundred blocks.
 ///
 /// The test:
 /// - Activates NU6.3 from the Sapling activation height, so anchor retention is live and its
@@ -5505,12 +5509,15 @@ pub fn anchor_checkpoints_retained_across_deep_scan<
 >(
     ds_factory: Dsf,
     cache: impl TestCache,
+    interval: AnchorRetentionInterval,
 ) {
     use std::collections::BTreeSet;
 
     use shardtree::{ShardTree, store::ShardStore};
 
-    use crate::data_api::ll::wallet::{ANCHOR_RETENTION_INTERVAL, PRUNING_DEPTH};
+    use crate::data_api::ll::wallet::PRUNING_DEPTH;
+
+    let interval_blocks = interval.block_count().get();
 
     // Reads, from any pool's note commitment tree, the set of surviving checkpoint heights, the
     // set of retained-anchor heights, and whether a witness for `note_position` as of
@@ -5562,6 +5569,7 @@ pub fn anchor_checkpoints_retained_across_deep_scan<
             .with_network(ironwood_active_network)
             .with_data_store_factory(ds_factory)
             .with_block_cache(cache)
+            .with_anchor_retention_interval(interval)
             .with_account_from_sapling_activation(BlockHash([0; 32])),
     )
     .build::<T>();
@@ -5574,9 +5582,9 @@ pub fn anchor_checkpoints_retained_across_deep_scan<
 
     // The first interval-aligned anchor height at or above the retention floor and strictly above
     // the received note, so the note's position precedes the anchor's checkpoint.
-    let mut anchor = floor.div_ceil(ANCHOR_RETENTION_INTERVAL) * ANCHOR_RETENTION_INTERVAL;
+    let mut anchor = u32::from(interval.boundary_at_or_above(BlockHeight::from(floor)));
     while anchor <= received {
-        anchor += ANCHOR_RETENTION_INTERVAL;
+        anchor += interval_blocks;
     }
 
     // Scan forward in a single batch so the anchor ages more than `PRUNING_DEPTH` checkpoints
@@ -5638,8 +5646,8 @@ pub fn anchor_checkpoints_retained_across_deep_scan<
 
     // Exactly the interval-aligned checkpoints at or above the retention floor are retained.
     let expected_anchors: BTreeSet<BlockHeight> = (floor..=tip)
-        .filter(|h| h % ANCHOR_RETENTION_INTERVAL == 0)
         .map(BlockHeight::from)
+        .filter(|h| interval.is_boundary(*h))
         .collect();
     assert_eq!(
         retained, expected_anchors,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -49,6 +49,12 @@ workspace.
   and `transparent_received_outputs` tables to support explicit note locking
   during concurrent proposal creation: `lock_expiry_height` bounds how long a
   lock lasts, and `lock_owner` records the flow that acquired it.
+- `zcash_client_sqlite::WalletDb::with_anchor_retention_interval` configures the
+  interval on which the wallet retains note commitment tree checkpoints as
+  durable anchors, for use on test networks where waiting out the ZIP 318
+  144-block interval makes exercising a pool migration impractical. The interval
+  is not persisted, so an application using a non-default value must apply it
+  every time it opens the wallet.
 
 ### Fixed
 - The coinbase branch of the transparent account-balance tally now classifies

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -52,11 +52,13 @@ workspace.
 - `zcash_client_sqlite::WalletDb::with_anchor_retention_interval` configures the
   interval on which the wallet retains note commitment tree checkpoints as
   durable anchors, for use on test networks where waiting out the ZIP 318
-  144-block interval makes exercising a pool migration impractical. The interval
-  is not persisted, so an application using a non-default value must apply it
-  every time it opens the wallet; a pool migration committed under a different
-  interval is rejected with `ProveError::AnchorIntervalMismatch` rather than
-  being left anchored to checkpoints the wallet no longer retains.
+  144-block interval makes exercising a pool migration impractical. The setting
+  governs what grid the next migration is planned against; the grid an in-flight
+  migration was committed under is recorded with it and keeps being retained
+  regardless, so reopening the wallet without reapplying the setting cannot
+  strand a migration.
+- `zcash_client_sqlite::WalletDb::set_anchor_retention_interval`, the
+  by-reference form of `with_anchor_retention_interval`.
 
 ### Fixed
 - The coinbase branch of the transparent account-balance tally now classifies

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -54,7 +54,9 @@ workspace.
   durable anchors, for use on test networks where waiting out the ZIP 318
   144-block interval makes exercising a pool migration impractical. The interval
   is not persisted, so an application using a non-default value must apply it
-  every time it opens the wallet.
+  every time it opens the wallet; a pool migration committed under a different
+  interval is rejected with `ProveError::AnchorIntervalMismatch` rather than
+  being left anchored to checkpoints the wallet no longer retains.
 
 ### Fixed
 - The coinbase branch of the transparent account-balance tally now classifies

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -61,6 +61,7 @@ use zcash_client_backend::{
         ReceivedNotes, ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, ScannedBlock,
         SeedRelevance, SentTransaction, TargetValue, TransactionDataRequest, WalletCommitmentTrees,
         WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
+        anchor_retention::{AnchorRetention, AnchorRetentionInterval},
         chain::{BlockSource, ChainState, CommitmentTreeRoot},
         error::{FindAccountForAddressError, LockError, RewindError},
         ll::{
@@ -282,6 +283,7 @@ pub struct WalletDb<C, P, CL, R> {
     params: P,
     clock: CL,
     rng: R,
+    anchor_retention_interval: AnchorRetentionInterval,
     #[cfg(feature = "transparent-inputs")]
     gap_limits: GapLimits,
 }
@@ -464,10 +466,30 @@ impl<P, CL, R> WalletDb<rusqlite::Connection, P, CL, R> {
                 params,
                 clock,
                 rng,
+                anchor_retention_interval: AnchorRetentionInterval::default(),
                 #[cfg(feature = "transparent-inputs")]
                 gap_limits: GapLimits::default(),
             })
         })
+    }
+}
+
+impl<C, P, CL, R> WalletDb<C, P, CL, R> {
+    /// Sets the interval on which this wallet retains note commitment tree checkpoints as durable
+    /// anchors, exempt from ordinary checkpoint pruning.
+    ///
+    /// A ZIP 318 pool migration run over this wallet reads the interval back through
+    /// [`WalletRead::anchor_retention_interval`] and draws its transfers' anchors from the same
+    /// grid, so the two cannot disagree. Note that the interval is not persisted: an application
+    /// that configures a non-default interval must apply it every time it opens the wallet, or a
+    /// migration committed under the old grid will be left anchored to checkpoints this wallet no
+    /// longer retains.
+    ///
+    /// The default is [`AnchorRetentionInterval::ZIP_318`], which every wallet on the production
+    /// network must use.
+    pub fn with_anchor_retention_interval(mut self, interval: AnchorRetentionInterval) -> Self {
+        self.anchor_retention_interval = interval;
+        self
     }
 }
 
@@ -501,6 +523,7 @@ impl<C: Borrow<rusqlite::Connection>, P, CL, R> WalletDb<C, P, CL, R> {
             params,
             clock,
             rng,
+            anchor_retention_interval: AnchorRetentionInterval::default(),
             #[cfg(feature = "transparent-inputs")]
             gap_limits: GapLimits::default(),
         }
@@ -528,6 +551,7 @@ impl<C: BorrowMut<rusqlite::Connection>, P, CL, R> WalletDb<C, P, CL, R> {
             params: &self.params,
             clock: &self.clock,
             rng: &mut self.rng,
+            anchor_retention_interval: self.anchor_retention_interval,
             #[cfg(feature = "transparent-inputs")]
             gap_limits: self.gap_limits,
         };
@@ -585,6 +609,7 @@ impl<C: BorrowMut<rusqlite::Connection>, P, CL, R> WalletDb<C, P, CL, R> {
             params: &self.params,
             clock: &self.clock,
             rng: &mut self.rng,
+            anchor_retention_interval: self.anchor_retention_interval,
             #[cfg(feature = "transparent-inputs")]
             gap_limits: self.gap_limits,
         };
@@ -1151,6 +1176,10 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
         wallet::chain_tip_height(self.conn.borrow()).map_err(SqliteClientError::from)
+    }
+
+    fn anchor_retention_interval(&self) -> AnchorRetentionInterval {
+        self.anchor_retention_interval
     }
 
     fn get_block_hash(&self, block_height: BlockHeight) -> Result<Option<BlockHash>, Self::Error> {
@@ -2041,13 +2070,14 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         from_state: &ChainState,
         blocks: Vec<ScannedBlock<Self::AccountId>>,
     ) -> Result<(), Self::Error> {
-        // Once the NU6.3 (Ironwood) activation height is reached, checkpoints on the anchor
-        // retention interval are retained as durable anchors. The activation height is `None`
-        // (and so anchor retention is inactive) on networks that do not yet have an assigned
-        // NU6.3 activation height.
-        let anchor_retention_height = self
+        // Once the NU6.3 (Ironwood) activation height is reached, checkpoints on this wallet's
+        // configured anchor retention interval are retained as durable anchors. The activation
+        // height is `None` (and so anchor retention is inactive) on networks that do not yet have
+        // an assigned NU6.3 activation height.
+        let anchor_retention = self
             .params
-            .activation_height(consensus::NetworkUpgrade::Nu6_3);
+            .activation_height(consensus::NetworkUpgrade::Nu6_3)
+            .map(|from_height| AnchorRetention::new(from_height, self.anchor_retention_interval));
 
         ll::wallet::put_blocks::<_, SqliteClientError, commitment_tree::Error>(
             self,
@@ -2055,7 +2085,7 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
             self.gap_limits,
             from_state,
             blocks,
-            anchor_retention_height,
+            anchor_retention,
         )
         .map_err(SqliteClientError::from)
     }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -478,18 +478,28 @@ impl<C, P, CL, R> WalletDb<C, P, CL, R> {
     /// Sets the interval on which this wallet retains note commitment tree checkpoints as durable
     /// anchors, exempt from ordinary checkpoint pruning.
     ///
-    /// A ZIP 318 pool migration run over this wallet reads the interval back through
+    /// A ZIP 318 pool migration planned over this wallet reads the interval back through
     /// [`WalletRead::anchor_retention_interval`] and draws its transfers' anchors from the same
-    /// grid, so the two cannot disagree. Note that the interval is not persisted: an application
-    /// that configures a non-default interval must apply it every time it opens the wallet, or a
-    /// migration committed under the old grid will be left anchored to checkpoints this wallet no
-    /// longer retains.
+    /// grid, so the two cannot disagree.
+    ///
+    /// This setting is not persisted, but it does not need to be: once a migration is committed,
+    /// the grid it was committed under is recorded with it, and this wallet keeps retaining that
+    /// grid's boundaries for as long as the migration is in flight, whatever it is currently
+    /// configured with. Reopening the wallet without reapplying a non-default interval therefore
+    /// cannot strand an in-flight migration; it only affects what grid the NEXT migration is
+    /// planned against.
     ///
     /// The default is [`AnchorRetentionInterval::ZIP_318`], which every wallet on the production
     /// network must use.
     pub fn with_anchor_retention_interval(mut self, interval: AnchorRetentionInterval) -> Self {
-        self.anchor_retention_interval = interval;
+        self.set_anchor_retention_interval(interval);
         self
+    }
+
+    /// Sets the anchor retention interval on an existing handle; see
+    /// [`Self::with_anchor_retention_interval`], of which this is the by-reference form.
+    pub fn set_anchor_retention_interval(&mut self, interval: AnchorRetentionInterval) {
+        self.anchor_retention_interval = interval;
     }
 }
 
@@ -2070,14 +2080,32 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         from_state: &ChainState,
         blocks: Vec<ScannedBlock<Self::AccountId>>,
     ) -> Result<(), Self::Error> {
-        // Once the NU6.3 (Ironwood) activation height is reached, checkpoints on this wallet's
-        // configured anchor retention interval are retained as durable anchors. The activation
-        // height is `None` (and so anchor retention is inactive) on networks that do not yet have
-        // an assigned NU6.3 activation height.
+        // Once the NU6.3 (Ironwood) activation height is reached, checkpoints on the anchor
+        // retention grids are retained as durable anchors. The activation height is `None` (and so
+        // anchor retention is inactive) on networks that do not yet have an assigned NU6.3
+        // activation height.
+        //
+        // The grids are this wallet's configured interval TOGETHER WITH the interval every
+        // in-flight migration was committed under. The latter comes from the database, not from
+        // configuration: a migration's transfers are anchored to boundaries of its committed grid
+        // and are provable only while those checkpoints survive, so an application that reopens the
+        // wallet without reapplying a non-default interval must not thereby cause this scan to pass
+        // a boundary that migration still needs. Retaining the union costs at most a few extra
+        // checkpoints and makes that failure unreachable.
         let anchor_retention = self
             .params
             .activation_height(consensus::NetworkUpgrade::Nu6_3)
-            .map(|from_height| AnchorRetention::new(from_height, self.anchor_retention_interval));
+            .map(|from_height| {
+                let committed = pool_migration::orchard_ironwood::active_anchor_bucket_intervals(
+                    self.conn.borrow(),
+                )?;
+                Ok::<_, SqliteClientError>(AnchorRetention::union(
+                    from_height,
+                    core::iter::once(self.anchor_retention_interval).chain(committed),
+                ))
+            })
+            .transpose()?
+            .flatten();
 
         ll::wallet::put_blocks::<_, SqliteClientError, commitment_tree::Error>(
             self,
@@ -2085,7 +2113,7 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
             self.gap_limits,
             from_state,
             blocks,
-            anchor_retention,
+            anchor_retention.as_ref(),
         )
         .map_err(SqliteClientError::from)
     }

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -128,6 +128,7 @@ mod tests {
     use zcash_pool_migration::engine::{
         MigrationTxId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
     };
+    use zcash_pool_migration::scheduling::AnchorBucketInterval;
     use zcash_pool_migration::testing::{
         arb_migration_state, arb_migration_tx_state, assert_empty_is_none,
         assert_put_get_roundtrip, assert_put_replaces, assert_update_transaction,
@@ -235,6 +236,7 @@ mod tests {
             note_split,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             vec![locked, unlocked],
+            AnchorBucketInterval::ZIP_318,
         );
 
         let mut store = fresh_store();
@@ -321,6 +323,7 @@ mod tests {
                 // A second transaction locked by A, to prove duplicates collapse.
                 tx(3, 3, Some(owner_a_bytes)),
             ],
+            AnchorBucketInterval::ZIP_318,
         );
 
         store.replace_migration(&state).expect("write succeeds");
@@ -357,6 +360,7 @@ mod tests {
             note_split,
             PreparationPlan::from_parts(vec![Vec::new()], Vec::new()),
             Vec::new(),
+            AnchorBucketInterval::ZIP_318,
         );
         let err = fresh_store()
             .replace_migration(&state)
@@ -400,6 +404,7 @@ mod tests {
             note_split,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             Vec::new(),
+            AnchorBucketInterval::ZIP_318,
         );
 
         PoolMigrations::for_account(&mut conn, account_a)

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -16,6 +16,9 @@ use zcash_pool_migration::engine::{
     MigrationState, MigrationTxId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 
+use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
+
+use crate::error::SqliteClientError;
 use crate::{AccountRef, AccountUuid};
 
 use super::store::{self, Store, Tables};
@@ -41,6 +44,30 @@ static TABLES: Tables = Tables {
 /// `up()` calls; it is idempotent (`IF NOT EXISTS`).
 pub(crate) fn init_migration_tables(conn: &Connection) -> rusqlite::Result<()> {
     store::init(conn, &TABLES)
+}
+
+/// The anchor bucket grids, in blocks, of every Orchard -> Ironwood migration in this database
+/// that is not yet complete.
+///
+/// A wallet must keep retaining the boundaries of the grid each in-flight migration was committed
+/// under, whatever it is currently configured to retain, or that migration's transfers become
+/// unprovable. Reading the grids back from the migrations themselves is what makes that
+/// independent of the application remembering to reapply a setting. See
+/// [`store::active_anchor_bucket_intervals`].
+pub(crate) fn active_anchor_bucket_intervals(
+    conn: &Connection,
+) -> Result<BTreeSet<AnchorRetentionInterval>, SqliteClientError> {
+    store::active_anchor_bucket_intervals(conn, &TABLES)
+        .map(|blocks| {
+            blocks
+                .into_iter()
+                .map(AnchorRetentionInterval::from_stored_block_count)
+                .collect()
+        })
+        .map_err(|e| match e {
+            Error::Db(e) => SqliteClientError::DbError(e),
+            other => SqliteClientError::CorruptedData(other.to_string()),
+        })
 }
 
 /// The Orchard -> Ironwood pool-migration store: a [`PoolMigrationRead`] / [`PoolMigrationWrite`]
@@ -114,6 +141,163 @@ impl<C: BorrowMut<Connection>> PoolMigrationWrite for PoolMigrations<C> {
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         self.0.update_transaction(id, state)
+    }
+}
+
+/// Retention follows the grid recorded WITH an in-flight migration, not the wallet's current
+/// configuration, so an application that reopens the wallet without reapplying a non-default
+/// interval cannot cause a scan to prune a boundary that migration still needs.
+///
+/// This is the gap the interval-mismatch check alone leaves: that check compares intervals at
+/// proving time, but the damage is done at scan time, and reapplying the setting afterwards repairs
+/// the comparison without bringing the checkpoint back.
+#[cfg(all(test, feature = "orchard"))]
+mod retention_follows_the_committed_migration {
+    use core::num::NonZeroU32;
+    use std::collections::BTreeSet;
+
+    use shardtree::store::ShardStore;
+    use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
+    use zcash_client_backend::data_api::testing::{
+        TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
+    };
+    use zcash_client_backend::data_api::{Account as _, WalletCommitmentTrees, WalletRead};
+    use zcash_pool_migration::engine::{
+        MigrationState, MigrationStatus, PoolMigrationRead, PoolMigrationWrite,
+    };
+    use zcash_pool_migration::note_splitting::NoteSplitPlan;
+    use zcash_pool_migration::preparation::PreparationPlan;
+    use zcash_pool_migration::scheduling::AnchorBucketInterval;
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::value::Zatoshis;
+
+    use super::PoolMigrations;
+    use crate::testing::{BlockCache, db::TestDbFactory};
+
+    /// A migration carrying no transactions, recorded as committed under `interval`. Only the
+    /// recorded grid matters here; the retention decision does not look at the transfers.
+    fn migration_committed_under(interval: AnchorBucketInterval) -> MigrationState {
+        MigrationState::from_parts(
+            MigrationStatus::Committed,
+            NoteSplitPlan::from_stored_parts(
+                Vec::new(),
+                Zatoshis::ZERO,
+                None,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+            )
+            .expect("an empty stored plan reconstructs"),
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            Vec::new(),
+            interval,
+        )
+    }
+
+    #[test]
+    fn misconfigured_reopen_keeps_retaining_the_committed_grid() {
+        let activation = zcash_protocol::consensus::BlockHeight::from_u32(100_000);
+        let network = zcash_protocol::local_consensus::LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        };
+
+        // The wallet is left at the ZIP 318 default: this stands for an application that
+        // configured a short grid when it committed, then reopened without reapplying it.
+        let mut st = TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+        assert_eq!(
+            st.wallet().anchor_retention_interval(),
+            AnchorRetentionInterval::ZIP_318,
+            "the wallet is configured with the default grid",
+        );
+
+        // Record a migration committed under a 12-block grid.
+        let committed = AnchorBucketInterval::custom(NonZeroU32::new(12).expect("nonzero"));
+        let account_id = st
+            .test_account()
+            .expect("the test account exists")
+            .account()
+            .id();
+        PoolMigrations::for_account(st.wallet_mut().conn_mut(), account_id)
+            .expect("the account exists")
+            .replace_migration(&migration_committed_under(committed))
+            .expect("persists the migration");
+
+        // Scan enough blocks to cross several boundaries of both grids. The account's birthday is
+        // the Sapling activation height, so the first generated block sits just above it.
+        let fvk = OrchardPoolTester::test_account_fvk(&st);
+        for _ in 0..600 {
+            let (h, _, _) = st.generate_next_block(
+                &fvk,
+                zcash_client_backend::data_api::testing::AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(10_000),
+            );
+            st.scan_cached_blocks(h, 1);
+        }
+        let tip = u32::from(
+            st.wallet()
+                .chain_height()
+                .expect("reads the chain height")
+                .expect("the wallet has a chain tip"),
+        );
+        let start = u32::from(activation);
+
+        let retained: BTreeSet<u32> = st
+            .wallet_mut()
+            .with_orchard_tree_mut(|tree| {
+                Ok::<_, crate::error::SqliteClientError>(
+                    tree.store()
+                        .retained_checkpoints()
+                        .expect("reads retained checkpoints"),
+                )
+            })
+            .expect("reads the Orchard tree")
+            .into_iter()
+            .map(u32::from)
+            .collect();
+
+        // Every boundary of the MIGRATION's grid in the scanned range was retained, despite the
+        // wallet being configured with a different one.
+        let expected_committed: BTreeSet<u32> = (start..=tip)
+            .filter(|h| h % 12 == 0 && *h > start)
+            .collect();
+        assert!(
+            expected_committed.is_subset(&retained),
+            "the committed 12-block grid must stay retained; missing {:?}",
+            expected_committed.difference(&retained).collect::<Vec<_>>(),
+        );
+
+        // The configured grid is retained too: the policy is the union, not a replacement.
+        let expected_configured: BTreeSet<u32> = (start..=tip)
+            .filter(|h| h % 144 == 0 && *h > start)
+            .collect();
+        assert!(
+            expected_configured.is_subset(&retained),
+            "the configured grid must also stay retained",
+        );
+
+        // Sanity: with no migration recorded, the 12-block grid would NOT have been retained, so
+        // the assertion above is load-bearing rather than incidentally true.
+        assert!(
+            !expected_committed.is_empty(),
+            "the scan must cross at least one boundary of the committed grid",
+        );
+        assert!(
+            PoolMigrations::for_account(st.wallet_mut().conn_mut(), account_id)
+                .expect("the account exists")
+                .get_migration()
+                .expect("reads the migration")
+                .is_some(),
+            "the migration is still recorded",
+        );
     }
 }
 

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -25,6 +25,7 @@
 
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::BTreeSet;
+use std::num::NonZeroU32;
 
 use rusqlite::{Connection, OptionalExtension, named_params, params};
 
@@ -35,6 +36,7 @@ use zcash_pool_migration::engine::{
 };
 use zcash_pool_migration::note_splitting::NoteSplitPlan;
 use zcash_pool_migration::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
+use zcash_pool_migration::scheduling::AnchorBucketInterval;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
 
@@ -87,7 +89,8 @@ fn create_migrations_sql(t: &Tables) -> String {
             note_split_change INTEGER,
             note_split_prep_fees INTEGER NOT NULL,
             note_split_total_input INTEGER NOT NULL,
-            note_split_total_migratable INTEGER NOT NULL
+            note_split_total_migratable INTEGER NOT NULL,
+            anchor_bucket_interval INTEGER NOT NULL
         )",
         t.migrations
     )
@@ -339,7 +342,7 @@ fn read_migration(
         .query_row(
             &format!(
                 "SELECT id, status, note_split_fee_buffer, note_split_change, note_split_prep_fees,
-                        note_split_total_input, note_split_total_migratable
+                        note_split_total_input, note_split_total_migratable, anchor_bucket_interval
                    FROM {} WHERE account_id = ?",
                 t.migrations
             ),
@@ -353,16 +356,28 @@ fn read_migration(
                     row.get::<_, u64>(4)?,
                     row.get::<_, u64>(5)?,
                     row.get::<_, u64>(6)?,
+                    row.get::<_, u32>(7)?,
                 ))
             },
         )
         .optional()?;
 
-    let Some((migration_id, status, fee_buffer, change, prep_fees, total_input, total_migratable)) =
-        row
+    let Some((
+        migration_id,
+        status,
+        fee_buffer,
+        change,
+        prep_fees,
+        total_input,
+        total_migratable,
+        anchor_bucket_interval,
+    )) = row
     else {
         return Ok(None);
     };
+    let anchor_bucket_interval = NonZeroU32::new(anchor_bucket_interval)
+        .map(AnchorBucketInterval::custom)
+        .ok_or(Error::Corrupt("anchor_bucket_interval"))?;
 
     let crossing_values = read_zatoshi_list(conn, t.crossing_values, migration_id)?;
     let note_split = NoteSplitPlan::from_stored_parts(
@@ -385,6 +400,7 @@ fn read_migration(
         note_split,
         preparation,
         transactions,
+        anchor_bucket_interval,
     )))
 }
 
@@ -741,8 +757,10 @@ fn replace_migration(
     tx.execute(
         &format!(
             "INSERT INTO {} (account_id, status, note_split_fee_buffer, note_split_change,
-                             note_split_prep_fees, note_split_total_input, note_split_total_migratable)
-             VALUES (:account_id, :status, :fee_buffer, :change, :prep_fees, :total_input, :total_migratable)",
+                             note_split_prep_fees, note_split_total_input, note_split_total_migratable,
+                             anchor_bucket_interval)
+             VALUES (:account_id, :status, :fee_buffer, :change, :prep_fees, :total_input, :total_migratable,
+                     :anchor_bucket_interval)",
             t.migrations
         ),
         named_params! {
@@ -753,6 +771,7 @@ fn replace_migration(
             ":prep_fees": ns.prep_fees().into_u64(),
             ":total_input": ns.total_input().into_u64(),
             ":total_migratable": ns.total_migratable().into_u64(),
+            ":anchor_bucket_interval": state.anchor_bucket_interval().block_count().get(),
         },
     )?;
     let migration_id = tx.last_insert_rowid();

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -333,6 +333,32 @@ fn resolve_migration_id(
         .optional()?)
 }
 
+/// The distinct anchor bucket intervals, in blocks, of every migration in `t.migrations` that is
+/// not yet complete — the grids the wallet still owes anchor-checkpoint retention to.
+///
+/// This is read from the database rather than from any in-memory configuration on purpose. A
+/// migration's transfers are anchored to boundaries of the grid it was COMMITTED under, and are
+/// provable only while those boundaries' checkpoints survive pruning. Were retention driven by a
+/// setting the application had to reapply on every open, forgetting to do so would let a scan pass
+/// a boundary the migration still needs without retaining it — unrecoverably, since the checkpoint
+/// is gone by the time anything notices.
+///
+/// A `complete` migration has no transfer left to prove, so its grid is dropped.
+pub(crate) fn active_anchor_bucket_intervals(
+    conn: &Connection,
+    t: &Tables,
+) -> Result<BTreeSet<NonZeroU32>, Error> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT DISTINCT anchor_bucket_interval FROM {} WHERE status <> ?",
+        t.migrations
+    ))?;
+    let rows = stmt.query_map(params![MigrationStatus::Complete.as_ref()], |row| {
+        row.get::<_, u32>(0)
+    })?;
+    rows.map(|blocks| NonZeroU32::new(blocks?).ok_or(Error::Corrupt("anchor_bucket_interval")))
+        .collect()
+}
+
 fn read_migration(
     conn: &Connection,
     t: &Tables,

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -22,6 +22,7 @@ use shardtree::{ShardTree, error::ShardTreeError};
 use zcash_client_backend::{
     data_api::{
         TargetValue,
+        anchor_retention::AnchorRetentionInterval,
         chain::{ChainState, CommitmentTreeRoot},
         error::{LockError, RewindError},
         scanning::{ScanPriority, ScanRange},
@@ -205,11 +206,15 @@ impl DataStoreFactory for TestDbFactory {
     fn new_data_store(
         &self,
         network: LocalNetwork,
+        anchor_retention_interval: Option<AnchorRetentionInterval>,
         #[cfg(feature = "transparent-inputs")] gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error> {
         let data_file = NamedTempFile::new().unwrap();
         let mut db_data =
             WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+        if let Some(interval) = anchor_retention_interval {
+            db_data = db_data.with_anchor_retention_interval(interval);
+        }
         #[cfg(feature = "transparent-inputs")]
         if let Some(gap_limits) = gap_limits {
             db_data = db_data.with_gap_limits(gap_limits);
@@ -234,6 +239,7 @@ impl Reset for TestDb {
 
     fn reset<C>(st: &mut TestState<C, Self, LocalNetwork>) -> NamedTempFile {
         let network = *st.network();
+        let anchor_retention_interval = st.wallet().db().anchor_retention_interval;
         #[cfg(feature = "transparent-inputs")]
         let gap_limits = st.wallet().db().gap_limits;
         let old_db = std::mem::replace(
@@ -241,6 +247,7 @@ impl Reset for TestDb {
             TestDbFactory::default()
                 .new_data_store(
                     network,
+                    Some(anchor_retention_interval),
                     #[cfg(feature = "transparent-inputs")]
                     Some(gap_limits),
                 )

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -2,13 +2,18 @@
 //!
 //! Generalised for sharing across the Sapling and Orchard implementations.
 
+use core::num::NonZeroU32;
+
 use crate::{
     SAPLING_TABLES_PREFIX,
     testing::{BlockCache, db::TestDbFactory},
 };
-use zcash_client_backend::data_api::testing::{
-    pool::{InputTrust, ShieldedPoolTester},
-    sapling::SaplingPoolTester,
+use zcash_client_backend::data_api::{
+    anchor_retention::AnchorRetentionInterval,
+    testing::{
+        pool::{InputTrust, ShieldedPoolTester},
+        sapling::SaplingPoolTester,
+    },
 };
 
 #[cfg(feature = "orchard")]
@@ -380,11 +385,19 @@ pub(crate) fn checkpoint_gaps<T: ShieldedPoolTester>() {
     )
 }
 
+/// Runs the deep-scan retention check at the ZIP 318 interval and at a short configured one, so
+/// that the wallet is shown to retain exactly the grid it was configured with rather than a
+/// hard-coded 144-block one.
 pub(crate) fn anchor_checkpoints_retained_across_deep_scan<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::anchor_checkpoints_retained_across_deep_scan::<
-        T,
-        _,
-    >(TestDbFactory::default(), BlockCache::new())
+    for interval in [
+        AnchorRetentionInterval::ZIP_318,
+        AnchorRetentionInterval::custom(NonZeroU32::new(12).expect("nonzero")),
+    ] {
+        zcash_client_backend::data_api::testing::pool::anchor_checkpoints_retained_across_deep_scan::<
+            T,
+            _,
+        >(TestDbFactory::default(), BlockCache::new(), interval)
+    }
 }
 
 #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -92,6 +92,7 @@ use zcash_client_backend::{
         AddressSource, BlockMetadata, Progress, Ratio, ReceivedTransactionOutput,
         SAPLING_SHARD_HEIGHT, SentTransaction, SentTransactionOutput, TransactionDataRequest,
         TransactionStatus, WalletSummary, Zip32Derivation,
+        anchor_retention::AnchorRetentionInterval,
         chain::ChainState,
         defaults::address_receiver_matches_ua,
         error::{FindAccountForAddressError, RewindError},
@@ -4164,6 +4165,9 @@ pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
             params: params.clone(),
             clock: (),
             rng: (),
+            // Truncation removes checkpoints; it never establishes them, so no anchor retention
+            // decision is made through this handle and the interval is immaterial.
+            anchor_retention_interval: AnchorRetentionInterval::default(),
             #[cfg(feature = "transparent-inputs")]
             gap_limits: *gap_limits,
         };

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -605,6 +605,11 @@ CREATE INDEX idx_ironwood_received_note_spends_transaction_id ON ironwood_receiv
 /// `account_id` is enforced unique by `INDEX_ORCHARD_IRONWOOD_MIGRATIONS_ACCOUNT`, so an account
 /// has at most one migration in progress. It is a foreign key into `accounts` with `ON DELETE
 /// CASCADE`, so deleting an account removes its migration (and its child rows cascade in turn).
+///
+/// `anchor_bucket_interval` records the anchor retention grid the migration was committed against,
+/// in blocks. Every transfer's `anchor_boundary` lies on that grid, and it is provable only while
+/// the wallet still retains those checkpoints, so a mismatch against the wallet's current interval
+/// is reported as an error rather than left to surface as a missing checkpoint at proving time.
 pub(super) const TABLE_ORCHARD_IRONWOOD_MIGRATIONS: &str = "
 CREATE TABLE orchard_ironwood_migrations (
     id INTEGER PRIMARY KEY,
@@ -614,7 +619,8 @@ CREATE TABLE orchard_ironwood_migrations (
     note_split_change INTEGER,
     note_split_prep_fees INTEGER NOT NULL,
     note_split_total_input INTEGER NOT NULL,
-    note_split_total_migratable INTEGER NOT NULL
+    note_split_total_migratable INTEGER NOT NULL,
+    anchor_bucket_interval INTEGER NOT NULL
 )";
 /// The note-split crossing values (an ordered list of zatoshi amounts). The funding-note values
 /// have no table of their own: each is its crossing value plus the note-split fee buffer.

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
@@ -8,6 +8,8 @@ use uuid::Uuid;
 use zcash_client_backend::data_api::WalletCommitmentTrees;
 use zcash_protocol::consensus::{self, BlockHeight, NetworkUpgrade};
 
+use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
+
 use crate::{
     error::SqliteClientError,
     wallet::{
@@ -207,6 +209,9 @@ fn truncate_to_height<P: consensus::Parameters>(
             params: params.clone(),
             clock: (),
             rng: (),
+            // Truncation removes checkpoints; it never establishes them, so no anchor retention
+            // decision is made through this handle and the interval is immaterial.
+            anchor_retention_interval: AnchorRetentionInterval::default(),
             #[cfg(feature = "transparent-inputs")]
             gap_limits: *gap_limits,
         };

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -86,6 +86,21 @@ pub trait MigrationBackend {
 
     /// The current chain-tip height, from which the transfer schedule's delays accumulate.
     fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error>;
+
+    /// The parameters this backend's migrations are scheduled under: the anchor bucket grid and the
+    /// transfer and preparation inter-arrival delays.
+    ///
+    /// The engine never takes these as its own argument; it asks the backend, because the anchor
+    /// bucket interval is not free to choose. A transfer proves against the note commitment tree
+    /// state at the boundary it anchored to, which requires the wallet to have RETAINED that
+    /// boundary's checkpoint. Sourcing the interval from the same backend that performs the
+    /// retention is what makes the two grids incapable of disagreeing; a backend that returns an
+    /// interval it does not retain on will produce transfers it cannot prove.
+    ///
+    /// A backend on the production network must return [`SchedulingParams::ZIP_318`].
+    ///
+    /// [`SchedulingParams::ZIP_318`]: crate::scheduling::SchedulingParams::ZIP_318
+    fn scheduling_params(&self) -> crate::scheduling::SchedulingParams;
 }
 
 /// Read access to a persisted pool migration: the store side of the migration interface, mirroring
@@ -693,6 +708,9 @@ where
     let commit_height = backend
         .chain_tip_height()
         .map_err(MigrationError::Backend)?;
+    // The anchor grid and delay distributions come from the backend, not from this function's
+    // caller: the grid must be the one the backend retains its anchor checkpoints on.
+    let sched_params = backend.scheduling_params();
 
     // The canonical fees, computed once from the canonical transaction shapes and reused throughout.
     let (prep_tx_fee, transfer_fee_buffer) =
@@ -732,7 +750,7 @@ where
     let mut layer_base = commit_height;
     for layer in preparation.layers() {
         let heights = scheduling::schedule_prep_broadcast_heights(
-            &scheduling::SchedulingParams::ZIP_318,
+            &sched_params,
             layer_base,
             layer.len(),
             rng,
@@ -754,7 +772,7 @@ where
         .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
         .ok_or(MigrationError::Nu63NotActive)?;
     let schedule_base = commit_height.max(scheduling::earliest_broadcast_height(
-        scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+        sched_params.anchor_bucket_interval(),
         nu63_activation,
         est_last_prep_height,
     ));
@@ -764,12 +782,7 @@ where
     // temporal sequence an observer could read the balance back out of. Drawing a uniform
     // permutation and assigning the i-th drawn slot to the permuted crossing makes the
     // broadcast order of denominations independent of the balance.
-    let slots = scheduling::schedule(
-        &scheduling::SchedulingParams::ZIP_318,
-        schedule_base,
-        funding_notes.len(),
-        rng,
-    );
+    let slots = scheduling::schedule(&sched_params, schedule_base, funding_notes.len(), rng);
     let mut schedule = slots.clone();
     for (slot, &crossing) in scheduling::shuffle_indices(funding_notes.len(), rng)
         .iter()
@@ -1657,13 +1670,11 @@ where
 
     // Reschedule the part with a fresh memoryless delay from the current tip, and derive its new
     // canonical expiry and a fresh boundary anchor for that schedule.
-    let scheduled_height = target_height
-        + scheduling::SchedulingParams::ZIP_318
-            .transfer_delay()
-            .draw(&mut *rng);
+    let sched_params = backend.scheduling_params();
+    let scheduled_height = target_height + sched_params.transfer_delay().draw(&mut *rng);
     let expiry_height = scheduling::expiry_height(scheduled_height);
     let anchor_boundary = scheduling::draw_anchor_boundary(
-        scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+        sched_params.anchor_bucket_interval(),
         nu63_activation,
         funding_creation,
         scheduled_height,
@@ -2285,6 +2296,9 @@ where
             .params
             .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
             .ok_or(CommitError::Nu63NotActive)?;
+        // The grid to draw from is the backend's, so the boundary each transfer anchors to is one
+        // whose checkpoint that backend retains.
+        let anchor_bucket_interval = self.backend.scheduling_params().anchor_bucket_interval();
         for (crossing, schedule) in plan.schedule().iter().enumerate() {
             let id = self.next_id();
 
@@ -2333,7 +2347,7 @@ where
             )
             .map_err(CommitError::Build)?;
             let anchor_boundary = scheduling::draw_anchor_boundary(
-                scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+                anchor_bucket_interval,
                 nu63_activation,
                 est_last_prep_height,
                 schedule.broadcast_height(),
@@ -2447,6 +2461,7 @@ mod tests {
         notes: Vec<Zatoshis>,
         tip: BlockHeight,
         stored: Option<MigrationState>,
+        sched_params: crate::scheduling::SchedulingParams,
     }
 
     impl MockBackend {
@@ -2458,6 +2473,7 @@ mod tests {
                     .collect(),
                 tip: BlockHeight::from_u32(tip),
                 stored: None,
+                sched_params: crate::scheduling::SchedulingParams::ZIP_318,
             }
         }
     }
@@ -2471,6 +2487,10 @@ mod tests {
 
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
             Ok(self.tip)
+        }
+
+        fn scheduling_params(&self) -> crate::scheduling::SchedulingParams {
+            self.sched_params
         }
     }
 
@@ -2822,6 +2842,7 @@ mod commit_tests {
         ask: SpendAuthorizingKey,
         stored: Option<MigrationState>,
         tip: BlockHeight,
+        sched_params: crate::scheduling::SchedulingParams,
     }
 
     impl CommitMock {
@@ -2840,6 +2861,7 @@ mod commit_tests {
                 ask: SpendAuthorizingKey::from(&sk),
                 stored: None,
                 tip: BlockHeight::from_u32(2_000_000),
+                sched_params: crate::scheduling::SchedulingParams::ZIP_318,
             }
         }
     }
@@ -2857,6 +2879,10 @@ mod commit_tests {
 
         fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
             Ok(self.tip)
+        }
+
+        fn scheduling_params(&self) -> crate::scheduling::SchedulingParams {
+            self.sched_params
         }
     }
 
@@ -3477,6 +3503,7 @@ mod commit_tests {
             ask: SpendAuthorizingKey::from(&sk),
             stored: None,
             tip: BlockHeight::from_u32(2_000_000),
+            sched_params: crate::scheduling::SchedulingParams::ZIP_318,
         };
         let params = regtest_network(true);
         let prep_count = plan.preparation().transaction_count();

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -555,7 +555,8 @@ impl MigrationPlan {
     /// The preparation broadcast schedule, one height per preparation transaction, in the same
     /// `[layer][index]` shape as [`preparation`](Self::preparation)'s layers: exponential
     /// inter-arrival delays with the tighter preparation spacing (see
-    /// [`scheduling::PREP_MEAN_DELAY`]), each layer based past
+    /// [`SchedulingParams::preparation_delay`](scheduling::SchedulingParams::preparation_delay)),
+    /// each layer based past
     /// the previous layer's last height plus a mining margin, so the transactions are temporally
     /// decoupled from one another while the layers stay serialized.
     pub fn prep_schedule(&self) -> &[Vec<BlockHeight>] {
@@ -730,7 +731,12 @@ where
     let mut prep_schedule: Vec<Vec<BlockHeight>> = Vec::with_capacity(preparation.layer_count());
     let mut layer_base = commit_height;
     for layer in preparation.layers() {
-        let heights = scheduling::schedule_prep_broadcast_heights(layer_base, layer.len(), rng);
+        let heights = scheduling::schedule_prep_broadcast_heights(
+            &scheduling::SchedulingParams::ZIP_318,
+            layer_base,
+            layer.len(),
+            rng,
+        );
         layer_base = heights.last().copied().unwrap_or(layer_base) + EST_PREP_LAYER_MINING_BLOCKS;
         prep_schedule.push(heights);
     }
@@ -748,6 +754,7 @@ where
         .activation_height(zcash_protocol::consensus::NetworkUpgrade::Nu6_3)
         .ok_or(MigrationError::Nu63NotActive)?;
     let schedule_base = commit_height.max(scheduling::earliest_broadcast_height(
+        scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
         nu63_activation,
         est_last_prep_height,
     ));
@@ -757,7 +764,12 @@ where
     // temporal sequence an observer could read the balance back out of. Drawing a uniform
     // permutation and assigning the i-th drawn slot to the permuted crossing makes the
     // broadcast order of denominations independent of the balance.
-    let slots = scheduling::schedule(schedule_base, funding_notes.len(), rng);
+    let slots = scheduling::schedule(
+        &scheduling::SchedulingParams::ZIP_318,
+        schedule_base,
+        funding_notes.len(),
+        rng,
+    );
     let mut schedule = slots.clone();
     for (slot, &crossing) in scheduling::shuffle_indices(funding_notes.len(), rng)
         .iter()
@@ -1645,11 +1657,19 @@ where
 
     // Reschedule the part with a fresh memoryless delay from the current tip, and derive its new
     // canonical expiry and a fresh boundary anchor for that schedule.
-    let scheduled_height = target_height + scheduling::draw_delay(&mut *rng);
+    let scheduled_height = target_height
+        + scheduling::SchedulingParams::ZIP_318
+            .transfer_delay()
+            .draw(&mut *rng);
     let expiry_height = scheduling::expiry_height(scheduled_height);
-    let anchor_boundary =
-        scheduling::draw_anchor_boundary(nu63_activation, funding_creation, scheduled_height, rng)
-            .ok_or(RebuildError::NoCandidateAnchor)?;
+    let anchor_boundary = scheduling::draw_anchor_boundary(
+        scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+        nu63_activation,
+        funding_creation,
+        scheduled_height,
+        rng,
+    )
+    .ok_or(RebuildError::NoCandidateAnchor)?;
 
     // Build the entirely new transfer against the same funding note and crossing value; anchors
     // and witnesses stay deferred (installed at proving time, ZIP 374). The expired artifact
@@ -2313,6 +2333,7 @@ where
             )
             .map_err(CommitError::Build)?;
             let anchor_boundary = scheduling::draw_anchor_boundary(
+                scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
                 nu63_activation,
                 est_last_prep_height,
                 schedule.broadcast_height(),
@@ -2518,8 +2539,11 @@ mod tests {
             .copied()
             .unwrap_or(BlockHeight::from_u32(2_000_000))
             + EST_PREP_LAYER_MINING_BLOCKS;
-        let earliest =
-            crate::scheduling::earliest_broadcast_height(BlockHeight::from_u32(10), est_last_prep);
+        let earliest = crate::scheduling::earliest_broadcast_height(
+            crate::scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+            BlockHeight::from_u32(10),
+            est_last_prep,
+        );
         assert!(
             plan.schedule()
                 .iter()
@@ -3003,15 +3027,12 @@ mod commit_tests {
                         tx.anchor_boundary
                             .expect("every transfer carries its boundary"),
                     );
-                    assert_eq!(b % crate::scheduling::BOUNDARY_MODULUS, 0);
+                    let interval =
+                        crate::scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval();
+                    assert!(interval.is_boundary(BlockHeight::from_u32(b)));
                     assert!(b > 10, "boundary above the regtest NU6.3 activation");
-                    assert!(
-                        b >= u32::from(est_last_prep).div_ceil(crate::scheduling::BOUNDARY_MODULUS)
-                            * crate::scheduling::BOUNDARY_MODULUS
-                    );
-                    assert!(
-                        b < u32::from(crate::scheduling::most_recent_boundary(tx.scheduled_height))
-                    );
+                    assert!(b >= u32::from(interval.boundary_at_or_above(est_last_prep)));
+                    assert!(b < u32::from(interval.boundary_at_or_below(tx.scheduled_height)));
                 }
             }
         }
@@ -3097,13 +3118,9 @@ mod commit_tests {
             new.anchor_boundary
                 .expect("the rebuilt transfer carries a boundary"),
         );
-        assert_eq!(boundary % crate::scheduling::BOUNDARY_MODULUS, 0);
-        assert!(
-            boundary
-                < u32::from(crate::scheduling::most_recent_boundary(
-                    new.scheduled_height
-                ))
-        );
+        let interval = crate::scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval();
+        assert!(interval.is_boundary(BlockHeight::from_u32(boundary)));
+        assert!(boundary < u32::from(interval.boundary_at_or_below(new.scheduled_height)));
 
         // The rebuilt PCZT is a valid pre-signed transfer with deferred anchors and the new expiry.
         let parsed = pczt::Pczt::parse(&new.pczt).expect("the rebuilt PCZT parses");
@@ -3419,6 +3436,7 @@ mod commit_tests {
         let mut layer_base = BlockHeight::from_u32(2_000_000);
         for layer in preparation.layers() {
             let heights = crate::scheduling::schedule_prep_broadcast_heights(
+                &crate::scheduling::SchedulingParams::ZIP_318,
                 layer_base,
                 layer.len(),
                 &mut rng,
@@ -3435,9 +3453,17 @@ mod commit_tests {
                 .activation_height(NetworkUpgrade::Nu6_3)
                 .expect("NU6.3 is active on the test network")
         };
-        let schedule_base =
-            crate::scheduling::earliest_broadcast_height(nu63_activation, layer_base);
-        let schedule = crate::scheduling::schedule(schedule_base, funding.len(), &mut rng);
+        let schedule_base = crate::scheduling::earliest_broadcast_height(
+            crate::scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval(),
+            nu63_activation,
+            layer_base,
+        );
+        let schedule = crate::scheduling::schedule(
+            &crate::scheduling::SchedulingParams::ZIP_318,
+            schedule_base,
+            funding.len(),
+            &mut rng,
+        );
         let plan = MigrationPlan {
             note_split,
             preparation,

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -494,6 +494,16 @@ pub struct MigrationState {
     /// Every migration transaction, in dependency order.
     #[getset(get = "pub")]
     pub(crate) transactions: Vec<MigrationTransaction>,
+    /// The anchor bucket grid this migration was COMMITTED under, recorded so a later change to the
+    /// wallet's anchor retention interval is caught as a typed error rather than surfacing as an
+    /// unexplained missing checkpoint.
+    ///
+    /// Every transfer's [`anchor_boundary`](MigrationTransaction::anchor_boundary) lies on this
+    /// grid. If the wallet is subsequently reconfigured, it stops retaining these boundaries'
+    /// checkpoints and they are pruned, at which point the committed transfers become unprovable —
+    /// so [`prove_transfer`] and the rebuild path reject the mismatch up front.
+    #[getset(get_copy = "pub")]
+    pub(crate) anchor_bucket_interval: crate::scheduling::AnchorBucketInterval,
 }
 
 impl MigrationState {
@@ -504,12 +514,14 @@ impl MigrationState {
         note_split: NoteSplitPlan,
         preparation: PreparationPlan,
         transactions: Vec<MigrationTransaction>,
+        anchor_bucket_interval: crate::scheduling::AnchorBucketInterval,
     ) -> Self {
         Self {
             status,
             note_split,
             preparation,
             transactions,
+            anchor_bucket_interval,
         }
     }
 
@@ -1154,6 +1166,15 @@ pub trait MigrationProver {
         pczt: pczt::Pczt,
         anchor: BlockHeight,
     ) -> Result<pczt::Pczt, Self::Error>;
+
+    /// The anchor bucket grid the wallet backing this prover currently retains its durable anchor
+    /// checkpoints on.
+    ///
+    /// [`prove_transfer`] compares this against the grid the migration was committed under and
+    /// refuses to prove a transfer whose boundary is no longer retained, so a reconfiguration
+    /// mid-migration surfaces as [`ProveError::AnchorIntervalMismatch`] rather than as a bare
+    /// missing checkpoint at witness-resolution time.
+    fn anchor_bucket_interval(&self) -> crate::scheduling::AnchorBucketInterval;
 }
 
 /// Why committing a migration's preparation failed.
@@ -1239,6 +1260,16 @@ pub enum ProveError<E> {
     /// A transfer carries no anchor boundary. Every transfer draws one at scheduling time, so this
     /// indicates a corrupt stored state rather than a normal condition.
     NoAnchorBoundary(MigrationTxId),
+    /// The wallet's anchor retention grid has changed since this migration was committed, so the
+    /// boundaries its transfers anchored to are no longer retained and their checkpoints will have
+    /// been pruned. The migration cannot be proved and must be re-planned under the current grid
+    /// (or the wallet reconfigured back to the committed one).
+    AnchorIntervalMismatch {
+        /// The grid the migration was committed under.
+        committed: crate::scheduling::AnchorBucketInterval,
+        /// The grid the wallet retains on now.
+        configured: crate::scheduling::AnchorBucketInterval,
+    },
     /// The stored PCZT could not be parsed.
     Parse(pczt::ParseError),
     /// The proven PCZT could not be serialized.
@@ -1275,6 +1306,17 @@ impl<E: fmt::Display> fmt::Display for ProveError<E> {
                 f,
                 "transfer {} has no drawn anchor boundary; the stored state is inconsistent",
                 u32::from(*id)
+            ),
+            ProveError::AnchorIntervalMismatch {
+                committed,
+                configured,
+            } => write!(
+                f,
+                "the migration was committed against a {}-block anchor bucket grid, but the wallet \
+                 now retains anchors on a {}-block grid; its transfers' anchors are no longer \
+                 retained",
+                committed.block_count(),
+                configured.block_count()
             ),
             ProveError::Parse(e) => write!(f, "parsing the stored PCZT failed: {e:?}"),
             ProveError::Serialize(e) => write!(f, "serializing the proven PCZT failed: {e:?}"),
@@ -1324,6 +1366,17 @@ where
     let anchor_boundary = tx
         .anchor_boundary()
         .ok_or(ProveError::NoAnchorBoundary(id))?;
+
+    // The stored boundary is only provable while the wallet still retains its checkpoint, which it
+    // does only if it is still retaining on the grid the migration was committed under.
+    let committed = state.anchor_bucket_interval();
+    let configured = prover.anchor_bucket_interval();
+    if committed != configured {
+        return Err(ProveError::AnchorIntervalMismatch {
+            committed,
+            configured,
+        });
+    }
 
     let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
     let proven = prover
@@ -1417,6 +1470,16 @@ pub enum RebuildError<E> {
     /// No candidate anchor boundary exists for the rebuilt schedule (the same stale condition
     /// [`CommitError::StalePlan`] models at commit time): the migration must be re-planned.
     NoCandidateAnchor,
+    /// The backend's anchor bucket grid has changed since this migration was committed. Rebuilding
+    /// would draw the replacement transfer's anchor from the NEW grid while its siblings remain on
+    /// the old one, leaving the migration anchored to two grids of which the wallet retains only
+    /// one. The migration must be re-planned instead.
+    AnchorIntervalMismatch {
+        /// The grid the migration was committed under.
+        committed: crate::scheduling::AnchorBucketInterval,
+        /// The grid the backend schedules against now.
+        configured: crate::scheduling::AnchorBucketInterval,
+    },
     /// Building the fresh transfer PCZT failed.
     Build(crate::build::BuildError),
     /// Serializing the rebuilt PCZT failed.
@@ -1455,6 +1518,16 @@ impl<E: fmt::Display> fmt::Display for RebuildError<E> {
             RebuildError::NoCandidateAnchor => f.write_str(
                 "no candidate anchor boundary exists for the rebuilt schedule; the migration must \
                  be re-planned",
+            ),
+            RebuildError::AnchorIntervalMismatch {
+                committed,
+                configured,
+            } => write!(
+                f,
+                "the migration was committed against a {}-block anchor bucket grid, but the backend \
+                 now schedules against a {}-block grid; the migration must be re-planned",
+                committed.block_count(),
+                configured.block_count()
             ),
             RebuildError::Build(e) => write!(f, "rebuilding the transfer failed: {e}"),
             RebuildError::Serialize(e) => {
@@ -1566,6 +1639,20 @@ where
     B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
     R: RngCore + rand_core::CryptoRng,
 {
+    // A rebuilt transfer draws a fresh anchor. If the backend's grid has moved since the commit,
+    // that anchor would sit on a different grid from its siblings', leaving the migration anchored
+    // to two grids of which the wallet retains only one — so the whole migration must be re-planned.
+    // This invalidates every transfer, not just this one, so it is checked before any condition
+    // specific to `id`.
+    let sched_params = backend.scheduling_params();
+    let committed_interval = state.anchor_bucket_interval();
+    if committed_interval != sched_params.anchor_bucket_interval() {
+        return Err(RebuildError::AnchorIntervalMismatch {
+            committed: committed_interval,
+            configured: sched_params.anchor_bucket_interval(),
+        });
+    }
+
     // The height of the next block this transfer could be mined into, against which expiry is judged.
     let target_height = backend.chain_tip_height().map_err(RebuildError::Backend)? + 1;
 
@@ -1670,7 +1757,6 @@ where
 
     // Reschedule the part with a fresh memoryless delay from the current tip, and derive its new
     // canonical expiry and a fresh boundary anchor for that schedule.
-    let sched_params = backend.scheduling_params();
     let scheduled_height = target_height + sched_params.transfer_delay().draw(&mut *rng);
     let expiry_height = scheduling::expiry_height(scheduled_height);
     let anchor_boundary = scheduling::draw_anchor_boundary(
@@ -2390,6 +2476,9 @@ where
             note_split: plan.note_split().clone(),
             preparation: plan.preparation().clone(),
             transactions: self.transactions,
+            // Stamp the grid the transfers were anchored to, so a later reconfiguration of the
+            // backend is detectable rather than silently invalidating them.
+            anchor_bucket_interval: self.backend.scheduling_params().anchor_bucket_interval(),
         };
         CommitOutput {
             state,
@@ -2774,6 +2863,7 @@ mod tests {
             note_split,
             preparation: crate::preparation::PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions: vec![tx],
+            anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
         };
         backend.replace_migration(&state).unwrap();
 
@@ -2946,6 +3036,10 @@ mod commit_tests {
             // passing the persisted `anchor_boundary`, and the Signed -> Proved transition) is what
             // the tests exercise.
             Ok(pczt)
+        }
+
+        fn anchor_bucket_interval(&self) -> crate::scheduling::AnchorBucketInterval {
+            self.sched_params.anchor_bucket_interval()
         }
 
         fn prove_preparation(
@@ -3977,5 +4071,76 @@ mod commit_tests {
             prove_transfer(&mut backend, &mut state, prep_id),
             Err(ProveError::NotATransfer(_))
         ));
+    }
+
+    /// A committed migration records the anchor bucket grid it was scheduled against, and both the
+    /// proving and rebuild paths refuse to act once the backend's grid has moved.
+    ///
+    /// Without this, a wallet reconfigured mid-migration would stop retaining the boundaries its
+    /// transfers anchored to; the failure would only appear much later, as an unexplained missing
+    /// checkpoint at witness-resolution time.
+    #[test]
+    fn a_changed_anchor_grid_is_rejected_rather_than_left_unprovable() {
+        use crate::scheduling::{AnchorBucketInterval, SchedulingParams};
+        use core::num::NonZeroU32;
+
+        let seed = 7u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+        let params = regtest_network(true);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration");
+
+        // The grid the backend was committed under is recorded on the state.
+        let committed = AnchorBucketInterval::ZIP_318;
+        assert_eq!(state.anchor_bucket_interval(), committed);
+
+        // Reconfigure the backend onto a different grid, as an application would by changing its
+        // wallet's anchor retention interval.
+        let moved = AnchorBucketInterval::custom(NonZeroU32::new(12).expect("nonzero"));
+        backend.sched_params = SchedulingParams::new(
+            moved,
+            SchedulingParams::ZIP_318.transfer_delay(),
+            SchedulingParams::ZIP_318.preparation_delay(),
+        );
+
+        let transfer_id = state
+            .transactions
+            .iter()
+            .find(|t| matches!(t.kind, MigrationTxKind::Transfer { .. }))
+            .expect("a committed migration has transfers")
+            .id;
+
+        // Proving reports the mismatch instead of resolving a boundary the wallet no longer retains.
+        assert!(matches!(
+            prove_transfer(&mut backend, &mut state, transfer_id),
+            Err(ProveError::AnchorIntervalMismatch {
+                committed: c,
+                configured: g,
+            }) if c == committed && g == moved
+        ));
+
+        // Rebuilding is rejected too, ahead of any per-transfer condition: a fresh anchor would
+        // come from the new grid while the siblings' remain on the old one, so the whole migration
+        // is invalid rather than this transfer being repairable.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, transfer_id, &mut rng),
+            Err(RebuildError::AnchorIntervalMismatch {
+                committed: c,
+                configured: g,
+            }) if c == committed && g == moved
+        ));
+
+        // Restoring the committed grid makes the migration provable again.
+        backend.sched_params = SchedulingParams::ZIP_318;
+        prove_transfer(&mut backend, &mut state, transfer_id)
+            .expect("the transfer proves once the grid matches again");
     }
 }

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -147,6 +147,26 @@ impl Default for AnchorBucketInterval {
     }
 }
 
+/// The grid a `zcash_client_backend` wallet retains its durable anchor checkpoints on is exactly
+/// the grid a migration over that wallet may anchor to, so the two are freely interconvertible.
+/// Converting rather than configuring the migration separately is what keeps them from diverging.
+#[cfg(feature = "wallet")]
+impl From<zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval>
+    for AnchorBucketInterval
+{
+    fn from(
+        interval: zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval,
+    ) -> Self {
+        Self(interval.block_count())
+    }
+}
+
+// The reverse conversion is deliberately absent. The wallet is the authority on the grid — it is
+// the side that retains the checkpoints — so a migration derives its interval from a wallet, never
+// the other way around. Constructing a non-ZIP-318 retention interval goes through
+// `AnchorRetentionInterval::custom`, which `zcash_client_backend` gates behind its `unstable`
+// feature precisely so that choosing a non-standard grid is a deliberate act.
+
 /// A truncated exponential inter-arrival delay distribution, in blocks: draws have mean
 /// [`Self::mean`], and a draw exceeding [`Self::cap`] is discarded and redrawn (truncating the
 /// exponential's heavy tail, so nothing is starved for an unbounded time).

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -24,13 +24,13 @@
 //!
 //! 1. SHUFFLE ([`shuffle_indices`]): the quantized parts are broadcast in a uniformly random order,
 //!    so the temporal sequence of denominations is independent of the balance.
-//! 2. DELAYS ([`draw_delay`]): the gap between successive transfers is an exponential inter-arrival
-//!    time (mean [`MEAN_DELAY`], capped at [`MAX_DELAY`]), so broadcasts look like an unremarkable
-//!    Poisson process rather than a burst.
+//! 2. DELAYS ([`DelayDistribution::draw`]): the gap between successive transfers is an exponential
+//!    inter-arrival time (mean and cap given by [`SchedulingParams::transfer_delay`]), so broadcasts
+//!    look like an unremarkable Poisson process rather than a burst.
 //! 3. CUMULATIVE ([`schedule_broadcast_heights`]): each transfer's scheduled height is the running
 //!    sum of independent delays from the commit height.
 //! 4. ANCHOR ([`draw_anchor_boundary`]): at PROVING time each transfer proves against the Orchard
-//!    tree state at a BOUNDARY block (height congruent to 0 mod [`BOUNDARY_MODULUS`]), chosen from a
+//!    tree state at a BOUNDARY block (a multiple of the [`AnchorBucketInterval`]), chosen from a
 //!    recency-weighted geometric draw over the candidate boundaries, so transfers share a small set
 //!    of common anchors (cohorts) instead of each pinning the latest state.
 //! 5. EXPIRY ([`expiry_height`]): a canonical rolling window gives every transfer 1 to 2 months of
@@ -63,38 +63,271 @@
 //! [ZIP 318]: https://zips.z.cash/zip-0318
 
 use alloc::vec::Vec;
+use core::num::NonZeroU32;
 
 use rand_core::{CryptoRng, RngCore};
 use zcash_protocol::consensus::BlockHeight;
 
-/// Mean of the exponential inter-arrival delay between successive transfers, in blocks. Also the
-/// [`BOUNDARY_MODULUS`]. 144 blocks is about three hours at the Zcash ~75-second target spacing.
-/// The exponential rate is `lambda = 1 / MEAN_DELAY`. See [`draw_delay`].
-pub const MEAN_DELAY: u32 = 144;
+/// The block-height grid defining the BOUNDARY blocks: a height `h` is a boundary iff `h` is a
+/// multiple of this interval. Boundaries are the only tree states a transfer may anchor to, so many
+/// transfers share a small, common set of anchors (cohorts) rather than each pinning a unique
+/// recent block. See [`draw_anchor_boundary`].
+///
+/// The wallet that will prove a transfer must have RETAINED the checkpoint at the boundary the
+/// transfer anchors to, so this interval must equal the one on which that wallet retains its
+/// durable anchors. A migration run over a `zcash_client_backend` wallet obtains it by converting
+/// the wallet's own `AnchorRetentionInterval` (see the `From` implementations available under the
+/// `wallet` feature), which is what keeps the two grids from diverging.
+///
+/// The interval is a modulus, so it is necessarily non-zero.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AnchorBucketInterval(NonZeroU32);
 
-/// Upper bound (inclusive) on a single inter-arrival delay, in blocks. A draw exceeding this is
-/// discarded and redrawn (truncating the exponential's heavy tail), so no transfer is starved for
-/// an unbounded time. 576 blocks is `4 * MEAN_DELAY`, about twelve hours. See [`draw_delay`].
-pub const MAX_DELAY: u32 = 576;
+impl AnchorBucketInterval {
+    /// The interval specified by [ZIP 318]: 144 blocks, about three hours at the Zcash ~75-second
+    /// target block spacing.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    pub const ZIP_318: Self = Self(NonZeroU32::new(144).expect("144 is nonzero"));
 
-/// Mean of the exponential inter-arrival delay between successive PREPARATION transactions, in
-/// blocks (~30 minutes at the ~75-second target spacing). Preparation transactions are fully
-/// shielded self-sends: they need TEMPORAL decoupling from one another (a burst of identically
-/// shaped transactions from one wallet is a linkable cluster), but no anchor bucketing — only the
-/// pool-crossing transfers anchor to boundaries — so their spacing can be much tighter than the
-/// transfers' [`MEAN_DELAY`]. Provisional; not yet specified by ZIP 318.
-pub const PREP_MEAN_DELAY: u32 = 24;
+    /// Constructs an interval other than the [ZIP 318] one, for use on test networks.
+    ///
+    /// A migration on the production network MUST use [`Self::ZIP_318`]: the anonymity set a shared
+    /// anchor provides is exactly the set of transfers that chose the same boundary, so a wallet
+    /// anchoring to a different grid than its peers is distinguishable from them.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    pub const fn custom(blocks: NonZeroU32) -> Self {
+        Self(blocks)
+    }
 
-/// Upper bound (inclusive) on a single preparation inter-arrival delay, in blocks: `4 *
-/// PREP_MEAN_DELAY` (~2 hours), the same tail-truncation ratio as the transfers' [`MAX_DELAY`].
-/// A draw exceeding this is discarded and redrawn. Provisional; not yet specified by ZIP 318.
-pub const PREP_MAX_DELAY: u32 = 4 * PREP_MEAN_DELAY;
+    /// Returns the interval as a number of blocks.
+    pub fn block_count(&self) -> NonZeroU32 {
+        self.0
+    }
 
-/// Block-height modulus defining the BOUNDARY blocks: a height `h` is a boundary iff
-/// `h % BOUNDARY_MODULUS == 0`. Boundaries are the only tree states a transfer may anchor to, so
-/// many transfers share a small, common set of anchors (cohorts) rather than each pinning a unique
-/// recent block. Equal to [`MEAN_DELAY`] (~three hours). See [`draw_anchor_boundary`].
-pub const BOUNDARY_MODULUS: u32 = MEAN_DELAY;
+    /// Returns whether `height` is a boundary of this interval.
+    pub fn is_boundary(&self, height: BlockHeight) -> bool {
+        u32::from(height) % self.0 == 0
+    }
+
+    /// Returns the greatest boundary height that does not exceed `height`, i.e. `height` rounded
+    /// DOWN to a multiple of this interval.
+    pub fn boundary_at_or_below(&self, height: BlockHeight) -> BlockHeight {
+        BlockHeight::from_u32(self.boundary_at_or_below_u32(u32::from(height)))
+    }
+
+    /// [`Self::boundary_at_or_below`] on the raw `u32` representation, for internal boundary
+    /// arithmetic.
+    fn boundary_at_or_below_u32(&self, height: u32) -> u32 {
+        height - (height % self.0)
+    }
+
+    /// Returns the least boundary height that is not below `height`, i.e. `height` rounded UP to a
+    /// multiple of this interval. Saturates at [`u32::MAX`].
+    pub fn boundary_at_or_above(&self, height: BlockHeight) -> BlockHeight {
+        BlockHeight::from_u32(self.boundary_at_or_above_u32(u32::from(height)))
+    }
+
+    /// [`Self::boundary_at_or_above`] on the raw `u32` representation, for internal boundary
+    /// arithmetic.
+    fn boundary_at_or_above_u32(&self, height: u32) -> u32 {
+        let r = height % self.0;
+        if r == 0 {
+            height
+        } else {
+            height.saturating_add(self.0.get() - r)
+        }
+    }
+}
+
+impl Default for AnchorBucketInterval {
+    fn default() -> Self {
+        Self::ZIP_318
+    }
+}
+
+/// A truncated exponential inter-arrival delay distribution, in blocks: draws have mean
+/// [`Self::mean`], and a draw exceeding [`Self::cap`] is discarded and redrawn (truncating the
+/// exponential's heavy tail, so nothing is starved for an unbounded time).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DelayDistribution {
+    mean: NonZeroU32,
+    cap: NonZeroU32,
+}
+
+impl DelayDistribution {
+    /// Constructs a delay distribution, or returns `None` if `cap` is below `mean`.
+    ///
+    /// A cap below the mean would reject the majority of draws, distorting the distribution into
+    /// something no longer recognizably exponential; the rejection region is meant to remove only
+    /// the tail.
+    pub const fn new(mean: NonZeroU32, cap: NonZeroU32) -> Option<Self> {
+        if cap.get() < mean.get() {
+            None
+        } else {
+            Some(Self { mean, cap })
+        }
+    }
+
+    /// The mean of the untruncated exponential, in blocks. The exponential rate is `1 / mean`.
+    pub fn mean(&self) -> NonZeroU32 {
+        self.mean
+    }
+
+    /// The inclusive upper bound on a single drawn delay, in blocks.
+    pub fn cap(&self) -> NonZeroU32 {
+        self.cap
+    }
+
+    /// Draws one inter-arrival delay in blocks, always in `[0, cap]`.
+    ///
+    /// Samples by inverse-CDF, `delay = round(-mean * ln(u))` for `u` uniform in `(0, 1]`,
+    /// discarding and redrawing above [`Self::cap`].
+    pub fn draw<R: RngCore + CryptoRng>(&self, rng: &mut R) -> u32 {
+        self.draw_inner(rng)
+    }
+
+    /// The RNG-generic body of [`Self::draw`]. The public entry point bounds its `rng` as
+    /// [`CryptoRng`] (the drawn delays are privacy-relevant observables); the tests exercise the
+    /// distribution through the same code path.
+    fn draw_inner<R: RngCore>(&self, rng: &mut R) -> u32 {
+        loop {
+            let u = draw_unit_left_open(rng);
+            // ln(u) <= 0 for u in (0, 1], so -mean * ln(u) >= 0.
+            let delay = round_nonneg_to_u32(-(self.mean.get() as f64) * libm::log(u));
+            if delay <= self.cap.get() {
+                return delay;
+            }
+        }
+    }
+}
+
+/// The ratio a [ZIP 318] delay distribution's cap bears to its mean: a draw more than four times
+/// the mean is discarded and redrawn, truncating the exponential's heavy tail. It is the same for
+/// the transfer and preparation delays. See [`SchedulingParams::new_with_default_distributions`].
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const DELAY_CAP_RATIO: NonZeroU32 = NonZeroU32::new(4).expect("4 is nonzero");
+
+/// The ratio the anchor bucket interval bears to the PREPARATION delay mean: at the [ZIP 318]
+/// values, 144 blocks per bucket against 24 blocks between preparations. Preparations need only
+/// temporal decoupling from one another, not anchor bucketing, so they are spaced this much more
+/// tightly than the transfers. See [`SchedulingParams::new_with_default_distributions`].
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const PREP_MEAN_DIVISOR: NonZeroU32 = NonZeroU32::new(6).expect("6 is nonzero");
+
+/// The scheduling parameters a migration runs under: the anchor bucket grid and the two
+/// inter-arrival delay distributions.
+///
+/// [`Self::ZIP_318`] carries the specified values, and is what a migration on the production
+/// network must use. A test network may shorten them so a migration completes in a workable time;
+/// the anchor bucket interval in particular is not free to choose, since it must match the grid the
+/// wallet retains its anchor checkpoints on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SchedulingParams {
+    anchor_bucket_interval: AnchorBucketInterval,
+    transfer_delay: DelayDistribution,
+    preparation_delay: DelayDistribution,
+}
+
+impl SchedulingParams {
+    /// The parameters specified by [ZIP 318] (with the provisional preparation spacing): a 144-block
+    /// anchor bucket interval, transfer delays of mean 144 blocks capped at 576 (`4 * mean`, about
+    /// twelve hours), and preparation delays of mean 24 blocks capped at 96.
+    ///
+    /// Preparation transactions are fully shielded self-sends: they need TEMPORAL decoupling from
+    /// one another (a burst of identically shaped transactions from one wallet is a linkable
+    /// cluster), but no anchor bucketing — only the pool-crossing transfers anchor to boundaries —
+    /// so their spacing is much tighter than the transfers'. That spacing is provisional; it is not
+    /// yet specified by ZIP 318.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    pub const ZIP_318: Self = Self {
+        anchor_bucket_interval: AnchorBucketInterval::ZIP_318,
+        transfer_delay: DelayDistribution {
+            mean: NonZeroU32::new(144).expect("144 is nonzero"),
+            cap: NonZeroU32::new(576).expect("576 is nonzero"),
+        },
+        preparation_delay: DelayDistribution {
+            mean: NonZeroU32::new(24).expect("24 is nonzero"),
+            cap: NonZeroU32::new(96).expect("96 is nonzero"),
+        },
+    };
+
+    /// Constructs scheduling parameters from their constituent parts.
+    pub fn new(
+        anchor_bucket_interval: AnchorBucketInterval,
+        transfer_delay: DelayDistribution,
+        preparation_delay: DelayDistribution,
+    ) -> Self {
+        Self {
+            anchor_bucket_interval,
+            transfer_delay,
+            preparation_delay,
+        }
+    }
+
+    /// Constructs scheduling parameters for `anchor_bucket_interval`, deriving both delay
+    /// distributions from it by the ratios [`Self::ZIP_318`] uses: the transfer delay has a mean of
+    /// one bucket interval, the preparation delay a mean of a
+    /// [`PREP_MEAN_DIVISOR`]th of one, and each is capped at [`DELAY_CAP_RATIO`] times its own mean.
+    ///
+    /// At [`AnchorBucketInterval::ZIP_318`] this reproduces [`Self::ZIP_318`] exactly. It is the
+    /// constructor to reach for on a test network: shortening the bucket interval alone would leave
+    /// the ZIP 318 delays spreading a migration over an impractical span of blocks, whereas scaling
+    /// the whole schedule by the same factor compresses it while preserving the shape ZIP 318
+    /// specifies.
+    ///
+    /// The preparation mean is clamped up to one block for bucket intervals below
+    /// [`PREP_MEAN_DIVISOR`], and the caps saturate at [`u32::MAX`], so every interval yields a
+    /// usable distribution.
+    pub fn new_with_default_distributions(anchor_bucket_interval: AnchorBucketInterval) -> Self {
+        let transfer_mean = anchor_bucket_interval.block_count();
+        // Integer division truncates, and a mean of zero is not a distribution, so clamp up.
+        let preparation_mean = match NonZeroU32::new(transfer_mean.get() / PREP_MEAN_DIVISOR.get())
+        {
+            Some(mean) => mean,
+            None => NonZeroU32::MIN,
+        };
+        // Built directly rather than through `DelayDistribution::new`: each cap is its own mean
+        // multiplied by `DELAY_CAP_RATIO` under saturating arithmetic, so it is never below that
+        // mean and the validated constructor's failure case is unreachable here.
+        Self {
+            anchor_bucket_interval,
+            transfer_delay: DelayDistribution {
+                mean: transfer_mean,
+                cap: transfer_mean.saturating_mul(DELAY_CAP_RATIO),
+            },
+            preparation_delay: DelayDistribution {
+                mean: preparation_mean,
+                cap: preparation_mean.saturating_mul(DELAY_CAP_RATIO),
+            },
+        }
+    }
+
+    /// The grid of boundary heights a transfer may anchor to.
+    pub fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
+        self.anchor_bucket_interval
+    }
+
+    /// The inter-arrival delay distribution between successive TRANSFER broadcasts.
+    pub fn transfer_delay(&self) -> DelayDistribution {
+        self.transfer_delay
+    }
+
+    /// The inter-arrival delay distribution between successive PREPARATION broadcasts.
+    pub fn preparation_delay(&self) -> DelayDistribution {
+        self.preparation_delay
+    }
+}
+
+impl Default for SchedulingParams {
+    fn default() -> Self {
+        Self::ZIP_318
+    }
+}
 
 /// Maximum anchor AGE, in boundaries, that the recency-weighted draw will accept. Age `a` counts
 /// boundaries strictly before the most recent boundary observed at proving time; a draw exceeding
@@ -136,17 +369,6 @@ impl Schedule {
     }
 }
 
-/// The most recent BOUNDARY block at or below `height`: the largest multiple of [`BOUNDARY_MODULUS`]
-/// that is `<= height`. Equivalently `height - (height % BOUNDARY_MODULUS)`.
-pub fn most_recent_boundary(height: BlockHeight) -> BlockHeight {
-    BlockHeight::from_u32(most_recent_boundary_u32(u32::from(height)))
-}
-
-/// [`most_recent_boundary`] on the raw `u32` representation, for internal boundary arithmetic.
-fn most_recent_boundary_u32(height: u32) -> u32 {
-    height - (height % BOUNDARY_MODULUS)
-}
-
 /// Width of one step when the unit interval `[0, 1)` is split into `2^53` equal parts, i.e.
 /// `1 / 2^53`. Drawing 53 random bits and scaling by this yields a value spread uniformly over those
 /// `2^53` evenly spaced points; see [`draw_unit_half_open`].
@@ -174,35 +396,6 @@ fn draw_unit_left_open<R: RngCore>(rng: &mut R) -> f64 {
 /// The caller guarantees `x` is non-negative and within `u32` range (delays are small).
 fn round_nonneg_to_u32(x: f64) -> u32 {
     (x + 0.5) as u64 as u32
-}
-
-/// Draw one inter-arrival delay in blocks from a truncated exponential distribution with the given
-/// `mean`, discarding and redrawing above `cap`. Samples by inverse-CDF, `delay = round(-mean *
-/// ln(u))` for `u` uniform in `(0, 1]` (so the exponential rate is `1 / mean`). The return is
-/// always in `[0, cap]`.
-fn draw_delay_with<R: RngCore>(mean: u32, cap: u32, rng: &mut R) -> u32 {
-    loop {
-        let u = draw_unit_left_open(rng);
-        // ln(u) <= 0 for u in (0, 1], so -mean * ln(u) >= 0.
-        let delay = round_nonneg_to_u32(-(mean as f64) * libm::log(u));
-        if delay <= cap {
-            return delay;
-        }
-    }
-}
-
-/// Draw one TRANSFER inter-arrival delay in blocks from the truncated exponential distribution:
-/// mean [`MEAN_DELAY`], discard-and-redraw above [`MAX_DELAY`] (ZIP 318 "Transfer scheduling"
-/// MUST). The return is always in `[0, MAX_DELAY]`.
-pub fn draw_delay<R: RngCore + CryptoRng>(rng: &mut R) -> u32 {
-    draw_delay_with(MEAN_DELAY, MAX_DELAY, rng)
-}
-
-/// Draw one PREPARATION inter-arrival delay in blocks: mean [`PREP_MEAN_DELAY`],
-/// discard-and-redraw above [`PREP_MAX_DELAY`]. See [`PREP_MEAN_DELAY`] for why preparations are
-/// spaced tighter than transfers. The return is always in `[0, PREP_MAX_DELAY]`.
-pub fn draw_prep_delay<R: RngCore + CryptoRng>(rng: &mut R) -> u32 {
-    draw_delay_with(PREP_MEAN_DELAY, PREP_MAX_DELAY, rng)
 }
 
 /// Produce a uniformly random permutation of `0..n` using an in-place Fisher-Yates shuffle driven by
@@ -275,29 +468,34 @@ fn cumulative_broadcast_heights<R: RngCore>(
 }
 
 /// Compute the per-part scheduled broadcast heights: starting at `commit_height`, advance a running
-/// height by an independently drawn [`draw_delay`] for each of the `n_parts` transfers (ZIP 318
-/// CUMULATIVE MUST). The returned vector has length `n_parts`, is non-decreasing, and every entry is
-/// `>= commit_height`. Heights saturate at `u32::MAX` rather than overflowing.
+/// height by an independently drawn `params.transfer_delay()` for each of the `n_parts` transfers
+/// (ZIP 318 CUMULATIVE MUST). The returned vector has length `n_parts`, is non-decreasing, and every
+/// entry is `>= commit_height`. Heights saturate at `u32::MAX` rather than overflowing.
 pub fn schedule_broadcast_heights<R: RngCore + CryptoRng>(
+    params: &SchedulingParams,
     commit_height: BlockHeight,
     n_parts: usize,
     rng: &mut R,
 ) -> Vec<BlockHeight> {
-    cumulative_broadcast_heights(commit_height, n_parts, draw_delay, rng)
+    let delay = params.transfer_delay();
+    cumulative_broadcast_heights(commit_height, n_parts, |rng| delay.draw_inner(rng), rng)
 }
 
 /// Compute per-transaction scheduled broadcast heights for one PREPARATION layer: starting at
-/// `start`, advance a running height by an independently drawn [`draw_prep_delay`] for each of the
-/// `n_txs` transactions. The returned vector has length `n_txs`, is non-decreasing, and every entry
-/// is `>= start`; heights saturate at `u32::MAX`. The caller (the engine) bases each later layer's
-/// `start` past the previous layer's last scheduled height plus a mining margin, so layers stay
-/// serialized while the transactions within and across layers remain temporally decoupled.
+/// `start`, advance a running height by an independently drawn `params.preparation_delay()` for
+/// each of the `n_txs` transactions. The returned vector has length `n_txs`, is non-decreasing, and
+/// every entry is `>= start`; heights saturate at `u32::MAX`. The caller (the engine) bases each
+/// later layer's `start` past the previous layer's last scheduled height plus a mining margin, so
+/// layers stay serialized while the transactions within and across layers remain temporally
+/// decoupled.
 pub fn schedule_prep_broadcast_heights<R: RngCore + CryptoRng>(
+    params: &SchedulingParams,
     start: BlockHeight,
     n_txs: usize,
     rng: &mut R,
 ) -> Vec<BlockHeight> {
-    cumulative_broadcast_heights(start, n_txs, draw_prep_delay, rng)
+    let delay = params.preparation_delay();
+    cumulative_broadcast_heights(start, n_txs, |rng| delay.draw_inner(rng), rng)
 }
 
 /// The canonical rolling EXPIRY height for a transfer at `current_height` (ZIP 318 EXPIRY MUST):
@@ -318,11 +516,12 @@ pub fn expiry_height(current_height: BlockHeight) -> BlockHeight {
 /// (see [`schedule_broadcast_heights`]) and pair each with its canonical [`expiry_height`]. Returns
 /// one [`Schedule`] per part, in the (already shuffled) part order the caller passes.
 pub fn schedule<R: RngCore + CryptoRng>(
+    params: &SchedulingParams,
     commit_height: BlockHeight,
     n_parts: usize,
     rng: &mut R,
 ) -> Vec<Schedule> {
-    schedule_broadcast_heights(commit_height, n_parts, rng)
+    schedule_broadcast_heights(params, commit_height, n_parts, rng)
         .into_iter()
         .map(|broadcast_height| Schedule {
             broadcast_height,
@@ -355,27 +554,28 @@ fn draw_anchor_age<R: RngCore>(rng: &mut R) -> u32 {
 /// set is empty. The wallet backend later resolves the actual tree state at that height (out of
 /// scope here).
 ///
-/// The CANDIDATE ANCHOR SET is the boundaries (multiples of [`BOUNDARY_MODULUS`]) that are
-/// simultaneously:
+/// The CANDIDATE ANCHOR SET is the boundaries of `interval` that are simultaneously:
 /// - (a) strictly above `nu63_activation` (the NU6.3 activation height),
 /// - (b) at or after `funding_creation_height` (the funding note's creation height), and
 /// - (c) at or before the most recent boundary at or below `chain_tip_height` (the chain tip the
 ///   wallet has observed at proving time).
 ///
-/// The most recent boundary is derived internally via [`most_recent_boundary`], so
-/// `chain_tip_height` may be any observed height; it need not itself be a boundary. A
-/// recency-weighted age `a` in `[1, ANCHOR_AGE_CAP]` is drawn (`Geometric(1/2)`) and the candidate
-/// is `most_recent_boundary(chain_tip_height) - a * BOUNDARY_MODULUS`; a draw exceeding
+/// The most recent boundary is derived internally via
+/// [`AnchorBucketInterval::boundary_at_or_below`], so `chain_tip_height` may be any observed
+/// height; it need not itself be a boundary. A recency-weighted age `a` in `[1, ANCHOR_AGE_CAP]` is
+/// drawn (`Geometric(1/2)`) and the candidate is `most_recent - a * interval`; a draw exceeding
 /// [`ANCHOR_AGE_CAP`] or landing outside the candidate set is discarded and redrawn. Because age is
 /// always `>= 1`, the chosen boundary is always strictly below the most recent boundary.
 pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
+    interval: AnchorBucketInterval,
     nu63_activation: BlockHeight,
     funding_creation_height: BlockHeight,
     chain_tip_height: BlockHeight,
     rng: &mut R,
 ) -> Option<BlockHeight> {
-    let most_recent = most_recent_boundary_u32(u32::from(chain_tip_height));
+    let most_recent = interval.boundary_at_or_below_u32(u32::from(chain_tip_height));
     let (lowest, highest) = candidate_boundary_bounds(
+        interval,
         u32::from(nu63_activation),
         u32::from(funding_creation_height),
         most_recent,
@@ -387,9 +587,12 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
         if age > ANCHOR_AGE_CAP {
             continue;
         }
-        let offset = age * BOUNDARY_MODULUS;
-        // most_recent - offset, guarding the underflow (too-old anchor -> redraw).
-        let candidate = match most_recent.checked_sub(offset) {
+        // age * interval, guarding the overflow a large interval could produce (too-old anchor ->
+        // redraw, the same outcome the underflow check below gives).
+        let candidate = match age
+            .checked_mul(interval.block_count().get())
+            .and_then(|offset| most_recent.checked_sub(offset))
+        {
             Some(c) => c,
             None => continue,
         };
@@ -403,35 +606,34 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
 /// if the set is empty. Encodes the three candidate-set conditions of [`draw_anchor_boundary`]:
 /// the highest usable boundary is the one strictly below `most_recent` (age `>= 1`), and the
 /// lowest is the first boundary that is both strictly above `nu63_activation` and at or after
-/// `funding_creation_height`. `most_recent` is the boundary derived from the observed chain tip
-/// (a multiple of [`BOUNDARY_MODULUS`]).
+/// `funding_creation_height`. `most_recent` is the boundary derived from the observed chain tip.
 fn candidate_boundary_bounds(
+    interval: AnchorBucketInterval,
     nu63_activation: u32,
     funding_creation_height: u32,
     most_recent: u32,
 ) -> Option<(u32, u32)> {
-    // Highest candidate: strictly below the most recent boundary, i.e. one modulus down.
-    let highest = most_recent.checked_sub(BOUNDARY_MODULUS)?;
+    // Highest candidate: strictly below the most recent boundary, i.e. one interval down.
+    let highest = most_recent.checked_sub(interval.block_count().get())?;
 
-    // Lowest candidate from condition (a): the first boundary strictly ABOVE nu63_activation.
-    let above_activation =
-        most_recent_boundary_u32(nu63_activation).saturating_add(BOUNDARY_MODULUS);
-    // Lowest candidate from condition (b): the first boundary at or AFTER the funding creation.
-    let at_or_after_funding = boundary_at_or_after(funding_creation_height);
-    let lowest = above_activation.max(at_or_after_funding);
+    let lowest = lowest_candidate_boundary(interval, nu63_activation, funding_creation_height);
 
     (lowest <= highest).then_some((lowest, highest))
 }
 
-/// The smallest BOUNDARY height at or after `height`: `height` rounded UP to a multiple of
-/// [`BOUNDARY_MODULUS`]. Saturates at `u32::MAX`.
-fn boundary_at_or_after(height: u32) -> u32 {
-    let r = height % BOUNDARY_MODULUS;
-    if r == 0 {
-        height
-    } else {
-        height.saturating_add(BOUNDARY_MODULUS - r)
-    }
+/// The lowest boundary that satisfies both lower-bound conditions of [`draw_anchor_boundary`]: the
+/// first boundary strictly ABOVE `nu63_activation`, and the first boundary at or AFTER
+/// `funding_creation_height`, whichever is higher. Saturates at `u32::MAX`.
+fn lowest_candidate_boundary(
+    interval: AnchorBucketInterval,
+    nu63_activation: u32,
+    funding_creation_height: u32,
+) -> u32 {
+    let above_activation = interval
+        .boundary_at_or_below_u32(nu63_activation)
+        .saturating_add(interval.block_count().get());
+    let at_or_after_funding = interval.boundary_at_or_above_u32(funding_creation_height);
+    above_activation.max(at_or_after_funding)
 }
 
 /// The first chain height at which a transfer's candidate anchor set (see
@@ -441,13 +643,16 @@ fn boundary_at_or_after(height: u32) -> u32 {
 /// has at least one boundary to anchor to, so a schedule that places every broadcast at or after it
 /// never needs an anchor fallback; the scheduler MUST NOT place a transfer before it.
 pub fn earliest_broadcast_height(
+    interval: AnchorBucketInterval,
     nu63_activation: BlockHeight,
     funding_creation_height: BlockHeight,
 ) -> BlockHeight {
-    let lowest = most_recent_boundary_u32(u32::from(nu63_activation))
-        .saturating_add(BOUNDARY_MODULUS)
-        .max(boundary_at_or_after(u32::from(funding_creation_height)));
-    BlockHeight::from_u32(lowest.saturating_add(BOUNDARY_MODULUS))
+    let lowest = lowest_candidate_boundary(
+        interval,
+        u32::from(nu63_activation),
+        u32::from(funding_creation_height),
+    );
+    BlockHeight::from_u32(lowest.saturating_add(interval.block_count().get()))
 }
 
 #[cfg(test)]
@@ -467,44 +672,74 @@ mod tests {
         BlockHeight::from_u32(h)
     }
 
-    // --- most_recent_boundary / boundary helpers ----------------------------------------------
+    /// The ZIP 318 parameters, under which every golden vector in this module was captured.
+    const P: SchedulingParams = SchedulingParams::ZIP_318;
+
+    /// The ZIP 318 anchor bucket interval as a raw block count, for arithmetic in test expectations.
+    const MODULUS: u32 = 144;
+
+    /// The ZIP 318 transfer delay cap, as a raw block count.
+    const MAX_DELAY: u32 = 576;
+
+    /// The ZIP 318 preparation delay cap, as a raw block count.
+    const PREP_MAX_DELAY: u32 = 96;
+
+    /// The ZIP 318 anchor bucket interval.
+    fn modulus() -> AnchorBucketInterval {
+        AnchorBucketInterval::ZIP_318
+    }
+
+    /// An anchor bucket interval of `blocks` blocks.
+    fn interval(blocks: u32) -> AnchorBucketInterval {
+        AnchorBucketInterval::custom(NonZeroU32::new(blocks).expect("nonzero"))
+    }
+
+    /// Scheduling parameters that differ from ZIP 318 only in the anchor bucket interval, for
+    /// checking that the boundary logic follows the configured grid.
+    fn params_with_interval(blocks: u32) -> SchedulingParams {
+        SchedulingParams::new(interval(blocks), P.transfer_delay(), P.preparation_delay())
+    }
+
+    // --- AnchorBucketInterval boundary helpers ------------------------------------------------
 
     proptest! {
-        /// [`most_recent_boundary`] returns a multiple of the modulus, does not exceed the height,
-        /// and is within one modulus of it.
+        /// Rounding DOWN yields a boundary of the configured interval that does not exceed the
+        /// height and is within one interval of it, whatever that interval is.
         #[test]
-        fn most_recent_boundary_props(h in 0u32..5_000_000) {
-            let b = u32::from(most_recent_boundary(bh(h)));
-            prop_assert_eq!(b % BOUNDARY_MODULUS, 0);
+        fn boundary_at_or_below_props(h in 0u32..5_000_000, blocks in 1u32..10_000) {
+            let i = interval(blocks);
+            let b = u32::from(i.boundary_at_or_below(bh(h)));
+            prop_assert!(i.is_boundary(bh(b)));
             prop_assert!(b <= h);
-            prop_assert!(h - b < BOUNDARY_MODULUS);
+            prop_assert!(h - b < blocks);
         }
 
-        /// [`boundary_at_or_after`] returns a multiple `>= height`, within one modulus above it.
+        /// Rounding UP yields a boundary `>= height`, within one interval above it.
         #[test]
-        fn boundary_at_or_after_props(h in 0u32..5_000_000) {
-            let b = boundary_at_or_after(h);
-            prop_assert_eq!(b % BOUNDARY_MODULUS, 0);
+        fn boundary_at_or_above_props(h in 0u32..5_000_000, blocks in 1u32..10_000) {
+            let i = interval(blocks);
+            let b = u32::from(i.boundary_at_or_above(bh(h)));
+            prop_assert!(i.is_boundary(bh(b)));
             prop_assert!(b >= h);
-            prop_assert!(b - h < BOUNDARY_MODULUS);
+            prop_assert!(b - h < blocks);
         }
     }
 
-    /// Assert one hand-derived [`most_recent_boundary`] value plus its invariants (a multiple of the
-    /// modulus, `<= height`, and within one modulus of it). `BOUNDARY_MODULUS` is 144.
+    /// Assert one hand-derived [`AnchorBucketInterval::boundary_at_or_below`] value plus its
+    /// invariants (a boundary, `<= height`, and within one interval of it) at the ZIP 318 interval.
     fn check_most_recent_boundary_golden(height: u32, expected: u32) {
-        let b = u32::from(most_recent_boundary(bh(height)));
-        assert_eq!(b, expected, "most_recent_boundary({height})");
-        assert_eq!(b % BOUNDARY_MODULUS, 0, "not a boundary");
+        let b = u32::from(modulus().boundary_at_or_below(bh(height)));
+        assert_eq!(b, expected, "boundary_at_or_below({height})");
+        assert!(modulus().is_boundary(bh(b)), "not a boundary");
         assert!(b <= height, "boundary {b} above height {height}");
         assert!(
-            height - b < BOUNDARY_MODULUS,
-            "boundary {b} more than a modulus below {height}"
+            height - b < MODULUS,
+            "boundary {b} more than an interval below {height}"
         );
     }
 
-    /// Golden vectors for [`most_recent_boundary`], hand-derived from `BOUNDARY_MODULUS == 144`:
-    /// the result is `height - (height % 144)`, i.e. `height` rounded DOWN to a multiple of 144.
+    /// Golden vectors for [`AnchorBucketInterval::boundary_at_or_below`], hand-derived from the
+    /// ZIP 318 interval of 144: the result is `height - (height % 144)`.
     #[test]
     fn most_recent_boundary_golden() {
         // Each case is (input height, expected boundary = height rounded down to a multiple of 144).
@@ -522,17 +757,107 @@ mod tests {
         }
     }
 
-    // --- draw_delay ---------------------------------------------------------------------------
+    // --- DelayDistribution::draw --------------------------------------------------------------
 
     proptest! {
-        /// Every drawn delay is in the closed range [0, MAX_DELAY] (DELAYS MUST).
+        /// Every drawn delay is in the closed range `[0, cap]`, whatever the configured
+        /// distribution (DELAYS MUST).
         #[test]
-        fn delay_within_bounds(seed in any::<u64>()) {
+        fn delay_within_bounds(seed in any::<u64>(), mean in 1u32..1_000, extra in 0u32..2_000) {
+            let dist = DelayDistribution::new(
+                NonZeroU32::new(mean).expect("nonzero"),
+                NonZeroU32::new(mean + extra).expect("nonzero"),
+            ).expect("cap >= mean");
             let mut r = rng(seed);
             for _ in 0..200 {
-                let d = draw_delay(&mut r);
-                prop_assert!(d <= MAX_DELAY);
+                prop_assert!(dist.draw(&mut r) <= dist.cap().get());
             }
+        }
+    }
+
+    /// The ratio-derived constructor reproduces the ZIP 318 parameters exactly at the ZIP 318
+    /// bucket interval. This is what binds the two encodings of the specified values: the literal
+    /// `ZIP_318` (which keeps the spec's numbers greppable) and the ratios
+    /// `new_with_default_distributions` generalizes them by. If either drifts, this fails.
+    #[test]
+    fn default_distributions_reproduce_zip_318() {
+        assert_eq!(
+            SchedulingParams::new_with_default_distributions(AnchorBucketInterval::ZIP_318),
+            SchedulingParams::ZIP_318,
+        );
+    }
+
+    /// A scaled-down interval scales the whole schedule by the same factor, so a test network gets
+    /// the ZIP 318 shape compressed rather than a distorted one.
+    #[test]
+    fn default_distributions_scale_with_the_interval() {
+        // A twelfth of the ZIP 318 interval: 12 blocks per bucket.
+        let p = SchedulingParams::new_with_default_distributions(interval(12));
+        assert_eq!(p.transfer_delay().mean().get(), 12);
+        assert_eq!(p.transfer_delay().cap().get(), 48);
+        assert_eq!(p.preparation_delay().mean().get(), 2);
+        assert_eq!(p.preparation_delay().cap().get(), 8);
+    }
+
+    /// Every bucket interval yields a usable pair of distributions, including the degenerate ends:
+    /// an interval below the preparation divisor would truncate that mean to zero, and a very large
+    /// one would overflow the caps.
+    #[test]
+    fn default_distributions_are_usable_at_the_extremes() {
+        // Below `PREP_MEAN_DIVISOR` the preparation mean truncates to zero, and is clamped up.
+        for blocks in 1..=PREP_MEAN_DIVISOR.get() {
+            let p = SchedulingParams::new_with_default_distributions(interval(blocks));
+            assert_eq!(p.preparation_delay().mean(), NonZeroU32::MIN, "{blocks}");
+            assert!(p.preparation_delay().cap() >= p.preparation_delay().mean());
+        }
+
+        // At the top of the range the caps saturate rather than wrapping below their means.
+        let huge = SchedulingParams::new_with_default_distributions(interval(u32::MAX));
+        assert_eq!(huge.transfer_delay().cap().get(), u32::MAX);
+        assert!(huge.transfer_delay().cap() >= huge.transfer_delay().mean());
+    }
+
+    proptest! {
+        /// Whatever the interval, the derived distributions satisfy `DelayDistribution`'s own
+        /// invariant (a cap not below the mean), so they are exactly what the validated constructor
+        /// would have accepted.
+        #[test]
+        fn default_distributions_always_valid(blocks in 1u32..) {
+            let p = SchedulingParams::new_with_default_distributions(interval(blocks));
+            prop_assert_eq!(p.anchor_bucket_interval().block_count().get(), blocks);
+            for dist in [p.transfer_delay(), p.preparation_delay()] {
+                prop_assert!(dist.cap() >= dist.mean());
+                prop_assert_eq!(DelayDistribution::new(dist.mean(), dist.cap()), Some(dist));
+            }
+        }
+    }
+
+    #[test]
+    fn delay_distribution_rejects_cap_below_mean() {
+        let nz = |n: u32| NonZeroU32::new(n).expect("nonzero");
+        assert!(DelayDistribution::new(nz(144), nz(143)).is_none());
+        assert!(DelayDistribution::new(nz(144), nz(144)).is_some());
+        assert!(DelayDistribution::new(nz(144), nz(576)).is_some());
+    }
+
+    /// The drawn delays scale with the configured mean: a distribution with `k` times the mean
+    /// produces approximately `k` times the delays from the same seed, so a shortened test-network
+    /// configuration compresses the schedule rather than distorting its shape.
+    #[test]
+    fn delay_scales_with_configured_mean() {
+        let nz = |n: u32| NonZeroU32::new(n).expect("nonzero");
+        let base = DelayDistribution::new(nz(24), nz(96)).expect("cap >= mean");
+        let scaled = DelayDistribution::new(nz(144), nz(576)).expect("cap >= mean");
+        let mut r_base = rng(1);
+        let mut r_scaled = rng(1);
+        for _ in 0..32 {
+            let b = base.draw(&mut r_base);
+            let s = scaled.draw(&mut r_scaled);
+            // Both round the same underlying unit draw, so they agree within the rounding slack.
+            assert!(
+                s.abs_diff(b * 6) <= 6,
+                "scaled draw {s} is not ~6x the base draw {b}"
+            );
         }
     }
 
@@ -544,7 +869,7 @@ mod tests {
         let n = 20_000u64;
         let mut sum = 0u64;
         for _ in 0..n {
-            sum += u64::from(draw_delay(&mut r));
+            sum += u64::from(P.transfer_delay().draw(&mut r));
         }
         let mean = sum as f64 / n as f64;
         // Analytic truncated mean is ~124 blocks; allow a wide band.
@@ -554,19 +879,21 @@ mod tests {
         );
     }
 
-    /// Assert a golden sequence of [`draw_delay`] draws for a fixed seed, pinning the exact
+    /// Assert a golden sequence of ZIP 318 transfer-delay draws for a fixed seed, pinning the exact
     /// deterministic [`ChaCha8Rng`] output as a regression guard, plus the documented invariant that
-    /// every delay is in the closed range `[0, MAX_DELAY]` (the truncated-exponential bound).
+    /// every delay is within the distribution's cap (the truncated-exponential bound).
     fn check_delay_golden(seed: u64, expected: &[u32]) {
         let mut r = rng(seed);
-        let got: Vec<u32> = (0..expected.len()).map(|_| draw_delay(&mut r)).collect();
-        assert_eq!(got, expected, "draw_delay(seed={seed})");
+        let got: Vec<u32> = (0..expected.len())
+            .map(|_| P.transfer_delay().draw(&mut r))
+            .collect();
+        assert_eq!(got, expected, "transfer_delay().draw(seed={seed})");
         for &d in &got {
-            assert!(d <= MAX_DELAY, "delay {d} exceeds MAX_DELAY {MAX_DELAY}");
+            assert!(d <= MAX_DELAY, "delay {d} exceeds the cap {MAX_DELAY}");
         }
     }
 
-    /// Golden vectors for [`draw_delay`] over several seeds. These are the captured deterministic
+    /// Golden vectors for the ZIP 318 transfer delay over several seeds. These are the captured deterministic
     /// draws; the `seed=1` sequence matches the per-step gaps pinned in
     /// [`schedule_broadcast_heights_golden`] (74, 12, 131, 36, 48, ...).
     #[test]
@@ -678,7 +1005,7 @@ mod tests {
                                       n in 0usize..40,
                                       seed in any::<u64>()) {
             let mut r = rng(seed);
-            let hs = schedule_broadcast_heights(bh(commit), n, &mut r);
+            let hs = schedule_broadcast_heights(&P, bh(commit), n, &mut r);
             prop_assert_eq!(hs.len(), n);
             let mut prev = bh(commit);
             for h in hs {
@@ -694,7 +1021,7 @@ mod tests {
     /// the invariant checks keep each vector auditable by eye, since each per-step GAP is the drawn
     /// inter-arrival delay and must be a valid `[0, MAX_DELAY]` value.
     fn check_schedule_golden(commit: u32, n: usize, seed: u64, expected: &[u32]) {
-        let hs: Vec<u32> = schedule_broadcast_heights(bh(commit), n, &mut rng(seed))
+        let hs: Vec<u32> = schedule_broadcast_heights(&P, bh(commit), n, &mut rng(seed))
             .into_iter()
             .map(u32::from)
             .collect();
@@ -707,17 +1034,15 @@ mod tests {
                 "heights must be non-decreasing (commit {commit})"
             );
             let gap = h - prev;
-            assert!(
-                gap <= MAX_DELAY,
-                "delay {gap} exceeds MAX_DELAY {MAX_DELAY}"
-            );
+            assert!(gap <= MAX_DELAY, "delay {gap} exceeds the cap {MAX_DELAY}");
             prev = h;
         }
     }
 
     /// Golden vectors for the cumulative broadcast schedule: fixed `(commit, n, seed)` triples pinned
     /// to their exact height sequences (a regression guard on the delay sampling), with the per-step
-    /// gaps noted so the drawn delays are visible. `MEAN_DELAY` is 144 and `MAX_DELAY` is 576 blocks.
+    /// gaps noted so the drawn delays are visible. The ZIP 318 transfer delay has mean 144 blocks
+    /// and cap 576.
     #[test]
     fn schedule_broadcast_heights_golden() {
         // n = 0 schedules nothing, whatever the seed.
@@ -753,7 +1078,7 @@ mod tests {
                                             n in 0usize..40,
                                             seed in any::<u64>()) {
             let mut r = rng(seed);
-            let hs = schedule_prep_broadcast_heights(bh(start), n, &mut r);
+            let hs = schedule_prep_broadcast_heights(&P, bh(start), n, &mut r);
             prop_assert_eq!(hs.len(), n);
             let mut prev = bh(start);
             for h in hs {
@@ -764,21 +1089,21 @@ mod tests {
         }
     }
 
-    /// Golden vectors for [`draw_prep_delay`]: the exact deterministic draws for fixed seeds,
-    /// pinning the tighter preparation spacing as a regression guard, with every delay within
-    /// `[0, PREP_MAX_DELAY]`. Derivable from the transfer goldens in [`draw_delay_golden`] by the
-    /// scale law: the same unit draws scaled by the mean ratio `MEAN_DELAY / PREP_MEAN_DELAY = 6`
-    /// (for example seed 1's 74, 12, 131, ... become 12, 2, 22, ...).
+    /// Golden vectors for the ZIP 318 preparation delay: the exact deterministic draws for fixed
+    /// seeds, pinning the tighter preparation spacing as a regression guard, with every delay within
+    /// its cap. Derivable from the transfer goldens in [`draw_delay_golden`] by the scale law: the
+    /// same unit draws scaled by the mean ratio `144 / 24 = 6` (for example seed 1's 74, 12, 131,
+    /// ... become 12, 2, 22, ...).
     #[test]
     fn draw_prep_delay_golden() {
         fn check(seed: u64, expected: &[u32]) {
             let mut r = rng(seed);
             let got: Vec<u32> = (0..expected.len())
-                .map(|_| draw_prep_delay(&mut r))
+                .map(|_| P.preparation_delay().draw(&mut r))
                 .collect();
-            assert_eq!(got, expected, "draw_prep_delay(seed={seed})");
+            assert_eq!(got, expected, "preparation_delay().draw(seed={seed})");
             for &d in &got {
-                assert!(d <= PREP_MAX_DELAY, "delay {d} exceeds PREP_MAX_DELAY");
+                assert!(d <= PREP_MAX_DELAY, "delay {d} exceeds the preparation cap");
             }
         }
         let exp_seed1 = [12, 2, 22, 6, 8, 30, 15, 4];
@@ -847,17 +1172,19 @@ mod tests {
     /// boundaries above the activation, and a funding-creation height at or below the highest
     /// candidate. The tip is offset off the boundary by an arbitrary amount, exercising the
     /// internal boundary derivation.
-    fn arb_anchor_inputs() -> impl Strategy<Value = (u32, u32, u32)> {
+    /// The interval is drawn too, so the candidate-set invariants are checked against whatever grid
+    /// the migration is configured with rather than only the ZIP 318 one.
+    fn arb_anchor_inputs() -> impl Strategy<Value = (AnchorBucketInterval, u32, u32, u32)> {
         // nu63_activation in a modest range; span in boundaries above it (>= 2 so a candidate exists).
-        (0u32..1000u32, 2u32..40u32, 0u32..BOUNDARY_MODULUS).prop_flat_map(
-            |(act, span_boundaries, tip_offset)| {
-                let most_recent = (most_recent_boundary_u32(act)
-                    + span_boundaries * BOUNDARY_MODULUS)
-                    .max(BOUNDARY_MODULUS);
-                let tip = most_recent + tip_offset;
+        (0u32..1000u32, 2u32..40u32, 1u32..500u32, 0u32..1000u32).prop_flat_map(
+            |(act, span_boundaries, blocks, tip_offset)| {
+                let i = interval(blocks);
+                let most_recent =
+                    (i.boundary_at_or_below_u32(act) + span_boundaries * blocks).max(blocks);
+                let tip = most_recent + (tip_offset % blocks);
                 // funding creation anywhere from activation up to the highest candidate boundary.
-                let highest = most_recent - BOUNDARY_MODULUS;
-                (Just(act), Just(tip), act..=highest)
+                let highest = most_recent - blocks;
+                (Just(i), Just(act), Just(tip), act..=highest.max(act))
             },
         )
     }
@@ -868,19 +1195,20 @@ mod tests {
         /// nu63_activation, and at/after the funding creation height (ANCHOR-SELECTION +
         /// ANCHOR-AGE-DRAW MUST).
         #[test]
-        fn anchor_in_candidate_set((act, tip, funding) in arb_anchor_inputs(),
+        fn anchor_in_candidate_set((i, act, tip, funding) in arb_anchor_inputs(),
                                    seed in any::<u64>()) {
             let mut r = rng(seed);
-            let most_recent = most_recent_boundary_u32(tip);
-            let chosen = draw_anchor_boundary(bh(act), bh(funding), bh(tip), &mut r);
+            let blocks = i.block_count().get();
+            let most_recent = i.boundary_at_or_below_u32(tip);
+            let chosen = draw_anchor_boundary(i, bh(act), bh(funding), bh(tip), &mut r);
             prop_assert!(chosen.is_some());
             let b = u32::from(chosen.unwrap());
-            prop_assert_eq!(b % BOUNDARY_MODULUS, 0);
+            prop_assert!(i.is_boundary(bh(b)));
             prop_assert!(b < most_recent, "boundary {b} must be below most_recent {most_recent}");
             prop_assert!(b > act, "boundary {b} must be strictly above activation {act}");
             prop_assert!(b >= funding, "boundary {b} must be at/after funding {funding}");
-            // Age is within the cap: (most_recent - b) / modulus in [1, ANCHOR_AGE_CAP].
-            let age = (most_recent - b) / BOUNDARY_MODULUS;
+            // Age is within the cap: (most_recent - b) / interval in [1, ANCHOR_AGE_CAP].
+            let age = (most_recent - b) / blocks;
             prop_assert!((1..=ANCHOR_AGE_CAP).contains(&age), "age {age} out of [1, cap]");
         }
 
@@ -888,18 +1216,21 @@ mod tests {
         /// boundary interval draws exactly the same anchors as the boundary itself under the same
         /// seed.
         #[test]
-        fn anchor_draw_derives_boundary_from_tip(tip_offset in 0u32..BOUNDARY_MODULUS,
+        fn anchor_draw_derives_boundary_from_tip(blocks in 1u32..500u32,
+                                                 tip_offset in 0u32..500u32,
                                                  seed in any::<u64>()) {
-            let (act, funding) = (BOUNDARY_MODULUS, 2 * BOUNDARY_MODULUS);
-            let boundary_tip = 20 * BOUNDARY_MODULUS;
+            let i = interval(blocks);
+            let (act, funding) = (blocks, 2 * blocks);
+            let boundary_tip = 20 * blocks;
+            let offset = tip_offset % blocks;
             let mut r_offset = rng(seed);
             let mut r_boundary = rng(seed);
             for _ in 0..16 {
                 prop_assert_eq!(
                     draw_anchor_boundary(
-                        bh(act), bh(funding), bh(boundary_tip + tip_offset), &mut r_offset,
+                        i, bh(act), bh(funding), bh(boundary_tip + offset), &mut r_offset,
                     ),
-                    draw_anchor_boundary(bh(act), bh(funding), bh(boundary_tip), &mut r_boundary)
+                    draw_anchor_boundary(i, bh(act), bh(funding), bh(boundary_tip), &mut r_boundary)
                 );
             }
         }
@@ -907,19 +1238,22 @@ mod tests {
 
     #[test]
     fn anchor_empty_candidate_set_is_none() {
-        let mut r = rng(1);
-        // Chain tip below the second boundary: no candidate strictly below the derived boundary
-        // that is also above activation.
-        assert_eq!(draw_anchor_boundary(bh(0), bh(0), bh(0), &mut r), None);
-        assert_eq!(
-            draw_anchor_boundary(bh(0), bh(0), bh(BOUNDARY_MODULUS), &mut r),
-            None
-        );
-        // A non-boundary tip derives the same (first) boundary, so the set is still empty.
-        assert_eq!(
-            draw_anchor_boundary(bh(0), bh(0), bh(2 * BOUNDARY_MODULUS - 1), &mut r),
-            None
-        );
+        for blocks in [MODULUS, 12] {
+            let i = interval(blocks);
+            let mut r = rng(1);
+            // Chain tip below the second boundary: no candidate strictly below the derived boundary
+            // that is also above activation.
+            assert_eq!(draw_anchor_boundary(i, bh(0), bh(0), bh(0), &mut r), None);
+            assert_eq!(
+                draw_anchor_boundary(i, bh(0), bh(0), bh(blocks), &mut r),
+                None
+            );
+            // A non-boundary tip derives the same (first) boundary, so the set is still empty.
+            assert_eq!(
+                draw_anchor_boundary(i, bh(0), bh(0), bh(2 * blocks - 1), &mut r),
+                None
+            );
+        }
     }
 
     proptest! {
@@ -928,17 +1262,19 @@ mod tests {
         #[test]
         fn earliest_broadcast_height_is_the_viability_threshold(act in 0u32..1_000_000,
                                                                funding_offset in 0u32..2_000,
+                                                               blocks in 1u32..500u32,
                                                                seed in any::<u64>()) {
+            let i = interval(blocks);
             let funding = act + funding_offset;
-            let earliest = earliest_broadcast_height(bh(act), bh(funding));
+            let earliest = earliest_broadcast_height(i, bh(act), bh(funding));
             let mut r = rng(seed);
             prop_assert!(
-                draw_anchor_boundary(bh(act), bh(funding), earliest, &mut r).is_some(),
+                draw_anchor_boundary(i, bh(act), bh(funding), earliest, &mut r).is_some(),
                 "a tip at the earliest broadcast height must have a candidate boundary"
             );
             let mut r = rng(seed);
             prop_assert!(
-                draw_anchor_boundary(bh(act), bh(funding), earliest - 1, &mut r).is_none(),
+                draw_anchor_boundary(i, bh(act), bh(funding), earliest - 1, &mut r).is_none(),
                 "a tip below the earliest broadcast height must not"
             );
         }
@@ -946,15 +1282,18 @@ mod tests {
 
     #[test]
     fn anchor_funding_after_most_recent_is_none() {
-        let mut r = rng(2);
-        // Funding note created after the tip's most recent boundary: nothing at/after it can be a
-        // candidate (candidates are all <= most_recent - modulus).
-        let tip = 10 * BOUNDARY_MODULUS;
-        let funding = tip + BOUNDARY_MODULUS;
-        assert_eq!(
-            draw_anchor_boundary(bh(0), bh(funding), bh(tip), &mut r),
-            None
-        );
+        for blocks in [MODULUS, 12] {
+            let i = interval(blocks);
+            let mut r = rng(2);
+            // Funding note created after the tip's most recent boundary: nothing at/after it can be
+            // a candidate (candidates are all <= most_recent - interval).
+            let tip = 10 * blocks;
+            let funding = tip + blocks;
+            assert_eq!(
+                draw_anchor_boundary(i, bh(0), bh(funding), bh(tip), &mut r),
+                None
+            );
+        }
     }
 
     /// Assert a golden sequence of [`draw_anchor_boundary`] draws for a fixed candidate set and seed,
@@ -963,21 +1302,21 @@ mod tests {
     /// boundary derived from `chain_tip`, at/after `funding`, and with an age in
     /// `[1, ANCHOR_AGE_CAP]`.
     fn check_anchor_golden(act: u32, funding: u32, chain_tip: u32, seed: u64, expected: &[u32]) {
-        let most_recent = most_recent_boundary_u32(chain_tip);
+        let i = modulus();
+        let most_recent = i.boundary_at_or_below_u32(chain_tip);
         let mut r = rng(seed);
         let got: Vec<u32> = (0..expected.len())
             .map(|_| {
                 u32::from(
-                    draw_anchor_boundary(bh(act), bh(funding), bh(chain_tip), &mut r).unwrap(),
+                    draw_anchor_boundary(i, bh(act), bh(funding), bh(chain_tip), &mut r).unwrap(),
                 )
             })
             .collect();
         assert_eq!(got, expected, "draw_anchor_boundary(seed={seed})");
         for &b in &got {
-            assert_eq!(
-                b % BOUNDARY_MODULUS,
-                0,
-                "boundary {b} not a multiple of the modulus"
+            assert!(
+                i.is_boundary(bh(b)),
+                "boundary {b} not a multiple of the interval"
             );
             assert!(
                 b > act,
@@ -991,7 +1330,7 @@ mod tests {
                 b >= funding,
                 "boundary {b} must be at/after funding {funding}"
             );
-            let age = (most_recent - b) / BOUNDARY_MODULUS;
+            let age = (most_recent - b) / MODULUS;
             assert!(
                 (1..=ANCHOR_AGE_CAP).contains(&age),
                 "age {age} out of [1, cap]"
@@ -1007,11 +1346,7 @@ mod tests {
     /// reproduce the same vectors.
     #[test]
     fn draw_anchor_boundary_golden() {
-        let (act, funding, tip) = (
-            BOUNDARY_MODULUS,
-            2 * BOUNDARY_MODULUS,
-            20 * BOUNDARY_MODULUS,
-        );
+        let (act, funding, tip) = (MODULUS, 2 * MODULUS, 20 * MODULUS);
         let exp_seed1 = [2736, 2736, 2736, 2592, 2736, 2304];
         let exp_seed42 = [2736, 2304, 2448, 2592, 2160, 2592];
         let exp_seed7 = [2736, 2592, 2736, 2736, 2304, 2592];
@@ -1022,22 +1357,64 @@ mod tests {
         check_anchor_golden(act, funding, tip, 100, &exp_seed100);
         // A mid-interval tip (not itself a boundary) must yield identical draws.
         check_anchor_golden(act, funding, tip + 100, 1, &exp_seed1);
-        check_anchor_golden(act, funding, tip + BOUNDARY_MODULUS - 1, 42, &exp_seed42);
+        check_anchor_golden(act, funding, tip + MODULUS - 1, 42, &exp_seed42);
+    }
+
+    /// The two axes of [`SchedulingParams`] are independent: changing only the anchor bucket
+    /// interval moves the boundary grid without perturbing the drawn delays, so a test network can
+    /// shorten the grid alone. (Shortening the delays as well is what compresses the schedule; see
+    /// [`delay_scales_with_configured_mean`].)
+    #[test]
+    fn interval_moves_the_grid_without_touching_the_delays() {
+        let short = params_with_interval(12);
+
+        // Identical delay draws under the same seed: only the grid differs.
+        assert_eq!(
+            schedule_broadcast_heights(&short, bh(2_000_000), 8, &mut rng(5)),
+            schedule_broadcast_heights(&P, bh(2_000_000), 8, &mut rng(5)),
+        );
+
+        // The anchor floor and every drawn anchor sit on the SHORT grid, not the ZIP 318 one.
+        let (act, funding) = (bh(1_000), bh(1_100));
+        let earliest = earliest_broadcast_height(short.anchor_bucket_interval(), act, funding);
+        assert!(short.anchor_bucket_interval().is_boundary(earliest));
+        assert_eq!(u32::from(earliest), 1_116); // 1_104 (first boundary >= funding) + 12
+        assert!(
+            earliest < earliest_broadcast_height(P.anchor_bucket_interval(), act, funding),
+            "a shorter interval must reach anchor viability sooner"
+        );
+
+        let mut r = rng(5);
+        for _ in 0..64 {
+            let b = draw_anchor_boundary(
+                short.anchor_bucket_interval(),
+                act,
+                funding,
+                bh(5_000),
+                &mut r,
+            )
+            .expect("the candidate set is non-empty");
+            assert!(short.anchor_bucket_interval().is_boundary(b));
+            assert!(b >= funding && b > act);
+        }
     }
 
     #[test]
     fn anchor_tiny_range_single_candidate() {
-        // Exactly one candidate: the boundary below the tip's, and it satisfies all bounds.
-        let mut r = rng(3);
-        let act = BOUNDARY_MODULUS; // first candidate above activation is 2*modulus
-        let tip = 3 * BOUNDARY_MODULUS; // highest candidate is 2*modulus
-        let funding = 2 * BOUNDARY_MODULUS;
-        // Only 2*BOUNDARY_MODULUS qualifies.
-        for _ in 0..50 {
-            assert_eq!(
-                draw_anchor_boundary(bh(act), bh(funding), bh(tip), &mut r),
-                Some(bh(2 * BOUNDARY_MODULUS))
-            );
+        for blocks in [MODULUS, 12] {
+            let i = interval(blocks);
+            // Exactly one candidate: the boundary below the tip's, and it satisfies all bounds.
+            let mut r = rng(3);
+            let act = blocks; // first candidate above activation is 2*interval
+            let tip = 3 * blocks; // highest candidate is 2*interval
+            let funding = 2 * blocks;
+            // Only 2*interval qualifies.
+            for _ in 0..50 {
+                assert_eq!(
+                    draw_anchor_boundary(i, bh(act), bh(funding), bh(tip), &mut r),
+                    Some(bh(2 * blocks))
+                );
+            }
         }
     }
 
@@ -1054,7 +1431,7 @@ mod tests {
         expected_broadcast: &[u32],
         expected_expiry: &[u32],
     ) {
-        let schedules = schedule(bh(commit), n, &mut rng(seed));
+        let schedules = schedule(&P, bh(commit), n, &mut rng(seed));
         let broadcast: Vec<u32> = schedules
             .iter()
             .map(|s| u32::from(s.broadcast_height()))
@@ -1074,7 +1451,7 @@ mod tests {
         // Broadcast heights equal the cumulative-delay schedule for the same seed.
         assert_eq!(
             broadcast,
-            schedule_broadcast_heights(bh(commit), n, &mut rng(seed))
+            schedule_broadcast_heights(&P, bh(commit), n, &mut rng(seed))
                 .into_iter()
                 .map(u32::from)
                 .collect::<Vec<u32>>(),
@@ -1135,12 +1512,15 @@ mod tests {
                                                n in 0usize..24,
                                                seed in any::<u64>()) {
             let mut r = rng(seed);
-            let schedules = schedule(bh(commit), n, &mut r);
+            let schedules = schedule(&P, bh(commit), n, &mut r);
             prop_assert_eq!(schedules.len(), n);
             // Broadcast heights follow the cumulative delay rule (same RNG => same heights).
             let broadcast: Vec<BlockHeight> =
                 schedules.iter().map(|s| s.broadcast_height()).collect();
-            prop_assert_eq!(&broadcast, &schedule_broadcast_heights(bh(commit), n, &mut rng(seed)));
+            prop_assert_eq!(
+                &broadcast,
+                &schedule_broadcast_heights(&P, bh(commit), n, &mut rng(seed))
+            );
             let mut prev = bh(commit);
             for s in &schedules {
                 prop_assert!(s.broadcast_height() >= prev, "broadcast heights must be non-decreasing");

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -720,6 +720,42 @@ mod tests {
         SchedulingParams::new(interval(blocks), P.transfer_delay(), P.preparation_delay())
     }
 
+    #[cfg(feature = "wallet")]
+    proptest! {
+        /// The wallet's `AnchorRetentionInterval` and this crate's `AnchorBucketInterval` implement
+        /// the same boundary arithmetic in two places. The `From` conversion is the seam between
+        /// them, and this is what keeps the two implementations from drifting: for any height and
+        /// any interval, converting and then asking must give the same answer as asking the
+        /// wallet's type directly.
+        ///
+        /// A drift here is exactly the failure this whole design exists to prevent — a migration
+        /// anchoring to a height the wallet does not consider a boundary, and so does not retain.
+        #[test]
+        fn conversion_preserves_the_boundary_arithmetic(
+            h in 0u32..5_000_000,
+            blocks in 1u32..10_000,
+        ) {
+            use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
+
+            let retention = AnchorRetentionInterval::custom(
+                NonZeroU32::new(blocks).expect("nonzero"),
+            );
+            let bucket = AnchorBucketInterval::from(retention);
+            let height = bh(h);
+
+            prop_assert_eq!(bucket.block_count(), retention.block_count());
+            prop_assert_eq!(bucket.is_boundary(height), retention.is_boundary(height));
+            prop_assert_eq!(
+                bucket.boundary_at_or_below(height),
+                retention.boundary_at_or_below(height)
+            );
+            prop_assert_eq!(
+                bucket.boundary_at_or_above(height),
+                retention.boundary_at_or_above(height)
+            );
+        }
+    }
+
     // --- AnchorBucketInterval boundary helpers ------------------------------------------------
 
     proptest! {

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -537,6 +537,7 @@ mod tests {
             .expect("an empty stored plan reconstructs"),
             preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions,
+            anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
         }
     }
 

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -15,6 +15,7 @@
 //! downstream crate reuses these directly rather than duplicating them.
 
 use core::fmt::Debug;
+use core::num::NonZeroU32;
 
 use proptest::prelude::*;
 
@@ -29,6 +30,7 @@ use crate::engine::{
 };
 use crate::note_splitting::NoteSplitPlan;
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
+use crate::scheduling::AnchorBucketInterval;
 
 /// Convert a bounded `u64` to [`Zatoshis`]; infallible for the ranges the strategies draw from.
 fn zat(value: u64) -> Zatoshis {
@@ -211,39 +213,60 @@ pub fn arb_migration_transaction() -> impl Strategy<Value = MigrationTransaction
         )
 }
 
+/// An arbitrary [`AnchorBucketInterval`]: the ZIP 318 grid or an arbitrary non-standard one, so a
+/// store is exercised on both the value it will almost always see and values it must not special-case.
+pub fn arb_anchor_bucket_interval() -> impl Strategy<Value = AnchorBucketInterval> {
+    prop_oneof![
+        1 => Just(AnchorBucketInterval::ZIP_318),
+        1 => (1u32..100_000).prop_map(|blocks| {
+            AnchorBucketInterval::custom(NonZeroU32::new(blocks).expect("nonzero"))
+        }),
+    ]
+}
+
 /// An arbitrary whole [`MigrationState`], built through [`MigrationState::from_parts`]: a status, a
-/// note split (from which the funding-note values derive), a preparation plan, and a small set of
+/// note split (from which the funding-note values derive), a preparation plan, a small set of
 /// transactions re-keyed with sequential [`MigrationTxId`]s (so their row keys are unique, as a
-/// store requires). Generated values are self-consistent enough to persist and read back unchanged.
+/// store requires), and the anchor bucket grid it was committed under. Generated values are
+/// self-consistent enough to persist and read back unchanged.
 pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
     (
         arb_migration_status(),
         arb_note_split_plan(),
         arb_preparation_plan(),
         prop::collection::vec(arb_migration_transaction(), 0..6),
+        arb_anchor_bucket_interval(),
     )
-        .prop_map(|(status, note_split, preparation, txs)| {
-            // Re-key the transactions with sequential ids so their row keys are unique; a store
-            // keys transaction rows by id and returns them in id order.
-            let transactions = txs
-                .into_iter()
-                .enumerate()
-                .map(|(i, tx)| {
-                    MigrationTransaction::from_parts(
-                        MigrationTxId::new(i as u32),
-                        tx.kind(),
-                        tx.pczt().clone(),
-                        tx.depends_on().clone(),
-                        tx.scheduled_height(),
-                        tx.expiry_height(),
-                        tx.anchor_boundary(),
-                        tx.state(),
-                        tx.lock_owner(),
-                    )
-                })
-                .collect();
-            MigrationState::from_parts(status, note_split, preparation, transactions)
-        })
+        .prop_map(
+            |(status, note_split, preparation, txs, anchor_bucket_interval)| {
+                // Re-key the transactions with sequential ids so their row keys are unique; a store
+                // keys transaction rows by id and returns them in id order.
+                let transactions = txs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, tx)| {
+                        MigrationTransaction::from_parts(
+                            MigrationTxId::new(i as u32),
+                            tx.kind(),
+                            tx.pczt().clone(),
+                            tx.depends_on().clone(),
+                            tx.scheduled_height(),
+                            tx.expiry_height(),
+                            tx.anchor_boundary(),
+                            tx.state(),
+                            tx.lock_owner(),
+                        )
+                    })
+                    .collect();
+                MigrationState::from_parts(
+                    status,
+                    note_split,
+                    preparation,
+                    transactions,
+                    anchor_bucket_interval,
+                )
+            },
+        )
 }
 
 // --- conformance suite over the store traits ---

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -51,6 +51,7 @@ use crate::engine::{
     MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTxId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
+use crate::scheduling::{DelayDistribution, SchedulingParams};
 
 /// A failure of the wallet-backed migration adapter. Parameterized by the error types of the two
 /// wallet traits and the store, which for `zcash_client_sqlite`'s `WalletDb` are all one type but in
@@ -119,6 +120,9 @@ where
     account: <W as InputSource>::AccountId,
     usk: UnifiedSpendingKey,
     store: St,
+    /// The inter-arrival delays to schedule under, or `None` to derive them from the wallet's own
+    /// anchor bucket interval by the ZIP 318 ratios.
+    scheduling_delays: Option<(DelayDistribution, DelayDistribution)>,
 }
 
 impl<'a, W, St> WalletMigration<'a, W, St>
@@ -128,6 +132,13 @@ where
     St: PoolMigrationRead,
 {
     /// Wrap a wallet, an account, its spending key, and a store as a migration wallet.
+    ///
+    /// The migration is scheduled under the wallet's own anchor retention interval — not
+    /// configurable here; see [`MigrationBackend::scheduling_params`] — with inter-arrival delays
+    /// derived from that interval by the ZIP 318 ratios. A wallet on the standard grid therefore
+    /// gets exactly the ZIP 318 delays, and a wallet configured with a shortened grid gets the same
+    /// schedule shape compressed by the same factor, rather than a short grid crossed with
+    /// three-hour delays. Override the delays with [`Self::with_scheduling_delays`].
     pub fn new(
         wallet: &'a W,
         account: <W as InputSource>::AccountId,
@@ -139,7 +150,22 @@ where
             account,
             usk,
             store,
+            scheduling_delays: None,
         }
+    }
+
+    /// Sets the inter-arrival delay distributions between successive transfer and preparation
+    /// broadcasts, replacing the ones otherwise derived from the wallet's anchor bucket interval.
+    ///
+    /// Only the delays are settable. The anchor bucket interval is read from the wallet, because a
+    /// transfer can only be proved against a boundary whose checkpoint the wallet retained.
+    pub fn with_scheduling_delays(
+        mut self,
+        transfer_delay: DelayDistribution,
+        preparation_delay: DelayDistribution,
+    ) -> Self {
+        self.scheduling_delays = Some((transfer_delay, preparation_delay));
+        self
     }
 
     /// Recover the store.
@@ -209,6 +235,20 @@ where
             .chain_height()
             .map_err(Error::WalletRead)?
             .ok_or(Error::ChainTipUnknown)
+    }
+
+    /// The anchor bucket interval is the wallet's own anchor retention interval, converted; the
+    /// delays are derived from it unless [`Self::with_scheduling_delays`] overrode them. Deriving
+    /// the grid from the wallet rather than accepting it here is what makes it impossible for a
+    /// migration to anchor to a boundary whose checkpoint the wallet has not retained.
+    fn scheduling_params(&self) -> SchedulingParams {
+        let interval = self.wallet.anchor_retention_interval().into();
+        match self.scheduling_delays {
+            Some((transfer_delay, preparation_delay)) => {
+                SchedulingParams::new(interval, transfer_delay, preparation_delay)
+            }
+            None => SchedulingParams::new_with_default_distributions(interval),
+        }
     }
 }
 

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -51,7 +51,7 @@ use crate::engine::{
     MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTxId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
-use crate::scheduling::{DelayDistribution, SchedulingParams};
+use crate::scheduling::{AnchorBucketInterval, DelayDistribution, SchedulingParams};
 
 /// A failure of the wallet-backed migration adapter. Parameterized by the error types of the two
 /// wallet traits and the store, which for `zcash_client_sqlite`'s `WalletDb` are all one type but in
@@ -648,6 +648,13 @@ where
         anchor: BlockHeight,
     ) -> Result<::pczt::Pczt, Self::Error> {
         self.prove_orchard(pczt, anchor)
+    }
+
+    /// The grid the wallet this prover reads its commitment trees from currently retains anchor
+    /// checkpoints on, so a transfer committed against a different grid is rejected before its
+    /// (by then pruned) checkpoint is looked up.
+    fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
+        self.wallet.anchor_retention_interval().into()
     }
 }
 

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -22,6 +22,7 @@ use zcash_pool_migration::note_splitting::{NoteSplitPlan, plan_note_split};
 use zcash_pool_migration::preparation::{
     FUNDING_OUTPUTS_PER_TX, PreparationPlan, plan_preparation,
 };
+use zcash_pool_migration::scheduling::AnchorBucketInterval;
 use zcash_pool_migration_memory::{MockBackend, regtest_network};
 
 /// Wrap a raw zatoshi amount as [`Zatoshis`] for the tests.
@@ -244,6 +245,7 @@ fn stores_loads_and_updates_a_migration() {
         note_split,
         PreparationPlan::from_parts(Vec::new(), Vec::new()),
         vec![tx],
+        AnchorBucketInterval::ZIP_318,
     );
     backend.replace_migration(&state).unwrap();
 

--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -556,7 +556,7 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
 fn migration_anchors_to_the_wallets_configured_retention_grid() {
     use core::num::NonZeroU32;
     use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
-    use zcash_pool_migration::engine::{MigrationBackend, MigrationTxKind};
+    use zcash_pool_migration::engine::{MigrationBackend, MigrationTxId, MigrationTxKind};
     use zcash_pool_migration::scheduling::{AnchorBucketInterval, SchedulingParams};
 
     // A short grid, so a migration reaches anchor viability without waiting out 144-block buckets.
@@ -609,11 +609,12 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
         engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
             .expect("commits the migration");
 
-    // Every transfer anchors to a boundary of the WALLET's grid; nothing lands off it.
-    let mut transfers = 0;
+    // Every transfer anchors to a boundary of the WALLET's grid; nothing lands off it, and the
+    // migration records that grid so a later reconfiguration is detectable.
+    assert_eq!(state.anchor_bucket_interval(), interval);
+    let mut transfer_boundaries = Vec::new();
     for tx in state.transactions() {
         if matches!(tx.kind(), MigrationTxKind::Transfer { .. }) {
-            transfers += 1;
             let boundary = tx
                 .anchor_boundary()
                 .expect("every committed transfer carries its boundary");
@@ -622,7 +623,81 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
                 "anchor {boundary:?} is not on the wallet's {}-block retention grid",
                 interval.block_count(),
             );
+            transfer_boundaries.push((tx.id(), boundary));
         }
     }
-    assert!(transfers > 0, "the migration commits at least one transfer");
+    assert!(
+        !transfer_boundaries.is_empty(),
+        "the migration commits at least one transfer"
+    );
+
+    // Now the part that ties the two grids together for real: mine the preparations so the funding
+    // notes exist, then bury each transfer's boundary far enough behind the chain tip that its
+    // checkpoint survives only because the wallet RETAINED it, and prove against it. Without
+    // retention on the wallet's configured grid this fails with `AnchorNotFound`.
+    let mut state = state;
+    let prep_ids: Vec<MigrationTxId> = state
+        .transactions()
+        .iter()
+        .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .map(|t| t.id())
+        .collect();
+    for prep_id in prep_ids {
+        let tip = st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        let anchor = highest_rooted_orchard_checkpoint(st.wallet_mut(), tip)
+            .expect("a rooted Orchard checkpoint exists");
+        {
+            let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+            engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+                .expect("proves the preparation transaction");
+        }
+        let proven = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == prep_id)
+            .expect("the preparation is present");
+        let tx = TransactionExtractor::new(
+            pczt::Pczt::parse(proven.pczt()).expect("parses the proven preparation PCZT"),
+        )
+        .extract()
+        .expect("extracts the preparation transaction");
+        let (prep_height, _) = st.generate_next_block_from_tx(1, &tx);
+        st.scan_cached_blocks(prep_height, 1);
+    }
+
+    // `zcash_client_sqlite` keeps only the most recent 100 checkpoints, so burying the boundary
+    // deeper than that is what makes the proof depend on retention rather than on ordinary
+    // checkpoint survival.
+    const PRUNING_DEPTH: u32 = 100;
+    transfer_boundaries.sort_by_key(|(_, boundary)| *boundary);
+    let deepest = transfer_boundaries
+        .last()
+        .map(|(_, boundary)| *boundary)
+        .expect("there is at least one transfer");
+    loop {
+        let tip = st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        if u32::from(tip) > u32::from(deepest) + PRUNING_DEPTH + 10 {
+            break;
+        }
+        let (h, _) = st.generate_empty_block();
+        st.scan_cached_blocks(h, 1);
+    }
+
+    for (transfer_id, boundary) in transfer_boundaries {
+        let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
+        engine::prove_transfer(&mut prover, &mut state, transfer_id).unwrap_or_else(|e| {
+            panic!(
+                "proving against the retained boundary {boundary:?} on the wallet's configured \
+                 grid failed: {e}"
+            )
+        });
+    }
 }

--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -545,3 +545,84 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
         scenario.prove_end_to_end();
     }
 }
+
+/// The adapter reports the WALLET's anchor retention interval as its anchor bucket interval, and
+/// every anchor a committed migration draws lands on that grid.
+///
+/// This is the property that makes the two grids incapable of disagreeing: the interval is never
+/// configured on the migration side, so a wallet configured with a non-default retention interval
+/// automatically schedules its migration against the boundaries it actually retains.
+#[test]
+fn migration_anchors_to_the_wallets_configured_retention_grid() {
+    use core::num::NonZeroU32;
+    use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
+    use zcash_pool_migration::engine::{MigrationBackend, MigrationTxKind};
+    use zcash_pool_migration::scheduling::{AnchorBucketInterval, SchedulingParams};
+
+    // A short grid, so a migration reaches anchor viability without waiting out 144-block buckets.
+    let retention = AnchorRetentionInterval::custom(NonZeroU32::new(12).expect("nonzero"));
+    let network = nu63_network();
+
+    let mut st = TestBuilder::new()
+        .with_network(network)
+        .with_data_store_factory(TestDbFactory::default())
+        .with_block_cache(BlockCache::new())
+        .with_anchor_retention_interval(retention)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().expect("the test account exists");
+    let account_id = account.id();
+    let usk = account.usk().clone();
+    let fvk = OrchardPoolTester::test_account_fvk(&st);
+
+    let (h, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, zats(4 * COIN));
+    st.scan_cached_blocks(h, 1);
+    for _ in 0..SHARD_COMPLETION_BLOCKS {
+        let (h, _) = st.generate_empty_block();
+        st.scan_cached_blocks(h, 1);
+    }
+
+    let tip = st
+        .wallet()
+        .chain_height()
+        .expect("reads the chain height")
+        .expect("the wallet has a chain tip");
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut adapter =
+        WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
+
+    // The adapter reports the wallet's grid, not the ZIP 318 default, and scales the delays to it
+    // rather than crossing a 12-block grid with three-hour ZIP 318 delays.
+    let sched_params = adapter.scheduling_params();
+    let interval = sched_params.anchor_bucket_interval();
+    assert_eq!(interval, AnchorBucketInterval::from(retention));
+    assert_ne!(interval, AnchorBucketInterval::ZIP_318);
+    assert_eq!(
+        sched_params,
+        SchedulingParams::new_with_default_distributions(interval),
+        "the adapter derives its delays from the wallet's interval",
+    );
+
+    let plan = engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+    let (state, _) =
+        engine::commit_preparation_with_funding(&network, tip, &mut adapter, &plan, &mut rng)
+            .expect("commits the migration");
+
+    // Every transfer anchors to a boundary of the WALLET's grid; nothing lands off it.
+    let mut transfers = 0;
+    for tx in state.transactions() {
+        if matches!(tx.kind(), MigrationTxKind::Transfer { .. }) {
+            transfers += 1;
+            let boundary = tx
+                .anchor_boundary()
+                .expect("every committed transfer carries its boundary");
+            assert!(
+                interval.is_boundary(boundary),
+                "anchor {boundary:?} is not on the wallet's {}-block retention grid",
+                interval.block_count(),
+            );
+        }
+    }
+    assert!(transfers > 0, "the migration commits at least one transfer");
+}

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -39,6 +39,7 @@ use zcash_pool_migration::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTxId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
+use zcash_pool_migration::scheduling::SchedulingParams;
 
 /// A post-NU6.3 height (past the regtest NU6.3 activation) at which the migration transactions are
 /// built and their fees computed.
@@ -247,6 +248,7 @@ pub struct MockBackend {
     notes: Vec<Zatoshis>,
     tip: BlockHeight,
     stored: Option<MigrationState>,
+    sched_params: SchedulingParams,
 }
 
 impl MockBackend {
@@ -260,7 +262,16 @@ impl MockBackend {
                 .collect(),
             tip: BlockHeight::from_u32(tip),
             stored: None,
+            sched_params: SchedulingParams::ZIP_318,
         }
+    }
+
+    /// Overrides the scheduling parameters this backend reports (the default is
+    /// [`SchedulingParams::ZIP_318`]), for tests that exercise a non-standard anchor bucket grid or
+    /// compressed delays.
+    pub fn with_scheduling_params(mut self, sched_params: SchedulingParams) -> Self {
+        self.sched_params = sched_params;
+        self
     }
 }
 
@@ -273,6 +284,10 @@ impl MigrationBackend for MockBackend {
 
     fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
         Ok(self.tip)
+    }
+
+    fn scheduling_params(&self) -> SchedulingParams {
+        self.sched_params
     }
 }
 
@@ -317,6 +332,8 @@ pub struct CommitMock {
     pub ask: SpendAuthorizingKey,
     /// The in-memory migration state (`None` until a migration is committed).
     pub stored: Option<MigrationState>,
+    /// The scheduling parameters this backend reports to the engine.
+    sched_params: SchedulingParams,
 }
 
 impl CommitMock {
@@ -334,7 +351,16 @@ impl CommitMock {
             fvk,
             ask: SpendAuthorizingKey::from(&sk),
             stored: None,
+            sched_params: SchedulingParams::ZIP_318,
         }
+    }
+
+    /// Overrides the scheduling parameters this backend reports (the default is
+    /// [`SchedulingParams::ZIP_318`]), for tests that exercise a non-standard anchor bucket grid or
+    /// compressed delays.
+    pub fn with_scheduling_params(mut self, sched_params: SchedulingParams) -> Self {
+        self.sched_params = sched_params;
+        self
     }
 }
 
@@ -351,6 +377,10 @@ impl MigrationBackend for CommitMock {
 
     fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
         Ok(BlockHeight::from_u32(2_000_000))
+    }
+
+    fn scheduling_params(&self) -> SchedulingParams {
+        self.sched_params
     }
 }
 

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -238,6 +238,7 @@ fn set_transaction_state(stored: &mut MigrationState, id: MigrationTxId, state: 
         stored.note_split().clone(),
         stored.preparation().clone(),
         transactions,
+        stored.anchor_bucket_interval(),
     );
 }
 


### PR DESCRIPTION
Closes #2758.

The ZIP 318 anchor bucketing interval was a hard-coded 144 blocks in two independent places, which had to agree or migration transfers became unprovable:

| | |
|---|---|
| `zcash_client_backend::data_api::ll::wallet::ANCHOR_RETENTION_INTERVAL` | which checkpoints survive pruning |
| `zcash_pool_migration::scheduling::BOUNDARY_MODULUS` (an alias of `MEAN_DELAY`) | which heights a transfer may anchor to |

They meet at `tree.root_at_checkpoint_id(&anchor_height)` in `WalletMigrationProver::prove_orchard`. A divergence surfaced only at proving time, as a bare `AnchorNotFound`.

## Approach

Newtypes carrying the arithmetic, threaded as arguments and configuration; no static or lazily initialized constants.

**`zcash_client_backend`** gains `data_api::anchor_retention::{AnchorRetentionInterval, AnchorRetention}`. The interval owns the boundary arithmetic — `is_boundary`, `boundary_at_or_below`, `boundary_at_or_above` — replacing the hand-written modulo expressions previously scattered across the retention and scheduling code. `put_blocks` and `update_tree` take `Option<AnchorRetention>` in place of a bare activation height.

**`zcash_pool_migration`** gains `AnchorBucketInterval`, `DelayDistribution` (a mean and the cap above which a draw is rejected, which must not be below it), and `SchedulingParams`. `MEAN_DELAY`, `MAX_DELAY`, `PREP_MEAN_DELAY`, `PREP_MAX_DELAY` and `BOUNDARY_MODULUS` are removed; `SchedulingParams::ZIP_318` carries the specified values.

**`zcash_client_sqlite`** gains `WalletDb::with_anchor_retention_interval`, following the `GapLimits` pattern.

## How divergence is closed

The interval is never configured on the migration side. `MigrationBackend::scheduling_params` is a **required** trait method — a default would silently reinstate the hazard — and `WalletMigration` implements it as `SchedulingParams::new(wallet.anchor_retention_interval().into(), …)`. On the wallet-backed path the interval is therefore unreachable from the caller; only the delays are settable, via `with_scheduling_delays`. `WalletRead::anchor_retention_interval` is the accessor a migration reads the grid back through, and it is defaulted, so downstream backends are unaffected.

Changing the interval mid-migration is caught rather than left to fail obscurely: the committed grid is recorded on `MigrationState` (and in a new `anchor_bucket_interval` column), and a mismatch is reported as `ProveError::AnchorIntervalMismatch` or `RebuildError::AnchorIntervalMismatch`. The rebuild check runs ahead of any per-transfer condition, since a moved grid invalidates every transfer rather than making one repairable.

The reverse `From<AnchorBucketInterval> for AnchorRetentionInterval` is deliberately omitted. It would have to call `AnchorRetentionInterval::custom`, which is `unstable`-gated, forcing `zcash_pool_migration`'s `wallet` feature to enable `zcash_client_backend/unstable`; it is also the wrong direction, since the wallet is the side that retains and so is the authority on the grid.

## Testing

A proptest across the `From` seam asserts the two implementations of the boundary arithmetic agree for any height and any interval — a drift there is precisely the failure this design exists to prevent.

`prove_chain_sim` gains an end-to-end test: a `WalletDb` configured with a 12-block retention interval commits a real migration, its preparations are mined, and each transfer's boundary is buried more than the pruning depth behind the chain tip before it is proved. The proof succeeds only because the wallet retained a checkpoint on its *configured* grid. Stubbing out `should_retain_anchor` makes it fail with `no root at the anchor checkpoint`, confirming the test is load-bearing rather than incidentally passing.

`anchor_checkpoints_retained_across_deep_scan` now runs at both the ZIP 318 interval and a short one, so the wallet is shown to retain the grid it was configured with. This makes that test somewhat slower; nothing else verified end to end that `with_anchor_retention_interval` takes effect.

## Note for review

The new `anchor_bucket_interval` column is added to the `orchard_ironwood_migration_tables` migration **in place** rather than via a follow-on migration, on the basis that it is not yet released: it was added on 2026-07-21 in a0e937819e, after the 0.22.0-rc.1 release of 2026-07-12, and sits under `[Unreleased]` in the changelog. If that rc reached users with the table present, this should become a separate migration instead.

---
Opened with Claude Code assistance.