### PR TITLE
PCZT signer-view follow-ups: leak-regression tests and v1 anchor normalization

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -34,6 +34,11 @@ workspace.
   even though they carry no Orchard-protocol data. An empty Orchard bundle
   now falls back to a placeholder anchor for the v1 encoding, matching the
   existing behavior for an empty Sapling bundle.
+- Parsing a v1-encoded PCZT with an empty Orchard bundle no longer
+  materializes the placeholder anchor substituted for it on encode. The
+  logical bundle now round-trips to its canonical empty form (with no
+  anchor), matching the invariant that the v1 decoder produces exactly the
+  same empty bundle as the Creator and the v2 decoder.
 
 ## [0.8.0] - 2026-07-23
 

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -775,6 +775,18 @@ pub mod v1 {
 
     impl From<Bundle> for super::Bundle {
         fn from(bundle: Bundle) -> Self {
+            // The v1 encoding has no placeholder for a missing anchor, so an empty
+            // bundle's anchor is substituted with `DEFAULT_ANCHOR` on encode (see
+            // `TryFrom<super::Bundle> for Bundle` above). Undo that substitution here
+            // so that decoding an empty bundle reproduces `super::EMPTY_ORCHARD`
+            // exactly, mirroring the `is_default_empty` treatment the v2 encoder
+            // applies for the same case.
+            let anchor = if bundle.actions.is_empty() && bundle.anchor == super::DEFAULT_ANCHOR {
+                None
+            } else {
+                Some(bundle.anchor)
+            };
+
             Self {
                 actions: bundle
                     .actions
@@ -783,7 +795,7 @@ pub mod v1 {
                     .collect(),
                 flags: bundle.flags,
                 value_sum: bundle.value_sum,
-                anchor: Some(bundle.anchor),
+                anchor,
                 note_version: NoteVersion::V2,
                 zkproof: bundle.zkproof,
                 bsk: bundle.bsk,
@@ -1170,8 +1182,9 @@ pub(crate) mod v2 {
         use alloc::{collections::BTreeMap, vec::Vec};
 
         use super::super::{
-            Action as LogicalAction, Bundle as LogicalBundle, EncCiphertext, MEMO_SIZE,
-            MemoPlaintext, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output, Spend,
+            Action as LogicalAction, Bundle as LogicalBundle, EMPTY_ORCHARD, EncCiphertext,
+            MEMO_SIZE, MemoPlaintext, NoteVersion, ORCHARD_SPENDS_AND_OUTPUTS_ENABLED, Output,
+            Spend,
         };
 
         fn logical_action(cv_net: Option<[u8; 32]>, cmx: Option<[u8; 32]>) -> LogicalAction {
@@ -1558,6 +1571,29 @@ pub(crate) mod v2 {
                 )),
                 Err(crate::EncodingError::RequiresV2)
             ));
+        }
+
+        #[test]
+        fn v1_empty_bundle_anchor_falls_back_to_default() {
+            // An empty bundle has no anchor to commit to, so the v1 encoding (whose
+            // anchor field is mandatory) falls back to `DEFAULT_ANCHOR`.
+            let bundle = LogicalBundle {
+                actions: Vec::new(),
+                flags: ORCHARD_SPENDS_AND_OUTPUTS_ENABLED,
+                value_sum: (0, false),
+                anchor: None,
+                note_version: NoteVersion::V2,
+                zkproof: None,
+                bsk: None,
+            };
+
+            let encoded = crate::orchard::v1::Bundle::try_from(bundle)
+                .expect("an empty bundle's anchor falls back to DEFAULT_ANCHOR");
+
+            // Decoding must undo the fallback substitution, reproducing the logical
+            // empty bundle exactly rather than materializing the placeholder anchor.
+            let decoded = super::super::Bundle::from(encoded);
+            assert_eq!(decoded, EMPTY_ORCHARD);
         }
     }
 }

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8089,6 +8089,32 @@ pub fn pczt_single_step<P0: ShieldedPoolTester, P1: ShieldedPoolTester, Dsf>(
             .iter()
             .all(|spend| spend.witness().is_none())
     );
+    // Redaction's primary purpose is removing the wallet's proprietary metadata,
+    // which the Signer has no use for and should never see.
+    assert!(
+        !full_view
+            .global()
+            .proprietary()
+            .contains_key("zcash_client_backend:proposal_info")
+    );
+    for bundle in [full_view.orchard(), full_view.ironwood()] {
+        assert!(bundle.actions().iter().all(|action| {
+            !action
+                .output()
+                .proprietary()
+                .contains_key("zcash_client_backend:output_info")
+        }));
+    }
+    assert!(full_view.sapling().outputs().iter().all(|output| {
+        !output
+            .proprietary()
+            .contains_key("zcash_client_backend:output_info")
+    }));
+    assert!(full_view.transparent().outputs().iter().all(|output| {
+        !output
+            .proprietary()
+            .contains_key("zcash_client_backend:output_info")
+    }));
     if *full_view.global().tx_version() == zcash_protocol::constants::V5_TX_VERSION {
         let full_view_bytes = full_view.clone().serialize().unwrap();
         assert!(pczt::v1::Pczt::try_from(full_view).is_ok());
@@ -9507,6 +9533,42 @@ where
     let memo_plaintexts = assert_redacted_bundle(pczt.orchard(), signer_view.orchard())
         + assert_redacted_bundle(pczt.ironwood(), signer_view.ironwood());
     assert!(memo_plaintexts > 0);
+
+    // The full signer view (for receivers that predate the compact view) commits to
+    // the same transaction effects and, unlike the compact view, retains v6 anchors.
+    let full_view = redact_pczt_for_signer(&pczt, SignerView::Full);
+    assert_eq!(
+        Signer::new(full_view.clone()).unwrap().shielded_sighash(),
+        original_sighash,
+    );
+    assert!(full_view.ironwood().actions().iter().all(|action| {
+        action.spend().witness().is_none() && action.spend().dummy_sk().is_none()
+    }));
+    assert_eq!(full_view.ironwood().anchor(), pczt.ironwood().anchor());
+    assert!(
+        !full_view
+            .global()
+            .proprietary()
+            .contains_key("zcash_client_backend:proposal_info")
+    );
+    for bundle in [full_view.orchard(), full_view.ironwood()] {
+        assert!(bundle.actions().iter().all(|action| {
+            !action
+                .output()
+                .proprietary()
+                .contains_key("zcash_client_backend:output_info")
+        }));
+    }
+    assert!(full_view.sapling().outputs().iter().all(|output| {
+        !output
+            .proprietary()
+            .contains_key("zcash_client_backend:output_info")
+    }));
+    assert!(full_view.transparent().outputs().iter().all(|output| {
+        !output
+            .proprietary()
+            .contains_key("zcash_client_backend:output_info")
+    }));
 
     let batch_view = redact_pczt_for_batch_signer(&pczt);
     let batch_view_bytes = batch_view.serialize().unwrap();


### PR DESCRIPTION
Closes #2775. Follow-ups from the final review of #2769.

**Commit 1 (test-only):** adds the missing leak-regression assertions to the `SignerView::Full` pool-test block — global `proposal_info` and per-output `output_info` proprietary metadata must be absent from the full signer view (the compact block already asserted this; the full view is the one with deployed hardware-signer exposure and had no such coverage). Also exercises the Full view against v6/Ironwood content in `create_pczt_supports_ironwood_output`: sighash equality, Ironwood witness/dummy clearing, v6 anchor retention, and proprietary removal.

**Commit 2:** normalizes the v1 decode of an empty Orchard bundle — a placeholder anchor written by the v1 encoder's canonicalization now decodes back to `anchor: None`, restoring the documented `EMPTY_ORCHARD` invariant that all decode paths produce exactly the canonical empty bundle. Adds the local pczt unit test for the #2769 anchor fallback (positive case beside `v1_rejects_missing_anchor_and_cv_net`) extended to assert the exact round trip. The Sapling side has the same pre-existing asymmetry and is deliberately untouched pending its own compatibility analysis (tracked in #2775).

Changelog note: `main`'s `pczt` `Unreleased` section still contains the (already-published-as-0.9.0) #2769 content, so the new Fixed bullet currently sits in that section; it belongs under the post-0.9.0 Unreleased heading once the release stamping lands on `main` — happy to rebase/adjust when that merge is in.

Tests: `cargo test -p pczt --all-features` (69), sqlite pool `pczt` tests (6), `cargo clippy --all-features --all-targets -- -D warnings`, `cargo fmt --all -- --check` — all clean.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
