### PR TITLE
Release pczt 0.9.0, zcash_client_backend 0.24.0-rc.3, zcash_pool_migration 0.1.0-rc.2, zcash_client_sqlite 0.22.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.2"
+version = "0.24.0-rc.3"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.2"
+version = "0.22.0-rc.3"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "corez",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zcash_client_sqlite = { version = "0.22.0-rc.1", path = "zcash_client_sqlite" }
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.0", path = "zcash_keys", default-features = false  }
-zcash_pool_migration = { version = "0.1.0-rc.1", path = "zcash_pool_migration" }
+zcash_pool_migration = { version = "0.1.0-rc.2", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.0", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.30.0", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.30.0", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.8.0", path = "pczt" }
+pczt = { version = "0.9.0", path = "pczt" }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ categories = ["cryptography::cryptocurrencies"]
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.24.0-rc.3", path = "zcash_client_backend" }
-zcash_client_sqlite = { version = "0.22.0-rc.1", path = "zcash_client_sqlite" }
+zcash_client_sqlite = { version = "0.22.0-rc.3", path = "zcash_client_sqlite" }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
 # migrate at once, the workspace default stays pinned to the published 0.4; only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.24.0-rc.2", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.3", path = "zcash_client_backend" }
 zcash_client_sqlite = { version = "0.22.0-rc.1", path = "zcash_client_sqlite" }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-26
+
 ### Added
 - `pczt::orchard::Bundle::zkproof`
 - `pczt::orchard::Spend::dummy_sk`

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -39,7 +39,6 @@ audit-as-crates-io = true
 [policy.incrementalmerkletree-testing]
 
 [policy.orchard]
-audit-as-crates-io = true
 
 [policy.pczt]
 audit-as-crates-io = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.9.0"
 audited_as = "0.8.0"
 
+[[unpublished.zcash_client_backend]]
+version = "0.24.0-rc.3"
+audited_as = "0.24.0-rc.2"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.8.0"
 version = "0.24.0-rc.3"
 audited_as = "0.24.0-rc.2"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.3"
+audited_as = "0.22.0-rc.2"
+
 [[unpublished.zcash_pool_migration]]
 version = "0.1.0-rc.2"
 audited_as = "0.1.0-rc.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,22 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.pczt]]
-version = "0.9.0"
-audited_as = "0.8.0"
-
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.3"
-audited_as = "0.24.0-rc.2"
-
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.3"
-audited_as = "0.22.0-rc.2"
-
-[[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.2"
-audited_as = "0.1.0-rc.1"
-
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"
@@ -109,8 +93,8 @@ user-login = "ebfull"
 user-name = "Sean Bowe"
 
 [[publisher.pczt]]
-version = "0.8.0"
-when = "2026-07-24"
+version = "0.9.0"
+when = "2026-07-26"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -465,15 +449,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.24.0-rc.2"
-when = "2026-07-25"
+version = "0.24.0-rc.3"
+when = "2026-07-26"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.2"
-when = "2026-07-25"
+version = "0.22.0-rc.3"
+when = "2026-07-26"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -507,8 +491,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.1"
-when = "2026-07-25"
+version = "0.1.0-rc.2"
+when = "2026-07-26"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.8.0"
 version = "0.24.0-rc.3"
 audited_as = "0.24.0-rc.2"
 
+[[unpublished.zcash_pool_migration]]
+version = "0.1.0-rc.2"
+audited_as = "0.1.0-rc.1"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.pczt]]
+version = "0.9.0"
+audited_as = "0.8.0"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.24.0-rc.3] - 2026-07-26
+
 ### Added
 - `zcash_client_backend::data_api::wallet::SignerView`, selecting the signer
   view produced by `redact_pczt_for_signer` according to the receiving

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -16,6 +16,7 @@ workspace.
   Signer's capabilities.
 
 ### Changed
+- Migrated to `pczt 0.9.0`.
 - `zcash_client_backend::data_api::wallet::redact_pczt_for_signer` now takes a
   `SignerView` argument. `SignerView::Compact` preserves the previous
   behavior; the new `SignerView::Full` produces a conservative view for

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.24.0-rc.2"
+version = "0.24.0-rc.3"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,7 +11,8 @@ workspace.
 ## [Unreleased]
 
 ### Changed
-- Migrated to `zcash_client_backend 0.24.0-rc.3`.
+- Migrated to `zcash_client_backend 0.24.0-rc.3`,
+  `zcash_pool_migration 0.1.0-rc.2`.
 
 ## [0.22.0-rc.2] - 2026-07-24
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.3`.
+
 ## [0.22.0-rc.2] - 2026-07-24
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.22.0-rc.3] - 2026-07-26
+
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.3`,
   `zcash_pool_migration 0.1.0-rc.2`.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.22.0-rc.2"
+version = "0.22.0-rc.3"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,4 +7,6 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.2] - 2026-07-26
+
 Initial release of the `zcash_pool_migration` crate.

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_pool_migration"
 description = "Backend-agnostic value-pool migration engine for Zcash wallets"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 authors = [
     "Danny Willems <be.danny.willems@gmail.com>",
     "John Boyd <john@coldnoise.net>",


### PR DESCRIPTION
Release stack for `pczt 0.9.0`, `zcash_client_backend 0.24.0-rc.3`,
`zcash_pool_migration 0.1.0-rc.2`, and `zcash_client_sqlite 0.22.0-rc.3`, one
commit per crate. Each release commit bumps the crate's `Cargo.toml` version,
adds the dated `CHANGELOG.md` section, updates the workspace dependency in the
root `Cargo.toml` and `Cargo.lock`, updates the `Migrated to` entries in the
dependent crates' CHANGELOGs, and records the `cargo vet` `[[unpublished.*]]`
entry.

Three things worth a reviewer's attention:

- The stack is preceded by a `cargo vet` fix. On `main`, `cargo vet` fails
  outright with "some audit-as-crates-io policies don't match first-party
  crates": `[policy.orchard] audit-as-crates-io` survived the removal of the
  orchard git pin, and such an entry is invalid for a crate that is no longer
  first-party (setting it to `true` is not enough — it has to be dropped, which
  is what `cargo vet regenerate audit-as-crates-io` does). Without this, none of
  the release commits can run the `pre-release-hook`. It is independent of the
  releases and can be cherry-picked out if preferred.
- `zcash_pool_migration` gets no `Migrated to` entry for `pczt 0.9.0` /
  `zcash_client_backend 0.24.0-rc.3`. Its CHANGELOG carries only the
  initial-release line, per the AGENTS.md rule that an initial release has no
  API changes for a user to adapt to; this matches how `0.1.0-rc.1` was handled.
- The root `Cargo.toml` entry for `zcash_client_sqlite` was stale at
  `0.22.0-rc.1` (the `0.22.0-rc.2` release commit did not bump it). It now reads
  `0.22.0-rc.3`.

Verification: `cargo vet` succeeds at each release commit, `cargo check
--workspace --all-features` is clean at the tip, and `cargo metadata --locked`
confirms `Cargo.lock` is consistent at every commit in the stack.

This PR was prepared with Claude Code assistance.
