### PR TITLE
Fluent test DSL: cut boilerplate across the pool + transparent test scenarios

### DIFF
--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1017,12 +1017,8 @@ where
         #[cfg(feature = "orchard")]
         let fallback_change_pool = ShieldedPool::Orchard;
 
-        let change_strategy = standard::SingleOutputChangeStrategy::new(
-            StandardFeeRule::Zip317,
-            None,
-            fallback_change_pool,
-            DustOutputPolicy::default(),
-        );
+        let change_strategy =
+            single_output_change_strategy(StandardFeeRule::Zip317, None, fallback_change_pool);
 
         let request =
             zip321::TransactionRequest::new(vec![Payment::without_memo(to, value)]).unwrap();

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2494,18 +2494,8 @@ pub fn send_multi_step_proposed_transfer<T: ShieldedPoolTester, Dsf>(
 
     let (colliding_addr, _) = &known_addrs[usize::try_from(gap_limits.ephemeral() - 1).unwrap()];
     let utxo_value = (value - zip317::MINIMUM_FEE).unwrap();
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            StandardFeeRule::Zip317,
-            ConfirmationsPolicy::MIN,
-            &Address::from(*colliding_addr),
-            utxo_value,
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    let to = Address::from(*colliding_addr);
+    let proposal = st.propose_transfer_to(&to, utxo_value);
 
     // Create the transaction. This will cause the the gap start to move & a new
     // `gap_limits.ephemeral()` of addresses to be created.
@@ -2801,20 +2791,9 @@ pub fn spend_all_funds_multi_step_proposed_transfer<T: ShieldedPoolTester, Dsf>(
     let tex_addr = Address::Tex([0x4; 20]);
 
     let change_memo: Option<MemoBytes> = None;
-    // We use `st.propose_standard_transfer` here in order to also test round-trip
-    // serialization of the proposal.
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            StandardFeeRule::Zip317,
-            ConfirmationsPolicy::MIN,
-            &tex_addr,
-            transfer_amount,
-            None,
-            change_memo.clone(),
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    // `propose_transfer_to` proposes a standard transfer, so this also tests
+    // round-trip serialization of the proposal.
+    let proposal = st.propose_transfer_to(&tex_addr, transfer_amount);
 
     let steps: Vec<_> = proposal.steps().iter().cloned().collect();
     assert_eq!(steps.len(), 2);
@@ -2946,18 +2925,7 @@ pub fn proposal_fails_if_not_all_ephemeral_outputs_consumed<T: ShieldedPoolTeste
 
     // Generate a ZIP 320 proposal, sending to an external TEX address.
     let tex_addr = Address::Tex([0x4; 20]);
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            StandardFeeRule::Zip317,
-            ConfirmationsPolicy::MIN,
-            &tex_addr,
-            transfer_amount,
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    let proposal = st.propose_transfer_to(&tex_addr, transfer_amount);
 
     // This is somewhat redundant with `send_multi_step_proposed_transfer`,
     // but tests the case with no change memo and ensures we haven't messed
@@ -3329,24 +3297,11 @@ pub fn spend_succeeds_to_t_addr_zero_change<T: ShieldedPoolTester>(
     let value = Zatoshis::const_from_u64(70000);
     st.add_a_single_note_checking_balance(value);
 
-    let fee_rule = StandardFeeRule::Zip317;
-
     // TODO: generate_next_block_from_tx does not currently support transparent outputs.
     let to = TransparentAddress::PublicKeyHash([7; 20]).into();
     let account = st.test_account().cloned().unwrap();
-    let account_id = account.id();
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(50000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    let amount_sent = Zatoshis::const_from_u64(50000);
+    let proposal = st.propose_transfer_to(&to, amount_sent);
 
     // Executing the proposal should succeed
     assert_matches!(
@@ -3387,22 +3342,10 @@ pub fn change_note_spends_succeed<T: ShieldedPoolTester>(
         .find_map(|note| (note.note().value() == value).then_some(note.spending_key_scope()));
     assert_matches!(change_note_scope, Some(Scope::Internal));
 
-    let fee_rule = StandardFeeRule::Zip317;
-
     // TODO: generate_next_block_from_tx does not currently support transparent outputs.
     let to = TransparentAddress::PublicKeyHash([7; 20]).into();
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(50000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    let amount_sent = Zatoshis::const_from_u64(50000);
+    let proposal = st.propose_transfer_to(&to, amount_sent);
 
     // Executing the proposal should succeed
     assert_matches!(

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -261,14 +261,7 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
 
     // Verify that the sent transaction was stored and that we can decrypt the memos
     let tx = st
@@ -391,12 +384,8 @@ pub fn scan_full_block_detects_outputs<T: ShieldedPoolTester>(
     )])
     .unwrap();
 
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
     let input_selector = GreedyInputSelector::new();
 
     let account = st.get_account();
@@ -711,14 +700,7 @@ pub fn spend_max_spendable_single_step_proposed_transfer<T: ShieldedPoolTester>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
 
     // Verify that the sent transaction was stored and that we can decrypt the memos
     let tx = st
@@ -849,14 +831,7 @@ pub fn spend_everything_single_step_proposed_transfer<T: ShieldedPoolTester>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
 
     // Verify that the sent transaction was stored and that we can decrypt the memos
     let tx = st
@@ -1044,12 +1019,7 @@ pub fn send_max_spendable_to_transparent<T: ShieldedPoolTester>(
         Some(payment) if payment.amount() == Some(expected_payment)
     );
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    st.create_proposed_expecting(&proposal, 1);
 }
 
 /// Tests that a send-max proposal whose total required fee overflows the maximum
@@ -1202,15 +1172,10 @@ pub fn send_max_spends_inputs_across_pools<P0: ShieldedPoolTester, P1: ShieldedP
         BTreeSet::from([P0::SHIELDED_PROTOCOL, P1::SHIELDED_PROTOCOL])
     );
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    let txids = st.create_proposed_expecting(&proposal, 1);
 
     // Mine the transaction and verify that the entire balance has been spent.
-    let (h, _) = st.generate_next_block_including(create_proposed_result.unwrap()[0]);
+    let (h, _) = st.generate_next_block_including(txids[0]);
     st.scan_cached_blocks(h, 1);
     assert_eq!(st.get_total_balance(account.id()), Zatoshis::ZERO);
 }
@@ -1315,12 +1280,7 @@ pub fn send_max_delivers_via_sapling_when_orchard_is_unavailable<T: ShieldedPool
         Some(payment) if payment.amount() == Some(expected_payment)
     );
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    st.create_proposed_expecting(&proposal, 1);
 }
 
 /// Tests that a send-max proposal to a unified address whose only receiver cannot be
@@ -1525,14 +1485,7 @@ pub fn send_max_spendable_proposal_succeeds_when_unconfirmed_funds_present<
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
 
     // Verify that the sent transaction was stored and that we can decrypt the memos
     let tx = st
@@ -1702,13 +1655,7 @@ pub fn spend_everything_multi_step_single_note_proposed_transfer<T: ShieldedPool
     );
     assert_eq!(steps[1].balance().proposed_change(), []);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
-    let txids = create_proposed_result.unwrap();
+    let txids = st.create_proposed_expecting(&proposal, 2);
 
     // Mine the created transactions.
     for txid in txids.iter() {
@@ -1853,13 +1800,7 @@ pub fn spend_everything_multi_step_many_notes_proposed_transfer<T: ShieldedPoolT
     );
     assert_eq!(steps[1].balance().proposed_change(), []);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
-    let txids = create_proposed_result.unwrap();
+    let txids = st.create_proposed_expecting(&proposal, 2);
 
     // Mine the created transactions.
     for txid in txids.iter() {
@@ -2014,13 +1955,7 @@ pub fn spend_everything_multi_step_with_marginal_notes_proposed_transfer<
     );
     assert_eq!(steps[1].balance().proposed_change(), []);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
-    let txids = create_proposed_result.unwrap();
+    let txids = st.create_proposed_expecting(&proposal, 2);
 
     // Mine the created transactions.
     for txid in txids.iter() {
@@ -2641,14 +2576,7 @@ pub fn spend_all_funds_single_step_proposed_transfer<T: ShieldedPoolTester>(
         )
         .unwrap();
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
-
-    let sent_tx_id = create_proposed_result.unwrap()[0];
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
 
     // Verify that the sent transaction was stored and that we can decrypt the memos
     let tx = st
@@ -2809,13 +2737,7 @@ pub fn spend_all_funds_multi_step_proposed_transfer<T: ShieldedPoolTester, Dsf>(
     );
     assert_eq!(steps[1].balance().proposed_change(), []);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 2);
-    let txids = create_proposed_result.unwrap();
+    let txids = st.create_proposed_expecting(&proposal, 2);
 
     // Mine the created transactions.
     for txid in txids.iter() {
@@ -3101,27 +3023,16 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     // Spend fails because there are insufficient verified notes
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
-    assert_matches!(
-        st.propose_standard_transfer::<Infallible>(
-            account_id,
-            StandardFeeRule::Zip317,
-            ConfirmationsPolicy::new_symmetrical_unchecked(
-                2,
-                #[cfg(feature = "transparent-inputs")]
-                false
-            ),
-            &to,
-            Zatoshis::const_from_u64(70000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
+    st.expect_insufficient_funds_with(
+        &to,
+        Zatoshis::const_from_u64(70000),
+        ConfirmationsPolicy::new_symmetrical_unchecked(
+            2,
+            #[cfg(feature = "transparent-inputs")]
+            false,
         ),
-        Err(data_api::error::Error::InsufficientFunds {
-            available,
-            required
-        })
-        if available == Zatoshis::const_from_u64(50000)
-            && required == Zatoshis::const_from_u64(80000)
+        Zatoshis::const_from_u64(50000),
+        Zatoshis::const_from_u64(80000),
     );
 
     // Mine blocks SAPLING_ACTIVATION_HEIGHT + 2 to 9 until just before the second
@@ -3135,23 +3046,12 @@ pub fn spend_fails_on_unverified_notes<T: ShieldedPoolTester>(
     assert_eq!(st.get_total_balance(account_id), (value * 10u64).unwrap());
 
     // Spend still fails
-    assert_matches!(
-        st.propose_standard_transfer::<Infallible>(
-            account_id,
-            StandardFeeRule::Zip317,
-            ConfirmationsPolicy::default(),
-            &to,
-            Zatoshis::const_from_u64(70000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        ),
-        Err(data_api::error::Error::InsufficientFunds {
-            available,
-            required
-        })
-        if available == Zatoshis::const_from_u64(50000)
-            && required == Zatoshis::const_from_u64(80000)
+    st.expect_insufficient_funds_with(
+        &to,
+        Zatoshis::const_from_u64(70000),
+        ConfirmationsPolicy::default(),
+        Zatoshis::const_from_u64(50000),
+        Zatoshis::const_from_u64(80000),
     );
 
     // Mine block 11 so that the second note becomes verified
@@ -3404,12 +3304,8 @@ where
     ])
     .unwrap();
 
-    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
     let input_selector = GreedyInputSelector::new();
 
     let txid1 = st
@@ -3580,12 +3476,8 @@ pub fn account_deletion_with_internal_transfer<T: ShieldedPoolTester, DSF>(
     )])
     .unwrap();
 
-    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
     let input_selector = GreedyInputSelector::new();
 
     let txid = st
@@ -3680,12 +3572,8 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     ])
     .unwrap();
 
-    let change_strategy = fees::standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
     let input_selector = GreedyInputSelector::new();
 
     let txid = st
@@ -4433,14 +4321,9 @@ pub fn pool_crossing_required<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     );
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal0,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    let txids = st.create_proposed_expecting(&proposal0, 1);
 
-    let (h, _) = st.generate_next_block_including(create_proposed_result.unwrap()[0]);
+    let (h, _) = st.generate_next_block_including(txids[0]);
     st.scan_cached_blocks(h, 1);
 
     assert_eq!(
@@ -4523,14 +4406,9 @@ pub fn fully_funded_fully_private<P0: ShieldedPoolTester, P1: ShieldedPoolTester
     );
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal0,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    let txids = st.create_proposed_expecting(&proposal0, 1);
 
-    let (h, _) = st.generate_next_block_including(create_proposed_result.unwrap()[0]);
+    let (h, _) = st.generate_next_block_including(txids[0]);
     st.scan_cached_blocks(h, 1);
 
     assert_eq!(
@@ -4609,14 +4487,9 @@ pub fn fully_funded_send_to_t<P0: ShieldedPoolTester, P1: ShieldedPoolTester>(
     assert_eq!(change_output.output_pool(), PoolType::SAPLING);
     assert_eq!(change_output.value(), expected_change);
 
-    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-        account.usk(),
-        OvkPolicy::Sender,
-        &proposal0,
-    );
-    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+    let txids = st.create_proposed_expecting(&proposal0, 1);
 
-    let (h, _) = st.generate_next_block_including(create_proposed_result.unwrap()[0]);
+    let (h, _) = st.generate_next_block_including(txids[0]);
     st.scan_cached_blocks(h, 1);
 
     // Since the recipient address is in the same account, the total balance includes the transfer
@@ -5866,12 +5739,8 @@ where
         send_value,
     )])
     .unwrap();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        T::SHIELDED_PROTOCOL,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
     let input_selector = GreedyInputSelector::new();
     let proposal = st
         .propose_transfer(
@@ -8019,12 +7888,8 @@ pub fn propose_v5_payment_to_orchard_receiver_is_rejected<Dsf>(
     )])
     .unwrap();
 
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
     let input_selector = GreedyInputSelector::new();
 
     let account = st.get_account();
@@ -8096,12 +7961,8 @@ where
     )])
     .unwrap();
 
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
     let input_selector = GreedyInputSelector::new();
 
     let account_id = st.get_account().id();
@@ -8557,12 +8418,8 @@ where
     )])
     .unwrap();
 
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
     let input_selector = GreedyInputSelector::new();
 
     let account_id = st.get_account().id();

--- a/zcash_client_backend/src/data_api/testing/pool/dsl.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/dsl.rs
@@ -1,21 +1,31 @@
 //! A convenient DSL for writing wallet tests.
 
 use std::{
+    convert::Infallible,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
+use assert_matches::assert_matches;
+use zcash_keys::address::Address;
 use zcash_primitives::{block::BlockHash, transaction::fees::zip317};
-use zcash_protocol::{consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis};
+use zcash_protocol::{
+    TxId, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
+};
 
-use crate::data_api::{
-    Account, AccountBalance, WalletRead,
-    chain::ScanSummary,
-    testing::{
-        AddressType, DataStoreFactory, FakeCompactOutput, TestAccount, TestBuilder, TestCache,
-        TestFvk, TestState,
+use crate::{
+    data_api::{
+        Account, AccountBalance, InputSource, WalletRead,
+        chain::ScanSummary,
+        testing::{
+            AddressType, DataStoreFactory, FakeCompactOutput, TestAccount, TestBuilder, TestCache,
+            TestFvk, TestState,
+        },
+        wallet::ConfirmationsPolicy,
     },
-    wallet::ConfirmationsPolicy,
+    fees::StandardFeeRule,
+    proposal::Proposal,
+    wallet::OvkPolicy,
 };
 
 use super::ShieldedPoolTester;
@@ -383,5 +393,106 @@ where
         );
 
         summary
+    }
+
+    /// Proposes a ZIP 317 transfer of `amount` zatoshis from the test account to
+    /// `to`, panicking if proposal construction fails.
+    ///
+    /// This fixes the values that are constant across most transfer scenarios:
+    /// the test account, [`StandardFeeRule::Zip317`], [`ConfirmationsPolicy::MIN`],
+    /// no memos, and the tester's shielded pool as the fallback change pool.
+    pub fn propose_transfer_to(
+        &mut self,
+        to: &Address,
+        amount: Zatoshis,
+    ) -> Proposal<StandardFeeRule, <Dsf::DataStore as InputSource>::NoteRef> {
+        let account_id = self.get_account().id();
+        self.propose_standard_transfer::<Infallible>(
+            account_id,
+            StandardFeeRule::Zip317,
+            ConfirmationsPolicy::MIN,
+            to,
+            amount,
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        )
+        .unwrap()
+    }
+
+    /// Proposes and executes a transfer of `amount` zatoshis to `to` with
+    /// [`OvkPolicy::Sender`], returning the single resulting transaction id.
+    ///
+    /// Shorthand for [`Self::propose_transfer_to`] followed by
+    /// [`TestState::create_proposed_transactions`]. (Named `spend_to` to avoid
+    /// clashing with the lower-level [`TestState::spend`].)
+    pub fn spend_to(&mut self, to: &Address, amount: Zatoshis) -> TxId {
+        let account = self.get_account();
+        let proposal = self.propose_transfer_to(to, amount);
+        self.create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .unwrap()[0]
+    }
+
+    /// Asserts that proposing a transfer of `amount` zatoshis to `to` fails with
+    /// [`Error::InsufficientFunds`], reporting `available` available and exactly
+    /// `required` required.
+    ///
+    /// [`Error::InsufficientFunds`]: crate::data_api::error::Error::InsufficientFunds
+    pub fn expect_insufficient_funds(
+        &mut self,
+        to: &Address,
+        amount: Zatoshis,
+        available: Zatoshis,
+        required: Zatoshis,
+    ) {
+        let account_id = self.get_account().id();
+        assert_matches!(
+            self.propose_standard_transfer::<Infallible>(
+                account_id,
+                StandardFeeRule::Zip317,
+                ConfirmationsPolicy::MIN,
+                to,
+                amount,
+                None,
+                None,
+                T::SHIELDED_PROTOCOL,
+            ),
+            Err(crate::data_api::error::Error::InsufficientFunds { available: a, required: r })
+                if a == available && r == required,
+            "expected InsufficientFunds (available={}, required={}) proposing {}",
+            u64::from(available),
+            u64::from(required),
+            u64::from(amount)
+        );
+    }
+
+    /// Mines a single "decoy" block that pays `value` to a throwaway external
+    /// address derived from `seed` (so the funds do not accrue to the test
+    /// account), returning the new block height. Does not scan.
+    pub fn mine_decoy_block(&mut self, seed: u8, value: Zatoshis) -> BlockHeight {
+        let (h, _, _) = self.generate_next_block(
+            &T::sk_to_fvk(&T::sk(&[seed; 32])),
+            AddressType::DefaultExternal,
+            value,
+        );
+        h
+    }
+
+    /// Mines one decoy block per `seed` (see [`Self::mine_decoy_block`]),
+    /// returning the height of the last block mined, if any. Does not scan.
+    pub fn mine_decoy_blocks(
+        &mut self,
+        seeds: impl IntoIterator<Item = u8>,
+        value: Zatoshis,
+    ) -> Option<BlockHeight> {
+        let mut last = None;
+        for seed in seeds {
+            last = Some(self.mine_decoy_block(seed, value));
+        }
+        last
     }
 }

--- a/zcash_client_backend/src/data_api/testing/pool/dsl.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/dsl.rs
@@ -10,22 +10,28 @@ use assert_matches::assert_matches;
 use zcash_keys::address::Address;
 use zcash_primitives::{block::BlockHash, transaction::fees::zip317};
 use zcash_protocol::{
-    TxId, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
+    PoolType, TxId, consensus::BlockHeight, local_consensus::LocalNetwork, value::Zatoshis,
 };
+
+use zip321::Payment;
 
 use crate::{
     data_api::{
-        Account, AccountBalance, InputSource, WalletRead,
+        Account, AccountBalance, InputSource, WalletRead, WalletTest,
         chain::ScanSummary,
         testing::{
             AddressType, DataStoreFactory, FakeCompactOutput, TestAccount, TestBuilder, TestCache,
-            TestFvk, TestState,
+            TestFvk, TestState, single_output_change_strategy,
         },
-        wallet::ConfirmationsPolicy,
+        wallet::{
+            ConfirmationsPolicy, LockRequest,
+            input_selection::{GreedyInputSelector, SpendPolicy},
+            propose_transfer,
+        },
     },
     fees::StandardFeeRule,
     proposal::Proposal,
-    wallet::OvkPolicy,
+    wallet::{LockOwner, OutputRef, OvkPolicy},
 };
 
 use super::ShieldedPoolTester;
@@ -494,5 +500,78 @@ where
             last = Some(self.mine_decoy_block(seed, value));
         }
         last
+    }
+
+    /// Returns an [`OutputRef`] for the wallet's single received note in the
+    /// tester's shielded pool, asserting that exactly one such note exists.
+    pub fn sole_note_ref(&self) -> OutputRef {
+        let notes = self.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+        assert_eq!(notes.len(), 1);
+        let note = &notes[0];
+        OutputRef::new(
+            *note.txid(),
+            PoolType::Shielded(note.note().pool()),
+            u32::from(note.output_index()),
+        )
+    }
+
+    /// Returns an [`OutputRef`] for the single received note whose value equals
+    /// `value`, panicking if no such note exists.
+    ///
+    /// Used by the multi-note scenarios, which fund the account with notes of
+    /// distinct values so that each note can be identified by its value.
+    pub fn note_ref_by_value(&self, value: Zatoshis) -> OutputRef {
+        let notes = self.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
+        let note = notes
+            .iter()
+            .find(|n| n.note().value() == value)
+            .expect("a note with the requested value exists");
+        OutputRef::new(
+            *note.txid(),
+            PoolType::Shielded(note.note().pool()),
+            u32::from(note.output_index()),
+        )
+    }
+
+    /// Proposes a ZIP 317 transfer of `amount` zatoshis to `to` that locks its
+    /// own selected inputs on behalf of `owner` for `lock_for_blocks` blocks,
+    /// panicking if proposal construction fails.
+    ///
+    /// This is the locking counterpart of [`Self::propose_transfer_to`]: it
+    /// goes through the lower-level [`propose_transfer`] so that a
+    /// [`LockRequest`] can be attached, and fixes the same constants (the test
+    /// account, a [`GreedyInputSelector`], the tester's single-output change
+    /// strategy, [`ConfirmationsPolicy::MIN`], the default [`SpendPolicy`], and
+    /// no requested transaction version).
+    pub fn propose_locking_transfer(
+        &mut self,
+        to: &Address,
+        amount: Zatoshis,
+        owner: LockOwner,
+        lock_for_blocks: u32,
+    ) -> Proposal<StandardFeeRule, <Dsf::DataStore as InputSource>::NoteRef> {
+        let account_id = self.get_account().id();
+        let input_selector = GreedyInputSelector::new();
+        let change_strategy =
+            single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
+        let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+            to.to_zcash_address(self.network()),
+            amount,
+        )])
+        .unwrap();
+        let network = *self.network();
+        propose_transfer::<_, _, _, _, Infallible>(
+            self.wallet_mut(),
+            &network,
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+            &SpendPolicy::default(),
+            Some(LockRequest::new(owner, lock_for_blocks)),
+            None,
+        )
+        .unwrap()
     }
 }

--- a/zcash_client_backend/src/data_api/testing/pool/dsl.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/dsl.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
+use nonempty::NonEmpty;
 use zcash_keys::address::Address;
 use zcash_primitives::{block::BlockHash, transaction::fees::zip317};
 use zcash_protocol::{
@@ -443,6 +444,31 @@ where
         .unwrap()[0]
     }
 
+    /// Creates the transactions for `proposal` with [`OvkPolicy::Sender`],
+    /// asserts that exactly `expected` transactions were produced, and returns
+    /// their ids.
+    ///
+    /// This collapses the common
+    /// [`TestState::create_proposed_transactions`]-then-assert-count
+    /// boilerplate. It fixes the values that are constant across nearly every
+    /// execution site: the test account's spending key and
+    /// [`OvkPolicy::Sender`]. On failure it reports the full result (including
+    /// any error), matching the diagnostics of the hand-written form.
+    pub fn create_proposed_expecting(
+        &mut self,
+        proposal: &Proposal<StandardFeeRule, <Dsf::DataStore as InputSource>::NoteRef>,
+        expected: usize,
+    ) -> NonEmpty<TxId> {
+        let account = self.get_account();
+        let result = self.create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            proposal,
+        );
+        assert_matches!(&result, Ok(txids) if txids.len() == expected);
+        result.unwrap()
+    }
+
     /// Asserts that proposing a transfer of `amount` zatoshis to `to` fails with
     /// [`Error::InsufficientFunds`], reporting `available` available and exactly
     /// `required` required.
@@ -455,12 +481,31 @@ where
         available: Zatoshis,
         required: Zatoshis,
     ) {
+        self.expect_insufficient_funds_with(
+            to,
+            amount,
+            ConfirmationsPolicy::MIN,
+            available,
+            required,
+        )
+    }
+
+    /// Like [`Self::expect_insufficient_funds`], but with an explicit
+    /// `confirmations_policy` instead of the fixed [`ConfirmationsPolicy::MIN`].
+    pub fn expect_insufficient_funds_with(
+        &mut self,
+        to: &Address,
+        amount: Zatoshis,
+        confirmations_policy: ConfirmationsPolicy,
+        available: Zatoshis,
+        required: Zatoshis,
+    ) {
         let account_id = self.get_account().id();
         assert_matches!(
             self.propose_standard_transfer::<Infallible>(
                 account_id,
                 StandardFeeRule::Zip317,
-                ConfirmationsPolicy::MIN,
+                confirmations_policy,
                 to,
                 amount,
                 None,

--- a/zcash_client_backend/src/data_api/testing/pool/locking.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/locking.rs
@@ -17,7 +17,7 @@ use crate::{
     data_api::{
         self, Account as _, InputSource, OutputLockStore, WalletRead, WalletTest, WalletWrite,
         error::LockError,
-        testing::{AddressType, DataStoreFactory, TestCache, single_output_change_strategy},
+        testing::{DataStoreFactory, TestCache, single_output_change_strategy},
         wallet::{
             ConfirmationsPolicy, LockRequest, TargetHeight,
             input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy},
@@ -49,8 +49,6 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
 ) {
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
 
-    let fee_rule = StandardFeeRule::Zip317;
-
     // Add funds to the wallet in a single note
     let value = Zatoshis::const_from_u64(50000);
     let (h1, _, _) = st.add_a_single_note_checking_balance(value);
@@ -58,82 +56,30 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     // Send some of the funds to another address, but don't mine the tx.
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
-    let account = st.test_account().cloned().unwrap();
-    let account_id = account.id();
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(15000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
+    let account_id = st.test_account().unwrap().id();
+    let amount_sent1 = Zatoshis::const_from_u64(15000);
+    st.spend_to(&to, amount_sent1);
 
-    // Executing the proposal should succeed
-    assert_matches!(
-        st.create_proposed_transactions::<Infallible, _, Infallible, _>(account.usk(), OvkPolicy::Sender, &proposal,),
-        Ok(txids) if txids.len() == 1
-    );
-
-    // A second proposal fails because there are no usable notes
-    assert_matches!(
-        st.propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(2000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        ),
-        Err(data_api::error::Error::InsufficientFunds {
-            available,
-            required
-        })
-        if available == Zatoshis::ZERO && required == Zatoshis::const_from_u64(12000)
-    );
+    // A second proposal fails because there are no usable notes: the sole note is
+    // committed to the unmined first transaction, so nothing is available even
+    // though the request plus the ZIP 317 fee would require `retry_required`.
+    let amount_retry = Zatoshis::const_from_u64(2000);
+    let zip317_fee = Zatoshis::const_from_u64(10000);
+    let nothing_available = Zatoshis::ZERO;
+    let retry_required = (amount_retry + zip317_fee).unwrap();
+    st.expect_insufficient_funds(&to, amount_retry, nothing_available, retry_required);
 
     // Mine blocks SAPLING_ACTIVATION_HEIGHT + 1 to 41 (that don't send us funds)
     // until just before the first transaction expires
-    for i in 1..42 {
-        st.generate_next_block(
-            &T::sk_to_fvk(&T::sk(&[i as u8; 32])),
-            AddressType::DefaultExternal,
-            value,
-        );
-    }
+    st.mine_decoy_blocks(1u8..42, value);
     st.scan_cached_blocks(h1 + 1, 40);
 
     // Second proposal still fails
-    assert_matches!(
-        st.propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(2000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        ),
-        Err(data_api::error::Error::InsufficientFunds {
-            available,
-            required
-        })
-        if available == Zatoshis::ZERO && required == Zatoshis::const_from_u64(12000)
-    );
+    st.expect_insufficient_funds(&to, amount_retry, nothing_available, retry_required);
 
     // Mine block SAPLING_ACTIVATION_HEIGHT + 42 so that the first transaction expires
-    let (h43, _, _) = st.generate_next_block(
-        &T::sk_to_fvk(&T::sk(&[42; 32])),
-        AddressType::DefaultExternal,
-        value,
-    );
+    let expiring_block_seed = 42;
+    let h43 = st.mine_decoy_block(expiring_block_seed, value);
     st.scan_cached_blocks(h43, 1);
 
     // Spendable balance matches total balance at 1 confirmation.
@@ -144,27 +90,8 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     );
 
     // Second spend should now succeed
-    let amount_sent2 = Zatoshis::const_from_u64(2000);
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            amount_sent2,
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
-
-    let txid2 = st
-        .create_proposed_transactions::<Infallible, _, Infallible, _>(
-            account.usk(),
-            OvkPolicy::Sender,
-            &proposal,
-        )
-        .unwrap()[0];
+    let amount_sent2 = amount_retry;
+    let txid2 = st.spend_to(&to, amount_sent2);
 
     let (h, _) = st.generate_next_block_including(txid2);
     st.scan_cached_blocks(h, 1);
@@ -172,7 +99,7 @@ pub fn spend_fails_on_locked_notes<T: ShieldedPoolTester>(
     // TODO: send to an account so that we can check its balance.
     assert_eq!(
         st.get_total_balance(account_id),
-        (value - (amount_sent2 + Zatoshis::from_u64(10000).unwrap()).unwrap()).unwrap()
+        (value - (amount_sent2 + zip317_fee).unwrap()).unwrap()
     );
 }
 
@@ -188,8 +115,7 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     let value = Zatoshis::const_from_u64(50000);
     let (_, _, _) = st.add_a_single_note_checking_balance(value);
 
-    let account = st.test_account().cloned().unwrap();
-    let account_id = account.id();
+    let account_id = st.test_account().unwrap().id();
 
     // Find the received note and construct an OutputRef for it
     let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
@@ -254,27 +180,8 @@ pub fn explicit_note_locking<T: ShieldedPoolTester>(
     );
 
     // Proposal should now succeed
-    let proposal = st
-        .propose_standard_transfer::<Infallible>(
-            account_id,
-            fee_rule,
-            ConfirmationsPolicy::MIN,
-            &to,
-            Zatoshis::const_from_u64(15000),
-            None,
-            None,
-            T::SHIELDED_PROTOCOL,
-        )
-        .unwrap();
-
-    assert_matches!(
-        st.create_proposed_transactions::<Infallible, _, Infallible, _>(
-            account.usk(),
-            OvkPolicy::Sender,
-            &proposal,
-        ),
-        Ok(txids) if txids.len() == 1
-    );
+    let amount_sent = Zatoshis::const_from_u64(15000);
+    st.spend_to(&to, amount_sent);
 }
 
 /// Exercises the exact height boundary of the note-locking semantics.

--- a/zcash_client_backend/src/data_api/testing/pool/locking.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/locking.rs
@@ -19,7 +19,7 @@ use crate::{
         error::LockError,
         testing::{DataStoreFactory, TestCache, single_output_change_strategy},
         wallet::{
-            ConfirmationsPolicy, LockRequest, TargetHeight,
+            ConfirmationsPolicy, TargetHeight,
             input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy},
         },
     },
@@ -208,14 +208,7 @@ pub fn note_locking_height_boundary<T: ShieldedPoolTester>(
     let target_height = chain_tip + 1;
 
     // Find the received note and construct an OutputRef for it
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 1);
-    let note = &notes[0];
-    let output_ref = OutputRef::new(
-        *note.txid(),
-        PoolType::Shielded(note.note().pool()),
-        u32::from(note.output_index()),
-    );
+    let output_ref = st.sole_note_ref();
 
     // Lock with expiry exactly at the target height: the output must be treated as locked.
     let owner = LockOwner::new([1; 32]);
@@ -277,14 +270,7 @@ pub fn clear_locked_outputs<T: ShieldedPoolTester>(
     let account_id = account.id();
 
     // Find the received note and construct an OutputRef for it
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 1);
-    let note = &notes[0];
-    let output_ref = OutputRef::new(
-        *note.txid(),
-        PoolType::Shielded(note.note().pool()),
-        u32::from(note.output_index()),
-    );
+    let output_ref = st.sole_note_ref();
 
     // Lock the note with a far-future expiry.
     let owner = LockOwner::new([1; 32]);
@@ -338,39 +324,12 @@ pub fn proposal_level_note_locking<T: ShieldedPoolTester>(
 
     // Remember the funding note's reference; it is spent at the end of this test, where the
     // lock-a-spent-note behavior is pinned.
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 1);
-    let funding_note_ref = OutputRef::new(
-        *notes[0].txid(),
-        PoolType::Shielded(notes[0].note().pool()),
-        u32::from(notes[0].output_index()),
-    );
+    let funding_note_ref = st.sole_note_ref();
 
     // Create a proposal with lock_for_blocks: Some(100) using propose_transfer
-    let input_selector = GreedyInputSelector::new();
-    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
-
-    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
-        to.to_zcash_address(st.network()),
-        Zatoshis::const_from_u64(15000),
-    )])
-    .unwrap();
-
-    let network = *st.network();
     let owner = LockOwner::new([1; 32]);
-    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
-        st.wallet_mut(),
-        &network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::MIN,
-        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(LockRequest::new(owner, 100)),
-        None,
-    )
-    .unwrap();
+    let amount_sent = Zatoshis::const_from_u64(15000);
+    let proposal = st.propose_locking_transfer(&to, amount_sent, owner, 100);
 
     // Notes should now be locked; a second proposal should fail
     assert_matches!(
@@ -456,41 +415,17 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
 ) {
     let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
 
-    let fee_rule = StandardFeeRule::Zip317;
-
     // Add funds to the wallet in a single note
     let value = Zatoshis::const_from_u64(50000);
     let (_, _, _) = st.add_a_single_note_checking_balance(value);
 
-    let account = st.test_account().cloned().unwrap();
-    let account_id = account.id();
+    let account_id = st.test_account().unwrap().id();
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
 
-    let input_selector = GreedyInputSelector::new();
-    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
-
-    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
-        to.to_zcash_address(st.network()),
-        Zatoshis::const_from_u64(15000),
-    )])
-    .unwrap();
-
-    let network = *st.network();
     let owner = LockOwner::new([1; 32]);
-    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
-        st.wallet_mut(),
-        &network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::MIN,
-        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(LockRequest::new(owner, 100)),
-        None,
-    )
-    .unwrap();
+    let amount_sent = Zatoshis::const_from_u64(15000);
+    let proposal = st.propose_locking_transfer(&to, amount_sent, owner, 100);
 
     // The proposal's input is locked.
     assert!(
@@ -503,6 +438,7 @@ pub fn locked_proposal_proto_roundtrip<T: ShieldedPoolTester>(
 
     // The serialized proposal must decode back to an identical proposal even though its inputs
     // are locked (a proposal legitimately references its own locked inputs).
+    let network = *st.network();
     let proto = crate::proto::proposal::Proposal::from_standard_proposal(&proposal);
     let decoded = proto
         .try_into_standard_proposal(&network, st.wallet())
@@ -530,14 +466,7 @@ pub fn lock_expiry_restores_spendability<T: ShieldedPoolTester>(
     let account_id = st.test_account().unwrap().id();
     let tip = st.latest_cached_block().unwrap().height();
 
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 1);
-    let note = &notes[0];
-    let output_ref = OutputRef::new(
-        *note.txid(),
-        PoolType::Shielded(note.note().pool()),
-        u32::from(note.output_index()),
-    );
+    let output_ref = st.sole_note_ref();
 
     // Lock the note until three blocks past the current tip.
     let owner = LockOwner::new([1; 32]);
@@ -631,21 +560,13 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
     let account_id = st.test_account().unwrap().id();
     let far_expiry = BlockHeight::from(u32::MAX);
 
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 2);
-    let output_ref = |value: Zatoshis| {
-        let note = notes
-            .iter()
-            .find(|n| n.note().value() == value)
-            .expect("a note with the requested value exists");
-        OutputRef::new(
-            *note.txid(),
-            PoolType::Shielded(note.note().pool()),
-            u32::from(note.output_index()),
-        )
-    };
-    let r1 = output_ref(value1);
-    let r2 = output_ref(value2);
+    // Each note is identified by its (distinct) value.
+    assert_eq!(
+        st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap().len(),
+        2
+    );
+    let r1 = st.note_ref_by_value(value1);
+    let r2 = st.note_ref_by_value(value2);
 
     let owner_a = LockOwner::new([0xA1; 32]);
     let owner_b = LockOwner::new([0xB2; 32]);
@@ -750,6 +671,7 @@ pub fn lock_conflict_and_batch_atomicity<T: ShieldedPoolTester>(
 /// recovery path), and that the release is scoped to the owner that took the locks.
 ///
 /// [`unlock_proposal_inputs`]: crate::data_api::wallet::unlock_proposal_inputs
+/// [`LockRequest`]: crate::data_api::wallet::LockRequest
 pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     ds_factory: impl DataStoreFactory,
     cache: impl TestCache,
@@ -766,30 +688,9 @@ pub fn unlock_proposal_inputs_releases_locks<T: ShieldedPoolTester>(
     let extsk2 = T::sk(&[0xf5; 32]);
     let to = T::sk_default_address(&extsk2);
 
-    let input_selector = GreedyInputSelector::new();
-    let change_strategy = single_output_change_strategy(fee_rule, None, T::SHIELDED_PROTOCOL);
-
-    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
-        to.to_zcash_address(st.network()),
-        Zatoshis::const_from_u64(15000),
-    )])
-    .unwrap();
-
-    let network = *st.network();
     let owner = LockOwner::new([1; 32]);
-    let proposal = crate::data_api::wallet::propose_transfer::<_, _, _, _, Infallible>(
-        st.wallet_mut(),
-        &network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::MIN,
-        &crate::data_api::wallet::input_selection::SpendPolicy::default(),
-        Some(LockRequest::new(owner, 100)),
-        None,
-    )
-    .unwrap();
+    let amount_sent = Zatoshis::const_from_u64(15000);
+    let proposal = st.propose_locking_transfer(&to, amount_sent, owner, 100);
 
     // The proposal's input is locked; a competing proposal cannot be created.
     assert_eq!(st.get_locked_balance(account_id), value);
@@ -878,21 +779,12 @@ pub fn spend_policy_locked_input_policy_reaches_selection<T: ShieldedPoolTester>
     let account = st.test_account().cloned().unwrap();
     let account_id = account.id();
 
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), 3);
-    let output_ref = |value: Zatoshis| {
-        let note = notes
-            .iter()
-            .find(|n| n.note().value() == value)
-            .expect("a note with the requested value exists");
-        OutputRef::new(
-            *note.txid(),
-            PoolType::Shielded(note.note().pool()),
-            u32::from(note.output_index()),
-        )
-    };
-    let locked_a_ref = output_ref(locked_a_value);
-    let locked_b_ref = output_ref(locked_b_value);
+    assert_eq!(
+        st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap().len(),
+        3
+    );
+    let locked_a_ref = st.note_ref_by_value(locked_a_value);
+    let locked_b_ref = st.note_ref_by_value(locked_b_value);
 
     let owner_a = LockOwner::new([0xA1; 32]);
     let owner_b = LockOwner::new([0xB2; 32]);
@@ -1069,22 +961,11 @@ pub fn check_note_locking_model<T: ShieldedPoolTester>(
 
     let account_id = st.test_account().unwrap().id();
 
-    let notes = st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap();
-    assert_eq!(notes.len(), values.len());
-    let refs: Vec<OutputRef> = values
-        .iter()
-        .map(|value| {
-            let note = notes
-                .iter()
-                .find(|n| n.note().value() == *value)
-                .expect("a note with the requested value exists");
-            OutputRef::new(
-                *note.txid(),
-                PoolType::Shielded(note.note().pool()),
-                u32::from(note.output_index()),
-            )
-        })
-        .collect();
+    assert_eq!(
+        st.wallet().get_notes(T::SHIELDED_PROTOCOL).unwrap().len(),
+        values.len()
+    );
+    let refs: Vec<OutputRef> = values.iter().map(|v| st.note_ref_by_value(*v)).collect();
 
     // The model: per-note lock expiry height and owner index, and the chain tip.
     let mut model: Vec<Option<(u32, usize)>> = vec![None; refs.len()];

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -34,7 +34,10 @@ use crate::{
     data_api::{
         Account as _, AccountBalance, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode,
         TargetValue, WalletRead as _, WalletTest as _, WalletWrite,
-        testing::{AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState},
+        testing::{
+            AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState,
+            single_output_change_strategy,
+        },
         wallet::{
             ConfirmationsPolicy, TargetHeight, decrypt_and_store_transaction,
             input_selection::{
@@ -43,7 +46,7 @@ use crate::{
             },
         },
     },
-    fees::{DustOutputPolicy, StandardFeeRule, standard},
+    fees::StandardFeeRule,
     wallet::WalletTransparentOutput,
 };
 
@@ -301,12 +304,8 @@ where
 
     // Shield the output.
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
     let txid = st
         .shield_transparent_funds(
             &input_selector,
@@ -444,12 +443,8 @@ where
 
     // Shield the transparent balance.
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
     let txids = st
         .shield_transparent_funds(
             &input_selector,
@@ -657,12 +652,8 @@ where
     // Propose shielding with a 1%-of-block-space input cap.
     let input_selector =
         GreedyInputSelector::new().with_shielding_block_space_percent(BLOCK_SPACE_PERCENT);
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
     let proposal = st
         .propose_shielding(
             &input_selector,
@@ -1490,12 +1481,8 @@ where
 
     // Shield the P2PKH UTXO.
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let prover = ::zcash_proofs::prover::LocalTxProver::bundled();
     let network = *st.network();
@@ -1834,12 +1821,8 @@ where
 
     // Shield the P2SH UTXO.
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let prover = ::zcash_proofs::prover::LocalTxProver::bundled();
     let network = *st.network();
@@ -2184,12 +2167,8 @@ where
     let request = t2t_request(&network, Zatoshis::const_from_u64(40_000));
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let result = st.propose_transfer_with_policy(
         account.id(),
@@ -2222,12 +2201,8 @@ where
     let request = t2t_request(&network, transfer_amount);
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let proposal = st
         .propose_transfer_with_policy(
@@ -2345,12 +2320,8 @@ where
     .unwrap();
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     // Independently reproduce the initial gather that `GreedyInputSelector` will perform
     // (bounded only by the payment amount, since that's the only information available
@@ -2480,12 +2451,8 @@ where
 
     let input_selector =
         GreedyInputSelector::new().with_shielding_block_space_percent(BLOCK_SPACE_PERCENT);
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let result = st.propose_transfer_with_policy(
         account.id(),
@@ -2577,12 +2544,8 @@ where
     let request = t2t_request(&network, Zatoshis::const_from_u64(40_000));
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    );
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling);
 
     let proposal = st
         .propose_transfer_with_policy(
@@ -2866,13 +2829,9 @@ where
     let request = t2t_request(&network, transfer_amount);
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    )
-    .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling)
+            .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
 
     let proposal = st
         .propose_transfer_with_policy(
@@ -3001,13 +2960,9 @@ where
     let request = t2t_request(&network, transfer_amount);
 
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = standard::SingleOutputChangeStrategy::new(
-        StandardFeeRule::Zip317,
-        None,
-        ShieldedPool::Sapling,
-        DustOutputPolicy::default(),
-    )
-    .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Sapling)
+            .with_transparent_change_policy(TransparentChangePolicy::TransparentChangeAllowed);
 
     let proposal = st
         .propose_transfer_with_policy(

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1211,12 +1211,12 @@ pub(crate) mod tests {
                 Account, WalletRead,
                 testing::{
                     AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
-                    pool::ShieldedPoolTester,
+                    pool::ShieldedPoolTester, single_output_change_strategy,
                 },
                 wallet::ConfirmationsPolicy,
                 wallet::input_selection::GreedyInputSelector,
             },
-            fees::{DustOutputPolicy, StandardFeeRule, standard},
+            fees::StandardFeeRule,
             wallet::OvkPolicy,
         };
         use zcash_keys::address::Address;
@@ -1274,12 +1274,7 @@ pub(crate) mod tests {
         .unwrap();
 
         let fee_rule = StandardFeeRule::Zip317;
-        let change_strategy = standard::SingleOutputChangeStrategy::new(
-            fee_rule,
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        );
+        let change_strategy = single_output_change_strategy(fee_rule, None, ShieldedPool::Orchard);
         let input_selector = GreedyInputSelector::new();
 
         let proposal = st
@@ -1383,13 +1378,13 @@ pub(crate) mod tests {
                 Account, WalletRead,
                 testing::{
                     AddressType, IronwoodFvk, TestBuilder, orchard::OrchardPoolTester,
-                    pool::ShieldedPoolTester,
+                    pool::ShieldedPoolTester, single_output_change_strategy,
                 },
                 wallet::ConfirmationsPolicy,
                 wallet::input_selection::GreedyInputSelector,
             },
             decrypt_transaction,
-            fees::{DustOutputPolicy, StandardFeeRule, standard},
+            fees::StandardFeeRule,
             wallet::OvkPolicy,
         };
         use zcash_keys::address::Address;
@@ -1441,12 +1436,8 @@ pub(crate) mod tests {
         )])
         .unwrap();
 
-        let change_strategy = standard::SingleOutputChangeStrategy::new(
-            StandardFeeRule::Zip317,
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        );
+        let change_strategy =
+            single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
         let input_selector = GreedyInputSelector::new();
         let proposal = st
             .propose_transfer(


### PR DESCRIPTION
Test-only. Targets `main` directly: the dependency #2742 (centralize note
locking + extract `OutputLockStore`) has merged, so this is no longer stacked on
it, and the branch is now four commits on top of `main`.

The pool / transparent test scenarios had bodies of 100-160+ lines whose length
was repeated boilerplate, not logic: the 8-arg
`propose_standard_transfer::<Infallible>(...)`, turbofish
`create_proposed_transactions::<...>(...) + assert len + unwrap()[0]`, ~17-line
`InsufficientFunds` assert blocks, `SingleOutputChangeStrategy::new(...)`
construction, and per-block decoy-mining loops.

This PR adds a small set of documented fluent helpers to the existing
`TestScenario` DSL (`data_api::testing::pool::dsl`) and rewrites the scenarios to
use them (and reuses the existing `single_output_change_strategy` free function
for change-strategy construction). Test-only, behavior-preserving. Four commits,
reviewable step by step:

1. Add the DSL helpers + convert two locking scenarios (the POC).
2. Roll them across the remaining locking scenarios.
3. Roll the transfer helpers across the general `pool.rs` scenarios.
4. Broaden further: more `pool.rs` sites, `transparent.rs`, `testing.rs`, and
   the SQLite `orchard.rs` tests, via a count-preserving
   `create_proposed_expecting` and a confirmations-generalized
   `expect_insufficient_funds_with`.

### Helpers (inherent methods on `TestScenario`, reached via `st`)

- `propose_transfer_to` / `spend_to` / `propose_locking_transfer`
- `create_proposed_expecting(&proposal, n)` - executes and asserts exactly `n`
  transactions, returning the ids (preserves the old `len() == n` assertions)
- `expect_insufficient_funds` / `expect_insufficient_funds_with` (explicit
  `ConfirmationsPolicy`)
- `mine_decoy_block[s]` / `sole_note_ref` / `note_ref_by_value`

### Metric (lines)

- Scenario test code removed: `pool/locking.rs` -212, `pool.rs` -200,
  `transparent.rs` -45, other (`testing.rs`, `orchard.rs`) -13 = -470.
- Reusable DSL added: `pool/dsl.rs` +235 (docs + helpers; reusable by every
  scenario).
- Total: net -235 over 6 files.

### Deliberately not converted

Sites that would need to weaken an assertion or drop a diagnostic are left raw:
wildcard `InsufficientFunds { .. }`, `Ok(_)`/`Err(...)`-only asserts,
non-default fee-rule proposals, `Some(prebuilt MemoBytes)` change memos, and
scenarios that build `st` as a bare `TestState` (not a `TestScenario`) where the
inherent helpers are unreachable.

### Verification

- `cargo build --release --all-features` (both crates): clean.
- `cargo test --release -p zcash_client_sqlite --all-features`: 467 passed,
  0 failed - identical to baseline (independently re-run).
- `cargo clippy --release --all-targets --all-features` (both crates): clean.
- `cargo fmt -- --check` (stable): clean.
