### PR TITLE
zcash_client_backend: apply timeouts to Tor network operations

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,10 @@ workspace.
 
 ### Added
 - `impl Debug for zcash_client_backend::data_api::ll::wallet::PutBlocksError`
+- `zcash_client_backend::tor::Timeouts`
+- `zcash_client_backend::tor::Client::create_with_timeouts`
+- `zcash_client_backend::tor::http::TimeoutPhase`
+- `zcash_client_backend::tor::http::HttpError::Timeout`
 
 ### Changed
 - Every public error enum in this crate is now `#[non_exhaustive]` 
@@ -35,6 +39,14 @@ workspace.
   already authorized or still authorizable. A batch Signer's response
   consequently carries the retained signatures back alongside the new ones;
   re-applying them to the authoritative PCZT is a no-op.
+- The Tor HTTP and gRPC transports now bound how long each network operation may
+  take. Previously a server that accepted a connection and then never responded
+  would leave the request pending indefinitely, and could thereby stall any caller
+  that aggregates several servers (such as `tor::Client::get_latest_zec_to_usd_rate`).
+  `tor::Client::create` applies `tor::Timeouts::default`; use
+  `tor::Client::create_with_timeouts` if those deadlines are too aggressive for your
+  expected circuit latency. HTTP requests that exceed a deadline now fail with
+  `tor::http::HttpError::Timeout` instead of hanging.
 
 ## [0.24.0-rc.4] - 2026-07-26
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -264,6 +264,7 @@ tor = [
     "dep:serde",
     "dep:serde_json",
     "dep:tokio",
+    "tokio?/time",
     "dep:tokio-rustls",
     "dep:tor-rtcompat",
     "dep:trait-variant",

--- a/zcash_client_backend/src/tor.rs
+++ b/zcash_client_backend/src/tor.rs
@@ -1,6 +1,6 @@
 //! Tor support for Zcash wallets.
 
-use std::{fmt, io, path::Path};
+use std::{fmt, io, path::Path, time::Duration};
 
 use arti_client::{TorClient, config::TorClientConfigBuilder};
 use tor_rtcompat::PreferredRuntime;
@@ -15,14 +15,99 @@ pub mod http;
 // our minimal client API.
 pub use arti_client::DormantMode;
 
+/// Deadlines applied to network operations performed by a [`Client`].
+///
+/// Without these, a server that accepts a connection and then goes silent would leave the
+/// corresponding future pending forever. Tor circuits make this more likely than it is on
+/// the clearnet: a half-open circuit can persist for a long time without the peer's TCP
+/// stack ever delivering a reset.
+///
+/// Use [`Timeouts::default`] for values suitable for typical Tor circuit latency, or the
+/// `with_*` methods to tune them.
+#[derive(Clone, Copy, Debug)]
+pub struct Timeouts {
+    connect: Duration,
+    request: Duration,
+    response_body: Duration,
+    grpc_keepalive_interval: Duration,
+    grpc_keepalive_timeout: Duration,
+}
+
+impl Default for Timeouts {
+    fn default() -> Self {
+        Self {
+            connect: Duration::from_secs(30),
+            request: Duration::from_secs(60),
+            response_body: Duration::from_secs(60),
+            grpc_keepalive_interval: Duration::from_secs(30),
+            grpc_keepalive_timeout: Duration::from_secs(20),
+        }
+    }
+}
+
+impl Timeouts {
+    /// Sets the maximum time allowed to establish a usable connection to a server.
+    ///
+    /// This covers opening the Tor stream and, for HTTPS or gRPC-over-TLS endpoints,
+    /// completing the TLS handshake.
+    ///
+    /// The default is 30 seconds.
+    #[must_use]
+    pub fn with_connect(mut self, timeout: Duration) -> Self {
+        self.connect = timeout;
+        self
+    }
+
+    /// Sets the maximum time allowed to send a request and receive its response headers.
+    ///
+    /// This does not bound the time taken to receive a response body; see
+    /// [`Self::with_response_body`] for HTTP, and [`Self::with_grpc_keepalive`] for gRPC.
+    ///
+    /// The default is 60 seconds.
+    #[must_use]
+    pub fn with_request(mut self, timeout: Duration) -> Self {
+        self.request = timeout;
+        self
+    }
+
+    /// Sets the maximum time allowed to receive a complete HTTP response body.
+    ///
+    /// This is not applied to gRPC responses, because a gRPC response may be a
+    /// long-running stream (such as `GetBlockRange`) for which no fixed deadline is
+    /// appropriate. Use [`Self::with_grpc_keepalive`] to bound those instead.
+    ///
+    /// The default is 60 seconds.
+    #[must_use]
+    pub fn with_response_body(mut self, timeout: Duration) -> Self {
+        self.response_body = timeout;
+        self
+    }
+
+    /// Sets the HTTP/2 keep-alive parameters used for gRPC connections.
+    ///
+    /// A ping is sent every `interval` while a request is in flight, and the connection is
+    /// closed if no acknowledgement is received within `timeout`. This is what detects a
+    /// gRPC peer that stalls partway through streaming a response, which no request
+    /// deadline can bound without also capping legitimately long streams.
+    ///
+    /// The defaults are a 30 second interval and a 20 second timeout.
+    #[must_use]
+    pub fn with_grpc_keepalive(mut self, interval: Duration, timeout: Duration) -> Self {
+        self.grpc_keepalive_interval = interval;
+        self.grpc_keepalive_timeout = timeout;
+        self
+    }
+}
+
 /// A Tor client that exposes capabilities designed for Zcash wallets.
 #[derive(Clone)]
 pub struct Client {
     inner: TorClient<PreferredRuntime>,
+    timeouts: Timeouts,
 }
 
 impl Client {
-    /// Creates and bootstraps a Tor client.
+    /// Creates and bootstraps a Tor client with default [`Timeouts`].
     ///
     /// The client's persistent data and cache are both stored in the given directory.
     /// Preserving the contents of this directory will speed up subsequent calls to
@@ -37,6 +122,19 @@ impl Client {
     pub async fn create(
         tor_dir: &Path,
         with_permissions: impl FnOnce(&mut fs_mistrust::MistrustBuilder),
+    ) -> Result<Self, Error> {
+        Self::create_with_timeouts(tor_dir, with_permissions, Timeouts::default()).await
+    }
+
+    /// Creates and bootstraps a Tor client that applies the given [`Timeouts`] to its
+    /// network operations.
+    ///
+    /// This is otherwise identical to [`Client::create`]; see its documentation for
+    /// details of the other arguments.
+    pub async fn create_with_timeouts(
+        tor_dir: &Path,
+        with_permissions: impl FnOnce(&mut fs_mistrust::MistrustBuilder),
+        timeouts: Timeouts,
     ) -> Result<Self, Error> {
         let runtime = PreferredRuntime::current()?;
 
@@ -61,7 +159,7 @@ impl Client {
         let inner = client_builder.create_bootstrapped().await?;
         debug!("Tor bootstrapped");
 
-        Ok(Self { inner })
+        Ok(Self { inner, timeouts })
     }
 
     /// Ensures the Tor client is bootstrapped.
@@ -97,10 +195,13 @@ impl Client {
     ///
     /// (Connections made with clones of the returned `tor::Client` may share circuits
     /// with each other.)
+    ///
+    /// The returned handle uses the same [`Timeouts`] as this one.
     #[must_use]
     pub fn isolated_client(&self) -> Self {
         Self {
             inner: self.inner.isolated_client(),
+            timeouts: self.timeouts,
         }
     }
 

--- a/zcash_client_backend/src/tor/grpc.rs
+++ b/zcash_client_backend/src/tor/grpc.rs
@@ -22,6 +22,14 @@ impl Client {
     /// Tor hidden services (`.onion` addresses). The caller is responsible for deciding
     /// whether onion connections are appropriate for the given endpoint; this crate
     /// does not infer that from the endpoint host.
+    ///
+    /// The returned client applies this `Client`'s [`Timeouts`] to every request it makes.
+    /// Note that the request deadline bounds the wait for a response's headers, not the
+    /// duration of the response itself, so long-running streaming methods such as
+    /// `GetBlockRange` are not capped by it; a peer that stalls partway through a stream
+    /// is instead detected by the HTTP/2 keep-alive.
+    ///
+    /// [`Timeouts`]: super::Timeouts
     pub async fn connect_to_lightwalletd(
         &self,
         endpoint: Uri,
@@ -37,7 +45,12 @@ impl Client {
             HttpTcpConnector::new(self.clone())
         };
 
-        let channel = Endpoint::from(endpoint);
+        let channel = Endpoint::from(endpoint)
+            .connect_timeout(self.timeouts.connect)
+            .timeout(self.timeouts.request)
+            .http2_keep_alive_interval(self.timeouts.grpc_keepalive_interval)
+            .keep_alive_timeout(self.timeouts.grpc_keepalive_timeout)
+            .keep_alive_while_idle(false);
         let channel = if is_https {
             channel
                 .tls_config(ClientTlsConfig::new().with_webpki_roots())

--- a/zcash_client_backend/src/tor/http.rs
+++ b/zcash_client_backend/src/tor/http.rs
@@ -1,6 +1,6 @@
 //! HTTP requests over Tor.
 
-use std::{fmt, future::Future, io, sync::Arc};
+use std::{fmt, future::Future, io, sync::Arc, time::Duration};
 
 use arti_client::TorClient;
 use futures_util::task::SpawnExt;
@@ -21,7 +21,7 @@ use tokio_rustls::{
 use tor_rtcompat::PreferredRuntime;
 use tracing::{debug, error};
 
-use super::{Client, Error};
+use super::{Client, Error, Timeouts};
 
 pub mod cryptex;
 
@@ -31,6 +31,39 @@ pub enum Retry {
     Same,
     /// Retry using separate Tor circuits isolated from any other Tor usage.
     Isolated,
+}
+
+/// The stage of an HTTP request that exceeded its deadline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TimeoutPhase {
+    /// Opening the Tor stream to the server, or completing the TLS handshake.
+    Connect,
+    /// Sending the request and receiving its response headers.
+    Request,
+    /// Receiving and parsing the response body.
+    ResponseBody,
+}
+
+impl fmt::Display for TimeoutPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TimeoutPhase::Connect => write!(f, "connecting to the server"),
+            TimeoutPhase::Request => write!(f, "awaiting the response headers"),
+            TimeoutPhase::ResponseBody => write!(f, "reading the response body"),
+        }
+    }
+}
+
+/// Runs `f`, failing with [`HttpError::Timeout`] if it does not finish within `limit`.
+async fn with_timeout<T>(
+    limit: Duration,
+    phase: TimeoutPhase,
+    f: impl Future<Output = Result<T, Error>>,
+) -> Result<T, Error> {
+    tokio::time::timeout(limit, f)
+        .await
+        .unwrap_or_else(|_| Err(HttpError::Timeout(phase).into()))
 }
 
 pub(super) fn url_is_https(url: &Uri) -> Result<bool, HttpError> {
@@ -73,6 +106,11 @@ impl Client {
     ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
     ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
     ///   Tor client identity across queries).
+    ///
+    /// The [`Timeouts`] this client was created with are applied to each attempt
+    /// individually, so the total time this method can take is bounded by `retry_limit + 1`
+    /// times those deadlines. A request that exceeds one of them fails with
+    /// [`HttpError::Timeout`], which `retry_filter` sees like any other error.
     #[tracing::instrument(skip(self, request, parse_response, retry_filter))]
     pub async fn http_get<T, F: Future<Output = Result<T, Error>>>(
         &self,
@@ -114,6 +152,11 @@ impl Client {
     ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
     ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
     ///   Tor client identity across queries).
+    ///
+    /// The [`Timeouts`] this client was created with are applied to each attempt
+    /// individually, so the total time this method can take is bounded by `retry_limit + 1`
+    /// times those deadlines. A request that exceeds one of them fails with
+    /// [`HttpError::Timeout`], which `retry_filter` sees like any other error.
     #[tracing::instrument(skip(self, request, body, parse_response, retry_filter))]
     pub async fn http_post<B, T, F>(
         &self,
@@ -151,6 +194,11 @@ impl Client {
     ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
     ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
     ///   Tor client identity across queries).
+    ///
+    /// The [`Timeouts`] this client was created with are applied to each attempt
+    /// individually, so the total time this method can take is bounded by `retry_limit + 1`
+    /// times those deadlines. A request that exceeds one of them fails with
+    /// [`HttpError::Timeout`], which `retry_filter` sees like any other error.
     async fn http_request<B, T, F>(
         &self,
         url: Uri,
@@ -170,8 +218,10 @@ impl Client {
         let mut client = None;
 
         let (parts, body) = loop {
+            let active = client.as_ref().unwrap_or(self);
             let response = one_http_request(
-                &client.as_ref().unwrap_or(self).inner,
+                &active.inner,
+                &active.timeouts,
                 url.clone(),
                 &request,
                 body.clone(),
@@ -199,7 +249,15 @@ impl Client {
         }?
         .into_parts();
 
-        Ok(Response::from_parts(parts, parse_response(body).await?))
+        Ok(Response::from_parts(
+            parts,
+            with_timeout(
+                self.timeouts.response_body,
+                TimeoutPhase::ResponseBody,
+                parse_response(body),
+            )
+            .await?,
+        ))
     }
 
     /// Makes an HTTP GET request over Tor, parsing the response as JSON.
@@ -219,6 +277,11 @@ impl Client {
     ///   to `|_| None`, and you can ensure the same circuit is reused by setting this to
     ///   `|res| res.is_err().then_some(Retry::Same)` (e.g. if you require a persistent
     ///   Tor client identity across queries).
+    ///
+    /// The [`Timeouts`] this client was created with are applied to each attempt
+    /// individually, so the total time this method can take is bounded by `retry_limit + 1`
+    /// times those deadlines. A request that exceeds one of them fails with
+    /// [`HttpError::Timeout`], which `retry_filter` sees like any other error.
     pub async fn http_get_json<T: DeserializeOwned>(
         &self,
         url: Uri,
@@ -247,6 +310,7 @@ impl Client {
 
 async fn one_http_request<B>(
     tor_client: &TorClient<PreferredRuntime>,
+    timeouts: &Timeouts,
     url: Uri,
     request: impl FnOnce(Builder) -> Builder,
     body: B,
@@ -258,30 +322,52 @@ where
 {
     let (is_https, host, port) = parse_url(&url)?;
 
-    // Connect to the server.
     debug!("Connecting through Tor to {}:{}", host, port);
-    let stream = tor_client.connect((host.as_str(), port)).await?;
 
+    // The Tor stream and the TLS handshake are bounded together, so that
+    // `Timeouts::connect` means the same thing here as it does for the gRPC transport
+    // (where `tonic` applies it to the connector as a whole).
     if is_https {
-        // On apple-darwin targets there's an issue with the native TLS implementation
-        // when used over Tor circuits. We use Rustls instead.
-        //
-        // https://gitlab.torproject.org/tpo/core/arti/-/issues/715
-        let root_store = RootCertStore {
-            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-        };
-        let config = ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        let connector = TlsConnector::from(Arc::new(config));
-        let dnsname = ServerName::try_from(host).expect("Already checked");
-        let stream = connector
-            .connect(dnsname, stream)
-            .await
-            .map_err(HttpError::Tls)?;
-        make_http_request(stream, url, request, body).await
+        let stream = with_timeout(timeouts.connect, TimeoutPhase::Connect, async {
+            let stream = tor_client.connect((host.as_str(), port)).await?;
+
+            // On apple-darwin targets there's an issue with the native TLS implementation
+            // when used over Tor circuits. We use Rustls instead.
+            //
+            // https://gitlab.torproject.org/tpo/core/arti/-/issues/715
+            let root_store = RootCertStore {
+                roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+            };
+            let config = ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+            let connector = TlsConnector::from(Arc::new(config));
+            let dnsname = ServerName::try_from(host).expect("Already checked");
+            Ok(connector
+                .connect(dnsname, stream)
+                .await
+                .map_err(HttpError::Tls)?)
+        })
+        .await?;
+
+        with_timeout(
+            timeouts.request,
+            TimeoutPhase::Request,
+            make_http_request(stream, url, request, body),
+        )
+        .await
     } else {
-        make_http_request(stream, url, request, body).await
+        let stream = with_timeout(timeouts.connect, TimeoutPhase::Connect, async {
+            Ok(tor_client.connect((host.as_str(), port)).await?)
+        })
+        .await?;
+
+        with_timeout(
+            timeouts.request,
+            TimeoutPhase::Request,
+            make_http_request(stream, url, request, body),
+        )
+        .await
     }
 }
 
@@ -344,6 +430,10 @@ pub enum HttpError {
     Spawn(futures_util::task::SpawnError),
     /// A TLS-specific IO error.
     Tls(io::Error),
+    /// The request did not complete within the corresponding [`Timeouts`] deadline.
+    ///
+    /// [`Timeouts`]: super::Timeouts
+    Timeout(TimeoutPhase),
     /// The status code indicated that the request was unsuccessful.
     ///
     /// This is only returned by APIs that make specific queries, such as
@@ -361,6 +451,7 @@ impl fmt::Display for HttpError {
             HttpError::Json(e) => write!(f, "Failed to parse JSON: {e}"),
             HttpError::Spawn(e) => write!(f, "Failed to spawn task: {e}"),
             HttpError::Tls(e) => write!(f, "TLS error: {e}"),
+            HttpError::Timeout(phase) => write!(f, "Timed out while {phase}"),
             HttpError::Unsuccessful(status) => write!(f, "Request was unsuccessful ({status:?})"),
         }
     }
@@ -375,6 +466,7 @@ impl std::error::Error for HttpError {
             HttpError::Json(e) => Some(e),
             HttpError::Spawn(e) => Some(e),
             HttpError::Tls(e) => Some(e),
+            HttpError::Timeout(_) => None,
             HttpError::Unsuccessful(_) => None,
         }
     }
@@ -401,6 +493,46 @@ impl From<serde_json::Error> for HttpError {
 impl From<futures_util::task::SpawnError> for HttpError {
     fn from(e: futures_util::task::SpawnError) -> Self {
         HttpError::Spawn(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use http_body_util::Empty;
+    use hyper::body::Bytes;
+
+    use super::{HttpError, TimeoutPhase, make_http_request, with_timeout};
+    use crate::tor::Error;
+
+    /// A server that accepts the connection and then never speaks must not be able to
+    /// hold a request pending forever.
+    #[tokio::test]
+    async fn silent_server_times_out() {
+        // The far end of this duplex stream is held open for the duration of the test but
+        // never read from or written to, modelling a peer that stalls after connecting.
+        let (stream, _silent_peer) = tokio::io::duplex(1024);
+
+        let res = with_timeout(
+            Duration::from_millis(100),
+            TimeoutPhase::Request,
+            make_http_request(
+                stream,
+                "http://example.com/".parse().unwrap(),
+                |builder| builder.method("GET"),
+                Empty::<Bytes>::new(),
+            ),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                res,
+                Err(Error::Http(HttpError::Timeout(TimeoutPhase::Request)))
+            ),
+            "expected a request timeout, got {res:?}",
+        );
     }
 }
 


### PR DESCRIPTION
Closes #2791.

Neither the HTTP-over-Tor client nor the gRPC-over-Tor connector bounded how long a
network operation could take. A server that accepted a connection and then went
silent — never completing the TLS handshake, never sending response headers, or
trickling a response body forever — would leave the corresponding future pending
indefinitely.

`arti` already bounds opening the Tor stream itself via
`StreamTimeoutConfig::connect_timeout` (10s by default), so the exposure was in the
layers above: the TLS handshake, the HTTP exchange, and the response body.

## Changes

- Adds `tor::Timeouts`, carried by `tor::Client` and propagated through
  `isolated_client`. `Client::create` keeps its signature and uses the defaults;
  the new `Client::create_with_timeouts` lets callers tune them.

  | Knob | Default | Bounds |
  |---|---|---|
  | `connect` | 30s | Tor stream + TLS handshake, both transports |
  | `request` | 60s | Sending the request through receiving response headers |
  | `response_body` | 60s | Reading a complete HTTP response body (HTTP only) |
  | `grpc_keepalive` | 30s / 20s | HTTP/2 ping interval + pong deadline (gRPC only) |

- HTTP: the Tor stream and TLS handshake are bounded together, so `connect` means the
  same thing here as it does for gRPC (where `tonic` applies it to the connector as a
  whole). Deadlines are enforced per attempt and surface as the new
  `HttpError::Timeout(TimeoutPhase)`, which `retry_filter` sees like any other error.

- gRPC: `Endpoint::connect_timeout`, `Endpoint::timeout`, and HTTP/2 keep-alive.

## Notes for review

The `Timeouts` fields are private with `with_*` setters rather than public, so future
knobs aren't breaking changes.

`Endpoint::timeout` bounds only the wait for response *headers*, not the response
itself, so streaming methods such as `GetBlockRange` are not capped by it. Those are
covered instead by the HTTP/2 keep-alive pings, which detect a peer that stalls partway
through a stream — the one failure mode no request deadline can catch without also
capping legitimate long streams. This piece goes slightly beyond what #2791 describes,
but it's the case that matters most for a syncing wallet.

The 30/60/60 defaults are reasoned for typical Tor circuit latency with headroom rather
than derived from measurements; if there are real numbers from downstream wallets they
should probably override these.

Adds a hermetic regression test (`silent_server_times_out`) that drives
`make_http_request` over a duplex stream whose far end never responds. No network or
Tor client needed, so it runs in normal CI.

---
Opened with Claude Code assistance.
