### PR TITLE
zcash_pool_migration: prove one representative scenario end to end

### DIFF
--- a/zcash_pool_migration/tests/prove_chain_sim.rs
+++ b/zcash_pool_migration/tests/prove_chain_sim.rs
@@ -478,9 +478,21 @@ fn scenarios() -> Vec<Scenario> {
 
 #[test]
 fn migration_proves_end_to_end_against_a_funded_wallet() {
-    for scenario in scenarios() {
-        scenario.prove_end_to_end();
-    }
+    // Proving dominates this test's cost: each preparation proves an Orchard bundle, and each
+    // transfer proves both an Orchard AND an Ironwood bundle, so proving every scenario in
+    // `MIGRATION_SCENARIOS` is ~149 real Halo2 proofs in a single test. The per-scenario
+    // accounting (preparations, transfers, migrated value, signing rounds) is already asserted for
+    // ALL scenarios without any proving by `migration_scenarios_end_to_end` in
+    // `signing_rounds_e2e.rs`; the only thing this test adds is exercising the real proving path.
+    // We therefore prove ONE representative scenario end to end. The "exchange" shape is the
+    // cheapest that still spans multi-layer preparation (2 preparations) and multiple transfers
+    // (3), so every proving code path runs exactly as it would for the larger shapes.
+    const REPRESENTATIVE: &str = "exchange, ten 5 ZEC notes";
+    let scenario = scenarios()
+        .into_iter()
+        .find(|scenario| scenario.label == REPRESENTATIVE)
+        .expect("the representative proving scenario exists");
+    scenario.prove_end_to_end();
 }
 
 /// The adapter reports the WALLET's anchor retention interval as its anchor bucket interval, and


### PR DESCRIPTION
## Motivation

The recently added migration proving tests have become a significant CI drag. `migration_proves_end_to_end_against_a_funded_wallet` in `zcash_pool_migration/tests/prove_chain_sim.rs` proved **every** scenario in `MIGRATION_SCENARIOS` against a funded wallet.

Proving dominates that test's cost: each preparation proves an Orchard bundle, and each transfer proves both an Orchard **and** an Ironwood bundle, so the loop generated roughly **149 real Halo2 proofs** in a single `#[test]` (21 preparations + 64 transfers x 2). That pushed the test into the multi-minute range (and effectively unbounded in CI's debug profile).

## Change

The per-scenario accounting (preparations, transfers, migrated value, signing rounds) is **already** asserted for all scenarios, with zero proving, by `migration_scenarios_end_to_end` in `signing_rounds_e2e.rs`. The proving test only needs to exercise the real proving path itself.

It now proves a **single representative scenario**, `"exchange, ten 5 ZEC notes"` — the cheapest shape that still spans multi-layer preparation (2 preparations) and multiple transfers (3), so every proving code path still runs exactly as it would for the larger shapes.

## Result

- `migration_proves_end_to_end_against_a_funded_wallet`: minutes -> **~17s in release**.
- **No loss of coverage**: all proving code paths still execute once; the numeric shape of the other 9 scenarios remains covered by the mock-backed `migration_scenarios_end_to_end`.

Test-only change; no crate behavior changes, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)