### PR TITLE
AGENTS.md: agent plans and design documents are not committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,18 @@ Maintenance branches exist for released crate versions (e.g. `maint/zcash_client
 
 New features and non-fix changes should branch from `main`.
 
+## Plans & Design Documents
+
+Plans, design specs, and brainstorming documents produced by agents are working
+artifacts of a development session, not repository history. Never commit them.
+
+- Write them to the `.plans/` directory at the repository root, which is listed
+  in `.gitignore`.
+- If `.plans/` does not exist yet, create it (and ensure `.plans/` appears in
+  the checked-in `.gitignore`).
+- After writing a plan or spec, report its full absolute path, untruncated, so
+  it can be copy-pasted.
+
 ## Changelog & Commit Discipline
 
 - Update the crate's `CHANGELOG.md` for any public API change, bug fix, or


### PR DESCRIPTION
Adopts the convention that agent-produced plans, design specs, and brainstorming documents are working artifacts of a development session, not repository history: they live in a git-ignored `.plans/` directory at the repository root. Adds the corresponding section to `AGENTS.md` (standard handling: create `.plans/` if absent, keep it in the checked-in `.gitignore`, report full untruncated paths) and the `.gitignore` entry.

No tracking issue — repository-convention documentation only, at maintainer request.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)