### PR TITLE
Close the two remaining paths to unsignable wallet-controlled spends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,6 +7349,7 @@ dependencies = [
  "zcash_pool_migration_memory",
  "zcash_primitives",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]
@@ -7362,6 +7363,7 @@ dependencies = [
  "rand_core 0.6.4",
  "zcash_pool_migration",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -25,6 +25,17 @@ workspace.
   `sync::Error`, `sync::decryptor::TryQueueError`, `tor::Error`,
   `tor::grpc::GrpcError`, and `tor::http::HttpError`.
 
+### Fixed
+- `zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer` no
+  longer removes existing spend authorization signatures. It previously
+  stripped the signatures of the pre-signed protocol padding dummies while
+  also removing their randomizers and (via the compact signer view) their
+  dummy signing keys, leaving actions that neither the batch Signer nor the
+  wallet could authorize. Every action in the returned view is now either
+  already authorized or still authorizable. A batch Signer's response
+  consequently carries the retained signatures back alongside the new ones;
+  re-applying them to the authoritative PCZT is a no-op.
+
 ## [0.24.0-rc.4] - 2026-07-26
 
 ### Changed

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -9657,10 +9657,20 @@ where
         assert_eq!(batch_bundle.len(), original_bundle.len());
         for (original, batch) in original_bundle.iter().zip(batch_bundle) {
             assert!(!batch.has_fvk);
-            assert!(!batch.has_signature);
+            // A pre-signed protocol padding dummy keeps its signature: the batch view has
+            // already dropped its `dummy_sk` and it carries no derivation, so nothing
+            // downstream could ever reproduce that signature.
+            assert_eq!(batch.has_signature, original.has_signature);
             assert_eq!(
                 batch.has_alpha,
                 original.has_alpha && !original.has_signature
+            );
+            // The invariant the redaction must preserve: every action is either already
+            // authorized or still authorizable. Neither the Signer nor the wallet can
+            // rescue an action that is left with no signature and no randomizer.
+            assert!(
+                batch.has_signature || batch.has_alpha,
+                "the batch signer view stranded an action: {batch:?}",
             );
 
             if original.has_signature {
@@ -9753,16 +9763,14 @@ where
         .unwrap()
         .finish();
 
+    // Every action is now authorized: the ones the Signer signed, plus the pre-signed
+    // padding dummies whose signatures the batch view retained. Those retained signatures
+    // ride back along with the new ones and re-apply to the authoritative PCZT unchanged.
     let signatures = pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_view);
-    let expected_signature_positions = orchard_signable
-        .iter()
-        .copied()
+    let expected_signature_positions = (0..original_spend_states.0.len())
         .map(|index| (orchard::ValuePool::Orchard, index))
         .chain(
-            ironwood_signable
-                .iter()
-                .copied()
-                .map(|index| (orchard::ValuePool::Ironwood, index)),
+            (0..original_spend_states.1.len()).map(|index| (orchard::ValuePool::Ironwood, index)),
         )
         .collect::<Vec<_>>();
     let signature_positions = signatures

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -3236,10 +3236,11 @@ fn compact_signer_view(pczt: &pczt::Pczt) -> pczt::Pczt {
 /// independently and returns only new Orchard and Ironwood signatures.
 ///
 /// In addition to the [`SignerView::Compact`] policy of [`redact_pczt_for_signer`],
-/// this removes spend full viewing keys and existing signatures. It also removes the
-/// randomizer from actions already authorized in `pczt`, while unsigned actions such
-/// as wallet controlled zero value spends retain theirs. Sapling signatures require a
-/// separate signing path.
+/// this removes spend full viewing keys, and removes the randomizer from actions already
+/// authorized in `pczt`, while unsigned actions such as wallet controlled zero value
+/// spends retain theirs. Existing signatures are retained, so every action in the
+/// returned view is either already authorized or still authorizable. Sapling signatures
+/// require a separate signing path.
 ///
 /// The caller must retain the authoritative PCZT and apply the returned signature
 /// contributions to it. This function must run before its existing signatures are
@@ -3264,10 +3265,12 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         preauthorized_action_indices: &[usize],
     ) {
         // The batch Signer derives its FVK and returns only new signatures.
-        redactor.redact_actions(|mut action| {
-            action.clear_spend_fvk();
-            action.clear_spend_auth_sig();
-        });
+        redactor.redact_actions(|mut action| action.clear_spend_fvk());
+        // An action that already carries a signature needs nothing further, so it gives up its
+        // randomizer. Its signature is RETAINED: the only pre-signed actions in a wallet PCZT
+        // are the protocol padding dummies, which carry no ZIP 32 derivation and whose
+        // `dummy_sk` the compact view has already cleared, so stripping the signature would
+        // leave an action that neither the Signer nor the wallet could ever authorize.
         // Unsigned actions keep alpha, including wallet controlled zero value spends.
         for &index in preauthorized_action_indices {
             redactor.redact_action(index, |mut action| action.clear_spend_alpha());

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,29 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_pool_migration::build::AccountDerivation`, the ZIP 32 account whose
+  spending key authorizes a migration's Orchard spends. Behind the `orchard`
+  feature; convertible from `zcash_client_backend`'s `Zip32Derivation` behind
+  the `wallet` feature.
+
+### Changed
+- `zcash_pool_migration::build::{build_prep_tx, build_transfer_pczt}` take an
+  additional `Option<&AccountDerivation>` argument, before the RNG. When it is
+  supplied, every spend the built transaction still needs a signature for is
+  stamped with the account's Orchard ZIP 32 key path, so an external Signer can
+  identify those spends as the account's; previously they carried no derivation
+  and such a Signer skipped them, leaving transactions that could not be
+  extracted. Pass the account's derivation whenever the wallet knows it; pass
+  `None` only for an account with no known derivation, whose transactions then
+  only an in-process signer (which matches by key) can authorize.
+- `zcash_pool_migration::engine::MigrationCrypto` has a new required method,
+  `account_derivation`, supplying the above to the builders. Implement it by
+  returning the account's derivation as the wallet records it.
+- `zcash_pool_migration::wallet::WalletMigration` implements `MigrationCrypto`
+  only where the wallet's `WalletRead::AccountId` and `InputSource::AccountId`
+  are the same type, which is required to read the account's derivation.
+
 ## [0.1.0-rc.3] - 2026-07-26
 
 ### Changed

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -32,6 +32,7 @@ proptest = { workspace = true, optional = true }
 
 # Enabled by the `orchard` feature.
 orchard = { workspace = true, optional = true }
+zip32 = { workspace = true, optional = true }
 pczt = { workspace = true, optional = true, features = [
     "io-finalizer",
     "orchard",
@@ -76,7 +77,7 @@ zcash_pool_migration_memory = { path = "../zcash_pool_migration_memory" }
 ## the cryptographic ingredients a wallet supplies into an unproven migration PCZT. Requires the
 ## Orchard pool; pulls in `orchard` and `pczt`. The caller supplies the RNG, so no `rand` dependency
 ## is added.
-orchard = ["dep:orchard", "dep:pczt"]
+orchard = ["dep:orchard", "dep:pczt", "dep:zip32"]
 ## Builds the wallet-backed adapter (`wallet` module): a `WalletMigration` that implements the
 ## engine's backend/crypto/store traits over a `zcash_client_backend` wallet, so any such wallet is a
 ## migration wallet with no hand-wired crypto. Implies `orchard`.

--- a/zcash_pool_migration/src/build.rs
+++ b/zcash_pool_migration/src/build.rs
@@ -13,12 +13,15 @@
 //! every builder reuses it.
 
 use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use core::fmt;
 
-use pczt::roles::{creator::Creator, io_finalizer::IoFinalizer};
+use pczt::roles::{creator::Creator, io_finalizer::IoFinalizer, updater::Updater};
 use zcash_primitives::transaction::builder::PcztParts;
-use zcash_protocol::consensus::Parameters;
+use zcash_protocol::consensus::{NetworkConstants, Parameters};
+use zip32::fingerprint::SeedFingerprint;
 
 mod prep;
 mod sign;
@@ -51,14 +54,126 @@ impl fmt::Display for BuildError {
 
 impl core::error::Error for BuildError {}
 
+/// The ZIP 32 account whose spending key authorizes a migration's Orchard spends.
+///
+/// This is what an external Signer matches on to recognize a spend as the account's, so a wallet
+/// that delegates signing must supply it to the builders. Only the network-independent part of the
+/// derivation is held: the builders compose the full Orchard path `m/32'/coin_type'/account'` from
+/// their own consensus parameters, so a caller cannot address a migration to the wrong coin type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountDerivation {
+    seed_fingerprint: SeedFingerprint,
+    account_index: zip32::AccountId,
+}
+
+impl AccountDerivation {
+    /// The account at `account_index` under the seed with the given fingerprint.
+    pub fn new(seed_fingerprint: SeedFingerprint, account_index: zip32::AccountId) -> Self {
+        Self {
+            seed_fingerprint,
+            account_index,
+        }
+    }
+
+    /// The [ZIP 32 seed fingerprint](https://zips.z.cash/zip-0032#seed-fingerprints) of the seed
+    /// the account is derived from.
+    pub fn seed_fingerprint(&self) -> &SeedFingerprint {
+        &self.seed_fingerprint
+    }
+
+    /// The account-level index in the ZIP 32 derivation path.
+    pub fn account_index(&self) -> zip32::AccountId {
+        self.account_index
+    }
+
+    /// This account's Orchard PCZT derivation metadata on the network `params` describes: the ZIP
+    /// 32 path `m/32'/coin_type'/account'`.
+    fn to_pczt_derivation<P: Parameters>(&self, params: &P) -> orchard::pczt::Zip32Derivation {
+        orchard::pczt::Zip32Derivation::parse(
+            self.seed_fingerprint.to_bytes(),
+            vec![
+                zip32::ChildIndex::hardened(32).index(),
+                zip32::ChildIndex::hardened(params.network_type().coin_type()).index(),
+                zip32::ChildIndex::hardened(u32::from(self.account_index)).index(),
+            ],
+        )
+        .expect("the standard Orchard account path is a valid derivation")
+    }
+}
+
+/// A wallet's account derivation identifies the same account here. The migration keeps its own
+/// type so the builders stay independent of the wallet layer; this conversion is what lets a
+/// `zcash_client_backend`-backed wallet hand its account record straight to them.
+#[cfg(feature = "wallet")]
+impl From<&zcash_client_backend::data_api::Zip32Derivation> for AccountDerivation {
+    fn from(derivation: &zcash_client_backend::data_api::Zip32Derivation) -> Self {
+        AccountDerivation::new(*derivation.seed_fingerprint(), derivation.account_index())
+    }
+}
+
 /// Finish an unproven PCZT from the transaction builder's parts: run the [`Creator`] and
-/// [`IoFinalizer`] roles.
-pub(crate) fn finalize_pczt<P: Parameters>(parts: PcztParts<P>) -> Result<pczt::Pczt, BuildError> {
+/// [`IoFinalizer`] roles, then stamp `account_derivation` (when known) onto every spend that
+/// still needs a signature.
+///
+/// The stamping runs through the [`Updater`] role AFTER IO finalization, and stamps exactly those
+/// actions whose spend has no `spend_auth_sig`. That predicate is what distinguishes the two kinds
+/// of dummy the Orchard builder produces: the protocol PADDING dummies hold a random spending key
+/// that the IO Finalizer signs with and then clears, so they are already signed and need no
+/// derivation; the WALLET-CONTROLLED zero-value spends that the post-NU6.3 builder pairs with each
+/// internal change output (the vanilla-pool cross-address rule precludes random-keyed dummies
+/// there) are spent with the account's own key and must be signed through the normal signing flow,
+/// exactly like the real spends. Without the derivation, a Signer that matches spends by
+/// derivation path correctly skips them as "not ours", nothing else can sign them, and extracting
+/// the transaction fails with a missing spend-auth signature.
+pub(crate) fn finalize_pczt<P: Parameters>(
+    params: &P,
+    parts: PcztParts<P>,
+    account_derivation: Option<&AccountDerivation>,
+) -> Result<pczt::Pczt, BuildError> {
     let created = Creator::build_from_parts(parts)
         .ok_or_else(|| BuildError::Build("pczt creation failed".into()))?;
-    IoFinalizer::new(created)
+    let finalized = IoFinalizer::new(created)
         .finalize_io()
-        .map_err(|e| BuildError::Build(format!("io finalize: {e:?}")))
+        .map_err(|e| BuildError::Build(format!("io finalize: {e:?}")))?;
+
+    let Some(derivation) = account_derivation else {
+        return Ok(finalized);
+    };
+
+    /// Stamps the account's derivation on every action of one bundle whose spend still needs a
+    /// signature. The `spend_auth_sig` state is read before entering the action updater, which
+    /// borrows the bundle mutably.
+    fn stamp<P: Parameters>(
+        mut updater: orchard::pczt::Updater<'_>,
+        params: &P,
+        derivation: &AccountDerivation,
+    ) -> Result<(), orchard::pczt::UpdaterError> {
+        let needs_signature = updater
+            .bundle()
+            .actions()
+            .iter()
+            .map(|action| action.spend().spend_auth_sig().is_none())
+            .collect::<Vec<_>>();
+
+        for (index, needs_signature) in needs_signature.into_iter().enumerate() {
+            if needs_signature {
+                updater.update_action_with(index, |mut action| {
+                    // Every spend a migration transaction needs authorized belongs to the one
+                    // account it migrates.
+                    action.set_spend_zip32_derivation(derivation.to_pczt_derivation(params));
+                    Ok(())
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    Updater::new(finalized)
+        .update_orchard_with(|updater| stamp(updater, params, derivation))
+        .map_err(|e| BuildError::Build(format!("stamp orchard derivation: {e:?}")))?
+        .update_ironwood_with(|updater| stamp(updater, params, derivation))
+        .map_err(|e| BuildError::Build(format!("stamp ironwood derivation: {e:?}")))
+        .map(|updater| updater.finish())
 }
 
 /// Map an output's request-order position to its real Orchard action index. The Orchard builder
@@ -87,5 +202,70 @@ pub(crate) mod test_util {
     /// An account's Orchard full viewing key (see [`spending_key`]).
     pub(crate) fn account(seed: u64) -> FullViewingKey {
         FullViewingKey::from(&spending_key(seed))
+    }
+
+    /// The ZIP 32 account derivation a wallet seeded with `seed` would report for the account
+    /// [`account`] views. Defined here rather than reused from `zcash_pool_migration_memory`
+    /// because that crate links this one as a library, so its `AccountDerivation` is a distinct
+    /// type from the one this crate's own test build sees.
+    pub(crate) fn account_derivation(seed: u64) -> super::AccountDerivation {
+        let mut seed_fingerprint = [0u8; 32];
+        seed_fingerprint[..8].copy_from_slice(&seed.to_le_bytes());
+        super::AccountDerivation::new(
+            zip32::fingerprint::SeedFingerprint::from_bytes(seed_fingerprint),
+            zip32::AccountId::ZERO,
+        )
+    }
+
+    /// How signable a built migration PCZT is, across both its Orchard and Ironwood bundles, as
+    /// `(needing a signature, of those, unidentifiable)`.
+    ///
+    /// An action needs a signature unless it is ALREADY SIGNED (a protocol padding dummy, which
+    /// the IO Finalizer signs with its throwaway key and then clears). One that needs a signature
+    /// is IDENTIFIABLE if it carries ZIP 32 derivation metadata, which is what lets an external
+    /// Signer that matches spends by derivation path recognize it as the account's. An action that
+    /// needs a signature and carries no derivation is one such a Signer skips as "not ours",
+    /// nothing else can sign, and whose transaction therefore fails to extract.
+    ///
+    /// The first count guards against a vacuous pass: a bundle of nothing but pre-signed dummies
+    /// has no unidentifiable spends while exercising nothing.
+    pub(crate) fn spend_signability(pczt: &pczt::Pczt) -> (usize, usize) {
+        fn count(bundle: &orchard::pczt::Bundle, unsigned: &mut usize, unidentifiable: &mut usize) {
+            for action in bundle.actions() {
+                if action.spend().spend_auth_sig().is_some() {
+                    continue;
+                }
+                *unsigned += 1;
+                if action.spend().zip32_derivation().is_none() {
+                    *unidentifiable += 1;
+                }
+            }
+        }
+
+        let (mut unsigned, mut unidentifiable) = (0, 0);
+        pczt::roles::verifier::Verifier::new(pczt.clone())
+            .with_orchard::<core::convert::Infallible, _>(|bundle| {
+                count(bundle, &mut unsigned, &mut unidentifiable);
+                Ok(())
+            })
+            .expect("the Orchard bundle parses")
+            .with_ironwood::<core::convert::Infallible, _>(|bundle| {
+                count(bundle, &mut unsigned, &mut unidentifiable);
+                Ok(())
+            })
+            .expect("the Ironwood bundle parses");
+        (unsigned, unidentifiable)
+    }
+
+    /// Asserts that every spend of `pczt` still needing a signature is identifiable to an external
+    /// Signer (see [`spend_signability`]), and returns how many such spends there are.
+    pub(crate) fn assert_every_spend_is_identifiable(pczt: &pczt::Pczt) -> usize {
+        let (unsigned, unidentifiable) = spend_signability(pczt);
+        assert_eq!(
+            unidentifiable, 0,
+            "{unidentifiable} of {unsigned} spends awaiting a signature carry no ZIP 32 \
+             derivation, so no external Signer can identify them as the account's",
+        );
+        unsigned
     }
 }

--- a/zcash_pool_migration/src/build/end_to_end.rs
+++ b/zcash_pool_migration/src/build/end_to_end.rs
@@ -7,7 +7,10 @@ use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 use zcash_protocol::value::COIN;
 
-use super::test_util::{TARGET_HEIGHT, regtest_network, single_note_witness, spending_key};
+use super::test_util::{
+    TARGET_HEIGHT, account_derivation, assert_every_spend_is_identifiable, regtest_network,
+    single_note_witness, spending_key,
+};
 use super::{build_prep_tx, build_transfer_pczt, sign_pczt};
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
@@ -81,6 +84,7 @@ fn migration_pipeline_end_to_end() {
         &fvk,
         vec![note],
         tx.outputs(),
+        Some(&account_derivation(seed)),
         ChaCha8Rng::seed_from_u64(seed + 1),
     )
     .expect("the preparation transaction builds");
@@ -90,6 +94,12 @@ fn migration_pipeline_end_to_end() {
         "the preparation bundle is padded to exactly 16 actions"
     );
     assert_eq!(placed.len(), tx.outputs().len(), "every output is located");
+    // Every spend the preparation transaction needs authorized is identifiable to an external
+    // Signer: the real spend plus one wallet-controlled zero-value spend per change output.
+    assert_eq!(
+        assert_every_spend_is_identifiable(&prep_pczt),
+        1 + tx.outputs().len(),
+    );
 
     // The REAL constructed preparation transaction pays exactly the canonical ZIP-317 fee of its
     // padded shape: the value its spends bring in, minus the value its outputs (including change
@@ -136,9 +146,12 @@ fn migration_pipeline_end_to_end() {
         &fvk,
         fnote,
         crossing,
+        Some(&account_derivation(seed)),
         ChaCha8Rng::seed_from_u64(seed + 3),
     )
     .expect("the transfer builds");
+    // Likewise for the transfer's single real Orchard spend.
+    assert_eq!(assert_every_spend_is_identifiable(&transfer_pczt), 1);
 
     // The REAL constructed transfer pays exactly the canonical fee of the 2-Orchard +
     // 1-Ironwood-action transfer

--- a/zcash_pool_migration/src/build/prep.rs
+++ b/zcash_pool_migration/src/build/prep.rs
@@ -63,7 +63,7 @@ use zcash_primitives::transaction::fees::zip317::{
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::memo::MemoBytes;
 
-use super::{BuildError, finalize_pczt, output_action_index};
+use super::{AccountDerivation, BuildError, finalize_pczt, output_action_index};
 use crate::preparation::{PREP_TX_ACTIONS, PrepOutput};
 
 /// The internal-scope diversifier index for the wallet's own preparation outputs.
@@ -108,10 +108,19 @@ pub type PlacedPrepOutput = (u32, PrepOutput, orchard::note::Note);
 /// (including when the spent notes do not balance the outputs plus the fee, and when
 /// `target_height` precedes NU6.3, whose V6 format is what permits deferring the anchor).
 ///
+/// `account_derivation` is the ZIP 32 account the spent notes belong to. When supplied, every
+/// spend the transaction still needs a signature for — the real spends AND the wallet-controlled
+/// zero-value spends the builder pairs with each change output — is stamped with the account's
+/// Orchard key path, so an EXTERNAL Signer can identify them as the account's. Pass `None` only
+/// when the account has no known derivation; a PCZT built without it can be signed in process
+/// (see [`sign_pczt`](super::sign_pczt), which matches by key rather than by path) but not by a
+/// derivation-matching Signer.
+///
 /// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
 /// pass a seeded one), keeping this builder pure.
 ///
 /// [ZIP 374]: https://zips.z.cash/zip-0374
+#[allow(clippy::too_many_arguments)]
 pub fn build_prep_tx<P, R>(
     params: &P,
     target_height: u32,
@@ -119,6 +128,7 @@ pub fn build_prep_tx<P, R>(
     orchard_fvk: &FullViewingKey,
     spends: Vec<orchard::note::Note>,
     outputs: &[PrepOutput],
+    account_derivation: Option<&AccountDerivation>,
     rng: R,
 ) -> Result<(pczt::Pczt, Vec<PlacedPrepOutput>), BuildError>
 where
@@ -227,7 +237,7 @@ where
         })
         .collect::<Result<_, BuildError>>()?;
 
-    let finalized = finalize_pczt(build_result.pczt_parts)?;
+    let finalized = finalize_pczt(params, build_result.pczt_parts, account_derivation)?;
     Ok((finalized, placed))
 }
 
@@ -240,7 +250,8 @@ mod tests {
     use zcash_protocol::value::COIN;
 
     use crate::build::test_util::{
-        TARGET_HEIGHT, account, regtest_network, shared_anchor_witnesses, single_note_witness,
+        TARGET_HEIGHT, account, account_derivation, assert_every_spend_is_identifiable,
+        regtest_network, shared_anchor_witnesses, single_note_witness,
     };
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
@@ -304,6 +315,7 @@ mod tests {
                 &fvk,
                 spends,
                 &outputs,
+                None,
                 rng,
             )
             .expect("a balanced preparation transaction builds");
@@ -337,6 +349,7 @@ mod tests {
                 &fvk,
                 vec![note],
                 &outputs,
+                None,
                 rng,
             )
             .expect("a balanced preparation transaction should build");
@@ -351,6 +364,42 @@ mod tests {
             indices.sort_unstable();
             indices.dedup();
             prop_assert_eq!(indices.len(), outputs.len());
+        }
+    }
+
+    /// Given the account's derivation, every spend a preparation transaction still needs a
+    /// signature for carries ZIP 32 derivation metadata, so an external Signer can identify it.
+    ///
+    /// This covers BOTH the real spend and the wallet-controlled zero-value spends that the
+    /// post-NU6.3 Orchard builder pairs with each internal change output; only the protocol
+    /// padding dummies, which the IO Finalizer has already signed, are allowed to lack it. Two
+    /// shapes are checked: a lightly-loaded transaction, which pads out with pre-signed dummies,
+    /// and one that fills the action budget exactly, which has none.
+    #[test]
+    fn stamps_derivation_on_every_spend_needing_a_signature() {
+        let fvk = account(11);
+        let derivation = account_derivation(11);
+        let params = regtest_network(true);
+        let fee = prep_fee();
+
+        for n_out in [2usize, PREP_TX_ACTIONS - 1] {
+            let outputs: Vec<PrepOutput> =
+                (0..n_out).map(|_| PrepOutput::Funding(zat(COIN))).collect();
+            let (note, _path, _anchor) = single_note_witness(&fvk, n_out as u64 * COIN + fee, 11);
+            let (pczt, _) = build_prep_tx(
+                &params,
+                TARGET_HEIGHT,
+                test_expiry(),
+                &fvk,
+                vec![note],
+                &outputs,
+                Some(&derivation),
+                ChaCha8Rng::seed_from_u64(11),
+            )
+            .expect("a balanced preparation transaction builds");
+
+            // One real spend plus one wallet-controlled zero-value spend per change output.
+            assert_eq!(assert_every_spend_is_identifiable(&pczt), 1 + n_out);
         }
     }
 
@@ -369,6 +418,7 @@ mod tests {
             &fvk,
             vec![note],
             &outputs,
+            None,
             ChaCha8Rng::seed_from_u64(7),
         )
         .unwrap();
@@ -391,6 +441,7 @@ mod tests {
             &fvk,
             Vec::new(),
             &one_output,
+            None,
             ChaCha8Rng::seed_from_u64(0),
         );
         assert!(matches!(no_spends, Err(BuildError::Balance(_))));
@@ -403,6 +454,7 @@ mod tests {
             &fvk,
             vec![note],
             &[],
+            None,
             ChaCha8Rng::seed_from_u64(0),
         );
         assert!(matches!(no_outputs, Err(BuildError::Balance(_))));
@@ -419,6 +471,7 @@ mod tests {
             &fvk,
             vec![note2],
             &too_many,
+            None,
             ChaCha8Rng::seed_from_u64(0),
         );
         assert!(matches!(over_budget, Err(BuildError::Balance(_))));

--- a/zcash_pool_migration/src/build/sign.rs
+++ b/zcash_pool_migration/src/build/sign.rs
@@ -78,6 +78,7 @@ mod tests {
             fvk,
             vec![note],
             &outputs,
+            None,
             rng,
         )
         .expect("the preparation transaction builds");

--- a/zcash_pool_migration/src/build/transfer.rs
+++ b/zcash_pool_migration/src/build/transfer.rs
@@ -32,7 +32,7 @@ use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::memo::MemoBytes;
 use zcash_protocol::value::Zatoshis;
 
-use super::{BuildError, finalize_pczt};
+use super::{AccountDerivation, BuildError, finalize_pczt};
 
 /// The transfer's destination-pool bundle padding: a SINGLE unpadded Ironwood action. The canonical
 /// transfer carries exactly one Ironwood output, and since every migration transfer shares this
@@ -58,6 +58,13 @@ const IRONWOOD_TRANSFER_PADDING: BundlePadding = BundlePadding {
 /// [`crossing_values`](crate::denomination::DenominationPlan::crossing_values): one transfer per
 /// self-funding note.
 ///
+/// `account_derivation` is the ZIP 32 account the funding note belongs to. When supplied, every
+/// spend the transfer still needs a signature for is stamped with the account's Orchard key path,
+/// so an EXTERNAL Signer can identify it as the account's. Pass `None` only when the account has
+/// no known derivation; a PCZT built without it can be signed in process (see
+/// [`sign_pczt`](super::sign_pczt), which matches by key rather than by path) but not by a
+/// derivation-matching Signer.
+///
 /// The caller supplies `rng` (a cryptographically secure RNG in production, e.g. `OsRng`; tests can
 /// pass a seeded one), keeping this builder pure.
 ///
@@ -66,6 +73,7 @@ const IRONWOOD_TRANSFER_PADDING: BundlePadding = BundlePadding {
 /// Returns [`BuildError::Build`] if the builder or PCZT pipeline fails (including when the note's
 /// buffer does not cover the transfer fee, which unbalances the transaction, and when
 /// `target_height` precedes NU6.3, whose V6 format is what permits deferring the anchors).
+#[allow(clippy::too_many_arguments)]
 pub fn build_transfer_pczt<P, R>(
     params: &P,
     target_height: u32,
@@ -73,6 +81,7 @@ pub fn build_transfer_pczt<P, R>(
     orchard_fvk: &FullViewingKey,
     note: orchard::note::Note,
     crossing_value: Zatoshis,
+    account_derivation: Option<&AccountDerivation>,
     rng: R,
 ) -> Result<pczt::Pczt, BuildError>
 where
@@ -110,7 +119,7 @@ where
         .build_for_pczt(rng, &Zip317FeeRule::standard())
         .map_err(|e| BuildError::Build(format!("transfer: build: {e}")))?;
 
-    finalize_pczt(build_result.pczt_parts)
+    finalize_pczt(params, build_result.pczt_parts, account_derivation)
 }
 
 #[cfg(test)]
@@ -121,7 +130,10 @@ mod tests {
     use rand_core::SeedableRng;
     use zcash_protocol::value::COIN;
 
-    use crate::build::test_util::{account, regtest_network, single_note_witness};
+    use crate::build::test_util::{
+        account, account_derivation, assert_every_spend_is_identifiable, regtest_network,
+        single_note_witness,
+    };
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
     use crate::denomination::{
@@ -161,6 +173,7 @@ mod tests {
                 &fvk,
                 note,
                 zat(crossing_value),
+                None,
                 rng,
             );
 
@@ -179,5 +192,34 @@ mod tests {
                 .count();
             prop_assert_eq!(unwitnessed, 1);
         }
+    }
+
+    /// Given the account's derivation, the transfer's real Orchard spend carries ZIP 32
+    /// derivation metadata, so an external Signer can identify and sign it. The Orchard padding
+    /// dummy and the Ironwood bundle's own dummy spend are pre-signed by the IO Finalizer and are
+    /// correctly left without it.
+    #[test]
+    fn stamps_derivation_on_the_spend_needing_a_signature() {
+        let fvk = account(13);
+        let derivation = account_derivation(13);
+        let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+            * MARGINAL_FEE.into_u64();
+        let crossing_value = 5 * COIN;
+        let (note, _path, _anchor) = single_note_witness(&fvk, crossing_value + buffer, 13);
+
+        let pczt = build_transfer_pczt(
+            &regtest_network(true),
+            100,
+            140,
+            &fvk,
+            note,
+            zat(crossing_value),
+            Some(&derivation),
+            ChaCha8Rng::seed_from_u64(13),
+        )
+        .expect("a self-funding note builds a balanced transfer");
+
+        // Exactly the one real Orchard spend still needs a signature.
+        assert_eq!(assert_every_spend_is_identifiable(&pczt), 1);
     }
 }

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -56,6 +56,8 @@ use zcash_protocol::value::{BalanceError, Zatoshis};
 use zcash_primitives::transaction::fees::FeeRule as _;
 use zcash_primitives::transaction::fees::{transparent, zip317};
 
+#[cfg(feature = "orchard")]
+use crate::build::AccountDerivation;
 use crate::denomination::{DenominationPlan, plan_denominations};
 use crate::preparation::{PrepError, PrepInput, PreparationPlan, plan_preparation};
 use crate::scheduling::{self, Schedule};
@@ -1286,6 +1288,16 @@ pub trait MigrationCrypto {
     /// The account's Orchard full viewing key.
     fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
 
+    /// The ZIP 32 account the migration's notes belong to, or `None` if the account has no known
+    /// derivation (an imported viewing key, say).
+    ///
+    /// The builders stamp this onto every spend a migration transaction still needs a signature
+    /// for, which is how an EXTERNAL Signer recognizes those spends as the account's. A backend
+    /// that returns `None` while signing is delegated (see [`Signing::External`]) produces
+    /// transactions no derivation-matching Signer can authorize, so return the derivation whenever
+    /// the wallet knows it, even if it currently signs in process.
+    fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error>;
+
     /// The plaintext of the spendable wallet note at `index` (into
     /// `spendable_orchard_note_values`).
     fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error>;
@@ -1919,6 +1931,9 @@ where
     // outside the migration), the remaining balance must be re-planned rather than this part
     // rebuilt, so a different note of coincidentally equal value is deliberately NOT substituted.
     let fvk = backend.orchard_fvk().map_err(RebuildError::Backend)?;
+    let account_derivation = backend
+        .account_derivation()
+        .map_err(RebuildError::Backend)?;
     let spendable_values = backend
         .spendable_orchard_note_values()
         .map_err(RebuildError::Backend)?;
@@ -1961,6 +1976,7 @@ where
         &fvk,
         note,
         crossing_value,
+        account_derivation.as_ref(),
         &mut *rng,
     )
     .map_err(RebuildError::Build)?;
@@ -2322,6 +2338,9 @@ struct Committer<'a, P, B, R> {
     rng: &'a mut R,
     signing: Signing,
     fvk: orchard::keys::FullViewingKey,
+    /// The ZIP 32 account every built transaction's spends are stamped with, so an external Signer
+    /// can identify them. Resolved once in [`Committer::start`], alongside `fvk`.
+    account_derivation: Option<AccountDerivation>,
     transactions: Vec<MigrationTransaction>,
     unsigned: Vec<UnsignedMigrationTx>,
     next_id: u32,
@@ -2366,6 +2385,7 @@ where
         }
 
         let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
+        let account_derivation = backend.account_derivation().map_err(CommitError::Backend)?;
 
         Ok(Self {
             params,
@@ -2374,6 +2394,7 @@ where
             rng,
             signing,
             fvk,
+            account_derivation,
             transactions: Vec::new(),
             unsigned: Vec::new(),
             next_id: 0,
@@ -2480,9 +2501,10 @@ where
                         ))
                     })?;
                 let expiry_height = crate::scheduling::expiry_height(scheduled_height);
-                // The field accesses `self.params`/`self.fvk`/`self.rng` are DISJOINT, so the
-                // borrow checker accepts them together here — as long as no whole-`self` method
-                // call (like `next_id`/`resolve_prep_spends` above) is interleaved.
+                // The field accesses `self.params`/`self.fvk`/`self.account_derivation`/`self.rng`
+                // are DISJOINT, so the borrow checker accepts them together here — as long as no
+                // whole-`self` method call (like `next_id`/`resolve_prep_spends` above) is
+                // interleaved.
                 let (pczt, placed) = build_prep_tx(
                     self.params,
                     u32::from(self.target_height),
@@ -2490,6 +2512,7 @@ where
                     &self.fvk,
                     spends,
                     prep_tx.outputs(),
+                    self.account_derivation.as_ref(),
                     &mut *self.rng,
                 )
                 .map_err(CommitError::Build)?;
@@ -2656,6 +2679,7 @@ where
                 &self.fvk,
                 note,
                 crossing_value,
+                self.account_derivation.as_ref(),
                 &mut *self.rng,
             )
             .map_err(CommitError::Build)?;
@@ -3134,7 +3158,8 @@ mod commit_tests {
 
     use crate::build::sign_pczt;
     use crate::build::test_util::{
-        TARGET_HEIGHT, regtest_network, single_note_witness, spending_key,
+        TARGET_HEIGHT, account_derivation, assert_every_spend_is_identifiable, regtest_network,
+        single_note_witness, spend_signability, spending_key,
     };
     use crate::denomination::{
         DESTINATION_ACTIONS_PER_TRANSFER, DenominationPlan, SOURCE_ACTIONS_PER_TRANSFER,
@@ -3160,6 +3185,7 @@ mod commit_tests {
         wallet_notes: Vec<orchard::note::Note>,
         fvk: FullViewingKey,
         ask: SpendAuthorizingKey,
+        account_derivation: Option<AccountDerivation>,
         stored: Option<MigrationState>,
         tip: BlockHeight,
         sched_params: crate::scheduling::SchedulingParams,
@@ -3179,6 +3205,7 @@ mod commit_tests {
                 wallet_notes,
                 fvk,
                 ask: SpendAuthorizingKey::from(&sk),
+                account_derivation: Some(account_derivation(seed)),
                 stored: None,
                 tip: BlockHeight::from_u32(2_000_000),
                 sched_params: crate::scheduling::SchedulingParams::ZIP_318,
@@ -3239,6 +3266,10 @@ mod commit_tests {
 
         fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
             Ok(self.fvk.clone())
+        }
+
+        fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error> {
+            Ok(self.account_derivation.clone())
         }
 
         fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error> {
@@ -3387,6 +3418,79 @@ mod commit_tests {
             }
         }
         assert!(backend.get_migration().unwrap().is_some());
+    }
+
+    /// Every transaction a commit hands to an EXTERNAL signer is identifiable to it: each spend
+    /// still awaiting a signature carries the account's ZIP 32 derivation, and the only actions
+    /// without it are the padding dummies the IO Finalizer already signed. A signer that matches
+    /// spends by derivation path skips what it cannot recognize, so an unstamped spend is one no
+    /// signature ever arrives for and the transaction can never be extracted.
+    ///
+    /// Covers the whole commit path — preparation layers and transfers alike — and its converse:
+    /// a backend that reports no derivation produces transactions only an in-process signer, which
+    /// matches by key, can authorize.
+    #[test]
+    fn externally_signed_migrations_identify_every_spend_to_the_signer() {
+        let seed = 77u64;
+        let params = regtest_network(true);
+        // A balance large enough to need preparation, so both builders are exercised.
+        let mut backend = CommitMock::new(seed, &[400 * COIN]);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        assert!(
+            plan.preparation().transaction_count() > 0,
+            "the balance needs preparation, so preparation transactions are built",
+        );
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (state, unsigned) = build_preparation_unsigned(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration for external signing");
+        assert!(
+            !unsigned.is_empty(),
+            "there is work for the external signer"
+        );
+
+        let mut spends_awaiting_signature = 0;
+        for tx in &state.transactions {
+            let pczt = pczt::Pczt::parse(&tx.pczt).expect("a stored PCZT parses");
+            spends_awaiting_signature += assert_every_spend_is_identifiable(&pczt);
+        }
+        assert!(
+            spends_awaiting_signature > 0,
+            "the external signer has spends to authorize",
+        );
+
+        // Without a known derivation nothing is stamped, so the same spends are left unidentifiable.
+        let mut anonymous = CommitMock::new(seed, &[400 * COIN]);
+        anonymous.account_derivation = None;
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (anonymous_state, _) = build_preparation_unsigned(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut anonymous,
+            &plan,
+            &mut rng,
+        )
+        .expect("commits the migration for external signing");
+        let unidentifiable = anonymous_state
+            .transactions
+            .iter()
+            .map(|tx| {
+                let pczt = pczt::Pczt::parse(&tx.pczt).expect("a stored PCZT parses");
+                spend_signability(&pczt).1
+            })
+            .sum::<usize>();
+        assert_eq!(
+            unidentifiable, spends_awaiting_signature,
+            "a backend with no derivation leaves every awaiting spend unidentifiable",
+        );
     }
 
     /// An expired transfer is rebuilt in place: rescheduled forward with a fresh boundary anchor and
@@ -3671,6 +3775,10 @@ mod commit_tests {
                 .all(|a| a.spend().spend_auth_sig().is_none()),
             "the account's spend authorization was not attached in-process"
         );
+        // Awaiting an external signer is only useful if that signer can RECOGNIZE the spend as
+        // the account's: the rebuild stamps the account's ZIP 32 derivation on the one spend it
+        // leaves unsigned.
+        assert_eq!(assert_every_spend_is_identifiable(&parsed), 1);
         assert_eq!(
             real_spend_nullifier(&rebuilt.pczt),
             real_spend_nullifier(&old.pczt),
@@ -3825,6 +3933,7 @@ mod commit_tests {
             wallet_notes: vec![single_note_witness(&fvk, whale, seed).0],
             fvk,
             ask: SpendAuthorizingKey::from(&sk),
+            account_derivation: Some(account_derivation(seed)),
             stored: None,
             tip: BlockHeight::from_u32(2_000_000),
             sched_params: crate::scheduling::SchedulingParams::ZIP_318,

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -36,7 +36,7 @@ use shardtree::error::ShardTreeError;
 use ::pczt::roles::prover::Prover;
 use ::pczt::roles::updater::{AnchorUpdateError, SpendWitnessUpdateError, Updater};
 use zcash_client_backend::data_api::{
-    InputSource, WalletCommitmentTrees, WalletRead,
+    Account as _, InputSource, WalletCommitmentTrees, WalletRead,
     wallet::{
         TargetHeight,
         input_selection::{LockFilter, LockedInputPolicy},
@@ -46,7 +46,7 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::builder::cached_orchard_proving_key;
 use zcash_protocol::{ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 
-use crate::build::sign_pczt;
+use crate::build::{AccountDerivation, sign_pczt};
 use crate::engine::{
     MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTransferId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
@@ -254,7 +254,9 @@ where
 
 impl<'a, W, St> MigrationCrypto for WalletMigration<'a, W, St>
 where
-    W: WalletRead + InputSource,
+    // Reading the account record requires the wallet's two account-id types to agree; a wallet
+    // whose note source and account store disagree could not identify one account anyway.
+    W: WalletRead<AccountId = <W as InputSource>::AccountId> + InputSource,
     <W as InputSource>::AccountId: Copy,
     St: PoolMigrationRead,
 {
@@ -262,6 +264,21 @@ where
 
     fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
         Ok(FullViewingKey::from(self.usk.orchard()))
+    }
+
+    /// The account's derivation as the wallet records it, or `None` for an account the wallet
+    /// holds no ZIP 32 derivation for.
+    fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error> {
+        Ok(self
+            .wallet
+            .get_account(self.account)
+            .map_err(Error::WalletRead)?
+            .and_then(|account| {
+                account
+                    .source()
+                    .key_derivation()
+                    .map(AccountDerivation::from)
+            }))
     }
 
     fn resolve_wallet_note(&self, index: usize) -> Result<OrchardNote, Self::Error> {
@@ -679,7 +696,7 @@ mod tests {
     fn assert_commit_bounds<'a, P, W, St, R>()
     where
         P: Parameters + Clone,
-        W: WalletRead + InputSource + 'a,
+        W: WalletRead<AccountId = <W as InputSource>::AccountId> + InputSource + 'a,
         <W as InputSource>::AccountId: Copy,
         St: PoolMigrationWrite,
         R: RngCore + CryptoRng,

--- a/zcash_pool_migration_memory/Cargo.toml
+++ b/zcash_pool_migration_memory/Cargo.toml
@@ -24,6 +24,8 @@ zcash_pool_migration = { path = "../zcash_pool_migration", features = [
 
 orchard = { workspace = true }
 pczt = { workspace = true }
+# Constructs the `AccountDerivation` the crypto mock reports.
+zip32 = { workspace = true }
 rand_chacha.workspace = true
 rand_core.workspace = true
 incrementalmerkletree.workspace = true

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -34,7 +34,7 @@ use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::value::Zatoshis;
 
-use zcash_pool_migration::build::sign_pczt;
+use zcash_pool_migration::build::{AccountDerivation, sign_pczt};
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTransferId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
@@ -62,6 +62,19 @@ pub fn spending_key(seed: u64) -> SpendingKey {
             return sk;
         }
     }
+}
+
+/// The ZIP 32 account derivation a wallet seeded with `seed` would report, matching the account
+/// [`spending_key`] derives. The seed fingerprint is a stand-in, not a real ZIP 32 fingerprint of
+/// the test seed: nothing downstream re-derives keys from it, and an external Signer only needs the
+/// derivation to be a stable identifier for the account.
+pub fn account_derivation(seed: u64) -> AccountDerivation {
+    let mut seed_fingerprint = [0u8; 32];
+    seed_fingerprint[..8].copy_from_slice(&seed.to_le_bytes());
+    AccountDerivation::new(
+        zip32::fingerprint::SeedFingerprint::from_bytes(seed_fingerprint),
+        zip32::AccountId::ZERO,
+    )
 }
 
 /// A regtest network with the pre-NU6.3 upgrades active, and NU6.3 active only when requested.
@@ -335,6 +348,9 @@ pub struct CommitMock {
     pub fvk: FullViewingKey,
     /// The account's Orchard spend-authorizing key, used to sign the migration PCZTs.
     pub ask: SpendAuthorizingKey,
+    /// The ZIP 32 account the notes belong to, as a seeded wallet would report it. `None` models a
+    /// wallet that knows no derivation for the account (an imported viewing key).
+    pub account_derivation: Option<AccountDerivation>,
     /// The in-memory migration state (`None` until a migration is committed).
     pub stored: Option<MigrationState>,
     /// The scheduling parameters this backend reports to the engine.
@@ -355,9 +371,17 @@ impl CommitMock {
             wallet_notes,
             fvk,
             ask: SpendAuthorizingKey::from(&sk),
+            account_derivation: Some(account_derivation(seed)),
             stored: None,
             sched_params: SchedulingParams::ZIP_318,
         }
+    }
+
+    /// Models a wallet that knows no ZIP 32 derivation for the account, so the migration's spends
+    /// carry no derivation metadata and only an in-process signer can authorize them.
+    pub fn without_account_derivation(mut self) -> Self {
+        self.account_derivation = None;
+        self
     }
 
     /// Overrides the scheduling parameters this backend reports (the default is
@@ -420,6 +444,10 @@ impl MigrationCrypto for CommitMock {
 
     fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
         Ok(self.fvk.clone())
+    }
+
+    fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error> {
+        Ok(self.account_derivation.clone())
     }
 
     fn resolve_wallet_note(&self, index: usize) -> Result<Note, Self::Error> {


### PR DESCRIPTION
Closes #2782. Addresses the two gaps raised in review of #2778 (whose fix is on `main`).

## 1. `redact_pczt_for_batch_signer` retains existing signatures

It cleared `spend_auth_sig` on every action. A protocol padding dummy reaches it already signed — so under the new derivation predicate it correctly carries no derivation — with its `dummy_sk` already cleared by the compact signer view it builds on. Clearing its signature too left an action with no signature, no dummy key, no derivation, and (as an already-authorized action) no randomizer: nothing the batch Signer or the wallet could ever authorize.

Only already-authorized actions carry a signature at that point, and the function already snapshots their indices, so the fix is to drop the blanket `clear_spend_auth_sig`. Every action in the returned view is now either already authorized or still authorizable.

**Consequence worth noting:** the batch Signer's response now carries the retained padding-dummy signatures back alongside the new ones. Re-applying an identical signature to the authoritative PCZT is a no-op, which the pool test exercises end to end — the flow already applied every returned signature and unwrapped. The test's expected signature positions became "every action in both bundles," which directly encodes the invariant: after the batch round, nothing is left unauthorized.

The signability invariant added to `pczt_single_step` alongside the #2778 fix runs pre-redaction and could not catch this, so the batch-view assertions in `create_pczt_supports_ironwood_output` gain the post-redaction form.

## 2. `zcash_pool_migration`'s builders stamp derivation

`build_prep_tx` and `build_transfer_pczt` do not go through `create_pczt_from_proposal`, so the #2778 fix did not reach them; see #2782 for the measured shapes. This is reachable via the engine's `Signing::External` path.

Stamping goes in `finalize_pczt`, which both builders funnel through, using the same predicate as `create_pczt_from_proposal`: after IO finalization, set the derivation on every action whose spend still lacks `spend_auth_sig`, in both the Orchard and Ironwood bundles. That covers the real spends and the wallet-controlled zero-value spends while excluding the pre-signed padding dummies.

The derivation crosses the API as a new `build::AccountDerivation`, holding only the seed fingerprint and account index; the builders compose `m/32'/coin_type'/account'` from their own consensus parameters, so a caller cannot address a migration to the wrong coin type. The migration crate keeps its own type rather than taking `zcash_client_backend`'s `Zip32Derivation`, which would pull the wallet layer into the backend-agnostic core that `MigrationCrypto` exists to keep at arm's length; a `From` conversion behind the `wallet` feature bridges the two.

`MigrationCrypto` gains a required `account_derivation` method, threaded to all three build sites. It is required rather than defaulting to `Ok(None)` so an implementor cannot silently reintroduce the bug.

`WalletMigration`'s `MigrationCrypto` impl now requires `W: WalletRead<AccountId = <W as InputSource>::AccountId>`, since reading the account record needs the two ids to agree — the same bound form already used in `zcash_client_backend::data_api::wallet`. `zcash_client_sqlite` satisfies it.

## Tests

TDD throughout. Disabling the stamping turns all five new/extended assertions red: `stamps_derivation_*` in both builders, the end-to-end pipeline test, `rebuild_expired_transfer_unsigned_awaits_the_external_signature`, and the new `externally_signed_migrations_identify_every_spend_to_the_signer`, which covers the whole commit path (preparation layers and transfers alike) and its converse under a derivation-less backend.

`cargo test` clean for `zcash_client_backend`, `zcash_pool_migration`, `zcash_pool_migration_memory`, and `zcash_client_sqlite` (460 passed); `cargo clippy --workspace --all-features --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean; `git rebase --exec 'cargo check --workspace --all-features --all-targets'` confirms each commit builds on its own.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
