### PR TITLE
zcash_pool_migration: denomination and transfer-id terminology, and expose the value a transfer crosses

### DIFF
--- a/zcash_client_sqlite/src/pool_migration.rs
+++ b/zcash_client_sqlite/src/pool_migration.rs
@@ -6,7 +6,7 @@
 //! committed migration is a set of pre-signed PCZTs plus their schedule and lifecycle state, so a
 //! wallet resumes a migration entirely from these tables after being closed or restarted.
 //!
-//! The schema is fully NORMALIZED: every structured value (the note-split plan, the preparation
+//! The schema is fully NORMALIZED: every structured value (the denomination plan, the preparation
 //! plan's transaction inputs/outputs and direct-funding notes, the transaction kind, and the
 //! dependency graph) is stored in typed columns and child tables, so it can be queried directly.
 //! The `BLOB` columns are the pre-signed transaction (`pczt`), which is genuinely unstructured,
@@ -42,7 +42,7 @@
 //!
 //! There is at most one migration in progress per pool per account, stored as a row in the pool's
 //! migrations table keyed by an `account_id` foreign key into `accounts` (with `ON DELETE CASCADE`,
-//! so an account's migration is removed with the account), with its transactions, note split, and
+//! so an account's migration is removed with the account), with its transactions, denomination plan, and
 //! preparation plan in the pool's child tables (addressed through that row's synthetic primary
 //! key). The pool's `PoolMigrations` type is the store: construct it over a `rusqlite::Connection`
 //! (the same one [`WalletDb`](crate::WalletDb) uses) and the [`AccountUuid`](crate::AccountUuid)

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -162,10 +162,10 @@ mod retention_follows_the_committed_migration {
         TestBuilder, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
     };
     use zcash_client_backend::data_api::{Account as _, WalletCommitmentTrees, WalletRead};
+    use zcash_pool_migration::denomination::DenominationPlan;
     use zcash_pool_migration::engine::{
         MigrationState, MigrationStatus, PoolMigrationRead, PoolMigrationWrite,
     };
-    use zcash_pool_migration::note_splitting::NoteSplitPlan;
     use zcash_pool_migration::preparation::PreparationPlan;
     use zcash_pool_migration::scheduling::AnchorBucketInterval;
     use zcash_primitives::block::BlockHash;
@@ -179,7 +179,7 @@ mod retention_follows_the_committed_migration {
     fn migration_committed_under(interval: AnchorBucketInterval) -> MigrationState {
         MigrationState::from_parts(
             MigrationStatus::Committed,
-            NoteSplitPlan::from_stored_parts(
+            DenominationPlan::from_stored_parts(
                 Vec::new(),
                 Zatoshis::ZERO,
                 None,
@@ -374,15 +374,15 @@ mod tests {
     /// covers the type more broadly.
     #[test]
     fn lock_owner_round_trips() {
+        use zcash_pool_migration::denomination::DenominationPlan;
         use zcash_pool_migration::engine::{
             MigrationState, MigrationStatus, MigrationTransaction, MigrationTxKind,
         };
-        use zcash_pool_migration::note_splitting::NoteSplitPlan;
         use zcash_pool_migration::preparation::PreparationPlan;
         use zcash_protocol::consensus::BlockHeight;
         use zcash_protocol::value::Zatoshis;
 
-        let note_split = NoteSplitPlan::from_stored_parts(
+        let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
             Zatoshis::ZERO,
             None,
@@ -417,7 +417,7 @@ mod tests {
         );
         let state = MigrationState::from_parts(
             MigrationStatus::Committed,
-            note_split,
+            denominations,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             vec![locked, unlocked],
             AnchorBucketInterval::ZIP_318,
@@ -454,10 +454,10 @@ mod tests {
         use std::collections::BTreeSet;
 
         use zcash_client_backend::wallet::LockOwner;
+        use zcash_pool_migration::denomination::DenominationPlan;
         use zcash_pool_migration::engine::{
             MigrationState, MigrationStatus, MigrationTransaction, MigrationTxKind,
         };
-        use zcash_pool_migration::note_splitting::NoteSplitPlan;
         use zcash_pool_migration::preparation::PreparationPlan;
         use zcash_protocol::consensus::BlockHeight;
         use zcash_protocol::value::Zatoshis;
@@ -472,7 +472,7 @@ mod tests {
         let owner_a_bytes = [0xA1u8; 32];
         let owner_b_bytes = [0xB2u8; 32];
 
-        let note_split = NoteSplitPlan::from_stored_parts(
+        let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
             Zatoshis::ZERO,
             None,
@@ -498,7 +498,7 @@ mod tests {
 
         let state = MigrationState::from_parts(
             MigrationStatus::Committed,
-            note_split,
+            denominations,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             vec![
                 tx(0, 0, Some(owner_a_bytes)),
@@ -525,12 +525,12 @@ mod tests {
     /// so an empty layer would leave no trace (and the engine never produces one).
     #[test]
     fn empty_prep_layer_is_rejected() {
+        use zcash_pool_migration::denomination::DenominationPlan;
         use zcash_pool_migration::engine::{MigrationState, MigrationStatus};
-        use zcash_pool_migration::note_splitting::NoteSplitPlan;
         use zcash_pool_migration::preparation::PreparationPlan;
         use zcash_protocol::value::Zatoshis;
 
-        let note_split = NoteSplitPlan::from_stored_parts(
+        let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
             Zatoshis::ZERO,
             None,
@@ -541,7 +541,7 @@ mod tests {
         .expect("an empty stored plan reconstructs");
         let state = MigrationState::from_parts(
             MigrationStatus::Committed,
-            note_split,
+            denominations,
             PreparationPlan::from_parts(vec![Vec::new()], Vec::new()),
             Vec::new(),
             AnchorBucketInterval::ZIP_318,
@@ -558,8 +558,8 @@ mod tests {
     /// cleanup the wallet's account-deletion path now relies on entirely (no explicit delete).
     #[test]
     fn deleting_an_account_cascades_to_its_migration() {
+        use zcash_pool_migration::denomination::DenominationPlan;
         use zcash_pool_migration::engine::{MigrationState, MigrationStatus};
-        use zcash_pool_migration::note_splitting::NoteSplitPlan;
         use zcash_pool_migration::preparation::PreparationPlan;
         use zcash_protocol::value::Zatoshis;
 
@@ -574,7 +574,7 @@ mod tests {
 
         // A minimal but non-trivial migration (one crossing value) so the cascade is observed to
         // reach a child table, not only the parent row.
-        let note_split = NoteSplitPlan::from_stored_parts(
+        let denominations = DenominationPlan::from_stored_parts(
             vec![Zatoshis::const_from_u64(1)],
             Zatoshis::ZERO,
             None,
@@ -585,7 +585,7 @@ mod tests {
         .expect("a one-crossing stored plan reconstructs");
         let state = MigrationState::from_parts(
             MigrationStatus::Committed,
-            note_split,
+            denominations,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             Vec::new(),
             AnchorBucketInterval::ZIP_318,

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -13,7 +13,7 @@ use rusqlite::{Connection, OptionalExtension};
 
 use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration::engine::{
-    MigrationState, MigrationTxId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 
 use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
@@ -137,7 +137,7 @@ impl<C: BorrowMut<Connection>> PoolMigrationWrite for PoolMigrations<C> {
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         self.0.update_transaction(id, state)
@@ -310,7 +310,7 @@ mod tests {
     use uuid::Uuid;
 
     use zcash_pool_migration::engine::{
-        MigrationTxId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+        MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
     };
     use zcash_pool_migration::scheduling::AnchorBucketInterval;
     use zcash_pool_migration::testing::{
@@ -394,7 +394,7 @@ mod tests {
 
         let owner_bytes = [7u8; 32];
         let locked = MigrationTransaction::from_parts(
-            MigrationTxId::new(0),
+            MigrationTransferId::new(0),
             MigrationTxKind::Preparation { layer: 0, index: 0 },
             vec![1, 2, 3],
             Vec::new(),
@@ -405,7 +405,7 @@ mod tests {
             Some(owner_bytes),
         );
         let unlocked = MigrationTransaction::from_parts(
-            MigrationTxId::new(1),
+            MigrationTransferId::new(1),
             MigrationTxKind::Transfer { crossing: 0 },
             vec![4, 5, 6],
             Vec::new(),
@@ -484,7 +484,7 @@ mod tests {
 
         let tx = |id: u32, crossing: usize, lock_owner: Option<[u8; 32]>| {
             MigrationTransaction::from_parts(
-                MigrationTxId::new(id),
+                MigrationTransferId::new(id),
                 MigrationTxKind::Transfer { crossing },
                 vec![id as u8],
                 Vec::new(),
@@ -679,7 +679,7 @@ mod tests {
             s.replace_migration(&state).expect("write");
             // Generated ids are `0..transactions.len()` (< 6), so `u32::MAX` is always absent.
             let err = s
-                .update_transaction(MigrationTxId::new(u32::MAX), MigrationTxState::Proved)
+                .update_transaction(MigrationTransferId::new(u32::MAX), MigrationTxState::Proved)
                 .expect_err("no such transaction");
             prop_assert!(matches!(err, Error::Corrupt(_)));
         }

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -16,7 +16,7 @@
 //! produces has at least one input and one output (and no layer is empty), so the store
 //! reconstructs the grid from those rows (and rejects a state it could not reconstruct with
 //! [`Error::Unrepresentable`]). Likewise the funding-note values have no table: the engine derives
-//! them from the note split (each crossing value plus the fee buffer).
+//! them from the denomination plan (each crossing value plus the fee buffer).
 //!
 //! The column set is the same for every pool; only the table and index names change.
 //!
@@ -30,11 +30,11 @@ use std::num::NonZeroU32;
 use rusqlite::{Connection, OptionalExtension, named_params, params};
 
 use zcash_client_backend::wallet::LockOwner;
+use zcash_pool_migration::denomination::DenominationPlan;
 use zcash_pool_migration::engine::{
     MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
     MigrationTxState,
 };
-use zcash_pool_migration::note_splitting::NoteSplitPlan;
 use zcash_pool_migration::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use zcash_pool_migration::scheduling::AnchorBucketInterval;
 use zcash_protocol::consensus::BlockHeight;
@@ -48,9 +48,9 @@ use super::error::Error;
 /// supplies a `'static` value of this for its own pool; the generic store interpolates these into
 /// every DDL and query, so one implementation serves every pool.
 pub(crate) struct Tables {
-    /// The migration-state table (one row per account; holds the note-split scalars).
+    /// The migration-state table (one row per account; holds the denomination scalars).
     pub migrations: &'static str,
-    /// The note-split crossing values (an ordered list).
+    /// The denomination crossing values (an ordered list).
     pub crossing_values: &'static str,
     /// The inputs of each preparation transaction, keyed by the transaction's `(layer, tx_index)`
     /// grid coordinate.
@@ -406,7 +406,7 @@ fn read_migration(
         .ok_or(Error::Corrupt("anchor_bucket_interval"))?;
 
     let crossing_values = read_zatoshi_list(conn, t.crossing_values, migration_id)?;
-    let note_split = NoteSplitPlan::from_stored_parts(
+    let denominations = DenominationPlan::from_stored_parts(
         crossing_values,
         Zatoshis::from_u64(fee_buffer)?,
         change.map(Zatoshis::from_u64).transpose()?,
@@ -414,7 +414,7 @@ fn read_migration(
         Zatoshis::from_u64(total_input)?,
         Zatoshis::from_u64(total_migratable)?,
     )
-    .map_err(|_| Error::Corrupt("note_split"))?;
+    .map_err(|_| Error::Corrupt("denominations"))?;
 
     let preparation = read_preparation(conn, t, migration_id)?;
     let transactions = read_transactions(conn, t, migration_id)?;
@@ -423,7 +423,7 @@ fn read_migration(
         MigrationStatus::try_from(status.as_str()).map_err(|_| Error::Corrupt("status"))?;
     Ok(Some(MigrationState::from_parts(
         status,
-        note_split,
+        denominations,
         preparation,
         transactions,
         anchor_bucket_interval,
@@ -779,7 +779,7 @@ fn replace_migration(
         )?;
     }
 
-    let ns = state.note_split();
+    let ns = state.denominations();
     tx.execute(
         &format!(
             "INSERT INTO {} (account_id, status, note_split_fee_buffer, note_split_change,

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -32,7 +32,7 @@ use rusqlite::{Connection, OptionalExtension, named_params, params};
 use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration::denomination::DenominationPlan;
 use zcash_pool_migration::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
+    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
     MigrationTxState,
 };
 use zcash_pool_migration::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
@@ -282,7 +282,7 @@ impl<C: BorrowMut<Connection>> Store<C> {
 
     pub(crate) fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Error> {
         let tables = self.tables;
@@ -622,7 +622,7 @@ fn read_transactions(
 
     let mut out = Vec::with_capacity(rows.len());
     for r in rows {
-        let id = MigrationTxId::new(r.tx_id);
+        let id = MigrationTransferId::new(r.tx_id);
         let kind = MigrationTxKind::from_stored(
             &r.kind,
             r.kind_layer.map(|x| x as usize),
@@ -712,7 +712,7 @@ fn read_deps(
     t: &Tables,
     migration_id: i64,
     tx_id: u32,
-) -> Result<Vec<MigrationTxId>, Error> {
+) -> Result<Vec<MigrationTransferId>, Error> {
     let mut stmt = conn.prepare(&format!(
         "SELECT depends_on_tx_id FROM {}
           WHERE migration_id = ? AND tx_id = ?
@@ -722,7 +722,7 @@ fn read_deps(
     let rows = stmt.query_map(params![migration_id, tx_id], |row| row.get::<_, u32>(0))?;
     let mut out = Vec::new();
     for r in rows {
-        out.push(MigrationTxId::new(r?));
+        out.push(MigrationTransferId::new(r?));
     }
     Ok(out)
 }

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -600,7 +600,7 @@ CREATE INDEX idx_ironwood_received_note_spends_transaction_id ON ironwood_receiv
 // install into `wallet.db`. Every structured value is stored in typed columns and child tables; the
 // only `BLOB` is the pre-signed transaction (`pczt`), which is already-versioned, unstructured bytes.
 
-/// One row per account's active migration: its status and the scalar fields of its note-split
+/// One row per account's active migration: its status and the scalar fields of its denomination
 /// plan. The crossing values are an ordered list in `orchard_ironwood_migration_crossing_values`.
 /// `account_id` is enforced unique by `INDEX_ORCHARD_IRONWOOD_MIGRATIONS_ACCOUNT`, so an account
 /// has at most one migration in progress. It is a foreign key into `accounts` with `ON DELETE
@@ -622,8 +622,8 @@ CREATE TABLE orchard_ironwood_migrations (
     note_split_total_migratable INTEGER NOT NULL,
     anchor_bucket_interval INTEGER NOT NULL
 )";
-/// The note-split crossing values (an ordered list of zatoshi amounts). The funding-note values
-/// have no table of their own: each is its crossing value plus the note-split fee buffer.
+/// The denomination crossing values (an ordered list of zatoshi amounts). The funding-note values
+/// have no table of their own: each is its crossing value plus the denomination fee buffer.
 pub(super) const TABLE_ORCHARD_IRONWOOD_MIGRATION_CROSSING_VALUES: &str = "
 CREATE TABLE orchard_ironwood_migration_crossing_values (
     migration_id INTEGER NOT NULL REFERENCES orchard_ironwood_migrations(id) ON DELETE CASCADE,

--- a/zcash_pool_migration/src/build/end_to_end.rs
+++ b/zcash_pool_migration/src/build/end_to_end.rs
@@ -1,5 +1,5 @@
 //! End-to-end test of the migration pipeline for a typical wallet, using only the crate's public API.
-//! It doubles as a usage example: plan the note split, plan the preparation transactions, build and
+//! It doubles as a usage example: plan the denomination plan, plan the preparation transactions, build and
 //! pre-sign one, then build and pre-sign a pool-crossing transfer.
 
 use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
@@ -14,12 +14,12 @@ use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
 
-use crate::note_splitting::{
-    DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, plan_note_split,
+use crate::denomination::{
+    DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, plan_denominations,
 };
 use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
 
-/// note split -> preparation plan -> build + sign a preparation transaction -> build + sign a
+/// denomination plan -> preparation plan -> build + sign a preparation transaction -> build + sign a
 /// pool-crossing transfer, for a typical single-note wallet.
 #[test]
 fn migration_pipeline_end_to_end() {
@@ -32,7 +32,7 @@ fn migration_pipeline_end_to_end() {
     let ask = SpendAuthorizingKey::from(&sk);
     let balance = 78 * COIN;
 
-    // 1. Note split: decompose the balance into canonical self-funding denominations, accounting
+    // 1. Denomination planning: decompose the balance into canonical self-funding denominations, accounting
     //    the true preparation cost (via the real preparation planner) at each step.
     let prep_fee = Zatoshis::const_from_u64(PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64());
     let buffer = Zatoshis::const_from_u64(
@@ -47,7 +47,7 @@ fn migration_pipeline_end_to_end() {
     };
     let split = {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        plan_note_split(
+        plan_denominations(
             Zatoshis::const_from_u64(balance),
             buffer,
             prep_fee,

--- a/zcash_pool_migration/src/build/prep.rs
+++ b/zcash_pool_migration/src/build/prep.rs
@@ -9,7 +9,7 @@
 //!
 //! - The *sources* are the wallet's spendable note values `W = {w_1, ..., w_m}` (in zatoshi); the
 //!   *sinks* are the funding-note values `F = {f_1, ..., f_l}` chosen by
-//!   [`note_splitting`](crate::note_splitting), plus at most one residual `r`.
+//!   [`denomination`](crate::denomination), plus at most one residual `r`.
 //! - A transaction `t = (I_t, O_t)` spends the notes `I_t` and creates the notes `O_t` subject to
 //!   three constraints:
 //!   - *budget*: `|I_t| + |O_t| <= A`, where `A` is [`PREP_TX_ACTIONS`], i.e. 16 Orchard actions;
@@ -244,7 +244,7 @@ mod tests {
     };
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::note_splitting::zat;
+    use crate::denomination::zat;
 
     /// The ZIP-317 fee of a padded [`PREP_TX_ACTIONS`]-action preparation transaction (each action
     /// costs one marginal fee), which the planner reserves per transaction.

--- a/zcash_pool_migration/src/build/sign.rs
+++ b/zcash_pool_migration/src/build/sign.rs
@@ -53,7 +53,7 @@ mod tests {
     use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::note_splitting::zat;
+    use crate::denomination::zat;
 
     /// Builds a note-preparation PCZT spending one note owned by `fvk`. Deterministic in `note_seed`.
     /// It uses one spend and `PREP_TX_ACTIONS - 1` outputs so the bundle fills the action budget

--- a/zcash_pool_migration/src/build/transfer.rs
+++ b/zcash_pool_migration/src/build/transfer.rs
@@ -1,7 +1,7 @@
 //! Building a migration transfer transaction: spending one self-funding note and crossing its value
 //! into the Ironwood pool.
 //!
-//! [`build_transfer_pczt`] spends a single self-funding note (one the note split minted, worth its
+//! [`build_transfer_pczt`] spends a single self-funding note (one the denomination plan minted, worth its
 //! crossing value plus a fee buffer) and outputs that crossing value into the destination Ironwood
 //! pool, to the account's own internal (change) address as ZIP 318 requires. It has no change output:
 //! the self-funding note's buffer funds the transfer's fee exactly. The Orchard spend pads to the
@@ -54,8 +54,8 @@ const IRONWOOD_TRANSFER_PADDING: BundlePadding = BundlePadding {
 /// destination: per ZIP 318 the crossing is sent to the account's own internal Ironwood change
 /// address. `target_height` and `expiry_height` bound the transaction; the pre-signature commits to
 /// the expiry, so the caller passes the canonical expiry for the transfer's drawn broadcast
-/// schedule. It mirrors the note split's
-/// [`crossing_values`](crate::note_splitting::NoteSplitPlan::crossing_values): one transfer per
+/// schedule. It mirrors the denomination plan's
+/// [`crossing_values`](crate::denomination::DenominationPlan::crossing_values): one transfer per
 /// self-funding note.
 ///
 /// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
@@ -124,7 +124,7 @@ mod tests {
     use crate::build::test_util::{account, regtest_network, single_note_witness};
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::note_splitting::{
+    use crate::denomination::{
         DESTINATION_ACTIONS_PER_TRANSFER, RESIDUAL_MIGRATION_MIN, SOURCE_ACTIONS_PER_TRANSFER, zat,
     };
 

--- a/zcash_pool_migration/src/denomination.rs
+++ b/zcash_pool_migration/src/denomination.rs
@@ -36,7 +36,7 @@
 //!
 //! # Common structure
 //!
-//! Whatever the strategy, the result is a [`NoteSplitPlan`]: a multiset of *denomination notes*,
+//! Whatever the strategy, the result is a [`DenominationPlan`]: a multiset of *denomination notes*,
 //! each holding `denomination + fee buffer` so that when it is later spent in a migration transfer
 //! it pays its own fee (the buffer is the ZIP-317 fee of the canonical transfer shape). Every note is bounded by a maximum
 //! denomination, so even a whale crosses many bounded, collision-prone amounts rather than one
@@ -47,9 +47,9 @@
 //!
 //! # Relation to known problems
 //!
-//! Note splitting is fundamentally a *constrained integer partition* problem: writing a known integer
+//! Denomination planning is fundamentally a *constrained integer partition* problem: writing a known integer
 //! as an unordered sum of positive parts. The known integer is `N`, the migratable balance to
-//! decompose (in zatoshi, after the note-split transaction fee is reserved), with
+//! decompose (in zatoshi, after the preparation transaction fee is reserved), with
 //! `0 <= N <= MAX_MONEY`. We choose a multiset of parts `n_1, n_2, ..., n_k` (the crossing values)
 //! such that
 //!
@@ -160,7 +160,7 @@ pub(crate) const SOURCE_ACTIONS_PER_TRANSFER: usize = 2;
 /// reveal.
 pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
 
-/// The outcome of planning a note split: the self-funding notes to create, the values that will
+/// The outcome of denomination planning: the self-funding notes to create, the values that will
 /// cross the turnstile, and the residual kept in the source pool. Produced by a
 /// [`DenominationStrategy`].
 ///
@@ -178,7 +178,7 @@ pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
 /// Value the strategy could not pack into a whole self-funding note is neither of these; it is
 /// [`change`](Self::change), left untouched in the source pool.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct NoteSplitPlan {
+pub struct DenominationPlan {
     crossing_values: Vec<Zatoshis>,
     note_fee_buffer: Zatoshis,
     change: Option<Zatoshis>,
@@ -187,7 +187,7 @@ pub struct NoteSplitPlan {
     total_migratable: Zatoshis,
 }
 
-impl NoteSplitPlan {
+impl DenominationPlan {
     /// Assemble a plan from a strategy's computed `crossing_values`, the per-note fee buffer they each
     /// carry (the prepared-note values are `crossing + note_fee_buffer`), and the `remaining_budget`
     /// left after them, which becomes source-pool change. The strategy's arithmetic partitions the
@@ -318,7 +318,7 @@ pub trait DenominationStrategy {
         prep_tx_fee: Zatoshis,
         prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         rng: &mut R,
-    ) -> NoteSplitPlan;
+    ) -> DenominationPlan;
 }
 
 /// Convert a strategy-internal value to [`Zatoshis`]. Infallible by construction: the strategies'
@@ -330,13 +330,13 @@ pub(crate) fn zat(value: u64) -> Zatoshis {
 
 /// Convenience wrapper: plan with the recommended [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
 /// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
-pub fn plan_note_split<R: RngCore + CryptoRng>(
+pub fn plan_denominations<R: RngCore + CryptoRng>(
     total_input: Zatoshis,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
     prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
     rng: &mut R,
-) -> NoteSplitPlan {
+) -> DenominationPlan {
     CanonicalOneTwoFive::recommended(transfer_fee_buffer).plan(
         total_input,
         prep_tx_fee,

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -17,8 +17,8 @@ use super::utils::largest_one_two_five;
 use zcash_protocol::value::Zatoshis;
 
 use super::{
-    DenominationStrategy, MIGRATION_MAX_DENOMINATION_ZEC, MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
-    NoteSplitPlan, RESIDUAL_MIGRATION_MIN, zat,
+    DenominationPlan, DenominationStrategy, MIGRATION_MAX_DENOMINATION_ZEC,
+    MIGRATION_MAX_PREPARED_NOTES_PER_RUN, RESIDUAL_MIGRATION_MIN, zat,
 };
 
 /// The canonical `{1, 2, 5} * 10^k` quantization of [ZIP 318]: at each step it takes the largest such
@@ -79,7 +79,7 @@ impl DenominationStrategy for CanonicalOneTwoFive {
         prep_tx_fee: Zatoshis,
         prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         _rng: &mut R,
-    ) -> NoteSplitPlan {
+    ) -> DenominationPlan {
         // The greedy partition arithmetic below runs in the u64 domain; every value it derives is
         // bounded by the validated total input, so `zat` conversions at the capability boundary and
         // in `from_notes` are infallible.
@@ -150,7 +150,7 @@ impl DenominationStrategy for CanonicalOneTwoFive {
         let remaining = total_input_zatoshi
             .saturating_sub(notes.iter().sum::<u64>())
             .saturating_sub(prep_fees_zatoshi);
-        NoteSplitPlan::from_notes(
+        DenominationPlan::from_notes(
             total_input_zatoshi,
             prep_fees_zatoshi,
             crossing_values,
@@ -169,7 +169,7 @@ mod tests {
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
     use zcash_protocol::value::MAX_MONEY;
 
-    use crate::note_splitting::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
+    use crate::denomination::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
     use crate::preparation::FUNDING_OUTPUTS_PER_TX;
 
     /// The ZIP-317 transfer-fee buffer of the canonical transfer shape (all four actions exceed the
@@ -187,7 +187,7 @@ mod tests {
     }
 
     /// Read a plan's crossing values back into the tests' u64 domain.
-    fn crossings_u64(p: &NoteSplitPlan) -> Vec<u64> {
+    fn crossings_u64(p: &DenominationPlan) -> Vec<u64> {
         p.crossing_values().iter().map(|&v| u64::from(v)).collect()
     }
 

--- a/zcash_pool_migration/src/denomination/utils.rs
+++ b/zcash_pool_migration/src/denomination/utils.rs
@@ -1,4 +1,4 @@
-//! Shared denomination-value helper for the note-split strategy: finding the largest
+//! Shared denomination-value helper for the denomination strategy: finding the largest
 //! `{1, 2, 5} * 10^k` denomination not exceeding a value. Pure integer arithmetic.
 
 /// The base of the denomination scale: every denomination is a multiple of a power of this radix.

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -530,11 +530,41 @@ impl MigrationState {
     }
 
     /// The self-funding note values (in zatoshi), one per crossing: a `Transfer { crossing }`
-    /// transaction spends `funding_notes()[crossing]` and crosses that value minus the fee buffer
-    /// into the destination pool. Derived from the denomination plan (each crossing value plus the
-    /// fee buffer), so a store persists only that plan.
+    /// transaction SPENDS `funding_notes()[crossing]`, of which the fee buffer pays that
+    /// transaction's own fee and the remainder crosses into the destination pool. Derived from the
+    /// denomination plan (each crossing value plus the fee buffer), so a store persists only that
+    /// plan.
+    ///
+    /// This is a SPEND-side value: it is neither what arrives in the destination pool nor the round
+    /// denomination the user consented to. To report what a transfer moves, use
+    /// [`crossing_values`](Self::crossing_values), or
+    /// [`transfer_crossing_value`](Self::transfer_crossing_value) for a single transaction.
     pub fn funding_notes(&self) -> Vec<Zatoshis> {
         self.denominations.migration_outputs()
+    }
+
+    /// The values (in zatoshi) that cross into the destination pool, one per crossing and
+    /// index-aligned with [`funding_notes`](Self::funding_notes): each is its funding note less the
+    /// fee buffer that funds the transfer's own fee, and so is one of the round denominations the
+    /// user was shown at proposal time.
+    ///
+    /// This is the value to display for a transfer, and the one the receiving wallet's own
+    /// accounting will agree with once the transfer mines.
+    pub fn crossing_values(&self) -> &[Zatoshis] {
+        self.denominations.crossing_values()
+    }
+
+    /// The value transaction `tx` crosses into the destination pool, or `None` when `tx` is not a
+    /// transfer (a preparation transaction crosses nothing).
+    ///
+    /// Equivalent to indexing [`crossing_values`](Self::crossing_values) by the transaction's
+    /// [`transfer_crossing`](MigrationTxKind::transfer_crossing) — the accessor to reach for when
+    /// marshaling one stored transaction into a user-facing amount, so consumers do not re-derive
+    /// the funding-note-minus-buffer arithmetic and get it wrong by a fee.
+    pub fn transfer_crossing_value(&self, tx: &MigrationTransaction) -> Option<Zatoshis> {
+        tx.kind()
+            .transfer_crossing()
+            .and_then(|crossing| self.crossing_values().get(crossing).copied())
     }
 
     /// Replace transfer `id`'s stored PCZT with its proven bytes and move it to
@@ -574,8 +604,19 @@ impl MigrationPlan {
 
     /// The funding-note values this migration will mint, one per phase-2 crossing. Derived from the
     /// denomination plan (each crossing value plus the fee buffer).
+    ///
+    /// A SPEND-side value, as on [`MigrationState::funding_notes`]: to display what a transfer
+    /// moves, use [`crossing_values`](Self::crossing_values).
     pub fn funding_notes(&self) -> Vec<Zatoshis> {
         self.denominations.migration_outputs()
+    }
+
+    /// The values that cross into the destination pool, one per phase-2 crossing, index-aligned
+    /// with both [`funding_notes`](Self::funding_notes) and [`schedule`](Self::schedule): each is
+    /// its funding note less the fee buffer, and so is one of the round denominations to show the
+    /// user for consent.
+    pub fn crossing_values(&self) -> &[Zatoshis] {
+        self.denominations.crossing_values()
     }
 
     /// The preparation transactions (in dependency layers) that mint the funding notes.

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -132,7 +132,7 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     /// it, or the chain mines it).
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error>;
 }
@@ -142,14 +142,20 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
 /// deferred preparation layers and transfers are recorded as unbuilt placeholders); it is NOT a
 /// Zcash transaction id. The real [`TxId`] becomes available once a transaction is built and signed
 /// (it commits only effecting data), and is carried by [`MigrationTxState::Broadcast`].
+///
+/// The two identities are not interchangeable, and this one is the one to key on. A [`TxId`]
+/// identifies a single broadcast ATTEMPT: [`rebuild_expired_transfer`] keeps this id while
+/// producing a new transaction with a new [`TxId`], so a consumer that keyed its own records on
+/// the [`TxId`] loses track of the transfer exactly when it most needs to follow it. Use the
+/// [`TxId`] to talk to the network about a transaction, and this id to talk about the transfer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct MigrationTxId(pub(crate) u32);
+pub struct MigrationTransferId(pub(crate) u32);
 
-impl MigrationTxId {
+impl MigrationTransferId {
     /// Wrap a stored ordinal as a migration-transaction row key (for a store reading a persisted
     /// migration back).
     pub const fn new(index: u32) -> Self {
-        MigrationTxId(index)
+        MigrationTransferId(index)
     }
 
     /// Writes this id as an unsigned 32-bit little-endian integer.
@@ -161,12 +167,12 @@ impl MigrationTxId {
     pub fn read<R: io::Read>(mut reader: R) -> io::Result<Self> {
         let mut bytes = [0u8; 4];
         reader.read_exact(&mut bytes)?;
-        Ok(MigrationTxId::new(u32::from_le_bytes(bytes)))
+        Ok(MigrationTransferId::new(u32::from_le_bytes(bytes)))
     }
 }
 
-impl From<MigrationTxId> for u32 {
-    fn from(id: MigrationTxId) -> u32 {
+impl From<MigrationTransferId> for u32 {
+    fn from(id: MigrationTransferId) -> u32 {
         id.0
     }
 }
@@ -272,7 +278,7 @@ pub enum MigrationTxState {
 pub struct MigrationTransaction {
     /// This transaction's stable id.
     #[getset(get_copy = "pub")]
-    pub(crate) id: MigrationTxId,
+    pub(crate) id: MigrationTransferId,
     /// What it does (a preparation transaction or a transfer).
     #[getset(get_copy = "pub")]
     pub(crate) kind: MigrationTxKind,
@@ -288,7 +294,7 @@ pub struct MigrationTransaction {
     /// The transactions that must be mined before this one may be broadcast (the preparation layer
     /// dependency graph; empty for an independent transaction).
     #[getset(get = "pub")]
-    pub(crate) depends_on: Vec<MigrationTxId>,
+    pub(crate) depends_on: Vec<MigrationTransferId>,
     /// The height at which to broadcast (for a transfer; a preparation transaction waits for its
     /// dependencies to mine and a boundary to pass rather than a fixed height).
     #[getset(get_copy = "pub")]
@@ -328,10 +334,10 @@ impl MigrationTransaction {
     /// consistent row.
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
-        id: MigrationTxId,
+        id: MigrationTransferId,
         kind: MigrationTxKind,
         pczt: Vec<u8>,
-        depends_on: Vec<MigrationTxId>,
+        depends_on: Vec<MigrationTransferId>,
         scheduled_height: BlockHeight,
         expiry_height: BlockHeight,
         anchor_boundary: Option<BlockHeight>,
@@ -572,7 +578,7 @@ impl MigrationState {
     /// anchor and witnesses and proves the transaction, so the durable artifact becomes the proven,
     /// ready-to-broadcast PCZT.
     #[cfg(feature = "orchard")]
-    pub fn set_transaction_proved(&mut self, id: MigrationTxId, proven_pczt: Vec<u8>) {
+    pub fn set_transaction_proved(&mut self, id: MigrationTransferId, proven_pczt: Vec<u8>) {
         for tx in &mut self.transactions {
             if tx.id() == id {
                 tx.pczt = proven_pczt;
@@ -644,7 +650,7 @@ impl MigrationPlan {
     }
 
     /// Every transaction this plan will build, enumerated BEFORE building in the exact order the
-    /// commit assigns [`MigrationTxId`]s (each preparation layer in order, then each transfer by
+    /// commit assigns [`MigrationTransferId`]s (each preparation layer in order, then each transfer by
     /// crossing), so a [`PlannedTx`]'s id equals the id the built transaction will carry. Each
     /// carries its [`action_weight`](crate::signing_rounds::action_weight). This is a pure function
     /// of the plan, recomputed on demand, so planning stays unchanged.
@@ -654,7 +660,7 @@ impl MigrationPlan {
         for (layer, layer_txs) in self.preparation.layers().iter().enumerate() {
             for index in 0..layer_txs.len() {
                 txs.push(PlannedTx::new(
-                    MigrationTxId::new(next),
+                    MigrationTransferId::new(next),
                     MigrationTxKind::Preparation { layer, index },
                 ));
                 next += 1;
@@ -662,7 +668,7 @@ impl MigrationPlan {
         }
         for crossing in 0..self.transfer_tx_count() {
             txs.push(PlannedTx::new(
-                MigrationTxId::new(next),
+                MigrationTransferId::new(next),
                 MigrationTxKind::Transfer { crossing },
             ));
             next += 1;
@@ -1423,19 +1429,19 @@ impl<E: core::error::Error> core::error::Error for CommitError<E> {}
 #[derive(Debug)]
 pub enum ProveError<E> {
     /// No transaction with the given id belongs to the migration.
-    UnknownTransaction(MigrationTxId),
+    UnknownTransaction(MigrationTransferId),
     /// The transaction is a preparation transaction, not a transfer; only transfers are proved
     /// against a drawn anchor boundary (a preparation transaction carries no boundary).
-    NotATransfer(MigrationTxId),
+    NotATransfer(MigrationTransferId),
     /// The transaction is a transfer, not a preparation transaction; only preparation transactions
     /// are proved against a caller-supplied anchor (a transfer proves against its drawn boundary).
-    NotAPreparation(MigrationTxId),
+    NotAPreparation(MigrationTransferId),
     /// The transaction is not in the [`Signed`](MigrationTxState::Signed) state, so it is not ready
     /// to prove (it is unsigned, already proved, or already broadcast).
-    NotReady(MigrationTxId),
+    NotReady(MigrationTransferId),
     /// A transfer carries no anchor boundary. Every transfer draws one at scheduling time, so this
     /// indicates a corrupt stored state rather than a normal condition.
-    NoAnchorBoundary(MigrationTxId),
+    NoAnchorBoundary(MigrationTransferId),
     /// The wallet's anchor retention grid has changed since this migration was committed, so the
     /// boundaries its transfers anchored to are no longer retained and their checkpoints will have
     /// been pruned. The migration cannot be proved and must be re-planned under the current grid
@@ -1523,7 +1529,7 @@ impl<E: core::error::Error> core::error::Error for ProveError<E> {}
 pub fn prove_transfer<P>(
     prover: &mut P,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
 ) -> Result<(), ProveError<P::Error>>
 where
     P: MigrationProver,
@@ -1584,7 +1590,7 @@ where
 pub fn prove_preparation<P>(
     prover: &mut P,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     anchor: BlockHeight,
 ) -> Result<(), ProveError<P::Error>>
 where
@@ -1617,17 +1623,17 @@ where
 #[derive(Debug)]
 pub enum RebuildError<E> {
     /// No transaction with the given id belongs to the migration.
-    UnknownTransaction(MigrationTxId),
+    UnknownTransaction(MigrationTransferId),
     /// The transaction is a preparation transaction, not a transfer. Only a transfer — a leaf of
     /// the dependency graph — is rebuilt this way (with a fresh boundary anchor and canonical
     /// expiry). An expired preparation has no single-transaction rebuild: its dependents'
     /// pre-signatures commit to the notes it would have minted, so its remediation (re-signing the
     /// affected subtree) is a follow-on slice.
-    NotATransfer(MigrationTxId),
+    NotATransfer(MigrationTransferId),
     /// The transaction has not expired at the current chain tip, so there is nothing to rebuild: it is
     /// still valid, or it has already mined. Guards against reissuing a live transaction as a second,
     /// double-spending copy.
-    NotExpired(MigrationTxId),
+    NotExpired(MigrationTransferId),
     /// The stored migration state is internally inconsistent: the denomination plan carries no crossing or
     /// funding value for this transfer's crossing index, or the transfer's stored PCZT is
     /// malformed.
@@ -1757,7 +1763,7 @@ pub fn rebuild_expired_transfer<P, B, R>(
     params: &P,
     backend: &B,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     rng: &mut R,
 ) -> Result<(), RebuildError<<B as MigrationBackend>::Error>>
 where
@@ -1786,7 +1792,7 @@ pub fn rebuild_expired_transfer_unsigned<P, B, R>(
     params: &P,
     backend: &B,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     rng: &mut R,
 ) -> Result<UnsignedMigrationTx, RebuildError<<B as MigrationBackend>::Error>>
 where
@@ -1806,7 +1812,7 @@ fn rebuild_expired_transfer_inner<P, B, R>(
     params: &P,
     backend: &B,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     rng: &mut R,
     signing: Signing,
 ) -> Result<Option<UnsignedMigrationTx>, RebuildError<<B as MigrationBackend>::Error>>
@@ -2013,7 +2019,7 @@ enum Signing {
 pub struct UnsignedMigrationTx {
     /// The transaction's id in the committed migration.
     #[getset(get_copy = "pub")]
-    pub(crate) id: MigrationTxId,
+    pub(crate) id: MigrationTransferId,
     /// The serialized UNSIGNED PCZT to sign out of band.
     #[getset(get = "pub")]
     pub(crate) pczt: Vec<u8>,
@@ -2029,7 +2035,7 @@ impl UnsignedMigrationTx {
     /// Take the id and the unsigned PCZT bytes (to route the bytes to the external signer while
     /// keeping the id to match the signed result back; see
     /// [`MigrationState::apply_signature`](crate::engine::MigrationState)).
-    pub fn into_parts(self) -> (MigrationTxId, Vec<u8>) {
+    pub fn into_parts(self) -> (MigrationTransferId, Vec<u8>) {
         (self.id, self.pczt)
     }
 }
@@ -2149,7 +2155,7 @@ struct MintedNote {
     value: Zatoshis,
     note: orchard::note::Note,
     consumed: bool,
-    producer: Option<MigrationTxId>,
+    producer: Option<MigrationTransferId>,
 }
 
 /// Commit a planned migration: build and pre-sign EVERY transaction — each preparation layer, in
@@ -2319,7 +2325,7 @@ struct Committer<'a, P, B, R> {
     transactions: Vec<MigrationTransaction>,
     unsigned: Vec<UnsignedMigrationTx>,
     next_id: u32,
-    layer_ids: Vec<Vec<MigrationTxId>>,
+    layer_ids: Vec<Vec<MigrationTransferId>>,
     minted: Vec<MintedNote>,
     /// Each transfer paired with the funding note it spends, captured as the transfer is built.
     /// The commit path already recovers every funding note's plaintext to build the transfer; a
@@ -2378,8 +2384,8 @@ where
     }
 
     /// Assign and consume the next sequential transaction id.
-    fn next_id(&mut self) -> MigrationTxId {
-        let id = MigrationTxId(self.next_id);
+    fn next_id(&mut self) -> MigrationTransferId {
+        let id = MigrationTransferId(self.next_id);
         self.next_id += 1;
         id
     }
@@ -2445,7 +2451,7 @@ where
         use crate::preparation::PrepOutput;
 
         for (layer, prep_layer) in plan.preparation().layers().iter().enumerate() {
-            let mut this_layer_ids: Vec<MigrationTxId> = Vec::with_capacity(prep_layer.len());
+            let mut this_layer_ids: Vec<MigrationTransferId> = Vec::with_capacity(prep_layer.len());
             for (index, prep_tx) in prep_layer.iter().enumerate() {
                 let id = self.next_id();
                 this_layer_ids.push(id);
@@ -2632,7 +2638,7 @@ where
             // Depend only on the preparation transaction that mints this funding note (or nothing,
             // for a direct-funding wallet note), so this crossing releases as soon as its own note
             // is mined.
-            let depends_on: Vec<MigrationTxId> = producer.into_iter().collect();
+            let depends_on: Vec<MigrationTransferId> = producer.into_iter().collect();
             let crossing_value = *plan
                 .denominations()
                 .crossing_values()
@@ -2713,7 +2719,7 @@ where
 /// bundles during a commit pass. A prover needs it to locate each transfer's spend in the wallet's
 /// commitment tree at proving time.
 #[cfg(feature = "orchard")]
-type TransferFunding = Vec<(MigrationTxId, orchard::note::Note)>;
+type TransferFunding = Vec<(MigrationTransferId, orchard::note::Note)>;
 
 /// What one commit pass produces. The public commit entry points drop the parts they do not
 /// surface.
@@ -2820,7 +2826,7 @@ mod tests {
 
         fn update_transaction(
             &mut self,
-            id: MigrationTxId,
+            id: MigrationTransferId,
             state: MigrationTxState,
         ) -> Result<(), Self::Error> {
             if let Some(stored) = &mut self.stored
@@ -3072,7 +3078,7 @@ mod tests {
             &mut rng,
         );
         let tx = MigrationTransaction {
-            id: MigrationTxId(0),
+            id: MigrationTransferId(0),
             kind: MigrationTxKind::Transfer { crossing: 0 },
             pczt: vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
             depends_on: Vec::new(),
@@ -3101,7 +3107,7 @@ mod tests {
 
         backend
             .update_transaction(
-                MigrationTxId(0),
+                MigrationTransferId(0),
                 MigrationTxState::Mined {
                     height: BlockHeight::from_u32(2_000_105),
                 },
@@ -3216,7 +3222,7 @@ mod commit_tests {
 
         fn update_transaction(
             &mut self,
-            id: MigrationTxId,
+            id: MigrationTransferId,
             state: MigrationTxState,
         ) -> Result<(), Self::Error> {
             if let Some(stored) = &mut self.stored
@@ -3705,7 +3711,7 @@ mod commit_tests {
             Err(RebuildError::NotExpired(rejected)) if rejected == id
         ));
         // An unknown id: rejected.
-        let unknown = MigrationTxId::new(9999);
+        let unknown = MigrationTransferId::new(9999);
         assert!(matches!(
             rebuild_expired_transfer(&params, &backend, &mut state, unknown, &mut rng),
             Err(RebuildError::UnknownTransaction(rejected)) if rejected == unknown
@@ -3842,7 +3848,7 @@ mod commit_tests {
             assert_eq!(tx.state, MigrationTxState::Signed, "signed at commit");
             assert!(!tx.pczt.is_empty());
         }
-        let layer0_ids: Vec<MigrationTxId> = state
+        let layer0_ids: Vec<MigrationTransferId> = state
             .transactions
             .iter()
             .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 0, .. }))
@@ -3884,7 +3890,7 @@ mod commit_tests {
         for id in &layer0_ids {
             state.mark_mined(*id, BlockHeight::from_u32(2_000_010));
         }
-        let layer1_ids: Vec<MigrationTxId> = state
+        let layer1_ids: Vec<MigrationTransferId> = state
             .transactions
             .iter()
             .filter(|t| matches!(t.kind, MigrationTxKind::Preparation { layer: 1, .. }))
@@ -3946,7 +3952,7 @@ mod commit_tests {
 
         // The crossings are funded by more than one preparation transaction (each transfer depends
         // on exactly its own producer).
-        let mut producers: Vec<MigrationTxId> = state
+        let mut producers: Vec<MigrationTransferId> = state
             .transactions
             .iter()
             .filter(|t| matches!(t.kind, MigrationTxKind::Transfer { .. }))
@@ -4017,7 +4023,7 @@ mod commit_tests {
         )
         .expect("commits the migration");
 
-        let layer_ids = |s: &MigrationState, layer: usize| -> Vec<MigrationTxId> {
+        let layer_ids = |s: &MigrationState, layer: usize| -> Vec<MigrationTransferId> {
             s.transactions
                 .iter()
                 .filter(|t| {

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1,6 +1,6 @@
 //! The migration engine: orchestrating a pool migration end to end through a wallet backend.
 //!
-//! The crate's other modules are the individual planners and builders: [`note_splitting`] decides the
+//! The crate's other modules are the individual planners and builders: [`denomination`] decides the
 //! denominations, [`preparation`] plans the transactions that mint them, [`scheduling`] shuffles and
 //! times the phase-2 transfers, and the `build` module turns plans into PCZTs. This module ties
 //! them together behind a [`MigrationBackend`] trait, so the engine drives the whole flow
@@ -37,7 +37,7 @@
 //! wallet closed between planning and broadcast, or restarted partway through, resumes from the stored
 //! PCZTs.
 //!
-//! [`note_splitting`]: crate::note_splitting
+//! [`denomination`]: crate::denomination
 //! [`preparation`]: crate::preparation
 //! [`scheduling`]: crate::scheduling
 
@@ -56,7 +56,7 @@ use zcash_protocol::value::{BalanceError, Zatoshis};
 use zcash_primitives::transaction::fees::FeeRule as _;
 use zcash_primitives::transaction::fees::{transparent, zip317};
 
-use crate::note_splitting::{NoteSplitPlan, plan_note_split};
+use crate::denomination::{DenominationPlan, plan_denominations};
 use crate::preparation::{PrepError, PrepInput, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
 use crate::signing_rounds::{
@@ -478,7 +478,7 @@ impl MigrationTxState {
     }
 }
 
-/// The persisted state of a migration: the note split (for the preview and residual accounting) and
+/// The persisted state of a migration: the denomination plan (for the preview and residual accounting) and
 /// every transaction, each as its pre-signed PCZT and metadata. A wallet resumes a migration entirely
 /// from this state after being closed or restarted; this is what a [`MigrationBackend`] stores.
 #[derive(Clone, Debug, PartialEq, Eq, Getters, CopyGetters)]
@@ -486,9 +486,9 @@ pub struct MigrationState {
     /// The overall status.
     #[getset(get_copy = "pub")]
     pub(crate) status: MigrationStatus,
-    /// The note-split decomposition (the denominations and residual).
+    /// The denomination decomposition (the denominations and residual).
     #[getset(get = "pub")]
-    pub(crate) note_split: NoteSplitPlan,
+    pub(crate) denominations: DenominationPlan,
     /// The preparation plan (its layers and direct-funding notes), retained for auditability and
     /// for rebuilding expired PREPARATION transactions (a follow-on slice). A
     /// `Preparation { layer, index }` transaction's spends resolve against
@@ -515,14 +515,14 @@ impl MigrationState {
     /// (the inverse of the accessors).
     pub fn from_parts(
         status: MigrationStatus,
-        note_split: NoteSplitPlan,
+        denominations: DenominationPlan,
         preparation: PreparationPlan,
         transactions: Vec<MigrationTransaction>,
         anchor_bucket_interval: crate::scheduling::AnchorBucketInterval,
     ) -> Self {
         Self {
             status,
-            note_split,
+            denominations,
             preparation,
             transactions,
             anchor_bucket_interval,
@@ -531,10 +531,10 @@ impl MigrationState {
 
     /// The self-funding note values (in zatoshi), one per crossing: a `Transfer { crossing }`
     /// transaction spends `funding_notes()[crossing]` and crosses that value minus the fee buffer
-    /// into the destination pool. Derived from the note split (each crossing value plus the fee
-    /// buffer), so a store persists only the note split.
+    /// into the destination pool. Derived from the denomination plan (each crossing value plus the
+    /// fee buffer), so a store persists only that plan.
     pub fn funding_notes(&self) -> Vec<Zatoshis> {
-        self.note_split.migration_outputs()
+        self.denominations.migration_outputs()
     }
 
     /// Replace transfer `id`'s stored PCZT with its proven bytes and move it to
@@ -558,24 +558,24 @@ impl MigrationState {
 /// preview a wallet shows the user for consent (ZIP 318) to the pool-crossing amounts.
 #[derive(Clone, Debug)]
 pub struct MigrationPlan {
-    note_split: NoteSplitPlan,
+    denominations: DenominationPlan,
     preparation: PreparationPlan,
     prep_schedule: Vec<Vec<BlockHeight>>,
     schedule: Vec<Schedule>,
 }
 
 impl MigrationPlan {
-    /// The note-split decomposition (the denominations and residual). The split already reflects
+    /// The denomination decomposition (the denominations and residual). It already reflects
     /// reconciliation against the preparation fees: when the fees did not fit the balance, the
     /// smallest denominations were dropped (left in the source pool) during the decomposition.
-    pub fn note_split(&self) -> &NoteSplitPlan {
-        &self.note_split
+    pub fn denominations(&self) -> &DenominationPlan {
+        &self.denominations
     }
 
     /// The funding-note values this migration will mint, one per phase-2 crossing. Derived from the
-    /// note split (each crossing value plus the fee buffer).
+    /// denomination plan (each crossing value plus the fee buffer).
     pub fn funding_notes(&self) -> Vec<Zatoshis> {
-        self.note_split.migration_outputs()
+        self.denominations.migration_outputs()
     }
 
     /// The preparation transactions (in dependency layers) that mint the funding notes.
@@ -642,7 +642,7 @@ impl MigrationPlan {
 
     /// The number of pool-crossing transfers (one per funding note).
     pub fn transfer_tx_count(&self) -> usize {
-        self.note_split.migration_outputs().len()
+        self.denominations.migration_outputs().len()
     }
 
     /// The number of sequential preparation layers (the phase's wall-clock depth).
@@ -661,13 +661,13 @@ impl MigrationPlan {
 
     /// The total value that migrates to the destination pool (the sum of the crossing values).
     pub fn value_migrated(&self) -> Zatoshis {
-        self.note_split.total_migratable()
+        self.denominations.total_migratable()
     }
 
     /// The source-pool value left untouched by this plan (change plus dust below a self-funding
     /// note); zero when the balance decomposed exactly.
     pub fn residual(&self) -> Zatoshis {
-        self.note_split.change().unwrap_or(Zatoshis::ZERO)
+        self.denominations.change().unwrap_or(Zatoshis::ZERO)
     }
 
     /// Group this plan's transactions into signing ROUNDS for a signer bounded by `budget` total
@@ -767,7 +767,7 @@ fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
     params: &P,
     height: BlockHeight,
 ) -> Result<(Zatoshis, Zatoshis), zip317::FeeError> {
-    use crate::note_splitting::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
+    use crate::denomination::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
     use crate::preparation::PREP_TX_ACTIONS;
 
     let fee_rule = zip317::FeeRule::standard();
@@ -802,9 +802,9 @@ fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
 /// the canonical fee, since a nonstandard fee would partition the anonymity set), so it is not a
 /// parameter. The decomposition reserves the TRUE preparation cost at each step, consulting the
 /// preparation planner as it grows the split. `rng` must be a cryptographically secure RNG (the
-/// schedule's shuffle, delays, and the note split's optional randomization draw from it).
+/// schedule's shuffle, delays, and the denomination plan's optional randomization draw from it).
 ///
-/// This is pure orchestration of the note-split, preparation, and scheduling planners: no cryptography,
+/// This is pure orchestration of the denomination, preparation, and scheduling planners: no cryptography,
 /// and nothing is built, signed, or persisted. The result is the [`MigrationPlan`] preview to present
 /// for user consent before committing the migration.
 pub fn plan_migration<P, B, R>(
@@ -849,14 +849,14 @@ where
             .ok()
             .map(|plan| plan.transaction_count())
     };
-    let note_split = plan_note_split(
+    let denominations = plan_denominations(
         balance,
         transfer_fee_buffer,
         prep_tx_fee,
         &prep_tx_count,
         rng,
     );
-    let funding_notes = note_split.migration_outputs();
+    let funding_notes = denominations.migration_outputs();
     if funding_notes.is_empty() {
         return Err(MigrationError::NothingToMigrate);
     }
@@ -917,14 +917,14 @@ where
     }
 
     Ok(MigrationPlan {
-        note_split,
+        denominations,
         preparation,
         prep_schedule,
         schedule,
     })
 }
 
-/// A per-run entry of a [`MigrationRunEstimate`]: what one migration run migrates (the note-split
+/// A per-run entry of a [`MigrationRunEstimate`]: what one migration run migrates (the denomination
 /// side) and what preparing it costs (the note-preparation side), so the two can be compared.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RunEstimate {
@@ -940,7 +940,7 @@ impl RunEstimate {
         self.migratable
     }
 
-    /// The number of pool-crossing transfers this run makes: one per self-funding note the note split
+    /// The number of pool-crossing transfers this run makes: one per self-funding note the denomination plan
     /// produced for it.
     pub fn crossings(&self) -> usize {
         self.crossings
@@ -995,7 +995,7 @@ impl RunEstimate {
 /// A balance beyond one run's capacity (the note cap times the maximum denomination) migrates over
 /// several runs, each run's spent notes and preparation residuals forming the next run's note
 /// structure (see [`estimate_migration_runs`]). Each run carries BOTH sides so an application can
-/// compare them: the note-split crossings it migrates and the note-preparation layers and
+/// compare them: the denomination crossings it migrates and the note-preparation layers and
 /// transactions it costs.
 ///
 /// A capacity-limited external signer adds a third dimension: given the signer's per-interaction
@@ -1089,7 +1089,7 @@ impl MigrationRunEstimate {
 
 /// Estimate how the account the `backend` represents will migrate its whole spendable balance: the
 /// number of migration RUNS ("rounds") it takes, and for each run BOTH what it migrates (the
-/// note-split crossings) and what preparing it costs (the note-preparation layers and transactions),
+/// denomination crossings) and what preparing it costs (the note-preparation layers and transactions),
 /// so an application can preview and compare the two before anything is planned or committed.
 ///
 /// A run prepares a bounded number of capped self-funding notes, so a balance beyond one run's
@@ -1098,16 +1098,16 @@ impl MigrationRunEstimate {
 /// (so its feasibility and fees are exact, exactly as [`plan_migration`] plans one run), and the notes
 /// that run spends and the residuals it leaves form the next run's structure.
 ///
-/// The note-split run count itself does NOT depend on an external signer's capacity. When a
+/// The denomination run count itself does NOT depend on an external signer's capacity. When a
 /// capacity-limited hardware signer (for example a Keystone) is bounded by a per-interaction action
 /// budget, pass that user-configured [`SigningRoundBudget`] to
 /// [`MigrationRunEstimate::total_signing_rounds`] to get the number of signing interactions the
 /// migration requires (each run is signed on its own; see that method). Because this iterates the
-/// note-split and preparation planners once per run, its cost is roughly one [`plan_migration`] per
+/// denomination and preparation planners once per run, its cost is roughly one [`plan_migration`] per
 /// run.
 ///
 /// A zero (or fully sub-quantum) balance yields a zero-run estimate rather than an error, since this
-/// is a preview. `rng` is drawn from only by a randomized note-split strategy; the recommended
+/// is a preview. `rng` is drawn from only by a randomized denomination strategy; the recommended
 /// canonical strategy ignores it.
 pub fn estimate_migration_runs<P, B, R>(
     params: &P,
@@ -1138,18 +1138,18 @@ where
             .sum::<Option<Zatoshis>>()
             .ok_or(MigrationError::InvalidBalance(BalanceError::Overflow))?;
 
-        // This run's note split, decomposing the CURRENT note set. Its per-step preparation cost and
+        // This run's denomination plan, decomposing the CURRENT note set. Its per-step preparation cost and
         // feasibility are backed by the real preparation planner over the current notes, so the split
         // — and hence the whole run count — depends on the wallet's note structure, not just its
         // total value. The closure's borrow of `notes` is released with the block, before `notes` is
         // reassigned below.
-        let note_split = {
+        let denominations = {
             let prep_tx_count = |funding: &[Zatoshis]| {
                 plan_preparation(&notes, funding, prep_tx_fee)
                     .ok()
                     .map(|plan| plan.transaction_count())
             };
-            plan_note_split(
+            plan_denominations(
                 balance,
                 transfer_fee_buffer,
                 prep_tx_fee,
@@ -1158,7 +1158,7 @@ where
             )
         };
 
-        let funding = note_split.migration_outputs();
+        let funding = denominations.migration_outputs();
         if funding.is_empty() {
             // Nothing more migrates from this note set: the remaining balance is the final residual
             // and the migration is complete.
@@ -1170,12 +1170,12 @@ where
 
         // The preparation that mints this run's funding notes: its layer and transaction counts are
         // the note-preparation side of the estimate, and which notes it spends and which residuals it
-        // leaves give the next run's note structure. The note split only ever proposes a funding
+        // leaves give the next run's note structure. The denomination plan only ever proposes a funding
         // multiset the preparation planner accepted, so this plan succeeds by construction.
         let preparation =
             plan_preparation(&notes, &funding, prep_tx_fee).map_err(MigrationError::Preparation)?;
         runs.push(RunEstimate {
-            migratable: note_split.total_migratable(),
+            migratable: denominations.total_migratable(),
             crossings: funding.len(),
             prep_layers: preparation.layer_count(),
             prep_transactions: preparation.transaction_count(),
@@ -1587,7 +1587,7 @@ pub enum RebuildError<E> {
     /// still valid, or it has already mined. Guards against reissuing a live transaction as a second,
     /// double-spending copy.
     NotExpired(MigrationTxId),
-    /// The stored migration state is internally inconsistent: the note split carries no crossing or
+    /// The stored migration state is internally inconsistent: the denomination plan carries no crossing or
     /// funding value for this transfer's crossing index, or the transfer's stored PCZT is
     /// malformed.
     InconsistentPlan(alloc::string::String),
@@ -1829,14 +1829,14 @@ where
         .unwrap_or(nu63_activation);
 
     let crossing_value = *state
-        .note_split
+        .denominations
         .crossing_values()
         .get(crossing)
         .ok_or_else(|| {
             RebuildError::InconsistentPlan(format!("no crossing value for transfer {crossing}"))
         })?;
     let funding_value = *state
-        .note_split
+        .denominations
         .migration_outputs()
         .get(crossing)
         .ok_or_else(|| {
@@ -1928,8 +1928,8 @@ where
             let unsigned = UnsignedMigrationTx {
                 id,
                 pczt: bytes.clone(),
-                actions: crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
-                    + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER,
+                actions: crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
+                    + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER,
             };
             (bytes, MigrationTxState::AwaitingSignature, Some(unsigned))
         }
@@ -2593,7 +2593,7 @@ where
             // is mined.
             let depends_on: Vec<MigrationTxId> = producer.into_iter().collect();
             let crossing_value = *plan
-                .note_split()
+                .denominations()
                 .crossing_values()
                 .get(crossing)
                 .ok_or_else(|| {
@@ -2625,8 +2625,8 @@ where
                 self.unsigned.push(UnsignedMigrationTx {
                     id,
                     pczt: bytes.clone(),
-                    actions: crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
-                        + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER,
+                    actions: crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
+                        + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER,
                 });
             }
             self.transactions.push(MigrationTransaction {
@@ -2653,7 +2653,7 @@ where
     fn into_state(self, plan: &MigrationPlan) -> CommitOutput {
         let state = MigrationState {
             status: MigrationStatus::Committed,
-            note_split: plan.note_split().clone(),
+            denominations: plan.denominations().clone(),
             preparation: plan.preparation().clone(),
             transactions: self.transactions,
             // Stamp the grid the transfers were anchored to, so a later reconfiguration of the
@@ -2882,7 +2882,7 @@ mod tests {
         ));
     }
 
-    /// A typical balance migrates in a single run, whose entry carries BOTH the note-split side
+    /// A typical balance migrates in a single run, whose entry carries BOTH the denomination side
     /// (migratable value and crossing count) and the note-preparation side (layers and transactions),
     /// and the aggregates match the single run.
     #[test]
@@ -2894,7 +2894,7 @@ mod tests {
 
         assert_eq!(est.run_count(), 1);
         let run = est.runs()[0];
-        // Note-split side: it crosses value in one or more canonical denominations.
+        // Denomination side: it crosses value in one or more canonical denominations.
         assert!(u64::from(run.migratable()) > 0);
         assert!(run.crossings() >= 1);
         // Note-preparation side: minting those notes costs at least one layer and one transaction.
@@ -2924,7 +2924,7 @@ mod tests {
     /// cap of 50 * 10,000 ZEC in 50 notes, and the aggregate crossings sum the per-run counts.
     #[test]
     fn whale_migrates_over_several_runs() {
-        use crate::note_splitting::{
+        use crate::denomination::{
             MIGRATION_MAX_DENOMINATION_ZEC, MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
         };
         let mut rng = ChaCha8Rng::seed_from_u64(1);
@@ -3023,7 +3023,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let (prep_tx_fee, transfer_buffer) = test_fees();
-        let note_split = crate::note_splitting::plan_note_split(
+        let denominations = crate::denomination::plan_denominations(
             Zatoshis::from_u64(100 * COIN).expect("test balance is valid"),
             transfer_buffer,
             prep_tx_fee,
@@ -3043,7 +3043,7 @@ mod tests {
         };
         let state = MigrationState {
             status: MigrationStatus::Committed,
-            note_split,
+            denominations,
             preparation: crate::preparation::PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions: vec![tx],
             anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
@@ -3089,8 +3089,8 @@ mod commit_tests {
     use crate::build::test_util::{
         TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
     };
-    use crate::note_splitting::{
-        DESTINATION_ACTIONS_PER_TRANSFER, NoteSplitPlan, SOURCE_ACTIONS_PER_TRANSFER,
+    use crate::denomination::{
+        DESTINATION_ACTIONS_PER_TRANSFER, DenominationPlan, SOURCE_ACTIONS_PER_TRANSFER,
     };
     use crate::preparation::{PREP_TX_ACTIONS, plan_preparation};
 
@@ -3716,10 +3716,10 @@ mod commit_tests {
             "15 funding notes fan out across two layers"
         );
 
-        // A note split whose outputs are the funding notes and whose crossings are those less
+        // A denomination plan whose outputs are the funding notes and whose crossings are those less
         // the buffer, so each transfer crosses one ZEC.
         let crossings: Vec<u64> = funding.iter().map(|&f| f - buffer).collect();
-        let note_split = NoteSplitPlan::from_stored_parts(
+        let denominations = DenominationPlan::from_stored_parts(
             crossings
                 .iter()
                 .map(|&v| Zatoshis::from_u64(v).expect("test crossings are valid"))
@@ -3768,7 +3768,7 @@ mod commit_tests {
             &mut rng,
         );
         let plan = MigrationPlan {
-            note_split,
+            denominations,
             preparation,
             prep_schedule,
             schedule,
@@ -4086,8 +4086,8 @@ mod commit_tests {
         // PREP_TX_ACTIONS actions, so a budget of one preparation plus one transfer splits the
         // list without ever exceeding the budget (every round is non-empty and within budget).
         let budget_actions = PREP_TX_ACTIONS
-            + crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
-            + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER;
+            + crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
+            + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER;
         let budget = crate::signing_rounds::SigningRoundBudget::new(
             core::num::NonZeroU32::new(budget_actions as u32).unwrap(),
         );

--- a/zcash_pool_migration/src/lib.rs
+++ b/zcash_pool_migration/src/lib.rs
@@ -1,10 +1,10 @@
 //! A backend-agnostic engine for migrating Zcash wallet funds between value pools. Zcash's first use
 //! is the Orchard -> Ironwood migration enabled by NU6.3.
 //!
-//! The engine plans a note split into self-funding denominations, builds and signs migration
+//! The engine decomposes the migratable balance into self-funding denominations, builds and signs migration
 //! transactions as PCZTs, schedules them by block height, and persists its state through a wallet
 //! backend; the consuming application broadcasts the transactions and reports results back. See
-//! [`note_splitting`] for the note-split denomination planning.
+//! [`denomination`] for the denomination planning.
 //!
 //! Inspired by an original implementation by Adam Tucker from ValarGroup, originally made
 //! available in [Vizor Wallet](https://github.com/chainapsis/vizor-wallet).
@@ -24,8 +24,8 @@ extern crate std;
 
 #[cfg(feature = "orchard")]
 pub mod build;
+pub mod denomination;
 pub mod engine;
-pub mod note_splitting;
 pub mod preparation;
 pub mod scheduling;
 pub mod signing_rounds;

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -4,7 +4,7 @@
 //!
 //! # The problem
 //!
-//! The [`note_splitting`](super::note_splitting) planner decides the *values* of the self-funding
+//! The [`denomination`](super::denomination) planner decides the *values* of the self-funding
 //! notes to mint. This module decides the *transactions* that mint them. [ZIP 318] requires each
 //! note-preparation transaction to be padded to exactly [`PREP_TX_ACTIONS`] Orchard actions (a
 //! mobile-proving-time and on-chain-uniformity constraint). Under NU6.3 a bundle's action count is

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -10,7 +10,7 @@
 //!
 //! # The problem
 //!
-//! The note split ([`crate::note_splitting`]) decides the crossing VALUES (quantized denominations)
+//! The denomination plan ([`crate::denomination`]) decides the crossing VALUES (quantized denominations)
 //! so many wallets emit colliding amounts. Scheduling decides the TEMPORAL and ANCHOR dimensions of
 //! the same crossings, which leak just as much if left predictable:
 //!

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -26,7 +26,7 @@
 use alloc::vec::Vec;
 use core::num::{NonZeroU32, NonZeroUsize};
 
-use crate::engine::{MigrationTxId, MigrationTxKind};
+use crate::engine::{MigrationTransferId, MigrationTxKind};
 
 /// The Orchard-family actions a padded preparation transaction carries.
 pub const PREPARATION_ACTIONS: u32 = crate::preparation::PREP_TX_ACTIONS as u32;
@@ -100,11 +100,11 @@ const fn nz(n: u32) -> NonZeroU32 {
 }
 
 /// A transaction a migration plan WILL build, described before it is built: its stable ordinal (the
-/// [`MigrationTxId`] the build later assigns, since the plan enumerates in commit order), what it
+/// [`MigrationTransferId`] the build later assigns, since the plan enumerates in commit order), what it
 /// does, and how many Orchard actions the signer processes for it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PlannedTx {
-    id: MigrationTxId,
+    id: MigrationTransferId,
     kind: MigrationTxKind,
     actions: u32,
 }
@@ -112,7 +112,7 @@ pub struct PlannedTx {
 impl PlannedTx {
     /// A planned transaction of `kind`, identified by `id`, with its canonical [`action_weight`].
     #[must_use]
-    pub const fn new(id: MigrationTxId, kind: MigrationTxKind) -> Self {
+    pub const fn new(id: MigrationTransferId, kind: MigrationTxKind) -> Self {
         Self {
             id,
             kind,
@@ -122,7 +122,7 @@ impl PlannedTx {
 
     /// The stable ordinal this transaction will carry once built.
     #[must_use]
-    pub const fn id(&self) -> MigrationTxId {
+    pub const fn id(&self) -> MigrationTransferId {
         self.id
     }
 

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -19,7 +19,7 @@
 //! separate concern of the schedule.
 //!
 //! The pluggable [`SigningRoundStrategy`] is the "named solution of the NP problem" seam, mirroring
-//! [`DenominationStrategy`](crate::note_splitting::DenominationStrategy): [`MinRounds`] (the optimal
+//! [`DenominationStrategy`](crate::denomination::DenominationStrategy): [`MinRounds`] (the optimal
 //! default) and [`NextFit`] (an order-preserving greedy). Any new solution inherits the crate's
 //! reusable conformance suite (`crate::testing`).
 
@@ -32,8 +32,8 @@ use crate::engine::{MigrationTxId, MigrationTxKind};
 pub const PREPARATION_ACTIONS: u32 = crate::preparation::PREP_TX_ACTIONS as u32;
 
 /// The Orchard-family actions a canonical migration transfer carries (2 source + 1 destination).
-pub const TRANSFER_ACTIONS: u32 = (crate::note_splitting::SOURCE_ACTIONS_PER_TRANSFER
-    + crate::note_splitting::DESTINATION_ACTIONS_PER_TRANSFER)
+pub const TRANSFER_ACTIONS: u32 = (crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
+    + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER)
     as u32;
 
 /// The number of Orchard-family actions a signer processes for a migration transaction of `kind`.

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -547,6 +547,79 @@ mod tests {
         }
     }
 
+    /// A state whose denomination plan carries the given crossing values and fee buffer, so the
+    /// funding notes are each crossing plus the buffer.
+    fn state_with_crossings(
+        crossings: &[u64],
+        buffer: u64,
+        transactions: Vec<MigrationTransaction>,
+    ) -> MigrationState {
+        let zats = |v: u64| Zatoshis::from_u64(v).expect("test values are valid");
+        let total = zats(crossings.iter().sum());
+        MigrationState {
+            status: MigrationStatus::Committed,
+            denominations: DenominationPlan::from_stored_parts(
+                crossings.iter().copied().map(zats).collect(),
+                zats(buffer),
+                None,
+                Zatoshis::ZERO,
+                total,
+                total,
+            )
+            .expect("a consistent stored plan reconstructs"),
+            preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            transactions,
+            anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
+        }
+    }
+
+    /// A transfer reports what it MOVES (its crossing value), not what it spends: the funding note
+    /// it spends is that value plus the fee buffer funding its own fee, and reporting the spend
+    /// side overstates every transfer by a fee.
+    #[test]
+    fn transfer_crossing_value_is_the_funding_note_less_the_fee_buffer() {
+        let buffer = 15_000;
+        let crossings = [100_000_000u64, 200_000_000];
+        let state = state_with_crossings(
+            &crossings,
+            buffer,
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                tx(1, transfer(0), MigrationTxState::Signed),
+                tx(2, transfer(1), MigrationTxState::Signed),
+            ],
+        );
+
+        for (i, &crossing) in crossings.iter().enumerate() {
+            let tx = &state.transactions[i + 1];
+            assert_eq!(
+                state.transfer_crossing_value(tx),
+                Some(Zatoshis::from_u64(crossing).expect("valid")),
+                "transfer {i} must report its crossing value"
+            );
+            assert_eq!(
+                state.funding_notes()[i],
+                Zatoshis::from_u64(crossing + buffer).expect("valid"),
+                "the funding note it spends is that value plus the buffer"
+            );
+        }
+    }
+
+    /// A preparation transaction crosses nothing, so it has no crossing value to report.
+    #[test]
+    fn transfer_crossing_value_is_none_for_a_preparation() {
+        let state = state_with_crossings(
+            &[100_000_000],
+            15_000,
+            vec![tx(0, prep(0, 0), MigrationTxState::Signed)],
+        );
+        assert_eq!(
+            state.transfer_crossing_value(&state.transactions[0]),
+            None,
+            "a preparation transaction crosses nothing"
+        );
+    }
+
     #[test]
     fn apply_signature_moves_awaiting_to_signed() {
         let mut state = state_with(vec![tx(0, prep(0, 0), MigrationTxState::AwaitingSignature)]);

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -495,7 +495,7 @@ mod tests {
     use crate::engine::MigrationTransaction;
     use zcash_protocol::value::Zatoshis;
 
-    use crate::note_splitting::NoteSplitPlan;
+    use crate::denomination::DenominationPlan;
     use crate::preparation::PreparationPlan;
     use alloc::vec;
 
@@ -526,7 +526,7 @@ mod tests {
     fn state_with(transactions: Vec<MigrationTransaction>) -> MigrationState {
         MigrationState {
             status: MigrationStatus::Committed,
-            note_split: NoteSplitPlan::from_stored_parts(
+            denominations: DenominationPlan::from_stored_parts(
                 Vec::new(),
                 Zatoshis::ZERO,
                 None,

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -23,7 +23,7 @@ use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
+    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
     MigrationTxState,
 };
 
@@ -42,13 +42,13 @@ pub enum AdvanceStep {
     /// must be proved while its boundary is fresh, not deferred to its (later) broadcast height.
     Prove {
         /// The transaction to prove.
-        id: MigrationTxId,
+        id: MigrationTransferId,
     },
     /// Broadcast this already-proven transaction: it is `Proved`, its dependencies are mined, and its
     /// scheduled broadcast height has arrived.
     Broadcast {
         /// The transaction to broadcast.
-        id: MigrationTxId,
+        id: MigrationTransferId,
     },
     /// Rebuild this TRANSFER: its [`expiry_height`](MigrationTransaction::expiry_height) has passed
     /// without it mining, so it can no longer be included in a block (ZIP 203). The pre-signed
@@ -66,7 +66,7 @@ pub enum AdvanceStep {
     /// one is holding up the schedule.
     Rebuild {
         /// The transaction to rebuild.
-        id: MigrationTxId,
+        id: MigrationTransferId,
     },
     /// Nothing to do now: waiting for one or more transactions to mine, for an anchor boundary to
     /// settle, or for a scheduled height to arrive.
@@ -128,7 +128,7 @@ pub enum Blocker {
 pub struct TransactionStatus {
     /// This transaction's stable id.
     #[getset(get_copy = "pub")]
-    pub(crate) id: MigrationTxId,
+    pub(crate) id: MigrationTransferId,
     /// What it does (a preparation transaction, carrying its layer / anchor bucket, or a transfer).
     #[getset(get_copy = "pub")]
     pub(crate) kind: MigrationTxKind,
@@ -137,7 +137,7 @@ pub struct TransactionStatus {
     pub(crate) state: MigrationTxState,
     /// The transactions that must be mined before this one can be built or broadcast.
     #[getset(get = "pub")]
-    pub(crate) depends_on: Vec<MigrationTxId>,
+    pub(crate) depends_on: Vec<MigrationTransferId>,
     /// The height at or after which it is due to broadcast.
     #[getset(get_copy = "pub")]
     pub(crate) scheduled_height: BlockHeight,
@@ -165,7 +165,7 @@ pub struct TransactionStatus {
 
 impl MigrationState {
     /// Whether every transaction in `depends_on` is mined.
-    pub fn deps_mined(&self, depends_on: &[MigrationTxId]) -> bool {
+    pub fn deps_mined(&self, depends_on: &[MigrationTransferId]) -> bool {
         depends_on.iter().all(|dep| {
             self.transactions
                 .iter()
@@ -198,7 +198,7 @@ impl MigrationState {
     /// is also surfaced as [`AdvanceStep::Rebuild`]; a PREPARATION is not (rebuilding it means
     /// re-signing its whole dependent subtree, a remediation beyond a single advance step), so a
     /// wallet uses this list to tell the user the migration needs a new signing ceremony.
-    pub fn expired_transactions(&self, target_height: BlockHeight) -> Vec<MigrationTxId> {
+    pub fn expired_transactions(&self, target_height: BlockHeight) -> Vec<MigrationTransferId> {
         self.transactions
             .iter()
             .filter(|t| Self::is_expired(t, target_height))
@@ -212,7 +212,7 @@ impl MigrationState {
     /// single-transaction remediation — its dependents' pre-signatures commit to the notes it would
     /// have minted, so rebuilding it means re-signing the whole dependent subtree (a follow-on
     /// slice); it stays visible through [`Blocker::Expired`] and [`Self::expired_transactions`].
-    fn next_rebuildable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+    fn next_rebuildable(&self, target_height: BlockHeight) -> Option<MigrationTransferId> {
         self.transactions
             .iter()
             .filter(|t| matches!(t.kind, MigrationTxKind::Transfer { .. }))
@@ -255,7 +255,7 @@ impl MigrationState {
     /// is resolvable now (see [`Self::prove_ready`]). Proving is decoupled from broadcasting so a
     /// transfer is proved while its anchor boundary checkpoint is still within the wallet's pruning
     /// window, then broadcast later at its scheduled height.
-    pub fn next_provable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+    pub fn next_provable(&self, target_height: BlockHeight) -> Option<MigrationTransferId> {
         self.transactions
             .iter()
             .find(|t| {
@@ -266,7 +266,7 @@ impl MigrationState {
 
     /// The id of the next transaction ready to BROADCAST: already `Proved`, its dependencies mined,
     /// and scheduled at or before `target_height` (`chain_tip + 1`).
-    pub fn next_broadcastable(&self, target_height: BlockHeight) -> Option<MigrationTxId> {
+    pub fn next_broadcastable(&self, target_height: BlockHeight) -> Option<MigrationTransferId> {
         self.transactions
             .iter()
             .find(|t| {
@@ -323,7 +323,7 @@ impl MigrationState {
     /// Records that the transaction `id` was broadcast with the given `txid`, then recomputes the
     /// overall status. The consumer calls this after it broadcasts the transaction the engine handed
     /// it.
-    pub fn mark_broadcast(&mut self, id: MigrationTxId, txid: TxId) {
+    pub fn mark_broadcast(&mut self, id: MigrationTransferId, txid: TxId) {
         if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
             tx.state = MigrationTxState::Broadcast { txid };
         }
@@ -333,7 +333,7 @@ impl MigrationState {
     /// Records that the transaction `id` was mined at `height`, then recomputes the overall status. The
     /// consumer detects mining through its own chain view (matching a broadcast transaction's txid) and
     /// calls this, which is what lets a later preparation layer or the transfers become actionable.
-    pub fn mark_mined(&mut self, id: MigrationTxId, height: BlockHeight) {
+    pub fn mark_mined(&mut self, id: MigrationTransferId, height: BlockHeight) {
         if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
             tx.state = MigrationTxState::Mined { height };
         }
@@ -352,7 +352,7 @@ impl MigrationState {
     /// transaction has that `id` or it is not awaiting a signature (already signed, still an unbuilt
     /// placeholder, or already broadcast or mined), so a caller can detect a stale or misrouted signature.
     #[must_use]
-    pub fn apply_signature(&mut self, id: MigrationTxId, signed_pczt: Vec<u8>) -> bool {
+    pub fn apply_signature(&mut self, id: MigrationTransferId, signed_pczt: Vec<u8>) -> bool {
         let Some(tx) = self
             .transactions
             .iter_mut()
@@ -502,7 +502,7 @@ mod tests {
     // A migration transaction with the given id/kind/state, no dependencies, scheduled at height 0.
     fn tx(id: u32, kind: MigrationTxKind, state: MigrationTxState) -> MigrationTransaction {
         MigrationTransaction {
-            id: MigrationTxId(id),
+            id: MigrationTransferId(id),
             kind,
             pczt: Vec::new(),
             depends_on: Vec::new(),
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn apply_signature_moves_awaiting_to_signed() {
         let mut state = state_with(vec![tx(0, prep(0, 0), MigrationTxState::AwaitingSignature)]);
-        assert!(state.apply_signature(MigrationTxId(0), vec![1u8, 2, 3]));
+        assert!(state.apply_signature(MigrationTransferId(0), vec![1u8, 2, 3]));
         assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
         assert_eq!(state.transactions[0].pczt, vec![1u8, 2, 3]);
     }
@@ -636,16 +636,16 @@ mod tests {
         ]);
         // An unknown id, and a transaction not awaiting a signature (already signed), are both
         // rejected without changing any state.
-        assert!(!state.apply_signature(MigrationTxId(9), vec![1u8]));
-        assert!(!state.apply_signature(MigrationTxId(1), vec![1u8]));
+        assert!(!state.apply_signature(MigrationTransferId(9), vec![1u8]));
+        assert!(!state.apply_signature(MigrationTransferId(1), vec![1u8]));
         assert_eq!(
             state.transactions[0].state,
             MigrationTxState::AwaitingSignature
         );
         // The first signature applies; a second, after it is already Signed, is rejected (a stale or
         // misrouted signature cannot overwrite the stored one).
-        assert!(state.apply_signature(MigrationTxId(0), vec![1u8]));
-        assert!(!state.apply_signature(MigrationTxId(0), vec![2u8]));
+        assert!(state.apply_signature(MigrationTransferId(0), vec![1u8]));
+        assert!(!state.apply_signature(MigrationTransferId(0), vec![2u8]));
         assert_eq!(state.transactions[0].pczt, vec![1u8]);
     }
 
@@ -664,8 +664,8 @@ mod tests {
             tx(0, prep(0, 0), mined(10)),
             tx(1, prep(0, 1), MigrationTxState::Signed),
         ]);
-        assert!(s.deps_mined(&[MigrationTxId(0)]));
-        assert!(!s.deps_mined(&[MigrationTxId(1)]));
+        assert!(s.deps_mined(&[MigrationTransferId(0)]));
+        assert!(!s.deps_mined(&[MigrationTransferId(1)]));
         assert!(s.deps_mined(&[])); // empty deps are trivially satisfied
     }
 
@@ -673,7 +673,7 @@ mod tests {
     fn next_broadcastable_respects_state_deps_and_schedule() {
         // Only a PROVED transaction is broadcastable (proving is a separate earlier step).
         let mut proved = tx(1, transfer(0), MigrationTxState::Proved);
-        proved.depends_on = vec![MigrationTxId(0)];
+        proved.depends_on = vec![MigrationTransferId(0)];
         proved.scheduled_height = BlockHeight::from_u32(5);
         let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), proved]);
 
@@ -682,7 +682,7 @@ mod tests {
         // Due and deps mined.
         assert_eq!(
             s.next_broadcastable(BlockHeight::from_u32(5)),
-            Some(MigrationTxId(1))
+            Some(MigrationTransferId(1))
         );
 
         // A Signed (not yet proved) transaction is NOT broadcastable: it must be proved first.
@@ -704,23 +704,23 @@ mod tests {
         // then layer 1 once layer 0 mines, then the transfer once the whole preparation mines. Each
         // transaction is PROVED (`Signed -> Proved`) before it is broadcast.
         let mut l1 = tx(1, prep(1, 0), MigrationTxState::Signed);
-        l1.depends_on = vec![MigrationTxId(0)];
+        l1.depends_on = vec![MigrationTransferId(0)];
         let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
-        xfer.depends_on = vec![MigrationTxId(1)];
+        xfer.depends_on = vec![MigrationTransferId(1)];
         let mut s = state_with(vec![tx(0, prep(0, 0), MigrationTxState::Signed), l1, xfer]);
 
         // 1) Layer 0 is signed and due -> prove it first, then broadcast it once proved.
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Prove {
-                id: MigrationTxId(0)
+                id: MigrationTransferId(0)
             }
         );
         s.transactions[0].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
-                id: MigrationTxId(0)
+                id: MigrationTransferId(0)
             }
         );
 
@@ -738,14 +738,14 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Prove {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
         s.transactions[1].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
 
@@ -754,14 +754,14 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Prove {
-                id: MigrationTxId(2)
+                id: MigrationTransferId(2)
             }
         );
         s.transactions[2].state = MigrationTxState::Proved;
         assert_eq!(
             s.next_step(BlockHeight::from_u32(100)),
             AdvanceStep::Broadcast {
-                id: MigrationTxId(2)
+                id: MigrationTransferId(2)
             }
         );
 
@@ -785,7 +785,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(50)),
             AdvanceStep::Prove {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
     }
@@ -798,7 +798,7 @@ mod tests {
         ]);
         assert_eq!(s.status, MigrationStatus::Committed);
 
-        s.mark_broadcast(MigrationTxId(0), TxId::from_bytes([7; 32]));
+        s.mark_broadcast(MigrationTransferId(0), TxId::from_bytes([7; 32]));
         assert!(matches!(
             s.transactions[0].state,
             MigrationTxState::Broadcast { txid } if txid == TxId::from_bytes([7; 32])
@@ -806,8 +806,8 @@ mod tests {
         assert_eq!(s.status, MigrationStatus::InProgress);
         assert!(!s.is_terminal());
 
-        s.mark_mined(MigrationTxId(0), BlockHeight::from_u32(10));
-        s.mark_mined(MigrationTxId(1), BlockHeight::from_u32(11));
+        s.mark_mined(MigrationTransferId(0), BlockHeight::from_u32(10));
+        s.mark_mined(MigrationTransferId(1), BlockHeight::from_u32(11));
         assert_eq!(s.status, MigrationStatus::Complete);
         assert!(s.is_terminal());
     }
@@ -844,16 +844,16 @@ mod tests {
         );
 
         // Detecting a mined transaction still does not resurrect it.
-        s.mark_mined(MigrationTxId(0), BlockHeight::from_u32(10));
+        s.mark_mined(MigrationTransferId(0), BlockHeight::from_u32(10));
         assert_eq!(s.status, MigrationStatus::Failed);
     }
 
     #[test]
     fn transaction_statuses_report_ready_and_blockers() {
         let mut l1 = tx(1, prep(1, 0), MigrationTxState::Signed);
-        l1.depends_on = vec![MigrationTxId(0)];
+        l1.depends_on = vec![MigrationTransferId(0)];
         let mut xfer = tx(2, transfer(0), MigrationTxState::Signed);
-        xfer.depends_on = vec![MigrationTxId(1)];
+        xfer.depends_on = vec![MigrationTransferId(1)];
         xfer.scheduled_height = BlockHeight::from_u32(30);
         let s = state_with(vec![tx(0, prep(0, 0), mined(10)), l1, xfer]);
 
@@ -894,7 +894,7 @@ mod tests {
         // A transfer anchors to a drawn boundary; it is not provable until the boundary block is
         // strictly below the tip (its checkpoint has settled), decoupled from the broadcast schedule.
         let mut xfer = tx(1, transfer(0), MigrationTxState::Signed);
-        xfer.depends_on = vec![MigrationTxId(0)];
+        xfer.depends_on = vec![MigrationTransferId(0)];
         xfer.anchor_boundary = Some(BlockHeight::from_u32(40));
         xfer.scheduled_height = BlockHeight::from_u32(60);
         let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
@@ -911,7 +911,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(42)),
             AdvanceStep::Prove {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
 
@@ -926,7 +926,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(60)),
             AdvanceStep::Broadcast {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
     }
@@ -966,14 +966,14 @@ mod tests {
         // At target 50 (tip 49) it can still be mined -> broadcastable.
         assert_eq!(
             s.next_broadcastable(BlockHeight::from_u32(50)),
-            Some(MigrationTxId(1))
+            Some(MigrationTransferId(1))
         );
         // At target 51 (tip 50) expiry has passed (51 > 50) -> not broadcastable, must be rebuilt.
         assert_eq!(s.next_broadcastable(BlockHeight::from_u32(51)), None);
         assert_eq!(
             s.next_step(BlockHeight::from_u32(51)),
             AdvanceStep::Rebuild {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
 
@@ -983,7 +983,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(51)),
             AdvanceStep::Rebuild {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
     }
@@ -1000,7 +1000,7 @@ mod tests {
         assert_eq!(v[1].expiry_height, BlockHeight::from_u32(50));
         assert_eq!(
             s.expired_transactions(BlockHeight::from_u32(51)),
-            vec![MigrationTxId(1)]
+            vec![MigrationTransferId(1)]
         );
     }
 
@@ -1031,7 +1031,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(51)),
             AdvanceStep::Prove {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
         // Once the valid transfer is proved and broadcast, the expired one is surfaced for rebuild.
@@ -1041,7 +1041,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(51)),
             AdvanceStep::Rebuild {
-                id: MigrationTxId(2)
+                id: MigrationTransferId(2)
             }
         );
     }
@@ -1062,7 +1062,7 @@ mod tests {
             50,
         );
         let mut dependent = tx(1, transfer(0), MigrationTxState::Signed);
-        dependent.depends_on = vec![MigrationTxId(0)];
+        dependent.depends_on = vec![MigrationTransferId(0)];
         let s = state_with(vec![expired_prep, dependent]);
 
         assert_eq!(s.next_step(BlockHeight::from_u32(51)), AdvanceStep::Waiting);
@@ -1070,7 +1070,7 @@ mod tests {
         assert_eq!(v[0].blocked_on, Some(Blocker::Expired));
         assert_eq!(
             s.expired_transactions(BlockHeight::from_u32(51)),
-            vec![MigrationTxId(0)]
+            vec![MigrationTransferId(0)]
         );
     }
 
@@ -1092,7 +1092,7 @@ mod tests {
         assert_eq!(
             s.next_step(BlockHeight::from_u32(51)),
             AdvanceStep::Rebuild {
-                id: MigrationTxId(1)
+                id: MigrationTransferId(1)
             }
         );
     }

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -26,7 +26,7 @@ use zcash_protocol::value::{COIN, Zatoshis};
 
 use crate::denomination::DenominationPlan;
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
+    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
@@ -45,9 +45,9 @@ fn zat(value: u64) -> Zatoshis {
 
 // --- leaf strategies ---
 
-/// An arbitrary [`MigrationTxId`] row key.
-pub fn arb_migration_tx_id() -> impl Strategy<Value = MigrationTxId> {
-    (0u32..1000).prop_map(MigrationTxId::new)
+/// An arbitrary [`MigrationTransferId`] row key.
+pub fn arb_migration_transfer_id() -> impl Strategy<Value = MigrationTransferId> {
+    (0u32..1000).prop_map(MigrationTransferId::new)
 }
 
 // --- preparation-plan strategies (moved from `preparation`'s codec tests) ---
@@ -182,10 +182,10 @@ pub fn arb_lock_owner() -> impl Strategy<Value = Option<[u8; 32]>> {
 /// unique within a migration.
 pub fn arb_migration_transaction() -> impl Strategy<Value = MigrationTransaction> {
     (
-        arb_migration_tx_id(),
+        arb_migration_transfer_id(),
         arb_migration_tx_kind(),
         prop::collection::vec(any::<u8>(), 0..64),
-        prop::collection::vec(arb_migration_tx_id(), 0..4),
+        prop::collection::vec(arb_migration_transfer_id(), 0..4),
         arb_block_height(),
         arb_block_height(),
         prop::option::of(arb_block_height()),
@@ -232,7 +232,7 @@ pub fn arb_anchor_bucket_interval() -> impl Strategy<Value = AnchorBucketInterva
 
 /// An arbitrary whole [`MigrationState`], built through [`MigrationState::from_parts`]: a status, a
 /// denomination plan (from which the funding-note values derive), a preparation plan, a small set of
-/// transactions re-keyed with sequential [`MigrationTxId`]s (so their row keys are unique, as a
+/// transactions re-keyed with sequential [`MigrationTransferId`]s (so their row keys are unique, as a
 /// store requires), and the anchor bucket grid it was committed under. Generated values are
 /// self-consistent enough to persist and read back unchanged.
 pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
@@ -252,7 +252,7 @@ pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
                     .enumerate()
                     .map(|(i, tx)| {
                         MigrationTransaction::from_parts(
-                            MigrationTxId::new(i as u32),
+                            MigrationTransferId::new(i as u32),
                             tx.kind(),
                             tx.pczt().clone(),
                             tx.depends_on().clone(),
@@ -340,7 +340,7 @@ pub fn assert_put_replaces<S: PoolMigrationWrite>(
 pub fn assert_update_transaction<S: PoolMigrationWrite>(
     store: &mut S,
     state: &MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     new: MigrationTxState,
 ) where
     S::Error: Debug,
@@ -365,7 +365,7 @@ pub fn assert_update_transaction<S: PoolMigrationWrite>(
 
 /// The id of the first transaction of `state`, or `None` if it has no transactions. A convenience
 /// for driving [`assert_update_transaction`] from a generated [`MigrationState`].
-pub fn first_transaction_id(state: &MigrationState) -> Option<MigrationTxId> {
+pub fn first_transaction_id(state: &MigrationState) -> Option<MigrationTransferId> {
     state.transactions().first().map(|t| t.id())
 }
 
@@ -407,14 +407,14 @@ pub fn planned_txs(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
     let mut id = 0u32;
     for index in 0..n_prep {
         txs.push(PlannedTx::new(
-            MigrationTxId::new(id),
+            MigrationTransferId::new(id),
             MigrationTxKind::Preparation { layer: 0, index },
         ));
         id += 1;
     }
     for crossing in 0..n_transfer {
         txs.push(PlannedTx::new(
-            MigrationTxId::new(id),
+            MigrationTransferId::new(id),
             MigrationTxKind::Transfer { crossing },
         ));
         id += 1;

--- a/zcash_pool_migration/src/testing.rs
+++ b/zcash_pool_migration/src/testing.rs
@@ -24,11 +24,11 @@ use zcash_protocol::consensus::testing::arb_block_height;
 use zcash_protocol::value::testing::arb_zatoshis;
 use zcash_protocol::value::{COIN, Zatoshis};
 
+use crate::denomination::DenominationPlan;
 use crate::engine::{
     MigrationState, MigrationStatus, MigrationTransaction, MigrationTxId, MigrationTxKind,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
-use crate::note_splitting::NoteSplitPlan;
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::scheduling::AnchorBucketInterval;
 use crate::signing_rounds::{
@@ -99,12 +99,12 @@ pub fn arb_preparation_plan() -> impl Strategy<Value = PreparationPlan> {
         .prop_map(|(layers, direct)| PreparationPlan::from_parts(layers, direct))
 }
 
-// --- note-split strategy (moved from `note_splitting`'s codec tests) ---
+// --- denomination strategy (moved from `denomination`'s codec tests) ---
 
-/// An arbitrary [`NoteSplitPlan`], covering all stored fields (an empty or populated crossing set,
+/// An arbitrary [`DenominationPlan`], covering all stored fields (an empty or populated crossing set,
 /// present or absent change). Bounded so every `crossing + note_fee_buffer` is representable, which
-/// is what [`NoteSplitPlan::from_stored_parts`] requires.
-pub fn arb_note_split_plan() -> impl Strategy<Value = NoteSplitPlan> {
+/// is what [`DenominationPlan::from_stored_parts`] requires.
+pub fn arb_denomination_plan() -> impl Strategy<Value = DenominationPlan> {
     (
         prop::collection::vec(arb_zatoshis(), 0..8),
         (0u64..1_000_000).prop_map(zat),
@@ -122,7 +122,7 @@ pub fn arb_note_split_plan() -> impl Strategy<Value = NoteSplitPlan> {
                 total_input,
                 total_migratable,
             )| {
-                NoteSplitPlan::from_stored_parts(
+                DenominationPlan::from_stored_parts(
                     crossing_values,
                     note_fee_buffer,
                     change,
@@ -231,20 +231,20 @@ pub fn arb_anchor_bucket_interval() -> impl Strategy<Value = AnchorBucketInterva
 }
 
 /// An arbitrary whole [`MigrationState`], built through [`MigrationState::from_parts`]: a status, a
-/// note split (from which the funding-note values derive), a preparation plan, a small set of
+/// denomination plan (from which the funding-note values derive), a preparation plan, a small set of
 /// transactions re-keyed with sequential [`MigrationTxId`]s (so their row keys are unique, as a
 /// store requires), and the anchor bucket grid it was committed under. Generated values are
 /// self-consistent enough to persist and read back unchanged.
 pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
     (
         arb_migration_status(),
-        arb_note_split_plan(),
+        arb_denomination_plan(),
         arb_preparation_plan(),
         prop::collection::vec(arb_migration_transaction(), 0..6),
         arb_anchor_bucket_interval(),
     )
         .prop_map(
-            |(status, note_split, preparation, txs, anchor_bucket_interval)| {
+            |(status, denominations, preparation, txs, anchor_bucket_interval)| {
                 // Re-key the transactions with sequential ids so their row keys are unique; a store
                 // keys transaction rows by id and returns them in id order.
                 let transactions = txs
@@ -266,7 +266,7 @@ pub fn arb_migration_state() -> impl Strategy<Value = MigrationState> {
                     .collect();
                 MigrationState::from_parts(
                     status,
-                    note_split,
+                    denominations,
                     preparation,
                     transactions,
                     anchor_bucket_interval,

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -48,7 +48,7 @@ use zcash_protocol::{ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 
 use crate::build::sign_pczt;
 use crate::engine::{
-    MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTxId,
+    MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTransferId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 use crate::scheduling::{AnchorBucketInterval, DelayDistribution, SchedulingParams};
@@ -301,7 +301,7 @@ where
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         self.store

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -13,12 +13,12 @@ use rand_core::SeedableRng;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::{COIN, Zatoshis};
 
+use zcash_pool_migration::denomination::{DenominationPlan, plan_denominations};
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTransaction,
     MigrationTxId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
     plan_migration,
 };
-use zcash_pool_migration::note_splitting::{NoteSplitPlan, plan_note_split};
 use zcash_pool_migration::preparation::{
     FUNDING_OUTPUTS_PER_TX, PreparationPlan, plan_preparation,
 };
@@ -51,7 +51,7 @@ fn plans_a_migration_from_a_balance() {
         plan.preparation().funding_notes().len(),
         plan.funding_notes().len()
     );
-    assert!(plan.funding_notes().len() <= plan.note_split().migration_outputs().len());
+    assert!(plan.funding_notes().len() <= plan.denominations().migration_outputs().len());
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn empty_balance_has_nothing_to_migrate() {
     ));
 }
 
-/// The full migration pipeline (note splitting then preparation) for the smallest migratable
+/// The full migration pipeline (denomination planning then preparation) for the smallest migratable
 /// balance: a lone source note of exactly one quantum plus its fees. A quantum is a canonical
 /// `{1, 2, 5} * 10^k` denomination; its fees are the ZIP-317 transfer buffer that funds the crossing
 /// note plus one padded preparation-transaction fee. Such a balance migrates that one denomination
@@ -82,8 +82,8 @@ fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
     let mut rng = ChaCha8Rng::seed_from_u64(1);
     let probe_plan = plan_migration(&params, &probe, &mut rng).expect("the probe balance plans");
     assert_eq!(probe_plan.preparation().transaction_count(), 1);
-    let buffer = u64::from(probe_plan.note_split().note_fee_buffer());
-    let prep_tx_fee = u64::from(probe_plan.note_split().prep_fees());
+    let buffer = u64::from(probe_plan.denominations().note_fee_buffer());
+    let prep_tx_fee = u64::from(probe_plan.denominations().prep_fees());
 
     // A few example quanta spanning the series from the 0.01 ZEC minimum to the 10,000 ZEC cap.
     let quanta = [
@@ -102,7 +102,7 @@ fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
 
         // The split: one crossing of exactly the quantum, and the whole balance consumed (no change).
         assert_eq!(
-            plan.note_split()
+            plan.denominations()
                 .crossing_values()
                 .iter()
                 .map(|&v| u64::from(v))
@@ -110,7 +110,7 @@ fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
             vec![quantum],
             "quantum {quantum}",
         );
-        assert_eq!(plan.note_split().change(), None, "quantum {quantum}");
+        assert_eq!(plan.denominations().change(), None, "quantum {quantum}");
 
         // The preparation: exactly one layer holding exactly one transaction, minting exactly the
         // single funding note (the crossing plus its transfer buffer).
@@ -153,13 +153,13 @@ fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
 
     let kept = plan.funding_notes();
 
-    // The baseline: the same split with an always-fundable preparation stub, i.e. what the strategy
-    // proposes for this balance absent the equal-note source's fundability constraint. Recover the
-    // exact fees `plan_migration` used from the produced note split so the baseline matches.
-    let transfer_buffer = plan.note_split().note_fee_buffer();
-    let prep_tx_fee = plan.note_split().prep_fees();
+    // The baseline: the same denominations with an always-fundable preparation stub, i.e. what the
+    // strategy proposes for this balance absent the equal-note source's fundability constraint.
+    // Recover the exact fees `plan_migration` used from the produced plan so the baseline matches.
+    let transfer_buffer = plan.denominations().note_fee_buffer();
+    let prep_tx_fee = plan.denominations().prep_fees();
     let mut ref_rng = ChaCha8Rng::seed_from_u64(1);
-    let proposed = plan_note_split(
+    let proposed = plan_denominations(
         zat(balance),
         transfer_buffer,
         prep_tx_fee,
@@ -219,8 +219,8 @@ fn stores_loads_and_updates_a_migration() {
     let mut backend = MockBackend::new(Vec::new(), 0);
     assert!(backend.get_migration().unwrap().is_none());
 
-    // A consistent stored note split (its exact values are immaterial to the store round-trip).
-    let note_split = NoteSplitPlan::from_stored_parts(
+    // A consistent stored denomination plan (its exact values are immaterial to the store round-trip).
+    let denominations = DenominationPlan::from_stored_parts(
         vec![zat(100 * COIN)],
         zat(10_000),
         None,
@@ -242,7 +242,7 @@ fn stores_loads_and_updates_a_migration() {
     );
     let state = MigrationState::from_parts(
         MigrationStatus::Committed,
-        note_split,
+        denominations,
         PreparationPlan::from_parts(Vec::new(), Vec::new()),
         vec![tx],
         AnchorBucketInterval::ZIP_318,

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -16,7 +16,7 @@ use zcash_protocol::value::{COIN, Zatoshis};
 use zcash_pool_migration::denomination::{DenominationPlan, plan_denominations};
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTransaction,
-    MigrationTxId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
     plan_migration,
 };
 use zcash_pool_migration::preparation::{
@@ -230,7 +230,7 @@ fn stores_loads_and_updates_a_migration() {
     )
     .expect("a consistent stored split reconstructs");
     let tx = MigrationTransaction::from_parts(
-        MigrationTxId::new(0),
+        MigrationTransferId::new(0),
         MigrationTxKind::Transfer { crossing: 0 },
         vec![1, 2, 3], // a stand-in for the serialized pre-signed PCZT
         Vec::new(),
@@ -259,7 +259,7 @@ fn stores_loads_and_updates_a_migration() {
 
     backend
         .update_transaction(
-            MigrationTxId::new(0),
+            MigrationTransferId::new(0),
             MigrationTxState::Mined {
                 height: BlockHeight::from_u32(2_000_105),
             },

--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -45,8 +45,8 @@ use zcash_protocol::value::testing::zats;
 use zcash_protocol::value::{COIN, Zatoshis};
 
 use zcash_pool_migration::engine::{
-    self, MigrationState, MigrationTxId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
-    PoolMigrationWrite,
+    self, MigrationState, MigrationTransferId, MigrationTxKind, MigrationTxState,
+    PoolMigrationRead, PoolMigrationWrite,
 };
 use zcash_pool_migration::wallet::{WalletMigration, WalletMigrationProver};
 
@@ -93,7 +93,7 @@ impl PoolMigrationWrite for MigrationTestStore {
 
     fn update_transaction(
         &mut self,
-        _id: MigrationTxId,
+        _id: MigrationTransferId,
         _state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         // Not exercised: the chain simulation advances proving state through the engine's
@@ -285,7 +285,7 @@ impl Run {
     /// (asserting it is Orchard-only), then mines and scans it so its minted funding notes become
     /// spendable; finally checks the wallet balance is the funding less the reserved preparation fees.
     fn prove_preparations(&mut self, committed: &mut Committed, scenario: &Scenario) {
-        let prep_ids: Vec<MigrationTxId> = committed
+        let prep_ids: Vec<MigrationTransferId> = committed
             .state
             .transactions()
             .iter()
@@ -358,7 +358,7 @@ impl Run {
     /// checks the destination pool: the migration created exactly one Ironwood note per transfer,
     /// together holding the whole migrated value.
     fn prove_transfers(&mut self, committed: &mut Committed, scenario: &Scenario) {
-        let mut transfers: Vec<(MigrationTxId, BlockHeight)> = committed
+        let mut transfers: Vec<(MigrationTransferId, BlockHeight)> = committed
             .state
             .transactions()
             .iter()
@@ -493,7 +493,7 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
 fn migration_anchors_to_the_wallets_configured_retention_grid() {
     use core::num::NonZeroU32;
     use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;
-    use zcash_pool_migration::engine::{MigrationBackend, MigrationTxId, MigrationTxKind};
+    use zcash_pool_migration::engine::{MigrationBackend, MigrationTransferId, MigrationTxKind};
     use zcash_pool_migration::scheduling::{AnchorBucketInterval, SchedulingParams};
 
     // A short grid, so a migration reaches anchor viability without waiting out 144-block buckets.
@@ -573,7 +573,7 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
     // checkpoint survives only because the wallet RETAINED it, and prove against it. Without
     // retention on the wallet's configured grid this fails with `AnchorNotFound`.
     let mut state = state;
-    let prep_ids: Vec<MigrationTxId> = state
+    let prep_ids: Vec<MigrationTransferId> = state
         .transactions()
         .iter()
         .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))

--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -243,8 +243,8 @@ impl Run {
             let plan = engine::plan_migration(&self.network, &adapter, &mut rng)
                 .expect("plans the migration");
             let funding_notes = plan.funding_notes();
-            let migrated = plan.note_split().total_migratable();
-            let change = plan.note_split().change().map(u64::from).unwrap_or(0);
+            let migrated = plan.denominations().total_migratable();
+            let change = plan.denominations().change().map(u64::from).unwrap_or(0);
             let mut adapter = adapter;
             let (state, _) = engine::commit_preparation_with_funding(
                 &self.network,
@@ -458,7 +458,7 @@ impl Run {
 }
 
 /// Every proving scenario, spanning the migration personas exercised across the codebase (the Python
-/// integration-test suite and the note-split golden vectors): single small / medium / large
+/// integration-test suite and the denomination golden vectors): single small / medium / large
 /// balances, the minimum-denomination and buffer-pruned edges, and the many-note "exchange" / dust /
 /// whale shapes whose consolidation drives multi-layer preparation.
 fn scenarios() -> Vec<Scenario> {

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -26,12 +26,12 @@ use rand_core::SeedableRng;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::COIN;
 
+#[cfg(feature = "test-dependencies")]
+use zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
 use zcash_pool_migration::engine::{
     MigrationCrypto, MigrationPlan, MigrationState, MigrationTxState, PoolMigrationWrite,
     UnsignedMigrationTx, build_preparation_unsigned, estimate_migration_runs, plan_migration,
 };
-#[cfg(feature = "test-dependencies")]
-use zcash_pool_migration::note_splitting::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
 use zcash_pool_migration::signing_rounds::{MinRounds, NextFit, SigningRoundBudget};
 #[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::testing::MIGRATION_SCENARIOS;

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -36,7 +36,7 @@ use zcash_protocol::value::Zatoshis;
 
 use zcash_pool_migration::build::sign_pczt;
 use zcash_pool_migration::engine::{
-    MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTxId,
+    MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTransferId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 use zcash_pool_migration::scheduling::SchedulingParams;
@@ -211,7 +211,11 @@ pub fn shared_anchor_witnesses(
 /// untouched. The engine's [`MigrationState`] keeps its transactions behind read-only accessors, so
 /// an external test backend advances one transaction's lifecycle by reconstructing the state from
 /// its public parts.
-fn set_transaction_state(stored: &mut MigrationState, id: MigrationTxId, state: MigrationTxState) {
+fn set_transaction_state(
+    stored: &mut MigrationState,
+    id: MigrationTransferId,
+    state: MigrationTxState,
+) {
     let transactions: Vec<MigrationTransaction> = stored
         .transactions()
         .iter()
@@ -308,7 +312,7 @@ impl PoolMigrationWrite for MockBackend {
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         if let Some(stored) = &mut self.stored {
@@ -401,7 +405,7 @@ impl PoolMigrationWrite for CommitMock {
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         if let Some(stored) = &mut self.stored {

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -235,7 +235,7 @@ fn set_transaction_state(stored: &mut MigrationState, id: MigrationTxId, state: 
         .collect();
     *stored = MigrationState::from_parts(
         stored.status(),
-        stored.note_split().clone(),
+        stored.denominations().clone(),
         stored.preparation().clone(),
         transactions,
         stored.anchor_bucket_interval(),


### PR DESCRIPTION
Two defects in the pool-migration API surface, found while reviewing the Swift SDK's FFI over this engine.

## 1. "Note split" names only half the operation

The planner decides the *values* of the self-funding notes a run mints, and reaching those values may split a large note **or consolidate several small ones** — `preparation` does both, up to 15 spends into one output when consolidating. The name leaked all the way out to the mobile SDKs' user-facing APIs, where it tells a user with many small notes that their wallet is about to "split" them.

Renamed to the vocabulary the module already speaks internally (`MIGRATION_MAX_DENOMINATION_ZEC`, `strategies::CanonicalOneTwoFive`) and that ZIP 318 uses for the 1-2-5 series — neutral between splitting and consolidating:

| before | after |
|---|---|
| `note_splitting` (module) | `denomination` |
| `NoteSplitPlan` | `DenominationPlan` |
| `plan_note_split` | `plan_denominations` |
| `MigrationState::note_split` / `MigrationPlan::note_split` | `::denominations` |
| `arb_note_split_plan` | `arb_denomination_plan` |

`crossing_values`, `migration_outputs`, `note_fee_buffer` and the `preparation` module keep their names.

The pool-migration store's `note_split_*` SQL columns keep theirs too: they are created by `CREATE TABLE IF NOT EXISTS` in databases already written by the published `0.1.0-rc.1`, so changing them is a schema migration rather than a rename, and they are invisible to API consumers. Happy to do that separately if you'd rather the storage vocabulary match.

## 2. There was no accessor for what a transfer actually moves

`funding_notes()` is a **spend-side** value: a transfer spends its funding note, of which the fee buffer pays that transaction's own fee and only the remainder crosses. It was also the only accessor indexed by crossing, so a consumer marshaling a transfer for display reached for it and reported an amount one transfer fee too large — and not the round `{1,2,5}×10ⁿ` denomination the user consented to. Both mobile SDKs hit this; one had already open-coded `funding_note - note_fee_buffer` with a comment explaining the trap.

Added:

```rust
MigrationState::crossing_values()           -> &[Zatoshis]
MigrationState::transfer_crossing_value(tx) -> Option<Zatoshis>
MigrationPlan::crossing_values()            -> &[Zatoshis]
```

The per-transaction accessor indexes the crossing values by the transaction's own `transfer_crossing()`, so no consumer re-derives the arithmetic or needs to know the buffer exists. Both slices stay index-aligned with `funding_notes()` and, on the plan, with `schedule()`, so amount/height pairing is unchanged. The spend-side accessors keep their names and now state which side they are on.

## 3. `MigrationTxId` invited confusion with a real transaction id

The name reads as a Zcash transaction id, and consumers marshaling a migration transaction for their platform reached for it as though it were one. It is a row key into the persisted migration, meaningful before a transaction is built at all. Renamed to **`MigrationTransferId`** (and `testing::arb_migration_tx_id` → `arb_migration_transfer_id`).

The distinction is load-bearing, and the type's docs now say which way it runs: a `TxId` identifies one broadcast **attempt**, while this id identifies the **transfer**. `rebuild_expired_transfer` keeps the transfer id and produces a new transaction with a new `TxId` — so a consumer that keyed its own records on the `TxId` loses the thread exactly when a transfer expires and is rebuilt. Use the `TxId` to talk to the network about a transaction, and this id to talk about the transfer.

As with the denomination rename, the persisted `tx_id` SQL columns keep their names — they exist in databases written by the published `0.1.0-rc.1`.

## Notes

- Three commits, one per change, each verified to build alone.
- No `CHANGELOG.md` entry: `AGENTS.md` says a newly added crate's changelog carries **only** the initial-release line, and `zcash_pool_migration`'s still does. Say the word if you'd rather rc.1 adopters got an explicit rename table there.
- No version bump — that belongs to the release PR that cuts the next rc.
- `cargo test -p zcash_pool_migration --all-features` passes (two new unit tests cover the accessor); `cargo clippy --all-features --all-targets` clean on the touched crates; `cargo fmt --all --check` clean; each commit builds on its own (`git rebase --exec`).

---

This PR was prepared with Claude Code assistance.

