### PR TITLE
Select PCZT signer views by receiver capability; minimal-encoding serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "document-features",
  "ff",
  "getset",
+ "hex",
  "incrementalmerkletree",
  "jubjub",
  "nonempty",

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::orchard::Bundle::zkproof`
+- `pczt::orchard::Spend::dummy_sk`
+- `pczt::sapling::Spend::witness`
+
 ### Changed
 - `pczt::Pczt::serialize` now emits the minimal encoding version capable of
   representing the PCZT's content: the v1 encoding whenever the content is
@@ -19,6 +24,14 @@ workspace.
   with receivers that predate the v2 encoding, such as deployed hardware
   signers. Callers that require a specific encoding version should use
   `pczt::v1::Pczt` or `pczt::v2::Pczt` directly.
+
+### Fixed
+- `pczt::v1::Pczt::try_from` (and thus `pczt::Pczt::serialize`'s v1 encoding
+  selection) incorrectly required an Orchard anchor even for a PCZT with an
+  empty Orchard bundle, returning `EncodingError::RequiresV2` for such PCZTs
+  even though they carry no Orchard-protocol data. An empty Orchard bundle
+  now falls back to a placeholder anchor for the v1 encoding, matching the
+  existing behavior for an empty Sapling bundle.
 
 ## [0.8.0] - 2026-07-23
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,16 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- `pczt::Pczt::serialize` now emits the minimal encoding version capable of
+  representing the PCZT's content: the v1 encoding whenever the content is
+  representable in it (a pre-v6 transaction with a canonical-empty Ironwood
+  bundle and no compact-only field state), and the v2 encoding otherwise.
+  Previously it always emitted the v2 encoding. This maximizes compatibility
+  with receivers that predate the v2 encoding, such as deployed hardware
+  signers. Callers that require a specific encoding version should use
+  `pczt::v1::Pczt` or `pczt::v2::Pczt` directly.
+
 ## [0.8.0] - 2026-07-23
 
 ### Added

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -54,6 +54,7 @@ getset.workspace = true
 document-features = { workspace = true, optional = true }
 
 [dev-dependencies]
+hex.workspace = true
 incrementalmerkletree.workspace = true
 rand_chacha.workspace = true
 ripemd.workspace = true

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -425,10 +425,26 @@ impl Pczt {
         }
     }
 
-    /// Serializes this PCZT as the latest PCZT version.
+    /// Serializes this PCZT in the minimal encoding version capable of
+    /// representing its content: the v1 encoding whenever the PCZT is
+    /// representable in it (maximizing compatibility with receivers that
+    /// predate the v2 encoding), and the v2 encoding otherwise.
     ///
-    /// To serialize a specific PCZT version, e.g. v1, use [`v1::Pczt::serialize`].
+    /// To force a specific PCZT version, use [`v1::Pczt`] or [`v2::Pczt`]
+    /// directly.
     pub fn serialize(self) -> Result<Vec<u8>, EncodingError> {
+        // Fast pre-checks for the conditions that most commonly rule out the
+        // v1 encoding, avoiding the speculative clone below.
+        if self.global.tx_version != zcash_protocol::constants::V6_TX_VERSION
+            && self.ironwood == orchard::EMPTY_IRONWOOD
+        {
+            // The full v1-representability conditions live in the bundle
+            // conversions; attempting the conversion is the single source of
+            // truth for them.
+            if let Ok(v1) = v1::Pczt::try_from(self.clone()) {
+                return Ok(v1.serialize());
+            }
+        }
         Ok(v2::Pczt::try_from(self)?.serialize())
     }
 
@@ -742,5 +758,69 @@ mod extraction_tests {
             pczt.into_effects(),
             Err(ExtractError::UnsupportedConsensusBranchId)
         ));
+    }
+}
+
+#[cfg(test)]
+mod serialize_tests {
+    use zcash_protocol::consensus::BranchId;
+
+    use crate::roles::creator::Creator;
+
+    fn encoding_version(bytes: &[u8]) -> u32 {
+        assert_eq!(&bytes[..4], crate::MAGIC_BYTES);
+        u32::from_le_bytes(bytes[4..8].try_into().unwrap())
+    }
+
+    #[test]
+    fn serialize_emits_minimal_encoding() {
+        // A v1-representable (v5, canonical-empty Ironwood) PCZT serializes as v1.
+        let pczt = Creator::new(
+            BranchId::Nu6.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let bytes = pczt.clone().serialize().unwrap();
+        assert_eq!(encoding_version(&bytes), crate::PCZT_VERSION_1);
+        // The minimal encoding still round-trips through the ordinary parser.
+        assert!(crate::Pczt::parse(&bytes).is_ok());
+
+        // Non-canonical Ironwood data forces the v2 encoding.
+        let mut with_ironwood = pczt.clone();
+        with_ironwood.ironwood.bsk = Some([1; 32]);
+        assert_eq!(
+            encoding_version(&with_ironwood.serialize().unwrap()),
+            crate::PCZT_VERSION_2,
+        );
+
+        // An Orchard note-plaintext version the v1 encoding cannot carry
+        // forces the v2 encoding.
+        let mut with_note_v3 = pczt;
+        with_note_v3.orchard.note_version = crate::orchard::NoteVersion::V3;
+        assert_eq!(
+            encoding_version(&with_note_v3.serialize().unwrap()),
+            crate::PCZT_VERSION_2,
+        );
+
+        // A v6 transaction forces the v2 encoding.
+        let v6 = Creator::new(
+            BranchId::Nu6_3.into(),
+            10_000_000,
+            133,
+            Some([0; 32]),
+            Some([0; 32]),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        assert_eq!(
+            encoding_version(&v6.serialize().unwrap()),
+            crate::PCZT_VERSION_2,
+        );
     }
 }

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -1378,7 +1378,14 @@ pub(crate) mod v2 {
                 .actions
                 .push(decryptable_action_with_memo(memo));
 
-            let encrypted_size = pczt.clone().serialize().unwrap().len();
+            // Pin both sides to the v2 encoding explicitly: `Pczt::serialize` now
+            // picks the minimal encoding capable of representing its content, and
+            // this comparison is measuring the size effect of the memo-plaintext
+            // compaction, not of the encoding version chosen for either PCZT.
+            let encrypted_size = crate::v2::Pczt::try_from(pczt.clone())
+                .unwrap()
+                .serialize()
+                .len();
             let redacted = Redactor::new(pczt)
                 .redact_orchard_with(|mut orchard| {
                     orchard.redact_actions(|mut action| {
@@ -1387,7 +1394,10 @@ pub(crate) mod v2 {
                     });
                 })
                 .finish();
-            let redacted_size = redacted.clone().serialize().unwrap().len();
+            let redacted_size = crate::v2::Pczt::try_from(redacted.clone())
+                .unwrap()
+                .serialize()
+                .len();
 
             assert_eq!(
                 redacted.orchard.actions[0].output.enc_ciphertext,

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -71,6 +71,7 @@ pub struct Bundle {
     /// The Orchard bundle proof.
     ///
     /// This is `None` until it is set by the Prover.
+    #[getset(get = "pub")]
     pub(crate) zkproof: Option<Vec<u8>>,
 
     /// The Orchard binding signature signing key.
@@ -589,6 +590,7 @@ pub struct Spend {
     /// - This is chosen by the Constructor.
     /// - This is required by the IO Finalizer, and is cleared by it once used.
     /// - Signers MUST reject PCZTs that contain `dummy_sk` values.
+    #[getset(get = "pub")]
     pub(crate) dummy_sk: Option<[u8; 32]>,
 
     /// Proprietary fields related to the note being spent.
@@ -750,6 +752,12 @@ pub mod v1 {
                 return Err(crate::EncodingError::UnsupportedOrchardNoteVersion);
             }
 
+            let anchor = match bundle.anchor {
+                Some(anchor) => anchor,
+                None if bundle.actions.is_empty() => super::DEFAULT_ANCHOR,
+                None => return Err(crate::EncodingError::RequiresV2),
+            };
+
             Ok(Self {
                 actions: bundle
                     .actions
@@ -758,7 +766,7 @@ pub mod v1 {
                     .collect::<Result<Vec<_>, _>>()?,
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: bundle.anchor.ok_or(crate::EncodingError::RequiresV2)?,
+                anchor,
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
             })

--- a/pczt/src/sapling.rs
+++ b/pczt/src/sapling.rs
@@ -146,6 +146,7 @@ pub struct Spend {
     ///
     /// - This is set by the Updater.
     /// - This is required by the Prover.
+    #[getset(get = "pub")]
     pub(crate) witness: Option<(u32, [[u8; 32]; 32])>,
 
     /// The spend authorization randomizer.

--- a/pczt/tests/end_to_end.rs
+++ b/pczt/tests/end_to_end.rs
@@ -60,19 +60,18 @@ fn post_nu6_3_orchard_proving_key() -> &'static orchard::circuit::ProvingKey {
 }
 
 fn check_round_trip(pczt: &Pczt) {
-    // The v1 encoding remains available explicitly.
+    // The v1 and v2 encodings both remain available explicitly.
     v1::Pczt::try_from(pczt.clone())
         .expect("v1 encoding succeeds")
         .serialize();
-
-    // The default encoding is the latest (v2) encoding.
-    let v2_encoded = v2::Pczt::try_from(pczt.clone())
+    v2::Pczt::try_from(pczt.clone())
         .expect("v2 encoding succeeds")
         .serialize();
 
+    // The default encoding is the minimal encoding capable of representing the
+    // PCZT's content (v1 or v2), and round-trips losslessly through parsing and
+    // re-serialization.
     let encoded = pczt.clone().serialize().expect("serialization succeeds");
-    assert_eq!(encoded, v2_encoded);
-
     let reencoded = Pczt::parse(&encoded)
         .expect("can parse encoded PCZT")
         .serialize()
@@ -1050,16 +1049,20 @@ fn orchard_low_level_signer_uses_preverified_signing_parse() {
     assert_eq!(u32::from(tx.expiry_height()), 10_000_040);
 }
 
-/// Checks that the PCZT round-trips through the default (v2) encoding.
+/// Checks that the PCZT round-trips through the v2 encoding, forced explicitly.
 ///
 /// This is [`check_round_trip`] minus the v1 encoding check: v6 PCZTs (which carry
-/// an Ironwood bundle) are not representable in the legacy v1 encoding.
+/// an Ironwood bundle) are not representable in the legacy v1 encoding. The v2
+/// encoding is forced explicitly (rather than using the default [`Pczt::serialize`])
+/// because some content that is v1-representable would otherwise take the minimal
+/// (v1) encoding, silently discarding v2-only information such as an absent anchor.
 fn check_v2_round_trip(pczt: &Pczt) {
-    let encoded = pczt.clone().serialize().expect("serialization succeeds");
-    let reencoded = Pczt::parse(&encoded)
-        .expect("can parse encoded PCZT")
-        .serialize()
-        .expect("serialization succeeds");
+    let encoded = v2::Pczt::try_from(pczt.clone())
+        .expect("v2 encoding succeeds")
+        .serialize();
+    let reencoded = v2::Pczt::try_from(Pczt::parse(&encoded).expect("can parse encoded PCZT"))
+        .expect("v2 encoding succeeds")
+        .serialize();
     assert_eq!(encoded, reencoded);
 }
 
@@ -1183,7 +1186,14 @@ fn assert_redacted_anchor_v2_round_trip(pczt: Pczt, pool: ShieldedPool) {
     assert_anchor_redacted(&redacted, pool);
     check_v2_round_trip(&redacted);
 
-    let reparsed = Pczt::parse(&redacted.serialize().unwrap()).unwrap();
+    // Force the v2 encoding explicitly here too: for an output-only Sapling
+    // bundle, an absent anchor is also v1-representable (v1 substitutes a
+    // placeholder), but this assertion is specifically checking the v2
+    // encoding's ability to preserve an absent anchor losslessly.
+    let v2_encoded = v2::Pczt::try_from(redacted)
+        .expect("v2 encoding succeeds")
+        .serialize();
+    let reparsed = Pczt::parse(&v2_encoded).unwrap();
     assert_anchor_redacted(&reparsed, pool);
 }
 

--- a/pczt/tests/firmware_compat.rs
+++ b/pczt/tests/firmware_compat.rs
@@ -1,0 +1,111 @@
+//! Cross-implementation PCZT wire-compatibility with the Keystone 3 firmware.
+//!
+//! This test is a reviewer's aid for PR #2769 (issue #2768): it confirms that
+//! the minimal-encoding `Pczt::serialize()` restored by this PR produces bytes
+//! that the deployed firmware (which uses the `pczt` 0.2.1 crate) already
+//! parses and produces.
+//!
+//! The vector below is the canonical Orchard->transparent PCZT embedded in the
+//! keystone3-firmware source, produced by the firmware's `pczt` 0.2.1. It is a
+//! **v1** encoding (`PCZT` magic + little-endian version `1`). Keeping the
+//! exact bytes here and in the firmware test makes this a shared encoding
+//! vector: if either side's v1 layout drifts, one of the two round-trip
+//! assertions fails.
+//!
+//! Source of the vector (KeystoneHQ/keystone3-firmware, pinned commit):
+//! <https://github.com/KeystoneHQ/keystone3-firmware/blob/8420703ad8674745ca8f086590371661747b7dca/rust/apps/zcash/src/pczt/sign.rs#L214>
+//!
+//! The crucial claim is on the DEFAULT `serialize()` path a wallet SDK calls.
+//! Before this PR that default emitted v2 (2748 bytes) and diverged from the
+//! firmware; with this PR it emits minimal-encoding v1 (2731 bytes) that is
+//! byte-identical to the firmware vector.
+
+fn encoding_version(bytes: &[u8]) -> u32 {
+    assert_eq!(&bytes[..4], b"PCZT", "not a PCZT (bad magic)");
+    u32::from_le_bytes(bytes[4..8].try_into().unwrap())
+}
+
+/// Byte-for-byte the same constant used by the firmware unit test
+/// (`PCZT_V1_ORCHARD_TO_TRANSPARENT`). Do not regenerate casually: a change
+/// here is a wire-format change that must be mirrored in the firmware.
+const FIRMWARE_V1_VECTOR: &str = "50435a5401000000058ace9cb502d5a09cc70c0100f083ae0185010000000180ade2041976a91467f7aa14f177a7e0058c66c7242e086488bd3d1088ac000001237431544d4c4a376b324e344e6172716b3546643575556f38324e58534d624b5267436300000000fbc2f4300c01f0b7820d00e3347c8da4ee614674376cbc45359daa54f9b5493e010000000000000000000000000000000000000000000000000000000000000000024d2eeb083d7c168f64239c3186d53c72e2b1a3a5140f5250f0963689c08cd61c0999baea13f0be05dc6a2554bb2f8f093f4d20911202567a5ab9fd17bce5142b3f79838a71d14757fcff03ba16486a3efb26c9773ec9596821d1e5f32039fe220001d5d3506f152f62c45198446223abf29e06da700990a779fb60a460712fb666a0ff1fab61e2b2b3566b263d0180b6dc05014b2225d5521d6dbb55ae03d22567ce98b242ba5520bc4e2493ec36fb9211c6350194215c2aa089dfa317c61bab4b9747f4e45abca855e45e00710a3dc5caa40a570186f6f9e818f6674c2df92918a55d20f340944de5c67c1c4a9ee347c2c2d6d71d4753d765f2859a3157f7b05cc3bc7089e3f2c9d5abb3fcb1708e74c790985d3dd90cfe2ed03276dfda527c6e8c08d9a1fdeedcb6aef59d9e5bf0ae5d9477ed030001872727f23f40a96896b66d04de905791bae2bc7ee9dc1f4e4ec5ae493dc2fc1001afb475105f1f5b477c52aa3c32ccf131b0c556b80f55ac555460e6b5148bf85303a0808080088581808008808080800800002585b32c42aa5a12b2763953f09aafed13450eda0c416e32d0978260c4171c375413b91e25fa826399623b6716ae8bbb0b4a1099de22478944627af7e5969aa0c404ffab4d35664c1dafd2d2c0cecf4fb3c8b054179f84b2d35d207077b3d256b429acdee34963c573b55ae20fffce73e0e3e575c8fde9d115e7ffab50b3bee60d2436b72c17677e1d7db141fafa72c7f89002908a7a8de3320e5ad3d1ed0bb545235e136904c5c5e4adfa5a100420ceb2196e5e197e919aeaeefa7cb2a1d98e011539af52d618bfb3ba1dfc2d2c01e9bd67523bb6787eb5a0d28e30ad483c6303efd4796795082cc67ea94ba8548a33da1a5ec7c56174bd6b260f548e83a924b7cdd32980ca489b44e981aa1d81cefe2581eebf3a585fb80542aea4a27862f593203b560a412ba4e737c8f678f239f3d1d07c5a82367435f0a0921c46600eb4f6f7387b3cb5984af98b1337f5148ad6388b62dab7cdc48c66ff81685894c2d1d0fe41716b7cb457fb5bd6ff13e321d2f91c15d431f942d7869955dfeadfff61638266ba38d7ba4db7ffe5ee03550d345715cebd9b378181b5769c22e1b20328165da02eeb5d246c70c008ac0c7f7b1bba2cf8270f013eb99cbc5d534270180f34892fdf08d8c16c518d8b7f62d832d676c65fcae34c640ff30d5bd9d65afeab509117a98374b4b9b016228a65bdd803d6c601d2ad6a654c2fe4487d9c7b088d886c36a6afe63d33f8c474f096500acabbb63968e7408c620cc8139331cf7227e9bdbf4b7bae292e15d310e66186b730f28d0515ac5bb71fcc5de09995fe89d005cc2c7afd0fb8f01b315815d38366ebeb6de9ed565b5d1f2ce14b7795b9ad784851f357beacc454be41aaec506f0148461ba5907043ab8618114bbbede979d7f0e0e0af914750df648079e3625e4f309d13ff74d4ada783203bb3652137abd8327cdd06b9332591c9abdcc0cc16f7fec2e0afd849bef8927b3b0ceeca2b90af7611875b78cf525852ee83e10c8f4cb2c80045cbf33c0801a55eeb15c9dca6e53b3dde8a12daf820f1f76624ee48e3128aaa0ef6f6fb32a0303d89e88be288be1b92a301e893790179ec07711e275f48de2f5f8e0ee7b000091c9d96159746d46f353e67463d7052000000000118c5796d39cd2bc56b0a062c20ebd32feb0b57cc231c262d6703520f8de603211edcf51f6084e3288cbdb02957a02cd68fb84973a6a98260fb60f30951dedb2e1240275687c0bd82a2653a2c212bd3c0ea75cd294f5a4d31dcf507c15461402760282899f6b560858c0b6bd95c708f62d1e856480a52401d0d7d6a642fa1c2a10176072c6147735b785ea4ad9276378885704a44c6246f4630ef1df59438562e055bba6c1411a790727ab27421e6c418df8b65cb636d6786ce9e5b632659f5d32401caffe6271e2d77d8634e67a116926d7566b5eb2f2aadba6498d7a1e120f27f52379bb3f8781090ae47e30b0100011a78b2abbab21b29d79141fdff8a389c2eacde5be75c69ae4c4fabc175aec10a0142b202630def2df1f7cd23fcf362c68194829282c57b0c4d5f0ca023b51a571f01bd466676b53cfc27ba4a94bb4ab3ed19d8db336042e09e1e756b560b5ce7fc05d5dc3269236828f541662db5bfd4ab6e07c4dac2682906ee85eca2d12b6522013dd286fc499141cfebfb53175ea4321e08e8a504604bbc2e9d3e59706a1fa439000130febcd5d0c57c6e3780d6fe1f6c07f01a9d5d7a053ac5562f29304418d33a20000000f7fa16a612e422c34d61c44ae692b255c921239547172fcd26519928a3abb10d22548d840b466f1fed5ccb4c442d97b4b59d1a728455ee1598bae8e316f819bac404c9112693c57e0733d550ddc984d82ecc9047721e7e7bc6f283ba00852e49a4d3cda4dad343a366650b1d75b26025eadc5200113ebcc2a4a7db9ac2291083d76e7a8c04831764caf35e4c18bfc58e58699b4a651ca3686a95a6db7133611b5ce80a14225cdac643311869ea0c4a6d760379f285fa9c396c435361044da7e077f236d589a3eb962129988ea6ccde694cb72fa986748fc106981320f478a1c5402fe75a26dee31ec9fad4240aa19932fa8361c43798aa381c63b0c0b17657ccf37792a28456cfe6562e15d9e4aa26ed2660b6c8fc8a92cd352a6025dabcbed5eba82d88b9df3ba73270ff2f9c44fca8b0c1df8ed4cbfa2a4ebe7d0bcc6e5ce73e43b51e054860d7939ca13d77813b372070fd24cdd9c0e2fad7567471c0279bba19a76f0cdbd3107220821dd676c1df6524c15b87c1318eda418d65f8c66d2a77a65f6894199d44611e60c0291c330d1692bd521aef0e316e2b3f8c377b0d6873b3b645196ba74a79c6e0509869ac66276c3e2dfefd54a12365b5945406e7b673321ed36e89a14a194ae8b864e9ac4684655bae7fcd3123a226f282ac6ac82ca88d6a383d8be90f87f4cb85225f697932abfb4c05cda3b6dadb003621fee663f3fcb8f1c96320a3f148bc106ec231961a8f5142dd614317eef16b81492668a8b8795b85d7b0f737fa8d79e9dc3d78840d158a73dc6d1700ce3a8de2a9f93ff1bc8108703b94fd5bd230a19dd0fd821b832d3508b335e07bac28e95c3ab0eb637334bf166fa2a440ea35c0372bb5a745ee86c727a80f0d0d080fef6642ae7aae1407d6a25c3050c498a52ae300105bded1f19829b10df00e7ba301a9aef2c99ad7c5338b0e259ab97ea852630606b8d59709ca067d32698c8761e0f7d5b76ac07d4860b0fe2992010ba88827bb37cf4e3436488580e79101b366d454f29aa2bdf76725130baa08b38af3a71c251521809c84fe3d086943f39f01d760884b6342fac60c010001c54930d4f4f9946dfe91ac3e94cf5b513871c4a5c0c21137959482da796d2d280000000001c4666732084baff2e402ed7d3e457303c73b77dbd4aa5bc943ac7ca96f3779070398a2e304004aed48232c44dbd0b0b5404063ecc4679436f28c6251cbba91e29388fcd98d0e0001dc2be19f4118dbb7500df3a95e304733b247cea7f8c681f6aaafceb8fc1d7d28";
+
+/// The firmware's v1 vector parses under this PR.
+#[test]
+fn parses_firmware_v1_vector() {
+    let bytes = hex::decode(FIRMWARE_V1_VECTOR).expect("valid hex");
+    assert_eq!(
+        encoding_version(&bytes),
+        1,
+        "vector must be the v1 encoding"
+    );
+    pczt::Pczt::parse(&bytes).expect("PR must parse the firmware v1 vector");
+}
+
+/// The core claim of PR #2769: the DEFAULT `serialize()` (the path a wallet SDK
+/// calls) emits minimal-encoding v1 that is byte-identical to the firmware
+/// vector. Pre-fix this default emitted v2 and diverged, breaking deployed
+/// signers.
+#[test]
+fn default_serialize_matches_firmware_bytes() {
+    let bytes = hex::decode(FIRMWARE_V1_VECTOR).expect("valid hex");
+    let pczt = pczt::Pczt::parse(&bytes).expect("parse");
+
+    let serialized = pczt.serialize().expect("serialize");
+
+    assert_eq!(
+        encoding_version(&serialized),
+        1,
+        "the fix must select the v1 minimal encoding for this content",
+    );
+    assert_eq!(
+        serialized, bytes,
+        "default serialize() must be byte-identical to the firmware v1 vector",
+    );
+}
+
+/// The explicit `v1::Pczt` path also reproduces the firmware bytes exactly,
+/// and the v2 path (the pre-fix default) does not, documenting the divergence
+/// the fix removes.
+#[test]
+fn v1_matches_and_v2_differs() {
+    let bytes = hex::decode(FIRMWARE_V1_VECTOR).expect("valid hex");
+    let pczt = pczt::Pczt::parse(&bytes).expect("parse");
+
+    let v1 = pczt::v1::Pczt::try_from(pczt.clone())
+        .expect("firmware PCZT is v1-representable")
+        .serialize();
+    assert_eq!(encoding_version(&v1), 1);
+    assert_eq!(
+        v1, bytes,
+        "explicit v1 encoding matches the firmware vector"
+    );
+
+    let v2 = pczt::v2::Pczt::try_from(pczt)
+        .expect("v2 encode")
+        .serialize();
+    assert_eq!(encoding_version(&v2), 2);
+    assert_ne!(
+        v2, bytes,
+        "the v2 encoding differs from the firmware v1 bytes (the pre-fix default)",
+    );
+}
+
+/// The bytes the PR emits re-parse and re-serialize stably (idempotent),
+/// so a device that echoes the PCZT back does not perturb the encoding.
+#[test]
+fn default_serialize_is_idempotent() {
+    let bytes = hex::decode(FIRMWARE_V1_VECTOR).expect("valid hex");
+    let once = pczt::Pczt::parse(&bytes)
+        .expect("parse")
+        .serialize()
+        .expect("serialize");
+    let twice = pczt::Pczt::parse(&once)
+        .expect("re-parse")
+        .serialize()
+        .expect("re-serialize");
+    assert_eq!(
+        once, twice,
+        "serialize() must be idempotent across a parse round-trip"
+    );
+}

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,21 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::wallet::SignerView`, selecting the signer
+  view produced by `redact_pczt_for_signer` according to the receiving
+  Signer's capabilities.
+
+### Changed
+- `zcash_client_backend::data_api::wallet::redact_pczt_for_signer` now takes a
+  `SignerView` argument. `SignerView::Compact` preserves the previous
+  behavior; the new `SignerView::Full` produces a conservative view for
+  Signers that predate the compact view (including deployed hardware
+  signers): it retains proofs, binding-signature keys, and anchors, clears
+  Orchard-protocol and Sapling spend witnesses and dummy signing keys, and
+  performs no field compaction, so its view of a v5 transaction remains
+  representable in the v1 PCZT encoding.
+
 ## [0.24.0-rc.2] - 2026-07-24
 
 ### Added

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -83,7 +83,7 @@ use zcash_protocol::{PoolType, TxId};
 
 #[cfg(feature = "pczt")]
 use {
-    crate::data_api::wallet::{redact_pczt_for_batch_signer, redact_pczt_for_signer},
+    crate::data_api::wallet::{SignerView, redact_pczt_for_batch_signer, redact_pczt_for_signer},
     pczt::roles::{combiner::Combiner, prover::Prover, signer::Signer},
     rand_core::OsRng,
     transparent::builder::TransparentSigningSet,
@@ -8032,7 +8032,7 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
     // exercises redaction of data that the external Signer does not need.
     let original_sighash = Signer::new(pczt_proven.clone()).unwrap().shielded_sighash();
     let original_len = pczt_proven.clone().serialize().unwrap().len();
-    let signer_view = redact_pczt_for_signer(&pczt_proven);
+    let signer_view = redact_pczt_for_signer(&pczt_proven, SignerView::Compact);
     assert_eq!(
         *signer_view.global().tx_version(),
         zcash_protocol::constants::V5_TX_VERSION,
@@ -8063,6 +8063,41 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
         Signer::new(signer_view.clone()).unwrap().shielded_sighash(),
         original_sighash,
     );
+
+    // The full signer view is for receivers that predate the compact view:
+    // it commits to the same transaction effects, retains proofs and anchors,
+    // clears witnesses and dummy signing keys, and (for v5 transactions)
+    // remains representable in the v1 PCZT encoding.
+    let full_view = redact_pczt_for_signer(&pczt_proven, SignerView::Full);
+    assert_eq!(
+        Signer::new(full_view.clone()).unwrap().shielded_sighash(),
+        original_sighash,
+    );
+    assert_eq!(full_view.orchard().anchor(), pczt_proven.orchard().anchor());
+    assert_eq!(full_view.sapling().anchor(), pczt_proven.sapling().anchor());
+    assert_eq!(
+        full_view.orchard().zkproof().is_some(),
+        pczt_proven.orchard().zkproof().is_some(),
+    );
+    assert!(full_view.orchard().actions().iter().all(|action| {
+        action.spend().witness().is_none() && action.spend().dummy_sk().is_none()
+    }));
+    assert!(
+        full_view
+            .sapling()
+            .spends()
+            .iter()
+            .all(|spend| spend.witness().is_none())
+    );
+    if *full_view.global().tx_version() == zcash_protocol::constants::V5_TX_VERSION {
+        let full_view_bytes = full_view.clone().serialize().unwrap();
+        assert!(pczt::v1::Pczt::try_from(full_view).is_ok());
+        assert_eq!(
+            u32::from_le_bytes(full_view_bytes[4..8].try_into().unwrap()),
+            1,
+            "the full signer view of a v5 PCZT serializes in the v1 encoding",
+        );
+    }
 
     // Apply signatures to the transported signer view, then combine the
     // contribution with the proof-bearing authoritative copy.
@@ -9400,7 +9435,7 @@ where
     let original_sighash = Signer::new(pczt.clone()).unwrap().shielded_sighash();
     let original_spend_states = spend_states(pczt.clone());
     let original_len = pczt.clone().serialize().unwrap().len();
-    let signer_view = redact_pczt_for_signer(&pczt);
+    let signer_view = redact_pczt_for_signer(&pczt, SignerView::Compact);
     let signer_view_bytes = signer_view.serialize().unwrap();
     assert!(signer_view_bytes.len() < original_len);
     let signer_view = pczt::Pczt::parse(&signer_view_bytes).unwrap();

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -3078,27 +3078,97 @@ where
     Ok(pczt)
 }
 
+/// Selects the view produced by [`redact_pczt_for_signer`], according to the
+/// capabilities of the receiving Signer.
+#[cfg(feature = "pczt")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignerView {
+    /// The conservative signer view, for general-purpose Signers including
+    /// deployed hardware signers (e.g. the Keystone ordinary send flow), which
+    /// this view is validated against in the field.
+    ///
+    /// It removes wallet metadata, Orchard-protocol and Sapling spend
+    /// witnesses, and dummy signing keys (a defensive no-op for IO-finalized
+    /// PCZTs, whose dummy keys were consumed by the IO Finalizer; per the PCZT
+    /// specification, Signers MUST reject PCZTs that contain them). It retains
+    /// proofs, binding-signature keys, and anchors, and performs no field
+    /// compaction, so the view of a v5 transaction remains representable in
+    /// the v1 PCZT encoding (which [`pczt::Pczt::serialize`] selects for it).
+    Full,
+    /// The compact signer view, for receivers that support the v2 PCZT
+    /// encoding and can restore compacted fields with
+    /// [`pczt::Pczt::resolve_fields`].
+    ///
+    /// In addition to the `Full` redactions — except that Sapling spend
+    /// witnesses are retained so that the Signer may verify nullifiers —
+    /// this clears zk-proofs and binding-signature keys, compacts resolvable
+    /// Orchard-protocol fields, and removes v6 shielded anchors (v5 anchors
+    /// are retained because signatures commit to them).
+    Compact,
+}
+
 /// Creates a redacted copy of a wallet PCZT for an external Signer.
 ///
-/// This is intended for PCZTs returned by [`create_pczt_from_proposal`]. It removes
-/// wallet metadata, proof data, binding and dummy signing keys, and Orchard-protocol
-/// spend witnesses that a Signer does not need. Sapling spend witnesses are retained
-/// because a Signer may use them to verify nullifiers. It also compacts Orchard and
-/// Ironwood fields that the receiver can restore with [`pczt::Pczt::resolve_fields`].
-/// For v6 transactions, it removes shielded anchors; v5 anchors are retained because
-/// signatures commit to them. The compact signer view requires the v2 PCZT encoding
-/// whenever it contains Orchard or Ironwood actions whose fields could be compacted.
+/// This is intended for PCZTs returned by [`create_pczt_from_proposal`]. The
+/// `view` argument selects the redaction policy; see [`SignerView`] for the
+/// receiver capabilities each view requires. When in doubt — in particular for
+/// hardware signers whose firmware predates the compact view — use
+/// [`SignerView::Full`].
 ///
-/// The returned PCZT retains information that a general-purpose Signer may need,
-/// including full viewing keys, spend authorization randomizers, key derivation
-/// paths, output recovery keys, and user-facing addresses. Applications may apply
-/// additional redaction when they know their Signer's capabilities.
+/// The returned PCZT retains information that a general-purpose Signer may
+/// need, including full viewing keys, spend authorization randomizers, key
+/// derivation paths, output recovery keys, and user-facing addresses.
+/// Applications may apply additional redaction when they know their Signer's
+/// capabilities. A Signer that independently obtains the relevant full viewing
+/// keys and returns only Orchard-protocol signature contributions can instead
+/// use [`redact_pczt_for_batch_signer`].
 ///
-/// The caller must retain `pczt` and combine the Signer's contribution into that
-/// authoritative copy. The returned signer view omits wallet metadata and other
-/// fields that [`extract_and_store_transaction_from_pczt`] requires.
+/// The caller must retain `pczt` and combine the Signer's contribution into
+/// that authoritative copy. The returned signer view omits wallet metadata and
+/// other fields that [`extract_and_store_transaction_from_pczt`] requires.
 #[cfg(feature = "pczt")]
-pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
+pub fn redact_pczt_for_signer(pczt: &pczt::Pczt, view: SignerView) -> pczt::Pczt {
+    match view {
+        SignerView::Full => full_signer_view(pczt),
+        SignerView::Compact => compact_signer_view(pczt),
+    }
+}
+
+#[cfg(feature = "pczt")]
+fn full_signer_view(pczt: &pczt::Pczt) -> pczt::Pczt {
+    fn redact_orchard_bundle(mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>) {
+        redactor.redact_actions(|mut action| {
+            action.clear_spend_witness();
+            action.clear_spend_dummy_sk();
+            action.redact_output_proprietary(PROPRIETARY_OUTPUT_INFO);
+        });
+    }
+
+    Redactor::new(pczt.clone())
+        .redact_global_with(|mut redactor| {
+            redactor.redact_proprietary(PROPRIETARY_PROPOSAL_INFO);
+        })
+        .redact_transparent_with(|mut redactor| {
+            redactor.redact_outputs(|mut output| {
+                output.redact_proprietary(PROPRIETARY_OUTPUT_INFO);
+            });
+        })
+        .redact_sapling_with(|mut redactor| {
+            redactor.redact_spends(|mut spend| {
+                spend.clear_witness();
+                spend.clear_dummy_ask();
+            });
+            redactor.redact_outputs(|mut output| {
+                output.redact_proprietary(PROPRIETARY_OUTPUT_INFO);
+            });
+        })
+        .redact_orchard_with(redact_orchard_bundle)
+        .redact_ironwood_with(redact_orchard_bundle)
+        .finish()
+}
+
+#[cfg(feature = "pczt")]
+fn compact_signer_view(pczt: &pczt::Pczt) -> pczt::Pczt {
     let redact_v6_anchors = *pczt.global().tx_version() == zcash_protocol::constants::V6_TX_VERSION;
 
     fn redact_orchard_bundle(
@@ -3155,10 +3225,11 @@ pub fn redact_pczt_for_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
 /// Creates a compact wallet PCZT for a batch Signer that obtains its full viewing key
 /// independently and returns only new Orchard and Ironwood signatures.
 ///
-/// In addition to [`redact_pczt_for_signer`], this removes spend full viewing keys and
-/// existing signatures. It also removes the randomizer from actions already authorized
-/// in `pczt`, while unsigned actions such as wallet controlled zero value spends retain
-/// theirs. Sapling signatures require a separate signing path.
+/// In addition to the [`SignerView::Compact`] policy of [`redact_pczt_for_signer`],
+/// this removes spend full viewing keys and existing signatures. It also removes the
+/// randomizer from actions already authorized in `pczt`, while unsigned actions such
+/// as wallet controlled zero value spends retain theirs. Sapling signatures require a
+/// separate signing path.
 ///
 /// The caller must retain the authoritative PCZT and apply the returned signature
 /// contributions to it. This function must run before its existing signatures are
@@ -3197,7 +3268,7 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
     let ironwood_preauthorized = preauthorized_action_indices(pczt.ironwood());
 
     // Apply the policy shared by every external Signer first.
-    Redactor::new(redact_pczt_for_signer(pczt))
+    Redactor::new(redact_pczt_for_signer(pczt, SignerView::Compact))
         .redact_orchard_with(|redactor| {
             redact_orchard_bundle(redactor, &orchard_preauthorized);
         })


### PR DESCRIPTION
Closes #2768.
Resolves MOB-1552

Two changes restoring a workable wire contract for deployed hardware signers:

**`pczt`: minimal-encoding `serialize()`.** `Pczt::serialize` previously always emitted the v2 encoding; it now emits the v1 encoding whenever the content is representable in it (pre-v6 transaction, canonical-empty Ironwood bundle, no compact-only field state), falling back to v2 otherwise. `parse()` already accepts both, so this is strictly compatibility-improving. Callers that need a pinned encoding use `pczt::v1::Pczt` / `pczt::v2::Pczt` directly.

Implementation note: v1-representability is decided by attempting `v1::Pczt::try_from` on a clone (gated behind cheap tx-version/Ironwood pre-checks) rather than by a parallel representability predicate — the full conditions live in private per-bundle `TryFrom` impls, and a duplicated predicate would drift. The clone only occurs on the pre-v6 path, where it is small relative to the serialization work itself.

**`zcash_client_backend`: explicit `SignerView` argument.** `redact_pczt_for_signer` now takes `SignerView::{Full, Compact}`. `Compact` is the previous behavior verbatim (and remains what `redact_pczt_for_batch_signer` composes on). `Full` is a conservative view for Signers that predate the compact view — including deployed hardware-signer firmware in its ordinary signing flow: it retains proofs, binding-signature keys, and anchors, clears Orchard/Ironwood/Sapling spend witnesses and dummy signing keys, and performs no field compaction, so its view of a v5 transaction stays representable in the v1 encoding (which the new `serialize()` then selects).

Along the way this surfaced and fixes a latent `pczt` bug: `v1::Pczt::try_from` required an Orchard anchor even for an empty Orchard bundle, wrongly rejecting Sapling-only v5 PCZTs from the v1 encoding; the empty bundle now gets the same placeholder-anchor fallback the Sapling bundle already had. Three field accessors (`orchard::Bundle::zkproof`, `orchard::Spend::dummy_sk`, `sapling::Spend::witness`) are added for the new pool-test assertions and as legitimate Signer-facing API.

Release implications: `pczt 0.9.0` (breaking: serialize behavior), `zcash_client_backend 0.24.0-rc.3` (breaking within the rc line: `redact_pczt_for_signer` signature). CHANGELOGs updated in the same commits as the API changes.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
