### PR TITLE
locking: move generic bounds into where clauses

### DIFF
--- a/zcash_client_backend/src/data_api/locking.rs
+++ b/zcash_client_backend/src/data_api/locking.rs
@@ -139,7 +139,10 @@ impl LockOwner {
     }
 
     /// Generates a fresh random `LockOwner`.
-    pub fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R>(rng: &mut R) -> Self
+    where
+        R: rand_core::RngCore,
+    {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
         Self(bytes)
@@ -179,7 +182,10 @@ pub enum LockError<S> {
     LockFailure(OutputRef),
 }
 
-impl<S: Display> Display for LockError<S> {
+impl<S> Display for LockError<S>
+where
+    S: Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LockError::Storage(e) => write!(f, "Note locking failed: {e}"),
@@ -193,7 +199,10 @@ impl<S: Display> Display for LockError<S> {
     }
 }
 
-impl<S: error::Error + 'static> error::Error for LockError<S> {
+impl<S> error::Error for LockError<S>
+where
+    S: error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             LockError::Storage(e) => Some(e),

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1595,8 +1595,12 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletTes
     }
 }
 
-impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R: RngCore>
-    OutputLockStore for WalletDb<C, P, CL, R>
+impl<C, P, CL, R> OutputLockStore for WalletDb<C, P, CL, R>
+where
+    C: BorrowMut<rusqlite::Connection>,
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
 {
     type Error = SqliteClientError;
     type AccountId = AccountUuid;
@@ -1885,8 +1889,11 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
 
 /// This impl block is only usable when you already have an [`SqlTransaction`], meaning
 /// you are inside a [`WalletDb::transactionally`] block with a lock on the database.
-impl<P: consensus::Parameters, CL: Clock, R: RngCore> OutputLockStore
-    for WalletDb<SqlTransaction<'_>, P, CL, R>
+impl<P, CL, R> OutputLockStore for WalletDb<SqlTransaction<'_>, P, CL, R>
+where
+    P: consensus::Parameters,
+    CL: Clock,
+    R: RngCore,
 {
     type Error = SqliteClientError;
     type AccountId = AccountUuid;


### PR DESCRIPTION
## Summary

Addresses the review comments on #2742 asking to move the type refinements
on the `OutputLockStore` impls into `where` statements ("We should move the
type refinement in a where statement.").

This PR is stacked on top of #2742 (base branch `danny/note-locking-module`)
and converts inline generic parameter bounds into `where` clauses across the
note-locking surface, for one consistent style. It is a pure style change;
behavior is identical.

## Changes

`zcash_client_sqlite/src/lib.rs`
- `impl OutputLockStore for WalletDb<C, P, CL, R>` (the flagged main impl):
  the four `C`/`P`/`CL`/`R` bounds moved into a `where` clause.
- `impl OutputLockStore for WalletDb<SqlTransaction<'_>, P, CL, R>` (the
  flagged `SqlTransaction` impl): the `P`/`CL`/`R` bounds moved into a
  `where` clause.

`zcash_client_backend/src/data_api/locking.rs`
- `LockOwner::random<R>`: `R: RngCore` moved into a `where` clause.
- `impl Display for LockError<S>`: `S: Display` moved into a `where` clause.
- `impl error::Error for LockError<S>`: `S: error::Error + 'static` moved
  into a `where` clause.

## Notes

- The `OutputLockStore` trait definition takes no generic parameters, and the
  free functions in the locking module (`lock_proposal_inputs`,
  `unlock_proposal_inputs`) already use `where` clauses, so no changes were
  needed there.
- The last three conversions in `zcash_client_backend` are single-bound
  generics; they were converted for a uniform style across the locking
  feature. Reviewers can easily drop any of these back to inline if the
  single-bound form is preferred.

## Verification

- `cargo build --release --all-features` (both crates): pass
- `cargo clippy --release --all-targets --all-features` (both crates): clean
- `cargo fmt -- --check`: clean
