### PR TITLE
zcash_client_backend: add standard ZIP 317 split change strategy

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,15 @@ workspace.
 
 ### Added
 - `impl Debug for zcash_client_backend::data_api::ll::wallet::PutBlocksError`
+- `zcash_client_backend::fees::SplitPolicy::standard`, along with the associated
+  constants `SplitPolicy::STANDARD_OUTPUT_COUNT` and
+  `SplitPolicy::STANDARD_MIN_OUTPUT_VALUE`, providing the general-purpose
+  change-splitting policy (at least 4 spendable notes of value at least 0.1 ZEC)
+  used by the mobile wallet SDKs.
+- `zcash_client_backend::fees::zip317::MultiOutputChangeStrategy::standard`,
+  which constructs the standard general-purpose multi-output change strategy
+  (ZIP 317 fees, Orchard change fallback, default dust policy, and
+  `SplitPolicy::standard`) previously hand-written in the mobile wallet SDKs.
 
 ### Changed
 - Every public error enum in this crate is now `#[non_exhaustive]` 

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -14,7 +14,7 @@ use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    value::{BalanceError, Zatoshis},
+    value::{BalanceError, COIN, Zatoshis},
 };
 
 use crate::data_api::{InputSource, wallet::TargetHeight};
@@ -436,6 +436,14 @@ impl SplitPolicy {
     /// [`MARGINAL_FEE`]: zcash_primitives::transaction::fees::zip317::MARGINAL_FEE
     pub(crate) const MIN_NOTE_VALUE: Zatoshis = Zatoshis::const_from_u64(500000);
 
+    /// The number of spendable notes that [`SplitPolicy::standard`] attempts to keep available in
+    /// an account by splitting change.
+    pub const STANDARD_OUTPUT_COUNT: NonZeroUsize = NonZeroUsize::new(4).expect("4 is nonzero");
+
+    /// The minimum value (0.1 ZEC) permitted for each note that [`SplitPolicy::standard`] produces
+    /// when splitting change.
+    pub const STANDARD_MIN_OUTPUT_VALUE: Zatoshis = Zatoshis::const_from_u64(COIN / 10);
+
     /// Constructs a new [`SplitPolicy`] that splits change to ensure the given number of spendable
     /// outputs exists within an account, each having at least the specified minimum note value.
     pub fn with_min_output_value(
@@ -454,6 +462,16 @@ impl SplitPolicy {
             target_output_count: NonZeroUsize::MIN,
             min_split_output_value: None,
         }
+    }
+
+    /// Constructs the standard general-purpose [`SplitPolicy`].
+    ///
+    /// This policy attempts to keep at least [`Self::STANDARD_OUTPUT_COUNT`] spendable notes, each
+    /// having at least value [`Self::STANDARD_MIN_OUTPUT_VALUE`], available within the account. It
+    /// is the change-splitting policy used by the mobile wallet SDKs and is suitable as a
+    /// general-purpose default.
+    pub fn standard() -> Self {
+        Self::with_min_output_value(Self::STANDARD_OUTPUT_COUNT, Self::STANDARD_MIN_OUTPUT_VALUE)
     }
 
     /// Returns the number of outputs that this policy will attempt to ensure that the wallet has
@@ -661,6 +679,34 @@ pub(crate) mod tests {
     use zcash_protocol::value::Zatoshis;
 
     use super::sapling;
+
+    #[test]
+    fn standard_split_policy_matches_wallet_defaults() {
+        use super::{COIN, SplitPolicy};
+
+        // These values are consumed verbatim by the mobile wallet SDKs; pin them so any change
+        // here is deliberate rather than a silent drift (see librustzcash issue #2785).
+        assert_eq!(SplitPolicy::STANDARD_OUTPUT_COUNT.get(), 4);
+        // 0.1 ZEC, matching the historical hardcoded 10_000_000 zatoshi value and COIN / 10.
+        assert_eq!(
+            SplitPolicy::STANDARD_MIN_OUTPUT_VALUE,
+            Zatoshis::const_from_u64(10_000_000),
+        );
+        assert_eq!(
+            SplitPolicy::STANDARD_MIN_OUTPUT_VALUE,
+            Zatoshis::const_from_u64(COIN / 10),
+        );
+
+        let policy = SplitPolicy::standard();
+        assert_eq!(
+            policy.target_output_count(),
+            SplitPolicy::STANDARD_OUTPUT_COUNT,
+        );
+        assert_eq!(
+            policy.min_split_output_value(),
+            Some(SplitPolicy::STANDARD_MIN_OUTPUT_VALUE),
+        );
+    }
 
     #[derive(Debug)]
     pub(crate) struct TestTransparentInput {

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -296,6 +296,26 @@ impl<R, I> MultiOutputChangeStrategy<R, I> {
     }
 }
 
+impl<I> MultiOutputChangeStrategy<StandardFeeRule, I> {
+    /// Constructs the standard general-purpose multi-output change strategy.
+    ///
+    /// This is the change strategy used by the mobile wallet SDKs. It applies the ZIP 317 fee
+    /// rule, falls back to the Orchard pool for change when the transaction has no shielded
+    /// inputs, uses the default [`DustOutputPolicy`], and splits change according to
+    /// [`SplitPolicy::standard`]. It is equivalent to a
+    /// [`crate::fees::standard::MultiOutputChangeStrategy`] pre-configured with the wallet
+    /// defaults; use [`MultiOutputChangeStrategy::new`] to customize any of them.
+    pub fn standard(change_memo: Option<MemoBytes>) -> Self {
+        Self::new(
+            StandardFeeRule::Zip317,
+            change_memo,
+            ShieldedPool::Orchard,
+            DustOutputPolicy::default(),
+            SplitPolicy::standard(),
+        )
+    }
+}
+
 impl<R, I> ChangeStrategy for MultiOutputChangeStrategy<R, I>
 where
     R: Zip317FeeRule + Clone,


### PR DESCRIPTION
Part of #2785 (item **A6**).

The Android and Swift wallet SDKs each hand-write an identical `zip317_helper`
that builds a ZIP 317 multi-output change strategy splitting change into at
least 4 notes of value at least 0.1 ZEC. The two copies have already drifted
(`.expect("4 is nonzero")` on Android vs `.unwrap()` on Swift), and the `4` /
`0.1 ZEC` constants are duplicated magic numbers.

This moves the shared logic upstream into `zcash_client_backend::fees` so both
SDKs (and zallet) consume one maintained implementation:

- `SplitPolicy::standard()`, plus the `SplitPolicy::STANDARD_OUTPUT_COUNT` (4)
  and `SplitPolicy::STANDARD_MIN_OUTPUT_VALUE` (0.1 ZEC, expressed as
  `COIN / 10`) constants.
- `MultiOutputChangeStrategy::<StandardFeeRule, I>::standard(change_memo)`,
  capturing the whole helper's change strategy: ZIP 317 fee rule, Orchard
  change fallback, default dust policy, and `SplitPolicy::standard()`. It is
  reachable through the existing `fees::standard::MultiOutputChangeStrategy<I>`
  type alias.

The trivial `GreedyInputSelector::new()` half of the SDK helper is intentionally
left in the SDKs (input selection is not a fee concern); each helper collapses
to `(MultiOutputChangeStrategy::standard(memo), GreedyInputSelector::new())`.

A new unit test pins the `4` and `10_000_000`-zatoshi values so any future
change to the wallet default is deliberate rather than silent.

Verified: builds with default features and with `orchard,transparent-inputs`;
`fees` tests pass; `cargo fmt --check` and `cargo clippy` clean.