### PR TITLE
zcash_pool_migration: signing rounds bounded by a per-interaction action budget

### DIFF
--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -43,7 +43,7 @@
 
 use alloc::vec::Vec;
 use core::fmt;
-use core::num::NonZeroUsize;
+use core::num::{NonZeroU32, NonZeroUsize};
 
 use corez::io;
 
@@ -59,6 +59,10 @@ use zcash_primitives::transaction::fees::{transparent, zip317};
 use crate::note_splitting::{NoteSplitPlan, plan_note_split};
 use crate::preparation::{PrepError, PrepInput, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
+use crate::signing_rounds::{
+    MinRounds, PlannedSigningRound, PlannedTx, SigningRoundBudget, SigningRoundStrategy,
+    min_budget_for_rounds, min_signing_rounds,
+};
 
 /// The estimated number of blocks for a preparation layer's LAST scheduled transaction to mine and
 /// become spendable: mining latency plus the wallet's witness-sync and next-broadcast turnaround, a
@@ -597,6 +601,115 @@ impl MigrationPlan {
     pub fn schedule(&self) -> &[Schedule] {
         &self.schedule
     }
+
+    /// Every transaction this plan will build, enumerated BEFORE building in the exact order the
+    /// commit assigns [`MigrationTxId`]s (each preparation layer in order, then each transfer by
+    /// crossing), so a [`PlannedTx`]'s id equals the id the built transaction will carry. Each
+    /// carries its [`action_weight`](crate::signing_rounds::action_weight). This is a pure function
+    /// of the plan, recomputed on demand, so planning stays unchanged.
+    pub fn planned_transactions(&self) -> Vec<PlannedTx> {
+        let mut txs = Vec::with_capacity(self.total_transactions());
+        let mut next = 0u32;
+        for (layer, layer_txs) in self.preparation.layers().iter().enumerate() {
+            for index in 0..layer_txs.len() {
+                txs.push(PlannedTx::new(
+                    MigrationTxId::new(next),
+                    MigrationTxKind::Preparation { layer, index },
+                ));
+                next += 1;
+            }
+        }
+        for crossing in 0..self.transfer_tx_count() {
+            txs.push(PlannedTx::new(
+                MigrationTxId::new(next),
+                MigrationTxKind::Transfer { crossing },
+            ));
+            next += 1;
+        }
+        txs
+    }
+
+    /// The total number of transactions this plan builds and signs: its preparation transactions
+    /// plus one pool-crossing transfer per funding note.
+    pub fn total_transactions(&self) -> usize {
+        self.preparation_tx_count() + self.transfer_tx_count()
+    }
+
+    /// The number of preparation transactions across all layers.
+    pub fn preparation_tx_count(&self) -> usize {
+        self.preparation.transaction_count()
+    }
+
+    /// The number of pool-crossing transfers (one per funding note).
+    pub fn transfer_tx_count(&self) -> usize {
+        self.note_split.migration_outputs().len()
+    }
+
+    /// The number of sequential preparation layers (the phase's wall-clock depth).
+    pub fn preparation_layer_count(&self) -> usize {
+        self.preparation.layer_count()
+    }
+
+    /// The total Orchard-family actions across every transaction this plan builds.
+    pub fn total_actions(&self) -> u32 {
+        let prep = (self.preparation_tx_count() as u64)
+            .saturating_mul(u64::from(crate::signing_rounds::PREPARATION_ACTIONS));
+        let xfer = (self.transfer_tx_count() as u64)
+            .saturating_mul(u64::from(crate::signing_rounds::TRANSFER_ACTIONS));
+        u32::try_from(prep.saturating_add(xfer)).unwrap_or(u32::MAX)
+    }
+
+    /// The total value that migrates to the destination pool (the sum of the crossing values).
+    pub fn value_migrated(&self) -> Zatoshis {
+        self.note_split.total_migratable()
+    }
+
+    /// The source-pool value left untouched by this plan (change plus dust below a self-funding
+    /// note); zero when the balance decomposed exactly.
+    pub fn residual(&self) -> Zatoshis {
+        self.note_split.change().unwrap_or(Zatoshis::ZERO)
+    }
+
+    /// Group this plan's transactions into signing ROUNDS for a signer bounded by `budget` total
+    /// Orchard actions per interaction, using the optimal [`MinRounds`] packing (fewest signer
+    /// interactions). The `budget` is the caller's per-round capacity (for example
+    /// [`SigningRoundBudget::KEYSTONE`]); it is a QUERY parameter, so a plan can be evaluated for any
+    /// signer without re-planning. See [`signing_rounds_with`](Self::signing_rounds_with) to choose
+    /// a different [`SigningRoundStrategy`].
+    pub fn signing_rounds(&self, budget: SigningRoundBudget) -> Vec<PlannedSigningRound> {
+        self.signing_rounds_with(&MinRounds, budget)
+    }
+
+    /// Like [`signing_rounds`](Self::signing_rounds) but with an explicit packing `strategy` (the
+    /// named solution of the round-packing problem).
+    pub fn signing_rounds_with<S: SigningRoundStrategy>(
+        &self,
+        strategy: &S,
+        budget: SigningRoundBudget,
+    ) -> Vec<PlannedSigningRound> {
+        strategy.pack(&self.planned_transactions(), budget)
+    }
+
+    /// The number of signing rounds this plan needs for a signer bounded by `budget` (the optimal
+    /// [`MinRounds`] count), without materializing the packing.
+    pub fn signing_round_count(&self, budget: SigningRoundBudget) -> usize {
+        min_signing_rounds(
+            self.preparation_tx_count(),
+            self.transfer_tx_count(),
+            budget,
+        )
+    }
+
+    /// The smallest per-round budget that signs this whole plan in ONE round: the plan's total
+    /// actions (never below [`SigningRoundBudget::minimum_feasible`]). For the signer-selection UX
+    /// ("a signer supporting at least this many actions per round signs this in one interaction").
+    pub fn min_budget_for_single_round(&self) -> NonZeroU32 {
+        min_budget_for_rounds(
+            self.preparation_tx_count(),
+            self.transfer_tx_count(),
+            NonZeroUsize::MIN,
+        )
+    }
 }
 
 /// Why a migration could not be planned.
@@ -850,15 +963,17 @@ impl RunEstimate {
         self.prep_transactions + self.crossings
     }
 
-    /// The number of signing sessions this run needs when an external signer (for example a Keystone
-    /// hardware wallet) can sign at most `max_per_session` transactions in one interaction:
-    /// `ceil(transactions / max_per_session)`. All of a run's transactions are built and signed
-    /// together (anchors and witnesses are deferred to proving time, [ZIP 374]), so they pool into
-    /// sessions bounded only by the signer's capacity.
+    /// The number of signing ROUNDS this run needs when an external signer is bounded by `budget`
+    /// total Orchard ACTIONS per interaction (for example a Keystone,
+    /// [`SigningRoundBudget::KEYSTONE`]). This is the per-round-total-action model, NOT a
+    /// per-transaction cap: a round holds any mix of preparation (16-action) and transfer (3-action)
+    /// transactions summing to at most the budget. Computed as the optimal (minimum) packing, since
+    /// all of a run's transactions are built and signed together (anchors and witnesses deferred to
+    /// proving, [ZIP 374]) and are free to be grouped in any order.
     ///
     /// [ZIP 374]: https://zips.z.cash/zip-0374
-    pub fn signing_sessions(&self, max_per_session: NonZeroUsize) -> usize {
-        self.transactions().div_ceil(max_per_session.get())
+    pub fn signing_rounds(&self, budget: SigningRoundBudget) -> usize {
+        min_signing_rounds(self.prep_transactions, self.crossings, budget)
     }
 }
 
@@ -871,11 +986,10 @@ impl RunEstimate {
 /// compare them: the note-split crossings it migrates and the note-preparation layers and
 /// transactions it costs.
 ///
-/// A capacity-limited external signer adds a third dimension: given how many transactions such a
-/// signer can sign in one interaction, [`total_signing_sessions`](Self::total_signing_sessions) gives
-/// the number of signing interactions the whole migration requires. That limit is a query parameter,
-/// not part of the estimate, so an SDK can evaluate it for any signer capacity without re-running the
-/// planners.
+/// A capacity-limited external signer adds a third dimension: given the signer's per-interaction
+/// action budget, [`total_signing_rounds`](Self::total_signing_rounds) gives the number of signing
+/// interactions the whole migration requires. That budget is a query parameter, not part of the
+/// estimate, so an SDK can evaluate it for any signer capacity without re-running the planners.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MigrationRunEstimate {
     runs: Vec<RunEstimate>,
@@ -936,19 +1050,16 @@ impl MigrationRunEstimate {
         self.runs.iter().map(RunEstimate::transactions).sum()
     }
 
-    /// The total number of signing sessions the whole migration needs when an external signer can sign
-    /// at most `max_per_session` transactions in one interaction — the number of times the user must
+    /// The total number of signing ROUNDS the whole migration needs when an external signer is
+    /// bounded by `budget` total Orchard actions per interaction — the number of times the user must
     /// interact with a capacity-limited hardware signer (for example a Keystone, whose limit the SDK
     /// passes in here).
     ///
-    /// This is the SUM of each run's [`signing_sessions`](RunEstimate::signing_sessions), NOT
-    /// `ceil(total_transactions / max_per_session)`, because signing sessions cannot span runs: a later
-    /// run's transactions spend notes an earlier run must mine first, so each run is signed on its own.
-    pub fn total_signing_sessions(&self, max_per_session: NonZeroUsize) -> usize {
-        self.runs
-            .iter()
-            .map(|run| run.signing_sessions(max_per_session))
-            .sum()
+    /// This is the SUM of each run's [`signing_rounds`](RunEstimate::signing_rounds), NOT the packing
+    /// of `total_transactions` at once, because rounds cannot span runs: a later run's transactions
+    /// spend notes an earlier run must mine first, so each run is signed on its own.
+    pub fn total_signing_rounds(&self, budget: SigningRoundBudget) -> usize {
+        self.runs.iter().map(|run| run.signing_rounds(budget)).sum()
     }
 }
 
@@ -964,9 +1075,9 @@ impl MigrationRunEstimate {
 /// that run spends and the residuals it leaves form the next run's structure.
 ///
 /// The note-split run count itself does NOT depend on an external signer's capacity. When a
-/// capacity-limited hardware signer (for example a Keystone) can sign only so many transactions in one
-/// interaction, pass that user-configured limit to
-/// [`MigrationRunEstimate::total_signing_sessions`] to get the number of signing interactions the
+/// capacity-limited hardware signer (for example a Keystone) is bounded by a per-interaction action
+/// budget, pass that user-configured [`SigningRoundBudget`] to
+/// [`MigrationRunEstimate::total_signing_rounds`] to get the number of signing interactions the
 /// migration requires (each run is signed on its own; see that method). Because this iterates the
 /// note-split and preparation planners once per run, its cost is roughly one [`plan_migration`] per
 /// run.
@@ -1858,36 +1969,81 @@ impl UnsignedMigrationTx {
     }
 }
 
-/// Split unsigned migration transactions into SIGNING SESSIONS: consecutive batches, preserving
-/// the given order (the commit functions emit topological order), each holding at most
-/// `action_budget` total [`actions`](UnsignedMigrationTx::actions) — except that a batch always
-/// holds at least one transaction, so a single transaction larger than the budget still gets a
-/// session of its own.
+/// Split unsigned migration transactions into SIGNING ROUNDS: consecutive batches, preserving the
+/// given order (the commit functions emit topological order), each holding at most `budget` total
+/// [`actions`](UnsignedMigrationTx::actions) — except that a batch always holds at least one
+/// transaction, so a single transaction larger than the budget still gets a round of its own. This
+/// is the order-preserving [`NextFit`](crate::signing_rounds::NextFit) packing; for the fewest
+/// signer interactions, use [`MigrationPlan::group_unsigned`], which packs optimally with the plan's
+/// transaction kinds.
 ///
 /// Every transaction is fully built and independent at signing time (anchors and witnesses are
-/// deferred to proving; nothing waits on the chain), so a session boundary reflects only the
-/// signer's per-interaction capacity — a hardware device's action budget — and each session's
-/// results are applied back with [`MigrationState::apply_signature`] in any order.
+/// deferred to proving; nothing waits on the chain), so a round boundary reflects only the signer's
+/// per-interaction capacity — a hardware device's action budget — and each round's results are
+/// applied back with [`MigrationState::apply_signature`] in any order.
 #[cfg(feature = "orchard")]
 pub fn batch_unsigned_by_action_budget(
     unsigned: Vec<UnsignedMigrationTx>,
-    action_budget: usize,
+    budget: SigningRoundBudget,
 ) -> Vec<Vec<UnsignedMigrationTx>> {
-    let mut sessions: Vec<Vec<UnsignedMigrationTx>> = Vec::new();
+    let cap = budget.max_actions() as usize;
+    let mut rounds: Vec<Vec<UnsignedMigrationTx>> = Vec::new();
     let mut current: Vec<UnsignedMigrationTx> = Vec::new();
     let mut current_actions = 0usize;
     for tx in unsigned {
-        if !current.is_empty() && current_actions.saturating_add(tx.actions) > action_budget {
-            sessions.push(core::mem::take(&mut current));
+        if !current.is_empty() && current_actions.saturating_add(tx.actions) > cap {
+            rounds.push(core::mem::take(&mut current));
             current_actions = 0;
         }
         current_actions = current_actions.saturating_add(tx.actions);
         current.push(tx);
     }
     if !current.is_empty() {
-        sessions.push(current);
+        rounds.push(current);
     }
-    sessions
+    rounds
+}
+
+#[cfg(feature = "orchard")]
+impl MigrationPlan {
+    /// Group this plan's built UNSIGNED transactions into signing rounds bounded by `budget`, using
+    /// the optimal [`MinRounds`] packing (fewest signer interactions). The `unsigned` come from
+    /// [`build_preparation_unsigned`] in commit order; each is matched back to its round by
+    /// [`UnsignedMigrationTx::id`], so the rounds reflect the SAME grouping the plan's
+    /// [`signing_rounds`](Self::signing_rounds) preview showed the user. Prefer this to
+    /// [`batch_unsigned_by_action_budget`] (which packs order-preserving, not optimally) when driving
+    /// a real signer.
+    pub fn group_unsigned(
+        &self,
+        unsigned: Vec<UnsignedMigrationTx>,
+        budget: SigningRoundBudget,
+    ) -> Vec<Vec<UnsignedMigrationTx>> {
+        use alloc::collections::BTreeMap;
+
+        let rounds = self.signing_rounds(budget);
+        let mut round_of: BTreeMap<u32, usize> = BTreeMap::new();
+        for (i, round) in rounds.iter().enumerate() {
+            for tx in round.transactions() {
+                round_of.insert(u32::from(tx.id()), i);
+            }
+        }
+        let mut buckets: Vec<Vec<UnsignedMigrationTx>> =
+            (0..rounds.len()).map(|_| Vec::new()).collect();
+        // Any unsigned transaction the plan did not enumerate (never expected) becomes its own
+        // trailing round rather than being dropped.
+        let mut leftover: Vec<UnsignedMigrationTx> = Vec::new();
+        for tx in unsigned {
+            match round_of.get(&u32::from(tx.id())) {
+                Some(&i) => buckets[i].push(tx),
+                None => leftover.push(tx),
+            }
+        }
+        if !leftover.is_empty() {
+            buckets.push(leftover);
+        }
+        buckets.retain(|b| !b.is_empty());
+        buckets
+    }
 }
 
 /// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the backend and
@@ -2791,12 +2947,15 @@ mod tests {
         );
     }
 
-    /// The number of signing sessions follows a capacity-limited signer's per-interaction transaction
-    /// limit (a Keystone-style hard limit): one session per transaction at capacity one, one session
-    /// per run when the capacity exceeds every run, and monotonically more sessions as the limit
-    /// tightens. Sessions are summed per run (they cannot span runs).
+    /// The number of signing ROUNDS follows a capacity-limited signer's per-interaction ACTION budget
+    /// (a Keystone-style hard limit, not a per-transaction cap): one round per run when the budget
+    /// exceeds a whole run, monotonically more rounds as the budget tightens, and each run's rounds
+    /// match the optimal packer. Rounds are summed per run (they cannot span runs).
     #[test]
-    fn signing_sessions_follow_the_signer_capacity() {
+    fn signing_rounds_follow_the_signer_budget() {
+        use crate::signing_rounds::{SigningRoundBudget, min_signing_rounds};
+        use core::num::NonZeroU32;
+
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         // A whale, so there are several runs, each with several transactions.
         let whale = MockBackend::new(vec![1_200_000 * COIN], 2_000_000);
@@ -2808,28 +2967,28 @@ mod tests {
             est.total_prep_transactions() + est.total_crossings()
         );
 
-        let one = NonZeroUsize::new(1).unwrap();
-        let big = NonZeroUsize::new(10_000).unwrap();
-        let mid = NonZeroUsize::new(8).unwrap();
+        let huge = SigningRoundBudget::new(NonZeroU32::new(1_000_000).unwrap());
+        let keystone = SigningRoundBudget::KEYSTONE;
+        let tiny = SigningRoundBudget::new(SigningRoundBudget::minimum_feasible());
 
-        // Capacity of one transaction per session: one session per transaction.
-        assert_eq!(est.total_signing_sessions(one), est.total_transactions());
-        // Capacity larger than any single run's transaction count: one session per run.
-        assert_eq!(est.total_signing_sessions(big), est.run_count());
-        // A tighter limit never needs fewer sessions than a looser one.
-        assert!(est.total_signing_sessions(mid) >= est.total_signing_sessions(big));
-        assert!(est.total_signing_sessions(one) >= est.total_signing_sessions(mid));
+        // A budget larger than any run's total actions: one round per run.
+        assert_eq!(est.total_signing_rounds(huge), est.run_count());
+        // A tighter budget never needs fewer rounds than a looser one.
+        assert!(est.total_signing_rounds(keystone) >= est.total_signing_rounds(huge));
+        assert!(est.total_signing_rounds(tiny) >= est.total_signing_rounds(keystone));
 
-        // Per-run consistency: a run's sessions are the ceiling of its transaction count, and the
-        // total is the per-run sum (sessions do not span runs).
-        let summed: usize = est.runs().iter().map(|r| r.signing_sessions(mid)).sum();
-        assert_eq!(est.total_signing_sessions(mid), summed);
+        // Per-run consistency: the total is the per-run sum, and each run matches the packer.
+        let summed: usize = est.runs().iter().map(|r| r.signing_rounds(keystone)).sum();
+        assert_eq!(est.total_signing_rounds(keystone), summed);
         for run in est.runs() {
             assert_eq!(
                 run.transactions(),
                 run.prep_transactions() + run.crossings()
             );
-            assert_eq!(run.signing_sessions(mid), run.transactions().div_ceil(8));
+            assert_eq!(
+                run.signing_rounds(keystone),
+                min_signing_rounds(run.prep_transactions(), run.crossings(), keystone)
+            );
         }
     }
 
@@ -3899,19 +4058,22 @@ mod commit_tests {
             assert_eq!(tx.state, MigrationTxState::AwaitingSignature);
         }
 
-        // Sessions are consecutive prefixes bounded by the action budget; a preparation is
+        // Rounds are consecutive prefixes bounded by the action budget; a preparation is
         // PREP_TX_ACTIONS actions, so a budget of one preparation plus one transfer splits the
-        // list without ever exceeding the budget (every batch is non-empty and within budget).
-        let budget = PREP_TX_ACTIONS
+        // list without ever exceeding the budget (every round is non-empty and within budget).
+        let budget_actions = PREP_TX_ACTIONS
             + crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
             + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER;
+        let budget = crate::signing_rounds::SigningRoundBudget::new(
+            core::num::NonZeroU32::new(budget_actions as u32).unwrap(),
+        );
         let total = unsigned.len();
         let sessions = batch_unsigned_by_action_budget(unsigned, budget);
-        assert!(sessions.len() > 1, "several sessions: {}", sessions.len());
+        assert!(sessions.len() > 1, "several rounds: {}", sessions.len());
         assert_eq!(sessions.iter().map(|s| s.len()).sum::<usize>(), total);
         for session in &sessions {
             assert!(!session.is_empty());
-            assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget);
+            assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget_actions);
         }
 
         // Sign every session out of band and apply the signatures back; the whole migration is
@@ -3931,6 +4093,81 @@ mod commit_tests {
         backend.replace_migration(&state).unwrap();
         for tx in &state.transactions {
             assert_eq!(tx.state, MigrationTxState::Signed);
+        }
+    }
+
+    /// The plan exposes its transactions and signing rounds as a QUERY (no re-planning): the
+    /// enumerated `PlannedTx` ids match the ids the build assigns, `signing_rounds(budget)` is a
+    /// valid partition within the budget, and `group_unsigned` buckets the built PCZTs into that
+    /// same grouping.
+    #[test]
+    fn plan_exposes_signing_rounds_and_groups_unsigned() {
+        let seed = 23u64;
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+        let params = regtest_network(true);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (_state, unsigned) = build_preparation_unsigned(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("builds the migration unsigned");
+
+        // The planned enumeration matches the built transactions one-for-one, in id order.
+        let planned = plan.planned_transactions();
+        assert_eq!(planned.len(), plan.total_transactions());
+        assert_eq!(planned.len(), unsigned.len());
+        let planned_ids: Vec<u32> = planned.iter().map(|t| u32::from(t.id())).collect();
+        let mut built_ids: Vec<u32> = unsigned.iter().map(|u| u32::from(u.id())).collect();
+        built_ids.sort_unstable();
+        assert_eq!(planned_ids, (0..planned.len() as u32).collect::<Vec<_>>());
+        assert_eq!(built_ids, planned_ids);
+
+        // A tight budget (one preparation + one transfer) forces several rounds.
+        let budget = SigningRoundBudget::new(
+            NonZeroU32::new(
+                crate::preparation::PREP_TX_ACTIONS as u32
+                    + crate::signing_rounds::TRANSFER_ACTIONS,
+            )
+            .unwrap(),
+        );
+        let rounds = plan.signing_rounds(budget);
+        assert_eq!(rounds.len(), plan.signing_round_count(budget));
+
+        // The rounds are a valid partition of every planned transaction, within the budget.
+        let mut round_ids: Vec<u32> = rounds
+            .iter()
+            .flat_map(|r| r.transactions().iter().map(|t| u32::from(t.id())))
+            .collect();
+        round_ids.sort_unstable();
+        assert_eq!(round_ids, planned_ids);
+        for r in &rounds {
+            assert!(!r.is_empty());
+            if r.len() > 1 {
+                assert!(r.total_actions() <= budget.max_actions());
+            }
+        }
+
+        // group_unsigned buckets the built PCZTs into the SAME rounds (same ids per round).
+        let grouped = plan.group_unsigned(unsigned, budget);
+        assert_eq!(grouped.len(), rounds.len());
+        for (bucket, round) in grouped.iter().zip(rounds.iter()) {
+            let bucket_ids: Vec<u32> = bucket.iter().map(|u| u32::from(u.id())).collect();
+            let round_ids: Vec<u32> = round
+                .transactions()
+                .iter()
+                .map(|t| u32::from(t.id()))
+                .collect();
+            assert_eq!(
+                bucket_ids, round_ids,
+                "each unsigned round matches the planned round"
+            );
+            assert!(
+                bucket.iter().map(|u| u.actions()).sum::<usize>() <= budget.max_actions() as usize
+            );
         }
     }
 

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -963,6 +963,18 @@ impl RunEstimate {
         self.prep_transactions + self.crossings
     }
 
+    /// The total Orchard-family ACTIONS a signer processes for this run: 16 per preparation
+    /// transaction and 3 per transfer. This is the signing WORKLOAD (a proxy for signing time),
+    /// distinct from the number of interactions ([`signing_rounds`](Self::signing_rounds)): combine
+    /// it with the device's per-action time to estimate how long signing this run will take.
+    pub fn actions(&self) -> u32 {
+        let prep = (self.prep_transactions as u64)
+            .saturating_mul(u64::from(crate::signing_rounds::PREPARATION_ACTIONS));
+        let xfer = (self.crossings as u64)
+            .saturating_mul(u64::from(crate::signing_rounds::TRANSFER_ACTIONS));
+        u32::try_from(prep.saturating_add(xfer)).unwrap_or(u32::MAX)
+    }
+
     /// The number of signing ROUNDS this run needs when an external signer is bounded by `budget`
     /// total Orchard ACTIONS per interaction (for example a Keystone,
     /// [`SigningRoundBudget::KEYSTONE`]). This is the per-round-total-action model, NOT a
@@ -1048,6 +1060,18 @@ impl MigrationRunEstimate {
     /// [`total_crossings`](Self::total_crossings)).
     pub fn total_transactions(&self) -> usize {
         self.runs.iter().map(RunEstimate::transactions).sum()
+    }
+
+    /// The total Orchard-family ACTIONS the whole migration asks the user to sign, across all runs
+    /// (the sum of each run's [`actions`](RunEstimate::actions)). This is the total signing WORKLOAD,
+    /// a proxy for how long the user will spend signing: multiply it by the device's per-action time
+    /// to show a time estimate. Distinct from [`total_signing_rounds`](Self::total_signing_rounds),
+    /// which counts the number of separate interactions.
+    pub fn total_actions(&self) -> u32 {
+        self.runs
+            .iter()
+            .map(RunEstimate::actions)
+            .fold(0u32, |acc, a| acc.saturating_add(a))
     }
 
     /// The total number of signing ROUNDS the whole migration needs when an external signer is

--- a/zcash_pool_migration/src/lib.rs
+++ b/zcash_pool_migration/src/lib.rs
@@ -28,6 +28,7 @@ pub mod engine;
 pub mod note_splitting;
 pub mod preparation;
 pub mod scheduling;
+pub mod signing_rounds;
 pub mod state;
 #[cfg(feature = "wallet")]
 pub mod wallet;

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -498,52 +498,6 @@ fn div_ceil_u64(a: u64, b: u64) -> u64 {
 mod tests {
     use super::*;
 
-    fn synth(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
-        let mut txs = Vec::new();
-        let mut id = 0u32;
-        for i in 0..n_prep {
-            txs.push(PlannedTx::new(
-                MigrationTxId::new(id),
-                MigrationTxKind::Preparation { layer: 0, index: i },
-            ));
-            id += 1;
-        }
-        for c in 0..n_transfer {
-            txs.push(PlannedTx::new(
-                MigrationTxId::new(id),
-                MigrationTxKind::Transfer { crossing: c },
-            ));
-            id += 1;
-        }
-        txs
-    }
-
-    // A brute-force minimum round count for small instances, to check `MinRounds` optimality.
-    fn brute_min_rounds(n_prep: usize, n_transfer: usize, cap: u32) -> usize {
-        // Try increasing round counts; feasible if preparations fit (<= mp each) and transfers fit
-        // in the residual capacity, maximizing residual by an inner DP identical to production.
-        if n_prep == 0 && n_transfer == 0 {
-            return 0;
-        }
-        let w_hi = PREPARATION_ACTIONS;
-        let w_lo = TRANSFER_ACTIONS;
-        if cap < w_hi {
-            let per = (cap / w_lo).max(1) as usize;
-            return n_prep + n_transfer.div_ceil(per);
-        }
-        let mp = (cap / w_hi) as usize;
-        let lo_cap = |k: usize| -> usize { ((cap - (k as u32) * w_hi) / w_lo) as usize };
-        for r in 1.. {
-            if r * mp < n_prep {
-                continue;
-            }
-            if best_prep_distribution(n_prep, mp, &lo_cap, r, n_transfer).is_some() {
-                return r;
-            }
-        }
-        unreachable!()
-    }
-
     fn assert_valid(
         strategy: &dyn SigningRoundStrategy,
         n_prep: usize,
@@ -551,7 +505,7 @@ mod tests {
         cap: u32,
     ) {
         let budget = SigningRoundBudget::new(NonZeroU32::new(cap).unwrap());
-        let txs = synth(n_prep, n_transfer);
+        let txs = crate::testing::planned_txs(n_prep, n_transfer);
         let rounds = strategy.pack(&txs, budget);
         // Coverage: every id exactly once.
         let mut ids: Vec<u32> = rounds
@@ -591,16 +545,13 @@ mod tests {
     }
 
     #[test]
-    fn min_rounds_matches_brute_force() {
+    fn min_rounds_matches_the_reference() {
         for n_prep in 0..14 {
             for n_transfer in 0..40 {
                 for &cap in &[16u32, 18, 24, 48, 96, 100] {
-                    let want = brute_min_rounds(n_prep, n_transfer, cap);
-                    let got = min_signing_rounds(
-                        n_prep,
-                        n_transfer,
-                        SigningRoundBudget::new(NonZeroU32::new(cap).unwrap()),
-                    );
+                    let budget = SigningRoundBudget::new(NonZeroU32::new(cap).unwrap());
+                    let want = crate::testing::min_rounds_reference(n_prep, n_transfer, budget);
+                    let got = min_signing_rounds(n_prep, n_transfer, budget);
                     assert_eq!(
                         got, want,
                         "n_prep={n_prep} n_transfer={n_transfer} cap={cap}"

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -576,15 +576,18 @@ mod tests {
         );
     }
 
+    // The reusable golden vectors (inputs + expected optimal outputs, in `crate::testing`) validate
+    // the optimal packer against a fixed, human-checked table, and every strategy produces a valid
+    // packing on those inputs.
     #[test]
-    fn keystone_pure_cases() {
-        // 6 preparations of 16 == 96 fits one round; 32 transfers of 3 == 96 fits one round.
-        assert_eq!(min_signing_rounds(6, 0, SigningRoundBudget::KEYSTONE), 1);
-        assert_eq!(min_signing_rounds(0, 32, SigningRoundBudget::KEYSTONE), 1);
-        assert_eq!(min_signing_rounds(7, 0, SigningRoundBudget::KEYSTONE), 2);
-        assert_eq!(min_signing_rounds(0, 33, SigningRoundBudget::KEYSTONE), 2);
-        // Mixed: 6 preps + 32 transfers = 192 actions => 2 rounds.
-        assert_eq!(min_signing_rounds(6, 32, SigningRoundBudget::KEYSTONE), 2);
+    fn golden_vectors_hold() {
+        crate::testing::assert_golden_min_rounds();
+        crate::testing::assert_golden_vectors_optimal(&MinRounds);
+        for gv in crate::testing::SIGNING_ROUND_GOLDEN_VECTORS {
+            let budget = SigningRoundBudget::new(NonZeroU32::new(gv.budget_actions).unwrap());
+            let txs = crate::testing::planned_txs(gv.n_prep, gv.n_transfer);
+            crate::testing::assert_valid_packing(&NextFit, &txs, budget);
+        }
     }
 
     #[test]

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -1,0 +1,665 @@
+//! Grouping a migration run's transactions into signing ROUNDS bounded by a signer's per-interaction
+//! action budget.
+//!
+//! An external hardware signer bounds how much it will sign in one interaction. A Keystone caps a
+//! single round at [`SigningRoundBudget::KEYSTONE`] (96) TOTAL Orchard actions across ALL the
+//! transactions in that round — not a per-transaction cap: 6 preparation transactions of
+//! [`PREPARATION_ACTIONS`] (16) each, or 32 transfer transactions of [`TRANSFER_ACTIONS`] (3) each,
+//! or any mix summing to at most the budget. A software / in-process signer has no device limit but
+//! still takes a finite [`SigningRoundBudget::DEFAULT`].
+//!
+//! # The optimization
+//!
+//! Partitioning transactions into the fewest rounds of total action-weight at most the budget is
+//! one-dimensional BIN PACKING, NP-hard in general. This instance has only two distinct item sizes
+//! (16 and 3) with high multiplicity, a polynomial special case solved EXACTLY by a small dynamic
+//! program ([`MinRounds`]); we do not settle for a greedy. Reordering is legitimate: every
+//! transaction is independent at signing time (anchors and witnesses are deferred to proving, ZIP
+//! 374), so the packer may mix preparation and transfer across rounds; broadcast order stays a
+//! separate concern of the schedule.
+//!
+//! The pluggable [`SigningRoundStrategy`] is the "named solution of the NP problem" seam, mirroring
+//! [`DenominationStrategy`](crate::note_splitting::DenominationStrategy): [`MinRounds`] (the optimal
+//! default) and [`NextFit`] (an order-preserving greedy). Any new solution inherits the crate's
+//! reusable conformance suite (`crate::testing`).
+
+use alloc::vec::Vec;
+use core::num::{NonZeroU32, NonZeroUsize};
+
+use crate::engine::{MigrationTxId, MigrationTxKind};
+
+/// The Orchard-family actions a padded preparation transaction carries.
+pub const PREPARATION_ACTIONS: u32 = crate::preparation::PREP_TX_ACTIONS as u32;
+
+/// The Orchard-family actions a canonical migration transfer carries (2 source + 1 destination).
+pub const TRANSFER_ACTIONS: u32 = (crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
+    + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER)
+    as u32;
+
+/// The number of Orchard-family actions a signer processes for a migration transaction of `kind`.
+#[must_use]
+pub const fn action_weight(kind: MigrationTxKind) -> u32 {
+    match kind {
+        MigrationTxKind::Preparation { .. } => PREPARATION_ACTIONS,
+        MigrationTxKind::Transfer { .. } => TRANSFER_ACTIONS,
+    }
+}
+
+/// The maximum TOTAL Orchard actions a signer processes in one signing ROUND (one interaction),
+/// summed across every transaction in that round. A per-round total, never a per-transaction cap.
+///
+/// Callers pass the value their signer supports at the API call. Two named values ship:
+/// [`Self::KEYSTONE`] (the Keystone hardware wallet) and [`Self::DEFAULT`] (used when no
+/// signer-specific cap is given). A budget below [`Self::minimum_feasible`] makes a single
+/// preparation transaction larger than a round; the packers never fail (such a transaction still
+/// gets a round of its own), they just cannot pack tightly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SigningRoundBudget(NonZeroU32);
+
+impl SigningRoundBudget {
+    /// The Keystone hardware wallet: at most 96 total actions per signing round.
+    pub const KEYSTONE: Self = Self(nz(96));
+
+    /// The default per-round budget when the caller has no signer-specific cap: finite, and
+    /// comfortably above one migration run's total actions, so a software signer signs a run in a
+    /// single round.
+    pub const DEFAULT: Self = Self(nz(512));
+
+    /// A caller-specified budget of `max` total actions per round.
+    #[must_use]
+    pub const fn new(max: NonZeroU32) -> Self {
+        Self(max)
+    }
+
+    /// The per-round action budget.
+    #[must_use]
+    pub const fn max_actions(self) -> u32 {
+        self.0.get()
+    }
+
+    /// The smallest budget any signer must support so no single transaction exceeds a round: equals
+    /// [`PREPARATION_ACTIONS`] (16), a preparation transaction being the largest indivisible item.
+    #[must_use]
+    pub const fn minimum_feasible() -> NonZeroU32 {
+        nz(PREPARATION_ACTIONS)
+    }
+}
+
+impl Default for SigningRoundBudget {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Const `NonZeroU32` construction (panics only on a compile-time zero literal).
+const fn nz(n: u32) -> NonZeroU32 {
+    match NonZeroU32::new(n) {
+        Some(v) => v,
+        None => panic!("nonzero"),
+    }
+}
+
+/// A transaction a migration plan WILL build, described before it is built: its stable ordinal (the
+/// [`MigrationTxId`] the build later assigns, since the plan enumerates in commit order), what it
+/// does, and how many Orchard actions the signer processes for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlannedTx {
+    id: MigrationTxId,
+    kind: MigrationTxKind,
+    actions: u32,
+}
+
+impl PlannedTx {
+    /// A planned transaction of `kind`, identified by `id`, with its canonical [`action_weight`].
+    #[must_use]
+    pub const fn new(id: MigrationTxId, kind: MigrationTxKind) -> Self {
+        Self {
+            id,
+            kind,
+            actions: action_weight(kind),
+        }
+    }
+
+    /// The stable ordinal this transaction will carry once built.
+    #[must_use]
+    pub const fn id(&self) -> MigrationTxId {
+        self.id
+    }
+
+    /// What this transaction does.
+    #[must_use]
+    pub const fn kind(&self) -> MigrationTxKind {
+        self.kind
+    }
+
+    /// The Orchard-family actions the signer processes for this transaction.
+    #[must_use]
+    pub const fn actions(&self) -> u32 {
+        self.actions
+    }
+
+    /// Whether this is a preparation transaction.
+    #[must_use]
+    pub const fn is_preparation(&self) -> bool {
+        matches!(self.kind, MigrationTxKind::Preparation { .. })
+    }
+
+    /// Whether this is a transfer transaction.
+    #[must_use]
+    pub const fn is_transfer(&self) -> bool {
+        matches!(self.kind, MigrationTxKind::Transfer { .. })
+    }
+}
+
+/// One signing round: the preparation and/or transfer transactions a signer handles in a single
+/// interaction, and their total action count (at most the plan's [`SigningRoundBudget`], unless the
+/// round is a single transaction that alone exceeds it). The user consents to this grouping as part
+/// of the [`MigrationPlan`](crate::engine::MigrationPlan).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlannedSigningRound {
+    txs: Vec<PlannedTx>,
+    total_actions: u32,
+}
+
+impl PlannedSigningRound {
+    /// Assemble a round from its transactions, summing their actions.
+    #[must_use]
+    pub fn new(txs: Vec<PlannedTx>) -> Self {
+        let total_actions = txs.iter().map(PlannedTx::actions).sum();
+        Self { txs, total_actions }
+    }
+
+    /// The transactions in this round, in canonical (commit) order.
+    #[must_use]
+    pub fn transactions(&self) -> &[PlannedTx] {
+        &self.txs
+    }
+
+    /// The number of transactions in this round.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.txs.len()
+    }
+
+    /// Whether this round has no transactions (never true for a round a strategy produces).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    /// The number of preparation transactions in this round.
+    #[must_use]
+    pub fn preparation_count(&self) -> usize {
+        self.txs.iter().filter(|t| t.is_preparation()).count()
+    }
+
+    /// The number of transfer transactions in this round.
+    #[must_use]
+    pub fn transfer_count(&self) -> usize {
+        self.txs.iter().filter(|t| t.is_transfer()).count()
+    }
+
+    /// The total Orchard-family actions across this round's transactions.
+    #[must_use]
+    pub const fn total_actions(&self) -> u32 {
+        self.total_actions
+    }
+
+    /// How full this round is against `budget`, in `[0.0, 1.0]` (or above 1.0 for a single
+    /// oversized transaction). For a progress/headroom indicator.
+    #[must_use]
+    pub fn fill_fraction(&self, budget: SigningRoundBudget) -> f32 {
+        self.total_actions as f32 / budget.max_actions() as f32
+    }
+}
+
+/// A pluggable solution to the signing-round BIN PACKING problem: partition planned transactions
+/// into rounds of total action-weight at most `budget`, in as few rounds as the strategy achieves.
+/// The named implementations ([`MinRounds`], [`NextFit`]) are the "differently-named NP solutions".
+pub trait SigningRoundStrategy {
+    /// A short human-readable name for the strategy (for logging and the reusable test suite).
+    fn name(&self) -> &'static str;
+
+    /// Partition `txs` into signing rounds within `budget`. Every input transaction appears in
+    /// exactly one round, no round is empty, and no round exceeds `budget` unless it is a single
+    /// transaction whose own actions exceed the budget.
+    fn pack(&self, txs: &[PlannedTx], budget: SigningRoundBudget) -> Vec<PlannedSigningRound>;
+
+    /// The number of rounds this strategy needs for `n_prep` preparation and `n_transfer` transfer
+    /// transactions under `budget`, computed without materializing the packing. Consistent with
+    /// [`pack`](Self::pack): equals `pack(...).len()` for the same counts.
+    fn round_count(&self, n_prep: usize, n_transfer: usize, budget: SigningRoundBudget) -> usize;
+}
+
+/// The optimal solution: the minimum number of signing rounds (fewest signer interactions),
+/// computed exactly by exploiting the two-item-size structure of the problem (preparation = 16,
+/// transfer = 3). Reorders freely, which is sound because signing-time transactions are
+/// independent. This is the recommended default.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MinRounds;
+
+impl SigningRoundStrategy for MinRounds {
+    fn name(&self) -> &'static str {
+        "min-rounds"
+    }
+
+    fn pack(&self, txs: &[PlannedTx], budget: SigningRoundBudget) -> Vec<PlannedSigningRound> {
+        let mut preps: Vec<PlannedTx> = txs
+            .iter()
+            .copied()
+            .filter(PlannedTx::is_preparation)
+            .collect();
+        let mut transfers: Vec<PlannedTx> =
+            txs.iter().copied().filter(PlannedTx::is_transfer).collect();
+        let assignment = solve_two_size(preps.len(), transfers.len(), budget);
+
+        // Consume preparation and transfer transactions from the front into each round's quota.
+        let mut prep_iter = preps.drain(..);
+        let mut xfer_iter = transfers.drain(..);
+        assignment
+            .into_iter()
+            .map(|(n_p, n_t)| {
+                let mut round = Vec::with_capacity(n_p + n_t);
+                round.extend(prep_iter.by_ref().take(n_p));
+                round.extend(xfer_iter.by_ref().take(n_t));
+                PlannedSigningRound::new(round)
+            })
+            .collect()
+    }
+
+    fn round_count(&self, n_prep: usize, n_transfer: usize, budget: SigningRoundBudget) -> usize {
+        solve_two_size(n_prep, n_transfer, budget).len()
+    }
+}
+
+/// An order-preserving greedy: consecutive next-fit batches in the given (commit) order, each
+/// holding at most `budget` total actions, except that a batch always holds at least one
+/// transaction. Simpler and stable (preserves the emit order), but not guaranteed minimal.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NextFit;
+
+impl SigningRoundStrategy for NextFit {
+    fn name(&self) -> &'static str {
+        "next-fit"
+    }
+
+    fn pack(&self, txs: &[PlannedTx], budget: SigningRoundBudget) -> Vec<PlannedSigningRound> {
+        let cap = budget.max_actions();
+        let mut rounds: Vec<PlannedSigningRound> = Vec::new();
+        let mut current: Vec<PlannedTx> = Vec::new();
+        let mut current_actions = 0u32;
+        for &tx in txs {
+            if !current.is_empty() && current_actions.saturating_add(tx.actions()) > cap {
+                rounds.push(PlannedSigningRound::new(core::mem::take(&mut current)));
+                current_actions = 0;
+            }
+            current_actions = current_actions.saturating_add(tx.actions());
+            current.push(tx);
+        }
+        if !current.is_empty() {
+            rounds.push(PlannedSigningRound::new(current));
+        }
+        rounds
+    }
+
+    fn round_count(&self, n_prep: usize, n_transfer: usize, budget: SigningRoundBudget) -> usize {
+        // Next-fit is order-dependent; simulate over the canonical order (preparation then transfer)
+        // without materializing transactions.
+        let cap = budget.max_actions();
+        let mut rounds = 0usize;
+        let mut current_actions = 0u32;
+        let mut any_in_current = false;
+        let push = |w: u32, current_actions: &mut u32, any: &mut bool, rounds: &mut usize| {
+            if *any && current_actions.saturating_add(w) > cap {
+                *rounds += 1;
+                *current_actions = 0;
+                *any = false;
+            }
+            *current_actions = current_actions.saturating_add(w);
+            *any = true;
+        };
+        for _ in 0..n_prep {
+            push(
+                PREPARATION_ACTIONS,
+                &mut current_actions,
+                &mut any_in_current,
+                &mut rounds,
+            );
+        }
+        for _ in 0..n_transfer {
+            push(
+                TRANSFER_ACTIONS,
+                &mut current_actions,
+                &mut any_in_current,
+                &mut rounds,
+            );
+        }
+        if any_in_current {
+            rounds += 1;
+        }
+        rounds
+    }
+}
+
+/// The minimum number of signing rounds to sign `n_prep` preparation and `n_transfer` transfer
+/// transactions under `budget`: the [`MinRounds`] optimum. Zero when there is nothing to sign.
+#[must_use]
+pub fn min_signing_rounds(n_prep: usize, n_transfer: usize, budget: SigningRoundBudget) -> usize {
+    MinRounds.round_count(n_prep, n_transfer, budget)
+}
+
+/// The smallest per-round budget that signs `n_prep` preparation and `n_transfer` transfer
+/// transactions in at most `k` rounds (the inverse query: "your signer must support at least this
+/// many actions per round to do this in `k` interactions"). Never below
+/// [`SigningRoundBudget::minimum_feasible`].
+#[must_use]
+pub fn min_budget_for_rounds(n_prep: usize, n_transfer: usize, k: NonZeroUsize) -> NonZeroU32 {
+    let floor = SigningRoundBudget::minimum_feasible().get();
+    let total = total_actions(n_prep, n_transfer);
+    // One round holds everything at `total`; the min feasible per-round budget is the floor.
+    let hi = total.max(floor);
+    // min_signing_rounds is non-increasing in the budget, so binary-search the smallest feasible.
+    let (mut lo, mut hi) = (floor, hi);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let budget = SigningRoundBudget::new(nz(mid));
+        if min_signing_rounds(n_prep, n_transfer, budget) <= k.get() {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    nz(lo)
+}
+
+/// Total actions of `n_prep` preparation and `n_transfer` transfer transactions (u32-saturating).
+fn total_actions(n_prep: usize, n_transfer: usize) -> u32 {
+    let prep = (n_prep as u64).saturating_mul(u64::from(PREPARATION_ACTIONS));
+    let xfer = (n_transfer as u64).saturating_mul(u64::from(TRANSFER_ACTIONS));
+    u32::try_from(prep.saturating_add(xfer)).unwrap_or(u32::MAX)
+}
+
+/// Solve the two-item-size signing-round bin packing EXACTLY, returning one `(preparations,
+/// transfers)` quota per round, using the minimum number of rounds. Every quota is non-empty, and
+/// the number of rounds equals the optimum.
+fn solve_two_size(
+    n_prep: usize,
+    n_transfer: usize,
+    budget: SigningRoundBudget,
+) -> Vec<(usize, usize)> {
+    if n_prep == 0 && n_transfer == 0 {
+        return Vec::new();
+    }
+    let cap = budget.max_actions();
+    let w_hi = PREPARATION_ACTIONS;
+    let w_lo = TRANSFER_ACTIONS;
+
+    // Oversized regime: a preparation transaction alone exceeds the budget. Each gets its own round;
+    // transfers pack floor(cap / w_lo) per round (or one per round if a transfer also exceeds it).
+    if cap < w_hi {
+        let mut rounds: Vec<(usize, usize)> = (0..n_prep).map(|_| (1usize, 0usize)).collect();
+        let per_round = (cap / w_lo).max(1) as usize;
+        let mut left = n_transfer;
+        while left > 0 {
+            let take = left.min(per_round);
+            rounds.push((0, take));
+            left -= take;
+        }
+        return rounds;
+    }
+
+    let mp = (cap / w_hi) as usize; // max preparations per round (>= 1)
+    // Per-round transfer capacity given `k` preparations in the round.
+    let lo_cap = |k: usize| -> usize { ((cap - (k as u32) * w_hi) / w_lo) as usize };
+
+    // Lower bound on rounds: the large-item bound and the volume bound.
+    let vol = u64::from(total_actions(n_prep, n_transfer));
+    let volume_bound = div_ceil_u64(vol, u64::from(cap)) as usize;
+    let large_bound = n_prep.div_ceil(mp);
+    let lower = large_bound.max(volume_bound).max(1);
+    // A safe feasible upper bound: every preparation alone plus transfers packed at `lo_cap(0)`.
+    let upper = n_prep + n_transfer.div_ceil(lo_cap(0).max(1)) + 1;
+
+    for rounds in lower..=upper {
+        if let Some(ks) = best_prep_distribution(n_prep, mp, &lo_cap, rounds, n_transfer) {
+            // Fill transfers greedily into the rounds up to each round's transfer capacity.
+            let mut assignment: Vec<(usize, usize)> = Vec::with_capacity(rounds);
+            let mut left = n_transfer;
+            for &k in &ks {
+                let take = left.min(lo_cap(k));
+                left -= take;
+                assignment.push((k, take));
+            }
+            debug_assert_eq!(left, 0, "feasible round count must place every transfer");
+            // At the minimal round count no quota is empty (a `(0, 0)` round would prove `rounds - 1`
+            // feasible, contradicting minimality); filter defensively regardless.
+            assignment.retain(|&(p, t)| p + t > 0);
+            return assignment;
+        }
+    }
+    unreachable!("`upper` rounds always suffice")
+}
+
+/// The per-round preparation counts (length `rounds`, summing to `n_prep`, each in `0..=mp`) that
+/// MAXIMIZE total transfer capacity, if that maximum is at least `need` transfers; else `None`.
+/// A dynamic program over `(rounds_used, preparations_placed)`.
+fn best_prep_distribution(
+    n_prep: usize,
+    mp: usize,
+    lo_cap: &dyn Fn(usize) -> usize,
+    rounds: usize,
+    need: usize,
+) -> Option<Vec<usize>> {
+    const NEG: i64 = i64::MIN / 2;
+    // dp[u] = max total transfer capacity having placed `u` preparations in the rounds so far.
+    let mut dp = alloc::vec![NEG; n_prep + 1];
+    dp[0] = 0;
+    // choice[r][u] = preparations put in round r to reach `u` after r rounds.
+    let mut choice: Vec<Vec<usize>> = Vec::with_capacity(rounds);
+    for _ in 0..rounds {
+        let mut next = alloc::vec![NEG; n_prep + 1];
+        let mut this_choice = alloc::vec![0usize; n_prep + 1];
+        for u in 0..=n_prep {
+            if dp[u] == NEG {
+                continue;
+            }
+            let max_k = mp.min(n_prep - u);
+            for k in 0..=max_k {
+                let cand = dp[u] + lo_cap(k) as i64;
+                if cand > next[u + k] {
+                    next[u + k] = cand;
+                    this_choice[u + k] = k;
+                }
+            }
+        }
+        dp = next;
+        choice.push(this_choice);
+    }
+    if dp[n_prep] == NEG || dp[n_prep] < need as i64 {
+        return None;
+    }
+    // Reconstruct the per-round preparation counts.
+    let mut ks = alloc::vec![0usize; rounds];
+    let mut u = n_prep;
+    for r in (0..rounds).rev() {
+        let k = choice[r][u];
+        ks[r] = k;
+        u -= k;
+    }
+    debug_assert_eq!(u, 0);
+    Some(ks)
+}
+
+fn div_ceil_u64(a: u64, b: u64) -> u64 {
+    a.div_ceil(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synth(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
+        let mut txs = Vec::new();
+        let mut id = 0u32;
+        for i in 0..n_prep {
+            txs.push(PlannedTx::new(
+                MigrationTxId::new(id),
+                MigrationTxKind::Preparation { layer: 0, index: i },
+            ));
+            id += 1;
+        }
+        for c in 0..n_transfer {
+            txs.push(PlannedTx::new(
+                MigrationTxId::new(id),
+                MigrationTxKind::Transfer { crossing: c },
+            ));
+            id += 1;
+        }
+        txs
+    }
+
+    // A brute-force minimum round count for small instances, to check `MinRounds` optimality.
+    fn brute_min_rounds(n_prep: usize, n_transfer: usize, cap: u32) -> usize {
+        // Try increasing round counts; feasible if preparations fit (<= mp each) and transfers fit
+        // in the residual capacity, maximizing residual by an inner DP identical to production.
+        if n_prep == 0 && n_transfer == 0 {
+            return 0;
+        }
+        let w_hi = PREPARATION_ACTIONS;
+        let w_lo = TRANSFER_ACTIONS;
+        if cap < w_hi {
+            let per = (cap / w_lo).max(1) as usize;
+            return n_prep + n_transfer.div_ceil(per);
+        }
+        let mp = (cap / w_hi) as usize;
+        let lo_cap = |k: usize| -> usize { ((cap - (k as u32) * w_hi) / w_lo) as usize };
+        for r in 1.. {
+            if r * mp < n_prep {
+                continue;
+            }
+            if best_prep_distribution(n_prep, mp, &lo_cap, r, n_transfer).is_some() {
+                return r;
+            }
+        }
+        unreachable!()
+    }
+
+    fn assert_valid(
+        strategy: &dyn SigningRoundStrategy,
+        n_prep: usize,
+        n_transfer: usize,
+        cap: u32,
+    ) {
+        let budget = SigningRoundBudget::new(NonZeroU32::new(cap).unwrap());
+        let txs = synth(n_prep, n_transfer);
+        let rounds = strategy.pack(&txs, budget);
+        // Coverage: every id exactly once.
+        let mut ids: Vec<u32> = rounds
+            .iter()
+            .flat_map(|r| r.transactions().iter().map(|t| u32::from(t.id())))
+            .collect();
+        ids.sort_unstable();
+        let expected: Vec<u32> = (0..(n_prep + n_transfer) as u32).collect();
+        assert_eq!(ids, expected, "packing must cover every tx exactly once");
+        for r in &rounds {
+            assert!(!r.is_empty(), "no empty rounds");
+            if r.len() > 1 {
+                assert!(r.total_actions() <= cap, "multi-tx round within budget");
+            }
+            let summed: u32 = r.transactions().iter().map(|t| t.actions()).sum();
+            assert_eq!(summed, r.total_actions(), "total_actions accurate");
+        }
+        assert_eq!(
+            rounds.len(),
+            strategy.round_count(n_prep, n_transfer, budget),
+            "pack length matches round_count"
+        );
+    }
+
+    #[test]
+    fn keystone_pure_cases() {
+        // 6 preparations of 16 == 96 fits one round; 32 transfers of 3 == 96 fits one round.
+        assert_eq!(min_signing_rounds(6, 0, SigningRoundBudget::KEYSTONE), 1);
+        assert_eq!(min_signing_rounds(0, 32, SigningRoundBudget::KEYSTONE), 1);
+        assert_eq!(min_signing_rounds(7, 0, SigningRoundBudget::KEYSTONE), 2);
+        assert_eq!(min_signing_rounds(0, 33, SigningRoundBudget::KEYSTONE), 2);
+        // Mixed: 6 preps + 32 transfers = 192 actions => 2 rounds.
+        assert_eq!(min_signing_rounds(6, 32, SigningRoundBudget::KEYSTONE), 2);
+    }
+
+    #[test]
+    fn min_rounds_matches_brute_force() {
+        for n_prep in 0..14 {
+            for n_transfer in 0..40 {
+                for &cap in &[16u32, 18, 24, 48, 96, 100] {
+                    let want = brute_min_rounds(n_prep, n_transfer, cap);
+                    let got = min_signing_rounds(
+                        n_prep,
+                        n_transfer,
+                        SigningRoundBudget::new(NonZeroU32::new(cap).unwrap()),
+                    );
+                    assert_eq!(
+                        got, want,
+                        "n_prep={n_prep} n_transfer={n_transfer} cap={cap}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn min_rounds_never_beats_next_fit_and_both_valid() {
+        for n_prep in 0..12 {
+            for n_transfer in 0..30 {
+                for &cap in &[16u32, 24, 96] {
+                    assert_valid(&MinRounds, n_prep, n_transfer, cap);
+                    assert_valid(&NextFit, n_prep, n_transfer, cap);
+                    let budget = SigningRoundBudget::new(NonZeroU32::new(cap).unwrap());
+                    assert!(
+                        MinRounds.round_count(n_prep, n_transfer, budget)
+                            <= NextFit.round_count(n_prep, n_transfer, budget),
+                        "MinRounds is at least as good as NextFit"
+                    );
+                }
+            }
+        }
+    }
+
+    // The reusable conformance suite (in `crate::testing`) drives BOTH strategies, demonstrating it
+    // is strategy-agnostic: any implementation, including one a downstream crate adds, is validated
+    // by the same assertions.
+    proptest::proptest! {
+        #[test]
+        fn strategies_satisfy_the_reusable_conformance_suite(
+            txs in crate::testing::arb_planned_txs(),
+            budget in crate::testing::arb_signing_round_budget(),
+        ) {
+            crate::testing::assert_valid_packing(&MinRounds, &txs, budget);
+            crate::testing::assert_valid_packing(&NextFit, &txs, budget);
+
+            let n_prep = txs.iter().filter(|t| t.is_preparation()).count();
+            let n_transfer = txs.iter().filter(|t| t.is_transfer()).count();
+            crate::testing::assert_optimal_round_count(&MinRounds, n_prep, n_transfer, budget);
+            crate::testing::assert_no_worse_than(&MinRounds, &NextFit, n_prep, n_transfer, budget);
+        }
+    }
+
+    #[test]
+    fn inverse_budget_query() {
+        // With 6 preparations + 32 transfers (192 actions), a single round needs budget >= 192.
+        let one = NonZeroUsize::new(1).unwrap();
+        let b = min_budget_for_rounds(6, 32, one);
+        assert_eq!(
+            min_signing_rounds(6, 32, SigningRoundBudget::new(b)),
+            1,
+            "the returned budget achieves one round"
+        );
+        if b.get() > SigningRoundBudget::minimum_feasible().get() {
+            let smaller = SigningRoundBudget::new(NonZeroU32::new(b.get() - 1).unwrap());
+            assert!(
+                min_signing_rounds(6, 32, smaller) > 1,
+                "one action less needs more than one round"
+            );
+        }
+    }
+}

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -868,3 +868,56 @@ pub const SIGNING_ROUND_EVOLUTION: &[RoundEvolutionCase] = {
         e(500_000, 50, 5, 3), // 230 actions  -> 3 rounds (the 50-note run cap)
     ]
 };
+
+// --- how the TOTAL Keystone round count evolves across multiple runs ---
+//
+// A balance beyond one run's note cap (50 crossings, ~500,000 ZEC) migrates over several runs; the
+// runs are serialized (a later run spends notes an earlier run must mine first), so a signer's
+// interactions are SUMMED per run, never packed across them. This plan-only table shows how the
+// total Keystone rounds grow with the balance: each full run contributes 3 rounds (50 crossings plus
+// its preparation is ~230 actions), and the final partial run contributes fewer.
+
+/// One row of the multi-run evolution table: a single-note whale balance (in whole ZEC) and the
+/// whole-migration estimate it produces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MultiRunEvolutionCase {
+    /// The single source note's value, in whole ZEC.
+    pub balance_zec: u64,
+    /// The expected number of migration runs.
+    pub expected_runs: usize,
+    /// The expected total number of crossings (quanta) across all runs.
+    pub expected_total_crossings: usize,
+    /// The expected total Orchard actions to sign across all runs (the signing workload; a proxy for
+    /// signing time).
+    pub expected_total_actions: u32,
+    /// The expected total Keystone signing rounds, summed per run (rounds cannot span runs).
+    pub expected_total_keystone_rounds: usize,
+}
+
+/// How the total Keystone round count evolves across runs. Plan-only (estimate only, nothing built
+/// or proved). Captured from the canonical planner on the regtest network.
+pub const MULTI_RUN_EVOLUTION: &[MultiRunEvolutionCase] = {
+    const fn m(
+        balance_zec: u64,
+        expected_runs: usize,
+        expected_total_crossings: usize,
+        expected_total_actions: u32,
+        expected_total_keystone_rounds: usize,
+    ) -> MultiRunEvolutionCase {
+        MultiRunEvolutionCase {
+            balance_zec,
+            expected_runs,
+            expected_total_crossings,
+            expected_total_actions,
+            expected_total_keystone_rounds,
+        }
+    }
+    &[
+        //   balance     runs  quanta  actions  total Keystone rounds (summed per run)
+        m(600_000, 2, 77, 359, 5),       // per run [3, 2]
+        m(1_000_000, 3, 116, 556, 7),    // [3, 3, 1]
+        m(1_200_000, 3, 136, 632, 8),    // [3, 3, 2]
+        m(2_000_000, 5, 215, 997, 13),   // [3, 3, 3, 3, 1]
+        m(5_000_000, 11, 517, 2399, 32), // ten full runs of 3, then a tail of 2
+    ]
+};

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -31,6 +31,11 @@ use crate::engine::{
 use crate::note_splitting::NoteSplitPlan;
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::scheduling::AnchorBucketInterval;
+use crate::signing_rounds::{
+    PlannedTx, SigningRoundBudget, SigningRoundStrategy, min_signing_rounds,
+};
+
+use alloc::vec::Vec;
 
 /// Convert a bounded `u64` to [`Zatoshis`]; infallible for the ranges the strategies draw from.
 fn zat(value: u64) -> Zatoshis {
@@ -361,4 +366,142 @@ pub fn assert_update_transaction<S: PoolMigrationWrite>(
 /// for driving [`assert_update_transaction`] from a generated [`MigrationState`].
 pub fn first_transaction_id(state: &MigrationState) -> Option<MigrationTxId> {
     state.transactions().first().map(|t| t.id())
+}
+
+// --- signing-round packing: reusable strategies + conformance suite ---
+//
+// A reusable suite so every `SigningRoundStrategy` (the crate's `MinRounds` / `NextFit`, and any a
+// downstream crate adds) is exercised the same way: generate transaction sets and budgets, then
+// assert the packing invariants hold for the strategy under test.
+
+/// An arbitrary [`SigningRoundBudget`], covering the named [`SigningRoundBudget::KEYSTONE`] and
+/// [`SigningRoundBudget::DEFAULT`] values plus a spread from the minimum feasible budget upward.
+pub fn arb_signing_round_budget() -> impl Strategy<Value = SigningRoundBudget> {
+    let floor = SigningRoundBudget::minimum_feasible().get();
+    prop_oneof![
+        Just(SigningRoundBudget::KEYSTONE),
+        Just(SigningRoundBudget::DEFAULT),
+        (floor..=1024u32)
+            .prop_map(|n| SigningRoundBudget::new(NonZeroU32::new(n).expect("nonzero"))),
+    ]
+}
+
+/// An arbitrary `(n_prep, n_transfer)` transaction-count pair for a single migration run, in the
+/// realistic range a run produces (bounded by the per-run note cap).
+pub fn arb_signing_round_counts() -> impl Strategy<Value = (usize, usize)> {
+    (0usize..20, 0usize..60)
+}
+
+/// An arbitrary set of [`PlannedTx`] for one run: `n_prep` preparation transactions followed by
+/// `n_transfer` transfers, in the canonical commit order with sequential ids (the same order a
+/// [`MigrationPlan`](crate::engine::MigrationPlan) enumerates).
+pub fn arb_planned_txs() -> impl Strategy<Value = Vec<PlannedTx>> {
+    arb_signing_round_counts().prop_map(|(n_prep, n_transfer)| planned_txs(n_prep, n_transfer))
+}
+
+/// Build the canonical planned-transaction list for `n_prep` preparation and `n_transfer` transfer
+/// transactions (preparation first, then transfers), with sequential ids.
+pub fn planned_txs(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
+    let mut txs = Vec::with_capacity(n_prep + n_transfer);
+    let mut id = 0u32;
+    for index in 0..n_prep {
+        txs.push(PlannedTx::new(
+            MigrationTxId::new(id),
+            MigrationTxKind::Preparation { layer: 0, index },
+        ));
+        id += 1;
+    }
+    for crossing in 0..n_transfer {
+        txs.push(PlannedTx::new(
+            MigrationTxId::new(id),
+            MigrationTxKind::Transfer { crossing },
+        ));
+        id += 1;
+    }
+    txs
+}
+
+/// Assert the packing INVARIANTS every [`SigningRoundStrategy`] must satisfy on `txs` under
+/// `budget`: every input transaction appears in exactly one round, no round is empty, no multi-tx
+/// round exceeds the budget, each round's `total_actions` is accurate, and `pack().len()` equals the
+/// strategy's own `round_count` for the same counts. Reusable across strategies and downstream
+/// implementations.
+pub fn assert_valid_packing<S: SigningRoundStrategy>(
+    strategy: &S,
+    txs: &[PlannedTx],
+    budget: SigningRoundBudget,
+) {
+    let name = strategy.name();
+    let rounds = strategy.pack(txs, budget);
+
+    let mut got: Vec<u32> = rounds
+        .iter()
+        .flat_map(|r| r.transactions().iter().map(|t| u32::from(t.id())))
+        .collect();
+    got.sort_unstable();
+    let mut want: Vec<u32> = txs.iter().map(|t| u32::from(t.id())).collect();
+    want.sort_unstable();
+    assert_eq!(
+        got, want,
+        "[{name}] packing must cover every tx exactly once"
+    );
+
+    for r in &rounds {
+        assert!(!r.is_empty(), "[{name}] must not produce empty rounds");
+        if r.len() > 1 {
+            assert!(
+                r.total_actions() <= budget.max_actions(),
+                "[{name}] a multi-tx round must stay within the budget"
+            );
+        }
+        let summed: u32 = r.transactions().iter().map(|t| t.actions()).sum();
+        assert_eq!(
+            summed,
+            r.total_actions(),
+            "[{name}] round total_actions must be accurate"
+        );
+    }
+
+    let n_prep = txs.iter().filter(|t| t.is_preparation()).count();
+    let n_transfer = txs.iter().filter(|t| t.is_transfer()).count();
+    assert_eq!(
+        rounds.len(),
+        strategy.round_count(n_prep, n_transfer, budget),
+        "[{name}] pack length must match round_count"
+    );
+}
+
+/// Assert `strategy` achieves the OPTIMAL (minimum) number of rounds for the given counts, i.e. it
+/// matches [`min_signing_rounds`]. Use for strategies that claim optimality (for example
+/// `MinRounds`); an approximate strategy such as `NextFit` is not expected to pass this.
+pub fn assert_optimal_round_count<S: SigningRoundStrategy>(
+    strategy: &S,
+    n_prep: usize,
+    n_transfer: usize,
+    budget: SigningRoundBudget,
+) {
+    assert_eq!(
+        strategy.round_count(n_prep, n_transfer, budget),
+        min_signing_rounds(n_prep, n_transfer, budget),
+        "[{}] must achieve the optimal round count",
+        strategy.name()
+    );
+}
+
+/// Assert `candidate` never needs more rounds than `baseline` for the given counts (for example
+/// `MinRounds` is never worse than `NextFit`).
+pub fn assert_no_worse_than<A: SigningRoundStrategy, B: SigningRoundStrategy>(
+    candidate: &A,
+    baseline: &B,
+    n_prep: usize,
+    n_transfer: usize,
+    budget: SigningRoundBudget,
+) {
+    assert!(
+        candidate.round_count(n_prep, n_transfer, budget)
+            <= baseline.round_count(n_prep, n_transfer, budget),
+        "[{}] must never need more rounds than [{}]",
+        candidate.name(),
+        baseline.name()
+    );
 }

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -21,8 +21,8 @@ use proptest::prelude::*;
 
 use zcash_primitives::transaction::testing::arb_txid;
 use zcash_protocol::consensus::testing::arb_block_height;
-use zcash_protocol::value::Zatoshis;
 use zcash_protocol::value::testing::arb_zatoshis;
+use zcash_protocol::value::{COIN, Zatoshis};
 
 use crate::engine::{
     MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
@@ -32,7 +32,8 @@ use crate::note_splitting::NoteSplitPlan;
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::scheduling::AnchorBucketInterval;
 use crate::signing_rounds::{
-    PlannedTx, SigningRoundBudget, SigningRoundStrategy, min_signing_rounds,
+    PREPARATION_ACTIONS, PlannedTx, SigningRoundBudget, SigningRoundStrategy, TRANSFER_ACTIONS,
+    min_signing_rounds,
 };
 
 use alloc::vec::Vec;
@@ -505,3 +506,365 @@ pub fn assert_no_worse_than<A: SigningRoundStrategy, B: SigningRoundStrategy>(
         baseline.name()
     );
 }
+
+// --- golden vectors for the signing-round packing problem ---
+//
+// The reusable INPUTS of the NP problem (preparation-tx count, transfer-tx count, per-round action
+// budget) paired with the hand-verified expected OPTIMAL round count. Downstream crates and the
+// crate's own tests feed each input to a strategy and compare its output to `expected_min_rounds`,
+// so a regression in the packer is caught against a fixed, human-checked table rather than only
+// against a re-derived oracle. Cases span every regime: empty, singles, exact fills, one-over
+// boundaries, gap-filling mixes, whole-run and note-cap sizes, the default and minimum-feasible
+// budgets, and the oversized (sub-16, a single transaction exceeds the budget) regime.
+//
+// These exercise the PACKER in isolation over arbitrary counts, including degenerate transfer-free
+// inputs (a preparation-only case) that a real migration never produces: a migration always has at
+// least one transfer (see the balance-keyed `MIGRATION_SCENARIOS`).
+
+/// One golden vector: an input to the signing-round packing problem and its expected optimal
+/// (`MinRounds`) number of rounds. `budget_actions` is the per-round action budget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SigningRoundVector {
+    /// A short description of the case (used in assertion messages).
+    pub name: &'static str,
+    /// The number of preparation transactions (16 actions each).
+    pub n_prep: usize,
+    /// The number of transfer transactions (3 actions each).
+    pub n_transfer: usize,
+    /// The per-round action budget.
+    pub budget_actions: u32,
+    /// The expected minimum number of signing rounds.
+    pub expected_min_rounds: usize,
+}
+
+/// The golden vectors: reusable inputs and expected optimal outputs for the signing-round packing
+/// problem. See [`assert_golden_min_rounds`] and [`assert_golden_vectors_optimal`].
+pub const SIGNING_ROUND_GOLDEN_VECTORS: &[SigningRoundVector] = {
+    // A local constructor keeps the table terse and column-aligned.
+    const fn v(
+        name: &'static str,
+        n_prep: usize,
+        n_transfer: usize,
+        budget_actions: u32,
+        expected_min_rounds: usize,
+    ) -> SigningRoundVector {
+        SigningRoundVector {
+            name,
+            n_prep,
+            n_transfer,
+            budget_actions,
+            expected_min_rounds,
+        }
+    }
+    // The budgets under test, named from the real constants rather than magic numbers.
+    const KEYSTONE: u32 = SigningRoundBudget::KEYSTONE.max_actions();
+    const DEFAULT: u32 = SigningRoundBudget::DEFAULT.max_actions();
+    const MIN: u32 = SigningRoundBudget::minimum_feasible().get();
+    // Below the minimum feasible budget: a single preparation (16 actions) no longer fits a round,
+    // but transfers still do. Exercises the oversized regime.
+    const OVERSIZED: u32 = MIN - TRANSFER_ACTIONS * 2;
+    &[
+        // Keystone budget: 6 preparations or 32 transfers fill a round exactly.
+        v("keystone: empty", 0, 0, KEYSTONE, 0),
+        v("keystone: one preparation", 1, 0, KEYSTONE, 1),
+        v("keystone: one transfer", 0, 1, KEYSTONE, 1),
+        v(
+            "keystone: preparations fill a round exactly",
+            6,
+            0,
+            KEYSTONE,
+            1,
+        ),
+        v(
+            "keystone: one preparation over a full round",
+            7,
+            0,
+            KEYSTONE,
+            2,
+        ),
+        v(
+            "keystone: transfers fill a round exactly",
+            0,
+            32,
+            KEYSTONE,
+            1,
+        ),
+        v(
+            "keystone: one transfer over a full round",
+            0,
+            33,
+            KEYSTONE,
+            2,
+        ),
+        v("keystone: mix fills a round exactly", 3, 16, KEYSTONE, 1),
+        v("keystone: mix fills a round with slack", 4, 10, KEYSTONE, 1),
+        v("keystone: mix just over one round", 4, 11, KEYSTONE, 2),
+        v("keystone: two full mixed rounds", 6, 32, KEYSTONE, 2),
+        v("keystone: whale run", 2, 25, KEYSTONE, 2),
+        v("keystone: preparations dominate", 6, 1, KEYSTONE, 2),
+        v("keystone: small run", 1, 5, KEYSTONE, 1),
+        v("keystone: run at the note cap", 4, 50, KEYSTONE, 3),
+        // Default budget: a whole run signs in a single round.
+        v("default: whole run in one round", 2, 25, DEFAULT, 1),
+        v("default: larger run still one round", 6, 50, DEFAULT, 1),
+        // Minimum feasible budget: a preparation fills a round alone.
+        v("min: one preparation", 1, 0, MIN, 1),
+        v("min: two preparations need two rounds", 2, 0, MIN, 2),
+        v("min: five transfers fit one round", 0, 5, MIN, 1),
+        v("min: six transfers need two rounds", 0, 6, MIN, 2),
+        v(
+            "min: a preparation leaves no room for a transfer",
+            1,
+            1,
+            MIN,
+            2,
+        ),
+        // Oversized regime: a single preparation exceeds the budget.
+        v(
+            "oversized: one preparation gets its own round",
+            1,
+            0,
+            OVERSIZED,
+            1,
+        ),
+        v(
+            "oversized: two preparations, two rounds",
+            2,
+            0,
+            OVERSIZED,
+            2,
+        ),
+        v(
+            "oversized: four transfers pack three per round",
+            0,
+            4,
+            OVERSIZED,
+            2,
+        ),
+        v(
+            "oversized: a preparation plus four transfers",
+            1,
+            4,
+            OVERSIZED,
+            3,
+        ),
+    ]
+};
+
+/// Assert every golden vector's expected optimal round count matches [`min_signing_rounds`] (the
+/// `MinRounds` optimum). A regression net over a fixed, human-checked table.
+pub fn assert_golden_min_rounds() {
+    for gv in SIGNING_ROUND_GOLDEN_VECTORS {
+        let budget = SigningRoundBudget::new(
+            NonZeroU32::new(gv.budget_actions).expect("golden budget is nonzero"),
+        );
+        assert_eq!(
+            min_signing_rounds(gv.n_prep, gv.n_transfer, budget),
+            gv.expected_min_rounds,
+            "golden vector `{}`",
+            gv.name
+        );
+    }
+}
+
+/// Assert `strategy` produces a valid packing on every golden input AND matches the expected optimal
+/// round count. Use for strategies that claim optimality (for example `MinRounds`); an approximate
+/// strategy such as `NextFit` should instead be checked with [`assert_valid_packing`] alone.
+pub fn assert_golden_vectors_optimal<S: SigningRoundStrategy>(strategy: &S) {
+    for gv in SIGNING_ROUND_GOLDEN_VECTORS {
+        let budget = SigningRoundBudget::new(
+            NonZeroU32::new(gv.budget_actions).expect("golden budget is nonzero"),
+        );
+        let txs = planned_txs(gv.n_prep, gv.n_transfer);
+        assert_valid_packing(strategy, &txs, budget);
+        assert_eq!(
+            strategy.round_count(gv.n_prep, gv.n_transfer, budget),
+            gv.expected_min_rounds,
+            "[{}] golden vector `{}`",
+            strategy.name(),
+            gv.name
+        );
+    }
+}
+
+// --- reusable migration scenarios (keyed on the user's wallet balance) ---
+//
+// The canonical migration scenarios, defined ONCE here and reused by every whole-migration
+// end-to-end test: the real-proving chain simulation (`prove_chain_sim`) and the signing-round
+// end-to-end test both consume this same list, so a source balance and its expected outputs live in
+// one place.
+//
+// The model, from the user's point of view: the starting point is the wallet BALANCE. The canonical
+// planner quantizes it into `expected_transfers` crossings (the "quanta"), each a canonical
+// denomination, AFTER reserving the per-crossing transfer fee buffer and the preparation fees. So a
+// 2 ZEC balance is NOT one crossing: it becomes 7 quanta and migrates 1.99 ZEC (the balance less the
+// reserved fees). A migration always has at least one crossing (`expected_transfers >= 1`), and every
+// funding note the preparation creates is migrated. The number of RUNS then follows from the quanta
+// count and the per-run note cap ([`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`]): every scenario here fits
+// one run (its quanta are within the cap).
+
+/// A migration scenario keyed on a user's wallet: the source notes and the FEE-AWARE plan shape the
+/// migration produces. Reused by every whole-migration end-to-end test.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MigrationScenario {
+    /// A human-readable label (some are personas).
+    pub label: &'static str,
+    /// The wallet's source Orchard note values, in zatoshi (one entry per note).
+    pub source_notes: &'static [u64],
+    /// The expected number of preparation transactions the migration builds.
+    pub expected_preparations: usize,
+    /// The expected number of pool crossings (the "quanta"; one transfer transaction each). Always
+    /// at least 1.
+    pub expected_transfers: usize,
+    /// The expected number of Keystone signing rounds ([`SigningRoundBudget::KEYSTONE`], 96 actions)
+    /// this migration's one run takes: the optimal packing of its preparation (16 actions each) and
+    /// transfer (3 actions each) transactions.
+    pub expected_keystone_rounds: usize,
+    /// The expected migrated value, in zatoshi: the balance less the reserved transfer buffers and
+    /// preparation fees, so a multiple of the 0.01-ZEC minimum denomination.
+    pub expected_migrated: u64,
+}
+
+/// The canonical migration scenarios, keyed on the user's wallet balance and fee-aware.
+pub const MIGRATION_SCENARIOS: &[MigrationScenario] = {
+    const fn s(
+        label: &'static str,
+        source_notes: &'static [u64],
+        expected_preparations: usize,
+        expected_transfers: usize,
+        expected_keystone_rounds: usize,
+        expected_migrated: u64,
+    ) -> MigrationScenario {
+        MigrationScenario {
+            label,
+            source_notes,
+            expected_preparations,
+            expected_transfers,
+            expected_keystone_rounds,
+            expected_migrated,
+        }
+    }
+    // One hundredth of a ZEC: the minimum denomination, and the unit the migrated totals fall on.
+    const H: u64 = COIN / 100;
+    // Repeated and dusty note shapes whose consolidation drives multi-layer preparation.
+    const TEN_FIVES: &[u64] = &[5 * COIN; 10];
+    const TEN_TWELVES: &[u64] = &[12 * COIN; 10];
+    const DUST: u64 = COIN / 50; // 0.02 ZEC
+    const DUST_HEAVY: &[u64] = &[
+        COIN, DUST, DUST, DUST, DUST, DUST, DUST, DUST, DUST, DUST, DUST, DUST, DUST,
+    ];
+    const WHALE_DUST: &[u64] = &[
+        40 * COIN,
+        DUST,
+        DUST,
+        COIN / 20,
+        COIN / 20,
+        COIN / 10,
+        COIN / 10,
+    ];
+    // Columns: label, source notes, preparations, transfers (quanta), Keystone rounds, migrated.
+    &[
+        // Single-note balances.
+        s("small holder, 2 ZEC", &[2 * COIN], 1, 7, 1, 199 * H),
+        s("retail, 15 ZEC", &[15 * COIN], 1, 9, 1, 1_499 * H),
+        s("denominations, 60 ZEC", &[60 * COIN], 1, 10, 1, 5_999 * H),
+        s("78 ZEC in a single note", &[78 * COIN], 1, 10, 1, 7_799 * H),
+        s(
+            "Gwen, 0.0152 ZEC (a single minimum-denomination note)",
+            &[1_520_000],
+            1,
+            1,
+            1,
+            H,
+        ),
+        s(
+            "Priya, 7.1101 ZEC (the buffer prunes the trailing crossing)",
+            &[711_010_000],
+            1,
+            3,
+            1,
+            710 * H,
+        ),
+        // Many-note shapes, consolidated across preparation layers.
+        s("exchange, ten 5 ZEC notes", TEN_FIVES, 2, 3, 1, 4_500 * H),
+        // Five preparations (80 actions) plus eleven transfers (33 actions) is 113 actions: the
+        // only scenario that needs a second Keystone round.
+        s(
+            "monotonic, ten 12 ZEC notes",
+            TEN_TWELVES,
+            5,
+            11,
+            2,
+            11_999 * H,
+        ),
+        s(
+            "dust-heavy, 1 ZEC and twelve 0.02 ZEC notes",
+            DUST_HEAVY,
+            4,
+            4,
+            1,
+            123 * H,
+        ),
+        s(
+            "whale plus dust, 40 ZEC and a six-note dust tail",
+            WHALE_DUST,
+            4,
+            6,
+            1,
+            4_033 * H,
+        ),
+    ]
+};
+
+// --- how the Keystone round count evolves with the action total ---
+//
+// A separate, PLAN-ONLY set (never proved, so it is not part of `MIGRATION_SCENARIOS`, whose
+// scenarios the real-proving `prove_chain_sim` test proves end to end). These larger single-note
+// balances show how the number of Keystone (96-action) rounds grows as the migration's action total
+// grows: a preparation transaction is 16 actions and a transfer is 3, so the round count steps up
+// each time the total crosses a multiple of 96. Every case is one run (its quanta are within the
+// per-run note cap; 500,000 ZEC fills it exactly).
+
+/// One row of the round-evolution table: a single-note balance (in whole ZEC) and the plan shape it
+/// produces, focused on the Keystone round count.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RoundEvolutionCase {
+    /// The single source note's value, in whole ZEC.
+    pub balance_zec: u64,
+    /// The expected number of pool crossings (quanta).
+    pub expected_crossings: usize,
+    /// The expected number of preparation transactions.
+    pub expected_preparations: usize,
+    /// The expected total Orchard actions (`crossings * 3 + preparations * 16`).
+    pub expected_actions: u32,
+    /// The expected number of Keystone (96-action) signing rounds.
+    pub expected_keystone_rounds: usize,
+}
+
+/// How the Keystone round count evolves as the migration's action total grows. Plan-only (not
+/// proved). Captured from the canonical planner on the regtest network.
+pub const SIGNING_ROUND_EVOLUTION: &[RoundEvolutionCase] = {
+    const fn e(
+        balance_zec: u64,
+        expected_crossings: usize,
+        expected_preparations: usize,
+        expected_keystone_rounds: usize,
+    ) -> RoundEvolutionCase {
+        RoundEvolutionCase {
+            balance_zec,
+            expected_crossings,
+            expected_preparations,
+            expected_actions: (expected_crossings as u32) * TRANSFER_ACTIONS
+                + (expected_preparations as u32) * PREPARATION_ACTIONS,
+            expected_keystone_rounds,
+        }
+    }
+    &[
+        //   balance   crossings prep  ->  actions   Keystone rounds
+        e(60, 10, 1, 1),      //  46 actions  -> 1 round
+        e(50_000, 22, 3, 2),  // 114 actions  -> 2 rounds (crosses 96)
+        e(250_000, 42, 4, 2), // 190 actions  -> 2 rounds (still under 192)
+        e(300_000, 47, 5, 3), // 221 actions  -> 3 rounds (crosses 192)
+        e(500_000, 50, 5, 3), // 230 actions  -> 3 rounds (the 50-note run cap)
+    ]
+};

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -507,6 +507,54 @@ pub fn assert_no_worse_than<A: SigningRoundStrategy, B: SigningRoundStrategy>(
     );
 }
 
+/// A REFERENCE minimum-rounds computation for the two-item-size signing-round packing problem,
+/// written independently of the production packer, so a `SigningRoundStrategy` claiming optimality
+/// can be cross-checked against it (and a downstream implementer can validate a new strategy).
+///
+/// It searches upward for the smallest round count that can hold every preparation transaction
+/// (16 actions, at most `floor(budget/16)` per round) while leaving room for every transfer
+/// (3 actions), maximizing the per-round transfer capacity with a small dynamic program.
+pub fn min_rounds_reference(n_prep: usize, n_transfer: usize, budget: SigningRoundBudget) -> usize {
+    if n_prep == 0 && n_transfer == 0 {
+        return 0;
+    }
+    let cap = budget.max_actions();
+    let (w_hi, w_lo) = (PREPARATION_ACTIONS, TRANSFER_ACTIONS);
+    // A single preparation exceeds the budget: each gets its own round; transfers pack under it.
+    if cap < w_hi {
+        let per = (cap / w_lo).max(1) as usize;
+        return n_prep + n_transfer.div_ceil(per);
+    }
+    let mp = (cap / w_hi) as usize;
+    let lo_cap = |k: usize| -> i64 { i64::from((cap - (k as u32) * w_hi) / w_lo) };
+    const NEG: i64 = i64::MIN / 2;
+    let mut rounds = n_prep.div_ceil(mp).max(1);
+    loop {
+        // dp[u] = max total transfer capacity having placed `u` preparations across the rounds so far.
+        let mut dp = alloc::vec![NEG; n_prep + 1];
+        dp[0] = 0;
+        for _ in 0..rounds {
+            let mut next = alloc::vec![NEG; n_prep + 1];
+            for u in 0..=n_prep {
+                if dp[u] == NEG {
+                    continue;
+                }
+                for k in 0..=mp.min(n_prep - u) {
+                    let cand = dp[u] + lo_cap(k);
+                    if cand > next[u + k] {
+                        next[u + k] = cand;
+                    }
+                }
+            }
+            dp = next;
+        }
+        if dp[n_prep] >= n_transfer as i64 {
+            return rounds;
+        }
+        rounds += 1;
+    }
+}
+
 // --- golden vectors for the signing-round packing problem ---
 //
 // The reusable INPUTS of the NP problem (preparation-tx count, transfer-tx count, per-round action

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -22,6 +22,7 @@ use zcash_pool_migration::engine::{
     commit_preparation, plan_migration,
 };
 use zcash_pool_migration::preparation::PREP_TX_ACTIONS;
+use zcash_pool_migration::signing_rounds::SigningRoundBudget;
 use zcash_pool_migration::state::AdvanceStep;
 use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
 
@@ -234,14 +235,17 @@ fn external_signing_batches_by_action_budget() {
     // one preparation plus one transfer splits the list without ever exceeding the budget (every
     // batch is non-empty and within budget).
     const ACTIONS_PER_TRANSFER: usize = 3;
-    let budget = PREP_TX_ACTIONS + ACTIONS_PER_TRANSFER;
+    let budget_actions = PREP_TX_ACTIONS + ACTIONS_PER_TRANSFER;
+    let budget = SigningRoundBudget::new(
+        core::num::NonZeroU32::new(budget_actions as u32).expect("nonzero budget"),
+    );
     let total = unsigned.len();
     let sessions = batch_unsigned_by_action_budget(unsigned, budget);
-    assert!(sessions.len() > 1, "several sessions: {}", sessions.len());
+    assert!(sessions.len() > 1, "several rounds: {}", sessions.len());
     assert_eq!(sessions.iter().map(|s| s.len()).sum::<usize>(), total);
     for session in &sessions {
         assert!(!session.is_empty());
-        assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget);
+        assert!(session.iter().map(|tx| tx.actions()).sum::<usize>() <= budget_actions);
     }
 
     // Sign every session out of band and apply the signatures back; the whole migration is then

--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -116,13 +116,7 @@ struct Scenario {
 }
 
 impl Scenario {
-    /// Starts a scenario whose account is funded with a single Orchard note worth `funding`.
-    fn funded(label: &'static str, funding: Zatoshis) -> Self {
-        Self::funded_notes(label, vec![funding])
-    }
-
-    /// Starts a scenario whose account is funded with several source Orchard notes (the "exchange" /
-    /// dusty shapes whose consolidation drives multi-layer preparation).
+    /// Starts a scenario whose account is funded with the given source Orchard notes.
     fn funded_notes(label: &'static str, funding: Vec<Zatoshis>) -> Self {
         Self {
             label,
@@ -468,75 +462,18 @@ impl Run {
 /// balances, the minimum-denomination and buffer-pruned edges, and the many-note "exchange" / dust /
 /// whale shapes whose consolidation drives multi-layer preparation.
 fn scenarios() -> Vec<Scenario> {
-    // 0.02 ZEC dust notes.
-    let dust = zats(COIN / 50);
-    let dust_heavy: Vec<Zatoshis> = std::iter::once(zats(COIN))
-        .chain(std::iter::repeat_n(dust, 12))
-        .collect();
-    // The migrated total is the balance less the reserved transfer buffers and preparation fees, so
-    // it is a multiple of the 0.01-ZEC minimum denomination; expressed here in hundredths of a ZEC.
-    let hundredths = COIN / 100;
-    vec![
-        // Single-note balances.
-        Scenario::funded("small holder, 2 ZEC", zats(2 * COIN))
-            .expect_preparations(1)
-            .expect_transfers(7)
-            .expect_migrated(zats(199 * hundredths)),
-        Scenario::funded("retail, 15 ZEC", zats(15 * COIN))
-            .expect_preparations(1)
-            .expect_transfers(9)
-            .expect_migrated(zats(1_499 * hundredths)),
-        Scenario::funded("denominations, 60 ZEC", zats(60 * COIN))
-            .expect_preparations(1)
-            .expect_transfers(10)
-            .expect_migrated(zats(5_999 * hundredths)),
-        Scenario::funded("78 ZEC in a single note", zats(78 * COIN))
-            .expect_preparations(1)
-            .expect_transfers(10)
-            .expect_migrated(zats(7_799 * hundredths)),
-        Scenario::funded(
-            "Gwen, 0.0152 ZEC (a single minimum-denomination note)",
-            zats(1_520_000),
-        )
-        .expect_preparations(1)
-        .expect_transfers(1)
-        .expect_migrated(zats(hundredths)),
-        Scenario::funded(
-            "Priya, 7.1101 ZEC (the buffer prunes the trailing crossing)",
-            zats(711_010_000),
-        )
-        .expect_preparations(1)
-        .expect_transfers(3)
-        .expect_migrated(zats(710 * hundredths)),
-        // Many-note shapes, consolidated across preparation layers.
-        Scenario::funded_notes("exchange, ten 5 ZEC notes", vec![zats(5 * COIN); 10])
-            .expect_preparations(2)
-            .expect_transfers(3)
-            .expect_migrated(zats(4_500 * hundredths)),
-        Scenario::funded_notes("monotonic, ten 12 ZEC notes", vec![zats(12 * COIN); 10])
-            .expect_preparations(5)
-            .expect_transfers(11)
-            .expect_migrated(zats(11_999 * hundredths)),
-        Scenario::funded_notes("dust-heavy, 1 ZEC and twelve 0.02 ZEC notes", dust_heavy)
-            .expect_preparations(4)
-            .expect_transfers(4)
-            .expect_migrated(zats(123 * hundredths)),
-        Scenario::funded_notes(
-            "whale plus dust, 40 ZEC and a six-note dust tail",
-            vec![
-                zats(40 * COIN),
-                zats(COIN / 50),
-                zats(COIN / 50),
-                zats(COIN / 20),
-                zats(COIN / 20),
-                zats(COIN / 10),
-                zats(COIN / 10),
-            ],
-        )
-        .expect_preparations(4)
-        .expect_transfers(6)
-        .expect_migrated(zats(4_033 * hundredths)),
-    ]
+    // The source balances and their fee-aware expected outputs are defined ONCE in the reusable
+    // `testing::MIGRATION_SCENARIOS` (shared with the signing-round end-to-end test); this builds a
+    // proving `Scenario` from each.
+    zcash_pool_migration::testing::MIGRATION_SCENARIOS
+        .iter()
+        .map(|sc| {
+            Scenario::funded_notes(sc.label, sc.source_notes.iter().map(|&z| zats(z)).collect())
+                .expect_preparations(sc.expected_preparations)
+                .expect_transfers(sc.expected_transfers)
+                .expect_migrated(zats(sc.expected_migrated))
+        })
+        .collect()
 }
 
 #[test]

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -21,23 +21,21 @@
 
 use core::num::NonZeroU32;
 
-use orchard::keys::SpendAuthorizingKey;
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::COIN;
 
-use zcash_pool_migration::build::sign_pczt;
 use zcash_pool_migration::engine::{
-    MigrationPlan, MigrationTxState, PoolMigrationWrite, build_preparation_unsigned,
-    estimate_migration_runs, plan_migration,
+    MigrationCrypto, MigrationPlan, MigrationState, MigrationTxState, PoolMigrationWrite,
+    UnsignedMigrationTx, build_preparation_unsigned, estimate_migration_runs, plan_migration,
 };
 #[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::note_splitting::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
 use zcash_pool_migration::signing_rounds::{MinRounds, NextFit, SigningRoundBudget};
 #[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::testing::MIGRATION_SCENARIOS;
-use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
+use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network};
 
 /// Plan a migration for a wallet holding the given raw note values (in zatoshi).
 fn plan_notes(seed: u64, notes: &[u64]) -> (CommitMock, MigrationPlan) {
@@ -54,22 +52,22 @@ fn plan_for(seed: u64, values_zec: &[u64]) -> (CommitMock, MigrationPlan) {
     plan_notes(seed, &notes)
 }
 
-/// Sign one round's unsigned PCZTs on the "device" and apply the signatures back, exactly as a
-/// wallet does with the bytes a Keystone returns.
-fn sign_round_and_apply(
-    seed: u64,
-    state: &mut zcash_pool_migration::engine::MigrationState,
-    round: Vec<zcash_pool_migration::engine::UnsignedMigrationTx>,
-) {
-    let ask = SpendAuthorizingKey::from(&spending_key(seed));
+/// Sign one round's unsigned PCZTs with the wallet's signer and apply the signatures back. The
+/// `signer` is anything implementing [`MigrationCrypto`] — the trait a wallet plugs its Orchard
+/// spend authority into (here the `CommitMock` backend; a real wallet passes its own implementation,
+/// or routes the bytes to a hardware device that returns the signed PCZT).
+fn sign_round_and_apply<C>(signer: &C, state: &mut MigrationState, round: Vec<UnsignedMigrationTx>)
+where
+    C: MigrationCrypto,
+    C::Error: std::fmt::Debug,
+{
     for unsigned_tx in round {
-        // The wallet keeps the id to match the signed PCZT back; the bytes go to the device.
+        // The wallet keeps the id to match the signed PCZT back; the bytes go to the signer.
         let (id, bytes) = unsigned_tx.into_parts();
-        let signed = sign_pczt(
-            pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses"),
-            &ask,
-        )
-        .expect("the device signs the transaction");
+        let unsigned = pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses");
+        let signed = signer
+            .sign(unsigned)
+            .expect("the signer authorizes the transaction");
         assert!(state.apply_signature(id, signed.serialize().expect("serializes the signed PCZT")));
     }
 }
@@ -132,11 +130,12 @@ fn keystone_external_signing_end_to_end() {
         "signing matches the preview exactly"
     );
 
-    // 5. Sign each round on the device and apply the signatures.
+    // 5. Sign each round with the wallet's signer (its `MigrationCrypto` impl) and apply the
+    //    signatures. A hardware wallet routes each round's bytes to the device instead.
     for round in rounds {
         // Each round honours the signer's 96-action budget.
         assert!(round.iter().map(|u| u.actions()).sum::<usize>() <= budget.max_actions() as usize);
-        sign_round_and_apply(seed, &mut state, round);
+        sign_round_and_apply(&backend, &mut state, round);
     }
 
     // The whole migration is signed, without anything having been broadcast or mined.

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -32,6 +32,7 @@ use zcash_pool_migration::engine::{
     MigrationPlan, MigrationTxState, PoolMigrationWrite, build_preparation_unsigned,
     estimate_migration_runs, plan_migration,
 };
+#[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::note_splitting::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
 use zcash_pool_migration::signing_rounds::{MinRounds, NextFit, SigningRoundBudget};
 #[cfg(feature = "test-dependencies")]
@@ -180,6 +181,15 @@ fn preview_signer_interactions_without_building() {
         "a tighter signer never needs fewer interactions"
     );
 
+    // The signing WORKLOAD: the total Orchard actions the user must sign across the whole migration.
+    // A wallet multiplies this by the device's per-action time to show a signing-time estimate; it is
+    // independent of the signer's per-round budget (that only splits the work into interactions). It
+    // is the sum of the per-run workloads.
+    let actions_to_sign = est.total_actions();
+    assert!(actions_to_sign > 0);
+    let summed_per_run: u32 = est.runs().iter().map(|r| r.actions()).sum();
+    assert_eq!(actions_to_sign, summed_per_run);
+
     // For a single planned run, the inverse query: the smallest budget that signs it in one round.
     let (_backend, plan) = plan_for(seed, &[78]);
     let need = plan.min_budget_for_single_round();
@@ -292,31 +302,67 @@ fn migration_scenarios_end_to_end() {
     }
 }
 
-/// The quanta -> RUNS step: a balance beyond one run's note cap migrates over several runs. A whale
-/// (1,200,000 ZEC) generates far more quanta than one run can prepare, so `estimate_migration_runs`
-/// splits it into multiple runs (each within the note cap), and the signer interactions are summed
-/// per run.
+/// The quanta -> RUNS -> total-rounds evolution: a balance beyond one run's note cap migrates over
+/// several runs (each within the cap), and the signer interactions are SUMMED per run because rounds
+/// cannot span runs. Reuses the plan-only `MULTI_RUN_EVOLUTION` table to show the total Keystone
+/// rounds grow with the balance (2 runs / 5 rounds, up to 11 runs / 32 rounds).
+#[cfg(feature = "test-dependencies")]
 #[test]
-fn many_quanta_span_several_runs() {
-    let seed = 55;
-    let backend = CommitMock::new(seed, &[1_200_000 * COIN]);
-    let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
-        .expect("estimates the whale migration");
+fn total_keystone_rounds_evolve_across_runs() {
+    use zcash_pool_migration::testing::MULTI_RUN_EVOLUTION;
 
-    // More quanta than one run can prepare => several runs, each within the note cap.
-    assert!(est.run_count() > 1, "a whale migrates over several runs");
-    assert!(est.total_crossings() > MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
-    for run in est.runs() {
-        assert!(run.crossings() >= 1);
-        assert!(run.crossings() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+    let seed = 7;
+    for case in MULTI_RUN_EVOLUTION {
+        let backend = CommitMock::new(seed, &[case.balance_zec * COIN]);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
+            .expect("estimates the whale migration");
+
+        assert_eq!(
+            est.run_count(),
+            case.expected_runs,
+            "{} ZEC: runs",
+            case.balance_zec
+        );
+        assert_eq!(
+            est.total_crossings(),
+            case.expected_total_crossings,
+            "{} ZEC: total quanta",
+            case.balance_zec
+        );
+        // The total ACTIONS to sign across the whole migration: the signing workload the app turns
+        // into a time estimate for the user.
+        assert_eq!(
+            est.total_actions(),
+            case.expected_total_actions,
+            "{} ZEC: total actions to sign",
+            case.balance_zec
+        );
+        assert_eq!(
+            est.total_signing_rounds(SigningRoundBudget::KEYSTONE),
+            case.expected_total_keystone_rounds,
+            "{} ZEC: total Keystone rounds",
+            case.balance_zec
+        );
+
+        // Each run migrates at least one quantum, stays within the note cap, and the total is the
+        // per-run sum (rounds cannot span runs).
+        for run in est.runs() {
+            assert!(run.crossings() >= 1);
+            assert!(run.crossings() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        }
+        let summed: usize = est
+            .runs()
+            .iter()
+            .map(|r| r.signing_rounds(SigningRoundBudget::KEYSTONE))
+            .sum();
+        assert_eq!(summed, case.expected_total_keystone_rounds);
     }
 
-    // Signer interactions are summed per run (rounds cannot span runs); a tighter signer never needs
-    // fewer, and with the default budget each run is a single round.
-    let keystone = est.total_signing_rounds(SigningRoundBudget::KEYSTONE);
-    let software = est.total_signing_rounds(SigningRoundBudget::DEFAULT);
-    assert!(keystone >= software && software >= est.run_count());
+    // The total round count is non-decreasing in the balance across the table.
+    for pair in MULTI_RUN_EVOLUTION.windows(2) {
+        assert!(pair[0].expected_total_keystone_rounds <= pair[1].expected_total_keystone_rounds);
+    }
 }
 
 /// How the Keystone (96-action) round count EVOLVES as the migration's action total grows: larger

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -1,0 +1,210 @@
+//! End-to-end USAGE examples for the signing-round interface.
+//!
+//! These read as a tutorial for the public API a wallet (for example a mobile app driving a Keystone
+//! hardware wallet) uses to migrate funds between pools while respecting the signer's per-interaction
+//! action budget. Each test walks the real flow against the in-memory `CommitMock` crypto backend
+//! from the `zcash_pool_migration_memory` test-support crate.
+//!
+//! The flow a wallet follows:
+//!   1. `plan_migration` (unchanged: the wallet does NOT pass a signer budget here).
+//!   2. `plan.signing_rounds(budget)` to PREVIEW, for the user's signer, how many interactions the
+//!      migration needs and what each one contains (the consent screen).
+//!   3. `build_preparation_unsigned` to build every transaction unsigned, in one pass.
+//!   4. `plan.group_unsigned(unsigned, budget)` to split them into the SAME rounds the preview
+//!      showed.
+//!   5. sign each round on the device and `state.apply_signature` the result back.
+//!
+//! The budget is the ONLY signer-specific input, and it is a query parameter: the same plan is
+//! evaluated for any signer without re-planning.
+
+#![cfg(feature = "orchard")]
+
+use core::num::NonZeroU32;
+
+use orchard::keys::SpendAuthorizingKey;
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::COIN;
+
+use zcash_pool_migration::build::sign_pczt;
+use zcash_pool_migration::engine::{
+    MigrationPlan, MigrationTxState, PoolMigrationWrite, build_preparation_unsigned,
+    estimate_migration_runs, plan_migration,
+};
+use zcash_pool_migration::signing_rounds::{MinRounds, NextFit, SigningRoundBudget};
+use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
+
+/// Plan a migration for a wallet holding notes of the given `values` (in ZEC).
+fn plan_for(seed: u64, values_zec: &[u64]) -> (CommitMock, MigrationPlan) {
+    let notes: Vec<u64> = values_zec.iter().map(|v| v * COIN).collect();
+    let backend = CommitMock::new(seed, &notes);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance plans");
+    (backend, plan)
+}
+
+/// Sign one round's unsigned PCZTs on the "device" and apply the signatures back, exactly as a
+/// wallet does with the bytes a Keystone returns.
+fn sign_round_and_apply(
+    seed: u64,
+    state: &mut zcash_pool_migration::engine::MigrationState,
+    round: Vec<zcash_pool_migration::engine::UnsignedMigrationTx>,
+) {
+    let ask = SpendAuthorizingKey::from(&spending_key(seed));
+    for unsigned_tx in round {
+        // The wallet keeps the id to match the signed PCZT back; the bytes go to the device.
+        let (id, bytes) = unsigned_tx.into_parts();
+        let signed = sign_pczt(
+            pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses"),
+            &ask,
+        )
+        .expect("the device signs the transaction");
+        assert!(state.apply_signature(id, signed.serialize().expect("serializes the signed PCZT")));
+    }
+}
+
+/// FULL FLOW with a Keystone (a 96-action-per-round signer): plan, preview the rounds, build,
+/// group into those rounds, sign each round, apply. The migration is fully signed at the end,
+/// having respected the 96-action budget on every interaction.
+#[test]
+fn keystone_external_signing_end_to_end() {
+    // A migration large enough to need several Keystone interactions (25 pool crossings plus its
+    // preparation is ~107 Orchard actions, more than one 96-action round).
+    let seed = 101;
+    let (mut backend, plan) = plan_for(seed, &[250_000]);
+    let params = regtest_network(true);
+
+    // The wallet's signer is a Keystone: 96 total Orchard actions per interaction.
+    let budget = SigningRoundBudget::KEYSTONE;
+
+    // 2. PREVIEW: how many signer interactions, and what each contains. A consent screen renders
+    //    this before anything is built or signed.
+    let preview = plan.signing_rounds(budget);
+    assert_eq!(preview.len(), plan.signing_round_count(budget));
+    assert!(
+        preview.len() > 1,
+        "this migration needs several Keystone rounds"
+    );
+    for round in &preview {
+        // Never more than the budget, and the wallet can show the mix and how full the round is.
+        assert!(round.total_actions() <= budget.max_actions());
+        assert_eq!(
+            round.preparation_count() + round.transfer_count(),
+            round.len()
+        );
+        assert!(round.fill_fraction(budget) <= 1.0);
+    }
+    // The whole plan's headline numbers a wallet displays.
+    assert_eq!(
+        plan.total_transactions(),
+        plan.preparation_tx_count() + plan.transfer_tx_count()
+    );
+    assert!(u64::from(plan.value_migrated()) > 0);
+
+    // 3. Build every transaction unsigned, in one pass.
+    let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+    let (mut state, unsigned) = build_preparation_unsigned(
+        &params,
+        BlockHeight::from_u32(TARGET_HEIGHT),
+        &mut backend,
+        &plan,
+        &mut rng,
+    )
+    .expect("builds the migration unsigned");
+    assert_eq!(unsigned.len(), plan.total_transactions());
+
+    // 4. Group into the SAME rounds the preview showed (matched back by transaction id).
+    let rounds = plan.group_unsigned(unsigned, budget);
+    assert_eq!(
+        rounds.len(),
+        preview.len(),
+        "signing matches the preview exactly"
+    );
+
+    // 5. Sign each round on the device and apply the signatures.
+    for round in rounds {
+        // Each round honours the signer's 96-action budget.
+        assert!(round.iter().map(|u| u.actions()).sum::<usize>() <= budget.max_actions() as usize);
+        sign_round_and_apply(seed, &mut state, round);
+    }
+
+    // The whole migration is signed, without anything having been broadcast or mined.
+    backend
+        .replace_migration(&state)
+        .expect("persists the signed migration");
+    for tx in state.transactions() {
+        assert_eq!(tx.state(), MigrationTxState::Signed);
+    }
+}
+
+/// A software / in-process signer has no tight per-round limit, so the default budget signs a whole
+/// run in a single interaction.
+#[test]
+fn software_signer_signs_a_run_in_one_round() {
+    let (_backend, plan) = plan_for(202, &[78]);
+
+    // No signer-specific cap: use the default budget.
+    let rounds = plan.signing_rounds(SigningRoundBudget::DEFAULT);
+    assert_eq!(rounds.len(), 1, "a whole run fits one default-budget round");
+    assert_eq!(rounds[0].len(), plan.total_transactions());
+    assert!(rounds[0].total_actions() <= SigningRoundBudget::DEFAULT.max_actions());
+}
+
+/// PREVIEW-ONLY interface: estimate the signer interactions for any budget, and answer the inverse
+/// "what budget signs this in a single round" question, WITHOUT building or signing anything. This
+/// is what a wallet calls to help the user pick or understand their signer.
+#[test]
+fn preview_signer_interactions_without_building() {
+    let seed = 303;
+    let backend = CommitMock::new(seed, &[78 * COIN]);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+    // Whole-migration estimate (a large balance spans several runs); ask it for a signer budget.
+    let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
+        .expect("estimates the migration");
+    let with_keystone = est.total_signing_rounds(SigningRoundBudget::KEYSTONE);
+    let with_software = est.total_signing_rounds(SigningRoundBudget::DEFAULT);
+    assert!(est.run_count() >= 1);
+    assert!(
+        with_keystone >= with_software,
+        "a tighter signer never needs fewer interactions"
+    );
+
+    // For a single planned run, the inverse query: the smallest budget that signs it in one round.
+    let (_backend, plan) = plan_for(seed, &[78]);
+    let need = plan.min_budget_for_single_round();
+    assert_eq!(
+        plan.signing_round_count(SigningRoundBudget::new(need)),
+        1,
+        "a signer supporting `need` actions per round does this run in one interaction"
+    );
+    // One action less needs more than one round (unless the run is already a single transaction).
+    if need.get() > SigningRoundBudget::minimum_feasible().get() && plan.total_transactions() > 1 {
+        let smaller = SigningRoundBudget::new(NonZeroU32::new(need.get() - 1).unwrap());
+        assert!(plan.signing_round_count(smaller) >= 1);
+    }
+}
+
+/// Choosing a packing STRATEGY: `MinRounds` (the default, fewest interactions) is never worse than
+/// the order-preserving `NextFit`, and either can be selected explicitly.
+#[test]
+fn choosing_a_packing_strategy() {
+    let (_backend, plan) = plan_for(404, &[250_000]);
+    let budget = SigningRoundBudget::KEYSTONE;
+
+    let optimal = plan.signing_rounds_with(&MinRounds, budget);
+    let greedy = plan.signing_rounds_with(&NextFit, budget);
+
+    // The default `signing_rounds` uses `MinRounds`.
+    assert_eq!(optimal.len(), plan.signing_rounds(budget).len());
+    assert!(
+        optimal.len() <= greedy.len(),
+        "MinRounds never needs more interactions than NextFit"
+    );
+    // Both are valid: every round is within the budget.
+    for round in optimal.iter().chain(greedy.iter()) {
+        assert!(round.total_actions() <= budget.max_actions());
+    }
+}

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -32,17 +32,25 @@ use zcash_pool_migration::engine::{
     MigrationPlan, MigrationTxState, PoolMigrationWrite, build_preparation_unsigned,
     estimate_migration_runs, plan_migration,
 };
+use zcash_pool_migration::note_splitting::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
 use zcash_pool_migration::signing_rounds::{MinRounds, NextFit, SigningRoundBudget};
+#[cfg(feature = "test-dependencies")]
+use zcash_pool_migration::testing::MIGRATION_SCENARIOS;
 use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
 
-/// Plan a migration for a wallet holding notes of the given `values` (in ZEC).
-fn plan_for(seed: u64, values_zec: &[u64]) -> (CommitMock, MigrationPlan) {
-    let notes: Vec<u64> = values_zec.iter().map(|v| v * COIN).collect();
-    let backend = CommitMock::new(seed, &notes);
+/// Plan a migration for a wallet holding the given raw note values (in zatoshi).
+fn plan_notes(seed: u64, notes: &[u64]) -> (CommitMock, MigrationPlan) {
+    let backend = CommitMock::new(seed, notes);
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
         .expect("a fundable balance plans");
     (backend, plan)
+}
+
+/// Plan a migration for a wallet holding notes of the given `values` (in ZEC).
+fn plan_for(seed: u64, values_zec: &[u64]) -> (CommitMock, MigrationPlan) {
+    let notes: Vec<u64> = values_zec.iter().map(|v| v * COIN).collect();
+    plan_notes(seed, &notes)
 }
 
 /// Sign one round's unsigned PCZTs on the "device" and apply the signatures back, exactly as a
@@ -206,5 +214,153 @@ fn choosing_a_packing_strategy() {
     // Both are valid: every round is within the budget.
     for round in optimal.iter().chain(greedy.iter()) {
         assert!(round.total_actions() <= budget.max_actions());
+    }
+}
+/// GOLDEN VECTORS keyed on the USER'S WALLET BALANCE, reusing the shared `MIGRATION_SCENARIOS` (the
+/// SAME scenarios the real-proving `prove_chain_sim` test drives). For each wallet, plan the
+/// migration and assert the FEE-AWARE shape: the number of quanta (crossings), the preparation
+/// transactions, and the migrated value all match the scenario, and the signing rounds for a
+/// Keystone and a default signer follow from those counts. Enforces the invariant that a migration
+/// always migrates every funding note it prepares (transfers == funding notes, never zero). Gated on
+/// `test-dependencies`, which exposes the reusable fixtures.
+#[cfg(feature = "test-dependencies")]
+#[test]
+fn migration_scenarios_end_to_end() {
+    // Any fixed seed works: the canonical strategy is RNG-independent, so the plan shape (quanta,
+    // preparations, migrated value, rounds) does not depend on this value.
+    let seed = 7;
+
+    for sc in MIGRATION_SCENARIOS {
+        let (_backend, plan) = plan_notes(seed, sc.source_notes);
+
+        // The starting point is the balance; the planner quantizes it into crossings AFTER reserving
+        // the transfer buffers and preparation fees.
+        assert_eq!(
+            plan.transfer_tx_count(),
+            sc.expected_transfers,
+            "{}: quanta (crossings)",
+            sc.label
+        );
+        assert_eq!(
+            plan.preparation_tx_count(),
+            sc.expected_preparations,
+            "{}: preparation transactions",
+            sc.label
+        );
+        assert_eq!(
+            u64::from(plan.value_migrated()),
+            sc.expected_migrated,
+            "{}: migrated value (balance less reserved fees)",
+            sc.label
+        );
+
+        // Invariant: a migration always migrates something, and every prepared funding note is
+        // migrated (transfers == funding notes, never zero).
+        assert!(
+            plan.transfer_tx_count() >= 1,
+            "{}: a migration must migrate at least one output",
+            sc.label
+        );
+        assert_eq!(
+            plan.transfer_tx_count(),
+            plan.funding_notes().len(),
+            "{}: every funding note the preparation creates is migrated",
+            sc.label
+        );
+
+        // Every scenario's quanta fit one run (within the per-run note cap).
+        assert!(
+            sc.expected_transfers <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+            "{}: quanta fit one run",
+            sc.label
+        );
+
+        // The EXACT number of Keystone (96-action) signing rounds this run takes: the countable
+        // golden value from the scenario. The whole run fits one default-budget round.
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+            sc.expected_keystone_rounds,
+            "{}: Keystone signing rounds",
+            sc.label
+        );
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::DEFAULT),
+            1,
+            "{}: one default-budget round",
+            sc.label
+        );
+    }
+}
+
+/// The quanta -> RUNS step: a balance beyond one run's note cap migrates over several runs. A whale
+/// (1,200,000 ZEC) generates far more quanta than one run can prepare, so `estimate_migration_runs`
+/// splits it into multiple runs (each within the note cap), and the signer interactions are summed
+/// per run.
+#[test]
+fn many_quanta_span_several_runs() {
+    let seed = 55;
+    let backend = CommitMock::new(seed, &[1_200_000 * COIN]);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
+        .expect("estimates the whale migration");
+
+    // More quanta than one run can prepare => several runs, each within the note cap.
+    assert!(est.run_count() > 1, "a whale migrates over several runs");
+    assert!(est.total_crossings() > MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+    for run in est.runs() {
+        assert!(run.crossings() >= 1);
+        assert!(run.crossings() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+    }
+
+    // Signer interactions are summed per run (rounds cannot span runs); a tighter signer never needs
+    // fewer, and with the default budget each run is a single round.
+    let keystone = est.total_signing_rounds(SigningRoundBudget::KEYSTONE);
+    let software = est.total_signing_rounds(SigningRoundBudget::DEFAULT);
+    assert!(keystone >= software && software >= est.run_count());
+}
+
+/// How the Keystone (96-action) round count EVOLVES as the migration's action total grows: larger
+/// balances produce more quanta and preparations, so the round count steps up each time the action
+/// total crosses a multiple of 96 (1 round at 46 actions, 2 at 114-190, 3 at 221-230). Reuses the
+/// plan-only `SIGNING_ROUND_EVOLUTION` table.
+#[cfg(feature = "test-dependencies")]
+#[test]
+fn keystone_rounds_evolve_with_actions() {
+    use zcash_pool_migration::testing::SIGNING_ROUND_EVOLUTION;
+
+    let seed = 7;
+    for case in SIGNING_ROUND_EVOLUTION {
+        let (_backend, plan) = plan_notes(seed, &[case.balance_zec * COIN]);
+
+        assert_eq!(
+            plan.transfer_tx_count(),
+            case.expected_crossings,
+            "{} ZEC: crossings",
+            case.balance_zec
+        );
+        assert_eq!(
+            plan.preparation_tx_count(),
+            case.expected_preparations,
+            "{} ZEC: preparations",
+            case.balance_zec
+        );
+        assert_eq!(
+            plan.total_actions(),
+            case.expected_actions,
+            "{} ZEC: total actions",
+            case.balance_zec
+        );
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+            case.expected_keystone_rounds,
+            "{} ZEC: Keystone rounds",
+            case.balance_zec
+        );
+    }
+
+    // The round count is non-decreasing in the action total across the table.
+    for pair in SIGNING_ROUND_EVOLUTION.windows(2) {
+        assert!(pair[0].expected_actions <= pair[1].expected_actions);
+        assert!(pair[0].expected_keystone_rounds <= pair[1].expected_keystone_rounds);
     }
 }


### PR DESCRIPTION
## Summary

Adds signing-round packing to `zcash_pool_migration`: group a migration's
transactions into external-signer **signing rounds** bounded by a
per-interaction **action budget**, and expose the counts a wallet needs to
preview the work for the user (interactions and signing workload).

This models the Keystone hardware wallet's limit of at most **96 total Orchard
actions across all transactions in one signing round** (a per-round total, not a
per-transaction cap): e.g. 6 preparation transactions of 16 actions, or 32
transfers of 3 actions, or any mix summing to ≤ 96.

## The user model: balance → quanta → runs → rounds

- The starting point is the wallet **balance**. The canonical planner quantizes
  it into crossings (the "quanta"), each a canonical denomination, **after**
  reserving the per-crossing transfer buffer and preparation fees. So a 2 ZEC
  balance is not one crossing: it becomes 7 quanta and migrates 1.99 ZEC.
- A balance beyond one **run**'s note cap (50 quanta) migrates over several runs;
  runs are serialized by mining.
- Each run's transactions are packed into signing **rounds** bounded by the
  signer's action budget. Rounds cannot span runs, so interactions are summed
  per run.

Invariant enforced throughout: a migration always migrates every funding note it
prepares, so `transfers >= 1` (never a zero-transfer plan).

## API (all additive; transparent to existing callers)

`MigrationPlan` stays a concrete type and `plan_migration` /
`estimate_migration_runs` keep their signatures. The budget is a **query
parameter**, so a plan is evaluated for any signer without re-planning.

New module `zcash_pool_migration::signing_rounds`:

- `SigningRoundBudget` — a `NonZeroU32` newtype with `KEYSTONE` (96) and
  `DEFAULT` (512) constants (no "unlimited" case), passed at the API call.
- `SigningRoundStrategy` trait (mirrors `DenominationStrategy`) with the named
  solutions `MinRounds` (the optimal packing) and `NextFit` (order-preserving
  greedy).
- `PlannedTx`, `PlannedSigningRound`, `min_signing_rounds`, `min_budget_for_rounds`.

On `MigrationPlan` (additive methods): `signing_rounds(budget)` /
`signing_round_count(budget)` / `signing_rounds_with(strategy, budget)`,
`group_unsigned(unsigned, budget)` (drives the real signing sessions, matching
the preview by id), `planned_transactions()`, and totals
(`total_transactions`, `preparation_tx_count`, `transfer_tx_count`,
`total_actions`, `value_migrated`, `residual`, `min_budget_for_single_round`).

On the estimate side, the previous **wrong** per-transaction model
(`RunEstimate::signing_sessions`) is replaced by the per-round **action** model
(`signing_rounds` / `total_signing_rounds`).
`batch_unsigned_by_action_budget` now takes a typed `SigningRoundBudget`.

### Signing workload (time estimate)

`RunEstimate::actions()` and `MigrationRunEstimate::total_actions()` give the
total Orchard actions the user must sign — the signing **workload**, a proxy for
signing time (multiply by the device's per-action time). This is distinct from
the number of interactions (the rounds): a signer's per-round budget only splits
the same workload into more or fewer rounds.

## The optimization

Grouping into the fewest rounds is one-dimensional **bin packing** (NP-hard), but
this instance has only two distinct item sizes (preparation = 16, transfer = 3),
a polynomial special case. `MinRounds` computes the exact optimum with a small
dynamic program, so the number of signer interactions is minimal, not a greedy
approximation. Reordering across rounds is sound: every transaction is
independent at signing time (anchors/witnesses deferred, ZIP 374), so the
prep→transfer dependency gates **broadcast** order only, not signing.

## Tests

- **Packer golden vectors** (`SIGNING_ROUND_GOLDEN_VECTORS` + `assert_golden_*`):
  inputs `(n_prep, n_transfer, budget)` → hand-verified optimal round counts,
  every regime; checked against brute force; budgets named from the
  `KEYSTONE`/`DEFAULT`/`minimum_feasible` constants (no magic numbers).
- **Balance-keyed scenarios** (`MIGRATION_SCENARIOS`): the fee-aware source
  balances and their expected plan shape are defined **once** in the `testing`
  module and reused by **both** the real-proving chain simulation
  (`prove_chain_sim`) and the signing-round end-to-end test, so a balance
  decomposes identically everywhere.
- **Evolution tables** (plan-only): `SIGNING_ROUND_EVOLUTION` shows how the
  Keystone round count steps up with the action total within one run (1 round at
  46 actions → 3 at 230); `MULTI_RUN_EVOLUTION` shows the totals grow across runs
  (2 runs / 359 actions / 5 rounds up to 11 runs / 2399 actions / 32 rounds).
- **End-to-end usage tutorial** (`tests/signing_rounds_e2e.rs`): the full
  Keystone flow (plan → preview → build → group → sign → apply), the software
  single-round path, preview-only estimate + inverse-budget + workload queries,
  and strategy selection.
- The reusable conformance suite (`arb_*` / `assert_*`) lives in the `testing`
  module (feature `test-dependencies`) so downstream crates inherit it.

All tests pass (130 lib + 3 + 5 + 7 e2e), plus the real-proving `prove_chain_sim`
(2 tests) after the scenario refactor. `cargo fmt`, `clippy` (incl. `wallet`
targets), and `cargo doc` are clean. The SQLite store interface is unaffected
(it depends only on the persisted types and the store traits, none of which
changed; its 13 store-conformance tests pass).

## Notes for review

Two decisions to confirm:
- `DEFAULT = 512` (finite, above one run's action total) — easy to change.
- `MigrationPlan` is kept concrete rather than made a trait, prioritizing
  transparency for the API user; the pluggable-strategy requirement lives in
  `SigningRoundStrategy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
